### PR TITLE
1020 & 249/Fixed link for tokens on gchain

### DIFF
--- a/src/custom/components/SearchModal/ManageTokens/ManageTokensMod.tsx
+++ b/src/custom/components/SearchModal/ManageTokens/ManageTokensMod.tsx
@@ -13,7 +13,7 @@ import { ButtonText, ExternalLink, ExternalLinkIcon, ThemedText, TrashIcon } fro
 import { isAddress } from 'utils'
 
 import useTheme from 'hooks/useTheme'
-import { ExplorerDataType, getExplorerLink } from 'utils/getExplorerLink'
+// import { ExplorerDataType, getExplorerLink } from 'utils/getExplorerLink'
 import { CurrencyModalView } from 'components/SearchModal/CurrencySearchModal'
 // import ImportRow from 'components/SearchModal/ImportRow'
 import { PaddedColumn, SearchInput, Separator } from 'components/SearchModal/styleds'
@@ -21,6 +21,7 @@ import { PaddedColumn, SearchInput, Separator } from 'components/SearchModal/sty
 // MOD imports
 import { ImportTokensRowProps } from '.' // mod
 import useNetworkName from 'hooks/useNetworkName'
+import { getBlockExplorerUrl as getExplorerLink } from 'utils'
 
 const Wrapper = styled.div`
   width: 100%;
@@ -86,7 +87,7 @@ export default function ManageTokens({ setModalView, setImportToken, ImportToken
         <RowBetween key={token.address} width="100%">
           <RowFixed>
             <CurrencyLogo currency={token} size={'20px'} />
-            <ExternalLink href={getExplorerLink(chainId, token.address, ExplorerDataType.ADDRESS)}>
+            <ExternalLink href={getExplorerLink(chainId, token.address, 'address')}>
               <ThemedText.Main ml={'10px'} fontWeight={600}>
                 {token.symbol}
               </ThemedText.Main>
@@ -94,7 +95,7 @@ export default function ManageTokens({ setModalView, setImportToken, ImportToken
           </RowFixed>
           <RowFixed>
             <TrashIcon onClick={() => removeToken(chainId, token.address)} />
-            <ExternalLinkIcon href={getExplorerLink(chainId, token.address, ExplorerDataType.ADDRESS)} />
+            <ExternalLinkIcon href={getExplorerLink(chainId, token.address, 'address')} />
           </RowFixed>
         </RowBetween>
       ))


### PR DESCRIPTION
# Summary

Follow up to #1021 addressing [comment #2](https://github.com/cowprotocol/cowswap/pull/1021#issuecomment-1237156406)

> Custom tokens point to Etherscan in GC (reported in https://github.com/cowprotocol/cowswap/issues/249 )

Closes https://github.com/cowprotocol/cowswap/issues/249

  # To Test

1. On gnosis chain, open the token selector and go to manage token lists > tokens
* The external link on the right the token should take you to gnosisscan rather than etherscan
![Screen Shot 2022-09-05 at 17 36 02](https://user-images.githubusercontent.com/43217/188490599-764a6b69-0742-4617-a62f-09674958d8f2.png)

