### PR TITLE
Updated meta tag for shared image to invalidate existing cache

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,14 +22,14 @@
   <meta property="og:title" content="CoW Swap | The smartest way to trade cryptocurrencies">
   <meta property="og:description"
     content="CoW Swap finds the lowest prices from all decentralized exchanges and DEX aggregators & saves you more with p2p trading and protection from MEV">
-  <meta property="og:image" content="https://cowswap.exchange/images/og-meta-cowswap.png?v=1">
+  <meta property="og:image" content="https://cowswap.exchange/images/og-meta-cowswap.png?v=2">
   <meta property="og:url" content="https://cowswap.exchange">
 
   <!-- Twitter media tags -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@MEVprotection">
   <meta name="twitter:title" content="CoW Swap | The smartest way to trade cryptocurrencies">
-  <meta name="twitter:image" content="https://cowswap.exchange/images/og-meta-cowswap.png?v=1">
+  <meta name="twitter:image" content="https://cowswap.exchange/images/og-meta-cowswap.png?v=2">
 
   <!-- Other tags -->
   <meta name="fortmatic-site-verification" content="%REACT_APP_FORTMATIC_SITE_VERIFICATION%" />
@@ -54,7 +54,7 @@
       }
     </style>
     <main>
-      <img src="https://cowswap.exchange/images/og-meta-cowswap.png?v=1" alt="CoW Swap Logo" />
+      <img src="https://cowswap.exchange/images/og-meta-cowswap.png?v=2" alt="CoW Swap Logo" />
       <p class="banner">CoW Swap uses JavasScript. Please <a
           href="https://support.google.com/adsense/answer/12654?hl=en" target="_blank" rel="noopener noreferrer">enable
           it in your browser</a> 🐮</p>

--- a/public/index.html
+++ b/public/index.html
@@ -13,9 +13,9 @@
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
   <meta name="theme-color" media="(prefers-color-scheme: light)" content="white">
   <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#163861">
-  <link rel="shortcut icon" type="image/png" href="%PUBLIC_URL%/favicon.png?v=1" />
-  <link rel="apple-touch-icon" sizes="192x192" href="%PUBLIC_URL%/favicon.png?v=1" />
-  <link rel="apple-touch-icon" sizes="512x512" href="%PUBLIC_URL%/favicon.png?v=1" />
+  <link rel="shortcut icon" type="image/png" href="%PUBLIC_URL%/favicon.png?v=2" />
+  <link rel="apple-touch-icon" sizes="192x192" href="%PUBLIC_URL%/favicon.png?v=2" />
+  <link rel="apple-touch-icon" sizes="512x512" href="%PUBLIC_URL%/favicon.png?v=2" />
 
   <!-- Social media tags -->
   <meta property="og:type" content="website" />


### PR DESCRIPTION
# Summary

Updating the cache flag so shared image from meta tag uses the new version

  # To Test

I guess it will only make sense once this is deployed to an environment where this was used before, because this PR won't have the shared imaged cached and will start with the latest