### PR TITLE
Added GA events for order out of market

### DIFF
--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -86,7 +86,7 @@ import { SupportedChainId } from 'constants/chains'
 import CowSubsidyModal from 'components/CowSubsidyModal'
 import { getProviderErrorMessage, isRejectRequestProviderError } from 'utils/misc'
 import { AlertWrapper } from './styleds' // mod
-import { approvalAnalytics, swapAnalytics, setMaxSellTokens, signSwapAnalytics } from 'utils/analytics'
+import { approvalAnalytics, swapAnalytics, setMaxSellTokensAnalytics, signSwapAnalytics } from 'utils/analytics'
 
 // const AlertWrapper = styled.div`
 //   max-width: 460px;
@@ -561,7 +561,7 @@ export default function Swap({
 
   const handleMaxInput = useCallback(() => {
     maxInputAmount && onUserInput(Field.INPUT, maxInputAmount.toExact())
-    setMaxSellTokens()
+    setMaxSellTokensAnalytics()
   }, [maxInputAmount, onUserInput])
 
   const handleOutputSelect = useCallback(

--- a/src/custom/state/index.ts
+++ b/src/custom/state/index.ts
@@ -30,6 +30,7 @@ import cowToken from 'state/cowToken/reducer'
 import { popupMiddleware, soundMiddleware } from './orders/middleware'
 import { cowTokenMiddleware } from 'state/cowToken/middleware'
 import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
+import { priceMiddleware } from 'state/price/middleware'
 
 const UNISWAP_REDUCERS = {
   application,
@@ -71,7 +72,8 @@ const store = configureStore({
       .concat(save({ states: PERSISTED_KEYS, debounce: 1000 }))
       .concat(popupMiddleware)
       .concat(cowTokenMiddleware)
-      .concat(soundMiddleware),
+      .concat(soundMiddleware)
+      .concat(priceMiddleware),
   preloadedState: load({ states: PERSISTED_KEYS, disableWarnings: process.env.NODE_ENV === 'test' }),
 })
 

--- a/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -83,7 +83,7 @@ export function UnfillableOrdersUpdater(): null {
         setIsOrderUnfillable({ chainId, id: order.id, isUnfillable })
 
         // order.isUnfillable by default is undefined, so we don't want to dispatch this in that case
-        if (typeof order.isUnfillable === 'boolean') {
+        if (typeof order.isUnfillable !== 'undefined') {
           const label = `${order.inputToken.symbol}, ${order.outputToken.symbol}`
           priceOutOfRangeAnalytics(isUnfillable, label)
         }

--- a/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -84,7 +84,7 @@ export function UnfillableOrdersUpdater(): null {
 
         // order.isUnfillable by default is undefined, so we don't want to dispatch this in that case
         if (typeof order.isUnfillable === 'boolean') {
-          const label = [order.inputToken.symbol, order.outputToken.symbol].join(',')
+          const label = `${order.inputToken.symbol}, ${order.outputToken.symbol}`
           priceOutOfRangeAnalytics(isUnfillable, label)
         }
       }

--- a/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -14,6 +14,7 @@ import { isOrderUnfillable } from 'state/orders/utils'
 import useGetGpPriceStrategy, { GpPriceStrategy } from 'hooks/useGetGpPriceStrategy'
 import { getPromiseFulfilledValue } from 'utils/misc'
 import { PriceInformation } from '@cowprotocol/cow-sdk'
+import { priceOutOfRangeAnalytics } from 'utils/analytics'
 
 /**
  * Thin wrapper around `getBestPrice` that builds the params and returns null on failure
@@ -78,7 +79,15 @@ export function UnfillableOrdersUpdater(): null {
       const isUnfillable = isOrderUnfillable(order, price)
 
       // Only trigger state update if flag changed
-      order.isUnfillable !== isUnfillable && setIsOrderUnfillable({ chainId, id: order.id, isUnfillable })
+      if (order.isUnfillable !== isUnfillable) {
+        setIsOrderUnfillable({ chainId, id: order.id, isUnfillable })
+
+        // order.isUnfillable by default is undefined, so we don't want to dispatch this in that case
+        if (typeof order.isUnfillable === 'boolean') {
+          const label = [order.inputToken.symbol, order.outputToken.symbol].join(',')
+          priceOutOfRangeAnalytics(isUnfillable, label)
+        }
+      }
     },
     [setIsOrderUnfillable]
   )

--- a/src/custom/state/price/middleware.ts
+++ b/src/custom/state/price/middleware.ts
@@ -10,6 +10,7 @@ export const priceMiddleware: Middleware<Record<string, unknown>, AppState> = (s
 
   if (isUpdateQuoteAction(action)) {
     if (!state.price.initialQuoteLoaded) {
+      // Send an event only on the first price load
       initialPriceLoadAnalytics()
     }
   }

--- a/src/custom/state/price/middleware.ts
+++ b/src/custom/state/price/middleware.ts
@@ -1,0 +1,18 @@
+import { Middleware, isAnyOf } from '@reduxjs/toolkit'
+import { AppState } from 'state'
+import { initialPriceLoadAnalytics } from 'utils/analytics'
+import * as PriceActions from './actions'
+
+const isUpdateQuoteAction = isAnyOf(PriceActions.updateQuote)
+
+export const priceMiddleware: Middleware<Record<string, unknown>, AppState> = (store) => (next) => (action) => {
+  const state = store.getState()
+
+  if (isUpdateQuoteAction(action)) {
+    if (!state.price.initialQuoteLoaded) {
+      initialPriceLoadAnalytics()
+    }
+  }
+
+  return next(action)
+}

--- a/src/custom/state/price/reducer.ts
+++ b/src/custom/state/price/reducer.ts
@@ -6,7 +6,6 @@ import { Writable } from 'custom/types'
 import { PrefillStateRequired } from '../orders/reducer'
 import { LegacyFeeQuoteParams } from 'api/gnosisProtocol/legacy/types'
 import { FeeInformation, PriceInformation } from '@cowprotocol/cow-sdk'
-import { initialPriceLoadAnalytics } from 'utils/analytics'
 
 // API Doc: https://protocol-rinkeby.dev.gnosisdev.com/api
 
@@ -138,10 +137,6 @@ export default createReducer(initialState, (builder) =>
 
       if (quoteInformation && shouldUpdate) {
         quotes[chainId][sellToken] = { ...quoteInformation, ...payload }
-      }
-
-      if (!state.initialQuoteLoaded) {
-        initialPriceLoadAnalytics()
       }
 
       // Stop the loader

--- a/src/custom/state/price/reducer.ts
+++ b/src/custom/state/price/reducer.ts
@@ -6,6 +6,7 @@ import { Writable } from 'custom/types'
 import { PrefillStateRequired } from '../orders/reducer'
 import { LegacyFeeQuoteParams } from 'api/gnosisProtocol/legacy/types'
 import { FeeInformation, PriceInformation } from '@cowprotocol/cow-sdk'
+import { initialPriceLoadAnalytics } from 'utils/analytics'
 
 // API Doc: https://protocol-rinkeby.dev.gnosisdev.com/api
 
@@ -28,9 +29,14 @@ export type QuoteInformationState = {
   readonly [chainId in ChainId]?: Partial<QuotesMap>
 }
 
-type InitialState = { loading: boolean; loadingBestQuote: boolean; quotes: QuoteInformationState }
+type InitialState = {
+  loading: boolean
+  loadingBestQuote: boolean
+  quotes: QuoteInformationState
+  initialQuoteLoaded: boolean
+}
 
-const initialState: InitialState = { loadingBestQuote: false, loading: false, quotes: {} }
+const initialState: InitialState = { initialQuoteLoaded: false, loadingBestQuote: false, loading: false, quotes: {} }
 
 // Makes sure there stat is initialized
 function initializeState(
@@ -134,8 +140,15 @@ export default createReducer(initialState, (builder) =>
         quotes[chainId][sellToken] = { ...quoteInformation, ...payload }
       }
 
+      if (!state.initialQuoteLoaded) {
+        initialPriceLoadAnalytics()
+      }
+
       // Stop the loader
       state.loading = false
+
+      // Mark that the first quote is loaded
+      state.initialQuoteLoaded = true
 
       // Stop the quote loader when the "best" quote is fetched
       if (isBestQuote) {

--- a/src/custom/utils/analytics/index.ts
+++ b/src/custom/utils/analytics/index.ts
@@ -8,6 +8,7 @@ export * from './settingsEvents'
 export * from './themeEvents'
 export * from './transactionEvents'
 export * from './walletEvents'
+export * from './swapEvents'
 
 export const GOOGLE_ANALYTICS_CLIENT_ID_STORAGE_KEY = 'ga_client_id'
 export const ANALITICS_EVENTS = {}
@@ -67,6 +68,6 @@ export function reportError(error: Error, errorInfo: ErrorInfo) {
   ReactGA.event('exception', { description: error.toString() + errorInfo.toString(), fatal: true })
 }
 
-export function _reportEvent(params: EventParams) {
+export function reportEvent(params: EventParams) {
   ReactGA.event(params)
 }

--- a/src/custom/utils/analytics/listEvents.ts
+++ b/src/custom/utils/analytics/listEvents.ts
@@ -1,8 +1,8 @@
-import { Category, _reportEvent } from './index'
+import { Category, reportEvent } from './index'
 
 type UpdateListLocation = 'Popup' | 'List Select'
 export function updateListAnalytics(location: UpdateListLocation, listUrl: string) {
-  _reportEvent({
+  reportEvent({
     category: Category.LIST,
     action: `Update List from ${location}`,
     label: listUrl,
@@ -11,7 +11,7 @@ export function updateListAnalytics(location: UpdateListLocation, listUrl: strin
 
 type RemoveListAction = 'Start' | 'Confirm'
 export function removeListAnalytics(action: RemoveListAction, listUrl: string) {
-  _reportEvent({
+  reportEvent({
     category: Category.LIST,
     action: `${action} Remove List`,
     label: listUrl,
@@ -19,7 +19,7 @@ export function removeListAnalytics(action: RemoveListAction, listUrl: string) {
 }
 
 export function toggleListAnalytics(enable: boolean, listUrl: string) {
-  _reportEvent({
+  reportEvent({
     category: Category.LIST,
     action: `${enable ? 'Enable' : 'Disable'} List`,
     label: listUrl,
@@ -28,7 +28,7 @@ export function toggleListAnalytics(enable: boolean, listUrl: string) {
 
 type AddListAction = 'Success' | 'Failed'
 export function addListAnalytics(action: AddListAction, listURL: string) {
-  _reportEvent({
+  reportEvent({
     category: Category.LIST,
     action: `Add List ${action}`,
     label: listURL,

--- a/src/custom/utils/analytics/settingsEvents.ts
+++ b/src/custom/utils/analytics/settingsEvents.ts
@@ -1,22 +1,22 @@
-import { Category, _reportEvent } from './index'
+import { Category, reportEvent } from './index'
 import { debounce } from 'utils/misc'
 
 export function toggleExpertModeAnalytics(enable: boolean) {
-  _reportEvent({
+  reportEvent({
     category: Category.EXPERT_MODE,
     action: `${enable ? 'Enable' : 'Disable'} Expert Mode`,
   })
 }
 
 export function showExpertModeConfirmationAnalytics() {
-  _reportEvent({
+  reportEvent({
     category: Category.EXPERT_MODE,
     action: 'Show Confirmation',
   })
 }
 
 export function toggleRecepientAddressAnalytics(enable: boolean) {
-  _reportEvent({
+  reportEvent({
     category: Category.RECIPIENT_ADDRESS,
     action: 'Toggle Recipient Address',
     label: enable ? 'Enabled' : 'Disabled',
@@ -24,7 +24,7 @@ export function toggleRecepientAddressAnalytics(enable: boolean) {
 }
 
 export function searchByAddressAnalytics(isAddressSearch: string) {
-  _reportEvent({
+  reportEvent({
     category: Category.CURRENCY_SELECT,
     action: 'Search by address',
     label: isAddressSearch,
@@ -33,7 +33,7 @@ export function searchByAddressAnalytics(isAddressSearch: string) {
 
 type SlipageToleranceType = 'Custom' | 'Default'
 function _slippageToleranceAnalytics(type: SlipageToleranceType, value: number) {
-  _reportEvent({
+  reportEvent({
     category: Category.ORDER_SLIPAGE_TOLERANCE,
     action: `Set ${type} Slipage Tolerance`,
     value,

--- a/src/custom/utils/analytics/swapEvents.ts
+++ b/src/custom/utils/analytics/swapEvents.ts
@@ -1,0 +1,44 @@
+import { Category, reportEvent } from './index'
+import { Field } from 'state/swap/actions'
+import { debounce } from 'utils/misc'
+
+export function currencySelectAnalytics(field: Field, label: string | undefined) {
+  reportEvent({
+    category: Category.CURRENCY_SELECT,
+    action: `Change ${field} token`,
+    label,
+  })
+}
+
+export function setMaxSellTokensAnalytics() {
+  reportEvent({
+    category: Category.SWAP,
+    action: 'Set Maximun Sell Tokens',
+  })
+}
+
+function _changeSwapAmountAnalytics(field: Field, value: number) {
+  reportEvent({
+    category: Category.SWAP,
+    action: `Change ${field} field amount`,
+    value,
+  })
+}
+
+export const changeSwapAmountAnalytics = debounce(([field, value]: [Field, number]) => {
+  _changeSwapAmountAnalytics(field, value)
+}, 2000)
+
+export function switchTokensAnalytics() {
+  reportEvent({
+    category: Category.SWAP,
+    action: 'Switch INPUT/OUTPUT tokens',
+  })
+}
+
+export function initialPriceLoadAnalytics() {
+  reportEvent({
+    category: Category.SWAP,
+    action: 'Initial Price estimation',
+  })
+}

--- a/src/custom/utils/analytics/themeEvents.ts
+++ b/src/custom/utils/analytics/themeEvents.ts
@@ -1,7 +1,7 @@
-import { Category, _reportEvent } from './index'
+import { Category, reportEvent } from './index'
 
 export function toggleDarkModeAnalytics(darkMode: boolean) {
-  _reportEvent({
+  reportEvent({
     category: Category.THEME,
     action: 'Toggle dark/light mode',
     label: `${darkMode ? 'Dark' : 'Light'} mode`,

--- a/src/custom/utils/analytics/transactionEvents.ts
+++ b/src/custom/utils/analytics/transactionEvents.ts
@@ -71,9 +71,17 @@ export function orderAnalytics(action: OrderType, label?: string) {
   })
 }
 
-export function setMaxSellTokens() {
+export function setMaxSellTokensAnalytics() {
   _reportEvent({
     category: Category.SWAP,
     action: 'Set Maximun Sell Tokens',
+  })
+}
+
+export function priceOutOfRangeAnalytics(isUnfillable: boolean, label: string) {
+  _reportEvent({
+    category: Category.SWAP,
+    action: `Order price is ${isUnfillable ? 'out of' : 'back to'} market`,
+    label,
   })
 }

--- a/src/custom/utils/analytics/transactionEvents.ts
+++ b/src/custom/utils/analytics/transactionEvents.ts
@@ -1,8 +1,8 @@
-import { Category, _reportEvent } from './index'
+import { Category, reportEvent } from './index'
 
 type ExpirationType = 'Default' | 'Custom'
 export function orderExpirationTimeAnalytics(type: ExpirationType, value: number) {
-  _reportEvent({
+  reportEvent({
     category: Category.ORDER_EXPIRATION_TIME,
     action: `Set ${type} Expiration Time`,
     value,
@@ -11,7 +11,7 @@ export function orderExpirationTimeAnalytics(type: ExpirationType, value: number
 
 type WrapAction = 'Send' | 'Sign' | 'Reject' | 'Error'
 export function wrapAnalytics(action: WrapAction, message: string) {
-  _reportEvent({
+  reportEvent({
     category: Category.WRAP_NATIVE_TOKEN,
     action: `${action} Wrap/Unwrap Transaction`,
     label: message,
@@ -20,7 +20,7 @@ export function wrapAnalytics(action: WrapAction, message: string) {
 
 type ClaimAction = 'Send' | 'Sign' | 'Reject' | 'Error'
 export function claimAnalytics(action: ClaimAction, value?: number) {
-  _reportEvent({
+  reportEvent({
     category: Category.CLAIM_COW_FOR_LOCKED_GNO,
     action: `${action} Claim Transaction`,
     value,
@@ -29,7 +29,7 @@ export function claimAnalytics(action: ClaimAction, value?: number) {
 
 type ApprovalAction = 'Send' | 'Sign' | 'Reject' | 'Error'
 export function approvalAnalytics(action: ApprovalAction, label?: string, value?: number) {
-  _reportEvent({
+  reportEvent({
     category: Category.SWAP,
     action: `${action} Token Approval`,
     label,
@@ -39,7 +39,7 @@ export function approvalAnalytics(action: ApprovalAction, label?: string, value?
 
 export type SwapAction = 'Send' | 'Error' | 'Reject'
 export function swapAnalytics(action: SwapAction, label?: string, value?: number) {
-  _reportEvent({
+  reportEvent({
     category: Category.SWAP,
     action: `${action} Swap Order`,
     label,
@@ -55,7 +55,7 @@ const signSwapActions = {
 
 export type SignSwapAction = 'Sign' | 'SignAndSend' | 'SignToSelf'
 export function signSwapAnalytics(action: SignSwapAction, label?: string) {
-  _reportEvent({
+  reportEvent({
     category: Category.SWAP,
     action: signSwapActions[action],
     label,
@@ -64,22 +64,15 @@ export function signSwapAnalytics(action: SignSwapAction, label?: string) {
 
 export type OrderType = 'Posted' | 'Executed' | 'Canceled' | 'Expired'
 export function orderAnalytics(action: OrderType, label?: string) {
-  _reportEvent({
+  reportEvent({
     category: Category.SWAP,
     action: `${action} Swap Order`,
     label,
   })
 }
 
-export function setMaxSellTokensAnalytics() {
-  _reportEvent({
-    category: Category.SWAP,
-    action: 'Set Maximun Sell Tokens',
-  })
-}
-
 export function priceOutOfRangeAnalytics(isUnfillable: boolean, label: string) {
-  _reportEvent({
+  reportEvent({
     category: Category.SWAP,
     action: `Order price is ${isUnfillable ? 'out of' : 'back to'} market`,
     label,

--- a/src/custom/utils/analytics/walletEvents.ts
+++ b/src/custom/utils/analytics/walletEvents.ts
@@ -1,7 +1,7 @@
-import { Category, _reportEvent } from './index'
+import { Category, reportEvent } from './index'
 
 export function changeWalletAnalytics(walletName: string) {
-  _reportEvent({
+  reportEvent({
     category: Category.WALLET,
     action: 'Change Wallet',
     label: walletName,

--- a/src/state/swap/hooks.tsx
+++ b/src/state/swap/hooks.tsx
@@ -19,6 +19,7 @@ import { AppState } from 'state'
 import { useCurrencyBalances } from '../wallet/hooks'
 import { Field, replaceSwapState, selectCurrency, setRecipient, switchCurrencies, typeInput } from './actions'
 import { SwapState } from './reducer'
+import { currencySelectAnalytics, changeSwapAmountAnalytics, switchTokensAnalytics } from 'utils/analytics'
 
 export function useSwapState(): AppState['swap'] {
   return useAppSelector((state) => state.swap)
@@ -33,6 +34,8 @@ export function useSwapActionHandlers(): {
   const dispatch = useAppDispatch()
   const onCurrencySelection = useCallback(
     (field: Field, currency: Currency) => {
+      currencySelectAnalytics(field, currency.symbol)
+
       dispatch(
         selectCurrency({
           field,
@@ -44,11 +47,13 @@ export function useSwapActionHandlers(): {
   )
 
   const onSwitchTokens = useCallback(() => {
+    switchTokensAnalytics()
     dispatch(switchCurrencies())
   }, [dispatch])
 
   const onUserInput = useCallback(
     (field: Field, typedValue: string) => {
+      changeSwapAmountAnalytics(field, Number(typedValue))
       dispatch(typeInput({ field, typedValue }))
     },
     [dispatch]


### PR DESCRIPTION
# Summary

Part of the #665

Adds GA events for:
- order price out of market range
- input/output currency select change
- input/output token amount change
- switch input/output tokens
- initial order quote loading
- adds small changes such as renaming and some refactoring

### To test
- Should be self explanatory how to activate these events but for more information, refer to the `CowSwap - Analytics events / dimensions` file for and for the "price out of market range" issue, place 2 orders to swap 100 GNO -> PAX one immediately after another on Rinkeby network and the second order should give this warning and trigger and event