### PR TITLE
Move notifications outside AppBody

### DIFF
--- a/src/custom/pages/App/AppMod.tsx
+++ b/src/custom/pages/App/AppMod.tsx
@@ -1,21 +1,22 @@
-import Loader from 'components/Loader'
 import ApeModeQueryParamReader from 'hooks/useApeModeQueryParamReader'
-import { /*Lazy,*/ Suspense, /* PropsWithChildren, */ ReactNode, useState, useEffect } from 'react'
-import { /*Redirect,*/ Route, Switch, useLocation } from 'react-router-dom'
+import { Suspense, /* PropsWithChildren, */ ReactNode, useState, useEffect } from 'react'
+import { Route, Switch, useLocation } from 'react-router-dom'
 import styled from 'styled-components/macro'
 import GoogleAnalyticsReporter from 'components/analytics/GoogleAnalyticsReporter'
 import AddressClaimModal from 'components/claim/AddressClaimModal'
 import ErrorBoundary from 'components/ErrorBoundary'
 import Header from 'components/Header'
 import Polling from 'components/Header/Polling'
-import Popups from 'components/Popups'
 import Web3ReactManager from 'components/Web3ReactManager'
-import { useModalOpen, useToggleModal } from 'state/application/hooks'
 import { ApplicationModal } from 'state/application/reducer'
+import { useModalOpen, useToggleModal } from 'state/application/hooks'
 import DarkModeQueryParamReader from 'theme'
 /* import AddLiquidity from './AddLiquidity'
-import { RedirectDuplicateTokenIds } from './AddLiquidity/redirects'
+import {
+  RedirectDuplicateTokenIds,
+} from './AddLiquidity/redirects'
 import { RedirectDuplicateTokenIdsV2 } from './AddLiquidityV2/redirects'
+import CreateProposal from './CreateProposal'
 import Earn from './Earn'
 import Manage from './Earn/Manage'
 import MigrateV2 from './MigrateV2'
@@ -28,16 +29,14 @@ import RemoveLiquidity from './RemoveLiquidity'
 import RemoveLiquidityV3 from './RemoveLiquidity/V3'
 import Swap from './Swap'
 import { OpenClaimAddressModalAndRedirectToSwap, RedirectPathToSwapOnly, RedirectToSwap } from './Swap/redirects'
+import Vote from './Vote'
+import VotePage from './Vote/VotePage'
 */
-
-// MOD imports
 import ReferralLinkUpdater from 'state/affiliate/updater'
 import URLWarning from 'components/Header/URLWarning'
 import Footer from 'components/Footer'
 import { BodyWrapper } from '.'
 import * as CSS from 'csstype' // mod
-
-// const Vote = lazy(() => import('./Vote'))
 
 interface AppWrapProps {
   bgBlur?: boolean
@@ -47,7 +46,6 @@ const AppWrapper = styled.div<Partial<CSS.Properties & AppWrapProps>>`
   display: flex;
   flex-flow: column;
   align-items: flex-start;
-  // MOD
   min-height: 100vh;
   /* overflow-x: hidden; */ // mod
   &:after {
@@ -76,7 +74,7 @@ const AppWrapper = styled.div<Partial<CSS.Properties & AppWrapProps>>`
   z-index: 1;
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
-    padding: 4rem 8px 16px 8px;
+    padding: 6rem 16px 16px 16px;
   `};
 ` */
 
@@ -84,9 +82,6 @@ const HeaderWrapper = styled.div`
   ${({ theme }) => theme.flexRowNoWrap}
   width: 100%;
   justify-content: space-between;
-  /* position: fixed;
-  top: 0;
-  z-index: 2; */
 `
 
 const FooterWrapper = styled(HeaderWrapper)`
@@ -112,21 +107,20 @@ export default function App(props?: { children?: ReactNode }) {
   }, [location.pathname])
   return (
     <ErrorBoundary>
-      <Route component={GoogleAnalyticsReporter} />
-      <Route component={DarkModeQueryParamReader} />
-      <Route component={ApeModeQueryParamReader} />
-      <Web3ReactManager>
-        <AppWrapper bgBlur={bgBlur}>
-          <URLWarning />
-          <HeaderWrapper>
-            <Header />
-          </HeaderWrapper>
-          <BodyWrapper>
-            <Popups />
-            <Polling />
-            <TopLevelModals />
-            <ReferralLinkUpdater />
-            <Suspense fallback={<Loader />}>
+      <Suspense fallback={null}>
+        <Route component={GoogleAnalyticsReporter} />
+        <Route component={DarkModeQueryParamReader} />
+        <Route component={ApeModeQueryParamReader} />
+        <Web3ReactManager>
+          <AppWrapper bgBlur={bgBlur}>
+            <URLWarning />
+            <HeaderWrapper>
+              <Header />
+            </HeaderWrapper>
+            <BodyWrapper>
+              <Polling />
+              <TopLevelModals />
+              <ReferralLinkUpdater />
               <Switch>
                 {props && props.children}
                 {/* <Route exact strict path="/vote" component={Vote} />
@@ -168,14 +162,14 @@ export default function App(props?: { children?: ReactNode }) {
               <Route exact strict path="/create-proposal" component={CreateProposal} />
               <Route component={RedirectPathToSwapOnly} /> */}
               </Switch>
-            </Suspense>
-            <Marginer />
-          </BodyWrapper>
-          <FooterWrapper>
-            <Footer />
-          </FooterWrapper>
-        </AppWrapper>
-      </Web3ReactManager>
+              <Marginer />
+            </BodyWrapper>
+            <FooterWrapper>
+              <Footer />
+            </FooterWrapper>
+          </AppWrapper>
+        </Web3ReactManager>
+      </Suspense>
     </ErrorBoundary>
   )
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,6 +30,7 @@ import EnhancedTransactionUpdater from 'state/enhancedTransactions/updater'
 import FeesUpdater from 'state/price/updater'
 import GasUpdater from 'state/gas/updater'
 import SentryUpdater from 'state/sentry/updater'
+import Popups from 'components/Popups'
 
 import {
   GpOrdersUpdater,
@@ -86,6 +87,7 @@ ReactDOM.render(
                 <Updaters />
                 <ThemeProvider>
                   <ThemedGlobalStyle />
+                  <Popups />
                   <AppziButton />
                   <App />
                 </ThemeProvider>


### PR DESCRIPTION
# Summary

Suggestion to move the Popup (notifications) outside the AppBody (just like we did with the `SideBanner` component) to prevent any future z-index type of collisions.

The test result of this PR should be that notifiactions are shown like usual and shown above any element. Right now it's placed right above the Appzi button. When we merge in the SideBanner component, it needs to be shown ABOVE the SideBanner component.

So suggest for hotfix 1.13.2 to be back merged to `develop` first.