### PR TITLE
332/exponential back off

### DIFF
--- a/src/custom/state/appData/atoms.ts
+++ b/src/custom/state/appData/atoms.ts
@@ -36,7 +36,7 @@ export const addAppDataToUploadQueueAtom = atom(
 
       return {
         ...docs,
-        [key]: { ...appData, uploading: false },
+        [key]: { ...appData, uploading: false, failedAttempts: 0 },
       }
     })
   }
@@ -47,7 +47,7 @@ export const addAppDataToUploadQueueAtom = atom(
  */
 export const updateAppDataOnUploadQueueAtom = atom(
   null,
-  (get, set, { chainId, orderId, uploading, tryAfter }: UpdateAppDataOnUploadQueueParams) => {
+  (get, set, { chainId, orderId, uploading, lastAttempt, failedAttempts }: UpdateAppDataOnUploadQueueParams) => {
     set(appDataUploadQueueAtom, () => {
       const docs = get(appDataUploadQueueAtom)
       const key = buildAppDataRecordKey({ chainId, orderId })
@@ -56,9 +56,16 @@ export const updateAppDataOnUploadQueueAtom = atom(
         return docs
       }
 
+      const current = docs[key]
+
       return {
         ...docs,
-        [key]: { ...docs[key], uploading, tryAfter },
+        [key]: {
+          ...current,
+          uploading: uploading ?? current.uploading,
+          lastAttempt: lastAttempt ?? current.lastAttempt,
+          failedAttempts: failedAttempts ?? current.failedAttempts,
+        },
       }
     })
   }

--- a/src/custom/state/appData/types.tsx
+++ b/src/custom/state/appData/types.tsx
@@ -6,7 +6,8 @@ export type AppDataInfo = {
 }
 
 type AppDataUploadStatus = {
-  tryAfter?: number
+  lastAttempt?: number
+  failedAttempts: number
   uploading: boolean
 }
 
@@ -22,7 +23,7 @@ export type AppDataKeyParams = {
 export type AddAppDataToUploadQueueParams = AppDataKeyParams & {
   appData: AppDataInfo
 }
-export type UpdateAppDataOnUploadQueueParams = AppDataKeyParams & AppDataUploadStatus
+export type UpdateAppDataOnUploadQueueParams = AppDataKeyParams & Partial<AppDataUploadStatus>
 export type RemoveAppDataFromUploadQueueParams = AppDataKeyParams
 
 export type FlattenedAppDataFromUploadQueue = AppDataKeyParams & AppDataRecord

--- a/src/custom/state/appData/updater.ts
+++ b/src/custom/state/appData/updater.ts
@@ -49,7 +49,7 @@ async function _uploadToIpfs(
   updatePending: (params: UpdateAppDataOnUploadQueueParams) => void,
   removePending: (params: AppDataKeyParams) => void
 ) {
-  const { doc, chainId, orderId, uploading, tryAfter, hash } = appDataRecord
+  const { doc, chainId, orderId, uploading, failedAttempts, lastAttempt, hash } = appDataRecord
 
   if (!doc) {
     // No actual doc to upload, nothing to do here

--- a/src/custom/state/appData/updater.ts
+++ b/src/custom/state/appData/updater.ts
@@ -77,9 +77,14 @@ async function _uploadToIpfs(
       }
     } catch (e) {
       // TODO: add sentry error to track soft failure
-      console.debug(`[UploadToIpfsUpdater] Failed to upload doc, will try again`, JSON.stringify(doc))
+      console.debug(
+        `[UploadToIpfsUpdater] Failed to upload doc, will try again. Reason: ${e.message}`,
+        JSON.stringify(doc)
+      )
       updatePending({ chainId, orderId, uploading: false, failedAttempts: failedAttempts + 1, lastAttempt: Date.now() })
     }
+  } else {
+    console.log(`[UploadToIpfsUpdater] Criteria not met, skipping ${chainId}-${orderId}`)
   }
 }
 

--- a/src/custom/state/appData/updater.ts
+++ b/src/custom/state/appData/updater.ts
@@ -77,7 +77,7 @@ async function _uploadToIpfs(
       }
     } catch (e) {
       // TODO: add sentry error to track soft failure
-      console.debug(
+      console.warn(
         `[UploadToIpfsUpdater] Failed to upload doc, will try again. Reason: ${e.message}`,
         JSON.stringify(doc)
       )

--- a/src/custom/state/appData/updater.ts
+++ b/src/custom/state/appData/updater.ts
@@ -17,7 +17,7 @@ import {
 } from 'state/appData/types'
 
 const UPLOAD_CHECK_INTERVAL = ms`10s`
-const BASE_TIME_BETWEEN_ATTEMPTS = 2 // in seconds, converted to milliseconds later
+const BASE_FOR_EXPONENTIAL_BACKOFF = 2 // in seconds, converted to milliseconds later
 const ONE_SECOND = ms`1s`
 const MAX_TIME_TO_WAIT = ms`5 minutes`
 
@@ -69,8 +69,8 @@ function _canUpload(uploading: boolean, attempts: number, lastAttempt?: number):
   }
 
   if (lastAttempt) {
-    // Every attempt takes BASE_TIME_BETWEEN_ATTEMPTS ˆ failedAttempts
-    const timeToWait = BASE_TIME_BETWEEN_ATTEMPTS ** attempts * ONE_SECOND
+    // Every attempt takes BASE_FOR_EXPONENTIAL_BACKOFF ˆ failedAttempts
+    const timeToWait = BASE_FOR_EXPONENTIAL_BACKOFF ** attempts * ONE_SECOND
     // Don't wait more than MAX_TIME_TO_WAIT.
     // Both are in milliseconds
     const timeDelta = Math.min(timeToWait, MAX_TIME_TO_WAIT)


### PR DESCRIPTION
# Summary

Part of #332 

Exponential back off retries.

Configured initially with:

Base attempt interval: 2s
Max attempt interval: 5min
Increment: Base interval ^ number of failed attempts

Keep in mind we run the check at every 10s, so effectively the retries will happen in multiples of 10

![Screen Shot 2022-06-21 at 16 51 04](https://user-images.githubusercontent.com/43217/174843473-592b0ffd-8e2e-4713-b633-c7d7bc7d3f2f.png)

  # To Test

1. We need to force a failure to upload to IPFS to test it.
  One quick way is to, running locally, not pass the Pinata keys.
  Another approach is to block Pinata request in the browser using an adblocker or similar
2. Having the IPFS request forced failure setup, place an order
3. Observe the console logs. Filter by `Ipfs` (Check the image above)
* You should see the attempt to upload fail
* You should see the time it takes between attempts to increase
* The maximum wait time between attempts should be capped at 5min (configurable)