### PR TITLE
Add cow from locked GNO to combined balance

### DIFF
--- a/src/custom/components/CowBalanceButton/index.tsx
+++ b/src/custom/components/CowBalanceButton/index.tsx
@@ -1,5 +1,5 @@
 import { Trans } from '@lingui/macro'
-import styled from 'styled-components/macro'
+import styled, { css } from 'styled-components/macro'
 import CowProtocolLogo from 'components/CowProtocolLogo'
 import { useCombinedBalance } from 'state/cowToken/hooks'
 import { ChainId } from 'state/lists/actions/actionsMod'
@@ -7,7 +7,7 @@ import { formatMax, formatSmartLocaleAware } from 'utils/format'
 import { AMOUNT_PRECISION } from 'constants/index'
 import { COW } from 'constants/tokens'
 
-export const Wrapper = styled.div`
+export const Wrapper = styled.div<{ isLoading: boolean }>`
   ${({ theme }) => theme.card.boxShadow};
   color: ${({ theme }) => theme.text1};
   padding: 0 12px;
@@ -19,6 +19,35 @@ export const Wrapper = styled.div`
   position: relative;
   border-radius: 12px;
   pointer-events: auto;
+
+  ${({ theme, isLoading }) =>
+    isLoading &&
+    css`
+      overflow: hidden;
+      &::after {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        transform: translateX(-100%);
+        background-image: linear-gradient(
+          90deg,
+          rgba(255, 255, 255, 0) 0,
+          ${theme.shimmer1} 20%,
+          ${theme.shimmer2} 60%,
+          rgba(255, 255, 255, 0)
+        );
+        animation: shimmer 2s infinite;
+        content: '';
+      }
+
+      @keyframes shimmer {
+        100% {
+          transform: translateX(100%);
+        }
+      }
+    `}
 
   > b {
     margin: 0 0 0 5px;
@@ -48,13 +77,13 @@ interface CowBalanceButtonProps {
 const COW_DECIMALS = COW[ChainId.MAINNET].decimals
 
 export default function CowBalanceButton({ onClick }: CowBalanceButtonProps) {
-  const combinedBalance = useCombinedBalance()
+  const { balance, isLoading } = useCombinedBalance()
 
-  const formattedBalance = formatSmartLocaleAware(combinedBalance, AMOUNT_PRECISION)
-  const formattedMaxBalance = formatMax(combinedBalance, COW_DECIMALS)
+  const formattedBalance = formatSmartLocaleAware(balance, AMOUNT_PRECISION)
+  const formattedMaxBalance = formatMax(balance, COW_DECIMALS)
 
   return (
-    <Wrapper onClick={onClick}>
+    <Wrapper isLoading={isLoading} onClick={onClick}>
       <CowProtocolLogo />
       <b title={formattedMaxBalance && `${formattedMaxBalance} (v)COW`}>
         <Trans>{formattedBalance || 0}</Trans>

--- a/src/custom/hooks/useCowBalanceAndSubsidy.ts
+++ b/src/custom/hooks/useCowBalanceAndSubsidy.ts
@@ -7,7 +7,7 @@ import { COW_SUBSIDY_DATA } from 'components/CowSubsidyModal/constants'
 const ZERO_BALANCE_SUBSIDY = { subsidy: { tier: 0, discount: COW_SUBSIDY_DATA[0][1] }, balance: undefined }
 
 export default function useCowBalanceAndSubsidy() {
-  const balance = useCombinedBalance()
+  const { balance } = useCombinedBalance()
 
   return useMemo(() => {
     if (!balance || balance?.equalTo('0')) return ZERO_BALANCE_SUBSIDY

--- a/src/custom/hooks/useCowBalanceAndSubsidy.ts
+++ b/src/custom/hooks/useCowBalanceAndSubsidy.ts
@@ -1,37 +1,13 @@
 import { useMemo } from 'react'
 import { BigNumber } from 'bignumber.js'
-import { JSBI } from '@uniswap/sdk'
-import { CurrencyAmount } from '@uniswap/sdk-core'
-
 import { getDiscountFromBalance } from 'components/CowSubsidyModal/utils'
-import { useVCowData } from 'state/cowToken/hooks'
-import { useTokenBalance } from 'state/wallet/hooks'
-import { useActiveWeb3React } from 'hooks/web3'
-
-import { COW } from 'constants/tokens'
-import { SupportedChainId } from 'constants/chains'
+import { useCombinedBalance } from 'state/cowToken/hooks'
 import { COW_SUBSIDY_DATA } from 'components/CowSubsidyModal/constants'
 
 const ZERO_BALANCE_SUBSIDY = { subsidy: { tier: 0, discount: COW_SUBSIDY_DATA[0][1] }, balance: undefined }
 
 export default function useCowBalanceAndSubsidy() {
-  const { account, chainId } = useActiveWeb3React()
-  // vcow balance
-  const { total: vCowBalance } = useVCowData()
-  // Cow balanc
-  const cowBalance = useTokenBalance(account || undefined, chainId ? COW[chainId] : undefined)
-
-  const balance = useMemo(() => {
-    if (vCowBalance && cowBalance) {
-      const totalBalance = JSBI.add(vCowBalance.quotient, cowBalance.quotient)
-
-      // COW and vCOW safely have the same identifying properties: decimals
-      // so we make JSBI maths and create a new currency as adding vCow and Cow throws and exception
-      return CurrencyAmount.fromRawAmount(COW[chainId || SupportedChainId.MAINNET], totalBalance)
-    } else {
-      return cowBalance || vCowBalance
-    }
-  }, [chainId, cowBalance, vCowBalance])
+  const balance = useCombinedBalance()
 
   return useMemo(() => {
     if (!balance || balance?.equalTo('0')) return ZERO_BALANCE_SUBSIDY


### PR DESCRIPTION
# Summary

Fixes #409

As mentioned in the ticket this will add cow from locked GNO to the combined balance that will be shown in the header button but also included in the discount calculation. 
