### PR TITLE
Updated ipfs build to use Pinata instead of Infura

### DIFF
--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -8,6 +8,9 @@ env:
   REPO_NAME_SLUG: cowswap
   REACT_APP_PINATA_API_KEY: ${{ secrets.REACT_APP_PINATA_API_KEY }}
   REACT_APP_PINATA_SECRET_API_KEY: ${{ secrets.REACT_APP_PINATA_SECRET_API_KEY }}
+  # Duplicated keys as these are required by `ipfs-deploy`
+  IPFS_DEPLOY_PINATA__API_KEY: ${{ secrets.REACT_APP_PINATA_API_KEY }}
+  IPFS_DEPLOY_PINATA__SECRET_API_KEY: ${{ secrets.REACT_APP_PINATA_SECRET_API_KEY }}
 
 jobs:
   ipfs:

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "build": "yarn i18n:compile && craco build && yarn writeVersion",
     "build:analyze": "cross-env REACT_APP_ANALYZE_BUNDLE=true yarn craco build && yarn writeVersion",
     "ipfs:build": "cross-env PUBLIC_URL=\".\" yarn build",
-    "ipfs:publish": "ipfs-deploy build -p infura -O",
+    "ipfs:publish": "ipfs-deploy build -p pinata -O",
     "test": "NODE_PATH=src/custom craco test --env=jsdom",
     "test:debug": "NODE_PATH=src/custom craco --inspect-brk test --runInBand --no-cache",
     "eject": "react-scripts eject",


### PR DESCRIPTION
# Summary

Latest IPFS deploy [failed](https://github.com/cowprotocol/cowswap/runs/8158132195?check_suite_focus=true), due to lack of infura credentials.

![Screen Shot 2022-09-02 at 16 06 02](https://user-images.githubusercontent.com/43217/188179046-0bddda08-f95c-44ed-a5de-eb1d949750b2.png)

I changed it instead to Pinata as we already have the keys available in the repo
 
  # To Test

Requires the ipfs step to be triggered