### PR TITLE
Fix import token popup issue

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,36 +1,36 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path')
-const SentryWebpackPlugin = require('@sentry/webpack-plugin')
+// const SentryWebpackPlugin = require('@sentry/webpack-plugin')
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
-const { version } = require('./package.json')
+// const { version } = require('./package.json')
 
 // see https://github.com/gsoft-inc/craco/blob/master/packages/craco/README.md#configuration-overview
 
 const plugins = []
-const SENTRY_AUTH_TOKEN = process.env.REACT_APP_SENTRY_AUTH_TOKEN
-const SENTRY_RELEASE_VERSION = 'CowSwap@v' + version
+// const SENTRY_AUTH_TOKEN = process.env.REACT_APP_SENTRY_AUTH_TOKEN
+// const SENTRY_RELEASE_VERSION = 'CowSwap@v' + version
 const ANALYZE_BUNDLE = process.env.REACT_APP_ANALYZE_BUNDLE
 
 if (ANALYZE_BUNDLE) {
   plugins.push(new BundleAnalyzerPlugin())
 }
 
-if (SENTRY_AUTH_TOKEN) {
-  plugins.push(
-    new SentryWebpackPlugin({
-      // sentry-cli configuration - can also be done directly through sentry-cli
-      // see https://docs.sentry.io/product/cli/configuration/ for details
-      authToken: SENTRY_AUTH_TOKEN,
-      org: 'cowprotocol',
-      project: 'cowswap',
-      release: SENTRY_RELEASE_VERSION,
+// if (SENTRY_AUTH_TOKEN) {
+//   plugins.push(
+//     new SentryWebpackPlugin({
+//       // sentry-cli configuration - can also be done directly through sentry-cli
+//       // see https://docs.sentry.io/product/cli/configuration/ for details
+//       authToken: SENTRY_AUTH_TOKEN,
+//       org: 'cowprotocol',
+//       project: 'cowswap',
+//       release: SENTRY_RELEASE_VERSION,
 
-      // other SentryWebpackPlugin configuration
-      include: '.',
-      ignore: ['node_modules', 'webpack.config.js'],
-    })
-  )
-}
+//       // other SentryWebpackPlugin configuration
+//       include: '.',
+//       ignore: ['node_modules', 'webpack.config.js'],
+//     })
+//   )
+// }
 
 module.exports = {
   babel: {

--- a/craco.config.js
+++ b/craco.config.js
@@ -1,36 +1,36 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path')
-// const SentryWebpackPlugin = require('@sentry/webpack-plugin')
+const SentryWebpackPlugin = require('@sentry/webpack-plugin')
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
-// const { version } = require('./package.json')
+const { version } = require('./package.json')
 
 // see https://github.com/gsoft-inc/craco/blob/master/packages/craco/README.md#configuration-overview
 
 const plugins = []
-// const SENTRY_AUTH_TOKEN = process.env.REACT_APP_SENTRY_AUTH_TOKEN
-// const SENTRY_RELEASE_VERSION = 'CowSwap@v' + version
+const SENTRY_AUTH_TOKEN = process.env.REACT_APP_SENTRY_AUTH_TOKEN
+const SENTRY_RELEASE_VERSION = 'CowSwap@v' + version
 const ANALYZE_BUNDLE = process.env.REACT_APP_ANALYZE_BUNDLE
 
 if (ANALYZE_BUNDLE) {
   plugins.push(new BundleAnalyzerPlugin())
 }
 
-// if (SENTRY_AUTH_TOKEN) {
-//   plugins.push(
-//     new SentryWebpackPlugin({
-//       // sentry-cli configuration - can also be done directly through sentry-cli
-//       // see https://docs.sentry.io/product/cli/configuration/ for details
-//       authToken: SENTRY_AUTH_TOKEN,
-//       org: 'cowprotocol',
-//       project: 'cowswap',
-//       release: SENTRY_RELEASE_VERSION,
+if (SENTRY_AUTH_TOKEN) {
+  plugins.push(
+    new SentryWebpackPlugin({
+      // sentry-cli configuration - can also be done directly through sentry-cli
+      // see https://docs.sentry.io/product/cli/configuration/ for details
+      authToken: SENTRY_AUTH_TOKEN,
+      org: 'cowprotocol',
+      project: 'cowswap',
+      release: SENTRY_RELEASE_VERSION,
 
-//       // other SentryWebpackPlugin configuration
-//       include: '.',
-//       ignore: ['node_modules', 'webpack.config.js'],
-//     })
-//   )
-// }
+      // other SentryWebpackPlugin configuration
+      include: '.',
+      ignore: ['node_modules', 'webpack.config.js'],
+    })
+  )
+}
 
 module.exports = {
   babel: {

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -129,8 +129,12 @@ export default function Swap({
 
   // dismiss warning if all imported tokens are in active lists
   const defaultTokens = useAllTokens()
-  const importTokensNotInDefault = useMemo(
-    () =>
+  const importTokensNotInDefault = useMemo(() => {
+    // We should return an empty array until the defaultTokens are loaded
+    // Otherwise WETH will be in urlLoadedTokens but defaultTokens will be empty
+    // Fix for https://github.com/cowprotocol/cowswap/issues/534
+    if (!Object.keys(defaultTokens).length) return []
+    return (
       urlLoadedTokens &&
       urlLoadedTokens
         .filter((token: Token) => {
@@ -144,9 +148,9 @@ export default function Swap({
             const shorthandTokenAddress = TOKEN_SHORTHANDS[shorthand][supported]
             return shorthandTokenAddress && shorthandTokenAddress === token.address
           })
-        }),
-    [chainId, defaultTokens, urlLoadedTokens]
-  )
+        })
+    )
+  }, [chainId, defaultTokens, urlLoadedTokens])
 
   const theme = useContext(ThemeContext)
 


### PR DESCRIPTION
# Summary

Fixes #534

- The issue happens because until the `defaultTokens` are loaded the WETH will be in the `importTokensNotInDefault` and this is why the imported token widget shows up. So this will check if there are no `defaultTokens` and return an empty array.

# Note
- The first commit for Sentry should be reverted before this is merged. That is just for the review because at this point the sentry auth key is not working