### PR TITLE
Improve NPS - more fields

### DIFF
--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -224,10 +224,14 @@ export const soundMiddleware: Middleware<Record<string, unknown>, AppState> = (s
 }
 
 export const appziMiddleware: Middleware<Record<string, unknown>, AppState> = (store) => (next) => (action) => {
-  if (isBatchFulfillOrderAction(action) || isSingleFulfillOrderAction(action) || isExpireOrdersAction(action)) {
+  if (isBatchFulfillOrderAction(action) || isSingleFulfillOrderAction(action)) {
+    console.warn(`appzi: fulfilled`, action.payload)
     // Shows NPS feedback (or attempts to) when there's a successful trade
-    // Or the order has expired
-    openNpsAppziSometimes()
+    openNpsAppziSometimes({ traded: true })
+  } else if (isExpireOrdersAction(action)) {
+    console.warn(`appzi: expired`, action.payload)
+    // Shows NPS feedback (or attempts to) when the order expired
+    openNpsAppziSometimes({ expired: true })
   }
 
   return next(action)

--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -241,7 +241,6 @@ export const appziMiddleware: Middleware<Record<string, unknown>, AppState> = (s
     const orders = store.getState().orders[chainId]
     const openSince = _getOrderById(orders, id)?.order?.openSince
 
-    console.warn('appzi: batch fulfillment', openSince)
     openNpsAppziSometimes({ traded: true, secondsSinceOpen: timeSinceInSeconds(openSince) })
   } else if (isSingleFulfillOrderAction(action)) {
     // Shows NPS feedback (or attempts to) when there's a successful trade
@@ -250,7 +249,6 @@ export const appziMiddleware: Middleware<Record<string, unknown>, AppState> = (s
     const orders = store.getState().orders[chainId]
     const openSince = _getOrderById(orders, id)?.order?.openSince
 
-    console.warn('appzi: single fulfillment', openSince)
     openNpsAppziSometimes({ traded: true, secondsSinceOpen: timeSinceInSeconds(openSince) })
   } else if (isBatchExpireOrderAction(action)) {
     // Shows NPS feedback (or attempts to) when the order expired
@@ -262,7 +260,6 @@ export const appziMiddleware: Middleware<Record<string, unknown>, AppState> = (s
     const orders = store.getState().orders[chainId]
     const openSince = _getOrderById(orders, id)?.order?.openSince
 
-    console.warn('appzi: batch expiration', openSince)
     openNpsAppziSometimes({ expired: true, secondsSinceOpen: timeSinceInSeconds(openSince) })
   } else if (isSingleExpireOrderAction(action)) {
     // Shows NPS feedback (or attempts to) when the order expired
@@ -271,7 +268,6 @@ export const appziMiddleware: Middleware<Record<string, unknown>, AppState> = (s
     const orders = store.getState().orders[chainId]
     const openSince = _getOrderById(orders, id)?.order?.openSince
 
-    console.warn('appzi: single expiration', openSince)
     openNpsAppziSometimes({ expired: true, secondsSinceOpen: timeSinceInSeconds(openSince) })
   }
 

--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -242,7 +242,7 @@ export const appziMiddleware: Middleware<Record<string, unknown>, AppState> = (s
     const openSince = _getOrderById(orders, id)?.order?.openSince
 
     console.warn('appzi: batch fulfillment', openSince)
-    openNpsAppziSometimes({ traded: true, pendingFor: timeSinceInSeconds(openSince) })
+    openNpsAppziSometimes({ traded: true, secondsSinceOpen: timeSinceInSeconds(openSince) })
   } else if (isSingleFulfillOrderAction(action)) {
     // Shows NPS feedback (or attempts to) when there's a successful trade
     const { chainId, id } = action.payload
@@ -251,7 +251,7 @@ export const appziMiddleware: Middleware<Record<string, unknown>, AppState> = (s
     const openSince = _getOrderById(orders, id)?.order?.openSince
 
     console.warn('appzi: single fulfillment', openSince)
-    openNpsAppziSometimes({ traded: true, pendingFor: timeSinceInSeconds(openSince) })
+    openNpsAppziSometimes({ traded: true, secondsSinceOpen: timeSinceInSeconds(openSince) })
   } else if (isBatchExpireOrderAction(action)) {
     // Shows NPS feedback (or attempts to) when the order expired
     const {
@@ -263,7 +263,7 @@ export const appziMiddleware: Middleware<Record<string, unknown>, AppState> = (s
     const openSince = _getOrderById(orders, id)?.order?.openSince
 
     console.warn('appzi: batch expiration', openSince)
-    openNpsAppziSometimes({ expired: true, pendingFor: timeSinceInSeconds(openSince) })
+    openNpsAppziSometimes({ expired: true, secondsSinceOpen: timeSinceInSeconds(openSince) })
   } else if (isSingleExpireOrderAction(action)) {
     // Shows NPS feedback (or attempts to) when the order expired
     const { chainId, id } = action.payload
@@ -272,7 +272,7 @@ export const appziMiddleware: Middleware<Record<string, unknown>, AppState> = (s
     const openSince = _getOrderById(orders, id)?.order?.openSince
 
     console.warn('appzi: single expiration', openSince)
-    openNpsAppziSometimes({ expired: true, pendingFor: timeSinceInSeconds(openSince) })
+    openNpsAppziSometimes({ expired: true, secondsSinceOpen: timeSinceInSeconds(openSince) })
   }
 
   return next(action)

--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -51,7 +51,7 @@ export const popupMiddleware: Middleware<Record<string, unknown>, AppState> = (s
     const orderObject = _getOrderById(orders, id)
 
     if (!orderObject) {
-      return
+      return result
     }
     // look up Order.summary for Popup
     const summary = orderObject.order.summary
@@ -105,7 +105,9 @@ export const popupMiddleware: Middleware<Record<string, unknown>, AppState> = (s
     // use current state to lookup orders' data
     const orders = store.getState().orders[chainId]
 
-    if (!orders) return
+    if (!orders) {
+      return result
+    }
 
     const { pending, fulfilled, expired, cancelled } = orders
 
@@ -197,11 +199,15 @@ export const soundMiddleware: Middleware<Record<string, unknown>, AppState> = (s
     const orders = store.getState().orders[chainId]
 
     // no orders were executed/expired
-    if (!orders) return result
+    if (!orders) {
+      return result
+    }
 
     const updatedElements = isBatchFulfillOrderAction(action) ? action.payload.ordersData : action.payload.ids
     // no orders were executed/expired
-    if (updatedElements.length === 0) return result
+    if (updatedElements.length === 0) {
+      return result
+    }
   }
 
   let cowSound

--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -225,11 +225,9 @@ export const soundMiddleware: Middleware<Record<string, unknown>, AppState> = (s
 
 export const appziMiddleware: Middleware<Record<string, unknown>, AppState> = (store) => (next) => (action) => {
   if (isBatchFulfillOrderAction(action) || isSingleFulfillOrderAction(action)) {
-    console.warn(`appzi: fulfilled`, action.payload)
     // Shows NPS feedback (or attempts to) when there's a successful trade
     openNpsAppziSometimes({ traded: true })
   } else if (isExpireOrdersAction(action)) {
-    console.warn(`appzi: expired`, action.payload)
     // Shows NPS feedback (or attempts to) when the order expired
     openNpsAppziSometimes({ expired: true })
   }

--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -33,7 +33,7 @@ const isExpireOrdersAction = isAnyOf(OrderActions.expireOrdersBatch, OrderAction
 const isCancelOrderAction = isAnyOf(OrderActions.cancelOrder, OrderActions.cancelOrdersBatch)
 
 // on each Pending, Expired, Fulfilled order action
-// a corresponsing Popup action is dispatched
+// a corresponding Popup action is dispatched
 export const popupMiddleware: Middleware<Record<string, unknown>, AppState> = (store) => (next) => (action) => {
   const result = next(action)
 
@@ -44,16 +44,13 @@ export const popupMiddleware: Middleware<Record<string, unknown>, AppState> = (s
 
     // use current state to lookup orders' data
     const orders = store.getState().orders[chainId]
+    const orderObject = _getOrderById(orders, id)
 
-    if (!orders) return
-
-    const { pending, presignaturePending, fulfilled, expired, cancelled } = orders
-
-    const orderObject =
-      pending?.[id] || presignaturePending?.[id] || fulfilled?.[id] || expired?.[id] || cancelled?.[id]
-
+    if (!orderObject) {
+      return
+    }
     // look up Order.summary for Popup
-    const summary = orderObject?.order.summary
+    const summary = orderObject.order.summary
 
     let popup: PopupPayload
     if (isPendingOrderAction(action)) {
@@ -233,4 +230,14 @@ export const appziMiddleware: Middleware<Record<string, unknown>, AppState> = (s
   }
 
   return next(action)
+}
+
+function _getOrderById(orders: OrdersStateNetwork | undefined, id: string): OrderObject | undefined {
+  if (!orders) {
+    return
+  }
+
+  const { pending, presignaturePending, fulfilled, expired, cancelled } = orders
+
+  return pending?.[id] || presignaturePending?.[id] || fulfilled?.[id] || expired?.[id] || cancelled?.[id]
 }

--- a/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
@@ -127,7 +127,7 @@ async function _updateOrders({
       // Check if there's any pending for more than `PENDING_TOO_LONG_TIME`
       if (openSince && now - openSince > PENDING_TOO_LONG_TIME) {
         // Trigger NPS display, controlled by Appzi
-        openNpsAppziSometimes({ waitedTooLong: true, pendingFor: timeSinceInSeconds(openSince) })
+        openNpsAppziSometimes({ waitedTooLong: true, secondsSinceOpen: timeSinceInSeconds(openSince) })
         // Break the loop, don't need to show more than once
         break
       }

--- a/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
@@ -26,6 +26,7 @@ import { fetchOrderPopupData, OrderLogPopupMixData } from 'state/orders/updaters
 import { GetSafeInfo, useGetSafeInfo } from 'hooks/useGetSafeInfo'
 import ms from 'ms.macro'
 import { openNpsAppziSometimes } from 'utils/appzi'
+import { timeSinceInSeconds } from 'utils/time'
 
 const PENDING_TOO_LONG_TIME = ms`5 min`
 
@@ -126,7 +127,7 @@ async function _updateOrders({
       // Check if there's any pending for more than `PENDING_TOO_LONG_TIME`
       if (openSince && now - openSince > PENDING_TOO_LONG_TIME) {
         // Trigger NPS display, controlled by Appzi
-        openNpsAppziSometimes({ waitedFor: `${Math.floor((now - openSince) / 60_000)} min` })
+        openNpsAppziSometimes({ waitedTooLong: true, pendingFor: timeSinceInSeconds(openSince) })
         // Break the loop, don't need to show more than once
         break
       }

--- a/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
@@ -126,7 +126,7 @@ async function _updateOrders({
       // Check if there's any pending for more than `PENDING_TOO_LONG_TIME`
       if (openSince && now - openSince > PENDING_TOO_LONG_TIME) {
         // Trigger NPS display, controlled by Appzi
-        openNpsAppziSometimes()
+        openNpsAppziSometimes({ waitedFor: `${Math.floor((now - openSince) / 60_000)} min` })
         // Break the loop, don't need to show more than once
         break
       }

--- a/src/custom/utils/appzi.ts
+++ b/src/custom/utils/appzi.ts
@@ -42,7 +42,8 @@ declare global {
 type AppziCustomSettings = {
   userTradedOrWaitedForLong?: true
   isTestNps?: true // to trigger test rather than prod NPS
-  waitedFor?: string
+  pendingFor?: number // how long has this order been open (in seconds)?
+  waitedTooLong?: true
   expired?: true
   traded?: true
 }

--- a/src/custom/utils/appzi.ts
+++ b/src/custom/utils/appzi.ts
@@ -42,6 +42,9 @@ declare global {
 type AppziCustomSettings = {
   userTradedOrWaitedForLong?: true
   isTestNps?: true // to trigger test rather than prod NPS
+  waitedFor?: string
+  expired?: true
+  traded?: true
 }
 
 type AppziSettings = {
@@ -123,9 +126,9 @@ const NPS_DATA = isProdLike ? PROD_NPS_DATA : TEST_NPS_DATA
  * It'll display only if the trigger rules are met
  * Check https://portal.appzi.com/portals/5ju0G/configs/55872789-593b-4c6c-9e49-9b5c7693e90a/trigger
  */
-export function openNpsAppziSometimes() {
+export function openNpsAppziSometimes(data?: Omit<AppziCustomSettings, 'userTradedOrWaitedForLong' | 'isTestNps'>) {
   applyOnceRestyleAppziNps()
-  updateAppziSettings({ data: NPS_DATA })
+  updateAppziSettings({ data: { ...data, ...NPS_DATA } })
 }
 
 initialize()

--- a/src/custom/utils/appzi.ts
+++ b/src/custom/utils/appzi.ts
@@ -42,7 +42,7 @@ declare global {
 type AppziCustomSettings = {
   userTradedOrWaitedForLong?: true
   isTestNps?: true // to trigger test rather than prod NPS
-  pendingFor?: number // how long has this order been open (in seconds)?
+  secondsSinceOpen?: number // how long has this order been open (in seconds)?
   waitedTooLong?: true
   expired?: true
   traded?: true

--- a/src/custom/utils/time.ts
+++ b/src/custom/utils/time.ts
@@ -18,3 +18,12 @@ export function formatDateWithTimezone(date: Date | number | undefined | null): 
 
   return `${_date.toLocaleString()} (${Intl.DateTimeFormat().resolvedOptions().timeZone})`
 }
+
+export function timeSinceInSeconds(timestamp?: number): number | undefined {
+  if (!timestamp) {
+    return
+  }
+  const timeDelta = Date.now() - timestamp
+
+  return Math.floor(timeDelta / 1000)
+}


### PR DESCRIPTION
# Summary

Further improving NPS tracking

## Edit 2022-08-18

Changed the flags based on Anxo's comment

- `traded`: true, if triggered after a trade
- `expired`: true, if triggered after a trade has been expired
- `waitedForTooLong`: true, if triggered after a trade takes more than X minutes
- `secondsSinceOpen`: number, set every time it's triggered

---

Added 3 custom fields depending on each NPS trigger:
- `traded` flag, if triggered after a trade
- `expired` flag, if triggered after a trade has been expired
- `waitedFor` field, if triggered after a trade takes more than X minutes
The last one will have as value how long, in minutes, the user waited for

# To Test

Before each test, make sure the appzi key on localStorage is cleared. Refresh the browser after removing it.

All NPS instances should contain `secondsSinceOpen` with a number, indicating how long the order has been open until the NPS modal was displayed.

## Traded

1. Place an order, wait for it to trade
* NPS modal should be displayed
* After submitting the feedback, it should contain the custom key `traded`
![Screen Shot 2022-08-10 at 14 06 59](https://user-images.githubusercontent.com/43217/183909141-e2f2d50e-0280-4ce6-8be0-abb731fa01df.png)

## Expired

1. Change the order expiration to 3 min and set slippage to `0`
2. Pick a pair with low liquidity, such as OWL/GNO on rinkeby
3. In two different browsers/devices, place an order that moves the price more than ~1%
4. After the first order is traded, the NPS should trigger. Ignore that, and if needed clear the appzi key and refresh the browser
5. Wait for the order to expire
* NPT modal should be displayed
* After submitting the feedback, it should contain the custom key `expired`
![Screen Shot 2022-08-10 at 14 07 17](https://user-images.githubusercontent.com/43217/183909819-6a4998e6-acef-4a13-949f-228e5b798c67.png)

## Pending for too long
1. Reset expiration time on settings
2. Repeat steps `2` to `4` from previous section
3. After 5 min pending
* NPT modal should be displayed
* After submitting the feedback, it should contain the custom key `waitedTooLong`
<img width="162" alt="Screen Shot 2022-08-18 at 18 10 20" src="https://user-images.githubusercontent.com/43217/185454559-8245bb39-2d0d-4cd9-814a-0bd5240558c6.png">


