### PR TITLE
[Hotfix] 1.15.3 - fix Cow Api USDC fetching logic

### DIFF
--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -413,9 +413,7 @@ export async function getGpUsdcPrice({ strategy, quoteParams }: Pick<QuoteParams
     quoteParams.validTo = MAX_VALID_TO_EPOCH
     const { quote } = await getQuote(quoteParams)
 
-    // BUY order always. We also need to add the fee to the sellAmount to get the unaffected price
-    const amountWithoutFee = new BigNumberJs(quote.feeAmount).plus(new BigNumberJs(quote.sellAmount))
-    return amountWithoutFee.toString(10)
+    return quote.sellAmount
   } else {
     console.debug(
       '[GP PRICE::API] getGpUsdcPrice - Attempting best USDC quote retrieval using LEGACY strategy, hang tight.'

--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -20,7 +20,6 @@ import { GetQuoteResponse, OrderKind } from '@cowprotocol/contracts'
 import { ChainId } from 'state/lists/actions'
 import { toErc20Address } from 'utils/tokens'
 import { GpPriceStrategy } from 'hooks/useGetGpPriceStrategy'
-import { MAX_VALID_TO_EPOCH } from 'hooks/useSwapCallback'
 import useSWR from 'swr'
 
 const FEE_EXCEEDS_FROM_ERROR = new GpQuoteError({
@@ -410,7 +409,6 @@ export async function getGpUsdcPrice({ strategy, quoteParams }: Pick<QuoteParams
     console.debug(
       '[GP PRICE::API] getGpUsdcPrice - Attempting best USDC quote retrieval using COWSWAP strategy, hang tight.'
     )
-    quoteParams.validTo = MAX_VALID_TO_EPOCH
     const { quote } = await getQuote(quoteParams)
 
     return quote.sellAmount


### PR DESCRIPTION
# Summary

Part of the issues with 1.15.0 and co (1.15.1, 1.15.2) - the ETH USD value, price impact, and WETH/ETH showing different USD values

What was wrong:
ETH//WETH price impact

`getGpUsdcPrice` -- (`custom/utils/price.ts`) has a bug: 
<img width="879" alt="Pasted Graphic" src="https://user-images.githubusercontent.com/21335563/173806524-76bc0fb5-7cf0-4cf1-921d-930ae4faf0bd.png">

Comment on L416 is wrong, `sellAmount` returned in the response is the amount WITHOUT the `feeAmount` applied, thus `L417` should not exist. By existing it was returning a worse price as the `sellAmount` returned was then higher making the price worse.

The reason we weren't seeing it in BARN/LOCAL is that the `feeAmount` was marginal and not affecting price so much in certain cases.

We started seeing this more since the change to the `COWSWAP` strategy as the primary price feed, and probably only really saw it now. This was on me, sorry y'all 😞 

## Testing
This is a bit tricky to test fully but easy testing can be done by using the PR link and testing switching between WETH and ETH to see the same/similar usd prices.
- USD price should be similar
- USD value should fill immediately, no delay or non values