### PR TITLE
Disable swap form when Gnosis safe in readonly mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,7 +248,7 @@
     "@davatar/react": "1.8.1",
     "@fontsource/ibm-plex-mono": "^4.5.1",
     "@fontsource/inter": "^4.5.1",
-    "@gnosis.pm/safe-apps-web3-react": "^0.6.0",
+    "@gnosis.pm/safe-apps-web3-react": "^1.5.0",
     "@gnosis.pm/safe-service-client": "^0.1.1",
     "@popperjs/core": "^2.4.4",
     "@reduxjs/toolkit": "^1.8.0",

--- a/src/custom/hooks/useGnosisSafeInfo.test.tsx
+++ b/src/custom/hooks/useGnosisSafeInfo.test.tsx
@@ -1,0 +1,77 @@
+import { render, unmountComponentAtNode } from 'react-dom'
+import { act } from 'react-dom/test-utils'
+import { gnosisSafe } from 'connectors'
+import { useWeb3React } from 'web3-react-core'
+import { useGnosisSafeInfo } from './useGnosisSafeInfo'
+import { waitFor } from '@testing-library/react'
+import { SafeInfo } from '@gnosis.pm/safe-apps-sdk'
+
+jest.mock('web3-react-core')
+
+const safeInfoMock: SafeInfo = {
+  safeAddress: '0xaaa',
+  chainId: 1,
+  threshold: 0,
+  owners: [],
+  isReadOnly: true,
+}
+
+function TestComponent() {
+  const safeInfo = useGnosisSafeInfo()
+
+  return <div>{JSON.stringify(safeInfo)}</div>
+}
+
+function mockWeb3React({ active }: { active: boolean }) {
+  const mockUseWeb3React = useWeb3React as jest.MockedFunction<typeof useWeb3React>
+
+  jest.spyOn(gnosisSafe, 'getSafeInfo').mockResolvedValue(safeInfoMock)
+  mockUseWeb3React.mockReturnValue({
+    active,
+    connector: gnosisSafe,
+    activate: jest.fn(),
+    setError: jest.fn(),
+    deactivate: jest.fn(),
+  })
+}
+
+describe('useGnosisSafeInfo - hook to get info from Gnosis safe', () => {
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (!container) return
+
+    unmountComponentAtNode(container)
+    container.remove()
+    container = null
+  })
+
+  it('When Gnosis safe is connected, then should return info', async () => {
+    mockWeb3React({ active: true })
+
+    act(() => {
+      render(<TestComponent />, container)
+    })
+
+    await waitFor(() => {
+      expect(container?.textContent).toBe(JSON.stringify(safeInfoMock))
+    })
+  })
+
+  it('When Gnosis safe is NOT connected, then should return null', async () => {
+    mockWeb3React({ active: false })
+
+    act(() => {
+      render(<TestComponent />, container)
+    })
+
+    await waitFor(() => {
+      expect(container?.textContent).toBe(JSON.stringify(null))
+    })
+  })
+})

--- a/src/custom/hooks/useGnosisSafeInfo.ts
+++ b/src/custom/hooks/useGnosisSafeInfo.ts
@@ -1,0 +1,19 @@
+import { useWeb3React } from 'web3-react-core'
+import { useEffect, useState } from 'react'
+import { gnosisSafe } from 'connectors'
+import { SafeInfo } from '@gnosis.pm/safe-apps-sdk'
+
+export function useGnosisSafeInfo(): SafeInfo | null {
+  const [gnosisSafeInfo, setGnosisSafeInfo] = useState<SafeInfo | null>(null)
+  const { active, connector } = useWeb3React()
+
+  useEffect(() => {
+    if (!active || connector !== gnosisSafe) {
+      setGnosisSafeInfo(null)
+    } else {
+      gnosisSafe.getSafeInfo().then(setGnosisSafeInfo)
+    }
+  }, [active, connector])
+
+  return gnosisSafeInfo
+}

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -87,6 +87,7 @@ import CowSubsidyModal from 'components/CowSubsidyModal'
 import { getProviderErrorMessage, isRejectRequestProviderError } from 'utils/misc'
 import { AlertWrapper } from './styleds' // mod
 import { approvalAnalytics, swapAnalytics, setMaxSellTokensAnalytics, signSwapAnalytics } from 'utils/analytics'
