### PR TITLE
Override swap state uni-files using src/custom

### DIFF
--- a/src/cow-react/swap/hooks/useSetupSwapState.test.tsx
+++ b/src/cow-react/swap/hooks/useSetupSwapState.test.tsx
@@ -52,7 +52,7 @@ describe('useSetupSwapState() - hook to setup a swap state considering URL and l
     await waitFor(() => {
       expect(result.current).toEqual({
         INPUT: {
-          currencyId: 'ETH',
+          currencyId: null,
         },
         OUTPUT: {
           currencyId: null,

--- a/src/custom/state/swap/actions.ts
+++ b/src/custom/state/swap/actions.ts
@@ -1,0 +1,22 @@
+import { createAction } from '@reduxjs/toolkit'
+
+export enum Field {
+  INPUT = 'INPUT',
+  OUTPUT = 'OUTPUT',
+}
+
+// Mod: interface for replaceSwapState() action. Added chainId parameter, field renamed to independentField
+export interface ReplaceSwapStatePayload {
+  chainId: number | null
+  independentField: Field
+  typedValue: string
+  inputCurrencyId?: string
+  outputCurrencyId?: string
+  recipient: string | null
+}
+
+export const selectCurrency = createAction<{ field: Field; currencyId: string }>('swap/selectCurrency')
+export const switchCurrencies = createAction<void>('swap/switchCurrencies')
+export const typeInput = createAction<{ field: Field; typedValue: string }>('swap/typeInput')
+export const replaceSwapState = createAction<ReplaceSwapStatePayload>('swap/replaceSwapState')
+export const setRecipient = createAction<{ recipient: string | null }>('swap/setRecipient')

--- a/src/custom/state/swap/hooks.tsx
+++ b/src/custom/state/swap/hooks.tsx
@@ -6,7 +6,7 @@ import { useWeb3React } from '@web3-react/core'
 import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
 import { ParsedQs } from 'qs'
 import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
-import { useAppDispatch /* , useAppSelector */ } from 'state/hooks'
+import { useAppDispatch, useAppSelector } from 'state/hooks'
 // import { InterfaceTrade, TradeState } from 'state/routing/types'
 import { useIsExpertMode, useUserSlippageToleranceWithDefault } from 'state/user/hooks'
 
@@ -22,7 +22,7 @@ import { SwapState } from 'state/swap/reducer'
 import { currencySelectAnalytics, changeSwapAmountAnalytics, switchTokensAnalytics } from 'utils/analytics'
 
 // MOD
-import { useSwapState, BAD_RECIPIENT_ADDRESSES } from '@src/state/swap/hooks'
+import { BAD_RECIPIENT_ADDRESSES } from '@src/state/swap/hooks'
 import { useGetQuoteAndStatus, useQuote } from '../price/hooks'
 import { registerOnWindow } from 'utils/misc'
 import { useTradeExactInWithFee, useTradeExactOutWithFee, stringToCurrency } from './extension'
@@ -43,12 +43,13 @@ import {
 } from '@src/state/swap/hooks'
 import { PriceImpact } from 'hooks/usePriceImpact'
 import { supportedChainId } from 'utils/supportedChainId'
+import { AppState } from 'state'
 
 export * from '@src/state/swap/hooks'
 
-/* export function useSwapState(): AppState['swap'] {
+export function useSwapState(): AppState['swap'] {
   return useAppSelector((state) => state.swap)
-} */
+}
 
 export type Currencies = { [field in Field]?: Currency | null }
 

--- a/src/custom/state/swap/reducer.ts
+++ b/src/custom/state/swap/reducer.ts
@@ -1,10 +1,12 @@
 import { createReducer } from '@reduxjs/toolkit'
 import { parsedQueryString } from 'hooks/useParsedQueryString'
 
-import { Field, replaceSwapState, selectCurrency, setRecipient, switchCurrencies, typeInput } from './actions'
-import { queryParametersToSwapState } from './hooks'
+import { Field, replaceSwapState, selectCurrency, setRecipient, switchCurrencies, typeInput } from 'state/swap/actions'
+import { queryParametersToSwapState } from 'state/swap/hooks'
 
 export interface SwapState {
+  // Mod: added chainId
+  chainId: number | null
   readonly independentField: Field
   readonly typedValue: string
   readonly [Field.INPUT]: {
@@ -17,26 +19,27 @@ export interface SwapState {
   readonly recipient: string | null
 }
 
-const initialState: SwapState = queryParametersToSwapState(parsedQueryString())
+// Mod: added second parameter
+const initialState: SwapState = queryParametersToSwapState(parsedQueryString(), '', null)
 
 export default createReducer<SwapState>(initialState, (builder) =>
   builder
-    .addCase(
-      replaceSwapState,
-      (state, { payload: { typedValue, recipient, field, inputCurrencyId, outputCurrencyId } }) => {
-        return {
-          [Field.INPUT]: {
-            currencyId: inputCurrencyId ?? null,
-          },
-          [Field.OUTPUT]: {
-            currencyId: outputCurrencyId ?? null,
-          },
-          independentField: field,
-          typedValue,
-          recipient,
-        }
+    // Mod: ranamed field => independentField, added chainId
+    .addCase(replaceSwapState, (state, { payload }) => {
+      const { chainId, typedValue, recipient, independentField, inputCurrencyId, outputCurrencyId } = payload
+      return {
+        chainId,
+        [Field.INPUT]: {
+          currencyId: inputCurrencyId ?? null,
+        },
+        [Field.OUTPUT]: {
+          currencyId: outputCurrencyId ?? null,
+        },
+        independentField,
+        typedValue,
+        recipient,
       }
-    )
+    })
     .addCase(selectCurrency, (state, { payload: { currencyId, field } }) => {
       const otherField = field === Field.INPUT ? Field.OUTPUT : Field.INPUT
       if (currencyId === state[otherField].currencyId) {

--- a/src/state/swap/actions.ts
+++ b/src/state/swap/actions.ts
@@ -5,18 +5,14 @@ export enum Field {
   OUTPUT = 'OUTPUT',
 }
 
-// Mod: interface for replaceSwapState() action. Added chainId parameter, field renamed to independentField
-export interface ReplaceSwapStatePayload {
-  chainId: number | null
-  independentField: Field
+export const selectCurrency = createAction<{ field: Field; currencyId: string }>('swap/selectCurrency')
+export const switchCurrencies = createAction<void>('swap/switchCurrencies')
+export const typeInput = createAction<{ field: Field; typedValue: string }>('swap/typeInput')
+export const replaceSwapState = createAction<{
+  field: Field
   typedValue: string
   inputCurrencyId?: string
   outputCurrencyId?: string
   recipient: string | null
-}
-
-export const selectCurrency = createAction<{ field: Field; currencyId: string }>('swap/selectCurrency')
-export const switchCurrencies = createAction<void>('swap/switchCurrencies')
-export const typeInput = createAction<{ field: Field; typedValue: string }>('swap/typeInput')
-export const replaceSwapState = createAction<ReplaceSwapStatePayload>('swap/replaceSwapState')
+}>('swap/replaceSwapState')
 export const setRecipient = createAction<{ recipient: string | null }>('swap/setRecipient')

--- a/src/state/swap/hooks.tsx
+++ b/src/state/swap/hooks.tsx
@@ -219,8 +219,7 @@ export function validatedRecipient(recipient: any): string | null {
   return null
 }
 
-// Mod: added chainId parameter
-export function queryParametersToSwapState(parsedQs: ParsedQs, chainId: number | null): SwapState {
+export function queryParametersToSwapState(parsedQs: ParsedQs): SwapState {
   let inputCurrency = parseCurrencyFromURLParameter(parsedQs.inputCurrency)
   let outputCurrency = parseCurrencyFromURLParameter(parsedQs.outputCurrency)
   const typedValue = parseTokenAmountURLParameter(parsedQs.exactAmount)
@@ -237,8 +236,6 @@ export function queryParametersToSwapState(parsedQs: ParsedQs, chainId: number |
   const recipient = validatedRecipient(parsedQs.recipient)
 
   return {
-    // Mod: added chainId parameter
-    chainId,
     [Field.INPUT]: {
       currencyId: inputCurrency === '' ? null : inputCurrency ?? null,
     },
@@ -258,9 +255,8 @@ export function useDefaultsFromURLSearch(): SwapState {
   const parsedQs = useParsedQueryString()
 
   const parsedSwapState = useMemo(() => {
-    // Mod: added chainId parameter
-    return queryParametersToSwapState(parsedQs, chainId || 1)
-  }, [chainId, parsedQs])
+    return queryParametersToSwapState(parsedQs)
+  }, [parsedQs])
 
   useEffect(() => {
     if (!chainId) return
@@ -269,11 +265,8 @@ export function useDefaultsFromURLSearch(): SwapState {
 
     dispatch(
       replaceSwapState({
-        // Mod: added chainId parameter
-        chainId,
         typedValue: parsedSwapState.typedValue,
-        // Mod: field renamed to independentField
-        independentField: parsedSwapState.independentField,
+        field: parsedSwapState.independentField,
         inputCurrencyId,
         outputCurrencyId,
         recipient: parsedSwapState.recipient,


### PR DESCRIPTION
# Summary
On https://github.com/cowprotocol/cowswap/pull/1040 the swap page was refactored.

These files were changed by wrong way: 
`src/state/swap/actions.ts`. 
`src/state/swap/hooks.tsx`. 
`src/state/swap/reducer.ts`. 

In this PR the files were reverted and overrided by `src/custom`