### PR TITLE
Added account page layout with subpages

### DIFF
--- a/src/custom/components/SideMenu/index.tsx
+++ b/src/custom/components/SideMenu/index.tsx
@@ -1,0 +1,69 @@
+import styled from 'styled-components/macro'
+import { transparentize } from 'polished'
+
+export const SideMenu = styled.div`
+  display: flex;
+  flex-flow: column wrap;
+  font-size: 16px;
+  font-weight: bold;
+  line-height: 1;
+  margin: 0 24px 0 0;
+  color: ${({ theme }) => theme.text1};
+  height: max-content;
+  position: sticky;
+  top: 0;
+  width: 100%;
+  padding: 38px 0 0;
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+  padding: 0;
+  position: relative;
+`}
+
+  > ul {
+    display: flex;
+    flex-flow: column wrap;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    font-size: inherit;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+    background: ${({ theme }) => transparentize(0.9, theme.text1)};
+    border-radius: 16px;
+    padding: 12px;
+  `}
+  }
+
+  > ul > li {
+    width: 100%;
+  }
+
+  > ul > li > a {
+    margin: 4px 0;
+    padding: 12px;
+    border-radius: 6px;
+    width: 100%;
+    text-decoration: none;
+    color: inherit;
+    opacity: 0.65;
+    transition: opacity 0.2s ease-in-out;
+    display: block;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+    margin: 0;
+  `}
+
+    &:hover,
+  &.active {
+      opacity: 1;
+    }
+
+    &.active {
+      ${({ theme }) => theme.mediaWidth.upToSmall`
+      background: ${({ theme }) => transparentize(0.9, theme.text1)};
+      border-radius: 16px;
+    `}
+    }
+  }
+`

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -161,3 +161,20 @@ export const SWR_OPTIONS = {
   // see https://koba04.medium.com/revalidating-options-of-swr-4d9f08bee813
   revalidateOnFocus: false,
 }
+
+// These are used for Account sidebar menu
+export const ACCOUNT_MENU_LINKS = [
+  { title: 'General', url: '/account' },
+  { title: 'Tokens', url: '/account/tokens' },
+  { title: 'Governance', url: '/account/governance' },
+  { title: 'Affiliate', url: '/account/affiliate' },
+]
+
+// These are used for FAQ sidebar menu
+export const FAQ_MENU_LINKS = [
+  { title: 'General', url: '/faq' },
+  { title: 'Protocol', url: '/faq/protocol' },
+  { title: 'Token', url: '/faq/token' },
+  { title: 'Trading', url: '/faq/trading' },
+  { title: 'Affiliate', url: '/faq/affiliate' },
+]

--- a/src/custom/pages/Account/Affiliate.tsx
+++ b/src/custom/pages/Account/Affiliate.tsx
@@ -1,0 +1,16 @@
+import { Content } from 'components/Page'
+import { Wrapper, AccountPageWrapper } from './styled'
+import { AccountMenu } from './Menu'
+
+export default function Affiliate() {
+  return (
+    <Wrapper>
+      <AccountMenu />
+      <AccountPageWrapper>
+        <Content>
+          <h2 id="general">Affiliate</h2>
+        </Content>
+      </AccountPageWrapper>
+    </Wrapper>
+  )
+}

--- a/src/custom/pages/Account/Governance.tsx
+++ b/src/custom/pages/Account/Governance.tsx
@@ -1,0 +1,16 @@
+import { Content } from 'components/Page'
+import { Wrapper, AccountPageWrapper } from './styled'
+import { AccountMenu } from './Menu'
+
+export default function Governance() {
+  return (
+    <Wrapper>
+      <AccountMenu />
+      <AccountPageWrapper>
+        <Content>
+          <h2 id="governance">Governance</h2>
+        </Content>
+      </AccountPageWrapper>
+    </Wrapper>
+  )
+}

--- a/src/custom/pages/Account/Menu.tsx
+++ b/src/custom/pages/Account/Menu.tsx
@@ -1,5 +1,5 @@
 import { NavLink } from 'react-router-dom'
-import { Menu } from './styled'
+import { SideMenu } from 'components/SideMenu'
 
 const LINKS = [
   { title: 'General', url: '/account' },
@@ -10,7 +10,7 @@ const LINKS = [
 
 export function AccountMenu() {
   return (
-    <Menu>
+    <SideMenu>
       <ul>
         {LINKS.map(({ title, url }, i) => (
           <li key={i}>
@@ -20,6 +20,6 @@ export function AccountMenu() {
           </li>
         ))}
       </ul>
-    </Menu>
+    </SideMenu>
   )
 }

--- a/src/custom/pages/Account/Menu.tsx
+++ b/src/custom/pages/Account/Menu.tsx
@@ -1,0 +1,25 @@
+import { NavLink } from 'react-router-dom'
+import { Menu } from './styled'
+
+const LINKS = [
+  { title: 'General', url: '/account' },
+  { title: 'Tokens', url: '/account/tokens' },
+  { title: 'Governance', url: '/account/governance' },
+  { title: 'Affiliate', url: '/account/affiliate' },
+]
+
+export function AccountMenu() {
+  return (
+    <Menu>
+      <ul>
+        {LINKS.map(({ title, url }, i) => (
+          <li key={i}>
+            <NavLink exact to={url} activeClassName={'active'}>
+              {title}
+            </NavLink>
+          </li>
+        ))}
+      </ul>
+    </Menu>
+  )
+}

--- a/src/custom/pages/Account/Menu.tsx
+++ b/src/custom/pages/Account/Menu.tsx
@@ -1,18 +1,12 @@
 import { NavLink } from 'react-router-dom'
 import { SideMenu } from 'components/SideMenu'
-
-const LINKS = [
-  { title: 'General', url: '/account' },
-  { title: 'Tokens', url: '/account/tokens' },
-  { title: 'Governance', url: '/account/governance' },
-  { title: 'Affiliate', url: '/account/affiliate' },
-]
+import { ACCOUNT_MENU_LINKS } from 'constants/index'
 
 export function AccountMenu() {
   return (
     <SideMenu>
       <ul>
-        {LINKS.map(({ title, url }, i) => (
+        {ACCOUNT_MENU_LINKS.map(({ title, url }, i) => (
           <li key={i}>
             <NavLink exact to={url} activeClassName={'active'}>
               {title}

--- a/src/custom/pages/Account/Tokens.tsx
+++ b/src/custom/pages/Account/Tokens.tsx
@@ -1,0 +1,16 @@
+import { Content } from 'components/Page'
+import { Wrapper, AccountPageWrapper } from './styled'
+import { AccountMenu } from './Menu'
+
+export default function Tokens() {
+  return (
+    <Wrapper>
+      <AccountMenu />
+      <AccountPageWrapper>
+        <Content>
+          <h2 id="tokens">Tokens</h2>
+        </Content>
+      </AccountPageWrapper>
+    </Wrapper>
+  )
+}

--- a/src/custom/pages/Account/index.tsx
+++ b/src/custom/pages/Account/index.tsx
@@ -1,0 +1,32 @@
+import { Content } from 'components/Page'
+import { Wrapper, AccountPageWrapper } from './styled'
+import { AccountMenu } from './Menu'
+
+export default function Account() {
+  return (
+    <Wrapper>
+      <AccountMenu />
+      <AccountPageWrapper>
+        <Content>
+          <h2 id="general">General</h2>
+
+          <h3>Subtitle</h3>
+          <p>
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Culpa consequuntur, nam modi perferendis dicta
+            nobis suscipit molestiae voluptatum quaerat, aliquam expedita aspernatur commodi inventore eos error?
+            Exercitationem non similique aperiam a facere, porro nam magni officia et praesentium, quisquam neque
+            placeat hic fugit fuga nisi sapiente cupiditate, quo sed architecto.
+          </p>
+
+          <h3>Subtitle</h3>
+          <p>
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Culpa consequuntur, nam modi perferendis dicta
+            nobis suscipit molestiae voluptatum quaerat, aliquam expedita aspernatur commodi inventore eos error?
+            Exercitationem non similique aperiam a facere, porro nam magni officia et praesentium, quisquam neque
+            placeat hic fugit fuga nisi sapiente cupiditate, quo sed architecto.
+          </p>
+        </Content>
+      </AccountPageWrapper>
+    </Wrapper>
+  )
+}

--- a/src/custom/pages/Account/styled.tsx
+++ b/src/custom/pages/Account/styled.tsx
@@ -1,0 +1,138 @@
+import styled from 'styled-components/macro'
+import { Content } from 'components/Page'
+import { transparentize } from 'polished'
+import { PageWrapper } from 'components/Page'
+import { MEDIA_WIDTHS } from '@src/theme'
+
+export const Wrapper = styled.div`
+  display: grid;
+  grid-template-columns: 160px auto;
+  flex-direction: column;
+
+  margin: 0 1rem;
+  max-width: ${MEDIA_WIDTHS.upToLarge}px;
+  width: 100%;
+
+  ${({ theme }) => theme.mediaWidth.upToLarge`
+    max-width: ${MEDIA_WIDTHS.upToMedium}px;
+  `}
+
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+    max-width: ${MEDIA_WIDTHS.upToSmall}px;
+  `}
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    max-width: ${MEDIA_WIDTHS.upToExtraSmall}px;
+    display: flex;
+    flex-flow: column wrap;
+  `}
+
+  h2 {
+    color: ${({ theme }) => theme.primary1};
+  }
+
+  > div:not(:first-child) {
+    margin: 2rem 0;
+  }
+
+  ${Content} {
+    > div > ul {
+      margin: 12px 0 24px;
+      padding: 0 0 0 20px;
+      color: ${({ theme }) => theme.primary1};
+      line-height: 1.2;
+    }
+
+    > div > ul > li {
+      margin: 0 0 12px;
+    }
+
+    > h3 {
+      margin: 0;
+
+      ::before {
+        border-top: none;
+      }
+    }
+  }
+
+  ol > li {
+    margin-bottom: 0.5rem;
+  }
+`
+
+export const Menu = styled.div`
+  display: flex;
+  flex-flow: column wrap;
+  font-size: 16px;
+  font-weight: bold;
+  line-height: 1;
+  margin: 0 24px 0 0;
+  color: ${({ theme }) => theme.text1};
+  height: max-content;
+  position: sticky;
+  top: 0;
+  width: 100%;
+  padding: 38px 0 0;
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    padding: 0;
+    position: relative;
+  `}
+
+  > ul {
+    display: flex;
+    flex-flow: column wrap;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    font-size: inherit;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      background: ${({ theme }) => transparentize(0.9, theme.text1)};
+      border-radius: 16px;
+      padding: 12px;
+    `}
+  }
+
+  > ul > li {
+    width: 100%;
+  }
+
+  > ul > li > a {
+    margin: 4px 0;
+    padding: 12px;
+    border-radius: 6px;
+    width: 100%;
+    text-decoration: none;
+    color: inherit;
+    opacity: 0.65;
+    transition: opacity 0.2s ease-in-out;
+    display: block;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      margin: 0;
+    `}
+
+    &:hover,
+    &.active {
+      opacity: 1;
+    }
+
+    &.active {
+      ${({ theme }) => theme.mediaWidth.upToSmall`
+        background: ${({ theme }) => transparentize(0.9, theme.text1)};
+        border-radius: 16px;
+      `}
+    }
+  }
+`
+
+export const AccountPageWrapper = styled(PageWrapper)`
+  width: 100%;
+  max-width: 100%;
+
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+    margin-left: 0;
+  `};
+`

--- a/src/custom/pages/Account/styled.tsx
+++ b/src/custom/pages/Account/styled.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components/macro'
 import { Content } from 'components/Page'
-import { transparentize } from 'polished'
 import { PageWrapper } from 'components/Page'
 import { MEDIA_WIDTHS } from '@src/theme'
 
@@ -58,73 +57,6 @@ export const Wrapper = styled.div`
 
   ol > li {
     margin-bottom: 0.5rem;
-  }
-`
-
-export const Menu = styled.div`
-  display: flex;
-  flex-flow: column wrap;
-  font-size: 16px;
-  font-weight: bold;
-  line-height: 1;
-  margin: 0 24px 0 0;
-  color: ${({ theme }) => theme.text1};
-  height: max-content;
-  position: sticky;
-  top: 0;
-  width: 100%;
-  padding: 38px 0 0;
-
-  ${({ theme }) => theme.mediaWidth.upToSmall`
-    padding: 0;
-    position: relative;
-  `}
-
-  > ul {
-    display: flex;
-    flex-flow: column wrap;
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    font-size: inherit;
-
-    ${({ theme }) => theme.mediaWidth.upToSmall`
-      background: ${({ theme }) => transparentize(0.9, theme.text1)};
-      border-radius: 16px;
-      padding: 12px;
-    `}
-  }
-
-  > ul > li {
-    width: 100%;
-  }
-
-  > ul > li > a {
-    margin: 4px 0;
-    padding: 12px;
-    border-radius: 6px;
-    width: 100%;
-    text-decoration: none;
-    color: inherit;
-    opacity: 0.65;
-    transition: opacity 0.2s ease-in-out;
-    display: block;
-
-    ${({ theme }) => theme.mediaWidth.upToSmall`
-      margin: 0;
-    `}
-
-    &:hover,
-    &.active {
-      opacity: 1;
-    }
-
-    &.active {
-      ${({ theme }) => theme.mediaWidth.upToSmall`
-        background: ${({ theme }) => transparentize(0.9, theme.text1)};
-        border-radius: 16px;
-      `}
-    }
   }
 `
 

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -25,11 +25,18 @@ const NotFound = lazy(() => import(/* webpackChunkName: "not_found" */ 'pages/er
 const CowRunner = lazy(() => import(/* webpackChunkName: "cow_runner" */ 'pages/games/CowRunner'))
 const MevSlicer = lazy(() => import(/* webpackChunkName: "mev_slicer" */ 'pages/games/MevSlicer'))
 
+// FAQ pages
 const Faq = lazy(() => import(/* webpackChunkName: "faq" */ 'pages/Faq'))
 const ProtocolFaq = lazy(() => import(/* webpackChunkName: "faq" */ 'pages/Faq/ProtocolFaq'))
 const TokenFaq = lazy(() => import(/* webpackChunkName: "faq" */ 'pages/Faq/TokenFaq'))
 const TradingFaq = lazy(() => import(/* webpackChunkName: "faq" */ 'pages/Faq/TradingFaq'))
 const AffiliateFaq = lazy(() => import(/* webpackChunkName: "faq" */ 'pages/Faq/AffiliateFaq'))
+
+// Account pages
+const Account = lazy(() => import(/* webpackChunkName: "account" */ 'pages/Account'))
+const Tokens = lazy(() => import(/* webpackChunkName: "account" */ 'pages/Account/Tokens'))
+const Governance = lazy(() => import(/* webpackChunkName: "account" */ 'pages/Account/Governance'))
+const Affiliate = lazy(() => import(/* webpackChunkName: "account" */ 'pages/Account/Affiliate'))
 
 if (SENTRY_DSN) {
   Sentry.init({
@@ -100,6 +107,11 @@ export default function App() {
             <Route exact strict path="/send" component={RedirectPathToSwapOnly} />
             <Route exact strict path="/about" component={About} />
             <Route exact strict path="/profile" component={Profile} />
+
+            <Route exact strict path="/account" component={Account} />
+            <Route exact strict path="/account/tokens" component={Tokens} />
+            <Route exact strict path="/account/governance" component={Governance} />
+            <Route exact strict path="/account/affiliate" component={Affiliate} />
 
             <Route exact path="/faq" component={Faq} />
             <Route exact strict path="/faq/protocol" component={ProtocolFaq} />

--- a/src/custom/pages/Faq/Menu.tsx
+++ b/src/custom/pages/Faq/Menu.tsx
@@ -1,5 +1,5 @@
 import { NavLink } from 'react-router-dom'
-import { Menu } from './styled'
+import { SideMenu } from 'components/SideMenu'
 
 const LINKS = [
   { title: 'General', url: '/faq' },
@@ -11,7 +11,7 @@ const LINKS = [
 
 export function FaqMenu() {
   return (
-    <Menu>
+    <SideMenu>
       <ul>
         {LINKS.map(({ title, url }, i) => (
           <li key={i}>
@@ -21,6 +21,6 @@ export function FaqMenu() {
           </li>
         ))}
       </ul>
-    </Menu>
+    </SideMenu>
   )
 }

--- a/src/custom/pages/Faq/Menu.tsx
+++ b/src/custom/pages/Faq/Menu.tsx
@@ -1,19 +1,12 @@
 import { NavLink } from 'react-router-dom'
 import { SideMenu } from 'components/SideMenu'
-
-const LINKS = [
-  { title: 'General', url: '/faq' },
-  { title: 'Protocol', url: '/faq/protocol' },
-  { title: 'Token', url: '/faq/token' },
-  { title: 'Trading', url: '/faq/trading' },
-  { title: 'Affiliate', url: '/faq/affiliate' },
-]
+import { FAQ_MENU_LINKS } from 'constants/index'
 
 export function FaqMenu() {
   return (
     <SideMenu>
       <ul>
-        {LINKS.map(({ title, url }, i) => (
+        {FAQ_MENU_LINKS.map(({ title, url }, i) => (
           <li key={i}>
             <NavLink exact to={url} activeClassName={'active'}>
               {title}

--- a/src/custom/pages/Faq/styled.tsx
+++ b/src/custom/pages/Faq/styled.tsx
@@ -2,7 +2,6 @@ import { ExternalLink as ExternalLinkTheme } from 'theme'
 import styled from 'styled-components/macro'
 import { Content } from 'components/Page'
 import { ButtonPrimary } from 'components/Button'
-import { transparentize } from 'polished'
 
 export const ExternalLinkFaq = styled(ExternalLinkTheme)`
   color: ${({ theme }) => theme.text1};
