### PR TITLE
[Limit orders 2] Set recipient to limit orders store from URL and user input

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/styled.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/styled.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components/macro'
 import { MEDIA_WIDTHS } from 'theme'
 import { Settings } from 'react-feather'
+import { RemoveRecipient } from 'cow-react/modules/swap/containers/RemoveRecipient'
 
 export const Container = styled.div`
   max-width: 460px;
@@ -62,4 +63,8 @@ export const SettingsIcon = styled(Settings)`
   > * {
     stroke: ${({ theme }) => theme.text1};
   }
+`
+
+export const StyledRemoveRecipient = styled(RemoveRecipient)`
+  margin: 15px 0;
 `

--- a/src/cow-react/modules/limitOrders/hooks/useSetupLimitOrdersState.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useSetupLimitOrdersState.ts
@@ -1,23 +1,20 @@
 import { useLimitOrdersStateFromUrl } from 'cow-react/modules/limitOrders/hooks/useLimitOrdersStateFromUrl'
-import { useAtom } from 'jotai'
 import {
   getDefaultLimitOrdersState,
-  limitOrdersAtom,
   LimitOrdersState,
+  useLimitOrdersStateManager,
 } from 'cow-react/modules/limitOrders/state/limitOrdersAtom'
-import { useHistory } from 'react-router-dom'
-import { parameterizeLimitOrdersRoute } from 'cow-react/modules/limitOrders/hooks/useParameterizeLimitOrdersRoute'
 import { useEffect } from 'react'
 
 export function useSetupLimitOrdersState() {
-  const history = useHistory()
   const tradeStateFromUrl = useLimitOrdersStateFromUrl()
-  const [state, setState] = useAtom(limitOrdersAtom)
+  const { state, setState, navigate } = useLimitOrdersStateManager()
 
   const chainIdWasChanged = tradeStateFromUrl.chainId !== state.chainId
 
   const shouldSkipUpdate =
     !chainIdWasChanged &&
+    (!tradeStateFromUrl.recipient || tradeStateFromUrl.recipient === state.recipient) &&
     tradeStateFromUrl.inputCurrencyId?.toLowerCase() === state.inputCurrencyId?.toLowerCase() &&
     tradeStateFromUrl.outputCurrencyId?.toLowerCase() === state.outputCurrencyId?.toLowerCase()
 
@@ -29,6 +26,7 @@ export function useSetupLimitOrdersState() {
       : {
           ...state,
           chainId: tradeStateFromUrl.chainId,
+          recipient: tradeStateFromUrl.recipient || state.recipient,
           inputCurrencyId: tradeStateFromUrl.inputCurrencyId || state.inputCurrencyId,
           outputCurrencyId: tradeStateFromUrl.outputCurrencyId || state.outputCurrencyId,
         }
@@ -36,7 +34,7 @@ export function useSetupLimitOrdersState() {
     console.log('UPDATE LIMIT ORDERS STATE:', newState)
     setState(newState)
     setTimeout(() => {
-      history.push(parameterizeLimitOrdersRoute(newState.chainId, newState.inputCurrencyId, newState.outputCurrencyId))
+      navigate(newState.chainId, newState.inputCurrencyId, newState.outputCurrencyId)
     }, 0)
-  }, [history, setState, state, tradeStateFromUrl, shouldSkipUpdate, chainIdWasChanged])
+  }, [navigate, setState, state, tradeStateFromUrl, shouldSkipUpdate, chainIdWasChanged])
 }

--- a/src/cow-react/modules/limitOrders/state/limitOrdersAtom.ts
+++ b/src/cow-react/modules/limitOrders/state/limitOrdersAtom.ts
@@ -1,6 +1,10 @@
 import { atomWithStorage } from 'jotai/utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { WRAPPED_NATIVE_CURRENCY as WETH } from 'constants/tokens'
+import { useAtom } from 'jotai'
+import { useMemo } from 'react'
+import { parameterizeLimitOrdersRoute } from '@src/cow-react/modules/limitOrders/hooks/useParameterizeLimitOrdersRoute'
+import { useHistory } from 'react-router-dom'
 
 export interface LimitOrdersState {
   readonly chainId: number | null
@@ -9,6 +13,19 @@ export interface LimitOrdersState {
   readonly inputCurrencyAmount: string | null
   readonly outputCurrencyAmount: string | null
   readonly recipient: string | null
+}
+
+export interface LimitOrdersStateManager {
+  state: LimitOrdersState
+  setState(state: LimitOrdersState): void
+  setInputCurrencyAmount(inputCurrencyAmount: string | null): void
+  setOutputCurrencyAmount(outputCurrencyAmount: string | null): void
+  setRecipient(recipient: string | null): void
+  navigate(
+    chainId: SupportedChainId | null | undefined,
+    outputCurrencyId: string | null,
+    inputCurrencyId: string | null
+  ): void
 }
 
 export function getDefaultLimitOrdersState(chainId: SupportedChainId | null): LimitOrdersState {
@@ -23,3 +40,35 @@ export function getDefaultLimitOrdersState(chainId: SupportedChainId | null): Li
 }
 
 export const limitOrdersAtom = atomWithStorage<LimitOrdersState>('limit-orders-atom', getDefaultLimitOrdersState(null))
+
+export const useLimitOrdersStateManager = (): LimitOrdersStateManager => {
+  const history = useHistory()
+  const [state, setState] = useAtom(limitOrdersAtom)
+
+  return useMemo(() => {
+    return {
+      state,
+      setState(state: LimitOrdersState) {
+        setState(state)
+      },
+      setInputCurrencyAmount(inputCurrencyAmount: string | null) {
+        setState({ ...state, inputCurrencyAmount })
+      },
+      setOutputCurrencyAmount(outputCurrencyAmount: string | null) {
+        setState({ ...state, outputCurrencyAmount })
+      },
+      setRecipient(recipient: string | null) {
+        setState({ ...state, recipient })
+      },
+      navigate(
+        chainId: SupportedChainId | null | undefined,
+        outputCurrencyId: string | null,
+        inputCurrencyId: string | null
+      ) {
+        const route = parameterizeLimitOrdersRoute(chainId, outputCurrencyId, inputCurrencyId)
+
+        history.push(route)
+      },
+    }
+  }, [history, state, setState])
+}


### PR DESCRIPTION
# Summary
Set recipient to limit orders store from URL and user input.
Cases:
 - input a recipient in the URL: http://localhost:3000/#/1/limit-orders/WETH/WBTC?recipient=0xabc
 - click to `+ Add a recipient (optional)` and input recipient from keyboard

# To Test
Nothing to test
