### PR TITLE
View contract token

### DIFF
--- a/src/custom/components/AddToMetamask/index.tsx
+++ b/src/custom/components/AddToMetamask/index.tsx
@@ -73,7 +73,7 @@ export default function AddToMetamask(props: AddToMetamaskProps) {
     <ButtonCustom onClick={addToken}>
       {!success ? (
         <RowFixed>
-          <StyledIcon src={MetaMaskLogo} /> {shortLabel ? 'Add Token' : `Add ${currency.symbol} to Metamask`}
+          <StyledIcon src={MetaMaskLogo} /> {shortLabel ? 'Add token' : `Add ${currency.symbol} to Metamask`}
         </RowFixed>
       ) : (
         <RowFixed>

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -209,8 +209,8 @@ export default function Profile() {
             </ConvertWrapper>
 
             <CardActions>
-              <ExtLink href={getBlockExplorerUrl(chainId, V_COW_CONTRACT_ADDRESS[chainId], 'address')}>
-                Contract ↗
+              <ExtLink href={getBlockExplorerUrl(chainId, V_COW_CONTRACT_ADDRESS[chainId], 'token')}>
+                View Contract ↗
               </ExtLink>
               <CopyHelper toCopy={V_COW_CONTRACT_ADDRESS[chainId]}>
                 <div title="Click to copy token contract address">Copy contract</div>
@@ -228,11 +228,8 @@ export default function Profile() {
             </span>
           </BalanceDisplay>
           <CardActions>
-            <ExtLink
-              title="View contract"
-              href={getBlockExplorerUrl(chainId, COW_CONTRACT_ADDRESS[chainId], 'address')}
-            >
-              Contract ↗
+            <ExtLink title="View contract" href={getBlockExplorerUrl(chainId, COW_CONTRACT_ADDRESS[chainId], 'token')}>
+              View Contract ↗
             </ExtLink>
 
             {library?.provider?.isMetaMask && <AddToMetamask shortLabel currency={currencyCOW} />}

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -210,7 +210,7 @@ export default function Profile() {
 
             <CardActions>
               <ExtLink href={getBlockExplorerUrl(chainId, V_COW_CONTRACT_ADDRESS[chainId], 'token')}>
-                View Contract ↗
+                View contract ↗
               </ExtLink>
               <CopyHelper toCopy={V_COW_CONTRACT_ADDRESS[chainId]}>
                 <div title="Click to copy token contract address">Copy contract</div>
@@ -229,7 +229,7 @@ export default function Profile() {
           </BalanceDisplay>
           <CardActions>
             <ExtLink title="View contract" href={getBlockExplorerUrl(chainId, COW_CONTRACT_ADDRESS[chainId], 'token')}>
-              View Contract ↗
+              View contract ↗
             </ExtLink>
 
             {library?.provider?.isMetaMask && <AddToMetamask shortLabel currency={currencyCOW} />}

--- a/src/custom/pages/Profile/index.tsx
+++ b/src/custom/pages/Profile/index.tsx
@@ -251,7 +251,7 @@ export default function Profile() {
             <span>
               {' '}
               <ExtLink href={'https://snapshot.org/#/cow.eth'}>View proposals ↗</ExtLink>
-              <ExtLink href={'https://forum.cow.fi/'}>CoW Forum ↗</ExtLink>
+              <ExtLink href={'https://forum.cow.fi/'}>CoW forum ↗</ExtLink>
             </span>
           </span>
           <SVG src={CowProtocolImage} description="CoWDAO Governance" />

--- a/src/custom/pages/Profile/styled.tsx
+++ b/src/custom/pages/Profile/styled.tsx
@@ -437,9 +437,10 @@ export const CardActions = styled.div`
   display: flex;
   flex-flow: row wrap;
   justify-content: space-between;
+  align-items: flex-end;
   margin: auto 0 0;
 
-  ${({ theme }) => theme.mediaWidth.upToSmall`
+  ${({ theme }) => theme.mediaWidth.upToMedium`
     justify-content: center;
     align-items: center;
     flex-flow: column wrap;
@@ -452,17 +453,19 @@ export const CardActions = styled.div`
     font-size: 13px;
     height: 100%;
     font-weight: 500;
-    margin: auto 0 0;
+    border-radius: 0;
+    min-height: initial;
+    margin: 0;
     padding: 0;
     line-height: 1;
     color: ${({ theme }) => theme.text1};
     display: flex;
-    align-items: flex-end;
+    align-items: center;
     text-decoration: underline;
     text-decoration-color: transparent;
     transition: text-decoration-color 0.2s ease-in-out, color 0.2s ease-in-out;
 
-    ${({ theme }) => theme.mediaWidth.upToSmall`
+    ${({ theme }) => theme.mediaWidth.upToMedium`
       font-size: 15px;
       margin: 0 auto;
     `};
@@ -488,13 +491,16 @@ export const CardActions = styled.div`
 
     > div > img,
     > div > svg {
-      width: 15px;
+      height: 13px;
+      width: auto;
+      object-fit: contain;
       margin: 0 6px 0 0;
     }
   }
 
   > ${ClickToCopy} svg {
-    width: 15px;
+    height: 13px;
+    width: auto;
     margin: 0 4px 0 0;
   }
 `


### PR DESCRIPTION
# Summary

- Change `Contract ↗` label to `View Contract ↗`
- Get block explorer URL with the `token` prop instead of `address`