### PR TITLE
Disable appzi old chrome

### DIFF
--- a/src/custom/utils/appzi.ts
+++ b/src/custom/utils/appzi.ts
@@ -1,8 +1,14 @@
 import EventEmitter from 'events'
 import ReactAppzi from 'react-appzi'
+import { userAgent, majorBrowserVersion } from 'utils/userAgent'
+
+// Metamask IOS app uses a version from July 2019 which causes problems in appZi
+const OLD_CHROME_FROM_METAMASK_IOS_APP = 76
+const isOldChrome =
+  userAgent.browser.name === 'Chrome' && majorBrowserVersion && majorBrowserVersion <= OLD_CHROME_FROM_METAMASK_IOS_APP
 
 export const isAppziEnabled =
-  process.env.REACT_APP_FEEDBACK_ENABLED_DEV === 'true' || process.env.NODE_ENV === 'production'
+  !isOldChrome && (process.env.REACT_APP_FEEDBACK_ENABLED_DEV === 'true' || process.env.NODE_ENV === 'production')
 
 export const FEEDBACK_KEY = process.env.REACT_APP_APPZI_FEEDBACK_KEY || 'f7591eca-72f7-4888-b15f-e7ff5fcd60cd'
 export const NPS_KEY = process.env.REACT_APP_APPZI_FEEDBACK_KEY || '55872789-593b-4c6c-9e49-9b5c7693e90a'

--- a/src/custom/utils/userAgent.ts
+++ b/src/custom/utils/userAgent.ts
@@ -1,0 +1,11 @@
+import { userAgent } from '@src/utils/userAgent'
+
+export * from '@src/utils/userAgent'
+
+function getBrowserMajorVersion() {
+  const major = userAgent.browser.version?.split('.')[0]
+
+  return major ? parseInt(major) : undefined
+}
+
+export const majorBrowserVersion = getBrowserMajorVersion()


### PR DESCRIPTION
# Summary

This PR tries to solve a problem that happens when using appZi in Metamask IOS app.

The error is reproducible in production right now.

1. Using Metamask IOS
2. Click on the button to leave a feedback using appZi --> instead of opening the appzi modal, it only shows the X icon, and blocks the user (they cannot click on anything else). 


Although this error is solved with a refresh, we cannot deploy the NPS that would make this error way more sever, because now on your first trade you will be propted with the appZi for,


# To Test
- Test the steps above for Metamask in IOS and Android. I only tested this in IOS, I would appreciate some test in android.