### PR TITLE
Move unsupported token text above gc banner

### DIFF
--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -960,9 +960,6 @@ export default function Swap({
           </BottomGrouping>
         </Wrapper>
       </StyledAppBody>
-      <AlertWrapper>
-        <NetworkAlert />
-      </AlertWrapper>
       {/*<SwitchLocaleLink />*/}
       {!swapIsUnsupported ? null : !isSupportedWallet ? (
         <UnsupportedCurrencyFooter
@@ -982,6 +979,9 @@ export default function Swap({
       ) : (
         <UnsupportedCurrencyFooter show={swapIsUnsupported} currencies={[currencies.INPUT, currencies.OUTPUT]} />
       )}
+      <AlertWrapper>
+        <NetworkAlert />
+      </AlertWrapper>
     </>
   )
 }


### PR DESCRIPTION
# Summary

Fixes #553

- As asked in the ticket this will move unsupported token text above Gnosis chain banner
![Screenshot from 2022-05-23 12-14-12](https://user-images.githubusercontent.com/34926005/169799751-f69c2015-6388-496c-8ca0-37b75c5720b3.png)

