### PR TITLE
Fix issue with Slippage calculation

### DIFF
--- a/src/custom/state/swap/TradeGp.ts
+++ b/src/custom/state/swap/TradeGp.ts
@@ -56,23 +56,8 @@ export function _maximumAmountIn(pct: Percent, trade: TradeGp) {
   if (trade.tradeType === TradeType.EXACT_INPUT) {
     return trade.inputAmount
   }
-  const priceDisplayed = trade.executionPrice.invert().asFraction
-  const slippage = new Fraction('1').subtract(pct)
-  // slippage is applied to the price
-  const slippagePrice = priceDisplayed.multiply(slippage)
-  // construct new price using slippage price
-  const maxPrice = new Price<Currency, Currency>(
-    trade.executionPrice.quoteCurrency,
-    trade.executionPrice.baseCurrency,
-    slippagePrice.denominator,
-    slippagePrice.numerator
-  )
 
-  // fee is in sell token so we
-  // add fee to the calculated input
-  const maximumAmountIn = maxPrice.invert().quote(trade.outputAmount).add(trade.fee.feeAsCurrency)
-
-  return maximumAmountIn
+  return trade.inputAmountWithFee.multiply(ONE.add(pct))
 }
 
 interface TradeGpConstructor {

--- a/src/custom/state/swap/TradeGp.ts
+++ b/src/custom/state/swap/TradeGp.ts
@@ -3,6 +3,7 @@ import { CurrencyAmount, Currency, TradeType, Price, Percent, Fraction } from '@
 import { Trade } from '@uniswap/v2-sdk'
 import { FeeInformation, PriceInformation } from '@cowprotocol/cow-sdk'
 
+const ONE = new Fraction('1')
 export type FeeForTrade = { feeAsCurrency: CurrencyAmount<Currency> } & Pick<FeeInformation, 'amount'>
 
 export type TradeWithFee = Omit<Trade<Currency, Currency, TradeType>, 'nextMidPrice' | 'exactIn' | 'exactOut'> & {
@@ -48,21 +49,7 @@ export function _minimumAmountOut(pct: Percent, trade: TradeGp) {
     return trade.outputAmount
   }
 
-  const priceDisplayed = trade.executionPrice.invert().asFraction
-  const slippage = new Fraction('1').add(pct)
-  // slippage is applied to PRICE
-  const slippagePrice = priceDisplayed.multiply(slippage)
-  // newly constructed price with slippage applied
-  const minPrice = new Price<Currency, Currency>(
-    trade.executionPrice.quoteCurrency,
-    trade.executionPrice.baseCurrency,
-    slippagePrice.denominator,
-    slippagePrice.numerator
-  )
-
-  const minimumAmountOut = minPrice.invert().quote(trade.inputAmountWithFee)
-
-  return minimumAmountOut
+  return trade.outputAmount.multiply(ONE.subtract(pct))
 }
 
 export function _maximumAmountIn(pct: Percent, trade: TradeGp) {

--- a/src/custom/state/swap/trade.test.ts
+++ b/src/custom/state/swap/trade.test.ts
@@ -65,25 +65,23 @@ describe('Swap PRICE Quote test', () => {
         })
       })
       it('Uses proper input amount WITHOUT fee in trade object', () => {
-        // WHEN --> Sold_tokens => From_amount - Fee
-        // THEN --> expected inputAmountMinusFee = 1 - 0.1
-        const expectedInputWithFee = '900000000000000000'
-        const actualInputWithFee = trade.inputAmount.subtract(trade.fee.feeAsCurrency)
-        expect(expectedInputWithFee).toEqual(actualInputWithFee.quotient.toString())
+        // GIVEN --> User is selling 1 WETH
+        // THEN --> we expect the trade inputAmount to be exactly 1 in weth atoms
+        const actualInputWithFee = trade.inputAmount.quotient.toString()
+        expect(actualInputWithFee).toEqual('1000000000000000000')
       })
       it('Has the correct execution price', () => {
-        // WHEN --> Price_displayed => Sold_tokens / Received_tokens
+        // WHEN --> Price_displayed = Sold_tokens / Received_tokens
         // THEN --> 900000000000000000 / 4000000000000000000000 = 0.000225
-        const expectedPrice = '0.000225'
         const actualPrice = trade.executionPrice.invert().toSignificant(DEFAULT_PRECISION)
-        expect(expectedPrice).toEqual(actualPrice)
+        expect(actualPrice).toEqual('0.000225')
       })
       it('Shows the proper minimumAmountOut', () => {
         // GIVEN --> An expected received amount of 4000 DAI
         // GIVEN --> Slippage of 0.5%
 
-        // WHEN --> Calculate the minimun received amount (accounting slippage)
-        // THEN --> 3,980     = 4000*0.995
+        // WHEN --> Calculating the minimum received amount (accounting slippage)
+        // THEN --> 4000*0.995 = 3980
         const actualMinimumAmountOut = trade.minimumAmountOut(SLIPPAGE_HALF_PERCENT).toSignificant(LONG_PRECISION)
         expect(actualMinimumAmountOut).toEqual('3980')
       })