@@ -112,71 +111,4 @@ export const PageIndex = styled.div`
 export const ButtonNav = styled(ButtonPrimary)`
   width: min-content;
   white-space: nowrap;
-`
-
-export const Menu = styled.div`
-  display: flex;
-  flex-flow: column wrap;
-  font-size: 16px;
-  font-weight: bold;
-  line-height: 1;
-  margin: 0 24px 0 0;
-  color: ${({ theme }) => theme.text1};
-  height: max-content;
-  position: sticky;
-  top: 0;
-  width: 100%;
-  padding: 38px 0 0;
-
-  ${({ theme }) => theme.mediaWidth.upToSmall`
-    padding: 0;
-    position: relative;
-  `}
-
-  > ul {
-    display: flex;
-    flex-flow: column wrap;
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    font-size: inherit;
-
-    ${({ theme }) => theme.mediaWidth.upToSmall`
-      background: ${({ theme }) => transparentize(0.9, theme.text1)};
-      border-radius: 16px;
-      padding: 12px;
-    `}
-  }
-
-  > ul > li {
-    width: 100%;
-  }
-
-  > ul > li > a {
-    margin: 4px 0;
-    padding: 12px;
-    border-radius: 6px;
-    width: 100%;
-    text-decoration: none;
-    color: inherit;
-    opacity: 0.65;
-    transition: opacity 0.2s ease-in-out;
-    display: block;
-
-    ${({ theme }) => theme.mediaWidth.upToSmall`
-      margin: 0;
-    `}
-
-    &:hover,
-    &.active {
-      opacity: 1;
-    }
-
-    &.active {
-      ${({ theme }) => theme.mediaWidth.upToSmall`
-        background: ${({ theme }) => transparentize(0.9, theme.text1)};
-        border-radius: 16px;
-      `}
-    }
-  }
 `


### PR DESCRIPTION
# Summary

First part of the  #571

This will add a basic layout for the account page with the sidebar menu and also sub pages
- General
- Tokens
- Governance
- Affiliate
![Screenshot from 2022-05-30 14-53-41](https://user-images.githubusercontent.com/34926005/170996521-465fbd05-c657-45ce-9f45-2e04143ae686.png)

# To test
- go to `/account?chain=mainnet`
- test menu links
- test responsive design


