### PR TITLE
[ 🔥 😮‍💨 H O T F I X ] 1.15.5 

### DIFF
--- a/.env
+++ b/.env
@@ -38,8 +38,8 @@ REACT_APP_DOMAIN_REGEX_LOCAL="^(:?localhost:\d{2,5}|(?:127|192)(?:\.[0-9]{1,3}){
 REACT_APP_DOMAIN_REGEX_PR="^pr\d+--cowswap\.review"
 REACT_APP_DOMAIN_REGEX_DEV="^cowswap\.dev"
 REACT_APP_DOMAIN_REGEX_STAGING="^cowswap\.staging"
-REACT_APP_DOMAIN_REGEX_PROD="^cowswap\.exchange$"
-REACT_APP_DOMAIN_REGEX_BARN="^barn\.cowswap\.exchange$"
+REACT_APP_DOMAIN_REGEX_PROD="^(cowswap\.exchange|swap\.cow\.fi)$"
+REACT_APP_DOMAIN_REGEX_BARN="^barn\.(cowswap\.exchange|swap\.cow\.fi)$"
 REACT_APP_DOMAIN_REGEX_ENS="(:?^cowswap\.eth|ipfs)"
 
 # Path regex (to detect environment)

--- a/.env.production
+++ b/.env.production
@@ -39,8 +39,8 @@ REACT_APP_DOMAIN_REGEX_LOCAL="^(:?localhost:\d{2,5}|(?:127|192)(?:\.[0-9]{1,3}){
 REACT_APP_DOMAIN_REGEX_PR="^pr\d+--cowswap\.review"
 REACT_APP_DOMAIN_REGEX_DEV="^cowswap\.dev"
 REACT_APP_DOMAIN_REGEX_STAGING="^cowswap\.staging"
-REACT_APP_DOMAIN_REGEX_PROD="^cowswap\.exchange$"
-REACT_APP_DOMAIN_REGEX_BARN="^barn\.cowswap\.exchange$"
+REACT_APP_DOMAIN_REGEX_PROD="^(cowswap\.exchange|swap\.cow\.fi)$"
+REACT_APP_DOMAIN_REGEX_BARN="^barn\.(cowswap\.exchange|swap\.cow\.fi)$"
 REACT_APP_DOMAIN_REGEX_ENS="(:?^cowswap\.eth|ipfs)"
 
 # Path regex (to detect environment)

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 
 # testing
 /coverage
+cypress.env.json
 
 # builds
 /build

--- a/cypress-custom/integration/swapMod.ts
+++ b/cypress-custom/integration/swapMod.ts
@@ -32,25 +32,36 @@ describe('Swap (mod)', () => {
   })
 
   it('can enter an amount into output', () => {
-    cy.get('#swap-currency-output .token-amount-input')
+    // first clear/reset the INPUT currency input field
+    // as it is auto prefilled with "1"
+    cy.get('#swap-currency-input .token-amount-input')
       .clear()
+      // then we select and clear the OUTPUT field
+      .get('#swap-currency-output .token-amount-input')
+      .clear()
+      // and type in an amount
       .type('0.001', { delay: 400, force: true })
       .should('have.value', '0.001')
   })
 
   it('zero output amount', () => {
-    cy.get('#swap-currency-output .token-amount-input')
-      // When `.clear() doesn't work, brute force it with the input below.
-      // From https://stackoverflow.com/a/65918033/1272513
-      .type('{selectall}{backspace}{selectall}{backspace}')
+    // first clear/reset the INPUT currency input field
+    // as it is auto prefilled with "1"
+    cy.get('#swap-currency-input .token-amount-input')
+      .clear()
+      // then we select and clear the OUTPUT field
+      .get('#swap-currency-output .token-amount-input')
+      .clear()
+      // and type in an amount
       .type('0.0')
       .should('have.value', '0.0')
   })
 
