### PR TITLE
[ETH-FLOW V2] - Modified slippage

### DIFF
--- a/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
+++ b/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
@@ -23,8 +23,11 @@ import {
   LOW_SLIPPAGE_BPS,
   HIGH_SLIPPAGE_BPS,
   DEFAULT_SLIPPAGE_BPS,
+  PERCENTAGE_PRECISION,
 } from 'constants/index'
 import { slippageToleranceAnalytics, orderExpirationTimeAnalytics } from 'utils/analytics'
+import { useIsUserNativeEthFlow } from 'state/ethFlow/hooks'
+import { ETH_FLOW_SLIPPAGE } from 'state/ethFlow/updater'
 
 const MAX_DEADLINE_MINUTES = 180 // 3h
 
@@ -113,6 +116,8 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
   const { chainId } = useWeb3React()
   const theme = useContext(ThemeContext)
 
+  const isUserNativeEthFlow = useIsUserNativeEthFlow()
+
   const userSlippageTolerance = useUserSlippageTolerance()
   const setUserSlippageTolerance = useSetUserSlippageTolerance()
 
@@ -149,9 +154,13 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
   }
 
   const tooLow =
-    userSlippageTolerance !== 'auto' && userSlippageTolerance.lessThan(new Percent(LOW_SLIPPAGE_BPS, 10_000))
+    !isUserNativeEthFlow &&
+    userSlippageTolerance !== 'auto' &&
+    userSlippageTolerance.lessThan(new Percent(LOW_SLIPPAGE_BPS, 10_000))
   const tooHigh =
-    userSlippageTolerance !== 'auto' && userSlippageTolerance.greaterThan(new Percent(HIGH_SLIPPAGE_BPS, 10_000))
+    !isUserNativeEthFlow &&
+    userSlippageTolerance !== 'auto' &&
+    userSlippageTolerance.greaterThan(new Percent(HIGH_SLIPPAGE_BPS, 10_000))
 
   function parseCustomDeadline(value: string) {
     // populate what the user typed and clear the error
@@ -215,7 +224,11 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
           >
             <Trans>Auto</Trans>
           </Option>
-          <OptionCustom active={userSlippageTolerance !== 'auto'} warning={!!slippageError} tabIndex={-1}>
+          <OptionCustom
+            active={userSlippageTolerance !== 'auto' || !isUserNativeEthFlow}
+            warning={!!slippageError}
+            tabIndex={-1}
+          >
             <RowBetween>
               {tooLow || tooHigh ? (
                 <SlippageEmojiContainer>
@@ -225,9 +238,12 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
                 </SlippageEmojiContainer>
               ) : null}
               <Input
+                disabled={isUserNativeEthFlow}
                 placeholder={placeholderSlippage.toFixed(2)}
                 value={
-                  slippageInput.length > 0
+                  isUserNativeEthFlow
+                    ? ETH_FLOW_SLIPPAGE.toSignificant(PERCENTAGE_PRECISION)
+                    : slippageInput.length > 0
                     ? slippageInput
                     : userSlippageTolerance === 'auto'
                     ? ''

--- a/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
+++ b/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
@@ -26,7 +26,7 @@ import {
   PERCENTAGE_PRECISION,
 } from 'constants/index'
 import { slippageToleranceAnalytics, orderExpirationTimeAnalytics } from 'utils/analytics'
-import { useIsUserNativeEthFlow } from 'state/ethFlow/hooks'
+import { useShowNativeEthFlowSlippageWarning } from 'state/ethFlow/hooks'
 import { ETH_FLOW_SLIPPAGE } from 'state/ethFlow/updater'
 
 const MAX_DEADLINE_MINUTES = 180 // 3h
@@ -116,7 +116,7 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
   const { chainId } = useWeb3React()
   const theme = useContext(ThemeContext)
 
-  const isUserNativeEthFlow = useIsUserNativeEthFlow()
+  const shouldShowEthFlowSlippage = useShowNativeEthFlowSlippageWarning()
 
   const userSlippageTolerance = useUserSlippageTolerance()
   const setUserSlippageTolerance = useSetUserSlippageTolerance()
@@ -154,11 +154,11 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
   }
 
   const tooLow =
-    !isUserNativeEthFlow &&
+    !shouldShowEthFlowSlippage &&
     userSlippageTolerance !== 'auto' &&
     userSlippageTolerance.lessThan(new Percent(LOW_SLIPPAGE_BPS, 10_000))
   const tooHigh =
-    !isUserNativeEthFlow &&
+    !shouldShowEthFlowSlippage &&
     userSlippageTolerance !== 'auto' &&
     userSlippageTolerance.greaterThan(new Percent(HIGH_SLIPPAGE_BPS, 10_000))
 
@@ -225,7 +225,7 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
             <Trans>Auto</Trans>
           </Option>
           <OptionCustom
-            active={userSlippageTolerance !== 'auto' || !isUserNativeEthFlow}
+            active={userSlippageTolerance !== 'auto' || !shouldShowEthFlowSlippage}
             warning={!!slippageError}
             tabIndex={-1}
           >
@@ -238,10 +238,10 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
                 </SlippageEmojiContainer>
               ) : null}
               <Input
