### PR TITLE
Improve nps orderid

### DIFF
--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -275,7 +275,7 @@ function _triggerNps(
   const openSince = _getOrderById(orders, orderId)?.order?.openSince
   const explorerUrl = getExplorerOrderLink(chainId, orderId)
 
-  openNpsAppziSometimes({ ...npsParams, secondsSinceOpen: timeSinceInSeconds(openSince), orderId, explorerUrl })
+  openNpsAppziSometimes({ ...npsParams, secondsSinceOpen: timeSinceInSeconds(openSince), explorerUrl, chainId })
 }
 
 function _getOrderById(orders: OrdersStateNetwork | undefined, id: string): OrderObject | undefined {

--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -14,6 +14,7 @@ import { orderAnalytics } from 'utils/analytics'
 import { openNpsAppziSometimes } from 'utils/appzi'
 import { OrderObject, OrdersStateNetwork } from 'state/orders/reducer'
 import { timeSinceInSeconds } from 'utils/time'
+import { getExplorerOrderLink } from 'utils/explorer'
 
 // action syntactic sugar
 const isSingleOrderChangeAction = isAnyOf(
@@ -267,13 +268,14 @@ export const appziMiddleware: Middleware<Record<string, unknown>, AppState> = (s
 function _triggerNps(
   store: MiddlewareAPI<Dispatch<AnyAction>>,
   chainId: ChainId,
-  id: string,
+  orderId: string,
   npsParams: Parameters<typeof openNpsAppziSometimes>[0]
 ) {
   const orders = store.getState().orders[chainId]
-  const openSince = _getOrderById(orders, id)?.order?.openSince
+  const openSince = _getOrderById(orders, orderId)?.order?.openSince
+  const explorerUrl = getExplorerOrderLink(chainId, orderId)
 
-  openNpsAppziSometimes({ ...npsParams, secondsSinceOpen: timeSinceInSeconds(openSince) })
+  openNpsAppziSometimes({ ...npsParams, secondsSinceOpen: timeSinceInSeconds(openSince), orderId, explorerUrl })
 }
 
 function _getOrderById(orders: OrdersStateNetwork | undefined, id: string): OrderObject | undefined {

--- a/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
@@ -194,8 +194,8 @@ function _triggerNps(pending: Order[], chainId: ChainId) {
       openNpsAppziSometimes({
         waitedTooLong: true,
         secondsSinceOpen: timeSinceInSeconds(openSince),
-        orderId,
         explorerUrl,
+        chainId,
       })
       // Break the loop, don't need to show more than once
       break

--- a/src/custom/utils/appzi.ts
+++ b/src/custom/utils/appzi.ts
@@ -46,6 +46,8 @@ type AppziCustomSettings = {
   waitedTooLong?: true
   expired?: true
   traded?: true
+  orderId?: string
+  explorerUrl?: string
 }
 
 type AppziSettings = {

--- a/src/custom/utils/appzi.ts
+++ b/src/custom/utils/appzi.ts
@@ -1,7 +1,7 @@
 import EventEmitter from 'events'
 import ReactAppzi from 'react-appzi'
 import { userAgent, majorBrowserVersion, isImTokenBrowser } from 'utils/userAgent'
-import { isProdLike } from 'utils/environments'
+import { environmentName, isProdLike } from 'utils/environments'
 
 // Metamask IOS app uses a version from July 2019 which causes problems in appZi
 const OLD_CHROME_FROM_METAMASK_IOS_APP = 76
@@ -40,14 +40,18 @@ declare global {
 }
 
 type AppziCustomSettings = {
+  // triggers to control when and which NPS is selected
   userTradedOrWaitedForLong?: true
   isTestNps?: true // to trigger test rather than prod NPS
+  // general data regarding the circumstances that caused the modal to be shown
   secondsSinceOpen?: number // how long has this order been open (in seconds)?
   waitedTooLong?: true
   expired?: true
   traded?: true
-  orderId?: string
+  // extra contextual data for statistics/debugging
   explorerUrl?: string
+  env?: string
+  chainId?: number
 }
 
 type AppziSettings = {
@@ -131,7 +135,7 @@ const NPS_DATA = isProdLike ? PROD_NPS_DATA : TEST_NPS_DATA
  */
 export function openNpsAppziSometimes(data?: Omit<AppziCustomSettings, 'userTradedOrWaitedForLong' | 'isTestNps'>) {
   applyOnceRestyleAppziNps()
-  updateAppziSettings({ data: { ...data, ...NPS_DATA } })
+  updateAppziSettings({ data: { env: environmentName, ...data, ...NPS_DATA } })
 }
 
 initialize()


### PR DESCRIPTION
# Summary

## Edit 2022-08-26

- Removed redundant `orderId`
- Added `env` and `chainId` 

![Screen Shot 2022-08-26 at 16 46 39](https://user-images.githubusercontent.com/43217/186943680-d7a44982-4363-41f2-9db4-cdfa414d2a1a.png)


## Original

Follow up to https://github.com/cowprotocol/cowswap/pull/905

Added 2 fields to appzi NPS:
- orderId
- explorerUrl

![Screen Shot 2022-08-23 at 11 39 10](https://user-images.githubusercontent.com/43217/186139149-9f453fbe-9850-45dd-823d-a5c30ee5346f.png)

Both are redundant, yes.
Couldn't decide which we should keep, so added both.
Let me know which is the preferred and I'll remove the other one

  # To Test

Same as #905, except that there are 2 new fields that should be included in all the NPS submitted