### PR TITLE
[ETH-FLOW] FIX hanging price: use input token for quote

### DIFF
--- a/src/custom/hooks/useStablecoinPrice/index.ts
+++ b/src/custom/hooks/useStablecoinPrice/index.ts
@@ -20,6 +20,7 @@ import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
 import useBlockNumber from 'lib/hooks/useBlockNumber'
 import useGetGpPriceStrategy from 'hooks/useGetGpPriceStrategy'
 import { useGetGpUsdcPrice } from 'utils/price'
+import { useDetectNativeToken } from 'state/swap/hooks'
 
 export * from '@src/hooks/useStablecoinPrice'
 
@@ -285,8 +286,11 @@ export function useCoingeckoUsdValue(currencyAmount: CurrencyAmount<Currency> | 
 }
 
 export function useHigherUSDValue(currencyAmount: CurrencyAmount<Currency> | undefined) {
-  const gpUsdPrice = useUSDCValue(currencyAmount)
-  const coingeckoUsdPrice = useCoingeckoUsdValue(currencyAmount)
+  const { isWrapOrUnwrap } = useDetectNativeToken()
+  const checkedCurrencyAmount = isWrapOrUnwrap ? undefined : currencyAmount
+  // if iswrap or unwrap use undefined values to not run expensive calculation
+  const gpUsdPrice = useUSDCValue(checkedCurrencyAmount)
+  const coingeckoUsdPrice = useCoingeckoUsdValue(checkedCurrencyAmount)
 
   /* TODO: review this capturing - it's super noisy in sentry 
   if (!!currencyAmount) {

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -195,7 +195,7 @@ export default function Swap({
   const [recipientToggleVisible] = useRecipientToggleManager()
 
   // swap state
-  const { independentField, typedValue, recipient, INPUT, OUTPUT } = useSwapState() // MOD: adds INPUT/OUTPUT
+  const { independentField, typedValue, recipient, INPUT } = useSwapState() // MOD: adds INPUT/OUTPUT
   const {
     v2Trade, // trade: { state: tradeState, trade },
     allowedSlippage,
@@ -216,11 +216,7 @@ export default function Swap({
 
   // Checks if either currency is native ETH
   // MOD: adds this hook
-  const { isNativeIn, native, wrappedToken, ...nativeRest } = useDetectNativeToken(
-    { currency: currencies.INPUT, address: INPUT.currencyId },
-    { currency: currencies.OUTPUT, address: OUTPUT.currencyId },
-    chainId
-  )
+  const { isNativeIn, native, wrappedToken, ...nativeRest } = useDetectNativeToken()
   // Is user swapping Eth as From token and not wrapping to WETH?
   const isNativeInSwap = isNativeIn
 

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -207,7 +207,7 @@ export default function Swap({
 
   // detects trade load
   const { quote, isGettingNewQuote } = useGetQuoteAndStatus({
-    token: currencies.INPUT?.isNative ? currencies.INPUT.wrapped.address : INPUT.currencyId,
+    token: INPUT.currencyId,
     chainId,
   })
 

--- a/src/custom/state/swap/hooks.tsx
+++ b/src/custom/state/swap/hooks.tsx
@@ -468,12 +468,16 @@ export function useReplaceSwapState() {
   )
 }
 
-interface CurrencyWithAddress {
-  currency?: Currency | null
-  address?: string | null
-}
+export function useDetectNativeToken() {
+  const { chainId } = useWeb3React()
+  const {
+    [Field.INPUT]: { currencyId: inputCurrencyId },
+    [Field.OUTPUT]: { currencyId: outputCurrencyId },
+  } = useSwapState()
 
-export function useDetectNativeToken(input?: CurrencyWithAddress, output?: CurrencyWithAddress, chainId?: ChainId) {
+  const input = useCurrency(inputCurrencyId)
+  const output = useCurrency(outputCurrencyId)
+
   return useMemo(() => {
     const activeChainId = supportedChainId(chainId)
     const wrappedToken: Token & { logoURI: string } = Object.assign(
@@ -486,11 +490,8 @@ export function useDetectNativeToken(input?: CurrencyWithAddress, output?: Curre
     // TODO: check the new native currency function
     const native = ETHER.onChain(activeChainId || DEFAULT_NETWORK_FOR_LISTS)
 
-    const [isNativeIn, isNativeOut] = [!!input?.currency?.isNative, !!output?.currency?.isNative]
-    const [isWrappedIn, isWrappedOut] = [
-      !!input?.currency?.equals(wrappedToken),
-      !!output?.currency?.equals(wrappedToken),
-    ]
+    const [isNativeIn, isNativeOut] = [!!input?.isNative, !!output?.isNative]
+    const [isWrappedIn, isWrappedOut] = [!!input?.equals(wrappedToken), !!output?.equals(wrappedToken)]
 
     return {
       isNativeIn: isNativeIn && !isWrappedOut,
@@ -499,6 +500,7 @@ export function useDetectNativeToken(input?: CurrencyWithAddress, output?: Curre
       isWrappedOut,
       wrappedToken,
       native,
+      isWrapOrUnwrap: (isNativeIn && isWrappedOut) || (isNativeOut && isWrappedIn),
     }
   }, [input, output, chainId])
 }


### PR DESCRIPTION
# Summary

Closes #1061 

*High-level description of what your changes are accomplishing*

[Hotfix 1.15.1](https://github.com/cowprotocol/cowswap/pull/676) for USD price fixed quickly an issue for USD price estimation/impact being incorrect. Since switching to ETH as a "tradable" (more accurately, quoteable) token in the ETH-FLOW update (only in dev) the UI needs to be aware of ETH quotes in redux, which contains quote errors (among other things). 

The change here reverts the hotfix change which after testing was irrelevant. Actually this was noted by Anxo in a review and now fixed. **THIS HAS NOT AFFECTED PROD IN ANY WAY!!** it would only affect it now, had we merged dev. So thanks @elena-zh and @anxolin !

*Add screenshots if applicable. Images are nice :)*
Mainnet, SUB token showing proper error
![image](https://user-images.githubusercontent.com/21335563/191017960-433ee233-4a32-4432-b887-4e9edc5e2e23.png)


  # To Test
Follow steps in #1061 
1. check that impact and prices between NATIVE & WRAPPED are even
2. any network
3. use ETH <> ERC20 which returns a price
4. switch to NATIVE <> SAME_ERC20 as 3
5. USD prices for both and impact are the same
6. errors appear if token pair returns an error
7. quotes requests in network tab use WRAPPED address for coingecko (and not NATIVE symbol as was issue in hotfix 1.15.1)