### PR TITLE
Add COW to Rinkeby list and update Rinkeby list link

### DIFF
--- a/src/custom/constants/lists.ts
+++ b/src/custom/constants/lists.ts
@@ -25,7 +25,7 @@ const BA_LIST = 'https://raw.githubusercontent.com/The-Blockchain-Association/se
 
 // Rinkeby Default
 const RINKEBY_LIST =
-  'https://raw.githubusercontent.com/gnosis/gp-swap-ui/master/src/custom/tokens/rinkeby-token-list.json'
+  'https://raw.githubusercontent.com/cowprotocol/cowswap/main/src/custom/tokens/rinkeby-token-list.json'
 
 // XDAI Default
 const HONEY_SWAP_XDAI = 'https://tokens.honeyswap.org'

--- a/src/custom/tokens/rinkeby-token-list.json
+++ b/src/custom/tokens/rinkeby-token-list.json
@@ -18,6 +18,14 @@
       "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png"
     },
     {
+      "name": "CoW Protocol Token",
+      "chainId": 4,
+      "symbol": "COW",
+      "decimals": 18,
+      "address": "0xbdf1e19f8c78A77fb741b44EbA5e4c0C8DBAeF91",
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB/logo.png"
+    },
+    {
       "name": "USDT",
       "chainId": 4,
       "symbol": "USDT",


### PR DESCRIPTION
# Summary

Fixes #363

- adds COW token to the list of Rinkeby tokens
- updates the Rinkeby list link to `cowprotocol/cowswap` and `main` branch instead of `master`

# Note
- cow token will not be visible until this is merged into `main` branch
- 