### PR TITLE
Change Mainnet Price Strategy to `COWSWAP` - Take 2

### DIFF
--- a/config/strategies/strategy-1.json
+++ b/config/strategies/strategy-1.json
@@ -1,4 +1,4 @@
 {
-  "primary": "LEGACY",
-  "secondary": "COWSWAP"
+  "primary": "COWSWAP",
+  "secondary": "LEGACY"
 }


### PR DESCRIPTION
# Summary

This PR re-applies #620 (description included below).

The original PR #620 was reverted as changes to the backend made the pricing requests that were made by the FE no longer work (we were rejecting quotes with `validTo`s set too far in the future, and for pricing, the frontend was using `0xffffffff` - i.e. the maximum possible value).

It should be safe to re-apply these changes as we now have configured the backend to skip the maximum `validTo` check.

Moving forward, we should probably stop using `0xffffffff` for the `validTo` value. There are some proposed changes (https://github.com/cowprotocol/services/pull/249) that add new semantics that can be used here:
- We have a new `validFor` that can be specified instead of `validTo` for specifying validity with a duration (instead of an absolute validity). The backend computes a `validTo` value based on the duration and returns it with the quote response.
- You can omit `validTo` and `validFor` for a "sane" default value (30min).

Also, more long term, the frontend should set the `validTo` to be the actual value configured in the UI, as it would be plausible for us to implement some different fee quoting based on the validity of the order (i.e. pay a premium for longer standing orders to account for gas price fluctuation risks).

---

**Original PR description**:

This PR just changes the mainnet price strategy to use `COWSWAP` as the primary strategy (that is, only use backend prices) and fallback to `LEGACY` (that is, using other DexAg prices).

This should have the effect of using the 0x and ParaSwap query configurations that we have in our backend (disabling Balancer V2 liquidity because of <https://forum.balancer.fi/t/medium-severity-bug-found/3161>).