### PR TITLE
574/tokens page saved tokens

### DIFF
--- a/src/custom/components/Button/index.tsx
+++ b/src/custom/components/Button/index.tsx
@@ -1,6 +1,8 @@
+import { HTMLAttributes } from 'react'
 import styled from 'styled-components/macro'
 import { ButtonProps } from 'rebass/styled-components'
-import { ChevronDown } from 'react-feather'
+import { ChevronDown, Star } from 'react-feather'
+import useTheme from 'hooks/useTheme'
 
 import { RowBetween } from 'components/Row'
 
@@ -186,6 +188,19 @@ export const ButtonEmpty = styled(ButtonEmptyMod)`
   // CSS overrides
 `
 
+const HoverIcon = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+  margin-right: 8px;
+
+  :hover {
+    cursor: pointer;
+    opacity: 0.6;
+  }
+`
+
 type ButtonCustomProps = ButtonProps & {
   buttonSize?: ButtonSize
 }
@@ -233,5 +248,18 @@ export function ButtonDropdownLight({
         <ChevronDown size={24} />
       </RowBetween>
     </ButtonOutlined>
+  )
+}
+
+export const ButtonStar = ({
+  fill = false,
+  size = '15px',
+  ...rest
+}: { fill: boolean; size?: string } & HTMLAttributes<HTMLDivElement>) => {
+  const theme = useTheme()
+  return (
+    <HoverIcon {...rest}>
+      <Star stroke={theme.text3} fill={fill ? theme.text3 : 'transparent'} size={size} />
+    </HoverIcon>
   )
 }

--- a/src/custom/components/Tokens/SavedTokenButton.tsx
+++ b/src/custom/components/Tokens/SavedTokenButton.tsx
@@ -1,0 +1,29 @@
+import { useCallback, useMemo } from 'react'
+import { Token } from '@uniswap/sdk-core'
+import { useSavedTokens, useToggleSavedToken } from 'state/user/hooks'
+import { ButtonStar } from 'components/Button'
+
+type SavedTokenButtonParams = {
+  tokenData: Token
+}
+
+export default function SavedTokenButton({ tokenData }: SavedTokenButtonParams) {
+  const savedTokens = useSavedTokens()
+
+  const toggleSavedToken = useToggleSavedToken()
+
+  const handleSavedToken = useCallback(
+    (event) => {
+      event.preventDefault()
+      toggleSavedToken(tokenData)
+    },
+    [toggleSavedToken, tokenData]
+  )
+
+  const isSavedToken = useMemo(
+    () => savedTokens.some((t: Token) => t.address === tokenData.address),
+    [savedTokens, tokenData]
+  )
+
+  return <ButtonStar fill={isSavedToken} onClick={handleSavedToken} />
+}

--- a/src/custom/components/Tokens/TokensTable.tsx
+++ b/src/custom/components/Tokens/TokensTable.tsx
@@ -16,9 +16,19 @@ const SORT_FIELD = {
 type TokenTableParams = {
   tokensData: Token[] | undefined
   maxItems?: number
+  tableType?: TableType
 }
 
-export default function TokenTable({ tokensData, maxItems = MAX_ITEMS }: TokenTableParams) {
+export enum TableType {
+  OVERVIEW = 'OVERVIEW',
+  SAVED = 'SAVED',
+}
+
+export default function TokenTable({
+  tokensData,
+  maxItems = MAX_ITEMS,
+  tableType = TableType.OVERVIEW,
+}: TokenTableParams) {
   // sorting
   const [sortField, setSortField] = useState(SORT_FIELD.name)
   const [sortDirection, setSortDirection] = useState<boolean>(false)
@@ -92,7 +102,7 @@ export default function TokenTable({ tokensData, maxItems = MAX_ITEMS }: TokenTa
               if (data) {
                 return (
                   <React.Fragment key={i}>
-                    <TokensTableRow index={(page - 1) * MAX_ITEMS + i} tokenData={data} />
+                    <TokensTableRow tableType={tableType} index={(page - 1) * MAX_ITEMS + i} tokenData={data} />
                     <Break />
                   </React.Fragment>
                 )
@@ -121,8 +131,8 @@ export default function TokenTable({ tokensData, maxItems = MAX_ITEMS }: TokenTa
         </AutoColumn>
       ) : (
         <LoadingRows>
-          {Array.from(Array(maxItems * 4), () => (
-            <div />
+          {Array.from(Array(maxItems * 4), (n, i) => (
+            <div key={i} />
           ))}
         </LoadingRows>
       )}

--- a/src/custom/components/Tokens/TokensTableRow.tsx
+++ b/src/custom/components/Tokens/TokensTableRow.tsx
@@ -2,17 +2,30 @@ import { Token } from '@uniswap/sdk-core'
 import { RowFixed } from 'components/Row'
 import useTheme from 'hooks/useTheme'
 import { LinkWrapper, ResponsiveGrid, Label, MediumOnly, HideMedium, ResponsiveLogo } from './styled'
+import SavedTokenButton from './SavedTokenButton'
+import { TableType } from './TokensTable'
 
-const DataRow = ({ tokenData, index }: { tokenData: Token; index: number }) => {
+type DataRowParams = {
+  tokenData: Token
+  index: number
+  tableType?: TableType
+}
+
+const DataRow = ({ tokenData, tableType, index }: DataRowParams) => {
   const theme = useTheme()
+
   return (
-    <LinkWrapper to={'tokens/' + tokenData.address}>
-      <ResponsiveGrid>
-        <Label>{index + 1}</Label>
-        <Label>
-          <RowFixed>
-            <ResponsiveLogo currency={tokenData} />
-          </RowFixed>
+    <ResponsiveGrid>
+      <Label>
+        {tableType === TableType.OVERVIEW ? <SavedTokenButton tokenData={tokenData} /> : null}
+        <span>{index + 1}</span>
+      </Label>
+      <Label>
+        <RowFixed>
+          <ResponsiveLogo currency={tokenData} />
+        </RowFixed>
+
+        <LinkWrapper to={'tokens/' + tokenData.address}>
           <MediumOnly style={{ marginLeft: '6px' }}>
             <Label ml="8px">{tokenData.symbol}</Label>
           </MediumOnly>
@@ -27,9 +40,9 @@ const DataRow = ({ tokenData, index }: { tokenData: Token; index: number }) => {
               </Label>
             </RowFixed>
           </HideMedium>
-        </Label>
-      </ResponsiveGrid>
-    </LinkWrapper>
+        </LinkWrapper>
+      </Label>
+    </ResponsiveGrid>
   )
 }
 

--- a/src/custom/components/Tokens/TokensTableRow.tsx
+++ b/src/custom/components/Tokens/TokensTableRow.tsx
@@ -1,7 +1,7 @@
 import { Token } from '@uniswap/sdk-core'
 import { RowFixed } from 'components/Row'
 import useTheme from 'hooks/useTheme'
-import { LinkWrapper, ResponsiveGrid, Label, MediumOnly, HideMedium, ResponsiveLogo } from './styled'
+import { LinkWrapper, ResponsiveGrid, Label, MediumOnly, HideMedium, ResponsiveLogo, IndexNumber } from './styled'
 import SavedTokenButton from './SavedTokenButton'
 import { TableType } from './TokensTable'
 
@@ -11,14 +11,14 @@ type DataRowParams = {
   tableType?: TableType
 }
 
-const DataRow = ({ tokenData, tableType, index }: DataRowParams) => {
+const DataRow = ({ tokenData, index }: DataRowParams) => {
   const theme = useTheme()
 
   return (
     <ResponsiveGrid>
       <Label>
-        {tableType === TableType.OVERVIEW ? <SavedTokenButton tokenData={tokenData} /> : null}
-        <span>{index + 1}</span>
+        <SavedTokenButton tokenData={tokenData} />
+        <IndexNumber>{index + 1}</IndexNumber>
       </Label>
       <Label>
         <RowFixed>

--- a/src/custom/components/Tokens/styled.ts
+++ b/src/custom/components/Tokens/styled.ts
@@ -120,3 +120,7 @@ export const TableHeader = styled(ResponsiveGrid)`
 export const TableBody = styled(AutoColumn)`
   margin-bottom: 0.8rem;
 `
