### PR TITLE
[analytics] Add analytics for slippage

### DIFF
--- a/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
+++ b/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
@@ -5,7 +5,7 @@ import { DEFAULT_DEADLINE_FROM_NOW } from 'constants/misc'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 // import ms from 'ms.macro'
 import { darken } from 'polished'
-import { useContext, useState } from 'react'
+import { useCallback, useContext, useState } from 'react'
 import { useSetUserSlippageTolerance, useUserSlippageTolerance, useUserTransactionTTL } from 'state/user/hooks'
 import styled, { ThemeContext } from 'styled-components/macro'
 
@@ -25,6 +25,7 @@ import {
   DEFAULT_SLIPPAGE_BPS,
 } from 'constants/index'
 import ReactGA from 'react-ga4'
+import { debounce } from 'utils/misc'
 
 enum SlippageError {
   InvalidInput = 'InvalidInput',
@@ -101,6 +102,14 @@ const SlippageEmojiContainer = styled.span`
   `}
 `
 
+const reportAnalytics = debounce((actionName: string, slippageBps: number) => {
+  ReactGA.event({
+    category: 'Order Slippage Tolerance',
+    action: actionName,
+    value: slippageBps,
+  })
+}, 2000)
+
 export interface TransactionSettingsProps {
   placeholderSlippage: Percent // varies according to the context in which the settings dialog is placed
 }
@@ -122,36 +131,32 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
   const [deadlineInput, setDeadlineInput] = useState('')
   const [deadlineError, setDeadlineError] = useState<DeadlineError | false>(false)
 
-  function parseSlippageInput(value: string) {
-    // populate what the user typed and clear the error
-    setSlippageInput(value)
-    setSlippageError(false)
+  const parseSlippageInput = useCallback(
+    (value: string) => {
+      // populate what the user typed and clear the error
+      setSlippageInput(value)
+      setSlippageError(false)
 
-    if (value.length === 0) {
-      setUserSlippageTolerance('auto')
-    } else {
-      const parsed = Math.floor(Number.parseFloat(value) * 100)
-
-      if (!Number.isInteger(parsed) || parsed < MIN_SLIPPAGE_BPS || parsed > MAX_SLIPPAGE_BPS) {
-        ReactGA.event({
-          category: 'Order Slippage Tolerance',
-          action: 'Set Default Slippage Tolerance',
-          value: DEFAULT_SLIPPAGE_BPS,
-        })
+      if (value.length === 0) {
+        reportAnalytics('Set Default Slippage Tolerance', DEFAULT_SLIPPAGE_BPS)
         setUserSlippageTolerance('auto')
-        if (value !== '.') {
-          setSlippageError(SlippageError.InvalidInput)
-        }
       } else {
-        ReactGA.event({
-          category: 'Order Slippage Tolerance',
-          action: 'Set Custom Slippage Tolerance',
-          value: parsed,
-        })
-        setUserSlippageTolerance(new Percent(parsed, 10_000))
+        const parsed = Math.floor(Number.parseFloat(value) * 100)
+
+        if (!Number.isInteger(parsed) || parsed < MIN_SLIPPAGE_BPS || parsed > MAX_SLIPPAGE_BPS) {
+          reportAnalytics('Set Default Slippage Tolerance', DEFAULT_SLIPPAGE_BPS)
+          setUserSlippageTolerance('auto')
+          if (value !== '.') {
+            setSlippageError(SlippageError.InvalidInput)
+          }
+        } else {
+          reportAnalytics('Set Custom Slippage Tolerance', parsed)
+          setUserSlippageTolerance(new Percent(parsed, 10_000))
+        }
       }
-    }
-  }
+    },
+    [setUserSlippageTolerance]
+  )
 
   const tooLow =
     userSlippageTolerance !== 'auto' && userSlippageTolerance.lessThan(new Percent(LOW_SLIPPAGE_BPS, 10_000))

--- a/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
+++ b/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
@@ -15,7 +15,16 @@ import QuestionHelper from '../QuestionHelper'
 import { RowBetween, RowFixed } from 'components/Row'
 
 // MOD imports
-import { INPUT_OUTPUT_EXPLANATION, MINIMUM_ORDER_VALID_TO_TIME_SECONDS } from 'constants/index'
+import {
+  INPUT_OUTPUT_EXPLANATION,
+  MINIMUM_ORDER_VALID_TO_TIME_SECONDS,
+  MIN_SLIPPAGE_BPS,
+  MAX_SLIPPAGE_BPS,
+  LOW_SLIPPAGE_BPS,
+  HIGH_SLIPPAGE_BPS,
+  DEFAULT_SLIPPAGE_BPS,
+} from 'constants/index'
+import ReactGA from 'react-ga4'
 
 enum SlippageError {
   InvalidInput = 'InvalidInput',
@@ -123,19 +132,31 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
     } else {
       const parsed = Math.floor(Number.parseFloat(value) * 100)
 
-      if (!Number.isInteger(parsed) || parsed < 0 || parsed > 5000) {
+      if (!Number.isInteger(parsed) || parsed < MIN_SLIPPAGE_BPS || parsed > MAX_SLIPPAGE_BPS) {
+        ReactGA.event({
+          category: 'Order Slippage Tolerance',
+          action: 'Set Default Slippage Tolerance',
+          value: DEFAULT_SLIPPAGE_BPS,
+        })
         setUserSlippageTolerance('auto')
         if (value !== '.') {
           setSlippageError(SlippageError.InvalidInput)
         }
       } else {
+        ReactGA.event({
+          category: 'Order Slippage Tolerance',
+          action: 'Set Custom Slippage Tolerance',
+          value: parsed,
+        })
         setUserSlippageTolerance(new Percent(parsed, 10_000))
       }
     }
   }
 
-  const tooLow = userSlippageTolerance !== 'auto' && userSlippageTolerance.lessThan(new Percent(5, 10_000))
-  const tooHigh = userSlippageTolerance !== 'auto' && userSlippageTolerance.greaterThan(new Percent(1, 100))
+  const tooLow =
+    userSlippageTolerance !== 'auto' && userSlippageTolerance.lessThan(new Percent(LOW_SLIPPAGE_BPS, 10_000))
+  const tooHigh =
+    userSlippageTolerance !== 'auto' && userSlippageTolerance.greaterThan(new Percent(HIGH_SLIPPAGE_BPS, 10_000))
 
   function parseCustomDeadline(value: string) {
     // populate what the user typed and clear the error

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -6,7 +6,12 @@ import { WalletInfo, SUPPORTED_WALLETS as SUPPORTED_WALLETS_UNISWAP } from 'cons
 import { SupportedChainId as ChainId } from 'constants/chains'
 import { getAppDataHash } from './appDataHash'
 
-export const INITIAL_ALLOWED_SLIPPAGE_PERCENT = new Percent('5', '1000') // 0.5%
+export const DEFAULT_SLIPPAGE_BPS = 50 // 0.5%
+export const MAX_SLIPPAGE_BPS = 5000 // 50%
+export const MIN_SLIPPAGE_BPS = 0 // 0%
+export const HIGH_SLIPPAGE_BPS = 100 // 1%
+export const LOW_SLIPPAGE_BPS = 5 // 0.05%
+export const INITIAL_ALLOWED_SLIPPAGE_PERCENT = new Percent(DEFAULT_SLIPPAGE_BPS, 10_000) // 0.5%
 export const RADIX_DECIMAL = 10
 export const RADIX_HEX = 16
 

--- a/src/custom/utils/misc.ts
+++ b/src/custom/utils/misc.ts
@@ -16,6 +16,16 @@ export function withTimeout<T>(promise: Promise<T>, ms: number, context?: string
   return Promise.race([promise, failOnTimeout])
 }
 
+export function debounce<F extends (...args: any) => any>(func: F, wait = 200) {
+  let timeout: NodeJS.Timeout
+  const debounced = (...args: any) => {
+    clearTimeout(timeout)
+    timeout = setTimeout(() => func(args), wait)
+  }
+
+  return debounced
+}
+
 export function isPromiseFulfilled<T>(
   promiseResult: PromiseSettledResult<T>
 ): promiseResult is PromiseFulfilledResult<T> {


### PR DESCRIPTION
# Summary

Adds tracking events for changing the default slippage tolerance
Adds the following action:
- Set Default Slippage Tolerance
- Set Custom Slippage Tolerance


See complete list of events:
https://docs.google.com/spreadsheets/d/1AwcuvmPaAyIRuKayOEp1cKcVGD3MLOpfS8UWA04fBtY/edit#gid=0


# To Test

1. Install and activate https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en 
2. Verify the events by changing the expiration time of the orders, or restoring the defaults
3. Verify the console, it should write the event that was sent to analytics
 