### PR TITLE
Fix popup position.

### DIFF
--- a/src/custom/pages/Profile/styled.tsx
+++ b/src/custom/pages/Profile/styled.tsx
@@ -11,6 +11,7 @@ import { CopyIcon as ClickToCopy } from 'components/Copy'
 export const Container = styled.div`
   max-width: 910px;
   width: 100%;
+  z-index: 1;
 `
 
 export const Wrapper = styled(Page)`


### PR DESCRIPTION
# Summary

Fixes the popup position and makes the the /profile/ pages elements aren't hidden:
<img width="1272" alt="Screen Shot 2022-04-27 at 14 59 45" src="https://user-images.githubusercontent.com/31534717/165536223-ace119b1-75c3-4931-8901-65293d8a27f8.png">
<img width="557" alt="Screen Shot 2022-04-27 at 14 59 36" src="https://user-images.githubusercontent.com/31534717/165536249-42a42e91-8e8b-42d4-94c4-74b0665fabfc.png">

