### PR TITLE
332/slippage bips rather than amounts on metadata

### DIFF
--- a/src/custom/hooks/useAppData.ts
+++ b/src/custom/hooks/useAppData.ts
@@ -29,12 +29,6 @@ export function useAppData({ chainId, allowedSlippage }: UseAppDataParams): AppD
   // AppCode is dynamic and based on how it's loaded (if used as a Gnosis Safe app)
   const appCode = useAppCode()
 
-  // TODO: Section commented out for future reference, in case we want to enable it again
-  // Sell and buy amounts, from trade param
-  // const sellAmount = trade?.inputAmountWithFee.quotient.toString()
-  // const buyAmount = trade?.outputAmount.quotient.toString()
-  // const quoteId = trade?.quoteId
-
   // Transform slippage Percent to bips
   const slippageBips = percentToBips(allowedSlippage)
 

--- a/src/custom/hooks/useAppData.ts
+++ b/src/custom/hooks/useAppData.ts
@@ -3,8 +3,7 @@ import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { useAtom } from 'jotai'
 import { Percent } from '@uniswap/sdk-core'
 
-import TradeGp from 'state/swap/TradeGp'
-import { APP_DATA_HASH, DEFAULT_SLIPPAGE_BPS } from 'constants/index'
+import { APP_DATA_HASH } from 'constants/index'
 import { buildAppData, BuildAppDataParams } from 'utils/appData'
 import { appDataInfoAtom } from 'state/appData/atoms'
 import { AppDataInfo } from 'state/appData/types'
@@ -12,13 +11,15 @@ import { useReferralAddress } from 'state/affiliate/hooks'
 import { useAppCode } from 'hooks/useAppCode'
 import { percentToBips } from 'utils/misc'
 
+type UseAppDataParams = {
+  chainId?: SupportedChainId
+  allowedSlippage: Percent
+}
+
 /**
  * Fetches and updates appDataInfo whenever a dependency changes
- *
- * @param chainId
- * @param trade
  */
