### PR TITLE
Added token links on account page

### DIFF
--- a/src/custom/components/Tokens/TokensTableRow.tsx
+++ b/src/custom/components/Tokens/TokensTableRow.tsx
@@ -21,7 +21,7 @@ import { formatMax, formatSmart } from 'utils/format'
 import { useApproveCallback, ApprovalState } from 'hooks/useApproveCallback'
 import { OperationType } from 'components/TransactionConfirmationModal'
 import { useErrorModal } from 'hooks/useErrorMessageAndModal'
-import { CardsSpinner } from 'pages/Account/styled'
+import { CardsSpinner, ExtLink } from 'pages/Account/styled'
 import usePrevious from 'hooks/usePrevious'
 import { useTokenAllowance } from 'hooks/useTokenAllowance'
 import { useWeb3React } from '@web3-react/core'
@@ -30,6 +30,8 @@ import { OrderKind } from '@cowprotocol/contracts'
 import BalanceCell from './BalanceCell'
 import FiatBalanceCell from './FiatBalanceCell'
 import Loader from 'components/Loader'
+import { getBlockExplorerUrl } from 'utils'
+import { SupportedChainId as ChainId } from 'constants/chains'
 
 type DataRowParams = {
   tokenData: Token
@@ -50,7 +52,7 @@ const DataRow = ({
   openTransactionConfirmationModal,
   toggleWalletModal,
 }: DataRowParams) => {
-  const { account, chainId } = useWeb3React()
+  const { account, chainId = ChainId.MAINNET } = useWeb3React()
 
   const theme = useTheme()
 
@@ -164,22 +166,24 @@ const DataRow = ({
           <ResponsiveLogo currency={tokenData} />
         </RowFixed>
 
-        <TokenText>
-          <LargeOnly style={{ marginLeft: '10px' }}>
-            <Label>{tokenData.symbol}</Label>
-          </LargeOnly>
+        <ExtLink href={getBlockExplorerUrl(chainId, tokenData.address, 'token')}>
+          <TokenText>
+            <LargeOnly style={{ marginLeft: '10px' }}>
+              <Label>{tokenData.symbol}</Label>
+            </LargeOnly>
 
-          <HideLarge style={{ marginLeft: '10px' }}>
-            <RowFixed>
-              <Label fontWeight={400} ml="8px" color={theme.text1}>
-                {tokenData.name}
-              </Label>
-              <Label ml="8px" color={theme.primary5}>
-                ({tokenData.symbol})
-              </Label>
-            </RowFixed>
-          </HideLarge>
-        </TokenText>
+            <HideLarge style={{ marginLeft: '10px' }}>
+              <RowFixed>
+                <Label fontWeight={400} ml="8px" color={theme.text1}>
+                  {tokenData.name}
+                </Label>
+                <Label ml="8px" color={theme.primary5}>
+                  ({tokenData.symbol})
+                </Label>
+              </RowFixed>
+            </HideLarge>
+          </TokenText>
+        </ExtLink>
       </Cell>
 
       <Cell>

--- a/src/custom/components/Tokens/styled.ts
+++ b/src/custom/components/Tokens/styled.ts
@@ -212,6 +212,7 @@ export const Cell = styled.div<{ center?: boolean }>`
   display: flex;
   padding: 1rem 0;
   justify-content: ${({ center }) => (center ? 'center' : 'flex-start')};
+  align-items: center;
 
   > * {
     max-width: 100%;


### PR DESCRIPTION
# Summary

Fixes #1066

Adds links for tokens on tokens page that lead to Etherscan or Blockscout depending on the current active chain.