### PR TITLE
Re-enable coingecko

### DIFF
--- a/src/custom/constants/lists.ts
+++ b/src/custom/constants/lists.ts
@@ -17,7 +17,7 @@ const WRAPPED_LIST = 'wrapped.tokensoft.eth'
 const SET_LIST = 'https://raw.githubusercontent.com/SetProtocol/uniswap-tokenlist/main/set.tokenlist.json'
 const OPYN_LIST = 'https://raw.githubusercontent.com/opynfinance/opyn-tokenlist/master/opyn-squeeth-tokenlist.json'
 const ROLL_LIST = 'https://app.tryroll.com/tokens.json'
-// const COINGECKO_LIST = 'https://tokens.coingecko.com/uniswap/all.json'
+const COINGECKO_LIST = 'https://tokens.coingecko.com/uniswap/all.json'
 const CMC_ALL_LIST = 'defi.cmc.eth'
 const CMC_STABLECOIN = 'stablecoin.cmc.eth'
 const KLEROS_LIST = 't2crtokens.eth'
@@ -57,7 +57,7 @@ export const DEFAULT_LIST_OF_LISTS_BY_NETWORK: NetworkLists = {
       SET_LIST,
       OPYN_LIST,
       ROLL_LIST,
-      // COINGECKO_LIST,
+      COINGECKO_LIST,
       CMC_ALL_LIST,
       CMC_STABLECOIN,
       KLEROS_LIST,


### PR DESCRIPTION
# Summary

This PR re-add a bunch of lists.

We add Uniswap list as enabled by default, plus, the COINGECKO and COINMARKETCAP which should have most of the tokens user expect.

# To Test
TODO