### PR TITLE
352/network dropdown

### DIFF
--- a/src/custom/components/Header/NetworkSelector/NetworkSelectorMod.tsx
+++ b/src/custom/components/Header/NetworkSelector/NetworkSelectorMod.tsx
@@ -11,7 +11,7 @@ import { ChevronDown } from 'react-feather'
 // import { useHistory } from 'react-router-dom'
 // import { useModalOpen, useToggleModal } from 'state/application/hooks'
 // import { addPopup, ApplicationModal } from 'state/application/reducer'
-import styled from 'styled-components/macro'
+import styled, { css } from 'styled-components/macro'
 import { ExternalLink, MEDIA_WIDTHS } from 'theme'
 // import { replaceURLParam } from 'utils/routes'
 
@@ -27,6 +27,10 @@ import {
 } from '@src/components/Header/NetworkSelector'
 import useChangeNetworks, { ChainSwitchCallbackOptions } from 'hooks/useChangeNetworks'
 import { transparentize } from 'polished'
+// mod
+import { UnsupportedChainIdError, useWeb3React } from 'web3-react-core'
+import { useAddPopup, useRemovePopup } from 'state/application/hooks'
+import { useEffect } from 'react'
 
 /* const ActiveRowLinkList = styled.div`
   display: flex;
@@ -284,6 +288,36 @@ export default function NetworkSelector() {
   // mod: refactored inner logic into useChangeNetworks hook
   const { node, open, toggle, info, handleChainSwitch } = useChangeNetworks({ account, chainId, library })
 
+  // mod: add error and isUnsupportedNetwork const and useEffect
+  const { error } = useWeb3React()
+  const isUnsupportedNetwork = error instanceof UnsupportedChainIdError
+  const addPopup = useAddPopup()
+  const removePopup = useRemovePopup()
+
+  useEffect(() => {
+    const POPUP_KEY = chainId?.toString()
+
+    if (POPUP_KEY && isUnsupportedNetwork) {
+      addPopup(
+        {
+          failedSwitchNetwork: chainId as SupportedChainId,
+          unsupportedNetwork: true,
+          styles: css`
+            background: ${({ theme }) => theme.yellow1};
+          `,
+        },
+        // ID
+        POPUP_KEY,
+        // null to disable auto hide
+        null
+      )
+    }
+
+    return () => {
+      POPUP_KEY && removePopup(POPUP_KEY)
+    }
+  }, [addPopup, chainId, isUnsupportedNetwork, removePopup])
+
   /* const parsedQs = useParsedQueryString()
   const { urlChain, urlChainId } = getParsedChainId(parsedQs)
   const prevChainId = usePrevious(chainId)
@@ -348,7 +382,7 @@ export default function NetworkSelector() {
     }
   }, [chainId, history, urlChainId, urlChain]) */
 
