### PR TITLE
Break down main menu logic

### DIFF
--- a/src/custom/components/Header/MenuTree/index.tsx
+++ b/src/custom/components/Header/MenuTree/index.tsx
@@ -103,19 +103,19 @@ const getDropdown = ({ index, title, handleMobileMenuOnClick, toggleDarkMode, da
   </MenuDropdown>
 )
 
-export interface MainMenuProps {
+export interface MenuTreeProps {
   isMobileMenuOpen: boolean
   darkMode: boolean
   toggleDarkMode: () => void
   handleMobileMenuOnClick: () => void
 }
 
-export default function MainMenu({
+export default function MenuTree({
   isMobileMenuOpen,
   darkMode,
   toggleDarkMode,
   handleMobileMenuOnClick,
-}: MainMenuProps) {
+}: MenuTreeProps) {
   const getMainMenu = useMemo(
     () =>
       MAIN_MENU.map(({ title, url, externalURL, items }: MAIN_MENU_TYPE, index) => (

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -26,7 +26,7 @@ import {
   HeaderControls,
   HeaderElement,
 } from './styled'
-import MainMenu from './mainMenu'
+import MainMenu from './MainMenu'
 import MobileMenuIcon from './MobileMenuIcon'
 import Web3Status from 'components/Web3Status'
 import OrdersPanel from 'components/OrdersPanel'

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -26,7 +26,7 @@ import {
   HeaderControls,
   HeaderElement,
 } from './styled'
-import MainMenu from './MainMenu'
+import MenuTree from './MenuTree'
 import MobileMenuIcon from './MobileMenuIcon'
 import Web3Status from 'components/Web3Status'
 import OrdersPanel from 'components/OrdersPanel'
@@ -107,7 +107,7 @@ export default function Header() {
               <LogoImage isMobileMenuOpen={isMobileMenuOpen} />
             </UniIcon>
           </Title>
-          <MainMenu
+          <MenuTree
             isMobileMenuOpen={isMobileMenuOpen}
             darkMode={darkMode}
             toggleDarkMode={toggleDarkMode}

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { SupportedChainId as ChainId } from 'constants/chains'
 import { Routes } from 'constants/routes'
 import { useHistory } from 'react-router-dom'
@@ -8,39 +8,30 @@ import { useNativeCurrencyBalances } from 'state/wallet/hooks'
 import { useDarkModeManager } from 'state/user/hooks'
 import { useMediaQuery, upToSmall, upToMedium, upToLarge, LargeAndUp } from 'hooks/useMediaQuery'
 import { AMOUNT_PRECISION } from 'constants/index'
-import { MAIN_MENU, MAIN_MENU_TYPE } from 'constants/mainMenu'
+
 import { supportedChainId } from 'utils/supportedChainId'
 import { formatSmart } from 'utils/format'
 import { addBodyClass, removeBodyClass } from 'utils/toggleBodyClass'
-import SVG from 'react-inlinesvg'
 
 // Components
-import { ExternalLink } from 'theme/components'
 import { HeaderRow } from './HeaderMod'
 import {
   Wrapper,
   Title,
   LogoImage,
-  HeaderLinks,
   HeaderModWrapper,
   UniIcon,
-  StyledNavLink,
   AccountElement,
   BalanceText,
   HeaderControls,
   HeaderElement,
 } from './styled'
+import MainMenu from './mainMenu'
 import MobileMenuIcon from './MobileMenuIcon'
-import MenuDropdown from 'components/MenuDropdown'
-import { MenuTitle, MenuSection } from 'components/MenuDropdown/styled'
 import Web3Status from 'components/Web3Status'
 import OrdersPanel from 'components/OrdersPanel'
 import NetworkSelector from 'components/Header/NetworkSelector'
 import CowBalanceButton from 'components/CowBalanceButton'
-
-// Assets
-import IMAGE_MOON from 'assets/cow-swap/moon.svg'
-import IMAGE_SUN from 'assets/cow-swap/sun.svg'
 
 export const NETWORK_LABELS: { [chainId in ChainId]?: string } = {
   [ChainId.RINKEBY]: 'Rinkeby',
@@ -107,67 +98,6 @@ export default function Header() {
     setIsTouch('ontouchstart' in document.documentElement)
   }, [isOrdersPanelOpen, isMobileMenuOpen, isUpToLarge, isUpToMedium, isUpToSmall, isLargeAndUp])
 
-  const getMainMenu = useMemo(
-    () =>
-      MAIN_MENU.map(({ title, url, externalURL, items }: MAIN_MENU_TYPE, index) =>
-        !items && !externalURL && url ? (
-          <StyledNavLink key={index} exact to={url} onClick={handleMobileMenuOnClick}>
-            {title}
-          </StyledNavLink>
-        ) : !items && externalURL && url ? (
-          <ExternalLink key={index} href={url} onClickOptional={handleMobileMenuOnClick}>
-            {title}
-          </ExternalLink>
-        ) : items ? (
-          <MenuDropdown key={index} title={title}>
-            {items.map(({ sectionTitle, links }, index) => {
-              return (
-                <MenuSection key={index}>
-                  {sectionTitle && <MenuTitle>{sectionTitle}</MenuTitle>}
-                  {links.map(({ title, url, externalURL, icon, iconSVG, action }, index) => {
-                    return action && action === 'setColorMode' ? (
-                      <button
-                        key={index}
-                        onClick={() => {
-                          handleMobileMenuOnClick()
-                          toggleDarkMode()
-                        }}
-                      >
-                        <SVG
-                          src={darkMode ? IMAGE_SUN : IMAGE_MOON}
-                          description={`${darkMode ? 'Sun/light' : 'Moon/dark'} mode icon`}
-                        />{' '}
-                        {darkMode ? 'Light' : 'Dark'} Mode
-                      </button>
-                    ) : !externalURL && url ? (
-                      <StyledNavLink key={index} exact to={url} onClick={handleMobileMenuOnClick}>
-                        {iconSVG ? (
-                          <SVG src={iconSVG} description={`${title} icon`} />
-                        ) : icon ? (
-                          <img src={icon} alt={`${title} icon`} />
-                        ) : null}{' '}
-                        {title}
-                      </StyledNavLink>
-                    ) : url ? (
-                      <ExternalLink key={index} href={url} onClickOptional={handleMobileMenuOnClick}>
-                        {iconSVG ? (
-                          <SVG src={iconSVG} description={`${title} icon`} />
-                        ) : icon ? (
-                          <img src={icon} alt={`${title} icon`} />
-                        ) : null}{' '}
-                        {title}
-                      </ExternalLink>
-                    ) : null
-                  })}
-                </MenuSection>
-              )
-            })}
-          </MenuDropdown>
-        ) : null
-      ),
-    [darkMode, handleMobileMenuOnClick, toggleDarkMode]
-  )
-
   return (
     <Wrapper isMobileMenuOpen={isMobileMenuOpen}>
       <HeaderModWrapper>
@@ -177,7 +107,12 @@ export default function Header() {
               <LogoImage isMobileMenuOpen={isMobileMenuOpen} />
             </UniIcon>
           </Title>
-          <HeaderLinks isMobileMenuOpen={isMobileMenuOpen}>{getMainMenu}</HeaderLinks>
+          <MainMenu
+            isMobileMenuOpen={isMobileMenuOpen}
+            darkMode={darkMode}
+            toggleDarkMode={toggleDarkMode}
+            handleMobileMenuOnClick={handleMobileMenuOnClick}
+          />
         </HeaderRow>
 
         <HeaderControls>

--- a/src/custom/components/Header/mainMenu/index.tsx
+++ b/src/custom/components/Header/mainMenu/index.tsx
@@ -80,27 +80,26 @@ interface DropdownType {
 
 const getDropdown = ({ index, title, handleMobileMenuOnClick, toggleDarkMode, darkMode, items }: DropdownType) => (
   <MenuDropdown key={index} title={title}>
-    {items &&
-      items.map(({ sectionTitle, links }, index) => {
-        return (
-          <MenuSection key={index}>
-            {sectionTitle && <MenuTitle>{sectionTitle}</MenuTitle>}
+    {items?.map(({ sectionTitle, links }, index) => {
+      return (
+        <MenuSection key={index}>
+          {sectionTitle && <MenuTitle>{sectionTitle}</MenuTitle>}
 
-            {links.map(({ title, url, externalURL, icon, iconSVG, action }, index) => (
-              <>
-                {!url &&
-                  action &&
-                  action === 'setColorMode' &&
-                  getDarkModeButton({ index, darkMode, toggleDarkMode, handleMobileMenuOnClick })}
-                {!action &&
-                  url &&
-                  title &&
-                  getLink({ title, externalURL, index, url, handleMobileMenuOnClick, icon, iconSVG })}
-              </>
-            ))}
-          </MenuSection>
-        )
-      })}
+          {links.map(({ title, url, externalURL, icon, iconSVG, action }, index) => (
+            <>
+              {!url &&
+                action &&
+                action === 'setColorMode' &&
+                getDarkModeButton({ index, darkMode, toggleDarkMode, handleMobileMenuOnClick })}
+              {!action &&
+                url &&
+                title &&
+                getLink({ title, externalURL, index, url, handleMobileMenuOnClick, icon, iconSVG })}
+            </>
+          ))}
+        </MenuSection>
+      )
+    })}
   </MenuDropdown>
 )
 

--- a/src/custom/components/Header/mainMenu/index.tsx
+++ b/src/custom/components/Header/mainMenu/index.tsx
@@ -1,0 +1,135 @@
+import { useMemo } from 'react'
+import { HeaderLinks as Wrapper, StyledNavLink } from '../styled'
+import { ExternalLink } from 'theme/components'
+import MenuDropdown from 'components/MenuDropdown'
+import { MenuTitle, MenuSection } from 'components/MenuDropdown/styled'
+import SVG from 'react-inlinesvg'
+import { MAIN_MENU, MAIN_MENU_TYPE } from 'constants/mainMenu'
+
+// Assets
+import IMAGE_MOON from 'assets/cow-swap/moon.svg'
+import IMAGE_SUN from 'assets/cow-swap/sun.svg'
+
+const getLinkComponent = {
+  internal: StyledNavLink,
+  external: ExternalLink,
+}
+
+interface LinkType {
+  title: MAIN_MENU_TYPE['title']
+  externalURL?: boolean
+  index: number
+  url: string
+  icon?: string
+  iconSVG?: string
+  handleMobileMenuOnClick: () => void
+}
+
+// Dynamic util function to render links based on internal or external type (with or without icon image)
+function getLink({ title, externalURL, index, url, iconSVG, icon, handleMobileMenuOnClick }: LinkType) {
+  const LinkComponent = externalURL ? getLinkComponent.external : getLinkComponent.internal
+  return (
+    <LinkComponent
+      key={index}
+      exact
+      to={url}
+      href={url}
+      onClick={handleMobileMenuOnClick}
+      onClickOptional={handleMobileMenuOnClick}
+    >
+      {iconSVG ? (
+        <SVG src={iconSVG} description={`${title} icon`} />
+      ) : icon ? (
+        <img src={icon} alt={`${title} icon`} />
+      ) : null}{' '}
+      {title}
+    </LinkComponent>
+  )
+}
+
+interface DarkModeButtonType {
+  index: number
+  darkMode: boolean
+  toggleDarkMode: () => void
+  handleMobileMenuOnClick: () => void
+}
+
+const getDarkModeButton = ({ index, darkMode, toggleDarkMode, handleMobileMenuOnClick }: DarkModeButtonType) => {
+  return (
+    <button
+      key={index}
+      onClick={() => {
+        handleMobileMenuOnClick()
+        toggleDarkMode()
+      }}
+    >
+      <SVG src={darkMode ? IMAGE_SUN : IMAGE_MOON} description={`${darkMode ? 'Sun/light' : 'Moon/dark'} mode icon`} />{' '}
+      {darkMode ? 'Light' : 'Dark'} Mode
+    </button>
+  )
+}
+
+interface DropdownType {
+  index: number
+  handleMobileMenuOnClick: () => void
+  darkMode: boolean
+  toggleDarkMode: () => void
+  title: MAIN_MENU_TYPE['title']
+  items: MAIN_MENU_TYPE['items']
+}
+
+const buildDropdown = ({ index, title, handleMobileMenuOnClick, toggleDarkMode, darkMode, items }: DropdownType) => (
+  <MenuDropdown key={index} title={title}>
+    {items &&
+      items.map(({ sectionTitle, links }, index) => {
+        return (
+          <MenuSection key={index}>
+            {sectionTitle && <MenuTitle>{sectionTitle}</MenuTitle>}
+
+            {links.map(({ title, url, externalURL, icon, iconSVG, action }, index) => (
+              <>
+                {!url &&
+                  action &&
+                  action === 'setColorMode' &&
+                  getDarkModeButton({ index, darkMode, toggleDarkMode, handleMobileMenuOnClick })}
+                {!action &&
+                  url &&
+                  title &&
+                  getLink({ title, externalURL, index, url, handleMobileMenuOnClick, icon, iconSVG })}
+              </>
+            ))}
+          </MenuSection>
+        )
+      })}
+  </MenuDropdown>
+)
+
+export interface MainMenuProps {
+  isMobileMenuOpen: boolean
+  darkMode: boolean
+  toggleDarkMode: () => void
+  handleMobileMenuOnClick: () => void
+}
+
+export default function MainMenu({
+  isMobileMenuOpen,
+  darkMode,
+  toggleDarkMode,
+  handleMobileMenuOnClick,
+}: MainMenuProps) {
+  const getMainMenu = useMemo(
+    () =>
+      MAIN_MENU.map(({ title, url, externalURL, items }: MAIN_MENU_TYPE, index) => (
+        <>
+          {/* 1st level main menu item: No dropdown items */}
+          {!items && url && getLink({ title, externalURL, index, url, handleMobileMenuOnClick })}
+
+          {/* 1st level main menu item: Has dropdown items */}
+          {items && buildDropdown({ index, title, handleMobileMenuOnClick, toggleDarkMode, darkMode, items })}
+        </>
+      )),
+    [darkMode, handleMobileMenuOnClick, toggleDarkMode]
+  )
+
+  return <Wrapper isMobileMenuOpen={isMobileMenuOpen}>{getMainMenu}</Wrapper>
+}

--- a/src/custom/components/Header/mainMenu/index.tsx
+++ b/src/custom/components/Header/mainMenu/index.tsx
@@ -78,7 +78,7 @@ interface DropdownType {
   items: MAIN_MENU_TYPE['items']
 }
 
-const buildDropdown = ({ index, title, handleMobileMenuOnClick, toggleDarkMode, darkMode, items }: DropdownType) => (
+const getDropdown = ({ index, title, handleMobileMenuOnClick, toggleDarkMode, darkMode, items }: DropdownType) => (
   <MenuDropdown key={index} title={title}>
     {items &&
       items.map(({ sectionTitle, links }, index) => {
@@ -125,7 +125,7 @@ export default function MainMenu({
           {!items && url && getLink({ title, externalURL, index, url, handleMobileMenuOnClick })}
 
           {/* 1st level main menu item: Has dropdown items */}
-          {items && buildDropdown({ index, title, handleMobileMenuOnClick, toggleDarkMode, darkMode, items })}
+          {items && getDropdown({ index, title, handleMobileMenuOnClick, toggleDarkMode, darkMode, items })}
         </>
       )),
     [darkMode, handleMobileMenuOnClick, toggleDarkMode]


### PR DESCRIPTION
# Summary

This PR breaks down the main menu logic in smaller pieces. Tries to keep the component markup dry by offloading it to helper functions.