+
+export const IndexNumber = styled.span`
+  font-size: 1rem;
+`

--- a/src/custom/components/Tokens/styled.ts
+++ b/src/custom/components/Tokens/styled.ts
@@ -15,12 +15,15 @@ export const ResponsiveGrid = styled.div`
   display: grid;
   grid-gap: 1em;
   align-items: center;
-  grid-template-columns: 25px 5fr repeat(2, 1fr);
+  grid-template-columns: 40px 5fr repeat(2, 1fr);
+  text-align: left;
 `
 
 export const LinkWrapper = styled(Link)`
   text-decoration: none;
   padding: 0.8rem 0;
+  display: flex;
+  align-items: center;
 
   :hover {
     cursor: pointer;
@@ -37,7 +40,7 @@ export const ResponsiveLogo = styled(CurrencyLogo)`
 
 export const Label = styled(ThemedText.Label)<{ end?: number }>`
   display: flex;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 400;
   justify-content: ${({ end }) => (end ? 'flex-end' : 'flex-start')};
   color: ${({ theme }) => theme.text1};

--- a/src/custom/pages/Account/Tokens/TokensOverview.tsx
+++ b/src/custom/pages/Account/Tokens/TokensOverview.tsx
@@ -1,16 +1,17 @@
 import { useEffect, useMemo } from 'react'
-import { Wrapper, AccountPageWrapper, Subtitle } from '../styled'
+import { Wrapper, AccountPageWrapper, Subtitle, MainText, AccountCard } from '../styled'
 import { AccountMenu } from '../Menu'
 import { useAllTokens } from 'hooks/Tokens'
 import { notEmpty } from 'utils'
-import { Card } from 'pages/Profile/styled'
 import TokensTable from 'components/Tokens/TokensTable'
+import { useSavedTokens } from 'state/user/hooks'
 
 export default function TokensOverview() {
   useEffect(() => {
     window.scrollTo(0, 0)
   }, [])
 
+  const savedTokens = useSavedTokens()
   const allTokens = useAllTokens()
 
   const formattedTokens = useMemo(() => {
@@ -21,10 +22,19 @@ export default function TokensOverview() {
     <Wrapper>
       <AccountMenu />
       <AccountPageWrapper>
+        <Subtitle>Saved tokens</Subtitle>
+        <AccountCard>
+          {savedTokens.length > 0 ? (
+            <TokensTable tokensData={savedTokens} />
+          ) : (
+            <MainText>Saved tokens will appear here</MainText>
+          )}
+        </AccountCard>
+
         <Subtitle>All tokens</Subtitle>
-        <Card>
+        <AccountCard>
           <TokensTable tokensData={formattedTokens} />
-        </Card>
+        </AccountCard>
       </AccountPageWrapper>
     </Wrapper>
   )

--- a/src/custom/pages/Account/Tokens/TokensOverview.tsx
+++ b/src/custom/pages/Account/Tokens/TokensOverview.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useMemo } from 'react'
-import { Wrapper, AccountPageWrapper, Subtitle, MainText, AccountCard } from '../styled'
+import { Wrapper, AccountPageWrapper, Subtitle, MainText, AccountCard, AccountHeading, RemoveTokens } from '../styled'
 import { AccountMenu } from '../Menu'
 import { useAllTokens } from 'hooks/Tokens'
 import { notEmpty } from 'utils'
 import TokensTable from 'components/Tokens/TokensTable'
-import { useSavedTokens } from 'state/user/hooks'
+import { useSavedTokens, useRemoveAllSavedTokens } from 'state/user/hooks'
 
 export default function TokensOverview() {
   useEffect(() => {
@@ -14,6 +14,8 @@ export default function TokensOverview() {
   const savedTokens = useSavedTokens()
   const allTokens = useAllTokens()
 
+  const removeAllSavedTokens = useRemoveAllSavedTokens()
+
   const formattedTokens = useMemo(() => {
     return Object.values(allTokens).filter(notEmpty)
   }, [allTokens])
@@ -22,7 +24,10 @@ export default function TokensOverview() {
     <Wrapper>
       <AccountMenu />
       <AccountPageWrapper>
-        <Subtitle>Saved tokens</Subtitle>
+        <AccountHeading>
+          <Subtitle>Saved tokens</Subtitle>
+          <RemoveTokens onClick={() => removeAllSavedTokens()}>(Clear)</RemoveTokens>
+        </AccountHeading>
         <AccountCard>
           {savedTokens.length > 0 ? (
             <TokensTable tokensData={savedTokens} />
@@ -31,7 +36,9 @@ export default function TokensOverview() {
           )}
         </AccountCard>
 
-        <Subtitle>All tokens</Subtitle>
+        <AccountHeading>
+          <Subtitle>All tokens</Subtitle>
+        </AccountHeading>
         <AccountCard>
           <TokensTable tokensData={formattedTokens} />
         </AccountCard>

--- a/src/custom/pages/Account/styled.tsx
+++ b/src/custom/pages/Account/styled.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components/macro'
 import { Content } from 'components/Page'
 import { PageWrapper } from 'components/Page'
 import { ThemedText, MEDIA_WIDTHS } from 'theme'
+import { Card } from 'pages/Profile/styled'
 
 export const Wrapper = styled.div`
   display: grid;
