### PR TITLE
Change Mainnet Price Strategy to `COWSWAP`

### DIFF
--- a/config/strategies/strategy-1.json
+++ b/config/strategies/strategy-1.json
@@ -1,4 +1,4 @@
 {
-  "primary": "LEGACY",
-  "secondary": "COWSWAP"
+  "primary": "COWSWAP",
+  "secondary": "LEGACY"
 }


### PR DESCRIPTION
# Summary

This PR just changes the mainnet price strategy to use `COWSWAP` as the primary strategy (that is, only use backend prices) and fallback to `LEGACY` (that is, using other DexAg prices).

This should have the effect of using the 0x and ParaSwap query configurations that we have in our backend (disabling Balancer V2 liquidity because of <https://forum.balancer.fi/t/medium-severity-bug-found/3161>).