-                disabled={isUserNativeEthFlow}
+                disabled={shouldShowEthFlowSlippage}
                 placeholder={placeholderSlippage.toFixed(2)}
                 value={
-                  isUserNativeEthFlow
+                  shouldShowEthFlowSlippage
                     ? ETH_FLOW_SLIPPAGE.toSignificant(PERCENTAGE_PRECISION)
                     : slippageInput.length > 0
                     ? slippageInput

--- a/src/custom/components/swap/TradeSummary/RowSlippage.tsx
+++ b/src/custom/components/swap/TradeSummary/RowSlippage.tsx
@@ -71,8 +71,8 @@ export function RowSlippage({
                   You are currently swapping {nativeSymbol || 'a native token'} with the classic{' '}
                   {wrappedSymbol || 'wrapped currency'} experience disabled.
                   <p>
-                    Slippage tolerance is defaulted to {formatSmart(ETH_FLOW_SLIPPAGE, PERCENTAGE_PRECISION)}% to ensure
-                    a high likelihood of order matching, even in volatile market situations.
+                    Slippage tolerance is defaulted to {ETH_FLOW_SLIPPAGE.toSignificant(PERCENTAGE_PRECISION)}% to
+                    ensure a high likelihood of order matching, even in volatile market situations.
                   </p>
                 </p>
               </Trans>

--- a/src/custom/components/swap/TradeSummary/RowSlippage.tsx
+++ b/src/custom/components/swap/TradeSummary/RowSlippage.tsx
@@ -13,6 +13,7 @@ import { useToggleSettingsMenu } from 'state/application/hooks'
 import { formatSmart } from 'utils/format'
 import { useShowNativeEthFlowSlippageWarning } from 'state/ethFlow/hooks'
 import TradeGp from 'state/swap/TradeGp'
+import { ETH_FLOW_SLIPPAGE } from 'state/ethFlow/updater'
 
 export interface RowSlippageProps {
   trade?: TradeGp
@@ -70,8 +71,8 @@ export function RowSlippage({
                   You are currently swapping {nativeSymbol || 'a native token'} with the classic{' '}
                   {wrappedSymbol || 'wrapped currency'} experience disabled.
                   <p>
-                    Slippage tolerance is defaulted to 2% to ensure a high likelihood of order matching, even in
-                    volatile market situations.
+                    Slippage tolerance is defaulted to {formatSmart(ETH_FLOW_SLIPPAGE, PERCENTAGE_PRECISION)}% to ensure
+                    a high likelihood of order matching, even in volatile market situations.
                   </p>
                 </p>
               </Trans>

--- a/src/custom/state/ethFlow/updater.tsx
+++ b/src/custom/state/ethFlow/updater.tsx
@@ -1,20 +1,33 @@
 import { Percent } from '@uniswap/sdk-core'
-import { useEffect } from 'react'
-import { useSetUserSlippageTolerance } from '../user/hooks'
-import { useIsUserNativeEthFlow } from './hooks'
+import { useEffect, useState } from 'react'
+import { useSetUserSlippageTolerance, useUserSlippageTolerance } from '../user/hooks'
+import { useShowNativeEthFlowSlippageWarning } from './hooks'
 
 export const ETH_FLOW_SLIPPAGE = new Percent(2, 100) // 2%
 
 export default function Updater() {
-  const isUserNativeEthFlow = useIsUserNativeEthFlow()
+  // use previous slippage for when user is not in native swap and set to native flow
+  const currentSlippage = useUserSlippageTolerance()
+  // save the last non eth-flow slippage amount to reset when user switches back to normal erc20 flow
+  const [erc20Slippage, setErc20Slippage] = useState<Percent | 'auto' | undefined>(currentSlippage)
+  // we show slippage warning when isNativeSwap and isUserNativeEthFlow are true
+  const shouldShowEthFlowSlippage = useShowNativeEthFlowSlippageWarning()
   const setUserSlippageTolerance = useSetUserSlippageTolerance()
   // change slippage set to 2% when detected eth swap and option is set to use native flow
   useEffect(() => {
-    if (isUserNativeEthFlow) {
+    if (shouldShowEthFlowSlippage) {
+      // user switched back to erc20, we need to reset their previous slippage back to what it was
+      if (currentSlippage instanceof Percent && !currentSlippage.equalTo(ETH_FLOW_SLIPPAGE)) {
+        // do sth
+        setErc20Slippage(currentSlippage)
+      }
       setUserSlippageTolerance(ETH_FLOW_SLIPPAGE)
     } else {
-      setUserSlippageTolerance('auto')
+      setUserSlippageTolerance(erc20Slippage ?? 'auto')
     }
-  }, [isUserNativeEthFlow, setUserSlippageTolerance])
+    // we only want to depend on shouldShowEthFlowSlippage
+    // to avoid re-renders
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [setUserSlippageTolerance, shouldShowEthFlowSlippage])
   return null
 }

--- a/src/custom/state/ethFlow/updater.tsx
+++ b/src/custom/state/ethFlow/updater.tsx
@@ -1,0 +1,20 @@
+import { Percent } from '@uniswap/sdk-core'
+import { useEffect } from 'react'
+import { useSetUserSlippageTolerance } from '../user/hooks'
+import { useIsUserNativeEthFlow } from './hooks'
+
+export const ETH_FLOW_SLIPPAGE = new Percent(2, 100) // 2%
+
+export default function Updater() {
+  const isUserNativeEthFlow = useIsUserNativeEthFlow()
+  const setUserSlippageTolerance = useSetUserSlippageTolerance()
+  // change slippage set to 2% when detected eth swap and option is set to use native flow
+  useEffect(() => {
+    if (isUserNativeEthFlow) {
+      setUserSlippageTolerance(ETH_FLOW_SLIPPAGE)
+    } else {
+      setUserSlippageTolerance('auto')
+    }
+  }, [isUserNativeEthFlow, setUserSlippageTolerance])
+  return null
+}

--- a/src/custom/state/ethFlow/updater.tsx
+++ b/src/custom/state/ethFlow/updater.tsx
@@ -1,7 +1,7 @@
 import { Percent } from '@uniswap/sdk-core'
 import { useEffect, useState } from 'react'
-import { useSetUserSlippageTolerance, useUserSlippageTolerance } from '../user/hooks'
-import { useShowNativeEthFlowSlippageWarning } from './hooks'
+import { useSetUserSlippageTolerance, useUserSlippageTolerance } from 'state/user/hooks'
+import { useShowNativeEthFlowSlippageWarning } from 'state/ethFlow/hooks'
 
 export const ETH_FLOW_SLIPPAGE = new Percent(2, 100) // 2%
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,6 +22,7 @@ import LogsUpdater from 'state/logs/updater'
 import TransactionUpdater from 'state/transactions/updater'
 import UserUpdater from 'state/user/updater'
 import GnosisSafeUpdater from 'state/gnosisSafe/updater'
+import EthFlowSlippageUpdater from 'state/ethFlow/updater'
 import ThemeProvider, { FixedGlobalStyle, ThemedGlobalStyle } from 'theme'
 import RadialGradientByChainUpdater from 'theme/RadialGradientByChainUpdater'
 
@@ -74,6 +75,7 @@ function Updaters() {
       <UploadToIpfsUpdater />
       <GnosisSafeUpdater />
       <GasPriceStrategyUpdater />
+      <EthFlowSlippageUpdater />
     </>
   )
 }


### PR DESCRIPTION
# Summary

Adds slippage related information given user is selling NATIVE token against an ERC20. Uses the `isUserNativeEthFlow` state from #901 to dynamically set slippage via an updater

Couple with the actual action handling component(s) in #921 (BANNER) and #903 (TOGGLER), this completes the slippage and userNativeEthFlow flag setting

# Testing
Inside devtools `Application > Storage > Local Storage > ` you see the `isUserNativeEthFlow` state item like so:
![image](https://user-images.githubusercontent.com/21335563/185104056-51d22fdf-67b6-49b6-b090-db63b2eaf8e0.png)

Try toggling this to `false` and back to `true` and seeing the UI update, assuming:
1. select the chain's NATIVE CURRENCY (ETH, XDAI) as IN (sell) token
2. select an ERC20 as OUT (buy) token
3. type amt into the IN (sell) token input field
4. see slippage information show up and change dynamically based on the `isUserNativeEthFlow` flag in localStorage

**UPDATE** - use #921 or #903 to test the component wired version of this