### PR TITLE
Fix network warning unreadable on dark mode

### DIFF
--- a/src/custom/components/Popups/FailedNetworkSwitchPopupMod.tsx
+++ b/src/custom/components/Popups/FailedNetworkSwitchPopupMod.tsx
@@ -29,7 +29,7 @@ export default function FailedNetworkSwitchPopup({
         <AlertCircle color={isUnsupportedNetwork ? theme.red3 : theme.red1} size={24} />
       </div>
       <AutoColumn gap="8px">
-        <ThemedText.Body fontWeight={500} color={theme.text1}>
+        <ThemedText.Body fontWeight={500} color={isUnsupportedNetwork ? theme.text2 : 'initial'}>
           <Trans>
             {isUnsupportedNetwork
               ? `Please connect your wallet to one of the supported networks: Ethereum Mainnet or Gnosis Chain.`

--- a/src/custom/components/Popups/FailedNetworkSwitchPopupMod.tsx
+++ b/src/custom/components/Popups/FailedNetworkSwitchPopupMod.tsx
@@ -29,7 +29,7 @@ export default function FailedNetworkSwitchPopup({
         <AlertCircle color={isUnsupportedNetwork ? theme.red3 : theme.red1} size={24} />
       </div>
       <AutoColumn gap="8px">
-        <ThemedText.Body fontWeight={500} color={isUnsupportedNetwork ? theme.text2 : 'initial'}>
+        <ThemedText.Body fontWeight={500} color={isUnsupportedNetwork ? theme.text2 : theme.text1}>
           <Trans>
             {isUnsupportedNetwork
               ? `Please connect your wallet to one of the supported networks: Ethereum Mainnet or Gnosis Chain.`

--- a/src/custom/components/Popups/FailedNetworkSwitchPopupMod.tsx
+++ b/src/custom/components/Popups/FailedNetworkSwitchPopupMod.tsx
@@ -29,7 +29,7 @@ export default function FailedNetworkSwitchPopup({
         <AlertCircle color={isUnsupportedNetwork ? theme.red3 : theme.red1} size={24} />
       </div>
       <AutoColumn gap="8px">
-        <ThemedText.Body fontWeight={500} color={isUnsupportedNetwork ? theme.text2 : 'initial'}>
+        <ThemedText.Body fontWeight={500} color={theme.text1}>
           <Trans>
             {isUnsupportedNetwork
               ? `Please connect your wallet to one of the supported networks: Ethereum Mainnet or Gnosis Chain.`


### PR DESCRIPTION
# Summary

Closes https://github.com/cowprotocol/cowswap/issues/529

![Screen Shot 2022-05-05 at 14 52 39](https://user-images.githubusercontent.com/43217/166952314-fe75194a-8aa0-4762-be4b-7a1a9b46f764.png)

  # To Test

1. Using a wallet that doesn't support network changing from the app, such as Nifty, open the on the same network as the wallet
2. Once loaded, change the network in the URL. E.g.: from `chain=rinkeby` to `chain=mainnet`
* An error message will be displayed
3. Change between dark and light modes
* The error message should be readable in both modes