### PR TITLE
Fix iOS scrolling mobile menu overlay attempt and improve events

### DIFF
--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -123,7 +123,7 @@ interface AccountDetailsProps {
   confirmedTransactions: string[]
   ENSName?: string
   toggleWalletModal: () => void
-  closeOrdersPanel: () => void
+  handleCloseOrdersPanel: () => void
 }
 
 export default function AccountDetails({
@@ -131,7 +131,7 @@ export default function AccountDetails({
   confirmedTransactions = [],
   ENSName,
   toggleWalletModal,
-  closeOrdersPanel,
+  handleCloseOrdersPanel,
 }: AccountDetailsProps) {
   const { account, connector, chainId: connectedChainId } = useActiveWeb3React()
   const chainId = supportedChainId(connectedChainId)
@@ -148,7 +148,7 @@ export default function AccountDetails({
   const handleDisconnectClick = () => {
     ;(connector as any).close()
     localStorage.removeItem(STORAGE_KEY_LAST_PROVIDER)
-    closeOrdersPanel()
+    handleCloseOrdersPanel()
     toggleWalletModal()
   }
 

--- a/src/custom/components/Header/styled.ts
+++ b/src/custom/components/Header/styled.ts
@@ -235,7 +235,10 @@ export const HeaderLinks = styled(HeaderLinksMod)<{ isMobileMenuOpen: boolean }>
     background: ${({ theme }) => theme.bg4};
     outline: 0;
     padding: 60px 8px;
-    overflow-y: auto;
+    overflow-x: hidden;
+    overflow-y: scroll;
+    -webkit-overflow-scrolling: touch; // iOS scroll fix
+    transform: translate3d(0,0,0); // iOS scroll fix
 
     ${
       isMobileMenuOpen &&

--- a/src/custom/components/Header/styled.ts
+++ b/src/custom/components/Header/styled.ts
@@ -91,6 +91,18 @@ export const Wrapper = styled.div<{ isMobileMenuOpen: boolean }>`
         css`
           position: absolute;
           top: 0;
+
+          &::before {
+            content: '';
+            width: 100%;
+            display: flex;
+            height: 60px;
+            background: ${({ theme }) => theme.bg4};
+            position: fixed;
+            top: 0;
+            left: 0;
+            z-index: 101;
+          }
         `
       }
     `}
@@ -244,20 +256,6 @@ export const HeaderLinks = styled(HeaderLinksMod)<{ isMobileMenuOpen: boolean }>
       isMobileMenuOpen &&
       css`
         display: flex;
-
-        &::before {
-          content: '';
-          width: 100%;
-          display: flex;
-          height: 60px;
-          background: ${({ theme }) => theme.bg4};
-          position: fixed;
-          top: 0;
-          left: 0;
-          z-index: 1;
-        }
-
-        // transform: translate3d(100%, 0, 0);
       `
     }
   `};

--- a/src/custom/components/OrdersPanel/index.tsx
+++ b/src/custom/components/OrdersPanel/index.tsx
@@ -147,10 +147,10 @@ const isConfirmed = (data: TransactionAndOrder) =>
   data.status === OrderStatus.FULFILLED || data.status === OrderStatus.EXPIRED || data.status === OrderStatus.CANCELLED
 
 export interface OrdersPanelProps {
-  closeOrdersPanel: () => void
+  handleCloseOrdersPanel: () => void
 }
 
-export default function OrdersPanel({ closeOrdersPanel }: OrdersPanelProps) {
+export default function OrdersPanel({ handleCloseOrdersPanel }: OrdersPanelProps) {
   const walletInfo = useWalletInfo()
   const toggleWalletModal = useWalletModalToggle()
 
@@ -177,12 +177,12 @@ export default function OrdersPanel({ closeOrdersPanel }: OrdersPanelProps) {
 
   return (
     <>
-      <SidebarBackground onClick={closeOrdersPanel} />
+      <SidebarBackground onClick={handleCloseOrdersPanel} />
       <SideBar>
         <Wrapper>
           <Header>
             <strong>Account</strong>
-            <CloseIcon onClick={closeOrdersPanel} />
+            <CloseIcon onClick={handleCloseOrdersPanel} />
           </Header>
 
           <AccountDetails
@@ -190,7 +190,7 @@ export default function OrdersPanel({ closeOrdersPanel }: OrdersPanelProps) {
             pendingTransactions={pendingActivity}
             confirmedTransactions={confirmedActivity}
             toggleWalletModal={toggleWalletModal}
-            closeOrdersPanel={closeOrdersPanel}
+            handleCloseOrdersPanel={handleCloseOrdersPanel}
           />
         </Wrapper>
       </SideBar>

--- a/src/custom/hooks/useMediaQuery.ts
+++ b/src/custom/hooks/useMediaQuery.ts
@@ -18,5 +18,8 @@ export const useMediaQuery = (query: string) => {
 }
 
 export const upToSmall = `(max-width: ${MEDIA_WIDTHS.upToSmall}px)`
+export const isMediumOnly = `(min-width: ${MEDIA_WIDTHS.upToSmall + 1}px) and (max-width: ${MEDIA_WIDTHS.upToMedium}px)`
 export const upToMedium = `(max-width: ${MEDIA_WIDTHS.upToMedium}px)`
+export const isLargeOnly = `(min-width: ${MEDIA_WIDTHS.upToMedium + 1}px) and (max-width: ${MEDIA_WIDTHS.upToLarge}px)`
 export const upToLarge = `(max-width: ${MEDIA_WIDTHS.upToLarge}px)`
+export const LargeAndUp = `(min-width: ${MEDIA_WIDTHS.upToLarge + 1}px)`

--- a/src/custom/utils/toggleBodyClass.ts
+++ b/src/custom/utils/toggleBodyClass.ts
@@ -7,9 +7,11 @@ export const toggleBodyClass = (className: string) => {
 }
 
 export const addBodyClass = (className: string) => {
+  console.log('addBodyClass ', className)
   !document.body.classList.contains(className) && document.body.classList.add(className)
 }
 
 export const removeBodyClass = (className: string) => {
+  console.log('removeBodyClass ', className)
   document.body.classList.contains(className) && document.body.classList.remove(className)
 }


### PR DESCRIPTION
# Summary

- Attempt to improve iOS janky scrolling in the mobile menu overlay
- Fix race condition with adding `noScroll` class to Body. It got added then removed right away when the mobile menu overlay was open. While it should stay added. Fixed now.
- Optimize media query detection by adding `isLargeAndUp`
- Detect if a device has touch capabilities with `isTouch` and use that to have the app pick `onClick` vs `onTouchStart` event.