### PR TITLE
Show quote errors even if disconnected

### DIFF
--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -761,10 +761,6 @@ export default function Swap({
                   <Trans>Unsupported Token</Trans>
                 </ThemedText.Main>
               </ButtonPrimary>
-            ) : !account ? (
-              <ButtonPrimary buttonSize={ButtonSize.BIG} onClick={toggleWalletModal}>
-                <SwapButton showLoading={swapBlankState || isGettingNewQuote}>Connect Wallet</SwapButton>
-              </ButtonPrimary>
             ) : !isSupportedWallet ? (
               <ButtonError buttonSize={ButtonSize.BIG} id="swap-button" disabled={!isSupportedWallet}>
                 <Text fontSize={20} fontWeight={500}>
@@ -822,6 +818,10 @@ export default function Swap({
               <GreyCard style={{ textAlign: 'center' }}>
                 <ThemedText.Main mb="4px">Error loading price. You are currently offline.</ThemedText.Main>
               </GreyCard>
+            ) : !account ? (
+              <ButtonPrimary buttonSize={ButtonSize.BIG} onClick={toggleWalletModal}>
+                <SwapButton showLoading={swapBlankState || isGettingNewQuote}>Connect Wallet</SwapButton>
+              </ButtonPrimary>
             ) : showApproveFlow ? (
               <AutoRow style={{ flexWrap: 'nowrap', width: '100%' }}>
                 <AutoColumn style={{ width: '100%' }} gap="12px">

--- a/src/custom/state/price/reducer.ts
+++ b/src/custom/state/price/reducer.ts
@@ -152,13 +152,12 @@ export default createReducer(initialState, (builder) =>
       initializeState(quotes, action)
 
       // Sets the error information
-      const quoteInformation = quotes[chainId][sellToken]
-      if (quoteInformation) {
-        quotes[chainId][sellToken] = {
-          ...quoteInformation,
-          ...payload,
-          price: getResetPrice(sellToken, buyToken, kind),
-        }
+      const quoteInformation = quotes[chainId][sellToken] || {}
+      quotes[chainId][sellToken] = {
+        ...quoteInformation,
+        ...payload,
+        price: getResetPrice(sellToken, buyToken, kind),
+        lastCheck: Date.now(),
       }
 
       // Stop the loaders


### PR DESCRIPTION
# Summary

This PR address an issue where we are silently hiding error when we quote the prices.

This happens when we quote prices with a disconnected wallet (which is perfectly fine), and then we get an error.

The fix is just to give more priority to show the error than show the connect button.

Before:
<img width="1010" alt="image" src="https://user-images.githubusercontent.com/2352112/170473801-422ba45f-a130-4e52-8bc8-b6ddc03a72af.png">



After:
<img width="853" alt="image" src="https://user-images.githubusercontent.com/2352112/170473722-93019597-55ce-4664-a01a-71843534a9e7.png">



## Note for reviewers
For doing a proper fix of this, we would need to refactor the whole component. The component is a nightmare, in this case the problem is the error handling hell: it's a series of nested ternary conditionals of dozens of lines of code.

I tried to move the button out of the error chain by trying to add it only under condition that is not connected, but I run into the conditional hook problem because of the last merge, see thread https://cowservices.slack.com/archives/C0361CDG8GP/p1653557763017379 

We will need to refactor this in the future, breaking down the component, and removing all that logic from the UI rendering.

# To Test

1. Make sure you are disconnected
2. Switch browser to offline mode 
3. Try to get a quote
4. Observe the error

In production, it shows the connect button instead