-  it('can swap Native for DAI', () => {
+  it('can find GNO and swap Native for GNO', () => {
     cy.get('#swap-currency-output .open-currency-select-button').click()
-    cy.get('.token-item-0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735').should('be.visible')
-    cy.get('.token-item-0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735').click({ force: true })
+    cy.get('#token-search-input').type('GNO')
+    cy.get('.token-item-0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c').should('be.visible')
+    cy.get('.token-item-0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c').click({ force: true })
     cy.get('#swap-currency-input .token-amount-input').should('be.visible')
     cy.get('#swap-currency-input .token-amount-input').type('{selectall}{backspace}{selectall}{backspace}').type('0.5')
     cy.get('#swap-currency-output .token-amount-input').should('not.equal', '')

--- a/src/custom/hooks/web3.ts
+++ b/src/custom/hooks/web3.ts
@@ -34,7 +34,8 @@ export function useEagerConnect() {
 
     if (!walletType || !active) {
       localStorage.removeItem(STORAGE_KEY_LAST_PROVIDER)
-    } else {
+    } else if (!IS_IN_IFRAME) {
+      // Set if its not from an Iframe
       localStorage.setItem(STORAGE_KEY_LAST_PROVIDER, walletType)
     }
   }, [connector, active])
@@ -88,8 +89,8 @@ export function useEagerConnect() {
     if (!active) {
       const latestProvider = localStorage.getItem(STORAGE_KEY_LAST_PROVIDER)
 
-      // If there is no last saved provider set tried state to true
-      if (!latestProvider) {
+      // If there is no last saved provider or its running in Iframe, try connecting with safe first
+      if (!latestProvider || IS_IN_IFRAME) {
         if (!triedSafe) {
           // First try to connect using Gnosis Safe
           connectSafe()

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -662,7 +662,7 @@ export default function Swap({
                 }
                 value={formattedAmounts[Field.INPUT]}
                 showMaxButton={showMaxButton}
-                currency={currencies[Field.INPUT]}
+                currency={currencies[Field.INPUT] ?? null}
                 onUserInput={handleTypeInput}
                 onMax={handleMaxInput}
                 fiatValue={fiatValueInput ?? undefined}
@@ -726,7 +726,7 @@ export default function Swap({
                 fiatValue={fiatValueOutput ?? undefined}
                 priceImpact={onWrap ? undefined : priceImpact}
                 priceImpactLoading={priceImpactLoading}
-                currency={currencies[Field.OUTPUT]}
+                currency={currencies[Field.OUTPUT] ?? null}
                 onCurrencySelect={handleOutputSelect}
                 otherCurrency={currencies[Field.INPUT]}
                 showCommonBases={true}

--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -413,9 +413,7 @@ export async function getGpUsdcPrice({ strategy, quoteParams }: Pick<QuoteParams
     quoteParams.validTo = MAX_VALID_TO_EPOCH
     const { quote } = await getQuote(quoteParams)
 
-    // BUY order always. We also need to add the fee to the sellAmount to get the unaffected price
-    const amountWithoutFee = new BigNumberJs(quote.feeAmount).plus(new BigNumberJs(quote.sellAmount))
-    return amountWithoutFee.toString(10)
+    return quote.sellAmount
   } else {
     console.debug(
       '[GP PRICE::API] getGpUsdcPrice - Attempting best USDC quote retrieval using LEGACY strategy, hang tight.'

--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -20,7 +20,6 @@ import { GetQuoteResponse, OrderKind } from '@cowprotocol/contracts'
 import { ChainId } from 'state/lists/actions'
 import { toErc20Address } from 'utils/tokens'
 import { GpPriceStrategy } from 'hooks/useGetGpPriceStrategy'
-import { MAX_VALID_TO_EPOCH } from 'hooks/useSwapCallback'
 import useSWR from 'swr'
 
 const FEE_EXCEEDS_FROM_ERROR = new GpQuoteError({
@@ -410,7 +409,6 @@ export async function getGpUsdcPrice({ strategy, quoteParams }: Pick<QuoteParams
     console.debug(
       '[GP PRICE::API] getGpUsdcPrice - Attempting best USDC quote retrieval using COWSWAP strategy, hang tight.'
     )
-    quoteParams.validTo = MAX_VALID_TO_EPOCH
     const { quote } = await getQuote(quoteParams)
 
     return quote.sellAmount


### PR DESCRIPTION
# HOTFIX 1.15.5

## 1. ETH USD value
### Summary

Part of the issues with 1.15.0 and co (1.15.1, 1.15.2) - the ETH USD value, price impact, and WETH/ETH showing different USD values

What was wrong:
ETH//WETH price impact

`getGpUsdcPrice` -- (`custom/utils/price.ts`) has a bug: 
<img width="879" alt="Pasted Graphic" src="https://user-images.githubusercontent.com/21335563/173806524-76bc0fb5-7cf0-4cf1-921d-930ae4faf0bd.png">

Comment on L416 is wrong, `sellAmount` returned in the response is the amount WITHOUT the `feeAmount` applied, thus `L417` should not exist. By existing it was returning a worse price as the `sellAmount` returned was then higher making the price worse.

The reason we weren't seeing it in BARN/LOCAL is that the `feeAmount` was marginal and not affecting price so much in certain cases.

We started seeing this more since the change to the `COWSWAP` strategy as the primary price feed, and probably only really saw it now. This was on me, sorry y'all 😞 

## Testing
This is a bit tricky to test fully but easy testing can be done by using the PR link and testing switching between WETH and ETH to see the same/similar usd prices.
- USD price should be similar
- USD value should fill immediately, no delay or non values

## 2. Empty token selector when URL contains VALID token address from DIFFERENT chain
#699 - logic was hiding selector if currency passed was `undefined`

## 3. 0x000 `appData` for `swap.cow.fi` domain
#698 - add `swap.cow.fi` and barn equivalents to `.env` regex

## 4. Broken cypress build
#710 - fix broken cypress tests