### PR TITLE
Improve FAQ text

### DIFF
--- a/src/custom/pages/Faq/AffiliateFaq.tsx
+++ b/src/custom/pages/Faq/AffiliateFaq.tsx
@@ -1,5 +1,6 @@
 import Page, { Content } from 'components/Page'
 import { LinkScrollable } from 'components/Link'
+import { Link } from 'react-router-dom'
 
 import { ExternalLinkFaq, Wrapper } from './styled'
 import { Footer } from '.'
@@ -18,11 +19,11 @@ export default function AffiliateFaq() {
         <Content>
           <h2 id="affiliate">Affiliate program</h2>
 
-          <h3 id="what-is-the-profile-page">What is the Profile page?</h3>
+          <h3 id="what-is-the-account-page">What is the Account page?</h3>
 
           <p>
-            It is a page where you can see your number of trades and volume that you have done with the wallet you have
-            connected with.
+            The <Link to="/account">account</Link> page is where you can see your number of trades and volume, generated
+            with the wallet you&amp;re connected with.
           </p>
 
           <p>
@@ -97,8 +98,8 @@ export default function AffiliateFaq() {
             counted.
           </p>
 
-          <h3 id="why-do-not-i-see-any-referral-trades-in-my-profile-page">
-            I shared my referral with a friend, who then also traded. Why do I not see any referral trades in my profile
+          <h3 id="why-do-not-i-see-any-referral-trades-in-my-account-page">
+            I shared my referral with a friend, who then also traded. Why do I not see any referral trades in my account
             page?
           </h3>
 
@@ -139,10 +140,12 @@ export default function AffiliateFaq() {
           </p>
 
           <h3 id="why-do-i-see-more-trades">
-            Why do I see more trades and referrals in my profile page than I actually see in the activity list?
+            Why do I see more trades and referrals in my account page than I actually see in the activity list?
           </h3>
 
-          <p>The number of trades on the profile page is calculated based on on-chain data.</p>
+          <p>
+            The number of trades on the <Link to="/account">account</Link> page is calculated based on on-chain data.
+          </p>
           <p>We have two publicly facing interfaces where both use the same contracts, which are:</p>
           <ul>
             <li>

--- a/src/custom/pages/Faq/TokenFaq.tsx
+++ b/src/custom/pages/Faq/TokenFaq.tsx
@@ -1,6 +1,7 @@
 import Page, { Content } from 'components/Page'
 
 import { ExternalLinkFaq, Wrapper } from './styled'
+import { Link } from 'react-router-dom'
 import { Footer } from '.'
 import { useToC } from './hooks'
 import ToC from './ToC'
@@ -51,9 +52,10 @@ export default function TokenFaq() {
           </h3>
           <p>
             {' '}
-            Directly in the CowSwap UI. Simply click on the profile section at the top left of the page, or in the menu
-            if you are on mobile, and you will be redirected to a page where you can see your total combined balance for
-            COW and vCOW and convert them instantly.
+            Directly in the CowSwap UI. Simply click on the <Link to="/account">account</Link> menu item at the top left
+            of the page (desktop) or in the mobile menu. You then will be redirected to the{' '}
+            <Link to="/account">account</Link> page where you can see your total COW and/or vCOW balance. You will then
+            be able to convert your vCOW to COW (if applicable).
           </p>
 
           <h3 id="what-is-the-purpose-of-cow-token">What is the purpose of COW Token?</h3>


### PR DESCRIPTION
# Summary

- Part of a waterfall PR, the final one being #596 
- Change some `/profile` link references to use `/account` instead.