### PR TITLE
Improve header 13

### DIFF
--- a/src/custom/components/Header/NetworkSelector/NetworkSelectorMod.tsx
+++ b/src/custom/components/Header/NetworkSelector/NetworkSelectorMod.tsx
@@ -67,19 +67,19 @@ const FlyoutHeader = styled.div`
   color: ${({ theme }) => theme.text2};
   font-weight: 400;
 ` */
-const FlyoutMenu = styled.div`
+export const FlyoutMenu = styled.div`
   position: absolute;
   top: 54px;
   width: 272px;
   z-index: 99;
   padding-top: 10px;
-  @media screen and (min-width: ${MEDIA_WIDTHS.upToSmall}px) {
+  /* @media screen and (min-width: ${MEDIA_WIDTHS.upToSmall}px) {
     top: 38px;
-  }
+  } */
 
-  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+  /* ${({ theme }) => theme.mediaWidth.upToExtraSmall`
     right: 20%;
-  `}
+  `} */
 `
 // mod: actually, this is closer to original version but I haven't yet pulled latest from uniswap
 const FlyoutMenuContents = styled.div`

--- a/src/custom/components/Header/NetworkSelector/index.tsx
+++ b/src/custom/components/Header/NetworkSelector/index.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components/macro'
 import NetworkSelectorMod, { SelectorLabel, SelectorControls, FlyoutMenu } from './NetworkSelectorMod'
 import { transparentize } from 'polished'
+export { getChainNameFromId, getParsedChainId } from './NetworkSelectorMod'
 
 const Wrapper = styled.div`
   display: flex;

--- a/src/custom/components/Header/NetworkSelector/index.tsx
+++ b/src/custom/components/Header/NetworkSelector/index.tsx
@@ -1,9 +1,20 @@
 import styled from 'styled-components/macro'
-import NetworkSelectorMod, { SelectorLabel, SelectorControls } from './NetworkSelectorMod'
+import NetworkSelectorMod, { SelectorLabel, SelectorControls, FlyoutMenu } from './NetworkSelectorMod'
 import { transparentize } from 'polished'
 
 const Wrapper = styled.div`
   display: flex;
+
+  ${FlyoutMenu} {
+    top: 38px;
+    right: 0;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      width: 100%;
+      left: 0;
+      top: 58px;
+    `};
+  }
 
   ${SelectorLabel} {
     ${({ theme }) => theme.mediaWidth.upToMedium`

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -117,7 +117,7 @@ export default function Header() {
                       >
                         <SVG
                           src={darkMode ? IMAGE_SUN : IMAGE_MOON}
-                          description={`${darkMode ? 'Sun/light mode' : 'Moon/dark'} mode icon`}
+                          description={`${darkMode ? 'Sun/light' : 'Moon/dark'} mode icon`}
                         />{' '}
                         {darkMode ? 'Light' : 'Dark'} Mode
                       </button>

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -69,7 +69,7 @@ export default function Header() {
 
   const [isOrdersPanelOpen, setIsOrdersPanelOpen] = useState<boolean>(false)
   const closeOrdersPanel = () => setIsOrdersPanelOpen(false)
-  const openOrdersPanel = () => setIsOrdersPanelOpen(true)
+  const openOrdersPanel = () => account && setIsOrdersPanelOpen(true)
 
   const history = useHistory()
   const handleBalanceButtonClick = () => history.push('/account')

--- a/src/custom/hooks/useChangeNetworks.ts
+++ b/src/custom/hooks/useChangeNetworks.ts
@@ -9,7 +9,7 @@ import usePrevious from 'hooks/usePrevious'
 import { addPopup, ApplicationModal } from 'state/application/reducer'
 import { useAppDispatch } from 'state/hooks'
 import { replaceURLParam } from 'utils/routes'
-import { getChainNameFromId, getParsedChainId } from 'components/Header/NetworkSelector/NetworkSelectorMod'
+import { getChainNameFromId, getParsedChainId } from 'components/Header/NetworkSelector'
 import { useHistory } from 'react-router-dom'
 
 type ChangeNetworksParams = Pick<ReturnType<typeof useActiveWeb3React>, 'account' | 'chainId' | 'library'>

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -66,7 +66,7 @@ export const BodyWrapper = styled.div<{ location: { pathname: string } }>`
   `}
 
   ${({ theme, location }) => theme.mediaWidth.upToMedium`
-    padding: ${location.pathname === '/swap' ? '0 0 16px' : '0 16px 16px'};
+    padding: ${location.pathname === Routes.SWAP ? '0 0 16px' : '0 16px 16px'};
   `}
 `
 


### PR DESCRIPTION
# Summary

Addresses general feedback on the waterfall PRs:
- Fix network selector position on medium/smaller resolutions (@alfetopito )
- Use a route from ENUM in place of '/swap' (@alfetopito )
- Only open the `ordersPanel` if `account` is true. There was a bug where on click of 'CONNECT A WALLET' it would open the orderspanel + connect a wallet modal (@nenadV91 )
- Fix/restore export/import mod path for the network selector (@W3stside )