### PR TITLE
804 - Fix ETH wrap font colour

### DIFF
--- a/src/custom/components/swap/EthWethWrap/WrapCard.tsx
+++ b/src/custom/components/swap/EthWethWrap/WrapCard.tsx
@@ -40,7 +40,7 @@ export const WrapCardContainer = styled.div`
   > ${WrapCardWrapper} {
     &:nth-of-type(1) {
       background-color: transparent;
-      color: ${({ theme }) => theme.wallet.color};
+      color: ${({ theme }) => theme.text2};
     }
 
     &:nth-of-type(2) {

--- a/src/custom/theme/baseTheme.tsx
+++ b/src/custom/theme/baseTheme.tsx
@@ -299,7 +299,7 @@ export function themeVariables(darkMode: boolean, colorsTheme: Colors) {
       text: colorsTheme.black,
     },
     wallet: {
-      color: darkMode ? colorsTheme.text1 : colorsTheme.text1,
+      color: colorsTheme.text2,
       background: darkMode ? colorsTheme.bg3 : colorsTheme.bg1,
     },
   }

--- a/src/custom/theme/baseTheme.tsx
+++ b/src/custom/theme/baseTheme.tsx
@@ -299,7 +299,7 @@ export function themeVariables(darkMode: boolean, colorsTheme: Colors) {
       text: colorsTheme.black,
     },
     wallet: {
-      color: colorsTheme.text2,
+      color: colorsTheme.text1,
       background: darkMode ? colorsTheme.bg3 : colorsTheme.bg1,
     },
   }


### PR DESCRIPTION
# Summary

Closes #804 

<img width="531" alt="image" src="https://user-images.githubusercontent.com/21335563/180168705-732cae6c-a768-4493-998e-33baf3e6a0ea.png">

## TEST
1. wrap eth flow
2. check colour modes