### PR TITLE
Fix replacement hash for both speedup and cancel txs

### DIFF
--- a/package.json
+++ b/package.json
@@ -245,7 +245,7 @@
     "@web3-react/url": "^8.0.25-beta.0",
     "@web3-react/walletconnect": "^8.0.35-beta.0",
     "ajv": "^6.12.3",
-    "bnc-sdk": "^3.5.0",
+    "bnc-sdk": "^4.6.0",
     "cids": "^1.0.0",
     "copy-to-clipboard": "^3.2.0",
     "cross-env": "^7.0.3",

--- a/src/custom/state/enhancedTransactions/reducer.ts
+++ b/src/custom/state/enhancedTransactions/reducer.ts
@@ -144,11 +144,20 @@ export default createReducer(initialState, (builder) =>
     .addCase(replaceTransaction, (transactions, { payload: { chainId, oldHash, newHash, type } }) => {
       const allTxs = transactions[chainId] ?? {}
       if (!allTxs[oldHash]) {
-        console.error('Attempted to replace an unknown transaction.')
+        console.warn('[replaceTransaction] Attempted to replace an unknown transaction.', {
+          chainId,
+          oldHash,
+          newHash,
+        })
         return
       }
 
       if (allTxs[newHash]) {
+        console.warn('[replaceTransaction] The new replacement hash was already added.', {
+          chainId,
+          oldHash,
+          newHash,
+        })
         return
       }
 

--- a/src/custom/state/enhancedTransactions/updater/CancelReplaceTxUpdater.tsx
+++ b/src/custom/state/enhancedTransactions/updater/CancelReplaceTxUpdater.tsx
@@ -19,14 +19,14 @@ function watchTxChanges(pendingHashes: string[], chainId: number, dispatch: Disp
       const currentHash = hash
 
       emitter.on('txSpeedUp', (e) => {
-        if ('hash' in e && typeof e.hash === 'string') {
-          dispatch(replaceTransaction({ chainId, oldHash: currentHash, newHash: e.hash, type: 'speedup' }))
+        if ('replaceHash' in e && typeof e.replaceHash === 'string') {
+          dispatch(replaceTransaction({ chainId, oldHash: currentHash, newHash: e.replaceHash, type: 'speedup' }))
         }
       })
 
       emitter.on('txCancel', (e) => {
-        if ('hash' in e && typeof e.hash === 'string') {
-          dispatch(replaceTransaction({ chainId, oldHash: currentHash, newHash: e.hash, type: 'cancel' }))
+        if ('replaceHash' in e && typeof e.replaceHash === 'string') {
+          dispatch(replaceTransaction({ chainId, oldHash: currentHash, newHash: e.replaceHash, type: 'cancel' }))
         }
       })
     } catch (error) {

--- a/src/custom/state/enhancedTransactions/updater/CancelReplaceTxUpdater.tsx
+++ b/src/custom/state/enhancedTransactions/updater/CancelReplaceTxUpdater.tsx
@@ -12,25 +12,29 @@ function watchTxChanges(pendingHashes: string[], chainId: number, dispatch: Disp
       const blocknativeSdk = sdk[chainId]
 
       if (!blocknativeSdk) {
+        console.error('[CancelReplaceTxUpdater][watchTxChanges] No blocknative sdk for chainId', chainId)
         return
       }
 
       const { emitter } = blocknativeSdk.transaction(hash)
+      console.info('[CancelReplaceTxUpdater][watchTxChanges]', { chainId, hash })
       const currentHash = hash
 
       emitter.on('txSpeedUp', (e) => {
+        console.info('[CancelReplaceTxUpdater][watchTxChanges][txSpeedUp event]', { ...e })
         if ('replaceHash' in e && typeof e.replaceHash === 'string') {
           dispatch(replaceTransaction({ chainId, oldHash: currentHash, newHash: e.replaceHash, type: 'speedup' }))
         }
       })
 
       emitter.on('txCancel', (e) => {
+        console.info('[CancelReplaceTxUpdater][watchTxChanges][txCancel event]', { ...e })
         if ('replaceHash' in e && typeof e.replaceHash === 'string') {
           dispatch(replaceTransaction({ chainId, oldHash: currentHash, newHash: e.replaceHash, type: 'cancel' }))
         }
       })
     } catch (error) {
-      console.error('Failed to watch', hash, error)
+      console.error('[CancelReplaceTxUpdater][watchTxChanges] Failed to watch tx', { hash }, error)
     }
   }
 }
@@ -46,7 +50,7 @@ function unwatchTxChanges(pendingHashes: string[], chainId: number) {
     try {
       blocknativeSdk.unsubscribe(hash)
     } catch (error) {
-      console.error('Failed to unsubscribe', hash)
+      console.error('[CancelReplaceTxUpdater][unwatchTxChanges] Failed to unsubscribe', { hash })
     }
   }
 }
@@ -59,7 +63,6 @@ export default function CancelReplaceTxUpdater(): null {
 
   useEffect(() => {
     if (!chainId || !provider) return
-
     // Watch the mempool for cancellation/replacement of tx
     watchTxChanges(pendingHashes, chainId, dispatch)
 

--- a/src/custom/utils/blocknative.ts
+++ b/src/custom/utils/blocknative.ts
@@ -1,4 +1,5 @@
 import BlocknativeSdk from 'bnc-sdk'
+import * as Sentry from '@sentry/browser'
 import { getSupportedChainIds } from 'connection'
 
 const BLOCKNATIVE_API_KEY = process.env.REACT_APP_BLOCKNATIVE_API_KEY
@@ -12,11 +13,18 @@ interface SDKError {
 
 if (!BLOCKNATIVE_API_KEY) {
   console.warn('[blocknative] Missing BLOCKNATIVE_API_KEY')
+  Sentry.captureException(new Error('Blocknative API key not set'), {
+    tags: { errorType: 'blocknative' },
+  })
 }
 
 export const sdk = !BLOCKNATIVE_API_KEY
   ? {}
   : getSupportedChainIds().reduce<Record<number, BlocknativeSdk | null>>((acc, networkId) => {
+      const params = {
+        apiKey: BLOCKNATIVE_API_KEY,
+        networkId,
+      }
       try {
         acc[networkId] = new BlocknativeSdk({
           dappId: BLOCKNATIVE_API_KEY,
@@ -24,10 +32,18 @@ export const sdk = !BLOCKNATIVE_API_KEY
           name: 'bnc_' + networkId,
           onerror: (error: SDKError) => {
             console.log('[blocknative]', error)
+            Sentry.captureException(error, {
+              tags: { errorType: 'blocknative' },
+              contexts: { params },
+            })
           },
         })
       } catch (error) {
         console.error('[blocknative] Instantiating BlocknativeSdk failed', error)
+        Sentry.captureException(error, {
+          tags: { errorType: 'blocknative' },
+          contexts: { params },
+        })
       }
 
       console.info(`[blocknative] BlocknativeSdk initialized on chain ${networkId}`)

--- a/src/custom/utils/blocknative.ts
+++ b/src/custom/utils/blocknative.ts
@@ -13,9 +13,9 @@ interface SDKError {
 
 if (!BLOCKNATIVE_API_KEY) {
   console.warn('[blocknative] Missing BLOCKNATIVE_API_KEY')
-  const sentryError = constructSentryError(new Error(), { message: 'Blocknative API key not set' })
+  const { sentryError, tags } = constructSentryError(new Error(), { message: 'Blocknative API key not set' })
   Sentry.captureException(sentryError, {
-    tags: sentryError.tags,
+    tags,
   })
 }
 
@@ -33,18 +33,18 @@ export const sdk = !BLOCKNATIVE_API_KEY
           name: 'bnc_' + networkId,
           onerror: (error: SDKError) => {
             console.log('[blocknative]', error)
-            const sentryError = constructSentryError(error, { message: 'Blocknative SDK error' })
+            const { sentryError, tags } = constructSentryError(error, { message: 'Blocknative SDK error' })
             Sentry.captureException(sentryError, {
-              tags: sentryError.tags,
+              tags,
               contexts: { params },
             })
           },
         })
       } catch (error) {
         console.error('[blocknative] Instantiating BlocknativeSdk failed', error)
-        const sentryError = constructSentryError(error, { message: 'Instantiating BlocknativeSdk failed' })
+        const { sentryError, tags } = constructSentryError(error, { message: 'Instantiating BlocknativeSdk failed' })
         Sentry.captureException(sentryError, {
-          tags: sentryError.tags,
+          tags,
           contexts: { params },
         })
       }

--- a/src/custom/utils/blocknative.ts
+++ b/src/custom/utils/blocknative.ts
@@ -10,6 +10,10 @@ interface SDKError {
   transaction?: string
 }
 
+if (!BLOCKNATIVE_API_KEY) {
+  console.warn('[blocknative] Missing BLOCKNATIVE_API_KEY')
+}
+
 export const sdk = !BLOCKNATIVE_API_KEY
   ? {}
   : getSupportedChainIds().reduce<Record<number, BlocknativeSdk | null>>((acc, networkId) => {
@@ -19,14 +23,14 @@ export const sdk = !BLOCKNATIVE_API_KEY
           networkId,
           name: 'bnc_' + networkId,
           onerror: (error: SDKError) => {
-            console.log(error)
+            console.log('[blocknative]', error)
           },
         })
       } catch (error) {
-        console.error('Instantiating BlocknativeSdk failed', error)
+        console.error('[blocknative] Instantiating BlocknativeSdk failed', error)
       }
 
-      console.info(`BlocknativeSdk initialized on chain ${networkId}`)
+      console.info(`[blocknative] BlocknativeSdk initialized on chain ${networkId}`)
 
       return acc
     }, {})

--- a/yarn.lock
+++ b/yarn.lock
@@ -6777,12 +6777,13 @@ bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.1.2, bn.js@^5.2.0, bn.js@^5.2.1:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
   integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
 
-bnc-sdk@^3.5.0:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/bnc-sdk/-/bnc-sdk-3.7.1.tgz#efc1eee6e24027a62165f1f9a1a67cd2a1cfed35"
-  integrity sha512-vM8KA61EU0JRCQw1ycRmj0Jkps8/8s5ifqHOV38KqVRsvig+M1QY1zKEYeDkdPKGSxWX78rzozYk9tbQys9aNg==
+bnc-sdk@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/bnc-sdk/-/bnc-sdk-4.6.0.tgz#968d80d53863336007b7b46cceff795cb0bc84fe"
+  integrity sha512-ESN5pRkbAXwYqcgoi4vuDkVBjdVwV0DcNbQKWShYTh0I0anzsIZd52mKM929HPi4iuSnfmNkqSrDqvFcMCAvFQ==
   dependencies:
     crypto-es "^1.2.2"
+    nanoid "^3.3.1"
     rxjs "^6.6.3"
     sturdy-websocket "^0.1.12"
 
@@ -15528,6 +15529,11 @@ nanoid@^3.0.2, nanoid@^3.1.12, nanoid@^3.1.20, nanoid@^3.1.3, nanoid@^3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
+
+nanoid@^3.3.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.2.tgz#c89622fafb4381cd221421c69ec58547a1eec557"
+  integrity sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==
 
 nanomatch@^1.2.9:
   version "1.2.13"


### PR DESCRIPTION
# Summary

Close #327 

There were a few [breaking changes](https://github.com/blocknative/sdk/releases/tag/4.0.0) in the blocknative sdk regarding speedup and cancel txs, also a [websocket fix](https://github.com/blocknative/sdk/releases/tag/3.7.1) that could have affected the app usage.

This is first try to fix the current wss errors we are getting from the bn sdk.

_UPDATE 2022/09/05_
* _added more logging and also some Sentry handlers to catch any Blocknative issue_
* _bumped the blocknative sdk to the latest version_