### PR TITLE
Improve nps user

### DIFF
--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -244,6 +244,7 @@ export const appziMiddleware: Middleware<Record<string, unknown>, AppState> = (s
     const orders = store.getState().orders[chainId]
     const userId = getOrderById(orders, id)?.order?.owner
 
+    console.warn('appzi: batch fulfillment', userId)
     openNpsAppziSometimes({ traded: true }, userId)
   } else if (isSingleFulfillOrderAction(action)) {
     // Shows NPS feedback (or attempts to) when there's a successful trade
@@ -252,6 +253,7 @@ export const appziMiddleware: Middleware<Record<string, unknown>, AppState> = (s
     const orders = store.getState().orders[chainId]
     const userId = getOrderById(orders, id)?.order?.owner
 
+    console.warn('appzi: single fulfillment', userId)
     openNpsAppziSometimes({ traded: true }, userId)
   } else if (isBatchExpireOrderAction(action)) {
     // Shows NPS feedback (or attempts to) when the order expired
@@ -263,6 +265,7 @@ export const appziMiddleware: Middleware<Record<string, unknown>, AppState> = (s
     const orders = store.getState().orders[chainId]
     const userId = getOrderById(orders, id)?.order?.owner
 
+    console.warn('appzi: batch expiration', userId)
     openNpsAppziSometimes({ expired: true }, userId)
   } else if (isSingleExpireOrderAction(action)) {
     // Shows NPS feedback (or attempts to) when the order expired
@@ -271,6 +274,7 @@ export const appziMiddleware: Middleware<Record<string, unknown>, AppState> = (s
     const orders = store.getState().orders[chainId]
     const userId = getOrderById(orders, id)?.order?.owner
 
+    console.warn('appzi: single expiration', userId)
     openNpsAppziSometimes({ expired: true }, userId)
   }
 

--- a/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
@@ -123,11 +123,11 @@ async function _updateOrders({
     // Check if there is any order pending for a long time
     // If so, trigger appzi
     const now = Date.now()
-    for (const { openSince } of pending) {
+    for (const { openSince, owner } of pending) {
       // Check if there's any pending for more than `PENDING_TOO_LONG_TIME`
       if (openSince && now - openSince > PENDING_TOO_LONG_TIME) {
         // Trigger NPS display, controlled by Appzi
-        openNpsAppziSometimes({ waitedFor: `${Math.floor((now - openSince) / 60_000)} min` })
+        openNpsAppziSometimes({ waitedFor: `${Math.floor((now - openSince) / 60_000)} min` }, owner)
         // Break the loop, don't need to show more than once
         break
       }

--- a/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
@@ -127,6 +127,7 @@ async function _updateOrders({
       // Check if there's any pending for more than `PENDING_TOO_LONG_TIME`
       if (openSince && now - openSince > PENDING_TOO_LONG_TIME) {
         // Trigger NPS display, controlled by Appzi
+        console.warn('appzi: pending order', owner)
         openNpsAppziSometimes({ waitedFor: `${Math.floor((now - openSince) / 60_000)} min` }, owner)
         // Break the loop, don't need to show more than once
         break

--- a/src/custom/utils/appzi.ts
+++ b/src/custom/utils/appzi.ts
@@ -82,6 +82,7 @@ function initialize() {
 
 export function updateAppziSettings({ data = {}, userId = '' }: AppziSettings) {
   window.appziSettings = { ...(window.appziSettings || {}), data, userId }
+  console.warn(`appzi: updated settings`, window.appziSettings)
 }
 
 export function openFeedbackAppzi() {
@@ -131,6 +132,7 @@ export function openNpsAppziSometimes(
   userId?: string
 ) {
   applyOnceRestyleAppziNps()
+  console.warn(`appzi: open nps sometimes`, data, userId)
   updateAppziSettings({ data: { ...data, ...NPS_DATA }, userId })
 }
 

--- a/src/custom/utils/appzi.ts
+++ b/src/custom/utils/appzi.ts
@@ -126,9 +126,12 @@ const NPS_DATA = isProdLike ? PROD_NPS_DATA : TEST_NPS_DATA
  * It'll display only if the trigger rules are met
  * Check https://portal.appzi.com/portals/5ju0G/configs/55872789-593b-4c6c-9e49-9b5c7693e90a/trigger
  */
-export function openNpsAppziSometimes(data?: Omit<AppziCustomSettings, 'userTradedOrWaitedForLong' | 'isTestNps'>) {
+export function openNpsAppziSometimes(
+  data?: Omit<AppziCustomSettings, 'userTradedOrWaitedForLong' | 'isTestNps'>,
+  userId?: string
+) {
   applyOnceRestyleAppziNps()
-  updateAppziSettings({ data: { ...data, ...NPS_DATA } })
+  updateAppziSettings({ data: { ...data, ...NPS_DATA }, userId })
 }
 
 initialize()


### PR DESCRIPTION
# Summary

Using account address as key to trigger or not NPS modal

This means that the same account on different devices will share the same local NPS rules

On the other hand different accounts on the same device will have different triggers

# To Test

Follow same steps as #905 

Except that, to avoid having to trade each time with a different account, you can use the console to track whether appzi has triggered:

![Screen Shot 2022-08-10 at 17 09 33](https://user-images.githubusercontent.com/43217/183965826-2efef1dd-f84f-4de4-add2-0d6737b07d3b.png)
