### PR TITLE
Fix issue with deadline

### DIFF
--- a/src/custom/hooks/useUSDCPrice/index.ts
+++ b/src/custom/hooks/useUSDCPrice/index.ts
@@ -19,7 +19,6 @@ import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
 import { currencyId } from 'utils/currencyId'
 import useBlockNumber from 'lib/hooks/useBlockNumber'
 import useGetGpPriceStrategy from 'hooks/useGetGpPriceStrategy'
-import { MAX_VALID_TO_EPOCH } from 'hooks/useSwapCallback'
 import { useIsQuoteLoading } from 'state/price/hooks'
 import { onlyResolvesLast } from 'utils/async'
 import { getGpUsdcPrice } from 'utils/price'
@@ -101,7 +100,8 @@ export default function useUSDCPrice(currency?: Currency) {
       toDecimals: stablecoin.decimals,
       userAddress: account,
       // we dont care about validTo here, just use max
-      validTo: MAX_VALID_TO_EPOCH,
+      // FIXME: I guess we care now, using 10min. Future versions of the API will make it optional
+      validTo: Math.ceil(Date.now() / 1000) + 600,
     }
 
     // tokens are the same, it's 1:1


### PR DESCRIPTION
# Summary

Sets the deadline to 10min in the future instead of the max value (in 84 years!)

This is just a temporary fix while this is an optional field in the backend.