### PR TITLE
GA events 4

### DIFF
--- a/src/custom/theme/components.tsx
+++ b/src/custom/theme/components.tsx
@@ -1,0 +1,33 @@
+import React, { HTMLProps } from 'react'
+import { StyledLink, handleClickExternalLink } from './baseTheme'
+import { externalLinkAnalytics } from 'utils/analytics'
+
+export * from '@src/theme/components'
+
+/**
+ * Outbound link that handles firing google analytics events
+ */
+export function ExternalLink({
+  target = '_blank',
+  href,
+  rel = 'noopener noreferrer',
+  onClickOptional,
+  ...rest
+}: Omit<HTMLProps<HTMLAnchorElement>, 'as' | 'ref' | 'onClick'> & {
+  href: string
+  onClickOptional?: React.MouseEventHandler<HTMLAnchorElement>
+}) {
+  return (
+    <StyledLink
+      target={target}
+      rel={rel}
+      href={href}
+      onClick={(event) => {
+        if (onClickOptional) onClickOptional(event)
+        handleClickExternalLink(event)
+        externalLinkAnalytics(href)
+      }}
+      {...rest}
+    />
+  )
+}

--- a/src/custom/theme/cowSwapTheme.tsx
+++ b/src/custom/theme/cowSwapTheme.tsx
@@ -13,7 +13,6 @@ import { theme as themeUniswap, MEDIA_WIDTHS as MEDIA_WIDTHS_UNISWAP } from '@sr
 import { useIsDarkMode } from 'state/user/hooks'
 
 export { MEDIA_WIDTHS, ThemedText } from '@src/theme'
-export * from '@src/theme/components'
 
 export function colors(darkMode: boolean): Colors {
   return colorsBaseTheme(darkMode)

--- a/src/custom/theme/index.tsx
+++ b/src/custom/theme/index.tsx
@@ -20,6 +20,7 @@ export enum Z_INDEX {
 // Cow theme
 export { default } from './cowSwapTheme'
 export * from './cowSwapTheme'
+export * from './components'
 
 // GP theme
 // export { default } from './baseTheme'

--- a/src/custom/utils/analytics/index.ts
+++ b/src/custom/utils/analytics/index.ts
@@ -34,6 +34,7 @@ export enum Category {
   CLAIM_COW_FOR_LOCKED_GNO = 'Claim COW for Locked GNO', // TODO: Maybe Claim COW was enough?
   THEME = 'Theme',
   GAMES = 'Games',
+  EXTERNAL_LINK = 'External Link',
 }
 
 export function persistClientId() {

--- a/src/custom/utils/analytics/otherEvents.ts
+++ b/src/custom/utils/analytics/otherEvents.ts
@@ -1,4 +1,5 @@
 import { Category, reportEvent } from './index'
+import { detectExplorer } from 'utils/explorer'
 
 type GameType = 'Cow Runner' | 'MEV Slicer'
 export function gameAnalytics(gameType: GameType) {
@@ -8,23 +9,13 @@ export function gameAnalytics(gameType: GameType) {
   })
 }
 
-function _detectExplorer(href: string) {
-  if (href.includes('explorer')) {
-    return 'Explorer'
-  } else if (href.includes('blockscout')) {
-    return 'Blockscout'
-  } else {
-    return undefined
-  }
-}
-
 export function externalLinkAnalytics(href: string) {
-  const explorer = _detectExplorer(href)
+  const explorer = detectExplorer(href)
 
   if (explorer) {
     reportEvent({
       category: Category.EXTERNAL_LINK,
-      action: `View on ${_detectExplorer(href)}`,
+      action: `View on ${explorer}`,
       label: href,
     })
   }

--- a/src/custom/utils/analytics/otherEvents.ts
+++ b/src/custom/utils/analytics/otherEvents.ts
@@ -7,3 +7,25 @@ export function gameAnalytics(gameType: GameType) {
     action: `Playing ${gameType} game`,
   })
 }
+
+function _detectExplorer(href: string) {
+  if (href.includes('explorer')) {
+    return 'Explorer'
+  } else if (href.includes('blockscout')) {
+    return 'Blockscout'
+  } else {
+    return undefined
+  }
+}
+
+export function externalLinkAnalytics(href: string) {
+  const explorer = _detectExplorer(href)
+
+  if (explorer) {
+    reportEvent({
+      category: Category.EXTERNAL_LINK,
+      action: `View on ${_detectExplorer(href)}`,
+      label: href,
+    })
+  }
+}

--- a/src/custom/utils/explorer.ts
+++ b/src/custom/utils/explorer.ts
@@ -46,14 +46,20 @@ export function getExplorerAddressLink(chainId: ChainId, address: string): strin
   return baseUrl + `/address/${address}`
 }
 
