### PR TITLE
Add missing events for claiming COW

### DIFF
--- a/src/custom/pages/Profile/LockedGnoVesting/index.tsx
+++ b/src/custom/pages/Profile/LockedGnoVesting/index.tsx
@@ -40,11 +40,10 @@ interface Props {
   loading: boolean
 }
 
-function reportAnalytics(action: string, label?: string, value?: number) {
+function reportAnalytics(action: string, value?: number) {
   ReactGA.event({
-    category: 'COW Claim',
+    category: 'Claim COW for Locked GNO',
     action,
-    label,
     value,
   })
 }
@@ -84,8 +83,10 @@ const LockedGnoVesting: React.FC<Props> = ({ openModal, closeModal, vested, allo
 
     setStatus(ClaimStatus.ATTEMPTING)
 
+    reportAnalytics('Send Transaction to Wallet')
     claimCallback()
       .then((tx) => {
+        reportAnalytics('Sign Transaction')
         setStatus(ClaimStatus.SUBMITTED)
         return tx.wait()
       })
@@ -101,10 +102,10 @@ const LockedGnoVesting: React.FC<Props> = ({ openModal, closeModal, vested, allo
         let errorMessage, actionAnalytics, errorCode
         if (isRejectRequestProviderError(error)) {
           errorMessage = 'User rejected signing COW claim transaction'
-          actionAnalytics = 'Reject'
+          actionAnalytics = 'Reject Signing Transaction'
         } else {
           errorMessage = getProviderErrorMessage(error)
-          actionAnalytics = 'Signing Error'
+          actionAnalytics = 'Error Signing Transaction'
 
           if (error?.code && typeof error.code === 'number') {
             errorCode = error.code
@@ -113,7 +114,7 @@ const LockedGnoVesting: React.FC<Props> = ({ openModal, closeModal, vested, allo
         }
         console.error('[Profile::LockedGnoVesting::index::claimCallback]::error', errorMessage)
         setStatus(ClaimStatus.INITIAL)
-        reportAnalytics(actionAnalytics, 'Locked GNO COW claiming', errorCode)
+        reportAnalytics(actionAnalytics, errorCode)
         handleSetError(errorMessage)
       })
   }, [handleCloseError, handleSetError, claimCallback])


### PR DESCRIPTION
# Summary

Completes David's PR https://github.com/cowprotocol/cowswap/pull/649

Add missing events that @elena-zh pointed out here:

>  Btw, there is no GA event for rejecting Convert transaction.

https://github.com/cowprotocol/cowswap/pull/655#issuecomment-1149762679

I also added the events in https://docs.google.com/spreadsheets/d/1AwcuvmPaAyIRuKayOEp1cKcVGD3MLOpfS8UWA04fBtY/edit#gid=0

# To Test
1. Install and activate https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en

2. Verify the events by claiming COW

3. Verify the console, it should write the event that was sent to analytics