### PR TITLE
Pr856/follow up

### DIFF
--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -224,12 +224,10 @@ export const soundMiddleware: Middleware<Record<string, unknown>, AppState> = (s
 }
 
 export const appziMiddleware: Middleware<Record<string, unknown>, AppState> = (store) => (next) => (action) => {
-  const result = next(action)
-
   if (isBatchFulfillOrderAction(action) || isSingleFulfillOrderAction(action)) {
     // Shows NPS feedback (or attempts to) when there's a successful trade
     openNpsAppziSometimes()
   }
 
-  return result
+  return next(action)
 }

--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -224,8 +224,9 @@ export const soundMiddleware: Middleware<Record<string, unknown>, AppState> = (s
 }
 
 export const appziMiddleware: Middleware<Record<string, unknown>, AppState> = (store) => (next) => (action) => {
-  if (isBatchFulfillOrderAction(action) || isSingleFulfillOrderAction(action)) {
+  if (isBatchFulfillOrderAction(action) || isSingleFulfillOrderAction(action) || isExpireOrdersAction(action)) {
     // Shows NPS feedback (or attempts to) when there's a successful trade
+    // Or the order has expired
     openNpsAppziSometimes()
   }
 

--- a/src/custom/state/orders/reducer.ts
+++ b/src/custom/state/orders/reducer.ts
@@ -4,9 +4,6 @@ import { SupportedChainId as ChainId } from 'constants/chains'
 import {
   addOrUpdateOrders,
   addPendingOrder,
-  preSignOrders,
-  updatePresignGnosisSafeTx,
-  removeOrder,
   cancelOrder,
   cancelOrdersBatch,
   clearOrders,
@@ -15,10 +12,13 @@ import {
   fulfillOrder,
   fulfillOrdersBatch,
   OrderStatus,
+  preSignOrders,
+  removeOrder,
   requestOrderCancellation,
   SerializedOrder,
   setIsOrderUnfillable,
   updateLastCheckedBlock,
+  updatePresignGnosisSafeTx,
 } from './actions'
 import { ContractDeploymentBlocks } from './consts'
 import { Writable } from 'types'
@@ -158,7 +158,7 @@ export default createReducer(initialState, (builder) =>
       const { order, id, chainId } = action.payload
 
       const orderStateList = order.status === OrderStatus.PRESIGNATURE_PENDING ? 'presignaturePending' : 'pending'
-      order.openSince = OrderStatus.PRESIGNATURE_PENDING ? undefined : Date.now()
+      order.openSince = order.status === OrderStatus.PRESIGNATURE_PENDING ? undefined : Date.now()
 
       addOrderToState(state, chainId, id, orderStateList, order)
     })

--- a/src/custom/utils/appzi.ts
+++ b/src/custom/utils/appzi.ts
@@ -21,7 +21,7 @@ declare global {
 }
 
 interface AppziCustomSettings {
-  userTradedOrWaitedForLong?: 'required-to-be-set'
+  userTradedOrWaitedForLong?: true
 }
 
 function initialize() {
@@ -56,7 +56,7 @@ export function openNpsAppzi() {
  */
 export function openNpsAppziSometimes() {
   console.debug(`Showing appzi NPS. Sometimes...`)
-  updateAppziSettings({ data: { userTradedOrWaitedForLong: 'required-to-be-set' } })
+  updateAppziSettings({ data: { userTradedOrWaitedForLong: true } })
 }
 
 initialize()


### PR DESCRIPTION
# Summary

Follow up to #856 

Fixes https://github.com/cowprotocol/cowswap/issues/864

- EOAs now do trigger NPS when > 5 min pending
- NPS triggered when order expires

# To Test

## Pending order test:

1. Using 2 different accounts, place two identical orders for the same pair, in a way that there is a price impact
2. One of them will execute while the other won't
* After 5 min pending, NPS modal should be displayed

## Expired order test

1. Remove appzi key from local storage and refresh the page
2. Set expiration to 2 min
3. Place identical orders
4. One of them will execute, the other won't
* After the order is expires, NPS should trigger