### PR TITLE
828/referral should be only mainnet

### DIFF
--- a/src/custom/utils/appData.ts
+++ b/src/custom/utils/appData.ts
@@ -12,7 +12,8 @@ export type BuildAppDataParams = {
 export async function buildAppData({ chainId, slippageBips, referrerAccount, appCode }: BuildAppDataParams) {
   const sdk = COW_SDK[chainId]
 
-  const referrerParams = referrerAccount ? { address: referrerAccount } : undefined
+  const referrerParams =
+    referrerAccount && chainId === SupportedChainId.MAINNET ? { address: referrerAccount } : undefined
 
   const quoteParams = { slippageBips }
 

--- a/src/custom/utils/appData.ts
+++ b/src/custom/utils/appData.ts
@@ -14,9 +14,11 @@ export async function buildAppData({ chainId, slippageBips, referrerAccount, app
 
   const referrerParams = referrerAccount ? { address: referrerAccount } : undefined
 
+  const quoteParams = { slippageBips }
+
   const doc = sdk.metadataApi.generateAppDataDoc({
     appDataParams: { appCode, environment: environmentName },
-    metadataParams: { referrerParams, quoteParams: { slippageBips } },
+    metadataParams: { referrerParams, quoteParams },
   })
 
   const calculatedAppData = await sdk.metadataApi.calculateAppDataHash(doc)


### PR DESCRIPTION
# Summary

Fixes #828 

Does not send referral metadata if not on mainnet

  # To Test

1. Place an order while NOT on mainnet
2. Observe the generated appData
* It should NOT contain a metadata referrer field