@@ -127,21 +125,20 @@ describe('Swap PRICE Quote test', () => {
 
       it('Shows correct sold amount', () => {
         // GIVEN --> Api response: price = 1000000000000000000 (1) & fee = 100000000000000000 (0.1)
-        // WHEN --> Estimated_sold_before_fee + Fee
-        // THEN --> From = 1000000000000000000 + 100000000000000000 = 1100000000000000000
-        const expectedSoldAmount = 1000000000000000000 + 100000000000000000
-        const actualSoldAmount = trade.inputAmountWithFee.quotient.toString()
-        expect(expectedSoldAmount.toString()).toEqual(actualSoldAmount)
+        // GIVEN --> Trade FROM amount for buy orders equals ESTIMATED_SELL_AMOUNT + FEE_AMOUNT
+        // THEN --> FROM = 1000000000000000000 (1) + 100000000000000000 (0.1)= 1100000000000000000 (1.1)
+        const tradeSoldAmount = trade.inputAmountWithFee.quotient.toString()
+        expect(tradeSoldAmount).toEqual((1100000000000000000).toString())
       })
       it('Display price correct', () => {
         const displayPrice = trade.executionPrice.invert()
 
-        // GIVEN --> To = 4000000000000000000000 & Estimated Sold Before Fee = 1000000000000000000
-        // WEHN --> Price_displayed => To / Estimated_sold_before_fee
-        // THEN --> Price_displayed = 4000000000000000000000 / 1000000000000000000 = 4000
-        const expectedDisplayPrice = '4000'
-        const actualDisplayPrice = displayPrice.toSignificant(DEFAULT_PRECISION)
-        expect(expectedDisplayPrice).toEqual(actualDisplayPrice)
+        // GIVEN --> EXACT_BUY_AMOUNT = 4000000000000000000000 (4000) and
+        // GIVEN --> ESTIMATED_SELL_AMOUNT_BEFORE_FEE = 1000000000000000000 (1)
+        // WHEN --> PRICE_DISPLAYED = EXACT_BUY_AMOUNT / ESTIMATED_SELL_AMOUNT_BEFORE_FEE
+        // THEN --> PRICE_DISPLAYED = 4000000000000000000000 (4000) / 1000000000000000000 (1) = 4000
+        const tradeDisplayPrice = displayPrice.toSignificant(DEFAULT_PRECISION)
+        expect(tradeDisplayPrice).toEqual('4000')
       })
       it('Price with 0.5% slippage correct', () => {
         const displayPrice = trade.executionPrice.invert()
@@ -149,12 +146,12 @@ describe('Swap PRICE Quote test', () => {
         // 0.995
         const slippage = new Fraction('1').subtract(userSlippage)
 
-        // GIVEN 0.5% slippage & displayPrice = 4000
-        // WHEN Max_price => Price_displayed * (1-slippage)
+        // GIVEN 0.5% slippage & display price = 4000
+        // WHEN MAX_PRICE = PRICE_DISPLAYED * (1-SLIPPAGE)
         // THEN
-        const expectedPriceWithSlippage = '3980' // 4000 * 0.995
-        const actualPriceWithSlipapge = slippage.multiply(displayPrice)
-        expect(expectedPriceWithSlippage).toEqual(actualPriceWithSlipapge.toSignificant(12))
+        const priceWithSlippage = '3980' // 4000 * 0.995
+        const actualPriceWithSlipapge = slippage.multiply(displayPrice).toSignificant(12)
+        expect(actualPriceWithSlipapge).toEqual(priceWithSlippage)
       })
       it('Expected maximum sold correct', () => {
         // GIVEN: An expected sell amount of 1.1 ETH   (1 ETH for the 4000 DAI, and 0.1 ETH for fee)

--- a/src/custom/state/swap/trade.test.ts
+++ b/src/custom/state/swap/trade.test.ts
@@ -79,16 +79,13 @@ describe('Swap PRICE Quote test', () => {
         expect(expectedPrice).toEqual(actualPrice)
       })
       it('Shows the proper minimumAmountOut', () => {
-        // GIVEN --> slippage is set @ 0.5%
-        const slippage = SLIPPAGE_HALF_PERCENT
-        // Min_price => Price_displayed * (1+slippage)
-        // Min_price_displayed = 0.000225 * (1.005) = 0.000226125
+        // GIVEN --> An expected received amount of 4000 DAI
+        // GIVEN --> Slippage of 0.5%
 
-        // WHEN --> Min_received_tokens = Sold_tokens / Min_price
-        // THEN --> 900000000000000000 / 0.000226125 / 10**18 = 3980.099502487562
-        const expectedMinimumAmountOut = '3980.099502'
-        const actualMinimumAmountOut = trade.minimumAmountOut(slippage).toSignificant(LONG_PRECISION)
-        expect(expectedMinimumAmountOut).toEqual(actualMinimumAmountOut)
+        // WHEN --> Calculate the minimun received amount (accounting slippage)
+        // THEN --> 3,980     = 4000*0.995
+        const actualMinimumAmountOut = trade.minimumAmountOut(SLIPPAGE_HALF_PERCENT).toSignificant(LONG_PRECISION)
+        expect(actualMinimumAmountOut).toEqual('3980')
       })
     })
   })
@@ -160,15 +157,12 @@ describe('Swap PRICE Quote test', () => {
         expect(expectedPriceWithSlippage).toEqual(actualPriceWithSlipapge.toSignificant(12))
       })
       it('Expected maximum sold correct', () => {
-        // GIVEN To = 4000000000000000000000, MaxPrice = 3980 & Fee = 0.1
-        // WHEN Maximum_sold = To / Max_price + Fee
-        // THEN
-        // 4000000000000000000000 / 3980 + 100000000000000000 = 1,105025125e18
-        // 1,105025125e18 * 1e-18 = 1,105025125
-        const userSlippage = SLIPPAGE_HALF_PERCENT
-        const expectedMaximumSold = '1.105025125'
-        const actualMaximumSold = trade.maximumAmountIn(userSlippage).toSignificant(LONG_PRECISION)
-        expect(expectedMaximumSold).toEqual(actualMaximumSold)
+        // GIVEN: An expected sell amount of 1.1 ETH   (1 ETH for the 4000 DAI, and 0.1 ETH for fee)
+        // GIVEN: Slippage of 0.5%
+        // WHEN: Calculate the maximum sold including slippage
+        // THEN: 1.1 * 1.005
+        const actualMaximumSold = trade.maximumAmountIn(SLIPPAGE_HALF_PERCENT).toSignificant(LONG_PRECISION)
+        expect(actualMaximumSold).toEqual('1.1055')
       })
     })
   })


### PR DESCRIPTION
# Summary

Slippage calculation was wrong, as pointed out by @nlordell in https://cowservices.slack.com/archives/C0369B303UN/p1655937383605559

Before we were calculating the slippage in a way more complex way (and wrong). We were using the price without fee, which is the one we show, then multiplying that by the original amount (to get what we would get if there was no fee), then we apply the slippage to the original price, and multiply it by the original amount after fee.

Now is way more simple. Just applies the slippage to the amount after fee. Similar approach was applied to buy Orders.

# To Test
- Use the UI and simulate buy orders and sell order
- Pay special attention to the sell amount and buy amount used when you sign the transaction, and the displayed amounts in the confirmation window