### PR TITLE
Uniswap as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/uniswap"]
+	path = src/uniswap
+	url = git@github.com:Uniswap/interface.git

--- a/craco.config.js
+++ b/craco.config.js
@@ -54,6 +54,7 @@ module.exports = {
     plugins,
     alias: {
       '@src': path.resolve(__dirname, 'src'),
+      '@uni_src': path.resolve(__dirname, 'src/uniswap/src'),
       'bn.js': path.resolve(__dirname, 'node_modules/bn.js/lib/bn.js'),
     },
     // https://webpack.js.org/configuration
@@ -61,7 +62,11 @@ module.exports = {
       ...webpackConfig,
       resolve: {
         ...webpackConfig.resolve,
-        modules: [path.resolve(__dirname, 'src/custom'), ...webpackConfig.resolve.modules],
+        modules: [
+          path.resolve(__dirname, 'src/custom'),
+          ...webpackConfig.resolve.modules,
+          path.resolve(__dirname, 'src/uniswap/src'),
+        ],
       },
     }),
   },

--- a/src/custom/lib/hooks/routing/clientSideSmartOrderRouter/clientSideSmartOrderRouterMod.ts
+++ b/src/custom/lib/hooks/routing/clientSideSmartOrderRouter/clientSideSmartOrderRouterMod.ts
@@ -10,3 +10,5 @@ export function isSupportedChainId(chainId: ChainId | undefined): boolean {
   if (chainId === undefined) return false
   return toSupportedChainId(chainId) !== undefined
 }
+
+export { getClientSideQuote } from '@src/lib/hooks/routing/clientSideSmartOrderRouter'

--- a/src/custom/tsconfig-paths-custom.json
+++ b/src/custom/tsconfig-paths-custom.json
@@ -1,17 +1,9 @@
 {
   "compilerOptions": {
     "paths": {
-      "@src/*": [
-        "*"
-      ],
-      "@uni_src/*": [
-        "src/uniswap/src"
-      ],
-      "*": [
-        "custom/*",
-        "*",
-        "src/uniswap/src"
-      ]
+      "@src/*": ["*"],
+      "@uni_src/*": ["src/uniswap/src"],
+      "*": ["custom/*", "*", "src/uniswap/src"]
     }
   }
 }

--- a/src/custom/tsconfig-paths-custom.json
+++ b/src/custom/tsconfig-paths-custom.json
@@ -1,8 +1,17 @@
 {
   "compilerOptions": {
     "paths": {
-      "@src/*": ["*"],
-      "*": ["custom/*", "*"]
+      "@src/*": [
+        "*"
+      ],
+      "@uni_src/*": [
+        "src/uniswap/src"
+      ],
+      "*": [
+        "custom/*",
+        "*",
+        "src/uniswap/src"
+      ]
     }
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,11 @@
   "extends": "./src/custom/tsconfig-paths-custom.json",
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
@@ -22,7 +26,15 @@
     "isolatedModules": true,
     "downlevelIteration": true,
     "allowSyntheticDefaultImports": true,
-    "types": ["react-spring", "jest"]
+    "types": [
+      "react-spring",
+      "jest"
+    ]
   },
-  "exclude": ["node_modules", "cypress"]
+  "exclude": [
+    "node_modules",
+    "cypress",
+    "src/uniswap/cypress.config.ts",
+    "src/uniswap/cypress"
+  ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,11 +2,7 @@
   "extends": "./src/custom/tsconfig-paths-custom.json",
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
@@ -26,15 +22,7 @@
     "isolatedModules": true,
     "downlevelIteration": true,
     "allowSyntheticDefaultImports": true,
-    "types": [
-      "react-spring",
-      "jest"
-    ]
+    "types": ["react-spring", "jest"]
   },
-  "exclude": [
-    "node_modules",
-    "cypress",
-    "src/uniswap/cypress.config.ts",
-    "src/uniswap/cypress"
-  ]
+  "exclude": ["node_modules", "cypress", "src/uniswap/cypress.config.ts", "src/uniswap/cypress"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,9 @@
     "src/page/App.tsx",
     "src/state/routing/slice.ts",
     "src/hooks/useBestTrade.ts",
-    "src/state/routing/useRoutingAPITrade.ts"
+    "src/state/routing/useRoutingAPITrade.ts",
+    "src/uniswap/cypress.config.ts",
+    "src/uniswap/cypress"
   ],
   "include": [
     "src/**/*"


### PR DESCRIPTION
# Summary

Attempt to include uniswap as a GIT submodule, so we can resolve all components and use the code but keep all of them outside of our project. 

If this works, we can eliminate most of Uniswap code (only leaving the overrides)

The idea is:
- Add Uniswap as a submodule in `src/uniswap`. See https://github.com/cowprotocol/cowswap/pull/1078/files#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R1
- Make sure we resolve Uniswap compoenents (with less prio than our own components, or the Mods). See https://github.com/cowprotocol/cowswap/pull/1078/files#diff-9531c01f38fb3a33c0a25db522822e353b143e69b9d43246d8e32bcb66662bfdR68

😢 However, im not having luck with this approach either. It seems harder to maintain than our previous one!