### PR TITLE
Fixed #834. Bug when changing to Goerli on first time

### DIFF
--- a/src/custom/state/lists/hooks/hooksMod.ts
+++ b/src/custom/state/lists/hooks/hooksMod.ts
@@ -97,7 +97,7 @@ export function useAllLists(): AppState['lists'][ChainId]['byUrl'] {
   const { chainId: connectedChainId } = useActiveWeb3React()
   const chainId = supportedChainId(connectedChainId) ?? DEFAULT_NETWORK_FOR_LISTS
   // return useAppSelector<AppState, AppState['lists']['byUrl']>(state => state.lists.byUrl)
-  return useAppSelector((state) => state.lists[chainId]?.byUrl)
+  return useAppSelector((state) => state.lists[chainId]?.byUrl || {})
 }
 
 /**

--- a/src/custom/state/lists/updater/updaterMod.ts
+++ b/src/custom/state/lists/updater/updaterMod.ts
@@ -25,7 +25,7 @@ export default function Updater(): null {
   const isWindowVisible = useIsWindowVisible()
 
   // get all loaded lists, and the active urls
-  const lists = useAllLists() || {}
+  const lists = useAllLists()
   const activeListUrls = useActiveListUrls()
 
   const fetchList = useFetchListCallback()


### PR DESCRIPTION
# Summary
Attempt to fix https://github.com/cowprotocol/cowswap/pull/835 compiler error.

-----
All credits of this PR should go to @alfetopito who found the issue and did the fix in the first place.

Fixes #834 - App crashes when switching to Goerli for the first time

This was not quite fixed on https://github.com/cowprotocol/cowswap/pull/805

  # To Test

1. Open the PR
2. Change the network to mainnet
3. Open local storage and replace the contents of `redux_localstorage_simple_lists` with https://paste.ee/p/MvQYv
4. Reload the page
5. Switch the network to Goerli
* It should not crash :)
6. Repeat the steps on https://cowswap.dev.gnosisdev.com/#/swap?chain=goerli
* It SHOULD crash since it does not contain this fix yet