### PR TITLE
Add goerli ens subgraph support

### DIFF
--- a/src/custom/pages/Account/ens/index.ts
+++ b/src/custom/pages/Account/ens/index.ts
@@ -4,6 +4,7 @@ import { EnsNamesQuery } from 'pages/Account/ens/types'
 
 const CHAIN_SUBGRAPH_URL: Record<number, string> = {
   [SupportedChainId.MAINNET]: 'https://api.thegraph.com/subgraphs/name/ensdomains/ens',
+  [SupportedChainId.GOERLI]: 'https://api.thegraph.com/subgraphs/name/ensdomains/ensgoerli',
   [SupportedChainId.RINKEBY]: 'https://api.thegraph.com/subgraphs/name/ensdomains/ensrinkeby',
 }
 


### PR DESCRIPTION
# Summary

This PR adds the ENS subgraph for Görli to support fetching all ENS names a given address could have.

<img width="1024" alt="image" src="https://user-images.githubusercontent.com/3328006/191770646-e169b4d9-61d5-4b15-9115-4e2fefc9094b.png">

  # To Test

1. Register a ENS for Görli in https://app.ens.domains/
2. Visit https://pr1091--cowswap.review.gnosisdev.com/#/account?chain=goerli
3. Check the ENS name is added to the dropdown in `Your referral url` section

