### PR TITLE
fix: remove redundant background due to page scroll performance

### DIFF
--- a/src/custom/pages/App/AppMod.tsx
+++ b/src/custom/pages/App/AppMod.tsx
@@ -1,6 +1,6 @@
 import Loader from 'components/Loader'
 import ApeModeQueryParamReader from 'hooks/useApeModeQueryParamReader'
-import { /*Lazy,*/ Suspense, /* PropsWithChildren, */ ReactNode, useState, useEffect } from 'react'
+import { /*Lazy,*/ Suspense, /* PropsWithChildren, */ ReactNode } from 'react'
 import { /*Redirect,*/ Route, Switch, useLocation } from 'react-router-dom'
 import styled from 'styled-components/macro'
 import GoogleAnalyticsReporter from 'components/analytics/GoogleAnalyticsReporter'
@@ -39,31 +39,13 @@ import * as CSS from 'csstype' // mod
 
 // const Vote = lazy(() => import('./Vote'))
 
-interface AppWrapProps {
-  bgBlur?: boolean
-}
-
-const AppWrapper = styled.div<Partial<CSS.Properties & AppWrapProps>>`
+const AppWrapper = styled.div<Partial<CSS.Properties>>`
   display: flex;
   flex-flow: column;
   align-items: flex-start;
   // MOD
   min-height: 100vh;
   /* overflow-x: hidden; */ // mod
-  &:after {
-    content: '';
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    filter: blur(20px);
-    backdrop-filter: blur(20px);
-    background-image: ${({ theme }) => theme.body.background};
-    opacity: 0;
-    transition: 0.5s;
-  }
-  ${(props) => (props.bgBlur ? '&:after {opacity: 1}' : '&:after {opacity:0}')};
 `
 
 /* const BodyWrapper = styled.div`
@@ -74,7 +56,6 @@ const AppWrapper = styled.div<Partial<CSS.Properties & AppWrapProps>>`
   align-items: center;
   flex: 1;
   z-index: 1;
-
   ${({ theme }) => theme.mediaWidth.upToSmall`
     padding: 4rem 8px 16px 8px;
   `};
@@ -105,18 +86,15 @@ function TopLevelModals() {
 }
 
 export default function App(props?: { children?: ReactNode }) {
-  const [bgBlur, setBgBlur] = useState(false)
   const location = useLocation()
-  useEffect(() => {
-    setBgBlur(location.pathname.length > 1 && location.pathname !== '/swap')
-  }, [location.pathname])
+
   return (
     <ErrorBoundary>
       <Route component={GoogleAnalyticsReporter} />
       <Route component={DarkModeQueryParamReader} />
       <Route component={ApeModeQueryParamReader} />
       <Web3ReactManager>
-        <AppWrapper bgBlur={bgBlur}>
+        <AppWrapper>
           <URLWarning />
           <HeaderWrapper>
             <Header />

--- a/src/custom/theme/baseTheme.tsx
+++ b/src/custom/theme/baseTheme.tsx
@@ -108,12 +108,14 @@ export function colors(darkMode: boolean): Colors {
   }
 }
 
-export function themeVariables(darkMode: boolean, colorsTheme: Colors) {
+export function themeVariables(darkMode: boolean, shouldBlurBackground: boolean, colorsTheme: Colors) {
+  const background = cowSwapBackground(darkMode, shouldBlurBackground)
+
   return {
     body: {
       background: css`
         background: rgba(164, 211, 227, 1);
-        background: url(data:image/svg+xml;base64,${cowSwapBackground(darkMode)}) no-repeat 100% / cover fixed,
+        background: url(data:image/svg+xml;base64,${background}) no-repeat 100% / cover fixed,
           ${darkMode
             ? 'linear-gradient(180deg,rgba(20, 45, 78, 1) 10%, rgba(22, 58, 100, 1) 30%)'
             : 'linear-gradient(180deg,rgba(164, 211, 227, 1) 5%, rgba(255, 255, 255, 1) 40%)'};

