### PR TITLE
EIP-1271 signature implementation

### DIFF
--- a/src/constants/misc.ts
+++ b/src/constants/misc.ts
@@ -40,3 +40,5 @@ export const TWO_PERCENT = new Percent(JSBI.BigInt(200), BIPS_BASE)
 export const ONE_HUNDRED_PERCENT = new Percent('1')
 
 export const IS_SIDE_BANNER_VISIBLE_KEY = 'IS_SIDEBAR_BANNER_VISIBLE'
+
+export const METHOD_NOT_FOUND_ERROR = 'Method not found'

--- a/src/custom/hooks/useCancelOrder.ts
+++ b/src/custom/hooks/useCancelOrder.ts
@@ -2,9 +2,11 @@ import { useCallback } from 'react'
 import { sendOrderCancellation } from 'utils/trade'
 import { useActiveWeb3React } from 'hooks/web3'
 import { useRequestOrderCancellation } from 'state/orders/hooks'
+import { useWalletInfo } from 'hooks/useWalletInfo'
 
 export const useCancelOrder = () => {
   const { account, chainId, library } = useActiveWeb3React()
+  const { isSmartContractWallet } = useWalletInfo()
   const cancelPendingOrder = useRequestOrderCancellation()
   return useCallback(
     async (orderId: string): Promise<void> => {
@@ -12,8 +14,8 @@ export const useCancelOrder = () => {
         return
       }
       const signer = library.getSigner()
-      return sendOrderCancellation({ chainId, orderId, signer, account, cancelPendingOrder })
+      return sendOrderCancellation({ chainId, orderId, signer, account, cancelPendingOrder, isSmartContractWallet })
     },
-    [account, cancelPendingOrder, chainId, library]
+    [account, cancelPendingOrder, chainId, isSmartContractWallet, library]
   )
 }


### PR DESCRIPTION
This PR , in concordance with [https://github.com/cowprotocol/contracts/pull/14](https://github.com/cowprotocol/contracts/pull/14), implements eip1271, a feature to be able to sign with smart contracts like Ambire Wallet or Argent (I've been informed that gnosis safe would (and should) return a method not found)

Notes : 
  - eth_sign + smart contract will NOT be attempted as the backend supports only 712 with 1271, therefore will throw a Method not found upstream
  - Gnosis safe, should as well return a Method not found, therefore triggering the above, and forwarding Method not found upstream, and finally fallback to presign