### PR TITLE
Remove underline on hover

### DIFF
--- a/src/custom/components/SideBanner/index.tsx
+++ b/src/custom/components/SideBanner/index.tsx
@@ -109,6 +109,10 @@ const FooterContent = styled.div`
     width: 100%;
   }
 
+  > a:hover {
+    text-decoration: none;
+  }
+
   button {
     display: flex;
     align-items: center;


### PR DESCRIPTION
# Summary

On hover of the `Share on Twitter` button removes the text underline

<img width="420" alt="Screen Shot 2022-04-28 at 13 15 11" src="https://user-images.githubusercontent.com/31534717/165749823-8f79f9ad-7b0c-4a88-8431-b568dc8502c3.png">

Addresses -> https://github.com/cowprotocol/cowswap/pull/477#issuecomment-1112061773