+import { useGnosisSafeInfo } from 'hooks/useGnosisSafeInfo'
 
 // const AlertWrapper = styled.div`
 //   max-width: 460px;
@@ -571,6 +572,8 @@ export default function Swap({
 
   const swapIsUnsupported = useIsSwapUnsupported(currencies[Field.INPUT], currencies[Field.OUTPUT])
 
+  const isReadonlyGnosisSafeUser = useGnosisSafeInfo()?.isReadOnly || false
+
   // const priceImpactTooHigh = priceImpactSeverity > 3 && !isExpertMode
 
   const [exactInLabel, exactOutLabel] = useMemo(
@@ -865,6 +868,12 @@ export default function Swap({
             ) : !account ? (
               <ButtonPrimary buttonSize={ButtonSize.BIG} onClick={toggleWalletModal}>
                 <SwapButton showLoading={swapBlankState || isGettingNewQuote}>Connect Wallet</SwapButton>
+              </ButtonPrimary>
+            ) : isReadonlyGnosisSafeUser ? (
+              <ButtonPrimary disabled={true} buttonSize={ButtonSize.BIG}>
+                <ThemedText.Main mb="4px">
+                  <Trans>Read Only</Trans>
+                </ThemedText.Main>
               </ButtonPrimary>
             ) : showApproveFlow ? (
               <AutoRow style={{ flexWrap: 'nowrap', width: '100%' }}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2223,29 +2223,29 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@gnosis.pm/safe-apps-provider@0.9.3":
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-provider/-/safe-apps-provider-0.9.3.tgz#d8913b0f8abc15fdca229571eefc5f9385c82ea7"
-  integrity sha512-WzsfEMrOTd7/epEKs7S0QBB+sgw25d1B4SeLCD7q9RYi0vYLaeWT3jTuVXVGqwAlT3tFyedmvXnryLV5SUwiug==
+"@gnosis.pm/safe-apps-provider@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-provider/-/safe-apps-provider-0.12.0.tgz#bf0b7de614627bd07d4023a3d0e3ee94d109ca34"
+  integrity sha512-HfBpbp4KC1cY10EgTgra2XGtPC9t7PES1OrUQvZHZdbp/2CdmlwrrmXCBfhpxmEr4C2DmGqoGBBZWPeli6rctA==
   dependencies:
-    "@gnosis.pm/safe-apps-sdk" "6.2.0"
+    "@gnosis.pm/safe-apps-sdk" "7.6.0"
     events "^3.3.0"
 
-"@gnosis.pm/safe-apps-sdk@6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-sdk/-/safe-apps-sdk-6.2.0.tgz#05751b4ae4c6cfa7e19839d3655e7d9b5fb72dfe"
-  integrity sha512-dOpVBlu+Nv7bOrOl9llTeRriEpdUnnbXEM/RgTkS1v8Q2swT6+M+WIKTuKB/cadFXbjUsBD/nd3IsihHP24b5g==
+"@gnosis.pm/safe-apps-sdk@7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-sdk/-/safe-apps-sdk-7.6.0.tgz#fdd8fa57eb3d6be3ba384ee51cb5b2f5f6416fbc"
+  integrity sha512-2MFdcNu/n2pioeX2TiXMmwtxvhl5SM8Y2RapDF8YxF11naubKvVXIg5KDJfmvGfXCn7wyqjLxkBcUkMPFbcS8w==
   dependencies:
-    "@gnosis.pm/safe-react-gateway-sdk" "^2.5.6"
-    ethers "^5.4.7"
+    "@gnosis.pm/safe-react-gateway-sdk" "^3.1.3"
+    ethers "^5.6.8"
 
-"@gnosis.pm/safe-apps-web3-react@^0.6.0":
-  version "0.6.8"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-web3-react/-/safe-apps-web3-react-0.6.8.tgz#be7917dd56b04ea41a40f66dd3320a438ae71676"
-  integrity sha512-G1Ho4GnMmKpsjtqz+nExyL8aFxAFFEHduN9wh5dJX3K0iZZi5HM3h4YfKaqiikCy4N/ghX9O4/4pAkzK1l5NnQ==
+"@gnosis.pm/safe-apps-web3-react@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-web3-react/-/safe-apps-web3-react-1.5.0.tgz#8295401ae5ed5eb7a58dcefce72e7b604b761cf9"
+  integrity sha512-pUSVicLyYnLFcEf6G/wQV8LIRDUPjXjO9LkcZepUq5YSHWloXGLMuS3ma6KQo/aoUZkJKUK1lrGBP+rulpi4GQ==
   dependencies:
-    "@gnosis.pm/safe-apps-provider" "0.9.3"
-    "@gnosis.pm/safe-apps-sdk" "6.2.0"
+    "@gnosis.pm/safe-apps-provider" "0.12.0"
+    "@gnosis.pm/safe-apps-sdk" "7.6.0"
     "@web3-react/abstract-connector" "6.0.7"
 
 "@gnosis.pm/safe-core-sdk-types@^0.1.0":
@@ -2253,10 +2253,10 @@
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-core-sdk-types/-/safe-core-sdk-types-0.1.1.tgz#908c394cb4660493b4e9c8e01b5a7aa36efafd30"
   integrity sha512-PghXGDaI5Foq37nZGmI90U2OKMeGtxh5KqkDqou9aFHwGVa/nf9HRQPxG9/XUzcyfe9OlKttDlJnR3XnC3dSDw==
 
-"@gnosis.pm/safe-react-gateway-sdk@^2.5.6":
-  version "2.10.3"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.10.3.tgz#4537442a78eb0508c483aabcac19296335a77ac3"
-  integrity sha512-ukaLACozdJQb2YGSAZgBUkF4CT9iKVjpnKFCKUnGGghXqp+Yyn9jpdcfFK0VYQJ6ZSwAm40tHtQaN3K9817Bcg==
+"@gnosis.pm/safe-react-gateway-sdk@^3.1.3":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-3.2.4.tgz#509f11ce34ddd920d05d4f2a21be137e858a57d3"
+  integrity sha512-Bupn8J4IgKAtrFxMBi8WVh4YiZ6rcCk/41C7Dz4+B8tQRhcCelc2YXQljcWMZAzS/yfv7yHlpjpMrNpj3jGGTw==
   dependencies:
     cross-fetch "^3.1.5"
 
@@ -11165,7 +11165,7 @@ ethereumjs-vm@^2.3.4:
     rustbn.js "~0.2.0"
     safe-buffer "^5.1.1"
 
-ethers@^5.1.4, ethers@^5.4.7, ethers@^5.6.8:
+ethers@^5.1.4, ethers@^5.6.8:
   version "5.6.8"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.6.8.tgz#d36b816b4896341a80a8bbd2a44e8cb6e9b98dd4"
   integrity sha512-YxIGaltAOdvBFPZwIkyHnXbW40f1r8mHUgapW6dxkO+6t7H6wY8POUn0Kbxrd/N7I4hHxyi7YCddMAH/wmho2w==


### PR DESCRIPTION
# Summary

Fixes #311

When Cow DAPP is opened inside Gnosis safe in Read-only mode, then we don't allow user to swap and show disabled button with text "Read Only"

<img width="1789" alt="image" src="https://user-images.githubusercontent.com/7122625/182309047-e7c64f22-0fc9-40fe-88bd-202e3c3625c3.png">

  # To Test

https://github.com/cowprotocol/cowswap/issues/311#issuecomment-1201053615

  # Background

I had to update `@gnosis.pm/safe-apps-web3-react` package up to `1.5.0` version because the old version doesn't have full typings of SafeInfo (particularly `isReadOnly` flag)
