### PR TITLE
322/store quote info on redux

### DIFF
--- a/src/custom/api/coingecko/index.ts
+++ b/src/custom/api/coingecko/index.ts
@@ -99,5 +99,5 @@ export function toPriceInformation(priceRaw: CoinGeckoUsdQuote | null): PriceInf
   }
 
   const { usd } = priceRaw[token]
-  return { amount: usd.toString(), token }
+  return { amount: usd.toString(), token, oppositeAmount: '1' }
 }

--- a/src/custom/api/gnosisProtocol/api.ts
+++ b/src/custom/api/gnosisProtocol/api.ts
@@ -353,7 +353,12 @@ async function _handleQuoteResponse<T = any, P extends FeeQuoteParams = FeeQuote
         },
       })
     } else {
-      return response.json()
+      const rawResponse = await response.json()
+      // The legacy quote endpoint does takes as part of the URL path the amount in
+      // and returns as response the amount out
+      // Since now we'll need to keep track of both, here we add to the response the amount in as oppositeAmount
+      const oppositeAmount = params.amount
+      return { ...rawResponse, oppositeAmount }
     }
   } catch (error) {
     throw _handleError(error, response, params, 'QUOTE')

--- a/src/custom/api/matcha-0x/index.ts
+++ b/src/custom/api/matcha-0x/index.ts
@@ -138,8 +138,8 @@ export function toPriceInformation(priceRaw: MatchaPriceQuote | null, kind: Orde
   const { sellAmount, buyAmount, sellTokenAddress, buyTokenAddress } = priceRaw
 
   if (kind === OrderKind.BUY) {
-    return { amount: sellAmount, token: sellTokenAddress }
+    return { amount: sellAmount, oppositeAmount: buyAmount, token: sellTokenAddress }
   } else {
-    return { amount: buyAmount, token: buyTokenAddress }
+    return { amount: buyAmount, oppositeAmount: sellAmount, token: buyTokenAddress }
   }
 }

--- a/src/custom/api/paraswap/index.ts
+++ b/src/custom/api/paraswap/index.ts
@@ -44,11 +44,13 @@ export function toPriceInformation(priceRaw: ParaSwapPriceQuote | null): PriceIn
   if (side === SwapSide.SELL) {
     return {
       amount: destAmount,
+      oppositeAmount: srcAmount,
       token: destToken,
     }
   } else {
     return {
       amount: srcAmount,
+      oppositeAmount: destAmount,
       token: srcToken,
     }
   }

--- a/src/custom/state/price/reducer.ts
+++ b/src/custom/state/price/reducer.ts
@@ -47,6 +47,7 @@ function initializeState(
 function getResetPrice(sellToken: string, buyToken: string, kind: OrderKind) {
   return {
     amount: null,
+    oppositeAmount: null,
     // When we buy, the price estimation is given in sell tokens (if we sell, we give it in sell tokens)
     // The price estimation is given in:
     //    - sell tokens (for buy orders)

--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -43,6 +43,7 @@ export interface FeeInformation {
 export interface PriceInformation {
   token: string
   amount: string | null
+  oppositeAmount: string | null
 }
 
 // GetQuoteResponse from @cowprotocol/contracts types Timestamp and BigNumberish

--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -111,13 +111,22 @@ function _filterWinningPrice(params: FilterWinningPriceParams) {
   const amount = BigNumberJs[aggregationFunction](...params.amounts).toString(10)
   const token = params.priceQuotes[0].token
 
-  const winningPrices = params.priceQuotes
-    .filter((quote) => quote.amount === amount)
-    .map((p) => p.source)
-    .join(', ')
-  console.debug('[util::filterWinningPrice] Winning price: ' + winningPrices + ' for token ' + token + ' @', amount)
+  const winningPrices = params.priceQuotes.filter((quote) => quote.amount === amount)
+  const oppositeAmount = winningPrices[0]?.oppositeAmount
 
-  return { token, amount }
+  console.debug(
+    '[util::filterWinningPrice] Winning price: ' +
+      winningPrices.map((p) => p.source).join(', ') +
+      ' for token ' +
+      token +
+      ' @ ' +
+      amount +
+      ' & oppositeAmount ' +
+      oppositeAmount,
+    winningPrices
+  )
+
+  return { token, amount, oppositeAmount }
 }
 
 export type QuoteResult = [PromiseSettledResult<PriceInformation>, PromiseSettledResult<FeeInformation>]
@@ -264,6 +273,7 @@ export async function getFullQuote({ quoteParams }: { quoteParams: FeeQuoteParam
 
   const price = {
     amount: kind === OrderKind.SELL ? quote.buyAmount : quote.sellAmount,
+    oppositeAmount: kind === OrderKind.SELL ? quote.sellAmount : quote.buyAmount,
     token: kind === OrderKind.SELL ? quote.buyToken : quote.sellToken,
   }
   const fee = {

--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -44,6 +44,7 @@ export interface PriceInformation {
   token: string
   amount: string | null
   oppositeAmount: string | null
+  // quoteId?: string // TODO fill in this info if we have it
 }
 
 // GetQuoteResponse from @cowprotocol/contracts types Timestamp and BigNumberish
@@ -55,6 +56,7 @@ export type SimpleGetQuoteResponse = Pick<GetQuoteResponse, 'from'> & {
     buyAmount: string
     validTo: string
     feeAmount: string
+    // quoteId?: string // TODO: not yet coming from the API, tracked on https://github.com/cowprotocol/services/issues/170
   }
   expiration: string
 }
@@ -270,11 +272,13 @@ export async function getBestPrice(params: PriceQuoteParams, options?: GetBestPr
 export async function getFullQuote({ quoteParams }: { quoteParams: FeeQuoteParams }): Promise<QuoteResult> {
   const { kind } = quoteParams
   const { quote, expiration: expirationDate } = await getQuote(quoteParams)
+  // TODO: store/pass down as response the buyAmount, sellAmount and quoteId from quote obj
 
   const price = {
     amount: kind === OrderKind.SELL ? quote.buyAmount : quote.sellAmount,
     oppositeAmount: kind === OrderKind.SELL ? quote.sellAmount : quote.buyAmount,
     token: kind === OrderKind.SELL ? quote.buyToken : quote.sellToken,
+    // quoteId: quote.quoteId,
   }
   const fee = {
     amount: quote.feeAmount,


### PR DESCRIPTION
# Summary

Part of [#332 ](https://github.com/cowprotocol/cowswap/issues/332)

Making both sell and buy amounts returned with the quote available in redux context

These amounts will later be stored in the order metadata to calculate real surplus (difference between quote prices and executed prices)

# To Test

1. Using redux developer addon/extension, load the page
2. Go to redux > actions > State
![Screen Shot 2022-05-20 at 13 23 12](https://user-images.githubusercontent.com/43217/169527343-0cf91fa5-94e5-4f49-8249-31db55eb0020.png)
3. Filter by `price`
4. Click on a `price/refreshQuote` action
5. In the tree navigation, open `price -> quotes -> 1 -> <token address> -> price`
![Screen Shot 2022-05-20 at 13 20 47](https://user-images.githubusercontent.com/43217/169527772-efa26d07-216b-4ef6-b729-61287a94b69b.png)
* You should see the field `oppositeAmount` populated
* There should be no changes at all to the behaviour