-  if (!chainId || !info || !library) {
+  if (!chainId || !info || !library || isUnsupportedNetwork) {
     return null
   }
 

--- a/src/custom/components/Header/NetworkSelector/NetworkSelectorMod.tsx
+++ b/src/custom/components/Header/NetworkSelector/NetworkSelectorMod.tsx
@@ -303,7 +303,13 @@ export default function NetworkSelector() {
           failedSwitchNetwork: chainId as SupportedChainId,
           unsupportedNetwork: true,
           styles: css`
-            background: ${({ theme }) => theme.yellow1};
+            background: ${({ theme }) => theme.yellow3};
+            &&& {
+              margin-top: 20px;
+              ${({ theme }) => theme.mediaWidth.upToSmall`
+                margin-top: 40px;
+              `}
+            }
           `,
         },
         // ID

--- a/src/custom/components/Popups/FailedNetworkSwitchPopupMod.tsx
+++ b/src/custom/components/Popups/FailedNetworkSwitchPopupMod.tsx
@@ -32,7 +32,7 @@ export default function FailedNetworkSwitchPopup({
         <ThemedText.Body fontWeight={500} color={isUnsupportedNetwork ? theme.text2 : 'initial'}>
           <Trans>
             {isUnsupportedNetwork
-              ? `Selected network is not supported by CoW Protocol. Please change the network in your wallet.`
+              ? `Please connect your wallet to one of the supported networks: Ethereum Mainnet or Gnosis Chain.`
               : `Failed to switch networks from the CowSwap Interface. In order to use CowSwap on ${chainInfo.label}, you must change the network in your wallet.`}
           </Trans>
         </ThemedText.Body>

--- a/src/custom/components/Popups/FailedNetworkSwitchPopupMod.tsx
+++ b/src/custom/components/Popups/FailedNetworkSwitchPopupMod.tsx
@@ -13,20 +13,27 @@ const RowNoFlex = styled(AutoRow)`
   flex-wrap: nowrap;
 `
 
-export default function FailedNetworkSwitchPopup({ chainId }: { chainId: SupportedChainId }) {
+export default function FailedNetworkSwitchPopup({
+  chainId,
+  isUnsupportedNetwork = false,
+}: {
+  chainId: SupportedChainId
+  isUnsupportedNetwork?: boolean
+}) {
   const chainInfo = CHAIN_INFO[chainId]
   const theme = useContext(ThemeContext)
 
   return (
     <RowNoFlex>
       <div style={{ paddingRight: 16 }}>
-        <AlertCircle color={theme.red1} size={24} />
+        <AlertCircle color={isUnsupportedNetwork ? theme.red3 : theme.red1} size={24} />
       </div>
       <AutoColumn gap="8px">
-        <ThemedText.Body fontWeight={500}>
+        <ThemedText.Body fontWeight={500} color={isUnsupportedNetwork ? theme.text2 : 'initial'}>
           <Trans>
-            Failed to switch networks from the CowSwap Interface. In order to use CowSwap on {chainInfo.label}, you must
-            change the network in your wallet.
+            {isUnsupportedNetwork
+              ? `Selected network is not supported by CoW Protocol. Please change the network in your wallet.`
+              : `Failed to switch networks from the CowSwap Interface. In order to use CowSwap on ${chainInfo.label}, you must change the network in your wallet.`}
           </Trans>
         </ThemedText.Body>
       </AutoColumn>

--- a/src/custom/components/Popups/PopupItem.tsx
+++ b/src/custom/components/Popups/PopupItem.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components/macro'
 import { PopupContent } from 'state/application/reducer'
-import { default as PopupItemUni, Popup, Fader, StyledClose } from './PopupItemMod'
+import { default as PopupItemUni, Popup, Fader } from './PopupItemMod'
 
 const Wrapper = styled.div`
   ${Popup} {
@@ -13,10 +13,6 @@ const Wrapper = styled.div`
   ${Fader} {
     background-color: ${({ theme }) => theme.disabled};
     height: 4px;
-  }
-
-  ${StyledClose} {
-    stroke: ${({ theme }) => theme.text1};
   }
 
   a {

--- a/src/custom/components/WalletModal/WalletModalMod.tsx
+++ b/src/custom/components/WalletModal/WalletModalMod.tsx
@@ -349,7 +349,10 @@ export default function WalletModal({
           <ContentWrapper>
             {error instanceof UnsupportedChainIdError ? (
               <h5>
-                <Trans>App/wallet network mismatch. Please connect to a supported network in your wallet.</Trans>
+                <Trans>
+                  App/wallet network mismatch. Please connect to a supported network in your wallet: Ethereum Mainnet or
+                  Gnosis Chain.
+                </Trans>
               </h5>
             ) : (
               <Trans>Error connecting. Try refreshing the page.</Trans>

--- a/src/custom/components/WalletModal/WalletModalMod.tsx
+++ b/src/custom/components/WalletModal/WalletModalMod.tsx
@@ -349,7 +349,7 @@ export default function WalletModal({
           <ContentWrapper>
             {error instanceof UnsupportedChainIdError ? (
               <h5>
-                <Trans>Please connect to a supported network in the dropdown menu or in your wallet.</Trans>
+                <Trans>App/wallet network mismatch. Please connect to a supported network in your wallet.</Trans>
               </h5>
             ) : (
               <Trans>Error connecting. Try refreshing the page.</Trans>

--- a/src/custom/state/application/hooks.ts
+++ b/src/custom/state/application/hooks.ts
@@ -1,7 +1,8 @@
 import { createAction } from '@reduxjs/toolkit'
+import { DEFAULT_TXN_DISMISS_MS } from '@src/constants/misc'
 import { useToggleModal } from '@src/state/application/hooks'
 import { useCallback } from 'react'
-import { ApplicationModal } from 'state/application/reducer'
+import { addPopup, ApplicationModal, PopupContent } from 'state/application/reducer'
 import { useAppDispatch } from 'state/hooks'
 
 export * from '@src/state/application/hooks'
@@ -21,4 +22,23 @@ export function useOpenModal(modal: ApplicationModal): () => void {
 export function useCloseModals(): () => void {
   const dispatch = useAppDispatch()
   return useCallback(() => dispatch(setOpenModal(null)), [dispatch])
+}
+
+// mod: add removeAfterMs change
+// returns a function that allows adding a popup
+export function useAddPopup(): (content: PopupContent, key?: string, removeAfterMs?: number | null) => void {
+  const dispatch = useAppDispatch()
+
+  return useCallback(
+    (content: PopupContent, key?: string, removeAfterMs?: number | null) => {
+      dispatch(
+        addPopup({
+          content,
+          key,
+          removeAfterMs: removeAfterMs === null ? null : removeAfterMs ?? DEFAULT_TXN_DISMISS_MS,
+        })
+      )
+    },
+    [dispatch]
+  )
 }

--- a/src/state/application/reducer.ts
+++ b/src/state/application/reducer.ts
@@ -2,6 +2,7 @@ import { createSlice, nanoid } from '@reduxjs/toolkit'
 import { DEFAULT_TXN_DISMISS_MS } from 'constants/misc'
 
 import { SupportedChainId } from 'constants/chains'
+import { FlattenInterpolation, ThemeProps, DefaultTheme } from 'styled-components/macro' // mod
 
 type BasePopupContent =
   //   | {
@@ -12,10 +13,15 @@ type BasePopupContent =
   //   | {
   {
     failedSwitchNetwork: SupportedChainId
+    // mod: unsupported network
+    unsupportedNetwork?: boolean
   }
 
 // MOD: Modified PopupContent. The mod happened directly in the src file, to avoid redefining the state/hoos/etc
-export type PopupContent = TxPopupContent | MetaTxPopupContent | BasePopupContent
+export type PopupContent = (TxPopupContent | MetaTxPopupContent | BasePopupContent) & {
+  // mod: custom styles
+  styles?: FlattenInterpolation<ThemeProps<DefaultTheme>>
+}
 
 export type TxPopupContent = {
   txn: {


### PR DESCRIPTION
# Summary

Closes #352 

- Hides NetworkSelector on unsupported network
- shows message toast that network is unsupoprted and what to do
- changes message in modal in wallet
- adds better customising props for toasts in future

<img width="1063" alt="image" src="https://user-images.githubusercontent.com/21335563/165493457-e9fdd470-b950-4cd0-b18b-44220b02e761.png">

# To Test
1. open app in wrong network in metamask
2. connect if need be
3. see message
4. change to supported chain
5. message disappears
6. switch to unsupported chain
7. see message
8. open wallet modal
9. see fixed message