### PR TITLE
Fix for double injected popup issue

### DIFF
--- a/src/custom/components/WalletModal/WalletModalMod.tsx
+++ b/src/custom/components/WalletModal/WalletModalMod.tsx
@@ -29,6 +29,7 @@ import PendingView from 'components/WalletModal/PendingView'
 
 // MOD imports
 import ModalMod from '@src/components/Modal'
+import { activateInjectedProvider } from 'utils/misc'
 
 export const CloseIcon = styled.div`
   position: absolute;
@@ -325,6 +326,11 @@ export default function WalletModal({
           <Option
             id={`connect-${key}`}
             onClick={() => {
+              // Solves the problem of opening both Coinbase and Metamask popups
+              if (option.name === 'MetaMask') {
+                activateInjectedProvider('MetaMask')
+              }
+
               option.connector === connector
                 ? setWalletView(WALLET_VIEWS.ACCOUNT)
                 : !option.href && tryActivation(option.connector)

--- a/src/custom/utils/misc.ts
+++ b/src/custom/utils/misc.ts
@@ -157,3 +157,35 @@ export function isRejectRequestProviderError(error: any) {
 
   return false
 }
+
+/**
+ *
+ * @param providerName Can be MetaMask or CoinBase (We might extend this in future)
+ *
+ * This solves the issue of injected provider opening both Metamask and Coinbase wallet popups
+ * The solution is to set selected provider on ethereum based on pased providerName parameter
+ * Link: https://github.com/NoahZinsmeister/web3-react/issues/300#issuecomment-995170556
+ *
+ * @returns void | undefined
+ */
+export function activateInjectedProvider(providerName: 'MetaMask' | 'CoinBase'): void | undefined {
+  const { ethereum } = window
+
+  if (!ethereum?.providers) {
+    return undefined
+  }
+
+  let provider
+  switch (providerName) {
+    case 'CoinBase':
+      provider = ethereum.providers.find(({ isCoinbaseWallet }) => isCoinbaseWallet)
+      break
+    case 'MetaMask':
+      provider = ethereum.providers.find(({ isMetaMask }) => isMetaMask)
+      break
+  }
+
+  if (provider) {
+    ethereum.setSelectedProvider(provider)
+  }
+}


### PR DESCRIPTION
# Summary

There seems to be a bug when you have both Metamask and Coinbase extensions and you select a Metamask wallet option, both Coinbase and Metamask wallet popups open. This PR fixes this issue so that only Metamask popup opens when user selects Matamask connect wallet option.

Video describing the issue https://watch.screencastify.com/v/xEZk1EmgjVzGLOjY468K

### To test
- install both Coinbase and Metamask wallets extensions
- make sure both of them are enabled
- click on Metamask wallet option
- only metamask wallet popup should open