### PR TITLE
Fix traded amount on notifications

### DIFF
--- a/src/custom/state/orders/helpers.tsx
+++ b/src/custom/state/orders/helpers.tsx
@@ -61,7 +61,7 @@ const Wrapper = styled.div`
     margin-top: 0;
   }
 
-  & > p:last-chid {
+  & > p:last-child {
     margin-bottom: 0;
   }
 `

--- a/src/custom/state/orders/updaters/utils.ts
+++ b/src/custom/state/orders/updaters/utils.ts
@@ -21,14 +21,18 @@ export function computeOrderSummary({
   // if we can find the order from the API
   // and our specific order exists in our state, let's use that
   if (orderFromApi) {
-    const { buyToken, sellToken, sellAmount, buyAmount, executedBuyAmount, executedSellAmount } = orderFromApi
+    const { buyToken, sellToken, sellAmount, feeAmount, buyAmount, executedBuyAmount, executedSellAmount } =
+      orderFromApi
 
     if (orderFromStore) {
       const { inputToken, outputToken, status, kind } = orderFromStore
       const isFulfilled = status === OrderStatus.FULFILLED
 
       // don't show amounts in atoms
-      const inputAmount = stringToCurrency(isFulfilled ? executedSellAmount : sellAmount, inputToken)
+      const inputAmount = isFulfilled
+        ? stringToCurrency(executedSellAmount, inputToken)
+        : // sellAmount doesn't include the fee, so we add it back to not show a different value when the order is traded
+          stringToCurrency(sellAmount, inputToken).add(stringToCurrency(feeAmount, inputToken))
       const outputAmount = stringToCurrency(isFulfilled ? executedBuyAmount : buyAmount, outputToken)
 
       const inputPrefix = !isFulfilled && kind === OrderKind.BUY ? 'at most ' : ''


### PR DESCRIPTION
# Summary

Every swap notification had the sell amount without accounting for the fee, different than the placement notification:

| Order placed | Order traded |
| - | - |
| ![Screen Shot 2022-07-21 at 10 58 31](https://user-images.githubusercontent.com/43217/180187008-d06bd88c-9bbe-45c0-b237-c131e258a79f.png) | ![Screen Shot 2022-07-21 at 10 59 10](https://user-images.githubusercontent.com/43217/180186967-cbbf0384-47bb-47bd-8e21-8ef4e180173c.png) |

After this change:

| Order placed | Order traded |
| - | - |
|![Screen Shot 2022-07-21 at 11 01 04](https://user-images.githubusercontent.com/43217/180187624-4ba666e3-2671-432f-9bb7-1b9baa54a7e6.png) | ![Screen Shot 2022-07-21 at 11 01 51](https://user-images.githubusercontent.com/43217/180187649-353e5f67-f14b-48fe-9ccf-4ec7567ab168.png) |


  # To Test

1. Place order and wait for it to trade
* Sell amount should be the same on both pop ups
* Same for buy and sell orders