### PR TITLE
332/upload right away

### DIFF
--- a/src/custom/state/appData/updater.ts
+++ b/src/custom/state/appData/updater.ts
@@ -26,6 +26,14 @@ export function UploadToIpfsUpdater(): null {
   const refToUpload = useRef(toUpload)
   refToUpload.current = toUpload
 
+  // Filtering only newly created and not yet attempted to upload docs
+  const newlyAdded = toUpload.filter(({ uploading, lastAttempt }) => !uploading && !lastAttempt)
+
+  useEffect(() => {
+    // Try to upload new docs as soon as they are added
+    newlyAdded.forEach((appDataRecord) => _uploadToIpfs(appDataRecord, updatePending, removePending))
+  }, [newlyAdded, removePending, updatePending])
+
   useEffect(() => {
     async function uploadPendingAppData() {
       console.debug(`[UploadToIpfsUpdater] Iterating over ${refToUpload.current.length} appData on upload queue`)

--- a/src/custom/state/appData/updater.ts
+++ b/src/custom/state/appData/updater.ts
@@ -12,7 +12,7 @@ import {
 } from 'state/appData/atoms'
 import { AppDataKeyParams, AppDataRecord, UpdateAppDataOnUploadQueueParams } from 'state/appData/types'
 
-const UPLOAD_CHECK_INTERVAL = ms`10s`
+const UPLOAD_CHECK_INTERVAL = ms`1 minute`
 const BASE_FOR_EXPONENTIAL_BACKOFF = 2 // in seconds, converted to milliseconds later
 const ONE_SECOND = ms`1s`
 const MAX_TIME_TO_WAIT = ms`5 minutes`


### PR DESCRIPTION
# Summary

Part of #332 

Addressing feedback from https://github.com/cowprotocol/cowswap/pull/758#pullrequestreview-1023808466

Upload appDataDoc right away.

In case of failure, the updater will try again once every minute (rather than every 10s)

  # To Test

1. Open the console and filter by `Ipfs`
2. Place an order
* Upload to IPFS message should appear right away (is a few 
![Screen Shot 2022-06-30 at 16 51 23](https://user-images.githubusercontent.com/43217/176722343-c5ede64a-b267-465f-8874-7401a200985a.png)
