### PR TITLE
Keep last orderId on state when popup is closed

### DIFF
--- a/src/custom/components/Popups/FollowPendingTxPopup/index.tsx
+++ b/src/custom/components/Popups/FollowPendingTxPopup/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react'
+import React, { useEffect, useMemo, useCallback, useRef } from 'react'
 
 import { useIsExpertMode } from '@src/state/user/hooks'
 import useRecentActivity, { TransactionAndOrder } from 'hooks/useRecentActivity'
@@ -9,9 +9,13 @@ import {
   handleFollowPendingTxPopupAtom,
   handleHidePopupPermanentlyAtom,
   showFollowTxPopupAtom,
+  followPendingTxPopupAtom,
+  selectAtom,
+  handleCloseOrderPopupAtom,
 } from 'state/application/atoms'
 import FollowPendingTxPopupUI from './FollowPendingTxPopupUI'
 import { isPending } from 'components/Web3Status'
+import { OrderID } from '@src/custom/api/gnosisProtocol'
 
 interface AddedOrder extends Order {
   addedTime: number
@@ -21,36 +25,83 @@ function isAnOrder(element: TransactionAndOrder): element is AddedOrder {
   return 'inputToken' in element && 'outputToken' in element
 }
 
-export const useLastPendingOrderId = (): AddedOrder | undefined => {
+function _cutOrderId(orderId: OrderID) {
+  return orderId.slice(0, 10)
+}
+
+export const useLastPendingOrder = (): { lastPendingOrder: AddedOrder | null; onClose: () => void } => {
+  const setShowFollowPendingTxPopup = useUpdateAtom(handleFollowPendingTxPopupAtom)
+  const setLastOrderClosed = useUpdateAtom(handleCloseOrderPopupAtom)
   const allRecentActivity = useRecentActivity()
   const lastPendingOrder = useMemo(() => {
     const pendings = allRecentActivity.filter(isPending)
     const lastOrder = pendings[pendings.length - 1]
 
-    return (isAnOrder(lastOrder) && lastOrder) || undefined
+    if (!lastOrder || !isAnOrder(lastOrder)) return null
+
+    return lastOrder
   }, [allRecentActivity])
 
-  return lastPendingOrder
+  const onClose = useCallback(() => {
+    lastPendingOrder && setLastOrderClosed(_cutOrderId(lastPendingOrder.id))
+    setShowFollowPendingTxPopup(false)
+  }, [lastPendingOrder, setLastOrderClosed, setShowFollowPendingTxPopup])
+
+  return { lastPendingOrder, onClose }
+}
+
+// Set pop up closed if it has not been closed and not fulfill a condition such as not pending tx
+export function useCloseFollowTxPopupIfNotPendingOrder() {
+  const showingPopup = useAtomValue(showFollowTxPopupAtom)
+  const { lastPendingOrder, onClose } = useLastPendingOrder()
+  const onCloseRef = useRef<() => void>()
+
+  useEffect(() => {
+    if (lastPendingOrder && showingPopup) {
+      onCloseRef.current = onClose
+    } else if (!lastPendingOrder && showingPopup && onCloseRef.current) {
+      onCloseRef.current()
+    }
+  }, [lastPendingOrder, onClose, showingPopup])
+}
+
+const useShowingPopupFirstTime = (orderId: OrderID | undefined) => {
+  const showingPopup = useAtomValue(showFollowTxPopupAtom)
+  const _orderPopupHasBeenClosed = useMemo(
+    () =>
+      selectAtom(followPendingTxPopupAtom, ({ lastOrderPopupClosed }) => {
+        if (!orderId) return
+
+        return lastOrderPopupClosed === _cutOrderId(orderId)
+      }),
+    [orderId]
+  )
+
+  const orderPopupHasBeenClosed = useAtomValue(_orderPopupHasBeenClosed)
+
+  return { showPopup: !orderPopupHasBeenClosed && showingPopup, orderPopupHasBeenClosed }
 }
 
 const FollowPendingTxPopup: React.FC = ({ children }): JSX.Element => {
   const setShowFollowPendingTxPopup = useUpdateAtom(handleFollowPendingTxPopupAtom)
   const setHidePendingTxPopupPermanently = useUpdateAtom(handleHidePopupPermanentlyAtom)
   const isExpertMode = useIsExpertMode()
-  const lastPendingOrder = useLastPendingOrderId()
-  const showFollowPendingTxPopup = useAtomValue(showFollowTxPopupAtom())
+  const { lastPendingOrder, onClose } = useLastPendingOrder()
+  const { showPopup: showFollowPendingTxPopup, orderPopupHasBeenClosed } = useShowingPopupFirstTime(
+    lastPendingOrder?.id
+  )
 
   useEffect(() => {
-    if (isExpertMode && lastPendingOrder) {
+    if (isExpertMode && lastPendingOrder && !orderPopupHasBeenClosed) {
       setShowFollowPendingTxPopup(true)
     }
-  }, [isExpertMode, lastPendingOrder, setShowFollowPendingTxPopup])
+  }, [isExpertMode, lastPendingOrder, orderPopupHasBeenClosed, setShowFollowPendingTxPopup])
 
   return (
     <FollowPendingTxPopupUI
       show={showFollowPendingTxPopup}
       onCheck={() => setHidePendingTxPopupPermanently(true)}
-      onClose={() => lastPendingOrder && setShowFollowPendingTxPopup(false)}
+      onClose={onClose}
     >
       {children}
     </FollowPendingTxPopupUI>

--- a/src/custom/components/Popups/FollowPendingTxPopup/index.tsx
+++ b/src/custom/components/Popups/FollowPendingTxPopup/index.tsx
@@ -25,10 +25,6 @@ function isAnOrder(element: TransactionAndOrder): element is AddedOrder {
   return 'inputToken' in element && 'outputToken' in element
 }
 
-function _cutOrderId(orderId: OrderID) {
-  return orderId.slice(0, 10)
-}
-
 export const useLastPendingOrder = (): { lastPendingOrder: AddedOrder | null; onClose: () => void } => {
   const setShowFollowPendingTxPopup = useUpdateAtom(handleFollowPendingTxPopupAtom)
   const setLastOrderClosed = useUpdateAtom(handleCloseOrderPopupAtom)
@@ -43,7 +39,7 @@ export const useLastPendingOrder = (): { lastPendingOrder: AddedOrder | null; on
   }, [allRecentActivity])
 
   const onClose = useCallback(() => {
-    lastPendingOrder && setLastOrderClosed(_cutOrderId(lastPendingOrder.id))
+    lastPendingOrder && setLastOrderClosed(lastPendingOrder.id)
     setShowFollowPendingTxPopup(false)
   }, [lastPendingOrder, setLastOrderClosed, setShowFollowPendingTxPopup])
 
@@ -72,7 +68,7 @@ const useShowingPopupFirstTime = (orderId: OrderID | undefined) => {
       selectAtom(followPendingTxPopupAtom, ({ lastOrderPopupClosed }) => {
         if (!orderId) return
 
-        return lastOrderPopupClosed === _cutOrderId(orderId)
+        return lastOrderPopupClosed === orderId
       }),
     [orderId]
   )

--- a/src/custom/components/Popups/FollowPendingTxPopup/index.tsx
+++ b/src/custom/components/Popups/FollowPendingTxPopup/index.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useMemo, useCallback, useRef } from 'react'
 
 import { useIsExpertMode } from '@src/state/user/hooks'
-import useRecentActivity, { TransactionAndOrder } from 'hooks/useRecentActivity'
-import { Order } from 'state/orders/actions'
+import { useRecentActivityLastPendingOrder, AddedOrder } from 'hooks/useRecentActivity'
 import {
   useUpdateAtom,
   useAtomValue,
@@ -14,29 +13,12 @@ import {
   handleCloseOrderPopupAtom,
 } from 'state/application/atoms'
 import FollowPendingTxPopupUI from './FollowPendingTxPopupUI'
-import { isPending } from 'components/Web3Status'
-import { OrderID } from '@src/custom/api/gnosisProtocol'
-
-interface AddedOrder extends Order {
-  addedTime: number
-}
-
-function isAnOrder(element: TransactionAndOrder): element is AddedOrder {
-  return 'inputToken' in element && 'outputToken' in element
-}
+import { OrderID } from 'api/gnosisProtocol'
 
 export const useLastPendingOrder = (): { lastPendingOrder: AddedOrder | null; onClose: () => void } => {
   const setShowFollowPendingTxPopup = useUpdateAtom(handleFollowPendingTxPopupAtom)
   const setLastOrderClosed = useUpdateAtom(handleCloseOrderPopupAtom)
-  const allRecentActivity = useRecentActivity()
-  const lastPendingOrder = useMemo(() => {
-    const pendings = allRecentActivity.filter(isPending)
-    const lastOrder = pendings[pendings.length - 1]
-
-    if (!lastOrder || !isAnOrder(lastOrder)) return null
-
-    return lastOrder
-  }, [allRecentActivity])
+  const lastPendingOrder = useRecentActivityLastPendingOrder()
 
   const onClose = useCallback(() => {
     lastPendingOrder && setLastOrderClosed(lastPendingOrder.id)
@@ -63,19 +45,19 @@ export function useCloseFollowTxPopupIfNotPendingOrder() {
 
 const useShowingPopupFirstTime = (orderId: OrderID | undefined) => {
   const showingPopup = useAtomValue(showFollowTxPopupAtom)
-  const _orderPopupHasBeenClosed = useMemo(
+  const _firstTimePopupOrderAppears = useMemo(
     () =>
       selectAtom(followPendingTxPopupAtom, ({ lastOrderPopupClosed }) => {
-        if (!orderId) return
+        if (!orderId) return false
 
-        return lastOrderPopupClosed === orderId
+        return lastOrderPopupClosed !== orderId
       }),
     [orderId]
   )
 
-  const orderPopupHasBeenClosed = useAtomValue(_orderPopupHasBeenClosed)
+  const firstTimePopupOrderAppears = useAtomValue(_firstTimePopupOrderAppears)
 
-  return { showPopup: !orderPopupHasBeenClosed && showingPopup, orderPopupHasBeenClosed }
+  return { showPopup: firstTimePopupOrderAppears && showingPopup, firstTimePopupOrderAppears }
 }
 
 const FollowPendingTxPopup: React.FC = ({ children }): JSX.Element => {
@@ -83,15 +65,15 @@ const FollowPendingTxPopup: React.FC = ({ children }): JSX.Element => {
   const setHidePendingTxPopupPermanently = useUpdateAtom(handleHidePopupPermanentlyAtom)
   const isExpertMode = useIsExpertMode()
   const { lastPendingOrder, onClose } = useLastPendingOrder()
-  const { showPopup: showFollowPendingTxPopup, orderPopupHasBeenClosed } = useShowingPopupFirstTime(
+  const { showPopup: showFollowPendingTxPopup, firstTimePopupOrderAppears } = useShowingPopupFirstTime(
     lastPendingOrder?.id
   )
 
   useEffect(() => {
-    if (isExpertMode && lastPendingOrder && !orderPopupHasBeenClosed) {
+    if (isExpertMode && lastPendingOrder && firstTimePopupOrderAppears) {
       setShowFollowPendingTxPopup(true)
     }
-  }, [isExpertMode, lastPendingOrder, orderPopupHasBeenClosed, setShowFollowPendingTxPopup])
+  }, [isExpertMode, lastPendingOrder, firstTimePopupOrderAppears, setShowFollowPendingTxPopup])
 
   return (
     <FollowPendingTxPopupUI

--- a/src/custom/components/Popups/FollowPendingTxPopup/index.tsx
+++ b/src/custom/components/Popups/FollowPendingTxPopup/index.tsx
@@ -15,7 +15,7 @@ import {
 import FollowPendingTxPopupUI from './FollowPendingTxPopupUI'
 import { OrderID } from 'api/gnosisProtocol'
 
-export const useLastPendingOrder = (): { lastPendingOrder: AddedOrder | null; onClose: () => void } => {
+export function useLastPendingOrder(): { lastPendingOrder: AddedOrder | null; onClose: () => void } {
   const setShowFollowPendingTxPopup = useUpdateAtom(handleFollowPendingTxPopupAtom)
   const setLastOrderClosed = useUpdateAtom(handleCloseOrderPopupAtom)
   const lastPendingOrder = useRecentActivityLastPendingOrder()

--- a/src/custom/components/Web3Status/Web3StatusMod.tsx
+++ b/src/custom/components/Web3Status/Web3StatusMod.tsx
@@ -20,9 +20,8 @@ import { RowBetween } from 'components/Row'
 // import WalletModal from '../WalletModal'
 
 // MOD imports
-import { useCloseFollowTxPopupIfNot } from 'state/application/hooks'
 import { Web3StatusGeneric as Web3StatusGenericUni } from '@src/components/Web3Status'
-import FollowPendingTxPopup from 'components/Popups/FollowPendingTxPopup'
+import FollowPendingTxPopup, { useCloseFollowTxPopupIfNotPendingOrder } from 'components/Popups/FollowPendingTxPopup'
 
 /* const IconWrapper = styled.div<{ size?: number }>`
   ${({ theme }) => theme.flexColumnNoWrap};
@@ -154,7 +153,7 @@ export function Web3StatusInner({ pendingCount }: { pendingCount: number }) {
   const hasPendingTransactions = !!pendingCount
   const hasSocks = useHasSocks()
   const toggleWalletModal = useToggleWalletModal()
-  useCloseFollowTxPopupIfNot(hasPendingTransactions)
+  useCloseFollowTxPopupIfNotPendingOrder()
 
   if (!chainId) {
     return null

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -270,7 +270,8 @@ export function groupActivitiesByDay(activities: ActivityDescriptors[]): Activit
 
 export function useRecentActivityLastPendingOrder() {
   const allRecentActivity = useRecentActivity()
-  const lastPendingOrder = useMemo(() => {
+
+  return useMemo(() => {
     const pendings = allRecentActivity.filter(isPending)
     const lastOrder = pendings[pendings.length - 1]
 
@@ -278,6 +279,4 @@ export function useRecentActivityLastPendingOrder() {
 
     return lastOrder
   }, [allRecentActivity])
-
-  return lastPendingOrder
 }

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -7,9 +7,13 @@ import { EnhancedTransactionDetails } from 'state/enhancedTransactions/reducer'
 import { SupportedChainId as ChainId } from 'constants/chains'
 import { getDateTimestamp } from 'utils/time'
 import { MAXIMUM_ORDERS_TO_DISPLAY } from 'constants/index'
+import { isPending } from 'components/Web3Status'
 
+export interface AddedOrder extends Order {
+  addedTime: number
+}
 export type TransactionAndOrder =
-  | (Order & { addedTime: number })
+  | AddedOrder
   | (EnhancedTransactionDetails & {
       id: string
       status: OrderStatus
@@ -32,6 +36,10 @@ export enum ActivityStatus {
 enum TxReceiptStatus {
   PENDING,
   CONFIRMED,
+}
+
+export function isAnOrder(element: TransactionAndOrder): element is AddedOrder {
+  return 'inputToken' in element && 'outputToken' in element
 }
 
 /**
@@ -258,4 +266,18 @@ export function groupActivitiesByDay(activities: ActivityDescriptors[]): Activit
     // For easier handling later, transform into a list of objects with nested lists
     return { date: new Date(timestamp), activities: mapByTimestamp[timestamp] }
   })
+}
+
+export function useRecentActivityLastPendingOrder() {
+  const allRecentActivity = useRecentActivity()
+  const lastPendingOrder = useMemo(() => {
+    const pendings = allRecentActivity.filter(isPending)
+    const lastOrder = pendings[pendings.length - 1]
+
+    if (!lastOrder || !isAnOrder(lastOrder)) return null
+
+    return lastOrder
+  }, [allRecentActivity])
+
+  return lastPendingOrder
 }

--- a/src/custom/state/application/atoms.ts
+++ b/src/custom/state/application/atoms.ts
@@ -4,10 +4,9 @@ import { OrderID } from 'api/gnosisProtocol'
 
 export { useUpdateAtom, useAtomValue, selectAtom }
 
-type LastOrderPopupClosed = OrderID | null
 type FollowPendingTxPopup = {
   showPopup: boolean
-  lastOrderPopupClosed: LastOrderPopupClosed
+  lastOrderPopupClosed: OrderID | undefined
   hidePopupPermanently: boolean
 }
 
@@ -16,7 +15,7 @@ type FollowPendingTxPopup = {
  */
 export const followPendingTxPopupAtom = atomWithStorage<FollowPendingTxPopup>('followPendingTxPopup', {
   showPopup: false,
-  lastOrderPopupClosed: null,
+  lastOrderPopupClosed: undefined,
   hidePopupPermanently: false,
 })
 

--- a/src/custom/state/application/atoms.ts
+++ b/src/custom/state/application/atoms.ts
@@ -32,9 +32,7 @@ export const handleCloseOrderPopupAtom = atom(null, (_get, set, orderIdClosed: O
   set(followPendingTxPopupAtom, (prev) => ({ ...prev, lastOrderPopupClosed: orderIdClosed }))
 })
 
-export const showFollowTxPopupAtom = (orderId?: LastOrderPopupClosed) =>
-  selectAtom(followPendingTxPopupAtom, ({ lastOrderPopupClosed, showPopup, hidePopupPermanently }) => {
-    const orderPopupHasBeenClosed = lastOrderPopupClosed === orderId
-
-    return showPopup && !orderPopupHasBeenClosed && !hidePopupPermanently
-  })
+export const showFollowTxPopupAtom = selectAtom(
+  followPendingTxPopupAtom,
+  ({ showPopup, hidePopupPermanently }) => showPopup && !hidePopupPermanently
+)

--- a/src/custom/state/application/hooks.ts
+++ b/src/custom/state/application/hooks.ts
@@ -1,10 +1,9 @@
 import { createAction } from '@reduxjs/toolkit'
 import { DEFAULT_TXN_DISMISS_MS } from '@src/constants/misc'
 import { useToggleModal } from '@src/state/application/hooks'
-import { useCallback, useEffect } from 'react'
+import { useCallback } from 'react'
 import { addPopup, ApplicationModal, PopupContent } from 'state/application/reducer'
 import { useAppDispatch } from 'state/hooks'
-import { handleFollowPendingTxPopupAtom, showFollowTxPopupAtom, useUpdateAtom, useAtomValue } from './atoms'
 
 export * from '@src/state/application/hooks'
 
@@ -42,23 +41,4 @@ export function useAddPopup(): (content: PopupContent, key?: string, removeAfter
     },
     [dispatch]
   )
-}
-
-// Set pop up closed if it has not been closed and not fulfill a condition such as not pending tx
-export function useCloseFollowTxPopupIfNot(fulfillsCondition: boolean) {
-  const setShowFollowTxPopup = useUpdateAtom(handleFollowPendingTxPopupAtom)
-  const showingPopup = useAtomValue(showFollowTxPopupAtom)
-
-  const closeIfNotFulfillsCondition = useCallback(
-    (_fulfillsCondition) => {
-      if (!showingPopup) return
-
-      !_fulfillsCondition && setShowFollowTxPopup(false)
-    },
-    [setShowFollowTxPopup, showingPopup]
-  )
-
-  useEffect(() => {
-    closeIfNotFulfillsCondition(fulfillsCondition)
-  }, [closeIfNotFulfillsCondition, fulfillsCondition])
 }


### PR DESCRIPTION
# Summary
Closes #872

This proposal stores the `orderId` when closing the **popUp** that signals where to **follow** a pending order.

**This will prevent:**
1. When switching to expert mode, a previously displayed popup will not be shown.
2. That when refreshing the page it is not shown again.


## To Test

1. Open an order, close the progress modal, close the popup notification. And finally switch to expert mode 

2. In expert mode put an Order, close the notification popup and finally refresh the page. 

💡 Note: The popup **should not appear again** in any of the cases