### PR TITLE
Fix unhandled exception on updaters

### DIFF
--- a/src/custom/state/orders/updaters/CancelledOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/CancelledOrdersUpdater.ts
@@ -76,8 +76,10 @@ export function CancelledOrdersUpdater(): null {
         // Group resolved promises by status
         // Only pick fulfilled
         const { fulfilled } = unfilteredOrdersData.reduce<Record<OrderTransitionStatus, OrderLogPopupMixData[]>>(
-          (acc, { status, popupData }) => {
-            popupData && acc[status].push(popupData)
+          (acc, orderData) => {
+            if (orderData && orderData.popupData) {
+              acc[orderData.status].push(orderData.popupData)
+            }
             return acc
           },
           {

--- a/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
@@ -128,15 +128,7 @@ async function _updateOrders({
 
   // Iterate over pending orders fetching API data
   const unfilteredOrdersData = await Promise.all(
-    pending.map(async (orderFromStore) =>
-      fetchOrderPopupData(orderFromStore, chainId).catch((e) => {
-        console.debug(
-          `[PendingOrdersUpdater] Failed to fetch order popup data on chain ${chainId} for order ${orderFromStore.id}`,
-          e
-        )
-        return null
-      })
-    )
+    pending.map(async (orderFromStore) => fetchOrderPopupData(orderFromStore, chainId))
   )
 
   // Group resolved promises by status
@@ -145,9 +137,8 @@ async function _updateOrders({
     Record<OrderTransitionStatus, OrderLogPopupMixData[]>
   >(
     (acc, orderData) => {
-      if (orderData) {
-        const { status, popupData } = orderData
-        popupData && acc[status].push(popupData)
+      if (orderData && orderData.popupData) {
+        acc[orderData.status].push(orderData.popupData)
       }
       return acc
     },

--- a/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -106,19 +106,26 @@ export function UnfillableOrdersUpdater(): null {
       }
 
       pending.forEach((order, index) =>
-        _getOrderPrice(chainId, order, strategy).then((quote) => {
-          if (quote) {
-            const [promisedPrice] = quote
-            const price = getPromiseFulfilledValue(promisedPrice, null)
+        _getOrderPrice(chainId, order, strategy)
+          .then((quote) => {
+            if (quote) {
+              const [promisedPrice] = quote
+              const price = getPromiseFulfilledValue(promisedPrice, null)
+              console.debug(
+                `[UnfillableOrdersUpdater::updateUnfillable] did we get any price? ${order.id.slice(0, 8)}|${index}`,
+                price ? price.amount : 'no :('
+              )
+              price?.amount && updateIsUnfillableFlag(chainId, order, price)
+            } else {
+              console.debug('[UnfillableOrdersUpdater::updateUnfillable] No price quote for', order.id.slice(0, 8))
+            }
+          })
+          .catch((e) => {
             console.debug(
-              `[UnfillableOrdersUpdater::updateUnfillable] did we get any price? ${order.id.slice(0, 8)}|${index}`,
-              price ? price.amount : 'no :('
+              `[UnfillableOrdersUpdater::updateUnfillable] Failed to get quote on chain ${chainId} for order ${order?.id}`,
+              e
             )
-            price?.amount && updateIsUnfillableFlag(chainId, order, price)
-          } else {
-            console.debug('[UnfillableOrdersUpdater::updateUnfillable] No price quote for', order.id.slice(0, 8))
-          }
-        })
+          })
       )
     } finally {
       isUpdating.current = false

--- a/src/custom/state/orders/updaters/utils.ts
+++ b/src/custom/state/orders/updaters/utils.ts
@@ -53,9 +53,17 @@ type PopupData = {
   popupData?: OrderLogPopupMixData
 }
 
-export async function fetchOrderPopupData(orderFromStore: Order, chainId: ChainId): Promise<PopupData> {
+export async function fetchOrderPopupData(orderFromStore: Order, chainId: ChainId): Promise<PopupData | null> {
   // Get order from API
-  const orderFromApi = await getOrder(chainId, orderFromStore.id)
+  let orderFromApi: OrderMetaData | null = null
+  try {
+    orderFromApi = await getOrder(chainId, orderFromStore.id)
+  } catch (e) {
+    console.debug(
+      `[PendingOrdersUpdater] Failed to fetch order popup data on chain ${chainId} for order ${orderFromStore.id}`
+    )
+    return null
+  }
   const status = classifyOrder(orderFromApi)
 
   let popupData = undefined


### PR DESCRIPTION
# Summary

Assorted fix on two unhandled exceptions that caused the app to crash locally.
On prod they are not an issue since they are swallowed and logged as errors.

- Unhandled exception on PendingOrdersUpdater
- Unhandled exception on UnfillableOrdersUpdater

# To Test

Can't really tell how to force them. It happened while developing locally.
It seems I was having connection issues at the time and it just caused the app to crash.