--- a/src/custom/theme/cowSwapAssets.ts
+++ b/src/custom/theme/cowSwapAssets.ts
@@ -1,4 +1,4 @@
-export function cowSwapBackground(darkMode: boolean): string {
+export function cowSwapBackground(darkMode: boolean, shouldBlurBackground: boolean): string {
   const image = `<svg viewBox="-613.259 -350 2132.13 1200" width="2132.13" height="1200" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <clipPath id="clip-path">
@@ -120,7 +120,13 @@ export function cowSwapBackground(darkMode: boolean): string {
     </style>
   </defs>
   
-  <g clip-path="url(#clip-path)" transform="matrix(1, 0, 0, 1, -613.25885, -350)">
+  <filter id="blurFilter">
+    <feGaussianBlur in="SourceGraphic" stdDeviation="20" />
+  </filter>
+  
+  <g clip-path="url(#clip-path)"
+  ${shouldBlurBackground ? 'filter="url(#blurFilter)"' : ''}
+  transform="matrix(1, 0, 0, 1, -613.25885, -350)">
   
     <!-- WIND POLE -->
     <path id="WINDPOLE_1" class="BROWN_WOOD" d="M364.39 480.48l2.8-.5-37.1-205.68a8.76 8.76 0 01-2.8 0L294.8 489.23h35.31V408.5h21.3zM317 361.22l4.82-31.81h5.43v31.81zm10.25 2.84v41.6h-17l6.29-41.6zm2.84-34.65h7l5.74 31.81h-12.72zm0-2.84v-36.14l6.52 36.14zm-2.84 0h-5l5-33.12zm0 159.82H298.1l11.78-77.89h17.39zm2.84-80.73v-41.6h13.28l7.51 41.6z"/>

--- a/src/custom/theme/cowSwapTheme.tsx
+++ b/src/custom/theme/cowSwapTheme.tsx
@@ -11,15 +11,13 @@ import {
 
 import { theme as themeUniswap, MEDIA_WIDTHS as MEDIA_WIDTHS_UNISWAP } from '@src/theme'
 import { useIsDarkMode } from 'state/user/hooks'
+import { useLocation } from 'react-router-dom'
+import { Routes } from 'constants/routes'
 
 export { MEDIA_WIDTHS, ThemedText } from '@src/theme'
 
 export function colors(darkMode: boolean): Colors {
   return colorsBaseTheme(darkMode)
-}
-
-function themeVariables(darkMode: boolean, colorsTheme: Colors) {
-  return baseThemeVariables(darkMode, colorsTheme)
 }
 
 const MEDIA_WIDTHS = {
@@ -39,23 +37,28 @@ const mediaWidthTemplates: { [width in keyof typeof MEDIA_WIDTHS]: typeof css } 
   {}
 ) as any
 
-export function theme(darkmode: boolean): DefaultTheme {
+export function theme(darkmode: boolean, shouldBlurBackground: boolean): DefaultTheme {
   const colorsTheme = colors(darkmode)
   return {
     ...themeUniswap(darkmode),
     ...colorsTheme,
 
     // Overide Theme
-    ...baseThemeVariables(darkmode, colorsTheme),
-    ...themeVariables(darkmode, colorsTheme),
+    ...baseThemeVariables(darkmode, shouldBlurBackground, colorsTheme),
     mediaWidth: mediaWidthTemplates,
   }
 }
 
 export default function ThemeProvider({ children }: { children: React.ReactNode }) {
   const darkMode = useIsDarkMode()
+  const location = useLocation()
 
-  const themeObject = useMemo(() => theme(darkMode), [darkMode])
+  const themeObject = useMemo(() => {
+    // Page background must be blurred for all pages besides Swap page
+    const shouldBlurBackground = location.pathname.length > 1 && location.pathname !== Routes.SWAP
+
+    return theme(darkMode, shouldBlurBackground)
+  }, [darkMode, location.pathname])
 
   return <StyledComponentsThemeProvider theme={themeObject}>{children}</StyledComponentsThemeProvider>
 }


### PR DESCRIPTION
Using the `after` element with `svg` + `filter` + `transition` creates a high rendering load.
As I can see, now this style is redundant, because background is set to the `html` DOM element.
Demo: https://github.com/cowprotocol/cowswap/pull/825#issuecomment-1193121746

# Summary

<<if there's an issue>>Fixes #issueNumber

*High-level description of what your changes are accomplishing*

*Add screenshots if applicable. Images are nice :)*

  # To Test

1. <<Step one>> Open the page `about`
- [ ] <<What to expect?>> Verify it contains about information...
- [ ] Checkbox Style list of things a QA person could verify, i.e.
- [ ] Should display Text Input our storybook
- [ ] Input should not accept Numbers
2. <<Step two>> ...

  # Background

*Optional: Give background information for changes you've made, that might be difficult to explain via comments*