@@ -75,4 +76,15 @@ export const AccountPageWrapper = styled(PageWrapper)`
 
 export const Subtitle = styled(ThemedText.MediumHeader)`
   padding-bottom: 1rem;
+  font-size: 1.1rem !important;
+`
+
+export const MainText = styled(ThemedText.Main)`
+  color: ${({ theme }) => theme.text1};
+  font-size: 14px;
+`
+
+export const AccountCard = styled(Card)`
+  min-height: auto;
+  margin-bottom: 1rem;
 `

--- a/src/custom/pages/Account/styled.tsx
+++ b/src/custom/pages/Account/styled.tsx
@@ -75,7 +75,6 @@ export const AccountPageWrapper = styled(PageWrapper)`
 `
 
 export const Subtitle = styled(ThemedText.MediumHeader)`
-  padding-bottom: 1rem;
   font-size: 1.1rem !important;
 `
 
@@ -87,4 +86,17 @@ export const MainText = styled(ThemedText.Main)`
 export const AccountCard = styled(Card)`
   min-height: auto;
   margin-bottom: 1rem;
+`
+
+export const AccountHeading = styled.div`
+  display: flex;
+  align-items: center;
+  padding-bottom: 1rem;
+`
+
+export const RemoveTokens = styled.button`
+  background: none;
+  border: none;
+  color: ${({ theme }) => theme.primary1};
+  cursor: pointer;
 `

