### PR TITLE
[analytics] Add wrap events for analytics

### DIFF
--- a/src/custom/components/TransactionConfirmationModal/index.tsx
+++ b/src/custom/components/TransactionConfirmationModal/index.tsx
@@ -368,7 +368,7 @@ function getWalletNameLabel(walletType: WalletType): string {
   }
 }
 
-function getOperationMessage(operationType: OperationType, chainId: number): string {
+export function getOperationMessage(operationType: OperationType, chainId: number): string {
   const { native, wrapped } = getChainCurrencySymbols(chainId)
 
   switch (operationType) {

--- a/src/custom/hooks/useWrapCallback.ts
+++ b/src/custom/hooks/useWrapCallback.ts
@@ -22,11 +22,13 @@ import { supportedChainId } from 'utils/supportedChainId'
 import { formatSmart } from 'utils/format'
 import { useWalletInfo } from './useWalletInfo'
 import { SafeInfoResponse } from '@gnosis.pm/safe-service-client'
-import { OperationType } from '../components/TransactionConfirmationModal'
+import { getOperationMessage, OperationType } from '../components/TransactionConfirmationModal'
 import { calculateGasMargin } from '@src/utils/calculateGasMargin'
+import ReactGA from 'react-ga4'
 
 // Use a 180K gas as a fallback if there's issue calculating the gas estimation (fixes some issues with some nodes failing to calculate gas costs for SC wallets)
 const WRAP_UNWRAP_GAS_LIMIT_DEFAULT = BigNumber.from('180000')
+const ANALYTICS_WRAP_CATEGORY = 'Wrapped Native Token'
 
 export enum WrapType {
   NOT_APPLICABLE,
@@ -129,10 +131,23 @@ function _getWrapUnwrapCallback(params: GetWrapUnwrapCallback): WrapUnwrapCallba
       confirmationMessage = t`Unwrapping ${baseSummary}`
     }
 
+    const operationMessage = getOperationMessage(operationType, chainId)
     wrapUnwrapCallback = async () => {
       try {
         openTransactionConfirmationModal(confirmationMessage, operationType)
+
+        ReactGA.event({
+          category: ANALYTICS_WRAP_CATEGORY,
+          action: 'Send transaction to Wallet',
+          label: operationMessage,
+        })
+
         const txReceipt = await wrapUnwrap()
+        ReactGA.event({
+          category: ANALYTICS_WRAP_CATEGORY,
+          action: 'Sign transaction',
+          label: operationMessage,
+        })
         addTransaction({
           hash: txReceipt.hash,
           summary,
@@ -142,8 +157,15 @@ function _getWrapUnwrapCallback(params: GetWrapUnwrapCallback): WrapUnwrapCallba
         return txReceipt
       } catch (error) {
         closeModals()
-        const actionName = WrapType.WRAP ? 'wrapping' : 'unwrapping'
-        console.error(t`Error ${actionName} ${symbol}`, error)
+
+        const action = (error?.code === 4001 ? 'Reject' : 'Error') + ' Signing transaction'
+
+        ReactGA.event({
+          category: ANALYTICS_WRAP_CATEGORY,
+          action,
+          label: operationMessage,
+        })
+        console.error(action, error)
 
         throw error.message ? error : new Error(error)
       }


### PR DESCRIPTION
# Summary

Adds tracking events for wrapping/unwrapping native token

Adds the following action
- Send transaction to Wallet
- Sign transaction
- Reject Signing transaction
- Error Signing transaction

See complete list of events:
https://docs.google.com/spreadsheets/d/1AwcuvmPaAyIRuKayOEp1cKcVGD3MLOpfS8UWA04fBtY/edit#gid=0


# To Test

1. Install and activate https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en 
2. Verify the events by wrapping/unwrapping native tokens
3. Verify the console, it should write the event that was sent to analytics