### PR TITLE
[SENTRY] disable price feed empty response reporting

### DIFF
--- a/src/custom/hooks/useUSDCPrice/index.ts
+++ b/src/custom/hooks/useUSDCPrice/index.ts
@@ -20,7 +20,6 @@ import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
 import useBlockNumber from 'lib/hooks/useBlockNumber'
 import useGetGpPriceStrategy from 'hooks/useGetGpPriceStrategy'
 import { useGetGpUsdcPrice } from 'utils/price'
-import { capturePriceFeedException, SentryTag } from 'utils/logging'
 
 export * from '@src/hooks/useUSDCPrice'
 
@@ -289,6 +288,7 @@ export function useHigherUSDValue(currencyAmount: CurrencyAmount<Currency> | und
   const gpUsdPrice = useUSDCValue(currencyAmount)
   const coingeckoUsdPrice = useCoingeckoUsdValue(currencyAmount)
 
+  /* TODO: review this capturing - it's super noisy in sentry 
   if (!!currencyAmount) {
     // report this to sentry
     capturePriceFeedException(
@@ -297,12 +297,12 @@ export function useHigherUSDValue(currencyAmount: CurrencyAmount<Currency> | und
       { res: !!gpUsdPrice, name: 'COW_API' },
       { res: !!coingeckoUsdPrice, name: 'COINGECKO' }
     )
-  }
+  } */
 
   return coingeckoUsdPrice || gpUsdPrice
 }
 
-function _buildExceptionIssueParams(currencyAmount: CurrencyAmount<Currency> | undefined) {
+/* function _buildExceptionIssueParams(currencyAmount: CurrencyAmount<Currency> | undefined) {
   const token = currencyAmount?.wrapped.currency
   return {
     // issue name
@@ -315,7 +315,7 @@ function _buildExceptionIssueParams(currencyAmount: CurrencyAmount<Currency> | u
       amount: currencyAmount?.toExact() || SentryTag.UNKNOWN,
     },
   }
-}
+} */
 
 /**
  *


### PR DESCRIPTION
# Summary

Right now the capturing of empty prices from our USD endpoints: coingecko & cow-api is returning way too much noise that can't be attributed directly to our price feeds constantly failing (we would have received external reports likely) and it is much more likely that there is something wrong with the way/place where we are reporting this to sentry

For now we disable

<img width="1185" alt="image" src="https://user-images.githubusercontent.com/21335563/180173434-eb59d8c2-b7c4-41c6-8816-cb579c3bf3c8.png">

https://sentry.io/organizations/cowprotocol/issues/3375350787/?project=5905822&query=is%3Aunresolved