### PR TITLE
Handle close and read/save localStorage.

### DIFF
--- a/src/constants/misc.ts
+++ b/src/constants/misc.ts
@@ -38,3 +38,5 @@ export const BETTER_TRADE_LESS_HOPS_THRESHOLD = new Percent(JSBI.BigInt(50), BIP
 export const ZERO_PERCENT = new Percent('0')
 export const TWO_PERCENT = new Percent(JSBI.BigInt(200), BIPS_BASE)
 export const ONE_HUNDRED_PERCENT = new Percent('1')
+
+export const IS_SIDE_BANNER_VISIBLE_KEY = 'IS_SIDEBAR_BANNER_VISIBLE'

--- a/src/custom/components/SideBanner/index.tsx
+++ b/src/custom/components/SideBanner/index.tsx
@@ -13,8 +13,12 @@ const HEIGHT = 440
 const ANNIVERSARY_TWEET_TEMPLATE =
   'Holy CoW, today @MEVprotection is 1 year old! Check out their UI growth over time to see the CoW-evolution https://youtu.be/nxU11DmBVMk'
 
+// create an enum with the types of banners we want to show
+export enum BannerType {
+  ANNIVERSARY = 'anniversary',
+}
 export interface BannerProps {
-  type: string
+  type: BannerType
   isVisible: boolean
 }
 

--- a/src/custom/components/SideBanner/index.tsx
+++ b/src/custom/components/SideBanner/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import styled from 'styled-components/macro'
 import AnniversaryImage from 'assets/cow-swap/anniversary-icons.png'
 import TwitterImage from 'assets/cow-swap/twitter.svg'
@@ -14,6 +14,7 @@ const ANNIVERSARY_TWEET_TEMPLATE =
 
 export interface BannerProps {
   type: string
+  isVisible: boolean
 }
 
 const Banner = styled.div<{ isActive: boolean }>`
@@ -26,14 +27,13 @@ const Banner = styled.div<{ isActive: boolean }>`
   box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.2);
   border-radius: 16px;
   display: ${({ isActive }) => (isActive ? 'flex' : 'none')};
-  z-index: 1;
+  z-index: 9999;
   overflow: hidden;
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
     bottom: 0;
     left: 0;
     width: 100%;
-    z-index: 9999;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
   `};
@@ -129,8 +129,8 @@ const FooterContent = styled.div`
   }
 `
 
-export default function SideBanner({ type }: BannerProps) {
-  const [isActive, setIsActive] = useState(true)
+export default function SideBanner({ type, isVisible }: BannerProps) {
+  const [isActive, setIsActive] = useState(isVisible)
 
   // const isHidden = !isVisible || !isActive
 
@@ -138,11 +138,12 @@ export default function SideBanner({ type }: BannerProps) {
     setIsActive(false)
   }
 
-  // useEffect(() => {
-  //   if (isNotificationClosed !== null) {
-  //     setIsActive(!isNotificationClosed)
-  //   }
-  // }, [isNotificationClosed, isActive])
+  useEffect(() => {
+    if (!isActive) {
+      // set a localstorage key to prevent banner from showing again
+      localStorage.setItem('isSideBannerVisible', 'false')
+    }
+  }, [isActive])
 
   return (
     <Banner isActive={isActive}>

--- a/src/custom/components/SideBanner/index.tsx
+++ b/src/custom/components/SideBanner/index.tsx
@@ -29,7 +29,7 @@ const Banner = styled.div<{ isActive: boolean }>`
   left: 28px;
   bottom: 86px;
   background: linear-gradient(180deg, ${({ theme }) => theme.blueShade} 0%, #091e32 100%);
-  box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.2);
+  box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.4);
   border-radius: 16px;
   display: ${({ isActive }) => (isActive ? 'flex' : 'none')};
   z-index: 9999;

--- a/src/custom/components/SideBanner/index.tsx
+++ b/src/custom/components/SideBanner/index.tsx
@@ -6,6 +6,7 @@ import ReactConfetti from 'react-confetti'
 import { transparentize } from 'polished'
 import SVG from 'react-inlinesvg'
 import { CloseIcon, ExternalLink } from 'theme'
+import { IS_SIDE_BANNER_VISIBLE_KEY } from '@src/constants/misc'
 
 const WIDTH = 440
 const HEIGHT = 440
