### PR TITLE
410/empty from field

### DIFF
--- a/src/custom/components/CurrencyInputPanel/CurrencyInputPanelMod.tsx
+++ b/src/custom/components/CurrencyInputPanel/CurrencyInputPanelMod.tsx
@@ -543,7 +543,7 @@ export default function CurrencyInputPanel({
               />
             )}
           </InputRow>
-          {!hideInput && !hideBalance && currency && (
+          {!hideInput && !hideBalance && currency !== undefined && (
             <FiatRow>
               <RowBetween>
                 {account ? (

--- a/src/custom/components/CurrencyInputPanel/CurrencyInputPanelMod.tsx
+++ b/src/custom/components/CurrencyInputPanel/CurrencyInputPanelMod.tsx
@@ -498,7 +498,7 @@ export default function CurrencyInputPanel({
         <Container hideInput={hideInput} showAux={!!label}>
           <InputRow style={hideInput ? { padding: '0', borderRadius: '8px' } : {}} selected={!onCurrencySelect}>
             <CurrencySelect
-              visible={currency !== null}
+              visible={currency !== undefined}
               selected={!!currency}
               hideInput={hideInput}
               className="open-currency-select-button"


### PR DESCRIPTION
# Summary

Fixes #410 

Fixed one condition causing `null` input tokens from URL to not show the token selector dropdown

  # To Test

1. Go to profile page
2. Click on `buy COW`
* On the swap page, the `sell` token input should have a token selector dropdown