### PR TITLE
785/app data repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-react": "^7.16.7",
     "@babel/preset-typescript": "^7.16.7",
-    "@cowprotocol/cow-sdk": "0.0.15",
+    "@cowprotocol/cow-sdk": "1.0.0-RC.0",
     "@craco/craco": "^5.7.0",
     "@ethersproject/experimental": "^5.4.0",
     "@graphql-codegen/cli": "1.21.5",

--- a/src/custom/state/appData/types.tsx
+++ b/src/custom/state/appData/types.tsx
@@ -1,7 +1,7 @@
-import { AppDataDoc, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { LatestAppDataDocVersion, SupportedChainId } from '@cowprotocol/cow-sdk'
 
 export type AppDataInfo = {
-  doc?: AppDataDoc // in case of default hash, there's no doc
+  doc?: LatestAppDataDocVersion // in case of default hash, there's no doc
   hash: string
 }
 

--- a/src/custom/state/appData/updater.ts
+++ b/src/custom/state/appData/updater.ts
@@ -1,7 +1,7 @@
 import { useAtomValue, useSetAtom } from 'jotai'
 import { useEffect, useRef } from 'react'
 import ms from 'ms.macro'
-import { AppDataDoc } from '@cowprotocol/cow-sdk'
+import { LatestAppDataDocVersion } from '@cowprotocol/cow-sdk'
 
 import { COW_SDK } from 'constants/index'
 
@@ -98,7 +98,7 @@ async function _actuallyUploadToIpfs(
   try {
     const sdk = COW_SDK[chainId]
 
-    const actualHash = await sdk.metadataApi.uploadMetadataDocToIpfs(doc as AppDataDoc)
+    const actualHash = await sdk.metadataApi.uploadMetadataDocToIpfs(doc as LatestAppDataDocVersion)
 
     removePending({ chainId, orderId })
 

--- a/src/custom/utils/appData.ts
+++ b/src/custom/utils/appData.ts
@@ -1,55 +1,25 @@
 import { COW_SDK } from 'constants/index'
-import { MetadataDoc, QuoteMetadata, ReferralMetadata, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { environmentName } from 'utils/environments'
-
-//TODO: move helper methods to SDK
-const QUOTE_METADATA_VERSION = '0.2.0'
-const REFERRER_METADATA_VERSION = '0.1.0'
 
 export type BuildAppDataParams = {
   chainId: SupportedChainId
   slippageBips: string
-  sellAmount?: string
-  buyAmount?: string
-  quoteId?: number
   referrerAccount?: string
   appCode: string
 }
 
-export async function buildAppData({
-  chainId,
-  slippageBips,
-  sellAmount,
-  buyAmount,
-  quoteId,
-  referrerAccount,
-  appCode,
-}: BuildAppDataParams) {
+export async function buildAppData({ chainId, slippageBips, referrerAccount, appCode }: BuildAppDataParams) {
   const sdk = COW_SDK[chainId]
 
-  // build quote metadata, not required in the schema but always present
-  const quoteMetadata = _buildQuoteMetadata(slippageBips)
-  const metadata: MetadataDoc = { quote: quoteMetadata }
+  const referrerParams = referrerAccount ? { address: referrerAccount } : undefined
 
-  // build referrer metadata, optional
-  if (referrerAccount) {
-    metadata.referrer = _buildReferralMetadata(referrerAccount)
-  }
-
-  const doc = sdk.metadataApi.generateAppDataDoc(metadata, { appCode, environment: environmentName })
+  const doc = sdk.metadataApi.generateAppDataDoc({
+    appDataParams: { appCode, environment: environmentName },
+    metadataParams: { referrerParams, quoteParams: { slippageBips } },
+  })
 
   const calculatedAppData = await sdk.metadataApi.calculateAppDataHash(doc)
 
   return { doc, calculatedAppData }
-}
-
-function _buildQuoteMetadata(slippageBips: string): QuoteMetadata {
-  return { version: QUOTE_METADATA_VERSION, slippageBips }
-}
-
-function _buildReferralMetadata(address: string): ReferralMetadata {
-  return {
-    address,
-    version: REFERRER_METADATA_VERSION,
-  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1196,10 +1196,10 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@cowprotocol/contracts@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.3.1.tgz#a812b27bdd0c046ab730eb24911ef7c641ed0df8"
-  integrity sha512-p93xODog3XG5eSDU5od1ERvYf7YIyXd7USknKcsWnka5VN5mDDjqjCKTLw8EoZdrCIEpf6fGd8At2nv+MsvNqA==
+"@cowprotocol/app-data@^0.0.1-RC.1":
+  version "0.0.1-RC.1"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-0.0.1-RC.1.tgz#1d00036a1f49ffb6128f424e7a778c50973e9248"
+  integrity sha512-LYMRjU7xDd8t9KZXkRI36AN1RtgdxACXvqv/9yqNpi0AxRiePH5bqTOYm9RuFwIzmAbHq5xGN2/rSCxfvfU9eQ==
 
 "@cowprotocol/contracts@^1.3.1":
   version "1.3.1"
@@ -1219,11 +1219,12 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/cow-runner-game/-/cow-runner-game-0.2.9.tgz#3f94b3f370bd114f77db8b1d238cba3ef4e9d644"
   integrity sha512-rX7HnoV+HYEEkBaqVUsAkGGo0oBrExi+d6Io+8nQZYwZk+IYLmS9jdcIObsLviM2h4YX8+iin6NuKl35AaiHmg==
 
-"@cowprotocol/cow-sdk@0.0.15":
-  version "0.0.15"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-0.0.15.tgz#844d51e8ea4969521d72086c54d09394bbb0750b"
-  integrity sha512-Lz5iTGjzMNJ+gHERnm+71HKLwcBGh60w3OJU4LRiU0X6Ug1Rzlrgp+3Ok84zpi3LQgc79IvB5v5riI0J4goHkQ==
+"@cowprotocol/cow-sdk@1.0.0-RC.0":
+  version "1.0.0-RC.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-1.0.0-RC.0.tgz#acadbaf46f8538665a55d84daed8bf4976f33a94"
+  integrity sha512-84GZNRFxl8ZJe6ZNGX6BlMj/UIZ9mwylaJv8HIJN3eEUnXGwZE48NElOQMINa4OaQv49cxh2C4K77E6HU9PiCQ==
   dependencies:
+    "@cowprotocol/app-data" "^0.0.1-RC.1"
     "@cowprotocol/contracts" "^1.3.1"
     ajv "^8.8.2"
     cross-fetch "^3.1.5"


### PR DESCRIPTION
# Summary

Closes #785

Applying SDK changes https://github.com/cowprotocol/cow-sdk/pull/50 to Cowswap

~⚠️ Depends on the SDK changes to be merged and published.~
~⚠️ This PR won't work until that's done~

Using exported type coming from https://github.com/cowprotocol/app-data
Using updated sdk method to generate appData

  # To Test

Regular order placing flow, verifying generated appData

1. Place order
2. On console, filter by `appData`
* Generated appData should use the latest version `0.4.0`
* It should contain `quote` metadata object with version `0.2.0`
3. Verify the order on the explorer (for now only on [develop](https://protocol-explorer.dev.gnosisdev.com/))
* The decoded appData should match what was printed on the console, as well as the appDataHash