### PR TITLE
Profile: Orange link hover and shorter Add to Metamask label: Waterfall PR[5]

### DIFF
--- a/src/custom/components/AddToMetamask/index.tsx
+++ b/src/custom/components/AddToMetamask/index.tsx
@@ -10,7 +10,10 @@ import MetaMaskLogo from 'assets/images/metamask.png'
 
 export type AddToMetamaskProps = {
   currency: Currency | undefined
+  shortLabel?: boolean
 }
+
+const SHORT_LABEL = 'Add Token'
 
 export const ButtonCustom = styled.button`
   display: flex;
@@ -59,7 +62,7 @@ const CheckCircleCustom = styled(CheckCircle)`
 `
 
 export default function AddToMetamask(props: AddToMetamaskProps) {
-  const { currency } = props
+  const { currency, shortLabel } = props
   const theme = useContext(ThemeContext)
   const { library } = useActiveWeb3React()
   const { addToken, success } = useAddTokenToMetamask(currency)
@@ -72,7 +75,7 @@ export default function AddToMetamask(props: AddToMetamaskProps) {
     <ButtonCustom onClick={addToken}>
       {!success ? (
         <RowFixed>
-          <StyledIcon src={MetaMaskLogo} /> Add {currency.symbol} to Metamask
+          <StyledIcon src={MetaMaskLogo} /> {shortLabel ? SHORT_LABEL : `Add ${currency.symbol} to Metamask`}
         </RowFixed>
       ) : (
         <RowFixed>

--- a/src/custom/components/AddToMetamask/index.tsx
+++ b/src/custom/components/AddToMetamask/index.tsx
@@ -13,8 +13,6 @@ export type AddToMetamaskProps = {
   shortLabel?: boolean
 }
 
-const SHORT_LABEL = 'Add Token'
-
 export const ButtonCustom = styled.button`
   display: flex;
   flex: 1 1 auto;
