### PR TITLE
[USD Price] Add sentry reporting to USD price feeds

### DIFF
--- a/src/custom/hooks/useUSDCPrice/index.ts
+++ b/src/custom/hooks/useUSDCPrice/index.ts
@@ -291,7 +291,7 @@ export function useHigherUSDValue(currencyAmount: CurrencyAmount<Currency> | und
   if (!gpUsdPrice || !coingeckoUsdPrice) {
     let failedEndpoint = ''
     if (!gpUsdPrice && !coingeckoUsdPrice) {
-      failedEndpoint = 'BOTH'
+      failedEndpoint = 'COINGECKO,COW_API'
     } else if (!gpUsdPrice) {
       failedEndpoint = 'COW_API'
     } else {
@@ -303,8 +303,9 @@ export function useHigherUSDValue(currencyAmount: CurrencyAmount<Currency> | und
     const contexts = {
       params: {
         endpoint: failedEndpoint,
-        quotedCurrency: token?.symbol || token?.address || 'UNKNOWN TOKEN',
-        amount: currencyAmount?.toExact() || 'UNKNOWN AMOUNT',
+        // TODO: use enum from pr #751
+        quotedCurrency: token?.symbol || token?.address || 'UNKNOWN',
+        amount: currencyAmount?.toExact() || 'UNKNOWN',
       },
     }
     // report this to sentry

--- a/src/custom/hooks/useUSDCPrice/index.ts
+++ b/src/custom/hooks/useUSDCPrice/index.ts
@@ -289,9 +289,9 @@ export function useHigherUSDValue(currencyAmount: CurrencyAmount<Currency> | und
   const coingeckoUsdPrice = useCoingeckoUsdValue(currencyAmount)
 
   if (!gpUsdPrice || !coingeckoUsdPrice) {
-    let failedEndpoint = ''
+    let failedEndpoint
     if (!gpUsdPrice && !coingeckoUsdPrice) {
-      failedEndpoint = 'COINGECKO,COW_API'
+      failedEndpoint = ['COINGECKO', 'COW_API']
     } else if (!gpUsdPrice) {
       failedEndpoint = 'COW_API'
     } else {

--- a/src/custom/state/sentry/updater/index.ts
+++ b/src/custom/state/sentry/updater/index.ts
@@ -6,11 +6,7 @@ import { useSwapState } from 'state/swap/hooks'
 import { useCurrency } from 'hooks/Tokens'
 import { useWalletInfo } from 'hooks/useWalletInfo'
 import { useAppSelector } from 'state/hooks'
-
-export enum SentryTag {
-  DISCONNECTED = 'DISCONNECTED',
-  UNKNOWN = 'UNKNOWN',
-}
+import { SentryTag } from 'utils/logging'
 
 /**
  * _getSentryChainId


### PR DESCRIPTION
## Summary

As discussed in the v1.15.0 [post-mortem doc](https://docs.google.com/document/u/2/d/1SfKDvGBRQFLScEoiQ3V2aGXG9ktIIaJ3WkIm_oghG9g/edit) this is a low hanging fruit follow up for adding better detection to downed services.

Adds sentry message reporting (non-error) for USD (coingecko/cow api) price feeds returning `null`

An example [can be seen here](https://sentry.io/organizations/cowprotocol/issues/3375350787/?environment=local&project=5905822&query=is%3Aunresolved)

### Screenshots
<img width="903" alt="image" src="https://user-images.githubusercontent.com/21335563/175523602-d891f748-aa7d-47c1-adb0-da49565e9129.png">

<img width="684" alt="image" src="https://user-images.githubusercontent.com/21335563/175523897-6b0a8aef-e8f2-477b-8dd5-cbd774378e2d.png">

### Testing
Open Cowswap
Change WETH to ETH token in the From field
Open Sentry, filter by PR environment --> the error should be at the top