### PR TITLE
Refactor: Replaced map upload queue with arrary

### DIFF
--- a/src/custom/state/appData/types.tsx
+++ b/src/custom/state/appData/types.tsx
@@ -11,19 +11,17 @@ type AppDataUploadStatus = {
   uploading: boolean
 }
 
-export type AppDataRecord = AppDataInfo & AppDataUploadStatus
-
-export type AppDataPendingToUpload = Record<string, AppDataRecord>
-
 export type AppDataKeyParams = {
   chainId: SupportedChainId
   orderId: string
 }
+
+export type AppDataRecord = AppDataInfo & AppDataUploadStatus & AppDataKeyParams
+
+export type AppDataPendingToUpload = Array<AppDataRecord>
 
 export type AddAppDataToUploadQueueParams = AppDataKeyParams & {
   appData: AppDataInfo
 }
 export type UpdateAppDataOnUploadQueueParams = AppDataKeyParams & Partial<AppDataUploadStatus>
 export type RemoveAppDataFromUploadQueueParams = AppDataKeyParams
-
-export type FlattenedAppDataFromUploadQueue = AppDataKeyParams & AppDataRecord

--- a/src/custom/state/appData/updater.ts
+++ b/src/custom/state/appData/updater.ts
@@ -6,15 +6,11 @@ import { AppDataDoc } from '@cowprotocol/cow-sdk'
 import { COW_SDK } from 'constants/index'
 
 import {
-  flattenedAppDataFromUploadQueueAtom,
+  appDataUploadQueueAtom,
   removeAppDataFromUploadQueueAtom,
   updateAppDataOnUploadQueueAtom,
 } from 'state/appData/atoms'
-import {
-  AppDataKeyParams,
-  FlattenedAppDataFromUploadQueue,
-  UpdateAppDataOnUploadQueueParams,
-} from 'state/appData/types'
+import { AppDataKeyParams, AppDataRecord, UpdateAppDataOnUploadQueueParams } from 'state/appData/types'
 
 const UPLOAD_CHECK_INTERVAL = ms`10s`
 const BASE_FOR_EXPONENTIAL_BACKOFF = 2 // in seconds, converted to milliseconds later
@@ -22,7 +18,7 @@ const ONE_SECOND = ms`1s`
 const MAX_TIME_TO_WAIT = ms`5 minutes`
 
 export function UploadToIpfsUpdater(): null {
-  const toUpload = useAtomValue(flattenedAppDataFromUploadQueueAtom)
+  const toUpload = useAtomValue(appDataUploadQueueAtom)
   const removePending = useSetAtom(removeAppDataFromUploadQueueAtom)
   const updatePending = useSetAtom(updateAppDataOnUploadQueueAtom)
 
@@ -47,7 +43,7 @@ export function UploadToIpfsUpdater(): null {
 }
 
 async function _uploadToIpfs(
-  appDataRecord: FlattenedAppDataFromUploadQueue,
+  appDataRecord: AppDataRecord,
   updatePending: (params: UpdateAppDataOnUploadQueueParams) => void,
   removePending: (params: AppDataKeyParams) => void
 ) {
@@ -82,7 +78,7 @@ function _canUpload(uploading: boolean, attempts: number, lastAttempt?: number):
 }
 
 async function _actuallyUploadToIpfs(
-  appDataRecord: FlattenedAppDataFromUploadQueue,
+  appDataRecord: AppDataRecord,
   updatePending: (params: UpdateAppDataOnUploadQueueParams) => void,
   removePending: (params: AppDataKeyParams) => void
 ) {

--- a/src/custom/state/appData/utils.ts
+++ b/src/custom/state/appData/utils.ts
@@ -1,11 +1,11 @@
-import { AppDataKeyParams } from 'state/appData/types'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
-export function buildAppDataRecordKey({ chainId, orderId }: AppDataKeyParams): string {
-  return `${chainId}-${orderId}`
+import { AppDataRecord } from 'state/appData/types'
+
+export function buildDocFilterFn(chainId: SupportedChainId, orderId: string) {
+  return (doc: AppDataRecord) => doc.chainId === chainId && doc.orderId === orderId
 }
 
-export function parseAppDataRecordKey(key: string): AppDataKeyParams {
-  const [chainId, orderId] = key.split('-')
-
-  return { chainId, orderId } as unknown as AppDataKeyParams
+export function buildInverseDocFilterFn(chainId: SupportedChainId, orderId: string) {
+  return (doc: AppDataRecord) => doc.chainId !== chainId && doc.orderId !== orderId
 }


### PR DESCRIPTION
# Summary

Refactored state management

Based on this thread https://github.com/cowprotocol/cowswap/pull/629#discussion_r903585607

## Note

If you see any error, go to your local storage and delete the key `appDataUploadQueue`

# To Test

Same steps as parent PR https://github.com/cowprotocol/cowswap/pull/629

1. Load the page and open the dev console.
2. Filter by `appData`
3. On every price change you should see a debug log similar to this image
<img width="491" alt="Screen Shot 2022-06-08 at 15 03 49" src="https://user-images.githubusercontent.com/43217/172636812-6a89b329-07b3-47a0-b5a2-006c17e7bcdb.png">

* Make sure the fields match what you are seeing:
* environment: `pr`
* CID and appDataHash: calculated but won't exist yet on IPFS
4. Place an order and open it on the browser `https://barn.api.cow.fi/mainnet/api/v1/orders/<orderId>`
* Check the appDataHash in the order matches the last console debug log
5. Filter the console log for `UploadToIpfs`
* Check the appData related to your order has been uploaded, like the image
<img width="475" alt="Screen Shot 2022-06-08 at 15 10 57" src="https://user-images.githubusercontent.com/43217/172638536-5634007f-d9fe-4a76-b77c-c624bec0d6ba.png">

7. Search for the appDataHash using https://codepen.io/pacara/pen/BadZgjg?editors=0101
* Check it exists and the fields match the last console debug log