-export function useAppData(chainId?: SupportedChainId, trade?: TradeGp, allowedSlippage?: Percent): AppDataInfo | null {
+export function useAppData({ chainId, allowedSlippage }: UseAppDataParams): AppDataInfo | null {
   // AppDataInfo, from Jotai
   const [appDataInfo, setAppDataInfo] = useAtom(appDataInfoAtom)
   // Referrer address, from Redux
@@ -35,10 +36,10 @@ export function useAppData(chainId?: SupportedChainId, trade?: TradeGp, allowedS
   // const quoteId = trade?.quoteId
 
   // Transform slippage Percent to bips
-  const slippageBips = allowedSlippage ? percentToBips(allowedSlippage) : DEFAULT_SLIPPAGE_BPS.toString()
+  const slippageBips = percentToBips(allowedSlippage)
 
   useEffect(() => {
-    if (!chainId || !slippageBips) {
+    if (!chainId) {
       // reset values when there is no price estimation or network changes
       setAppDataInfo(null)
       return

--- a/src/custom/hooks/useSwapCallback.ts
+++ b/src/custom/hooks/useSwapCallback.ts
@@ -350,7 +350,7 @@ export function useSwapCallback(params: SwapCallbackParams): {
 
   const [deadline] = useUserTransactionTTL()
 
-  const appData = useAppData(chainId, trade, allowedSlippage)
+  const appData = useAppData({ chainId, allowedSlippage })
   const { hash: appDataHash } = appData || {}
   const addAppDataToUploadQueue = useAddAppDataToUploadQueue(chainId, appData)
 

--- a/src/custom/hooks/useSwapCallback.ts
+++ b/src/custom/hooks/useSwapCallback.ts
@@ -350,7 +350,7 @@ export function useSwapCallback(params: SwapCallbackParams): {
 
   const [deadline] = useUserTransactionTTL()
 
-  const appData = useAppData(chainId, trade)
+  const appData = useAppData(chainId, trade, allowedSlippage)
   const { hash: appDataHash } = appData || {}
   const addAppDataToUploadQueue = useAddAppDataToUploadQueue(chainId, appData)
 

--- a/src/custom/utils/appData.ts
+++ b/src/custom/utils/appData.ts
@@ -2,7 +2,7 @@ import { COW_SDK } from 'constants/index'
 import { MetadataDoc, QuoteMetadata, ReferralMetadata, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { environmentName } from 'utils/environments'
 
-const QUOTE_METADATA_VERSION = '0.1.0'
+const QUOTE_METADATA_VERSION = '0.2.0'
 const REFERRER_METADATA_VERSION = '0.1.0'
 
 export async function buildAppData(

--- a/src/custom/utils/appData.ts
+++ b/src/custom/utils/appData.ts
@@ -8,7 +8,7 @@ const REFERRER_METADATA_VERSION = '0.1.0'
 
 export type BuildAppDataParams = {
   chainId: SupportedChainId
-  slippageBips?: string
+  slippageBips: string
   sellAmount?: string
   buyAmount?: string
   quoteId?: number
@@ -28,7 +28,7 @@ export async function buildAppData({
   const sdk = COW_SDK[chainId]
 
   // build quote metadata, not required in the schema but always present
-  const quoteMetadata = _buildQuoteMetadata({ slippageBips, sellAmount, buyAmount, quoteId })
+  const quoteMetadata = _buildQuoteMetadata(slippageBips)
   const metadata: MetadataDoc = { quote: quoteMetadata }
 
   // build referrer metadata, optional
@@ -43,26 +43,8 @@ export async function buildAppData({
   return { doc, calculatedAppData }
 }
 
-type BuildQuoteMetadataParams = Omit<QuoteMetadata, 'version' | 'id'> & {
-  quoteId?: number | undefined
-}
-
-function _buildQuoteMetadata({
-  slippageBips,
-  sellAmount,
-  buyAmount,
-  quoteId,
-}: BuildQuoteMetadataParams): QuoteMetadata | undefined {
-  const base = { version: QUOTE_METADATA_VERSION, id: quoteId?.toString() }
-
-  if (slippageBips) {
-    return { ...base, slippageBips }
-  } else if (sellAmount && buyAmount) {
-    return { ...base, sellAmount, buyAmount }
-  }
-
-  console.warn(`Neither slippageBips nor sellAmount and buyAmount set. Cannot build quote metadata`)
-  return
+function _buildQuoteMetadata(slippageBips: string): QuoteMetadata | undefined {
+  return { version: QUOTE_METADATA_VERSION, slippageBips }
 }
 
 function _buildReferralMetadata(address: string): ReferralMetadata {

--- a/src/custom/utils/appData.ts
+++ b/src/custom/utils/appData.ts
@@ -43,7 +43,7 @@ export async function buildAppData({
   return { doc, calculatedAppData }
 }
 
-function _buildQuoteMetadata(slippageBips: string): QuoteMetadata | undefined {
+function _buildQuoteMetadata(slippageBips: string): QuoteMetadata {
   return { version: QUOTE_METADATA_VERSION, slippageBips }
 }
 

--- a/src/custom/utils/misc.ts
+++ b/src/custom/utils/misc.ts
@@ -1,6 +1,7 @@
 import { SupportedChainId as ChainId } from 'constants/chains'
 import { Market } from 'types/index'
 import { OrderKind } from '@cowprotocol/contracts'
+import { Percent } from '@uniswap/sdk-core'
 
 const PROVIDER_REJECT_REQUEST_CODE = 4001 // See https://eips.ethereum.org/EIPS/eip-1193
 const PROVIDER_REJECT_REQUEST_ERROR_MESSAGES = ['User denied message signature', 'User rejected the transaction']
@@ -156,4 +157,12 @@ export function isRejectRequestProviderError(error: any) {
   }
 
   return false
+}
+
+/**
+ * Helper function that transforms a Percent instance into the correspondent BIPS value as a string
+ * @param percent
+ */
+export function percentToBips(percent: Percent): string {
+  return percent.multiply('100').toSignificant()
 }


### PR DESCRIPTION
# Summary

Part of #332 

Waterfalls onto/supersedes https://github.com/cowprotocol/cowswap/pull/750

Using the latest version of the appData.

Updating metadata way less often by storing only the slippage instead of sell/buyAmounts and quoteId

  # To Test

1. Open the console, filter by `appData`
2. Play with the slippage in the settings
* Every update should trigger a new appData being generated
* The slippage will be stored as [BIPs](https://www.investopedia.com/ask/answers/what-basis-point-bps/). For example, the default 0.50% will be stored as `50`
3. Place an order
* Verify it contains the appData hash calculated in the previous step