### PR TITLE
Fix unhandled exception when checking whether address is SC

### DIFF
--- a/src/custom/hooks/useWalletInfo.ts
+++ b/src/custom/hooks/useWalletInfo.ts
@@ -38,8 +38,13 @@ async function checkIsSmartContractWallet(
     return false
   }
 
-  const code = await web3.getCode(address)
-  return code !== '0x'
+  try {
+    const code = await web3.getCode(address)
+    return code !== '0x'
+  } catch (e) {
+    console.debug(`checkIsSmartContractWallet: failed to check address ${address}`, e.message)
+    return false
+  }
 }
 
 function checkIsSupportedWallet(params: {


### PR DESCRIPTION
# Summary

"You see something, you do something" kind of fix

While testing locally the app broke because this check was unhandled
Not a through investigation of what caused it, just handling it to prevent the app from crashing

Not a problem on prod where it'll be swallowed and logged as an error

![Screen Shot 2022-05-04 at 15 22 06](https://user-images.githubusercontent.com/43217/166706046-27f80a0f-9e28-47a9-b7ce-334666eedcd0.png)
![Screen Shot 2022-05-04 at 15 21 50](https://user-images.githubusercontent.com/43217/166706053-702b073f-dd20-4862-a940-7eb78ecc5c1c.png)


  # To Test

Only visible locally, no way to reproduce in the PR
Besides, no clear path for reproduction either, happened while switching to unsupported networks back and forth trying to reproduce https://github.com/cowprotocol/cowswap/issues/514
Maybe related, but unsure