### PR TITLE
Remove COW from locked GNO from subsidy calculation

### DIFF
--- a/src/custom/hooks/useCowBalanceAndSubsidy.ts
+++ b/src/custom/hooks/useCowBalanceAndSubsidy.ts
@@ -7,7 +7,7 @@ import { COW_SUBSIDY_DATA } from 'components/CowSubsidyModal/constants'
 const ZERO_BALANCE_SUBSIDY = { subsidy: { tier: 0, discount: COW_SUBSIDY_DATA[0][1] }, balance: undefined }
 
 export default function useCowBalanceAndSubsidy() {
-  const { balance } = useCombinedBalance(false)
+  const { balance } = useCombinedBalance()
 
   return useMemo(() => {
     if (!balance || balance?.equalTo('0')) return ZERO_BALANCE_SUBSIDY

--- a/src/custom/hooks/useCowBalanceAndSubsidy.ts
+++ b/src/custom/hooks/useCowBalanceAndSubsidy.ts
@@ -7,7 +7,7 @@ import { COW_SUBSIDY_DATA } from 'components/CowSubsidyModal/constants'
 const ZERO_BALANCE_SUBSIDY = { subsidy: { tier: 0, discount: COW_SUBSIDY_DATA[0][1] }, balance: undefined }
 
 export default function useCowBalanceAndSubsidy() {
-  const { balance } = useCombinedBalance()
+  const { balance } = useCombinedBalance(false)
 
   return useMemo(() => {
     if (!balance || balance?.equalTo('0')) return ZERO_BALANCE_SUBSIDY

--- a/src/custom/state/cowToken/hooks.ts
+++ b/src/custom/state/cowToken/hooks.ts
@@ -167,7 +167,7 @@ export function useCowBalance() {
 /**
  * Hook that returns combined vCOW + COW balance + vCow from locked GNO
  */
-export function useCombinedBalance() {
+export function useCombinedBalance(includeFromLockedGNO = true) {
   const { chainId, account } = useActiveWeb3React()
   const { total: vCowBalance } = useVCowData()
   const { allocated, claimed } = useCowFromLockedGnoBalances()
@@ -190,12 +190,12 @@ export function useCombinedBalance() {
 
     if (account) {
       if (vCowBalance) tmpBalance = JSBI.add(tmpBalance, vCowBalance.quotient)
-      if (lockedGnoBalance) tmpBalance = JSBI.add(tmpBalance, lockedGnoBalance)
+      if (lockedGnoBalance && includeFromLockedGNO) tmpBalance = JSBI.add(tmpBalance, lockedGnoBalance)
       if (cowBalance) tmpBalance = JSBI.add(tmpBalance, cowBalance.quotient)
     }
 
     const balance = CurrencyAmount.fromRawAmount(cow, tmpBalance)
 
     return { balance, isLoading }
-  }, [vCowBalance, lockedGnoBalance, cowBalance, chainId, account])
+  }, [vCowBalance, lockedGnoBalance, cowBalance, chainId, account, includeFromLockedGNO])
 }

--- a/src/custom/state/cowToken/hooks.ts
+++ b/src/custom/state/cowToken/hooks.ts
@@ -14,7 +14,7 @@ import { setSwapVCowStatus, SwapVCowStatus } from './actions'
 import { OperationType } from 'components/TransactionConfirmationModal'
 import { APPROVE_GAS_LIMIT_DEFAULT } from 'hooks/useApproveCallback/useApproveCallbackMod'
 import { useTokenBalance } from 'state/wallet/hooks'
-import { useCowFromLockedGnoBalances } from 'pages/Profile/LockedGnoVesting/hooks'
+// import { useCowFromLockedGnoBalances } from 'pages/Profile/LockedGnoVesting/hooks'
 import { SupportedChainId } from 'constants/chains'
 import JSBI from 'jsbi'
 
@@ -167,35 +167,35 @@ export function useCowBalance() {
 /**
  * Hook that returns combined vCOW + COW balance + vCow from locked GNO
  */
-export function useCombinedBalance(includeFromLockedGNO = true) {
+export function useCombinedBalance() {
   const { chainId, account } = useActiveWeb3React()
   const { total: vCowBalance } = useVCowData()
-  const { allocated, claimed } = useCowFromLockedGnoBalances()
+  // const { allocated, claimed } = useCowFromLockedGnoBalances()
   const cowBalance = useCowBalance()
 
-  const lockedGnoBalance = useMemo(() => {
-    if (!allocated || !claimed) {
-      return
-    }
+  // const lockedGnoBalance = useMemo(() => {
+  //   if (!allocated || !claimed) {
+  //     return
+  //   }
 
-    return JSBI.subtract(allocated.quotient, claimed.quotient)
-  }, [allocated, claimed])
+  //   return JSBI.subtract(allocated.quotient, claimed.quotient)
+  // }, [allocated, claimed])
 
   return useMemo(() => {
     let tmpBalance = JSBI.BigInt(0)
 
-    const isLoading = account && (!vCowBalance || !lockedGnoBalance || !cowBalance) ? true : false
+    const isLoading = account && (!vCowBalance /* || !lockedGnoBalance */ || !cowBalance) ? true : false
 
     const cow = COW[chainId || SupportedChainId.MAINNET]
 
     if (account) {
       if (vCowBalance) tmpBalance = JSBI.add(tmpBalance, vCowBalance.quotient)
-      if (lockedGnoBalance && includeFromLockedGNO) tmpBalance = JSBI.add(tmpBalance, lockedGnoBalance)
+      // if (lockedGnoBalance) tmpBalance = JSBI.add(tmpBalance, lockedGnoBalance)
       if (cowBalance) tmpBalance = JSBI.add(tmpBalance, cowBalance.quotient)
     }
 
     const balance = CurrencyAmount.fromRawAmount(cow, tmpBalance)
 
     return { balance, isLoading }
-  }, [vCowBalance, lockedGnoBalance, cowBalance, chainId, account, includeFromLockedGNO])
+  }, [vCowBalance, /* lockedGnoBalance, */ cowBalance, chainId, account])
 }


### PR DESCRIPTION
# Summary

Fixes #497

Removes COW from locked GNO from vested calculation and also from header balance button

## To test
- we want to make sure that the COW vested from locked GNO is not included in the subsidy percentage and balance button