### PR TITLE
FIX CYPRESS TESTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 
 # testing
 /coverage
+cypress.env.json
 
 # builds
 /build

--- a/cypress-custom/integration/swapMod.ts
+++ b/cypress-custom/integration/swapMod.ts
@@ -32,23 +32,27 @@ describe('Swap (mod)', () => {
   })
 
   it('can enter an amount into output', () => {
-    // clear the INPUT currency input field first
-    // as it is auto filled with "1"
+    // first clear/reset the INPUT currency input field
+    // as it is auto prefilled with "1"
     cy.get('#swap-currency-input .token-amount-input')
       .clear()
+      // then we select and clear the OUTPUT field
       .get('#swap-currency-output .token-amount-input')
       .clear()
+      // and type in an amount
       .type('0.001', { delay: 400, force: true })
       .should('have.value', '0.001')
   })
 
   it('zero output amount', () => {
-    // clear the INPUT currency input field first
-    // as it is auto filled with "1"
+    // first clear/reset the INPUT currency input field
+    // as it is auto prefilled with "1"
     cy.get('#swap-currency-input .token-amount-input')
       .clear()
+      // then we select and clear the OUTPUT field
       .get('#swap-currency-output .token-amount-input')
       .clear()
+      // and type in an amount
       .type('0.0')
       .should('have.value', '0.0')
   })

--- a/cypress-custom/integration/swapMod.ts
+++ b/cypress-custom/integration/swapMod.ts
@@ -32,17 +32,23 @@ describe('Swap (mod)', () => {
   })
 
   it('can enter an amount into output', () => {
-    cy.get('#swap-currency-output .token-amount-input')
+    // first, clear the INPUT currency input field
+    // as it is auto filled with "1"
+    cy.get('#swap-currency-input .token-amount-input')
+      .clear()
+      .get('#swap-currency-output .token-amount-input')
       .clear()
       .type('0.001', { delay: 400, force: true })
       .should('have.value', '0.001')
   })
 
   it('zero output amount', () => {
-    cy.get('#swap-currency-output .token-amount-input')
-      // When `.clear() doesn't work, brute force it with the input below.
-      // From https://stackoverflow.com/a/65918033/1272513
-      .type('{selectall}{backspace}{selectall}{backspace}')
+    // first, clear the INPUT currency input field
+    // as it is auto filled with "1"
+    cy.get('#swap-currency-input .token-amount-input')
+      .clear()
+      .get('#swap-currency-output .token-amount-input')
+      .clear()
       .type('0.0')
       .should('have.value', '0.0')
   })

--- a/cypress-custom/integration/swapMod.ts
+++ b/cypress-custom/integration/swapMod.ts
@@ -32,7 +32,7 @@ describe('Swap (mod)', () => {
   })
 
   it('can enter an amount into output', () => {
-    // first, clear the INPUT currency input field
+    // clear the INPUT currency input field first
     // as it is auto filled with "1"
     cy.get('#swap-currency-input .token-amount-input')
       .clear()
@@ -43,7 +43,7 @@ describe('Swap (mod)', () => {
   })
 
   it('zero output amount', () => {
-    // first, clear the INPUT currency input field
+    // clear the INPUT currency input field first
     // as it is auto filled with "1"
     cy.get('#swap-currency-input .token-amount-input')
       .clear()
@@ -53,10 +53,11 @@ describe('Swap (mod)', () => {
       .should('have.value', '0.0')
   })
 
-  it('can swap Native for DAI', () => {
+  it('can find GNO and swap Native for GNO', () => {
     cy.get('#swap-currency-output .open-currency-select-button').click()
-    cy.get('.token-item-0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735').should('be.visible')
-    cy.get('.token-item-0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735').click({ force: true })
+    cy.get('#token-search-input').type('GNO')
+    cy.get('.token-item-0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c').should('be.visible')
+    cy.get('.token-item-0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c').click({ force: true })
     cy.get('#swap-currency-input .token-amount-input').should('be.visible')
     cy.get('#swap-currency-input .token-amount-input').type('{selectall}{backspace}{selectall}{backspace}').type('0.5')
     cy.get('#swap-currency-output .token-amount-input').should('not.equal', '')


### PR DESCRIPTION
# Summary

1. Fixes broken `SwapMod.tsx` test and small fixes to the hacky `.type({selectAll}{backspace})` workaround

The issue is that on the SwapMod "output currency output field" tests, we weren't clearing the input currency field, thus a race condition between the amount prefilled in the output (expected output) was clashing with the test instructions and failing.

This clears first the input field, then inputs in the output + returns the use of the `.clear()` method

2. Change WETH against DAI tests to use GNO. DAI (incorrect contract address) returns enormous amounts which causes (correctly) the `high fee vs amount`  to appear, blocking the swap button

## Testing
- check cypress is green