### PR TITLE
Apply the NPS restyle also in automatic mode, and only once

### DIFF
--- a/src/custom/utils/appzi.ts
+++ b/src/custom/utils/appzi.ts
@@ -73,7 +73,8 @@ export function openFeedbackAppzi() {
 
 let appziRestyleApplied = false
 function applyOnceRestyleAppziNps() {
-  if (appziRestyleApplied) {
+  if (!appziRestyleApplied) {
+    appziRestyleApplied = true
     // Make sure we apply the re-style once the appzi NPS is loaded
     onceAppziEvent(restyleAppziNps)
   }

--- a/src/custom/utils/appzi.ts
+++ b/src/custom/utils/appzi.ts
@@ -44,7 +44,7 @@ export function offAppziEvent(callback: EventCallback) {
 }
 
 function triggerAppziEvent(payload: any) {
-  console.log('[appzi] Event', payload)
+  // console.log('[appzi] Event', payload)
   eventEmitter.emit(EVENT, payload)
 }
 
@@ -67,7 +67,6 @@ export function updateAppziSettings({ data = {}, userId = '' }: AppziSettings) {
 }
 
 export function openFeedbackAppzi() {
-  console.debug(`Showing appzi feedback. Always!`)
   window.appzi?.openWidget(FEEDBACK_KEY)
 }
 
@@ -80,18 +79,18 @@ function applyOnceRestyleAppziNps() {
   }
 }
 
-function restyleAppziNps() {
-  // Add a unique class based on NPS_KEY
-  const appziRoot = document.querySelector("div[id^='appzi-wfo-']")
-  if (appziRoot) {
-    appziRoot.classList.add(`appzi-nps-${NPS_KEY}`)
-    appziRestyleApplied = true
+function restyleAppziNps(event: any) {
+  if (event && event.type && event.type === 'open-survey') {
+    // Add a unique class based on NPS_KEY
+    const appziRoot = document.querySelector("div[id^='appzi-wfo-']")
+    if (appziRoot) {
+      appziRoot.classList.add(`appzi-nps-${NPS_KEY}`)
+      appziRestyleApplied = true
+    }
   }
 }
 
 export function openNpsAppzi() {
-  console.debug(`Showing appzi NPS. Always!`)
-
   applyOnceRestyleAppziNps()
   window.appzi?.openWidget(NPS_KEY)
 }
@@ -102,8 +101,6 @@ export function openNpsAppzi() {
  * Check https://portal.appzi.com/portals/5ju0G/configs/55872789-593b-4c6c-9e49-9b5c7693e90a/trigger
  */
 export function openNpsAppziSometimes() {
-  console.debug(`Showing appzi NPS. Sometimes...`)
-
   applyOnceRestyleAppziNps()
   updateAppziSettings({ data: { userTradedOrWaitedForLong: true } })
 }

--- a/src/custom/utils/appzi.ts
+++ b/src/custom/utils/appzi.ts
@@ -71,20 +71,27 @@ export function openFeedbackAppzi() {
   window.appzi?.openWidget(FEEDBACK_KEY)
 }
 
+let appziRestyleApplied = false
+function applyOnceRestyleAppziNps() {
+  if (appziRestyleApplied) {
+    // Make sure we apply the re-style once the appzi NPS is loaded
+    onceAppziEvent(restyleAppziNps)
+  }
+}
+
 function restyleAppziNps() {
   // Add a unique class based on NPS_KEY
   const appziRoot = document.querySelector("div[id^='appzi-wfo-']")
   if (appziRoot) {
     appziRoot.classList.add(`appzi-nps-${NPS_KEY}`)
+    appziRestyleApplied = true
   }
 }
 
 export function openNpsAppzi() {
   console.debug(`Showing appzi NPS. Always!`)
 
-  // Make sure we apply the re-style once the appzi NPS is loaded
-  onceAppziEvent(restyleAppziNps)
-
+  applyOnceRestyleAppziNps()
   window.appzi?.openWidget(NPS_KEY)
 }
 
@@ -95,6 +102,8 @@ export function openNpsAppzi() {
  */
 export function openNpsAppziSometimes() {
   console.debug(`Showing appzi NPS. Sometimes...`)
+
+  applyOnceRestyleAppziNps()
   updateAppziSettings({ data: { userTradedOrWaitedForLong: true } })
 }
 


### PR DESCRIPTION
# Summary
AppZi has two modes in which it can be invoked:
1) Imperative mode. You order the NPS widget to show. This is controled by our util `openNpsAppzi()`
2) Automatic. You report to appzi that the user has traded, or has waited long enough. Appzi decides if it should open the NPS. This is controlled by our util `openNpsAppziSometimes()`

We did the test and development of the feature using  `openNpsAppzi()`, which made development/testing easier. This had the code to inject the styles.

However, and here it comes the bug, I forgot to add the code also in `openNpsAppziSometimes()`


<img width="1449" alt="image" src="https://user-images.githubusercontent.com/2352112/182702180-0db86fec-5f96-40bc-9e52-05c0efc3c92f.png">


# Bonus
- Additionally, makes sure we inject the styles only once
- Also removes some console logs


 # To Test
Trade and observe now the NPS form has the right styles