### PR TITLE
Fix for lingui warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
     "graphql:generate": "graphql-codegen --config codegen.yml",
     "prei18n:extract": "touch src/locales/en-US.po",
     "postinstall": "yarn contracts:compile && yarn graphql:generate && yarn i18n:compile",
-    "i18n:extract": "lingui extract --locale en-US",
+    "i18n:extract": "cross-env NODE_ENV=development lingui extract --locale en-US",
     "i18n:compile": "yarn i18n:extract && lingui compile",
     "i18n:pseudo": "lingui extract --locale pseudo && lingui compile",
     "prepare": "yarn contracts:compile && yarn graphql:generate && yarn i18n:compile",


### PR DESCRIPTION
# Summary

Fixes these warnings when running `yarn` command which also activates `prei18n:extract` at some point, as suggested in this thread https://github.com/lingui/js-lingui/issues/433#issuecomment-454678661 
![Screenshot from 2022-06-20 13-17-01](https://user-images.githubusercontent.com/34926005/174591802-40d5da83-ef74-476e-9044-a013e718f568.png)