--- a/src/state/user/actions.ts
+++ b/src/state/user/actions.ts
@@ -37,3 +37,4 @@ export const removeSerializedPair = createAction<{ chainId: number; tokenAAddres
   'user/removeSerializedPair'
 )
 export const toggleURLWarning = createAction<void>('app/toggleURLWarning') // MOD - legacy Uni we want to keep
+export const toggleSavedToken = createAction<{ serializedToken: SerializedToken }>('user/toggleSavedToken')

--- a/src/state/user/actions.ts
+++ b/src/state/user/actions.ts
@@ -38,3 +38,4 @@ export const removeSerializedPair = createAction<{ chainId: number; tokenAAddres
 )
 export const toggleURLWarning = createAction<void>('app/toggleURLWarning') // MOD - legacy Uni we want to keep
 export const toggleSavedToken = createAction<{ serializedToken: SerializedToken }>('user/toggleSavedToken')
+export const removeAllSavedTokens = createAction<{ chainId: number }>('user/removeAllSavedTokens')

--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -30,6 +30,7 @@ import {
   updateUserLocale,
   updateUserSlippageTolerance,
   toggleSavedToken,
+  removeAllSavedTokens,
 } from './actions'
 // TODO: mod, move to mod file
 import { useSwapActionHandlers } from '../swap/hooks'
@@ -404,4 +405,15 @@ export function useToggleSavedToken(): (token: Token) => void {
     },
     [dispatch]
   )
+}
+
+export function useRemoveAllSavedTokens(): () => void {
+  const { chainId } = useActiveWeb3React()
+  const dispatch = useAppDispatch()
+
+  return useCallback(() => {
+    if (chainId) {
+      dispatch(removeAllSavedTokens({ chainId }))
+    }
+  }, [dispatch, chainId])
 }

--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -29,6 +29,7 @@ import {
   updateUserExpertMode,
   updateUserLocale,
   updateUserSlippageTolerance,
+  toggleSavedToken,
 } from './actions'
 // TODO: mod, move to mod file
 import { useSwapActionHandlers } from '../swap/hooks'
