### PR TITLE
[ETH-FLOW V2] - Atoms state + RowSlippage component update

### DIFF
--- a/src/custom/components/swap/TradeSummary/RowSlippage.tsx
+++ b/src/custom/components/swap/TradeSummary/RowSlippage.tsx
@@ -18,6 +18,7 @@ export interface RowSlippageProps {
   fontSize?: number
   rowHeight?: number
   showSettingOnClick?: boolean
+  nativeSymbolInNativeFlow?: string
 }
 export function RowSlippage({
   allowedSlippage,
@@ -25,6 +26,9 @@ export function RowSlippage({
   fontWeight = 500,
   rowHeight,
   showSettingOnClick = true,
+  // undefined if NOT in native flow
+  // else is symbol of native currency
+  nativeSymbolInNativeFlow,
 }: RowSlippageProps) {
   const theme = useContext(ThemeContext)
   const toggleSettings = useToggleSettingsMenu()
@@ -34,7 +38,11 @@ export function RowSlippage({
     <RowBetween height={rowHeight}>
       <RowFixed>
         <ThemedText.Black fontSize={fontSize} fontWeight={fontWeight} color={theme.text2}>
-          {showSettingOnClick ? (
+          {nativeSymbolInNativeFlow ? (
+            <Trans>
+              Slippage tolerance <ThemedText.Warn override>(modified)</ThemedText.Warn>
+            </Trans>
+          ) : showSettingOnClick ? (
             <ClickableText fontWeight={500} fontSize={14} color={theme.text2} onClick={toggleSettings}>
               <Trans>Slippage tolerance</Trans>
             </ClickableText>
@@ -47,13 +55,24 @@ export function RowSlippage({
           color={theme.text1}
           wrap
           content={
-            <Trans>
-              <p>Your slippage is MEV protected: all orders are submitted with tight spread (0.1%) on-chain.</p>
-              <p>
-                The slippage you pick here enables a resubmission of your order in case of unfavourable price movements.
-              </p>
-              <p>{INPUT_OUTPUT_EXPLANATION}</p>
-            </Trans>
+            nativeSymbolInNativeFlow ? (
+              <Trans>
+                <p>
+                  You are currently swapping {nativeSymbolInNativeFlow || 'a native token'} with the classic native
+                  currency CowSwap experience disabled. Slippage tolerance is defaulted to a 2% spread to maximise
+                  chances of order matching success.
+                </p>
+              </Trans>
+            ) : (
+              <Trans>
+                <p>Your slippage is MEV protected: all orders are submitted with tight spread (0.1%) on-chain.</p>
+                <p>
+                  The slippage you pick here enables a resubmission of your order in case of unfavourable price
+                  movements.
+                </p>
+                <p>{INPUT_OUTPUT_EXPLANATION}</p>
+              </Trans>
+            )
           }
         >
           <StyledInfo />

--- a/src/custom/components/swap/TradeSummary/RowSlippage.tsx
+++ b/src/custom/components/swap/TradeSummary/RowSlippage.tsx
@@ -11,6 +11,7 @@ import { StyledInfo } from 'pages/Swap/styleds'
 import { ClickableText } from 'pages/Pool/styleds'
 import { useToggleSettingsMenu } from 'state/application/hooks'
 import { formatSmart } from 'utils/format'
+import { useShowNativeEthFlowSlippageWarning } from 'state/ethFlow/hooks'
 
 export interface RowSlippageProps {
   allowedSlippage: Percent
@@ -20,25 +21,25 @@ export interface RowSlippageProps {
   showSettingOnClick?: boolean
   nativeFlowSymbol?: false | string
 }
+
 export function RowSlippage({
   allowedSlippage,
   fontSize = 14,
   fontWeight = 500,
   rowHeight,
   showSettingOnClick = true,
-  // false/undefined if NOT in native flow
-  // else is symbol of native currency
-  nativeFlowSymbol,
 }: RowSlippageProps) {
   const theme = useContext(ThemeContext)
   const toggleSettings = useToggleSettingsMenu()
   const displaySlippage = `${formatSmart(allowedSlippage, PERCENTAGE_PRECISION)}%`
 
+  const nativeEthFlowSymbol = useShowNativeEthFlowSlippageWarning()
+
   return (
     <RowBetween height={rowHeight}>
       <RowFixed>
         <ThemedText.Black fontSize={fontSize} fontWeight={fontWeight} color={theme.text2}>
-          {nativeFlowSymbol ? (
+          {nativeEthFlowSymbol ? (
             <Trans>
               Slippage tolerance <ThemedText.Warn override>(modified)</ThemedText.Warn>
             </Trans>
@@ -55,12 +56,15 @@ export function RowSlippage({
           color={theme.text1}
           wrap
           content={
-            nativeFlowSymbol ? (
+            nativeEthFlowSymbol ? (
               <Trans>
                 <p>
-                  You are currently swapping {nativeFlowSymbol || 'a native token'} with the classic{' '}
-                  {nativeFlowSymbol || 'native currency'} CowSwap experience disabled.
-                  <p>Slippage tolerance is defaulted to a 2% spread to maximise chances of order matching success.</p>
+                  You are currently swapping {nativeEthFlowSymbol || 'a native token'} with the classic{' '}
+                  {nativeEthFlowSymbol || 'wrapped currency'} experience disabled.
+                  <p>
+                    Slippage tolerance is defaulted to 2% to ensure a high likelihood of order matching, even in
+                    volatile market situations.
+                  </p>
                 </p>
               </Trans>
             ) : (

--- a/src/custom/components/swap/TradeSummary/RowSlippage.tsx
+++ b/src/custom/components/swap/TradeSummary/RowSlippage.tsx
@@ -18,7 +18,7 @@ export interface RowSlippageProps {
   fontSize?: number
   rowHeight?: number
   showSettingOnClick?: boolean
-  nativeSymbolInNativeFlow?: false | string
+  nativeFlowSymbol?: false | string
 }
 export function RowSlippage({
   allowedSlippage,
@@ -26,9 +26,9 @@ export function RowSlippage({
   fontWeight = 500,
   rowHeight,
   showSettingOnClick = true,
-  // undefined if NOT in native flow
+  // false/undefined if NOT in native flow
   // else is symbol of native currency
-  nativeSymbolInNativeFlow,
+  nativeFlowSymbol,
 }: RowSlippageProps) {
   const theme = useContext(ThemeContext)
   const toggleSettings = useToggleSettingsMenu()
@@ -38,7 +38,7 @@ export function RowSlippage({
     <RowBetween height={rowHeight}>
       <RowFixed>
         <ThemedText.Black fontSize={fontSize} fontWeight={fontWeight} color={theme.text2}>
-          {nativeSymbolInNativeFlow ? (
+          {nativeFlowSymbol ? (
             <Trans>
               Slippage tolerance <ThemedText.Warn override>(modified)</ThemedText.Warn>
             </Trans>
@@ -55,12 +55,12 @@ export function RowSlippage({
           color={theme.text1}
           wrap
           content={
-            nativeSymbolInNativeFlow ? (
+            nativeFlowSymbol ? (
               <Trans>
                 <p>
-                  You are currently swapping {nativeSymbolInNativeFlow || 'a native token'} with the classic native
-                  currency CowSwap experience disabled. Slippage tolerance is defaulted to a 2% spread to maximise
-                  chances of order matching success.
+                  You are currently swapping {nativeFlowSymbol || 'a native token'} with the classic{' '}
+                  {nativeFlowSymbol || 'native currency'} CowSwap experience disabled.
+                  <p>Slippage tolerance is defaulted to a 2% spread to maximise chances of order matching success.</p>
                 </p>
               </Trans>
             ) : (

--- a/src/custom/components/swap/TradeSummary/RowSlippage.tsx
+++ b/src/custom/components/swap/TradeSummary/RowSlippage.tsx
@@ -12,8 +12,10 @@ import { ClickableText } from 'pages/Pool/styleds'
 import { useToggleSettingsMenu } from 'state/application/hooks'
 import { formatSmart } from 'utils/format'
 import { useShowNativeEthFlowSlippageWarning } from 'state/ethFlow/hooks'
+import TradeGp from 'state/swap/TradeGp'
 
 export interface RowSlippageProps {
+  trade?: TradeGp
   allowedSlippage: Percent
   fontWeight?: number
   fontSize?: number
@@ -23,6 +25,7 @@ export interface RowSlippageProps {
 }
 
 export function RowSlippage({
+  trade,
   allowedSlippage,
   fontSize = 14,
   fontWeight = 500,
@@ -33,13 +36,15 @@ export function RowSlippage({
   const toggleSettings = useToggleSettingsMenu()
   const displaySlippage = `${formatSmart(allowedSlippage, PERCENTAGE_PRECISION)}%`
 
-  const nativeEthFlowSymbol = useShowNativeEthFlowSlippageWarning()
+  // should we show the warning?
+  const showEthFlowSlippageWarning = useShowNativeEthFlowSlippageWarning()
+  const [nativeSymbol, wrappedSymbol] = [trade?.inputAmount.currency.symbol, trade?.inputAmount.currency.wrapped.symbol]
 
   return (
     <RowBetween height={rowHeight}>
       <RowFixed>
         <ThemedText.Black fontSize={fontSize} fontWeight={fontWeight} color={theme.text2}>
-          {nativeEthFlowSymbol ? (
+          {showEthFlowSlippageWarning ? (
             <Trans>
               Slippage tolerance{' '}
               <ThemedText.Warn display="inline-block" override>
@@ -59,11 +64,11 @@ export function RowSlippage({
           color={theme.text1}
           wrap
           content={
-            nativeEthFlowSymbol ? (
+            showEthFlowSlippageWarning ? (
               <Trans>
                 <p>
-                  You are currently swapping {nativeEthFlowSymbol || 'a native token'} with the classic{' '}
-                  {nativeEthFlowSymbol || 'wrapped currency'} experience disabled.
+                  You are currently swapping {nativeSymbol || 'a native token'} with the classic{' '}
+                  {wrappedSymbol || 'wrapped currency'} experience disabled.
                   <p>
                     Slippage tolerance is defaulted to 2% to ensure a high likelihood of order matching, even in
                     volatile market situations.

--- a/src/custom/components/swap/TradeSummary/RowSlippage.tsx
+++ b/src/custom/components/swap/TradeSummary/RowSlippage.tsx
@@ -18,7 +18,7 @@ export interface RowSlippageProps {
   fontSize?: number
   rowHeight?: number
   showSettingOnClick?: boolean
-  nativeSymbolInNativeFlow?: string
+  nativeSymbolInNativeFlow?: false | string
 }
 export function RowSlippage({
   allowedSlippage,

--- a/src/custom/components/swap/TradeSummary/RowSlippage.tsx
+++ b/src/custom/components/swap/TradeSummary/RowSlippage.tsx
@@ -41,7 +41,10 @@ export function RowSlippage({
         <ThemedText.Black fontSize={fontSize} fontWeight={fontWeight} color={theme.text2}>
           {nativeEthFlowSymbol ? (
             <Trans>
-              Slippage tolerance <ThemedText.Warn override>(modified)</ThemedText.Warn>
+              Slippage tolerance{' '}
+              <ThemedText.Warn display="inline-block" override>
+                (modified)
+              </ThemedText.Warn>
             </Trans>
           ) : showSettingOnClick ? (
             <ClickableText fontWeight={500} fontSize={14} color={theme.text2} onClick={toggleSettings}>

--- a/src/custom/components/swap/TradeSummary/index.tsx
+++ b/src/custom/components/swap/TradeSummary/index.tsx
@@ -43,6 +43,7 @@ export default function TradeSummary({ trade, allowedSlippage, showHelpers, show
 
         {/* Slippage */}
         <RowSlippage
+          trade={trade}
           allowedSlippage={allowedSlippage}
           fontSize={12}
           fontWeight={400}

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -816,17 +816,19 @@ export default function Swap({
                     <Price trade={trade} theme={theme} showInverted={showInverted} setShowInverted={setShowInverted} />
                   )}
 
-                  {isUserNativeEthFlow ||
-                    (!isExpertMode && !allowedSlippage.equalTo(INITIAL_ALLOWED_SLIPPAGE_PERCENT) && (
-                      <RowSlippage
-                        allowedSlippage={allowedSlippage}
-                        fontSize={12}
-                        fontWeight={400}
-                        rowHeight={24}
-                        nativeSymbolInNativeFlow={isUserNativeEthFlow && trade?.inputAmount.currency.symbol}
-                      />
-                    ))}
-                  {(isFeeGreater || trade) && fee && <TradeBasicDetails trade={trade} fee={fee} />}
+                  {((!isExpertMode && isUserNativeEthFlow) ||
+                    !allowedSlippage.equalTo(INITIAL_ALLOWED_SLIPPAGE_PERCENT)) && (
+                    <RowSlippage
+                      allowedSlippage={allowedSlippage}
+                      fontSize={12}
+                      fontWeight={400}
+                      rowHeight={24}
+                      nativeFlowSymbol={isNativeIn && trade?.inputAmount.currency.symbol}
+                    />
+                  )}
+                  {(isFeeGreater || trade) && fee && (
+                    <TradeBasicDetails trade={trade} fee={fee} isNativeIn={isNativeIn} />
+                  )}
                   {/* FEES DISCOUNT */}
                   {/* TODO: check cow balance and set here, else don't show */}
                   <FeesDiscount theme={theme} onClick={openCowSubsidyModal} />

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -94,7 +94,7 @@ import { approvalAnalytics, swapAnalytics, setMaxSellTokensAnalytics, signSwapAn
 import { useGnosisSafeInfo } from 'hooks/useGnosisSafeInfo'
 
 import { WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
-import { useEthFlowActionHandlers, useIsUserNativeEthFlow } from 'state/ethFlow/hooks'
+import { useEthFlowActionHandlers, useShowNativeEthFlowSlippageWarning } from 'state/ethFlow/hooks'
 
 // const AlertWrapper = styled.div`
 //   max-width: 460px;
@@ -210,8 +210,8 @@ export default function Swap({
   // Log all trade information
   // logTradeDetails(v2Trade, allowedSlippage)
 
-  // enable when components ready
-  const isUserNativeEthFlow = useIsUserNativeEthFlow()
+  // shows slippage (modified) warning when nativeEthFlow is enabled
+  const showNativeEthFlowSlippageWarning = useShowNativeEthFlowSlippageWarning()
 
   // Checks if either currency is native ETH
   // MOD: adds this hook
@@ -821,10 +821,17 @@ export default function Swap({
                     <Price trade={trade} theme={theme} showInverted={showInverted} setShowInverted={setShowInverted} />
                   )}
 
-                  {((!isExpertMode && isUserNativeEthFlow) ||
-                    !allowedSlippage.equalTo(INITIAL_ALLOWED_SLIPPAGE_PERCENT)) && (
-                    <RowSlippage allowedSlippage={allowedSlippage} fontSize={12} fontWeight={400} rowHeight={24} />
-                  )}
+                  {!isExpertMode &&
+                    showNativeEthFlowSlippageWarning &&
+                    !allowedSlippage.equalTo(INITIAL_ALLOWED_SLIPPAGE_PERCENT) && (
+                      <RowSlippage
+                        trade={trade}
+                        allowedSlippage={allowedSlippage}
+                        fontSize={12}
+                        fontWeight={400}
+                        rowHeight={24}
+                      />
+                    )}
                   {(isFeeGreater || trade) && fee && (
                     <TradeBasicDetails trade={trade} fee={fee} isNativeIn={isNativeIn} />
                   )}

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -819,13 +819,7 @@ export default function Swap({
 
                   {((!isExpertMode && isUserNativeEthFlow) ||
                     !allowedSlippage.equalTo(INITIAL_ALLOWED_SLIPPAGE_PERCENT)) && (
-                    <RowSlippage
-                      allowedSlippage={allowedSlippage}
-                      fontSize={12}
-                      fontWeight={400}
-                      rowHeight={24}
-                      nativeFlowSymbol={isNativeIn && trade?.inputAmount.currency.symbol}
-                    />
+                    <RowSlippage allowedSlippage={allowedSlippage} fontSize={12} fontWeight={400} rowHeight={24} />
                   )}
                   {(isFeeGreater || trade) && fee && (
                     <TradeBasicDetails trade={trade} fee={fee} isNativeIn={isNativeIn} />

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -214,7 +214,7 @@ export default function Swap({
   // logTradeDetails(v2Trade, allowedSlippage)
 
   // enable when components ready
-  /* const isUserNativeEthFlow =  */ useIsUserNativeEthFlow()
+  const isUserNativeEthFlow = useIsUserNativeEthFlow()
 
   // Checks if either currency is native ETH
   // MOD: adds this hook
@@ -816,9 +816,16 @@ export default function Swap({
                     <Price trade={trade} theme={theme} showInverted={showInverted} setShowInverted={setShowInverted} />
                   )}
 
-                  {!isExpertMode && !allowedSlippage.equalTo(INITIAL_ALLOWED_SLIPPAGE_PERCENT) && (
-                    <RowSlippage allowedSlippage={allowedSlippage} fontSize={12} fontWeight={400} rowHeight={24} />
-                  )}
+                  {isUserNativeEthFlow ||
+                    (!isExpertMode && !allowedSlippage.equalTo(INITIAL_ALLOWED_SLIPPAGE_PERCENT) && (
+                      <RowSlippage
+                        allowedSlippage={allowedSlippage}
+                        fontSize={12}
+                        fontWeight={400}
+                        rowHeight={24}
+                        nativeSymbolInNativeFlow={isUserNativeEthFlow && trade?.inputAmount.currency.symbol}
+                      />
+                    ))}
                   {(isFeeGreater || trade) && fee && <TradeBasicDetails trade={trade} fee={fee} />}
                   {/* FEES DISCOUNT */}
                   {/* TODO: check cow balance and set here, else don't show */}

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -94,7 +94,7 @@ import { approvalAnalytics, swapAnalytics, setMaxSellTokensAnalytics, signSwapAn
 import { useGnosisSafeInfo } from 'hooks/useGnosisSafeInfo'
 
 import { WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
-import { useIsUserNativeEthFlow } from 'state/ethFlow/hooks'
+import { useEthFlowActionHandlers, useIsUserNativeEthFlow } from 'state/ethFlow/hooks'
 
 // const AlertWrapper = styled.div`
 //   max-width: 460px;
@@ -184,10 +184,6 @@ export default function Swap({
   // Cow subsidy modal
   const openCowSubsidyModal = useOpenModal(ApplicationModal.COW_SUBSIDY)
   const showCowSubsidyModal = useModalIsOpen(ApplicationModal.COW_SUBSIDY)
-  // Native wrap modals
-  const [showNativeWrapModal, setOpenNativeWrapModal] = useState(false)
-  const openNativeWrapModal = () => setOpenNativeWrapModal(true)
-  const dismissNativeWrapModal = () => setOpenNativeWrapModal(false)
 
   // for expert mode
   const [isExpertMode] = useExpertModeManager()
@@ -242,6 +238,14 @@ export default function Swap({
     ? tradeCurrentVersion?.inputAmount
     : // else use the slippage + fee adjusted amount
       computeSlippageAdjustedAmounts(tradeCurrentVersion, allowedSlippage).INPUT
+
+  // eth-flow action handler cbs
+  // and state
+  const {
+    openModal: openNativeWrapModal,
+    closeModal: dismissNativeWrapModal,
+    isModalOpen: showNativeWrapModal,
+  } = useEthFlowActionHandlers()
 
   const {
     wrapType,

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -213,6 +213,9 @@ export default function Swap({
   // Log all trade information
   // logTradeDetails(v2Trade, allowedSlippage)
 
+  // enable when components ready
+  /* const isUserNativeEthFlow =  */ useIsUserNativeEthFlow()
+
   // Checks if either currency is native ETH
   // MOD: adds this hook
   const { isNativeIn, native, wrappedToken, ...nativeRest } = useDetectNativeToken(

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -94,6 +94,7 @@ import { approvalAnalytics, swapAnalytics, setMaxSellTokensAnalytics, signSwapAn
 import { useGnosisSafeInfo } from 'hooks/useGnosisSafeInfo'
 
 import { WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
+import { useIsUserNativeEthFlow } from 'state/ethFlow/hooks'
 
 // const AlertWrapper = styled.div`
 //   max-width: 460px;

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -38,10 +38,12 @@ import { StyledInfo } from './styleds'
 import { SUBSIDY_INFO_MESSAGE } from 'components/CowSubsidyModal/constants'
 
 import useCowBalanceAndSubsidy from 'hooks/useCowBalanceAndSubsidy'
+import { useIsUserNativeEthFlow } from 'state/ethFlow/hooks'
 
 interface TradeBasicDetailsProp extends BoxProps {
   trade?: TradeGp
   fee: CurrencyAmount<Currency>
+  isNativeIn: boolean
 }
 
 const BottomGrouping = styled.div`
@@ -237,9 +239,10 @@ export const LightGreyText = styled.span`
   color: ${({ theme }) => theme.text4};
 `
 
-function TradeBasicDetails({ trade, fee, ...boxProps }: TradeBasicDetailsProp) {
+function TradeBasicDetails({ trade, fee, isNativeIn, ...boxProps }: TradeBasicDetailsProp) {
   const allowedSlippage = useUserSlippageToleranceWithDefault(INITIAL_ALLOWED_SLIPPAGE_PERCENT)
   const [isExpertMode] = useExpertModeManager()
+  const isNativeEthFlow = useIsUserNativeEthFlow()
   const { allowsOffchainSigning } = useWalletInfo()
 
   // trades are null when there is a fee quote error e.g
@@ -262,7 +265,10 @@ function TradeBasicDetails({ trade, fee, ...boxProps }: TradeBasicDetailsProp) {
       {isExpertMode && trade && (
         <>
           {/* Slippage */}
-          <RowSlippage allowedSlippage={allowedSlippage} />
+          <RowSlippage
+            allowedSlippage={allowedSlippage}
+            nativeFlowSymbol={isNativeEthFlow && isNativeIn && trade.inputAmount.currency.symbol}
+          />
 
           {/* Min/Max received */}
           <RowReceivedAfterSlippage

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -263,7 +263,7 @@ function TradeBasicDetails({ trade, fee, isNativeIn, ...boxProps }: TradeBasicDe
       {isExpertMode && trade && (
         <>
           {/* Slippage */}
-          <RowSlippage allowedSlippage={allowedSlippage} />
+          <RowSlippage trade={trade} allowedSlippage={allowedSlippage} />
 
           {/* Min/Max received */}
           <RowReceivedAfterSlippage

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -38,7 +38,6 @@ import { StyledInfo } from './styleds'
 import { SUBSIDY_INFO_MESSAGE } from 'components/CowSubsidyModal/constants'
 
 import useCowBalanceAndSubsidy from 'hooks/useCowBalanceAndSubsidy'
-import { useIsUserNativeEthFlow } from 'state/ethFlow/hooks'
 
 interface TradeBasicDetailsProp extends BoxProps {
   trade?: TradeGp
@@ -242,7 +241,6 @@ export const LightGreyText = styled.span`
 function TradeBasicDetails({ trade, fee, isNativeIn, ...boxProps }: TradeBasicDetailsProp) {
   const allowedSlippage = useUserSlippageToleranceWithDefault(INITIAL_ALLOWED_SLIPPAGE_PERCENT)
   const [isExpertMode] = useExpertModeManager()
-  const isNativeEthFlow = useIsUserNativeEthFlow()
   const { allowsOffchainSigning } = useWalletInfo()
 
   // trades are null when there is a fee quote error e.g
@@ -265,10 +263,7 @@ function TradeBasicDetails({ trade, fee, isNativeIn, ...boxProps }: TradeBasicDe
       {isExpertMode && trade && (
         <>
           {/* Slippage */}
-          <RowSlippage
-            allowedSlippage={allowedSlippage}
-            nativeFlowSymbol={isNativeEthFlow && isNativeIn && trade.inputAmount.currency.symbol}
-          />
+          <RowSlippage allowedSlippage={allowedSlippage} />
 
           {/* Min/Max received */}
           <RowReceivedAfterSlippage

--- a/src/custom/state/ethFlow/atoms.ts
+++ b/src/custom/state/ethFlow/atoms.ts
@@ -1,6 +1,4 @@
-import { atomWithStorage, useUpdateAtom, useAtomValue, selectAtom } from 'jotai/utils'
-
-export { useUpdateAtom, useAtomValue, selectAtom }
+import { atomWithStorage, selectAtom } from 'jotai/utils'
 
 /**
  * Base atom that stores the user's set native ETH sell value

--- a/src/custom/state/ethFlow/atoms.ts
+++ b/src/custom/state/ethFlow/atoms.ts
@@ -1,7 +1,8 @@
-import { atomWithStorage, selectAtom } from 'jotai/utils'
+import { selectAtom } from 'jotai/utils'
+import { atomWithStorage } from './atoms/utils'
 
 /**
  * Base atom that stores the user's set native ETH sell value
  */
-export const userNativeEthFlow = atomWithStorage<boolean>('userNativeEthFlow', false)
+export const userNativeEthFlow = atomWithStorage<boolean>('userNativeEthFlow', true)
 export const isUserNativeEthFlow = selectAtom(userNativeEthFlow, (value) => value)

--- a/src/custom/state/ethFlow/atoms.ts
+++ b/src/custom/state/ethFlow/atoms.ts
@@ -1,0 +1,9 @@
+import { atomWithStorage, useUpdateAtom, useAtomValue, selectAtom } from 'jotai/utils'
+
+export { useUpdateAtom, useAtomValue, selectAtom }
+
+/**
+ * Base atom that stores the user's set native ETH sell value
+ */
+export const userNativeEthFlow = atomWithStorage<boolean>('userNativeEthFlow', false)
+export const isUserNativeEthFlow = selectAtom(userNativeEthFlow, (value) => value)

--- a/src/custom/state/ethFlow/atoms/utils.ts
+++ b/src/custom/state/ethFlow/atoms/utils.ts
@@ -1,0 +1,56 @@
+import { atom, PrimitiveAtom, SetStateAction } from 'jotai'
+
+type Storage<Value> = {
+  getItem: (key: string) => Value
+  setItem: (key: string, newValue: Value) => void
+}
+
+const defaultStorage: Storage<unknown> = {
+  getItem: (key) => {
+    const storedValue = localStorage.getItem(key)
+    if (storedValue === null) {
+      throw new Error('no value stored')
+    }
+    return JSON.parse(storedValue)
+  },
+  setItem: (key, newValue) => {
+    localStorage.setItem(key, JSON.stringify(newValue))
+  },
+}
+
+export function atomWithStorage<Value>(
+  key: string,
+  initialValue: Value,
+  storage: Storage<Value> = defaultStorage as Storage<Value>
+): PrimitiveAtom<Value> {
+  const getInitialValue = () => {
+    try {
+      return { value: storage.getItem(key), needsSetting: false }
+    } catch {
+      return { value: initialValue, needsSetting: true }
+    }
+  }
+
+  const baseAtom = atom(initialValue)
+
+  baseAtom.onMount = (setAtom) => {
+    Promise.resolve(getInitialValue()).then(({ value, needsSetting }) => {
+      if (needsSetting) {
+        localStorage.setItem(key, JSON.stringify(value))
+      }
+
+      setAtom(value)
+    })
+  }
+
+  const anAtom = atom(
+    (get) => get(baseAtom),
+    (get, set, update: SetStateAction<Value>) => {
+      const newValue = typeof update === 'function' ? (update as (prev: Value) => Value)(get(baseAtom)) : update
+      set(baseAtom, newValue)
+      storage.setItem(key, newValue)
+    }
+  )
+
+  return anAtom
+}

--- a/src/custom/state/ethFlow/hooks.ts
+++ b/src/custom/state/ethFlow/hooks.ts
@@ -1,6 +1,27 @@
 import { useAtomValue } from 'jotai/utils'
 import { isUserNativeEthFlow } from './atoms'
 
+import { useSwapState } from 'state/swap/hooks'
+import { useCurrency } from 'hooks/Tokens'
+import { Field } from 'state/swap/actions'
+import { useDetectNativeToken } from 'state/swap/hooks'
+
 export function useIsUserNativeEthFlow() {
   return useAtomValue(isUserNativeEthFlow)
+}
+
+export function useShowNativeEthFlowSlippageWarning() {
+  const {
+    [Field.INPUT]: { currencyId: inputCurrencyId },
+    [Field.OUTPUT]: { currencyId: outputCurrencyId },
+  } = useSwapState()
+  const inputCurrency = useCurrency(inputCurrencyId)
+  const outputCurrency = useCurrency(outputCurrencyId)
+
+  const isNativeEthFlow = useIsUserNativeEthFlow()
+  const { isNativeIn } = useDetectNativeToken({ currency: inputCurrency }, { currency: outputCurrency })
+
+  const showNativeEthFlow = isNativeEthFlow && isNativeIn
+
+  return showNativeEthFlow ? inputCurrency?.wrapped.symbol : undefined
 }

--- a/src/custom/state/ethFlow/hooks.ts
+++ b/src/custom/state/ethFlow/hooks.ts
@@ -1,0 +1,6 @@
+import { useAtomValue } from 'jotai/utils'
+import { isUserNativeEthFlow } from './atoms'
+
+export function useIsUserNativeEthFlow() {
+  return useAtomValue(isUserNativeEthFlow)
+}

--- a/src/custom/state/ethFlow/hooks.ts
+++ b/src/custom/state/ethFlow/hooks.ts
@@ -1,6 +1,18 @@
+import { useCurrency } from '@src/hooks/Tokens'
+import { Field } from '@src/state/swap/actions'
 import { useAtomValue } from 'jotai/utils'
+import { useDetectNativeToken, useSwapState } from '../swap/hooks'
 import { isUserNativeEthFlow } from './atoms'
 
 export function useIsUserNativeEthFlow() {
-  return useAtomValue(isUserNativeEthFlow)
+  const {
+    [Field.INPUT]: { currencyId },
+  } = useSwapState()
+  const currency = useCurrency(currencyId)
+  // we check if user is selling native currency (not pure wrapping either)
+  const { isNativeIn } = useDetectNativeToken({ currency })
+  // get the user set native flow option
+  const isUserNativeEthFlowSet = useAtomValue(isUserNativeEthFlow)
+
+  return isNativeIn && isUserNativeEthFlowSet
 }

--- a/src/custom/state/ethFlow/hooks.ts
+++ b/src/custom/state/ethFlow/hooks.ts
@@ -22,9 +22,7 @@ export function useShowNativeEthFlowSlippageWarning() {
   const isNativeEthFlow = useIsUserNativeEthFlow()
   const { isNativeIn } = useDetectNativeToken({ currency: inputCurrency }, { currency: outputCurrency })
 
-  const showNativeEthFlow = isNativeEthFlow && isNativeIn
-
-  return showNativeEthFlow ? inputCurrency?.wrapped.symbol : undefined
+  return isNativeEthFlow && isNativeIn
 }
 
 export function useEthFlowActionHandlers() {

--- a/src/custom/state/ethFlow/hooks.ts
+++ b/src/custom/state/ethFlow/hooks.ts
@@ -1,6 +1,7 @@
 import { useAtomValue } from 'jotai/utils'
 import { isUserNativeEthFlow } from './atoms'
 
+import { useState } from 'react'
 import { useSwapState } from 'state/swap/hooks'
 import { useCurrency } from 'hooks/Tokens'
 import { Field } from 'state/swap/actions'
@@ -24,4 +25,17 @@ export function useShowNativeEthFlowSlippageWarning() {
   const showNativeEthFlow = isNativeEthFlow && isNativeIn
 
   return showNativeEthFlow ? inputCurrency?.wrapped.symbol : undefined
+}
+
+export function useEthFlowActionHandlers() {
+  // modal
+  const [isModalOpen, setOpenNativeWrapModal] = useState(false)
+  const openModal = () => setOpenNativeWrapModal(true)
+  const closeModal = () => setOpenNativeWrapModal(false)
+
+  return {
+    openModal,
+    closeModal,
+    isModalOpen,
+  }
 }

--- a/src/custom/state/ethFlow/hooks.ts
+++ b/src/custom/state/ethFlow/hooks.ts
@@ -1,18 +1,6 @@
-import { useCurrency } from '@src/hooks/Tokens'
-import { Field } from '@src/state/swap/actions'
 import { useAtomValue } from 'jotai/utils'
-import { useDetectNativeToken, useSwapState } from '../swap/hooks'
 import { isUserNativeEthFlow } from './atoms'
 
 export function useIsUserNativeEthFlow() {
-  const {
-    [Field.INPUT]: { currencyId },
-  } = useSwapState()
-  const currency = useCurrency(currencyId)
-  // we check if user is selling native currency (not pure wrapping either)
-  const { isNativeIn } = useDetectNativeToken({ currency })
-  // get the user set native flow option
-  const isUserNativeEthFlowSet = useAtomValue(isUserNativeEthFlow)
-
-  return isNativeIn && isUserNativeEthFlowSet
+  return useAtomValue(isUserNativeEthFlow)
 }

--- a/src/custom/theme/baseTheme.tsx
+++ b/src/custom/theme/baseTheme.tsx
@@ -67,6 +67,7 @@ export function colors(darkMode: boolean): Colors {
     blue2: darkMode ? '#a3beff' : '#0c40bf',
     purple: '#8958FF',
     yellow: '#fff6dc',
+    yellow1: '#ebd6a2',
     orange: '#FF784A',
     greenShade: '#376c57',
     blueShade: '#0f2644',

--- a/src/custom/theme/index.tsx
+++ b/src/custom/theme/index.tsx
@@ -1,3 +1,8 @@
+import styled from 'styled-components/macro'
+import { Text } from 'rebass'
+import { ThemedText as ThemedTextUni, TextProps as TextPropsUni } from '@src/theme'
+import { Colors } from './styled'
+
 export enum ButtonSize {
   SMALL,
   DEFAULT,
@@ -15,6 +20,30 @@ export enum Z_INDEX {
   modal = 1060,
   popover = 1070,
   tooltip = 1080,
+}
+
+type TextProps = TextPropsUni & { override?: boolean }
+
+export const TextWrapper = styled(Text)<{ color: keyof Colors; override?: boolean }>`
+  color: ${({ color, theme, override }) => {
+    const colour = (theme as any)[color]
+    if (colour && override) {
+      return colour + '!important'
+    } else {
+      return colour
+    }
+  }};
+`
+
+/**
+ * Preset styles of the Rebass Text component
+ * MOD of UNI's in @src/theme/index.ts
+ */
+export const ThemedText = {
+  ...ThemedTextUni,
+  Warn(props: TextProps) {
+    return <TextWrapper fontWeight={500} color={'yellow1'} {...props} />
+  },
 }
 
 // Cow theme

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -11,7 +11,7 @@ import { Colors } from './styled'
 
 export * from './components'
 
-type TextProps = Omit<TextPropsOriginal, 'css'>
+export type TextProps = Omit<TextPropsOriginal, 'css'>
 
 export const MEDIA_WIDTHS = {
   upToExtraSmall: 500,
@@ -153,7 +153,7 @@ export function getTheme(darkMode: boolean): DefaultTheme {
 //   return <StyledComponentsThemeProvider theme={themeObject}>{children}</StyledComponentsThemeProvider>
 // }
 
-const TextWrapper = styled(Text)<{ color: keyof Colors }>`
+export const TextWrapper = styled(Text)<{ color: keyof Colors }>`
   color: ${({ color, theme }) => (theme as any)[color]};
 `
 


### PR DESCRIPTION
# Summary

Adds a simple state item `isUserNativeEthFlow` which denotes whether or not user is currently using the native ETH (native currency) flow (`isUserNativeEthFlow === true`) or whether they are using the "classic" WETH (native wrapped currency) experience

Additionally adds changes required to the `RowSlippage` component which is shown to users (currently only in non-expert mode) under the swap currency selectors as part of the trade information.

Following PR #902 will add the modified 2% slippage where necessary using the `isUserNativeEthFlow` prop

# Testing
The main changes to test here is that inside devtools `Application > Storage > Local Storage > ` you see the `isUserNativeEthFlow` state item like so:
![image](https://user-images.githubusercontent.com/21335563/185104056-51d22fdf-67b6-49b6-b090-db63b2eaf8e0.png)

There isn't any interactibility yet, to follow in subsequent PRs.

**UPDATE** - use #921 or #903 to test the component wired version of this