### PR TITLE
[fix] Pass validTo time inside callback

### DIFF
--- a/src/custom/hooks/useUSDCPrice/index.ts
+++ b/src/custom/hooks/useUSDCPrice/index.ts
@@ -102,8 +102,6 @@ export default function useCowUsdPrice(currency?: Currency) {
       fromDecimals: sellTokenDecimals,
       toDecimals: stablecoin.decimals,
       userAddress: account,
-      // we dont care about validTo here, just use max
-      // FIXME: I guess we care now, using 10min. Future versions of the API will make it optional
       validTo: USD_QUOTE_VALID_TO,
     }
   }, [account, baseAmountRaw, isStablecoin, sellTokenAddress, sellTokenDecimals, stablecoin, supportedChain])

--- a/src/custom/hooks/useUSDCPrice/index.ts
+++ b/src/custom/hooks/useUSDCPrice/index.ts
@@ -23,6 +23,7 @@ import { useGetGpUsdcPrice } from 'utils/price'
 
 export * from '@src/hooks/useUSDCPrice'
 
+export const USD_QUOTE_VALID_TO = Math.ceil(Date.now() / 1000) + 600
 const STABLECOIN_AMOUNT_OUT: { [chain in SupportedChainId]: CurrencyAmount<Token> } = {
   ...STABLECOIN_AMOUNT_OUT_UNI,
   // MOD: lowers threshold from 100k to 100
@@ -103,7 +104,7 @@ export default function useCowUsdPrice(currency?: Currency) {
       userAddress: account,
       // we dont care about validTo here, just use max
       // FIXME: I guess we care now, using 10min. Future versions of the API will make it optional
-      validTo: Math.ceil(Date.now() / 1000) + 600,
+      validTo: USD_QUOTE_VALID_TO,
     }
   }, [account, baseAmountRaw, isStablecoin, sellTokenAddress, sellTokenDecimals, stablecoin, supportedChain])
 

--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -29,7 +29,7 @@ import {
 import { FeeInformation, PriceInformation } from '@cowprotocol/cow-sdk'
 import { GpPriceStrategy } from 'hooks/useGetGpPriceStrategy'
 import useSWR from 'swr'
-import { USD_QUOTE_VALID_TO } from '../hooks/useUSDCPrice'
+import { USD_QUOTE_VALID_TO } from 'hooks/useUSDCPrice'
 
 const FEE_EXCEEDS_FROM_ERROR = new GpQuoteError({
   errorType: GpQuoteErrorCodes.FeeExceedsFrom,

--- a/src/custom/utils/price.ts
+++ b/src/custom/utils/price.ts
@@ -29,6 +29,7 @@ import {
 import { FeeInformation, PriceInformation } from '@cowprotocol/cow-sdk'
 import { GpPriceStrategy } from 'hooks/useGetGpPriceStrategy'
 import useSWR from 'swr'
+import { USD_QUOTE_VALID_TO } from '../hooks/useUSDCPrice'
 
 const FEE_EXCEEDS_FROM_ERROR = new GpQuoteError({
   errorType: GpQuoteErrorCodes.FeeExceedsFrom,
@@ -357,6 +358,8 @@ export async function getGpUsdcPrice({ strategy, quoteParams }: Pick<LegacyQuote
     console.debug(
       '[GP PRICE::API] getGpUsdcPrice - Attempting best USDC quote retrieval using COWSWAP strategy, hang tight.'
     )
+    // we need to explicitly set the validTo time to 10m in future on every call
+    quoteParams.validTo = USD_QUOTE_VALID_TO
     const { quote } = await getQuote(quoteParams)
 
     return quote.sellAmount


### PR DESCRIPTION
# Summary

Related to [this slack thread](https://cowservices.slack.com/archives/C0361CDG8GP/p1656002311466639)

We had changed the `validTo` param and we need it to stay inside the calculating callback and NOT only the hook. Keeping it inside the hook can pass stale values to the cb and cause a "Valid To time cannot be in the past" error

## Testing
1. swap any token with networks tab open
2. filter by "quote"
3. look for buy orders for USDC at 100000000 (100 in usdc atoms)
4. see that there are no errors for valid to time being in the past