@@ -141,7 +142,7 @@ export default function SideBanner({ type, isVisible }: BannerProps) {
   useEffect(() => {
     if (!isActive) {
       // set a localstorage key to prevent banner from showing again
-      localStorage.setItem('isSideBannerVisible', 'false')
+      localStorage.setItem(IS_SIDE_BANNER_VISIBLE_KEY, 'false')
     }
   }, [isActive])
 

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -90,12 +90,7 @@ function createRedirectExternal(url: string) {
 const Loading = <LoadingWrapper>Loading...</LoadingWrapper>
 
 const getShowBannerState = (key: string) => {
-  const value = localStorage.getItem(key)
-  if (value === 'false') {
-    return false
-  }
-
-  return true
+  return JSON.parse(localStorage.getItem(key) || 'true') // show banner by default
 }
 
 export default function App() {

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -1,7 +1,7 @@
 import AppMod from './AppMod'
 import styled from 'styled-components/macro'
 import { RedirectPathToSwapOnly, RedirectToSwap } from 'pages/Swap/redirects'
-import { Suspense, lazy } from 'react'
+import { Suspense, lazy, useMemo } from 'react'
 import { Redirect, Route, Switch } from 'react-router-dom'
 
 import AnySwapAffectedUsers from 'pages/error/AnySwapAffectedUsers'
@@ -13,6 +13,7 @@ import RedirectAnySwapAffectedUsers from 'pages/error/AnySwapAffectedUsers/Redir
 import { SENTRY_IGNORED_GP_QUOTE_ERRORS } from 'api/gnosisProtocol/errors/QuoteError'
 
 import SideBanner from 'components/SideBanner'
+const SIDE_BANNER_VISIBLE_KEY = 'isSideBannerVisible'
 
 const SENTRY_DSN = process.env.REACT_APP_SENTRY_DSN
 const SENTRY_TRACES_SAMPLE_RATE = process.env.REACT_APP_SENTRY_TRACES_SAMPLE_RATE
@@ -94,10 +95,12 @@ const getShowBannerState = (key: string) => {
 }
 
 export default function App() {
+  const isVisible = useMemo(() => getShowBannerState(SIDE_BANNER_VISIBLE_KEY), []) // empty array only calls on mount
+
   return (
     <>
       <RedirectAnySwapAffectedUsers />
-      <SideBanner isVisible={getShowBannerState('isSideBannerVisible')} type={'anniversary'} />
+      <SideBanner isVisible={isVisible} type={'anniversary'} />
       <Wrapper>
         <Suspense fallback={Loading}>
           <Switch>

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -89,12 +89,23 @@ function createRedirectExternal(url: string) {
 
 const Loading = <LoadingWrapper>Loading...</LoadingWrapper>
 
+const getShowBannerState = (key: string) => {
+  const value = localStorage.getItem(key)
+  console.log('getShowBannerState ================')
+  console.log(value)
+  if (value === 'false') {
+    return false
+  }
+
+  return true
+}
+
 export default function App() {
   return (
     <>
       <RedirectAnySwapAffectedUsers />
+      <SideBanner isVisible={getShowBannerState('isSideBannerVisible')} type={'anniversary'} />
       <Wrapper>
-        <SideBanner type={'anniversary'} />
         <Suspense fallback={Loading}>
           <Switch>
             <Redirect from="/claim" to="/profile" />

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -13,7 +13,7 @@ import RedirectAnySwapAffectedUsers from 'pages/error/AnySwapAffectedUsers/Redir
 import { SENTRY_IGNORED_GP_QUOTE_ERRORS } from 'api/gnosisProtocol/errors/QuoteError'
 
 import SideBanner from 'components/SideBanner'
-const SIDE_BANNER_VISIBLE_KEY = 'isSideBannerVisible'
+import { IS_SIDE_BANNER_VISIBLE_KEY } from '@src/constants/misc'
 
 const SENTRY_DSN = process.env.REACT_APP_SENTRY_DSN
 const SENTRY_TRACES_SAMPLE_RATE = process.env.REACT_APP_SENTRY_TRACES_SAMPLE_RATE
@@ -95,7 +95,7 @@ const getShowBannerState = (key: string) => {
 }
 
 export default function App() {
-  const isVisible = useMemo(() => getShowBannerState(SIDE_BANNER_VISIBLE_KEY), []) // empty array only calls on mount
+  const isVisible = useMemo(() => getShowBannerState(IS_SIDE_BANNER_VISIBLE_KEY), []) // empty array only calls on mount
 
   return (
     <>

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -91,11 +91,7 @@ function createRedirectExternal(url: string) {
 const Loading = <LoadingWrapper>Loading...</LoadingWrapper>
 
 const getShowBannerState = (key: string) => {
-  const localStorageValue = localStorage.getItem(key)
-  if (localStorageValue && typeof localStorageValue === 'string') {
-    return JSON.parse(localStorageValue)
-  }
-  return true
+  return JSON.parse(localStorage.getItem(key) || 'true') // show banner by default
 }
 
 export default function App() {

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -104,9 +104,9 @@ export default function App() {
   return (
     <>
       <RedirectAnySwapAffectedUsers />
-      <SideBanner isVisible={isVisible} type={BannerType.ANNIVERSARY} />
       <Wrapper>
         <Suspense fallback={Loading}>
+          <SideBanner isVisible={isVisible} type={BannerType.ANNIVERSARY} />
           <Switch>
             <Redirect from="/claim" to="/profile" />
             <Route exact strict path="/swap" component={Swap} />

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -91,7 +91,13 @@ function createRedirectExternal(url: string) {
 const Loading = <LoadingWrapper>Loading...</LoadingWrapper>
 
 const getShowBannerState = (key: string) => {
-  return JSON.parse(localStorage.getItem(key) || 'true') // show banner by default
+  const localStorageValue = localStorage.getItem(key)
+
+  // item doesn't exist, show banner (true)
+  if (localStorageValue === null) return true
+
+  // else return localstorage state (!! for type safety)
+  return !!JSON.parse(localStorageValue)
 }
 
 export default function App() {

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -101,14 +101,14 @@ const getShowBannerState = (key: string) => {
 }
 
 export default function App() {
-  const isVisible = useMemo(() => getShowBannerState(IS_SIDE_BANNER_VISIBLE_KEY), []) // empty array only calls on mount
+  const isSideBannerVisible = useMemo(() => getShowBannerState(IS_SIDE_BANNER_VISIBLE_KEY), []) // empty array only calls on mount
 
   return (
     <>
       <RedirectAnySwapAffectedUsers />
       <Wrapper>
         <Suspense fallback={Loading}>
-          <SideBanner isVisible={isVisible} type={BannerType.ANNIVERSARY} />
+          <SideBanner isVisible={isSideBannerVisible} type={BannerType.ANNIVERSARY} />
           <Switch>
             <Redirect from="/claim" to="/profile" />
             <Route exact strict path="/swap" component={Swap} />

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -12,7 +12,7 @@ import { environmentName } from 'utils/environments'
 import RedirectAnySwapAffectedUsers from 'pages/error/AnySwapAffectedUsers/RedirectAnySwapAffectedUsers'
 import { SENTRY_IGNORED_GP_QUOTE_ERRORS } from 'api/gnosisProtocol/errors/QuoteError'
 
-import SideBanner from 'components/SideBanner'
+import SideBanner, { BannerType } from 'components/SideBanner'
 import { IS_SIDE_BANNER_VISIBLE_KEY } from '@src/constants/misc'
 
 const SENTRY_DSN = process.env.REACT_APP_SENTRY_DSN
@@ -91,7 +91,11 @@ function createRedirectExternal(url: string) {
 const Loading = <LoadingWrapper>Loading...</LoadingWrapper>
 
 const getShowBannerState = (key: string) => {
-  return JSON.parse(localStorage.getItem(key) || 'true') // show banner by default
+  const localStorageValue = localStorage.getItem(key)
+  if (localStorageValue && typeof localStorageValue === 'string') {
+    return JSON.parse(localStorageValue)
+  }
+  return true
 }
 
 export default function App() {
@@ -100,7 +104,7 @@ export default function App() {
   return (
     <>
       <RedirectAnySwapAffectedUsers />
-      <SideBanner isVisible={isVisible} type="anniversary" />
+      <SideBanner isVisible={isVisible} type={BannerType.ANNIVERSARY} />
       <Wrapper>
         <Suspense fallback={Loading}>
           <Switch>

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -91,8 +91,6 @@ const Loading = <LoadingWrapper>Loading...</LoadingWrapper>
 
 const getShowBannerState = (key: string) => {
   const value = localStorage.getItem(key)
-  console.log('getShowBannerState ================')
-  console.log(value)
   if (value === 'false') {
     return false
   }

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -100,7 +100,7 @@ export default function App() {
   return (
     <>
       <RedirectAnySwapAffectedUsers />
-      <SideBanner isVisible={isVisible} type={'anniversary'} />
+      <SideBanner isVisible={isVisible} type="anniversary" />
       <Wrapper>
         <Suspense fallback={Loading}>
           <Switch>


### PR DESCRIPTION
# Summary

Reads/writes the 'visible' state of the SideBanner. Should not show the banner on page refreshes if the users closes the banner using the X icon.