### PR TITLE
Update contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
   "license": "GPL-3.0-or-later",
   "dependencies": {
     "@babel/runtime": "^7.17.0",
-    "@cowprotocol/contracts": "^1.1.3-RC.0",
+    "@cowprotocol/contracts": "^1.3.0",
     "@davatar/react": "1.8.1",
     "@ethersproject/abi": "^5.4.1",
     "@ethersproject/abstract-provider": "^5.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1160,10 +1160,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@cowprotocol/contracts@^1.1.3-RC.0":
-  version "1.1.3-RC.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.1.3-RC.0.tgz#23c400a7cbf50c1c2e7dca317a0b2940975b6867"
-  integrity sha512-WwPvBKbBvRIj/W3I1/8yJPh0DLMx8EoDw/MTpF07rDq2W0QQ1r9GXq+GWIclt5Rcw7ZGwZMRlnM3XOYEWA+qpg==
+"@cowprotocol/contracts@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.3.0.tgz#7bfc2995ef02906aac2bb9891b125b14315ce7c5"
+  integrity sha512-emDqUHK95qYgnrVKoA2z4RI/hjuP4QwK9i6AOG/E2zqg4uC0gD5gq7JH0BM5c9FKpkTkkGUH8qOmZwBpDHAopQ==
 
 "@craco/craco@^5.7.0":
   version "5.9.0"


### PR DESCRIPTION
# Summary

This PR just makes use of the 1.3.0 version of the smart contracts. There shouldn't be any noticeable changes comparing the version with the Release Candidate that is currently in production. 


## Details
Only changes comparing with 1.1.3-RC.0 are:

```
9d00715 1.3.0
fa0d976 Versioned signers (#7)
eac3fe1 1.2.0
a067bda Show balance origin in decoder (#6)
6b1f908 1.1.3-RC.0
8d85709 Add versioned signers
```