### PR TITLE
Fix for Injected wallet issue

### DIFF
--- a/src/custom/components/WalletModal/WalletModalMod.tsx
+++ b/src/custom/components/WalletModal/WalletModalMod.tsx
@@ -291,7 +291,7 @@ export default function WalletModal({
       // overwrite injected when needed
       if (option.connector === injected) {
         // don't show injected if there's no injected provider
-        if (!(window.web3 || window.ethereum)) {
+        if (!(window.web3 || window.ethereum) || !isMetamask) {
           if (option.name === 'MetaMask') {
             return (
               <Option


### PR DESCRIPTION
# Summary

Fixes #537
- fixes the problem described in linked issue
- reason for this is that Coinbase wallet extension is also injecting `window.web3` and `window.ethereum` so we need to check if the injected `window.ethereum` is metamask or not.
  
### Steps to reproduce

- Install Coinbase extension
- Disable Metamask
- Reload Cowswap page and open wallets modal
- Now there should be no Inject option but instead Install Metamask link