### PR TITLE
Use the same config URLs defined in the envs

### DIFF
--- a/src/custom/connectors/index.ts
+++ b/src/custom/connectors/index.ts
@@ -75,11 +75,12 @@ function getRpcNetworks(): [RpcNetworks, number[]] {
   return [rpcNetworks, supportedChainIds]
 }
 
-const [rpcNetworks, supportedChainIds] = getRpcNetworks()
-export const NETWORK_CHAIN_ID = supportedChainIds[0]
+export const [RPC_NETWORKS, SUPPORTED_CHAIN_IDS] = getRpcNetworks()
+
+export const NETWORK_CHAIN_ID = SUPPORTED_CHAIN_IDS[0]
 
 export const network = new NetworkConnector({
-  urls: rpcNetworks, // INFURA_NETWORK_URLS
+  urls: RPC_NETWORKS, // INFURA_NETWORK_URLS
   defaultChainId: NETWORK_CHAIN_ID, // 1
 })
 
@@ -96,7 +97,7 @@ export const gnosisSafe = new SafeAppConnector()
 
 export const walletconnect = new WalletConnectConnector({
   supportedChainIds: ALL_SUPPORTED_CHAIN_IDS,
-  rpc: rpcNetworks,
+  rpc: RPC_NETWORKS,
   bridge: WALLET_CONNECT_BRIDGE,
   qrcode: true,
 })
@@ -116,7 +117,7 @@ export const portis = new PortisConnector({
 }) */
 
 export const walletlink = new WalletLinkConnector({
-  url: rpcNetworks[NETWORK_CHAIN_ID],
+  url: RPC_NETWORKS[NETWORK_CHAIN_ID],
   appName: 'CowSwap',
   appLogoUrl: 'https://raw.githubusercontent.com/cowprotocol/cowswap/develop/public/favicon.png',
   supportedChainIds: getSupportedChainIds(),

--- a/src/custom/utils/switchToNetwork.ts
+++ b/src/custom/utils/switchToNetwork.ts
@@ -3,7 +3,7 @@ import { hexStripZeros } from '@ethersproject/bytes'
 import { ExternalProvider } from '@ethersproject/providers'
 import { CHAIN_INFO } from 'constants/chainInfo'
 import { SupportedChainId } from 'constants/chains'
-import { INFURA_NETWORK_URLS } from 'constants/infura'
+import { RPC_NETWORKS } from '../connectors'
 
 interface SwitchNetworkArguments {
   provider: ExternalProvider
@@ -11,31 +11,12 @@ interface SwitchNetworkArguments {
 }
 
 export function getRpcUrls(chainId: SupportedChainId): [string] {
-  switch (chainId) {
-    case SupportedChainId.MAINNET:
-    case SupportedChainId.RINKEBY:
-      /*case SupportedChainId.ROPSTEN:
-    case SupportedChainId.KOVAN:
-    case SupportedChainId.GOERLI:*/
-      return [INFURA_NETWORK_URLS[chainId]]
-    /*case SupportedChainId.OPTIMISM:
-      return ['https://mainnet.optimism.io']
-    case SupportedChainId.OPTIMISTIC_KOVAN:
-      return ['https://kovan.optimism.io']
-    case SupportedChainId.ARBITRUM_ONE:
-      return ['https://arb1.arbitrum.io/rpc']
-    case SupportedChainId.ARBITRUM_RINKEBY:
-      return ['https://rinkeby.arbitrum.io/rpc']
-    case SupportedChainId.POLYGON:
-      return ['https://polygon-rpc.com/']
-    case SupportedChainId.POLYGON_MUMBAI:
-      return ['https://rpc-endpoints.superfluid.dev/mumbai']*/
-    case SupportedChainId.GNOSIS_CHAIN:
-      return ['https://rpc.gnosischain.com/']
-    default:
+  const rpcUrl = RPC_NETWORKS[chainId]
+  if (!rpcUrl) {
+    throw new Error('RPC URLs must use public endpoints')
   }
-  // Our API-keyed URLs will fail security checks when used with external wallets.
-  throw new Error('RPC URLs must use public endpoints')
+
+  return [rpcUrl]
 }
 
 // provider.request returns Promise<any>, but wallet_switchEthereumChain must return null or throw


### PR DESCRIPTION
# Summary

This PR is some change we need to do on how we get the RPC endpoints and we didn't want to include it in the hotfix `1.15.4`

Basically there was some duplication on how we load the RPC endpoints. We use our own system based on env vars. We use it for WalletConnect. However for the network switch we were using another method


# To Test

1. Test using notmal EOA and one wallet connect wallet
2. Special focus to switching networks