### PR TITLE
[Analytics] Sign flow: send to wallet & Cancel & Error

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -32,6 +32,8 @@ export const APP_DATA_HASH = getAppDataHash()
 export const PRODUCTION_URL = 'cowswap.exchange'
 export const BARN_URL = `barn.${PRODUCTION_URL}`
 
+export const PROVIDER_REJECT_REQUEST_CODE = 4001
+
 // Allow WALLET_LINK to be activated on mobile
 // since COINBASE_LINK is limited to use only 1 deeplink on mobile
 SUPPORTED_WALLETS_UNISWAP.WALLET_LINK = {

--- a/src/custom/hooks/useWrapCallback.ts
+++ b/src/custom/hooks/useWrapCallback.ts
@@ -16,7 +16,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { TransactionResponse } from '@ethersproject/providers'
 import { Contract } from '@ethersproject/contracts'
 import { getChainCurrencySymbols } from 'utils/gnosis_chain/hack'
-import { AMOUNT_PRECISION, RADIX_HEX } from 'constants/index'
+import { AMOUNT_PRECISION, PROVIDER_REJECT_REQUEST_CODE, RADIX_HEX } from 'constants/index'
 import { SupportedChainId as ChainId } from 'constants/chains'
 import { supportedChainId } from 'utils/supportedChainId'
 import { formatSmart } from 'utils/format'
@@ -158,7 +158,7 @@ function _getWrapUnwrapCallback(params: GetWrapUnwrapCallback): WrapUnwrapCallba
       } catch (error) {
         closeModals()
 
-        const action = (error?.code === 4001 ? 'Reject' : 'Error') + ' Signing transaction'
+        const action = (error?.code === PROVIDER_REJECT_REQUEST_CODE ? 'Reject' : 'Error') + ' Signing transaction'
 
         ReactGA.event({
           category: ANALYTICS_WRAP_CATEGORY,

--- a/src/custom/hooks/useWrapCallback.ts
+++ b/src/custom/hooks/useWrapCallback.ts
@@ -138,7 +138,7 @@ function _getWrapUnwrapCallback(params: GetWrapUnwrapCallback): WrapUnwrapCallba
 
         ReactGA.event({
           category: ANALYTICS_WRAP_CATEGORY,
-          action: 'Send Transaction to Wallet',
+          action: 'Send Order to Wallet',
           label: operationMessage,
         })
 

--- a/src/custom/hooks/useWrapCallback.ts
+++ b/src/custom/hooks/useWrapCallback.ts
@@ -138,14 +138,14 @@ function _getWrapUnwrapCallback(params: GetWrapUnwrapCallback): WrapUnwrapCallba
 
         ReactGA.event({
           category: ANALYTICS_WRAP_CATEGORY,
-          action: 'Send transaction to Wallet',
+          action: 'Send Transaction to Wallet',
           label: operationMessage,
         })
 
         const txReceipt = await wrapUnwrap()
         ReactGA.event({
           category: ANALYTICS_WRAP_CATEGORY,
-          action: 'Sign transaction',
+          action: 'Sign Transaction',
           label: operationMessage,
         })
         addTransaction({

--- a/src/custom/hooks/useWrapCallback.ts
+++ b/src/custom/hooks/useWrapCallback.ts
@@ -138,7 +138,7 @@ function _getWrapUnwrapCallback(params: GetWrapUnwrapCallback): WrapUnwrapCallba
 
         ReactGA.event({
           category: ANALYTICS_WRAP_CATEGORY,
-          action: 'Send Order to Wallet',
+          action: 'Send Transaction to Wallet',
           label: operationMessage,
         })
 

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -434,18 +434,25 @@ export default function Swap({
 
     const marketLabel = [trade?.inputAmount?.currency?.symbol, trade?.outputAmount?.currency?.symbol].join(',')
 
+    ReactGA.event({
+      category: 'Swap',
+      action: 'Send Order to Wallet',
+      label: marketLabel,
+    })
+
     setSwapState({ attemptingTxn: true, tradeToConfirm, showConfirm, swapErrorMessage: undefined, txHash: undefined })
     swapCallback()
       .then((hash) => {
         setSwapState({ attemptingTxn: false, tradeToConfirm, showConfirm, swapErrorMessage: undefined, txHash: hash })
+        let analyticsAction
+        if (recipient === null) {
+          analyticsAction = 'Swap'
+        } else {
+          analyticsAction = (recipientAddress ?? recipient) === account ? 'Swap and Send to Self' : 'Swap and Send'
+        }
         ReactGA.event({
           category: 'Swap',
-          action:
-            recipient === null
-              ? 'Swap w/o Send'
-              : (recipientAddress ?? recipient) === account
-              ? 'Swap w/o Send + recipient'
-              : 'Swap w/ Send',
+          action: analyticsAction,
           label: marketLabel,
         })
       })

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -524,10 +524,7 @@ export default function Swap({
 
   const handleMaxInput = useCallback(() => {
     maxInputAmount && onUserInput(Field.INPUT, maxInputAmount.toExact())
-    ReactGA.event({
-      category: 'Swap',
-      action: 'Max',
-    })
+    reportAnalytics('Max')
   }, [maxInputAmount, onUserInput])
 
   const handleOutputSelect = useCallback(

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -463,7 +463,7 @@ export default function Swap({
           swapErrorMessage = error.message
           actionAnalytics = 'Signing Error'
 
-          if (error?.code && !isNaN(error.code)) {
+          if (error?.code && typeof error.code === 'number') {
             errorCode = error.code
           }
           console.error('Error Signing Order', error)

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -448,9 +448,10 @@ export default function Swap({
 
         let actionAnalytics
         if (recipient === null) {
-          actionAnalytics = 'Swap'
+          actionAnalytics = 'Signed: Swap'
         } else {
-          actionAnalytics = (recipientAddress ?? recipient) === account ? 'Swap and Send to Self' : 'Swap and Send'
+          actionAnalytics =
+            (recipientAddress ?? recipient) === account ? 'Signed: Swap and Send to Self' : 'Signed: Swap and Send'
         }
         reportAnalytics(actionAnalytics, marketLabel)
       })

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -65,7 +65,7 @@ import { supportedChainId } from 'utils/supportedChainId'
 // import AppBody from 'pages/AppBody'
 
 // MOD imports
-import { AMOUNT_PRECISION, INITIAL_ALLOWED_SLIPPAGE_PERCENT } from 'constants/index'
+import { AMOUNT_PRECISION, INITIAL_ALLOWED_SLIPPAGE_PERCENT, PROVIDER_REJECT_REQUEST_CODE } from 'constants/index'
 import FeeInformationTooltip from 'components/swap/FeeInformationTooltip'
 import { useWalletInfo } from 'hooks/useWalletInfo'
 import { HashLink } from 'react-router-hash-link'
@@ -361,7 +361,7 @@ export default function Swap({
         await gatherPermitSignature()
       } catch (error) {
         // try to approve if gatherPermitSignature failed for any reason other than the user rejecting it
-        if (error?.code !== 4001) {
+        if (error?.code !== PROVIDER_REJECT_REQUEST_CODE) {
           approveRequired = true
         }
       }

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -90,11 +90,12 @@ const AlertWrapper = styled.div`
   width: 100%;
 `
 
-function reportAnalytics(action: string, label?: string) {
+function reportAnalytics(action: string, label?: string, value?: number) {
   ReactGA.event({
     category: 'Swap',
     action,
     label,
+    value,
   })
 }
 
@@ -454,13 +455,17 @@ export default function Swap({
         reportAnalytics(actionAnalytics, marketLabel)
       })
       .catch((error) => {
-        let swapErrorMessage, actionAnalytics
+        let swapErrorMessage, actionAnalytics, errorCode
         if (error?.code === PROVIDER_REJECT_REQUEST_CODE) {
           swapErrorMessage = 'User rejected signing the order'
           actionAnalytics = 'Reject'
         } else {
           swapErrorMessage = error.message
           actionAnalytics = 'Signing Error'
+
+          if (error?.code && !isNaN(error.code)) {
+            errorCode = error.code
+          }
           console.error('Error Signing Order', error)
         }
 
@@ -471,7 +476,7 @@ export default function Swap({
           swapErrorMessage,
           txHash: undefined,
         })
-        reportAnalytics(actionAnalytics, marketLabel)
+        reportAnalytics(actionAnalytics, marketLabel, errorCode)
       })
   }, [swapCallback, priceImpact, tradeToConfirm, showConfirm, recipient, recipientAddress, account, trade])
 


### PR DESCRIPTION
# Summary

Adds events for order signing.

Adds the following action that were not tracked:
- Send transaction to Wallet
- Reject
- Signing Error

See complete list of events:
https://docs.google.com/spreadsheets/d/1AwcuvmPaAyIRuKayOEp1cKcVGD3MLOpfS8UWA04fBtY/edit#gid=0

# Bonus

## Handle rejections case
Before this PR we were not handling the rejections of the signing differently from any other error. This was making the error message displayed to the user not very clear

Before:
<img width="992" alt="image" src="https://user-images.githubusercontent.com/2352112/171931893-17283811-e276-4ea3-a994-6b9639fa2c23.png">

This PR improves the message (I had to differentiate between errors and rejections, so I just went for this change, i hope its OK) 

after:
<img width="1079" alt="Screenshot at Jun 03 19-17-52" src="https://user-images.githubusercontent.com/2352112/171932224-3f0ed86e-8c5d-4621-a914-20aecce65820.png">


## Rename some event names
This PR gets rid of some weird error names, now the events that tract the success singing the order are:
- **Signed: Swap**:  Normal swap (before `Swap w/o Send`)
- **Signed: Swap and Send to Self**: Swap and send tokens to yourself (before `Swap w/o Send + recipient`)
- **Signed: Swap and Send**: Swap and send tokens to someone else (before `Swap w/ Send`)

## Small refactor event reporting
I took the license of changing some Mod code since this mod differs so much from the original already and we plan to refactor it (for limit order implementation).

This PR creates a convenient function to reduce some repetition in the event tracking (`reportAnalytics`)

## Small Refactor Rejection of TX
The code uses the code 4001 as a magic number to check if a request sent to a wallet has been rejected. This PR moves it to a const `PROVIDER_REJECT_REQUEST_CODE = 4001`


# To Test

1. Install and activate https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en 
2. Verify the events by changing the expiration time of the orders, or restoring the defaults
3. Verify the console, it should write the event that was sent to analytics
 