### PR TITLE
Improve blocknative sdk error reporting

### DIFF
--- a/src/custom/utils/blocknative.ts
+++ b/src/custom/utils/blocknative.ts
@@ -31,12 +31,13 @@ export const sdk = !BLOCKNATIVE_API_KEY
           dappId: BLOCKNATIVE_API_KEY,
           networkId,
           name: 'bnc_' + networkId,
-          onerror: (error: SDKError) => {
-            console.log('[blocknative]', error)
-            const { sentryError, tags } = constructSentryError(error, { message: 'Blocknative SDK error' })
+          onerror: (sdkError: SDKError) => {
+            console.log('[blocknative]', sdkError)
+            const { sentryError, tags } = constructSentryError(sdkError.error, { message: sdkError.message })
             Sentry.captureException(sentryError, {
               tags,
               contexts: { params },
+              extra: { ...sdkError },
             })
           },
         })


### PR DESCRIPTION
# Summary

Currently we have limitations on the Blocknative SDK usage for users who are in countries affected by OFAC sanctions (such as Belarus or Russia), which cause errors during the connection to the Blocknative API. These errors are mainly websocket connection errors and they were logged not in the best way to Sentry, this PR improves that logging a bit and allow searching/filtering the logs by the error message.

Before:
<img width="374" alt="image" src="https://user-images.githubusercontent.com/3328006/192877954-3ca5d40e-6af3-4100-afca-a217f9a63e51.png">

After:
<img width="462" alt="image" src="https://user-images.githubusercontent.com/3328006/192878061-573005a3-d022-4812-945f-38bfdb2d696b.png">


# To Test

This PR doesn't introduce anything new, just improves logging in Sentry.