+enum Explorers {
+  Explorer = 'Explorer',
+  Blockscout = 'Blockscout',
+  Etherscan = 'Etherscan',
+}
+
 // Used for GA ExternalLink detection
 export function detectExplorer(href: string) {
   if (href.includes('explorer')) {
-    return 'Explorer'
+    return Explorers.Explorer
   } else if (href.includes('blockscout')) {
-    return 'Blockscout'
+    return Explorers.Blockscout
   } else if (href.includes('etherscan')) {
-    return 'Etherscan'
+    return Explorers.Etherscan
   } else {
     return undefined
   }

--- a/src/custom/utils/explorer.ts
+++ b/src/custom/utils/explorer.ts
@@ -45,3 +45,16 @@ export function getExplorerAddressLink(chainId: ChainId, address: string): strin
 
   return baseUrl + `/address/${address}`
 }
+
+// Used for GA ExternalLink detection
+export function detectExplorer(href: string) {
+  if (href.includes('explorer')) {
+    return 'Explorer'
+  } else if (href.includes('blockscout')) {
+    return 'Blockscout'
+  } else if (href.includes('etherscan')) {
+    return 'Etherscan'
+  } else {
+    return undefined
+  }
+}

--- a/src/hooks/useAddTokenToMetamask.ts
+++ b/src/hooks/useAddTokenToMetamask.ts
@@ -2,6 +2,7 @@ import { Currency, Token } from '@uniswap/sdk-core'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import useCurrencyLogoURIs from 'lib/hooks/useCurrencyLogoURIs'
 import { useCallback, useState } from 'react'
+import { addTokenToMetamaskAnalytics } from 'utils/analytics'
 
 export default function useAddTokenToMetamask(currencyToAdd: Currency | undefined): {
   addToken: () => void
@@ -31,9 +32,13 @@ export default function useAddTokenToMetamask(currencyToAdd: Currency | undefine
           },
         })
         .then((success) => {
+          addTokenToMetamaskAnalytics('Success', token.symbol)
           setSuccess(success)
         })
-        .catch(() => setSuccess(false))
+        .catch(() => {
+          addTokenToMetamaskAnalytics('Fail', token.symbol)
+          setSuccess(false)
+        })
     } else {
       setSuccess(false)
     }

--- a/src/hooks/useAddTokenToMetamask.ts
+++ b/src/hooks/useAddTokenToMetamask.ts
@@ -2,7 +2,6 @@ import { Currency, Token } from '@uniswap/sdk-core'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import useCurrencyLogoURIs from 'lib/hooks/useCurrencyLogoURIs'
 import { useCallback, useState } from 'react'
-import { addTokenToMetamaskAnalytics } from 'utils/analytics'
 
 export default function useAddTokenToMetamask(currencyToAdd: Currency | undefined): {
   addToken: () => void
@@ -32,11 +31,9 @@ export default function useAddTokenToMetamask(currencyToAdd: Currency | undefine
           },
         })
         .then((success) => {
-          addTokenToMetamaskAnalytics('Success', token.symbol)
           setSuccess(success)
         })
         .catch(() => {
-          addTokenToMetamaskAnalytics('Fail', token.symbol)
           setSuccess(false)
         })
     } else {

--- a/src/theme/components.tsx
+++ b/src/theme/components.tsx
@@ -167,7 +167,7 @@ export const UniTokenAnimated = styled.img`
   filter: drop-shadow(0px 2px 4px rgba(0, 0, 0, 0.15));
 `
 
-function handleClickExternalLink(event: React.MouseEvent<HTMLAnchorElement>) {
+export function handleClickExternalLink(event: React.MouseEvent<HTMLAnchorElement>) {
   const { target, href } = event.currentTarget
 
   const anonymizedHref = anonymizeLink(href)


### PR DESCRIPTION
# Summary

This PR adds GA event
- when user click on external link that leads to protocol-explorer or to blockscout

### To test
- Make an successful trade and click on view on explorer link in modal or in notification popup
- Open account details and click on some external link