### PR TITLE
Header/Menu improvement (waterfall PR FINAL) 

### DIFF
--- a/src/custom/components/Footer/index.tsx
+++ b/src/custom/components/Footer/index.tsx
@@ -20,6 +20,10 @@ const Wrapper = styled.div`
   justify-content: space-evenly;
   margin: auto 16px;
   width: 100%;
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    margin: auto 0 100px;
+  `}
 `
 
 const FooterWrapper = styled.div`

--- a/src/custom/components/Header/NetworkSelector/NetworkSelectorMod.tsx
+++ b/src/custom/components/Header/NetworkSelector/NetworkSelectorMod.tsx
@@ -67,19 +67,19 @@ const FlyoutHeader = styled.div`
   color: ${({ theme }) => theme.text2};
   font-weight: 400;
 ` */
-const FlyoutMenu = styled.div`
+export const FlyoutMenu = styled.div`
   position: absolute;
   top: 54px;
   width: 272px;
   z-index: 99;
   padding-top: 10px;
-  @media screen and (min-width: ${MEDIA_WIDTHS.upToSmall}px) {
+  /* @media screen and (min-width: ${MEDIA_WIDTHS.upToSmall}px) {
     top: 38px;
-  }
+  } */
 
-  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+  /* ${({ theme }) => theme.mediaWidth.upToExtraSmall`
     right: 20%;
-  `}
+  `} */
 `
 // mod: actually, this is closer to original version but I haven't yet pulled latest from uniswap
 const FlyoutMenuContents = styled.div`

--- a/src/custom/components/Header/NetworkSelector/index.tsx
+++ b/src/custom/components/Header/NetworkSelector/index.tsx
@@ -1,9 +1,21 @@
 import styled from 'styled-components/macro'
-import NetworkSelectorMod, { SelectorLabel, SelectorControls } from './NetworkSelectorMod'
+import NetworkSelectorMod, { SelectorLabel, SelectorControls, FlyoutMenu } from './NetworkSelectorMod'
 import { transparentize } from 'polished'
+export { getChainNameFromId, getParsedChainId } from './NetworkSelectorMod'
 
 const Wrapper = styled.div`
   display: flex;
+
+  ${FlyoutMenu} {
+    top: 38px;
+    right: 0;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      width: 100%;
+      left: 0;
+      top: 58px;
+    `};
+  }
 
   ${SelectorLabel} {
     ${({ theme }) => theme.mediaWidth.upToMedium`

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -151,7 +151,7 @@ export default function Header() {
   )
 
   return (
-    <Wrapper>
+    <Wrapper isMobileMenuOpen={isMobileMenuOpen}>
       <HeaderModWrapper>
         <HeaderRow>
           <Title href={Routes.HOME} isMobileMenuOpen={isMobileMenuOpen}>

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -69,7 +69,7 @@ export default function Header() {
 
   const [isOrdersPanelOpen, setIsOrdersPanelOpen] = useState<boolean>(false)
   const closeOrdersPanel = () => setIsOrdersPanelOpen(false)
-  const openOrdersPanel = () => setIsOrdersPanelOpen(true)
+  const openOrdersPanel = () => account && setIsOrdersPanelOpen(true)
 
   const history = useHistory()
   const handleBalanceButtonClick = () => history.push('/account')
@@ -117,7 +117,7 @@ export default function Header() {
                       >
                         <SVG
                           src={darkMode ? IMAGE_SUN : IMAGE_MOON}
-                          description={`${darkMode ? 'Sun/light mode' : 'Moon/dark'} mode icon`}
+                          description={`${darkMode ? 'Sun/light' : 'Moon/dark'} mode icon`}
                         />{' '}
                         {darkMode ? 'Light' : 'Dark'} Mode
                       </button>

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -105,7 +105,7 @@ export default function Header() {
             {items.map(({ sectionTitle, links }, index) => {
               return (
                 <MenuSection key={index}>
-                  <MenuTitle>{sectionTitle}</MenuTitle>
+                  {sectionTitle && <MenuTitle>{sectionTitle}</MenuTitle>}
                   {links.map(({ title, url, externalURL, icon, iconSVG, action }, index) => {
                     return action && action === 'setColorMode' ? (
                       <button

--- a/src/custom/components/Header/styled.ts
+++ b/src/custom/components/Header/styled.ts
@@ -76,19 +76,23 @@ export const HeaderElement = styled(HeaderElementUni)`
   `}
 `
 
-export const Wrapper = styled.div`
+export const Wrapper = styled.div<{ isMobileMenuOpen: boolean }>`
   width: 100%;
 
   ${HeaderFrame} {
     padding: 16px;
     display: flex;
 
-    ${({ theme }) => theme.mediaWidth.upToLarge`
+    ${({ theme, isMobileMenuOpen }) => theme.mediaWidth.upToLarge`
       grid-template-columns: unset;
-    `}
 
-    ${({ theme }) => theme.mediaWidth.upToExtraSmall`
-      padding: 10px;
+      ${
+        isMobileMenuOpen &&
+        css`
+          position: absolute;
+          top: 0;
+        `
+      }
     `}
   }
 

--- a/src/custom/constants/mainMenu.ts
+++ b/src/custom/constants/mainMenu.ts
@@ -16,7 +16,7 @@ export interface MAIN_MENU_TYPE {
   url?: string
   externalURL?: boolean
   items?: {
-    sectionTitle: string
+    sectionTitle?: string
     links: {
       title?: string
       url?: string // If URL is an internal route
@@ -31,7 +31,20 @@ export interface MAIN_MENU_TYPE {
 export const MAIN_MENU = [
   { title: 'Swap', url: Routes.SWAP },
   { title: 'Account', url: Routes.ACCOUNT },
-  { title: 'FAQ', url: Routes.FAQ },
+  {
+    title: 'FAQ',
+    items: [
+      {
+        links: [
+          { title: 'Overview', url: Routes.FAQ },
+          { title: 'Protocol', url: Routes.FAQ_PROTOCOL },
+          { title: 'Token', url: Routes.FAQ_TOKEN },
+          { title: 'Trading', url: Routes.FAQ_TRADING },
+          { title: 'Affiliate', url: Routes.FAQ_AFFILIATE },
+        ],
+      },
+    ],
+  },
   {
     title: 'More',
     items: [

--- a/src/custom/hooks/useChangeNetworks.ts
+++ b/src/custom/hooks/useChangeNetworks.ts
@@ -9,7 +9,7 @@ import usePrevious from 'hooks/usePrevious'
 import { addPopup, ApplicationModal } from 'state/application/reducer'
 import { useAppDispatch } from 'state/hooks'
 import { replaceURLParam } from 'utils/routes'
-import { getChainNameFromId, getParsedChainId } from 'components/Header/NetworkSelector/NetworkSelectorMod'
+import { getChainNameFromId, getParsedChainId } from 'components/Header/NetworkSelector'
 import { useHistory } from 'react-router-dom'
 
 type ChangeNetworksParams = Pick<ReturnType<typeof useActiveWeb3React>, 'account' | 'chainId' | 'library'>

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -66,7 +66,7 @@ export const BodyWrapper = styled.div<{ location: { pathname: string } }>`
   `}
 
   ${({ theme, location }) => theme.mediaWidth.upToMedium`
-    padding: ${location.pathname === '/swap' ? '0 0 16px' : '0 16px 16px'};
+    padding: ${location.pathname === Routes.SWAP ? '0 0 16px' : '0 16px 16px'};
   `}
 `
 

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -19,7 +19,7 @@ import ReactGA from 'react-ga'
 // import { RouteComponentProps } from 'react-router-dom'
 import { Text } from 'rebass'
 // import { TradeState } from 'state/routing/types'
-import styled, { ThemeContext } from 'styled-components/macro'
+import { ThemeContext } from 'styled-components/macro'
 
 import AddressInputPanel from 'components/AddressInputPanel'
 import { ButtonConfirmed /*, ButtonError, ButtonLight, ButtonPrimary*/ } from 'components/Button'
@@ -84,11 +84,12 @@ import { useErrorMessage } from 'hooks/useErrorMessageAndModal'
 import { GpEther } from 'constants/tokens'
 import { SupportedChainId } from 'constants/chains'
 import CowSubsidyModal from 'components/CowSubsidyModal'
+import { AlertWrapper } from './styleds' // mod
 
-const AlertWrapper = styled.div`
-  max-width: 460px;
-  width: 100%;
-`
+// const AlertWrapper = styled.div`
+//   max-width: 460px;
+//   width: 100%;
+// `
 export default function Swap({
   history,
   location,

--- a/src/custom/pages/Swap/styleds.tsx
+++ b/src/custom/pages/Swap/styleds.tsx
@@ -23,3 +23,13 @@ export const StyledAppBody = styled(AppBody)`
     box-shadow: ${({ theme }) => theme.appBody.boxShadowMobile};
   `};
 `
+
+export const AlertWrapper = styled.div`
+  max-width: 460px;
+  width: 100%;
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    margin: 26px auto 0;
+    padding: 0 16px;
+  `}
+`


### PR DESCRIPTION
# Summary

This branch `improve-header-12` is the last in the waterfall PR to improve the header/menu for all viewports:
- Addresses issue #570 
- Removes decimals for the shown COW balance
- For small/mobile devices, it shows a fixed footer menu, with the COW button and the connected account.
- Introduces a drop down menu structure/component. Incl. mobile (hamburger) menu support.

https://user-images.githubusercontent.com/31534717/171024272-72bc698f-b964-4f39-8c7a-f650ed1100f4.mov


https://user-images.githubusercontent.com/31534717/171028109-03144cd2-8a5b-45ab-a4f9-9603efc02100.mov



https://user-images.githubusercontent.com/31534717/171024292-a42c5be5-d0d2-41dd-9296-e780e6d518b8.mov

https://user-images.githubusercontent.com/31534717/171024294-368cf18c-466d-40b4-a324-24c13004aad3.mov

https://user-images.githubusercontent.com/31534717/171024298-2ea96c02-3b15-4552-a5fe-a51f4c7161f2.mov

https://user-images.githubusercontent.com/31534717/171024300-d9b44700-1227-43c2-9354-48bd54f2b05b.mov


https://user-images.githubusercontent.com/31534717/171028399-471bd937-a2f4-4be5-811f-d8e4a620eb92.mov



**Todo for future PRs:**
- Style the network selector for mobile/small viewports. Specifically to have it be an overlay menu covering ~70% of the viewport.
- Appzi button probably should not overlay the mobile main menu.
