### PR TITLE
[CLA] Disable check on " uni-merge/** " branch name

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,6 +4,10 @@ on:
     types: [created]
   pull_request_target:
     types: [opened, closed, synchronize]
+  pull_request:
+    # ignore PR from branches names 'uni-merge/**'
+    branches:    
+      - '!uni-merge/**'
 
 jobs:
   CLAssistant:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,17 +4,16 @@ on:
     types: [created]
   pull_request_target:
     types: [opened, closed, synchronize]
-  pull_request:
-    # ignore PR from branches names 'uni-merge/**'
-    branches:    
-      - '!uni-merge/**'
 
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest
     steps:
       - name: 'CLA Assistant'
-        if: github.base_ref != 'main' && ((github.event.comment.body == 'recheckcla' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target')
+        if: 
+          github.base_ref != 'main' && 
+          startsWith(github.head_ref, 'uni-merge') == false && 
+          ((github.event.comment.body == 'recheckcla' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target')
         # Alpha Release
         uses: gnosis/github-action@master
         # GitHub token, automatically provided to the action


### PR DESCRIPTION
CLA runs every time still 😢 

@anxolin @alfetopito @nenadV91 any ideas why?
the conditional in the `if` seems to be ignored even in a new PR i opened to test (CLA still runs) - could it be because it checks it anyways and sees it's already all signed by the team so it posts the comment despite the `if` check?

A better solution would be to conditionally run this at the top level (in the `on` check for example) 