### PR TITLE
Modded and fixed issue when token image loading failed

### DIFF
--- a/src/custom/hooks/useColor/index.ts
+++ b/src/custom/hooks/useColor/index.ts
@@ -1,0 +1,1 @@
+export * from './useColorMod'

--- a/src/custom/hooks/useColor/useColorMod.ts
+++ b/src/custom/hooks/useColor/useColorMod.ts
@@ -1,13 +1,18 @@
-import { Token } from '@uniswap/sdk-core'
+/* import { Token } from '@uniswap/sdk-core'
 import { SupportedChainId } from 'constants/chains'
 import uriToHttp from 'lib/utils/uriToHttp'
 import Vibrant from 'node-vibrant/lib/bundle.js'
-import { shade } from 'polished'
+import { shade } from 'polished' */
 import { useLayoutEffect, useState } from 'react'
-import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
-import { hex } from 'wcag-contrast'
+/* import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
+import { hex } from 'wcag-contrast' */
 
-function URIForEthToken(address: string) {
+// MOD imports
+import { getColorFromUriPath } from '@src/hooks/useColor'
+
+export * from '@src/hooks/useColor'
+
+/* function URIForEthToken(address: string) {
   return `https://raw.githubusercontent.com/uniswap/assets/master/blockchains/ethereum/assets/${address}/logo.png`
 }
 
@@ -43,7 +48,7 @@ async function getColorFromToken(token: Token): Promise<string | null> {
   return null
 }
 
-export async function getColorFromUriPath(uri: string): Promise<string | null> {
+async function getColorFromUriPath(uri: string): Promise<string | null> {
   const formattedPath = uriToHttp(uri)[0]
 
   const palette = await Vibrant.from(formattedPath).getPalette()
@@ -82,7 +87,7 @@ export function useColor(token?: Token) {
   }, [token])
 
   return color
-}
+} */
 
 export function useListColor(listImageUri?: string) {
   const [color, setColor] = useState('#2172E5')
@@ -91,11 +96,13 @@ export function useListColor(listImageUri?: string) {
     let stale = false
 
     if (listImageUri) {
-      getColorFromUriPath(listImageUri).then((color) => {
-        if (!stale && color !== null) {
-          setColor(color)
-        }
-      })
+      getColorFromUriPath(listImageUri)
+        .then((color) => {
+          if (!stale && color !== null) {
+            setColor(color)
+          }
+        })
+        .catch(console.warn) // mod: error handling
     }
 
     return () => {


### PR DESCRIPTION
# Summary

Part of #438 

Fixed one issue that was causing the dev build to blow up with an unhandled exception when the token list image failed to load.
That wasn't visible on prod as it was just swallowed and logged as an error in the console.

Now it's handled and logged as a warning.


  # To Test

1. On mainnet, go to manage token lists
* There should be a warning about an image not being found like this
![Screen Shot 2022-04-22 at 10 49 31](https://user-images.githubusercontent.com/43217/164691470-55306b90-e443-4fe0-8cce-994745621303.png)
* If you running this locally, this page should no longer crash

# Note

I did not manage to fix the issue on #438 
Need some CSS help on that front