### PR TITLE
Use amountWithoutFee to calculate fiat values

### DIFF
--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -272,8 +272,8 @@ export default function Swap({
 
   // const fiatValueInput = useUSDCValue(trade?.inputAmount)
   // const fiatValueOutput = useUSDCValue(trade?.outputAmount)
-  const fiatValueInput = useHigherUSDValue(trade?.inputAmount)
-  const fiatValueOutput = useHigherUSDValue(trade?.outputAmount)
+  const fiatValueInput = useHigherUSDValue(trade?.inputAmountWithoutFee)
+  const fiatValueOutput = useHigherUSDValue(trade?.outputAmountWithoutFee)
 
   const priceImpactParams = usePriceImpact({ abTrade: v2Trade, parsedAmounts, isWrapping: !!onWrap })
   const { priceImpact, error: priceImpactError, loading: priceImpactLoading } = priceImpactParams


### PR DESCRIPTION
# Summary

Closes #808 

Wrong FIAT values for buy/sell orders

[Change introduced](https://github.com/cowprotocol/cowswap/commit/9dc74925212249333c59cbe14f77755fb3f34958#diff-c37ec3af5898ba774058622a5311bd8322eb2cee83b914e9bcd6e20326f75b64L262-R265) in a past UNI merge and released on [v1.15.0](https://github.com/cowprotocol/cowswap/releases/tag/v1.15.0)

## Sell
![Screen Shot 2022-07-19 at 15 45 34](https://user-images.githubusercontent.com/43217/179798157-63cbaff1-03df-4d12-a650-a2dc97370c69.png)

## Buy
![Screen Shot 2022-07-19 at 16 58 26](https://user-images.githubusercontent.com/43217/179798084-7b8d1ba6-5d25-4812-b57d-98c022b7255c.png)

# To Test

1. On mainnet, pick a stable coin pair
2. Fill in a relatively small sell amount, e.g.: 30
* The estimated buy amount of the opposite token should be close to `30`
3. Do the same, but instead filling in the buy amount
* The estimated sell amount of the opposite token should be close to `30`

Repeating those steps on production will give you values including/discounting the fee