### PR TITLE
Set the right branch for goerli list

### DIFF
--- a/src/custom/constants/lists.ts
+++ b/src/custom/constants/lists.ts
@@ -28,7 +28,6 @@ const BA_LIST = 'https://raw.githubusercontent.com/The-Blockchain-Association/se
 const RINKEBY_LIST = RAW_CODE_LINK + '/main/src/custom/tokens/rinkeby-token-list.json'
 
 // Goerli Default
-// TODO: This should be reverted back to main before merge
 const GOERLI_LIST = RAW_CODE_LINK + '/main/src/custom/tokens/goerli-token-list.json'
 
 // XDAI Default

--- a/src/custom/constants/lists.ts
+++ b/src/custom/constants/lists.ts
@@ -29,7 +29,7 @@ const RINKEBY_LIST = RAW_CODE_LINK + '/main/src/custom/tokens/rinkeby-token-list
 
 // Goerli Default
 // TODO: This should be reverted back to main before merge
-const GOERLI_LIST = RAW_CODE_LINK + '/cypress-goerli/src/custom/tokens/goerli-token-list.json'
+const GOERLI_LIST = RAW_CODE_LINK + '/main/src/custom/tokens/goerli-token-list.json'
 
 // XDAI Default
 const HONEY_SWAP_XDAI = 'https://tokens.honeyswap.org'


### PR DESCRIPTION
# Summary

Sets the main branch for the url of goerli tokens list.
Fixes the failing cypress tests.