@@ -75,7 +73,7 @@ export default function AddToMetamask(props: AddToMetamaskProps) {
     <ButtonCustom onClick={addToken}>
       {!success ? (
         <RowFixed>
-          <StyledIcon src={MetaMaskLogo} /> {shortLabel ? SHORT_LABEL : `Add ${currency.symbol} to Metamask`}
+          <StyledIcon src={MetaMaskLogo} /> {shortLabel ? 'Add Token' : `Add ${currency.symbol} to Metamask`}
         </RowFixed>
       ) : (
         <RowFixed>

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -229,7 +229,7 @@ export default function Profile() {
 
             <AddToMetamask currency={COW[chainId || 1] as Currency | undefined} />
 
-            <Link to={`/swap?outputCurrency=${COW_CONTRACT_ADDRESS[chainId || 1]}`}>Buy COW ↗</Link>
+            <Link to={`/swap?outputCurrency=${COW_CONTRACT_ADDRESS[chainId || 1]}`}>Buy COW</Link>
           </CardActions>
         </Card>
 

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -163,6 +163,8 @@ export default function Profile() {
     </>
   )
 
+  const currencyCOW = COW[chainId || ChainId.MAINNET]
+
   return (
     <Container>
       <TransactionConfirmationModal />
@@ -244,9 +246,7 @@ export default function Profile() {
               Contract ↗
             </ExtLink>
 
-            {library?.provider?.isMetaMask && (
-              <AddToMetamask shortLabel={true} currency={COW[chainId || ChainId.MAINNET] as Currency | undefined} />
-            )}
+            {currencyCOW && library?.provider?.isMetaMask && <AddToMetamask shortLabel={true} currency={currencyCOW} />}
 
             {!library?.provider?.isMetaMask && (
               <CopyHelper toCopy={COW_CONTRACT_ADDRESS[chainId || ChainId.MAINNET]}>

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -235,7 +235,7 @@ export default function Profile() {
               Contract ↗
             </ExtLink>
 
-            {currencyCOW && library?.provider?.isMetaMask && <AddToMetamask shortLabel={true} currency={currencyCOW} />}
+            {currencyCOW && library?.provider?.isMetaMask && <AddToMetamask shortLabel currency={currencyCOW} />}
 
             {!library?.provider?.isMetaMask && (
               <CopyHelper toCopy={COW_CONTRACT_ADDRESS[chainId]}>

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -235,7 +235,7 @@ export default function Profile() {
               Contract ↗
             </ExtLink>
 
-            {currencyCOW && library?.provider?.isMetaMask && <AddToMetamask shortLabel currency={currencyCOW} />}
+            {library?.provider?.isMetaMask && <AddToMetamask shortLabel currency={currencyCOW} />}
 
             {!library?.provider?.isMetaMask && (
               <CopyHelper toCopy={COW_CONTRACT_ADDRESS[chainId]}>

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -1,5 +1,4 @@
 import { useCallback } from 'react'
-import { Currency } from '@uniswap/sdk-core'
 import { Txt } from 'assets/styles/styled'
 import {
   FlexCol,
@@ -60,7 +59,7 @@ const COW_DECIMALS = COW[ChainId.MAINNET].decimals
 
 export default function Profile() {
   const referralLink = useReferralLink()
-  const { account, chainId, library } = useActiveWeb3React()
+  const { account, chainId = ChainId.MAINNET, library } = useActiveWeb3React()
   const { profileData, isLoading, error } = useFetchProfile()
   const lastUpdated = useTimeAgo(profileData?.lastUpdated)
   const isTradesTooltipVisible = account && chainId == 1 && !!profileData?.totalTrades
@@ -163,7 +162,7 @@ export default function Profile() {
     </>
   )
 
-  const currencyCOW = COW[chainId || ChainId.MAINNET]
+  const currencyCOW = COW[chainId]
 
   return (
     <Container>
@@ -210,16 +209,10 @@ export default function Profile() {
             </ConvertWrapper>
 
             <CardActions>
-              <ExtLink
-                href={getBlockExplorerUrl(
-                  chainId || ChainId.MAINNET,
-                  V_COW_CONTRACT_ADDRESS[chainId || ChainId.MAINNET],
-                  'address'
-                )}
-              >
+              <ExtLink href={getBlockExplorerUrl(chainId, V_COW_CONTRACT_ADDRESS[chainId], 'address')}>
                 Contract ↗
               </ExtLink>
-              <CopyHelper toCopy={V_COW_CONTRACT_ADDRESS[chainId || ChainId.MAINNET]}>
+              <CopyHelper toCopy={V_COW_CONTRACT_ADDRESS[chainId]}>
                 <div title="Click to copy token contract address">Copy contract</div>
               </CopyHelper>
             </CardActions>
@@ -237,11 +230,7 @@ export default function Profile() {
           <CardActions>
             <ExtLink
               title="View contract"
-              href={getBlockExplorerUrl(
-                chainId || ChainId.MAINNET,
-                COW_CONTRACT_ADDRESS[chainId || ChainId.MAINNET],
-                'address'
-              )}
+              href={getBlockExplorerUrl(chainId, COW_CONTRACT_ADDRESS[chainId], 'address')}
             >
               Contract ↗
             </ExtLink>
@@ -249,12 +238,12 @@ export default function Profile() {
             {currencyCOW && library?.provider?.isMetaMask && <AddToMetamask shortLabel={true} currency={currencyCOW} />}
 
             {!library?.provider?.isMetaMask && (
-              <CopyHelper toCopy={COW_CONTRACT_ADDRESS[chainId || ChainId.MAINNET]}>
+              <CopyHelper toCopy={COW_CONTRACT_ADDRESS[chainId]}>
                 <div title="Click to copy token contract address">Copy contract</div>
               </CopyHelper>
             )}
 
-            <Link to={`/swap?outputCurrency=${COW_CONTRACT_ADDRESS[chainId || ChainId.MAINNET]}`}>Buy COW</Link>
+            <Link to={`/swap?outputCurrency=${COW_CONTRACT_ADDRESS[chainId]}`}>Buy COW</Link>
           </CardActions>
         </Card>
 
@@ -298,7 +287,7 @@ export default function Profile() {
                     )}
                   </Txt>
                   {hasOrders && (
-                    <ExtLink href={getExplorerAddressLink(chainId || ChainId.MAINNET, account)}>
+                    <ExtLink href={getExplorerAddressLink(chainId, account)}>
                       <Txt secondary>View all orders ↗</Txt>
                     </ExtLink>
                   )}

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -54,12 +54,13 @@ import useTransactionConfirmationModal from 'hooks/useTransactionConfirmationMod
 import { SwapVCowStatus } from 'state/cowToken/actions'
 import AddToMetamask from 'components/AddToMetamask'
 import { Link } from 'react-router-dom'
+import CopyHelper from 'components/Copy'
 
 const COW_DECIMALS = COW[ChainId.MAINNET].decimals
 
 export default function Profile() {
   const referralLink = useReferralLink()
-  const { account, chainId } = useActiveWeb3React()
+  const { account, chainId, library } = useActiveWeb3React()
   const { profileData, isLoading, error } = useFetchProfile()
   const lastUpdated = useTimeAgo(profileData?.lastUpdated)
   const isTradesTooltipVisible = account && chainId == 1 && !!profileData?.totalTrades
@@ -210,6 +211,9 @@ export default function Profile() {
               <ExtLink href={getBlockExplorerUrl(chainId || 1, V_COW_CONTRACT_ADDRESS[chainId || 1], 'address')}>
                 Contract ↗
               </ExtLink>
+              <CopyHelper toCopy={V_COW_CONTRACT_ADDRESS[chainId || 1]}>
+                <div title="Click to copy token contract address">Copy contract</div>
+              </CopyHelper>
             </CardActions>
           </Card>
         )}
@@ -223,11 +227,22 @@ export default function Profile() {
             </span>
           </BalanceDisplay>
           <CardActions>
-            <ExtLink href={getBlockExplorerUrl(chainId || 1, COW_CONTRACT_ADDRESS[chainId || 1], 'address')}>
+            <ExtLink
+              title="View contract"
+              href={getBlockExplorerUrl(chainId || 1, COW_CONTRACT_ADDRESS[chainId || 1], 'address')}
+            >
               Contract ↗
             </ExtLink>
 
-            <AddToMetamask shortLabel={true} currency={COW[chainId || 1] as Currency | undefined} />
+            {library?.provider?.isMetaMask && (
+              <AddToMetamask shortLabel={true} currency={COW[chainId || 1] as Currency | undefined} />
+            )}
+
+            {!library?.provider?.isMetaMask && (
+              <CopyHelper toCopy={COW_CONTRACT_ADDRESS[chainId || 1]}>
+                <div title="Click to copy token contract address">Copy contract</div>
+              </CopyHelper>
+            )}
 
             <Link to={`/swap?outputCurrency=${COW_CONTRACT_ADDRESS[chainId || 1]}`}>Buy COW</Link>
           </CardActions>

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -208,10 +208,16 @@ export default function Profile() {
             </ConvertWrapper>
 
             <CardActions>
-              <ExtLink href={getBlockExplorerUrl(chainId || 1, V_COW_CONTRACT_ADDRESS[chainId || 1], 'address')}>
+              <ExtLink
+                href={getBlockExplorerUrl(
+                  chainId || ChainId.MAINNET,
+                  V_COW_CONTRACT_ADDRESS[chainId || ChainId.MAINNET],
+                  'address'
+                )}
+              >
                 Contract ↗
               </ExtLink>
-              <CopyHelper toCopy={V_COW_CONTRACT_ADDRESS[chainId || 1]}>
+              <CopyHelper toCopy={V_COW_CONTRACT_ADDRESS[chainId || ChainId.MAINNET]}>
                 <div title="Click to copy token contract address">Copy contract</div>
               </CopyHelper>
             </CardActions>
@@ -229,22 +235,26 @@ export default function Profile() {
           <CardActions>
             <ExtLink
               title="View contract"
-              href={getBlockExplorerUrl(chainId || 1, COW_CONTRACT_ADDRESS[chainId || 1], 'address')}
+              href={getBlockExplorerUrl(
+                chainId || ChainId.MAINNET,
+                COW_CONTRACT_ADDRESS[chainId || ChainId.MAINNET],
+                'address'
+              )}
             >
               Contract ↗
             </ExtLink>
 
             {library?.provider?.isMetaMask && (
-              <AddToMetamask shortLabel={true} currency={COW[chainId || 1] as Currency | undefined} />
+              <AddToMetamask shortLabel={true} currency={COW[chainId || ChainId.MAINNET] as Currency | undefined} />
             )}
 
             {!library?.provider?.isMetaMask && (
-              <CopyHelper toCopy={COW_CONTRACT_ADDRESS[chainId || 1]}>
+              <CopyHelper toCopy={COW_CONTRACT_ADDRESS[chainId || ChainId.MAINNET]}>
                 <div title="Click to copy token contract address">Copy contract</div>
               </CopyHelper>
             )}
 
-            <Link to={`/swap?outputCurrency=${COW_CONTRACT_ADDRESS[chainId || 1]}`}>Buy COW</Link>
+            <Link to={`/swap?outputCurrency=${COW_CONTRACT_ADDRESS[chainId || ChainId.MAINNET]}`}>Buy COW</Link>
           </CardActions>
         </Card>
 
@@ -288,7 +298,7 @@ export default function Profile() {
                     )}
                   </Txt>
                   {hasOrders && (
-                    <ExtLink href={getExplorerAddressLink(chainId || 1, account)}>
+                    <ExtLink href={getExplorerAddressLink(chainId || ChainId.MAINNET, account)}>
                       <Txt secondary>View all orders ↗</Txt>
                     </ExtLink>
                   )}

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -227,7 +227,7 @@ export default function Profile() {
               Contract ↗
             </ExtLink>
 
-            <AddToMetamask currency={COW[chainId || 1] as Currency | undefined} />
+            <AddToMetamask shortLabel={true} currency={COW[chainId || 1] as Currency | undefined} />
 
             <Link to={`/swap?outputCurrency=${COW_CONTRACT_ADDRESS[chainId || 1]}`}>Buy COW</Link>
           </CardActions>

--- a/src/custom/pages/Profile/styled.tsx
+++ b/src/custom/pages/Profile/styled.tsx
@@ -472,7 +472,8 @@ export const CardActions = styled.div`
       }
     }
 
-    > div > img {
+    > div > img,
+    > div > svg {
       width: 15px;
       margin: 0 6px 0 0;
     }

--- a/src/custom/pages/Profile/styled.tsx
+++ b/src/custom/pages/Profile/styled.tsx
@@ -447,6 +447,14 @@ export const CardActions = styled.div`
     color: ${({ theme }) => theme.text1};
     display: flex;
     align-items: flex-end;
+    text-decoration: underline;
+    text-decoration-color: transparent;
+    transition: text-decoration-color 0.2s ease-in-out, color 0.2s ease-in-out;
+
+    &:hover {
+      text-decoration-color: ${({ theme }) => theme.primary1};
+      color: ${({ theme }) => theme.primary1};
+    }
   }
 
   ${AddToMetaMask} {

--- a/src/custom/pages/Profile/styled.tsx
+++ b/src/custom/pages/Profile/styled.tsx
@@ -6,6 +6,7 @@ import * as CSS from 'csstype'
 import { transparentize } from 'polished'
 import { ExternalLink } from 'theme'
 import { ButtonCustom as AddToMetaMask } from 'components/AddToMetamask'
+import { CopyIcon as ClickToCopy } from 'components/Copy'
 
 export const Container = styled.div`
   max-width: 910px;
@@ -438,11 +439,21 @@ export const CardActions = styled.div`
   justify-content: space-between;
   margin: auto 0 0;
 
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    justify-content: center;
+    align-items: center;
+    flex-flow: column wrap;
+    gap: 32px 0;
+    margin: 12px 0;
+  `};
+
   > a,
-  ${AddToMetaMask} {
+  ${AddToMetaMask}, > ${ClickToCopy} {
     font-size: 13px;
     height: 100%;
     font-weight: 500;
+    margin: auto 0 0;
+    padding: 0;
     line-height: 1;
     color: ${({ theme }) => theme.text1};
     display: flex;
@@ -450,6 +461,11 @@ export const CardActions = styled.div`
     text-decoration: underline;
     text-decoration-color: transparent;
     transition: text-decoration-color 0.2s ease-in-out, color 0.2s ease-in-out;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      font-size: 15px;
+      margin: 0 auto;
+    `};
 
     &:hover {
       text-decoration-color: ${({ theme }) => theme.primary1};
@@ -459,9 +475,7 @@ export const CardActions = styled.div`
 
   ${AddToMetaMask} {
     border: 0;
-    padding: 0;
     min-height: initial;
-    margin: 0;
     border-radius: initial;
 
     &:hover {
@@ -477,6 +491,11 @@ export const CardActions = styled.div`
       width: 15px;
       margin: 0 6px 0 0;
     }
+  }
+
+  > ${ClickToCopy} svg {
+    width: 15px;
+    margin: 0 4px 0 0;
   }
 `
 


### PR DESCRIPTION
# Summary

- Adds orange hover links for consistency (reported by @nenadV91 )

https://user-images.githubusercontent.com/31534717/161947167-a9bd1550-2b53-406e-9f77-aeb27ba59b0b.mov

- Added an optional `shortLabel` prop to the AddToMetamask component, which only outputs `Add token`  (inspired by @nenadV91 's comment here https://github.com/cowprotocol/cowswap/pull/371#issuecomment-1090059251)


https://user-images.githubusercontent.com/31534717/161947313-e14178ae-7cdc-4a4f-bb0a-123c54bbf67a.mov


Existing Add to Metamask modal seem fine without the optional `shortLabel` prop:
<img width="504" alt="Screen Shot 2022-04-06 at 10 42 39" src="https://user-images.githubusercontent.com/31534717/161947501-623e30c7-fdc8-408d-a2d6-c35ee1b30757.png">


