### PR TITLE
Add event handlers for appzi events

### DIFF
--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -34,6 +34,7 @@ import CowBalanceButton from 'components/CowBalanceButton'
 
 // Assets
 import { toggleDarkModeAnalytics } from 'utils/analytics'
+import { openNpsAppzi } from 'utils/appzi'
 
 export const NETWORK_LABELS: { [chainId in ChainId]?: string } = {
   [ChainId.RINKEBY]: 'Rinkeby',
@@ -68,6 +69,7 @@ export default function Header() {
   const [isOrdersPanelOpen, setIsOrdersPanelOpen] = useState<boolean>(false)
   const handleOpenOrdersPanel = () => {
     account && setIsOrdersPanelOpen(true)
+    openNpsAppzi()
   }
   const handleCloseOrdersPanel = () => {
     setIsOrdersPanelOpen(false)

--- a/src/custom/utils/appzi.ts
+++ b/src/custom/utils/appzi.ts
@@ -35,6 +35,10 @@ export function onAppziEvent(callback: EventCallback) {
   eventEmitter.on(EVENT, callback)
 }
 
+export function onceAppziEvent(callback: EventCallback) {
+  eventEmitter.once(EVENT, callback)
+}
+
 export function offAppziEvent(callback: EventCallback) {
   eventEmitter.off(EVENT, callback)
 }
@@ -67,15 +71,21 @@ export function openFeedbackAppzi() {
   window.appzi?.openWidget(FEEDBACK_KEY)
 }
 
-export function openNpsAppzi() {
-  console.debug(`Showing appzi NPS. Always!`)
-  window.appzi?.openWidget(NPS_KEY)
-
+function restyleAppziNps() {
   // Add a unique class based on NPS_KEY
   const appziRoot = document.querySelector("div[id^='appzi-wfo-']")
   if (appziRoot) {
     appziRoot.classList.add(`appzi-nps-${NPS_KEY}`)
   }
+}
+
+export function openNpsAppzi() {
+  console.debug(`Showing appzi NPS. Always!`)
+
+  // Make sure we apply the re-style once the appzi NPS is loaded
+  onceAppziEvent(restyleAppziNps)
+
+  window.appzi?.openWidget(NPS_KEY)
 }
 
 /**

--- a/src/custom/utils/appzi.ts
+++ b/src/custom/utils/appzi.ts
@@ -1,3 +1,4 @@
+import EventEmitter from 'events'
 import ReactAppzi from 'react-appzi'
 
 export const isAppziEnabled =
@@ -7,6 +8,9 @@ export const FEEDBACK_KEY = process.env.REACT_APP_APPZI_FEEDBACK_KEY || 'f7591ec
 export const NPS_KEY = process.env.REACT_APP_APPZI_FEEDBACK_KEY || '55872789-593b-4c6c-9e49-9b5c7693e90a'
 
 const APPZI_TOKEN = process.env.REACT_APP_APPZI_TOKEN || '5ju0G'
+const EVENT = 'message'
+
+type EventCallback = (event: any) => void
 
 declare global {
   interface Window {
@@ -16,6 +20,7 @@ declare global {
     appziSettings: {
       userId: string
       data: AppziCustomSettings
+      onEvent: EventCallback
     }
   }
 }
@@ -24,9 +29,27 @@ interface AppziCustomSettings {
   userTradedOrWaitedForLong?: 'required-to-be-set'
 }
 
+const eventEmitter = new EventEmitter()
+
+export function onAppziEvent(callback: EventCallback) {
+  eventEmitter.on(EVENT, callback)
+}
+
+export function offAppziEvent(callback: EventCallback) {
+  eventEmitter.off(EVENT, callback)
+}
+
+function triggerAppziEvent(payload: any) {
+  console.log('[appzi] Event', payload)
+  eventEmitter.emit(EVENT, payload)
+}
+
 function initialize() {
   if (isAppziEnabled) {
     ReactAppzi.initialize(APPZI_TOKEN)
+
+    window.appziSettings = window.appziSettings || {}
+    window.appziSettings.onEvent = triggerAppziEvent
   }
 }
 


### PR DESCRIPTION
# Summary

Experimenting to add events to appZi.

The reason is to:
* Try to help @fairlighteth  with this issue he is having re-styling appzi: https://github.com/cowprotocol/cowswap/pull/866 
* We will like to add Google Analytics events for opening and closing appzi

This PR is highly experimental, because their event handling is deprecated. Although AppZi mentioned that we should be able to use it. Maybe we will just need to check with them if they can enable it and make it official

See for context: https://docs.appzi.io/deprecations/events


This PR allows us to register to the events, so we can add arbitrary logic. 

See console: 
<img width="1131" alt="image" src="https://user-images.githubusercontent.com/2352112/182443963-b5109e53-545b-4a8e-a18d-4052fce4c5d2.png">


# Disclamer
- I see that currently the info in the event doesn't help with adding the dynamic CSS @fairlighteth needed. 
- Also, i see they don't trigger an event when I close the modal. I think they should, so we can use it for analytics too

# Not included
- Doesn't fix any style issue
- Doesn't fix the issue where the styles break a bit the buttons (u can only click the top part of them)


# Test
Just test to click here:
<img width="1011" alt="image" src="https://user-images.githubusercontent.com/2352112/182657091-a94e3e59-3a90-4de1-aa04-a58e74e5cb65.png">
