### PR TITLE
Hide Appzi container with display none when closed.

### DIFF
--- a/src/custom/theme/baseTheme.tsx
+++ b/src/custom/theme/baseTheme.tsx
@@ -390,8 +390,13 @@ export const ThemedGlobalStyle = createGlobalStyle`
   }
 
   // Appzi Container override
+  div[id^='appzi-wfo-'] {
+    display: none!important; // Force hiding Appzi container when not opened
+  }
+
   body[class^='appzi-f-w-open-'] div[id^='appzi-wfo-'] {
     z-index: 2147483004!important;
+    display: block!important;
 
     ${({ theme }) => theme.mediaWidth.upToMedium`
       transform: none!important;


### PR DESCRIPTION
# Summary

- Addresses https://github.com/cowprotocol/cowswap/issues/765
- The issue is that when the Appzi container is closed, it still exists in the DOM. Display: none is not applied and only visibility:hidden;. This causes scrolling issues on iOS mobile when another overlay is active (orders panel).