### PR TITLE
Conditional explorer external url: Waterfall PR[2]

### DIFF
--- a/src/custom/components/AddToMetamask/index.tsx
+++ b/src/custom/components/AddToMetamask/index.tsx
@@ -10,9 +10,10 @@ import MetaMaskLogo from 'assets/images/metamask.png'
 
 export type AddToMetamaskProps = {
   currency: Currency | undefined
+  shortLabel?: boolean
 }
 
-const ButtonCustom = styled.button`
+export const ButtonCustom = styled.button`
   display: flex;
   flex: 1 1 auto;
   align-self: center;
@@ -59,7 +60,7 @@ const CheckCircleCustom = styled(CheckCircle)`
 `
 
 export default function AddToMetamask(props: AddToMetamaskProps) {
-  const { currency } = props
+  const { currency, shortLabel } = props
   const theme = useContext(ThemeContext)
   const { library } = useActiveWeb3React()
   const { addToken, success } = useAddTokenToMetamask(currency)
@@ -72,7 +73,7 @@ export default function AddToMetamask(props: AddToMetamaskProps) {
     <ButtonCustom onClick={addToken}>
       {!success ? (
         <RowFixed>
-          <StyledIcon src={MetaMaskLogo} /> Add {currency.symbol} to Metamask
+          <StyledIcon src={MetaMaskLogo} /> {shortLabel ? 'Add Token' : `Add ${currency.symbol} to Metamask`}
         </RowFixed>
       ) : (
         <RowFixed>

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -27,6 +27,7 @@ import { RefreshCcw } from 'react-feather'
 import Web3Status from 'components/Web3Status'
 import useReferralLink from 'hooks/useReferralLink'
 import useFetchProfile from 'hooks/useFetchProfile'
+import { getBlockExplorerUrl } from 'utils'
 import { formatMax, formatSmartLocaleAware, numberFormatter } from 'utils/format'
 import { getExplorerAddressLink } from 'utils/explorer'
 import useTimeAgo from 'hooks/useTimeAgo'
@@ -44,7 +45,11 @@ import CowImage from 'assets/cow-swap/cow_v2.svg'
 import CowProtocolImage from 'assets/cow-swap/cowprotocol.svg'
 import { useTokenBalance } from 'state/wallet/hooks'
 import { useVCowData } from 'state/claim/hooks'
-import { AMOUNT_PRECISION } from 'constants/index'
+import {
+  // V_COW_CONTRACT_ADDRESS,
+  COW_CONTRACT_ADDRESS,
+  AMOUNT_PRECISION,
+} from 'constants/index'
 import { COW } from 'constants/tokens'
 import { useErrorModal } from 'hooks/useErrorMessageAndModal'
 import { OperationType } from 'components/TransactionConfirmationModal'
@@ -53,6 +58,7 @@ import { useClaimDispatchers, useClaimState } from 'state/claim/hooks'
 import { SwapVCowStatus } from 'state/claim/actions'
 import { useSwapVCowCallback } from 'state/claim/hooks'
 import MetamaskIcon from 'assets/images/metamask.png'
+import {} from 'constants/index'
 
 const COW_DECIMALS = COW[ChainId.MAINNET].decimals
 
@@ -216,7 +222,9 @@ export default function Profile() {
             </span>
           </BalanceDisplay>
           <CardActions>
-            <ExtLink href={'#'}>Etherscan ↗</ExtLink>
+            <ExtLink href={getBlockExplorerUrl(chainId || 1, COW_CONTRACT_ADDRESS[chainId || 1], 'address')}>
+              {chainId === ChainId.XDAI ? 'Blockscout' : 'Etherscan'} ↗
+            </ExtLink>
             <ExtLink href={'#'}>
               <img src={MetamaskIcon} alt="MetaMask" width="15" height="14" /> Add to MetaMask
             </ExtLink>

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -45,20 +45,21 @@ import CowImage from 'assets/cow-swap/cow_v2.svg'
 import CowProtocolImage from 'assets/cow-swap/cowprotocol.svg'
 import { useTokenBalance } from 'state/wallet/hooks'
 import { useVCowData, useSwapVCowCallback, useSetSwapVCowStatus, useSwapVCowStatus } from 'state/cowToken/hooks'
-import { COW_CONTRACT_ADDRESS, AMOUNT_PRECISION } from 'constants/index'
+import { V_COW_CONTRACT_ADDRESS, COW_CONTRACT_ADDRESS, AMOUNT_PRECISION } from 'constants/index'
 import { COW } from 'constants/tokens'
 import { useErrorModal } from 'hooks/useErrorMessageAndModal'
 import { OperationType } from 'components/TransactionConfirmationModal'
 import useTransactionConfirmationModal from 'hooks/useTransactionConfirmationModal'
 import { SwapVCowStatus } from 'state/cowToken/actions'
-import MetamaskIcon from 'assets/images/metamask.png'
-import {} from 'constants/index'
+import AddToMetamask from 'components/AddToMetamask'
+import { Link } from 'react-router-dom'
+import CopyHelper from 'components/Copy'
 
 const COW_DECIMALS = COW[ChainId.MAINNET].decimals
 
 export default function Profile() {
   const referralLink = useReferralLink()
-  const { account, chainId } = useActiveWeb3React()
+  const { account, chainId = ChainId.MAINNET, library } = useActiveWeb3React()
   const { profileData, isLoading, error } = useFetchProfile()
   const lastUpdated = useTimeAgo(profileData?.lastUpdated)
   const isTradesTooltipVisible = account && chainId == 1 && !!profileData?.totalTrades
@@ -161,6 +162,8 @@ export default function Profile() {
     </>
   )
 
+  const currencyCOW = COW[chainId]
+
   return (
     <Container>
       <TransactionConfirmationModal />
@@ -204,6 +207,15 @@ export default function Profile() {
                 )}
               </ButtonPrimary>
             </ConvertWrapper>
+
+            <CardActions>
+              <ExtLink href={getBlockExplorerUrl(chainId, V_COW_CONTRACT_ADDRESS[chainId], 'address')}>
+                Contract ↗
+              </ExtLink>
+              <CopyHelper toCopy={V_COW_CONTRACT_ADDRESS[chainId]}>
+                <div title="Click to copy token contract address">Copy contract</div>
+              </CopyHelper>
+            </CardActions>
           </Card>
         )}
 
@@ -216,13 +228,22 @@ export default function Profile() {
             </span>
           </BalanceDisplay>
           <CardActions>
-            <ExtLink href={getBlockExplorerUrl(chainId || 1, COW_CONTRACT_ADDRESS[chainId || 1], 'address')}>
-              {chainId === ChainId.XDAI ? 'Blockscout' : 'Etherscan'} ↗
+            <ExtLink
+              title="View contract"
+              href={getBlockExplorerUrl(chainId, COW_CONTRACT_ADDRESS[chainId], 'address')}
+            >
+              Contract ↗
             </ExtLink>
-            <ExtLink href={'#'}>
-              <img src={MetamaskIcon} alt="MetaMask" width="15" height="14" /> Add to MetaMask
-            </ExtLink>
-            <ExtLink href={'#'}>Buy COW ↗</ExtLink>
+
+            {library?.provider?.isMetaMask && <AddToMetamask shortLabel currency={currencyCOW} />}
+
+            {!library?.provider?.isMetaMask && (
+              <CopyHelper toCopy={COW_CONTRACT_ADDRESS[chainId]}>
+                <div title="Click to copy token contract address">Copy contract</div>
+              </CopyHelper>
+            )}
+
+            <Link to={`/swap?outputCurrency=${COW_CONTRACT_ADDRESS[chainId]}`}>Buy COW</Link>
           </CardActions>
         </Card>
 
@@ -266,7 +287,7 @@ export default function Profile() {
                     )}
                   </Txt>
                   {hasOrders && (
-                    <ExtLink href={getExplorerAddressLink(chainId || 1, account)}>
+                    <ExtLink href={getExplorerAddressLink(chainId, account)}>
                       <Txt secondary>View all orders ↗</Txt>
                     </ExtLink>
                   )}

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -45,11 +45,7 @@ import CowImage from 'assets/cow-swap/cow_v2.svg'
 import CowProtocolImage from 'assets/cow-swap/cowprotocol.svg'
 import { useTokenBalance } from 'state/wallet/hooks'
 import { useVCowData } from 'state/claim/hooks'
-import {
-  // V_COW_CONTRACT_ADDRESS,
-  COW_CONTRACT_ADDRESS,
-  AMOUNT_PRECISION,
-} from 'constants/index'
+import { COW_CONTRACT_ADDRESS, AMOUNT_PRECISION } from 'constants/index'
 import { COW } from 'constants/tokens'
 import { useErrorModal } from 'hooks/useErrorMessageAndModal'
 import { OperationType } from 'components/TransactionConfirmationModal'

--- a/src/custom/pages/Profile/styled.tsx
+++ b/src/custom/pages/Profile/styled.tsx
@@ -5,6 +5,8 @@ import { BannerExplainer } from 'pages/Claim/styled'
 import * as CSS from 'csstype'
 import { transparentize } from 'polished'
 import { ExternalLink } from 'theme'
+import { ButtonCustom as AddToMetaMask } from 'components/AddToMetamask'
+import { CopyIcon as ClickToCopy } from 'components/Copy'
 
 export const Container = styled.div`
   max-width: 910px;
@@ -263,6 +265,7 @@ export const Card = styled.div<{ showLoader?: boolean }>`
   gap: 24px 0;
   border-radius: 16px;
   border: 1px solid ${({ theme }) => theme.cardBorder};
+  align-items: flex-end;
 
   ${({ showLoader, theme }) =>
     showLoader &&
@@ -434,17 +437,65 @@ export const CardActions = styled.div`
   display: flex;
   flex-flow: row wrap;
   justify-content: space-between;
+  margin: auto 0 0;
 
-  > a {
-    font-size: 14px;
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    justify-content: center;
+    align-items: center;
+    flex-flow: column wrap;
+    gap: 32px 0;
+    margin: 12px 0;
+  `};
+
+  > a,
+  ${AddToMetaMask}, > ${ClickToCopy} {
+    font-size: 13px;
+    height: 100%;
+    font-weight: 500;
+    margin: auto 0 0;
+    padding: 0;
     line-height: 1;
     color: ${({ theme }) => theme.text1};
     display: flex;
     align-items: flex-end;
+    text-decoration: underline;
+    text-decoration-color: transparent;
+    transition: text-decoration-color 0.2s ease-in-out, color 0.2s ease-in-out;
 
-    > img {
-      margin: 0 3px 0 0;
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      font-size: 15px;
+      margin: 0 auto;
+    `};
+
+    &:hover {
+      text-decoration-color: ${({ theme }) => theme.primary1};
+      color: ${({ theme }) => theme.primary1};
     }
+  }
+
+  ${AddToMetaMask} {
+    border: 0;
+    min-height: initial;
+    border-radius: initial;
+
+    &:hover {
+      background: transparent;
+
+      > div {
+        text-decoration: underline;
+      }
+    }
+
+    > div > img,
+    > div > svg {
+      width: 15px;
+      margin: 0 6px 0 0;
+    }
+  }
+
+  > ${ClickToCopy} svg {
+    width: 15px;
+    margin: 0 4px 0 0;
   }
 `
 

--- a/src/custom/utils/index.ts
+++ b/src/custom/utils/index.ts
@@ -80,6 +80,18 @@ function getBlockscoutUrl(chainId: ChainId, data: string, type: BlockExplorerLin
   return `https://blockscout.com/${getBlockscoutUrlPrefix(chainId)}/${getBlockscoutUrlSuffix(type, data)}`
 }
 
+// Get the right block explorer URL by chainId
+export function getBlockExplorerUrl(chainId: ChainId, data: string, type: BlockExplorerLinkType): string {
+  switch (chainId) {
+    // Check if chain is xDAI to use Blockscout
+    case ChainId.XDAI:
+      return getBlockscoutUrl(chainId, data, type)
+    // Otherwise always use Etherscan for other chains
+    default:
+      return getEtherscanUrl(chainId, data, type)
+  }
+}
+
 export function isGpOrder(data: string, type: BlockExplorerLinkType) {
   return type === 'transaction' && data.length === GP_ORDER_ID_LENGTH
 }


### PR DESCRIPTION
# Summary

<img width="442" alt="Screen Shot 2022-04-05 at 17 07 01" src="https://user-images.githubusercontent.com/31534717/161797616-c5fcea45-eb98-4d99-9d28-6f006b5227bb.png">


- Conditionally shows the right external block explorer (Rinkeby, Ethereum Mainnet, Gnosis Chain) text label and outgoing url for the COW balance card.
- Creates a tiny util function (`getBlockExplorerUrl`) to leverage existing functions returning its respective block explorer urls (from: `getBlockscoutUrl` and `getEtherscanUrl`)

