### PR TITLE
Add link to gnosis safe tx details

### DIFF
--- a/src/custom/api/gnosisSafe/index.ts
+++ b/src/custom/api/gnosisSafe/index.ts
@@ -42,14 +42,15 @@ function _getClientOrThrow(chainId: number): SafeServiceClient {
   return client
 }
 
-export function getSafeWebUrl(chaindId: number, safeAddress: string): string | null {
+export function getSafeWebUrl(chaindId: number, safeAddress: string, safeTxHash?: string): string | null {
   const safeWebUrl = SAFE_WEB_URL[chaindId]
 
   if (!safeWebUrl) {
     return null
   }
 
-  return `${safeWebUrl}/app/#/safes/${safeAddress}/transactions`
+  const baseUrl = `${safeWebUrl}/app/#/safes/${safeAddress}/transactions`
+  return safeTxHash ? `${baseUrl}/${safeTxHash}` : baseUrl
 }
 
 export function getSafeTransaction(chainId: number, safeTxHash: string): Promise<SafeMultisigTransactionResponse> {

--- a/src/custom/components/AccountDetails/Transaction/StatusDetails.tsx
+++ b/src/custom/components/AccountDetails/Transaction/StatusDetails.tsx
@@ -26,8 +26,8 @@ export function GnosisSafeLink(props: {
     return null
   }
 
-  const { safe } = safeTransaction
-  const safeUrl = getSafeWebUrl(chainId, safe)
+  const { safe, safeTxHash } = safeTransaction
+  const safeUrl = getSafeWebUrl(chainId, safe, safeTxHash)
 
   // Only show the link to the safe, if we have the "safeUrl"
   if (safeUrl === null) {

--- a/src/custom/components/AccountDetails/Transaction/index.tsx
+++ b/src/custom/components/AccountDetails/Transaction/index.tsx
@@ -93,8 +93,8 @@ function getActivityLinkUrl(params: {
       return getEtherscanLink(chainId, transactionHash, 'transaction')
     } else if (safeTransaction && safeTransaction) {
       // Its a safe transaction: Gnosis Safe Web link
-      const { safe } = safeTransaction
-      return getSafeWebUrl(chainId, safe) ?? undefined
+      const { safe, safeTxHash } = safeTransaction
+      return getSafeWebUrl(chainId, safe, safeTxHash) ?? undefined
     }
   } else if (order) {
     // Its an order: GP Explorer link


### PR DESCRIPTION
Summary
Gnosis safe is implementing a new page for the details of the transaction: https://github.com/gnosis/safe-react/pull/2974

This page will have have an URL with the following structure:
`gnosis-safe.io/app/{{shortName}}:{{safeAddress}}/transactions/{{safeTxHash}}`

![image](https://user-images.githubusercontent.com/2352112/161445052-1c667853-b6ce-4405-959d-58b7f681b55d.png)

## To Test
Wait for https://github.com/gnosis/safe-react/pull/2974 to be in PRODUCTION

1. Create a gnosis safe transaction (tx or just send an order)
2. Follow the link, verify that goest to the right transaction and the URL is correct

## Context
https://gnosisinc.slack.com/archives/C63LQTGNB/p1636721773081900