@@ -380,4 +381,27 @@ export function useTrackedTokenPairs(): [Token, Token][] {
 
     return Object.keys(keyed).map((key) => keyed[key])
   }, [combinedList])
+}
+
+export function useSavedTokens(): Token[] {
+  const { chainId } = useActiveWeb3React()
+  const serializedTokensMap = useAppSelector(({ user: { savedTokens } }) => savedTokens)
+
+  return useMemo(() => {
+    if (!chainId) return []
+    const tokenMap: Token[] = serializedTokensMap?.[chainId]
+      ? Object.values(serializedTokensMap[chainId]).map(deserializeToken)
+      : []
+    return tokenMap
+  }, [serializedTokensMap, chainId])
+}
+
+export function useToggleSavedToken(): (token: Token) => void {
+  const dispatch = useAppDispatch()
+  return useCallback(
+    (token: Token) => {
+      dispatch(toggleSavedToken({ serializedToken: serializeToken(token) }))
+    },
+    [dispatch]
+  )
 }

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -23,6 +23,8 @@ import {
   updateUserLocale,
   // TODO: mod, shouldn't be here
   updateRecipientToggleVisible,
+  // saved tokens
+  toggleSavedToken,
 } from './actions'
 
 const currentTimestamp = () => new Date().getTime()
@@ -71,6 +73,13 @@ export interface UserState {
 
   // undefined means has not gone through A/B split yet
   showSurveyPopup: boolean | undefined
+
+  // saved tokens
+  savedTokens: {
+    [chainId: number]: {
+      [address: string]: SerializedToken
+    }
+  }
 }
 
 function pairKey(token0Address: string, token1Address: string) {
@@ -94,6 +103,7 @@ export const initialState: UserState = {
   timestamp: currentTimestamp(),
   URLWarningVisible: true,
   showSurveyPopup: undefined,
+  savedTokens: {},
 }
 
 export default createReducer(initialState, (builder) =>
@@ -206,5 +216,22 @@ export default createReducer(initialState, (builder) =>
     // MOD - legacy Uni code we want to keep
     .addCase(toggleURLWarning, (state) => {
       state.URLWarningVisible = !state.URLWarningVisible
+    })
+    .addCase(toggleSavedToken, (state, { payload: { serializedToken } }) => {
+      const { chainId, address } = serializedToken
+
+      if (!state.savedTokens) {
+        state.savedTokens = {}
+      }
+
+      if (!state.savedTokens[chainId]) {
+        state.savedTokens[chainId] = {}
+      }
+
+      if (!state.savedTokens[chainId][address]) {
+        state.savedTokens[chainId][address] = serializedToken
+      } else {
+        delete state.savedTokens[chainId][address]
+      }
     })
 )

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -25,6 +25,7 @@ import {
   updateRecipientToggleVisible,
   // saved tokens
   toggleSavedToken,
+  removeAllSavedTokens,
 } from './actions'
 
 const currentTimestamp = () => new Date().getTime()
@@ -233,5 +234,12 @@ export default createReducer(initialState, (builder) =>
       } else {
         delete state.savedTokens[chainId][address]
       }
+    })
+    .addCase(removeAllSavedTokens, (state, { payload: { chainId } }) => {
+      if (!state.savedTokens) {
+        state.savedTokens = {}
+      }
+
+      state.savedTokens[chainId] = {}
     })
 )


### PR DESCRIPTION
# Summary

Fixes #574

This PR adds a functionality to save token (add to favorite) and this will be stored in the redux and also in the local storage. Each chain will have a separate saved token list. There is also a button to clear all saved tokens.

![Screenshot from 2022-06-01 20-54-41](https://user-images.githubusercontent.com/34926005/171480990-3234963c-c300-4d6e-bfd7-d9029a014a9a.png)

With no saved tokens
![Screenshot from 2022-06-01 20-55-44](https://user-images.githubusercontent.com/34926005/171481121-c239cad9-7bbe-4297-86db-eec3ab2da73a.png)

Note: One thing I've just noticed is the token icons for all and saved are not same for 1Inch :thinking: but :man_shrugging: 