### PR TITLE
[438] Fix truncated token list manager

### DIFF
--- a/src/custom/components/SearchModal/ManageLists/ManageListsMod.tsx
+++ b/src/custom/components/SearchModal/ManageLists/ManageListsMod.tsx
@@ -246,7 +246,6 @@ ListRowProps & { listUrl: string }) {
 })
 
 export const ListContainer = styled.div`
-  padding-bottom: 80px;
   height: 100%;
   overflow-y: auto;
   /* MOD */

--- a/src/custom/components/SearchModal/ManageLists/index.tsx
+++ b/src/custom/components/SearchModal/ManageLists/index.tsx
@@ -24,6 +24,7 @@ const Wrapper = styled.div`
   ${ListContainer} {
     ${({ theme }) => theme.neumorphism.boxShadow}
     padding: 1rem;
+    padding-bottom: 80px;
   }
 `
 


### PR DESCRIPTION
# Summary

Closes #438 

<img width="857" alt="image" src="https://user-images.githubusercontent.com/21335563/165580485-da62f464-0daa-46e3-bfd0-035be47305a4.png">*Add screenshots if applicable. Images are nice :)*

# To Test
1. mainnet
2. open token list
3. open manage token lists
4. scroll to bottom