### PR TITLE
[Limit orders] store and widget

### DIFF
--- a/cypress-custom/integration/swap.test.ts
+++ b/cypress-custom/integration/swap.test.ts
@@ -40,7 +40,7 @@ describe('Swap (custom)', () => {
     // cy.get('.token-item-0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735').click({ force: true })
     // input amounts
     cy.get('#swap-currency-input .token-amount-input').should('be.visible')
-    cy.get('#swap-currency-input .token-amount-input').type('0.0007', { force: true, delay: 400 })
+    cy.get('#swap-currency-input .token-amount-input').type('0.05', { force: true, delay: 400 })
     cy.get('#swap-currency-output .token-amount-input').should('not.equal', '')
     cy.get('#swap-button').should('contain', 'Swap with WETH')
   })

--- a/src/cow-react/common/hooks/useAllTokensList.ts
+++ b/src/cow-react/common/hooks/useAllTokensList.ts
@@ -1,0 +1,9 @@
+import { Token } from '@uniswap/sdk-core'
+import { useMemo } from 'react'
+import { useAllTokens } from 'hooks/Tokens'
+
+export function useAllTokensList(): Token[] {
+  const allTokens = useAllTokens()
+
+  return useMemo(() => Object.values(allTokens), [allTokens])
+}

--- a/src/cow-react/common/hooks/useParameterizedMainMenu.ts
+++ b/src/cow-react/common/hooks/useParameterizedMainMenu.ts
@@ -1,0 +1,20 @@
+import { BasicMenuLink, isBasicMenuLink, MAIN_MENU, MenuTreeItem } from 'constants/mainMenu'
+import { useParameterizeLimitOrdersRoute } from 'cow-react/modules/limitOrders/hooks/useParameterizeLimitOrdersRoute'
+import { Routes } from 'constants/routes'
+import { useMemo } from 'react'
+
+export function useParameterizedMainMenu(): MenuTreeItem[] {
+  const limitOrdersRouteWithParams = useParameterizeLimitOrdersRoute()
+
+  return useMemo(() => {
+    const copy: MenuTreeItem[] = JSON.parse(JSON.stringify(MAIN_MENU))
+
+    const limitOrdersRoute = copy.filter<BasicMenuLink>(isBasicMenuLink).find((item) => item.url === Routes.LIMIT_ORDER)
+
+    if (limitOrdersRoute) {
+      limitOrdersRoute.url = limitOrdersRouteWithParams
+    }
+
+    return copy
+  }, [limitOrdersRouteWithParams])
+}

--- a/src/cow-react/common/hooks/useTokenBySymbolOrAddress.ts
+++ b/src/cow-react/common/hooks/useTokenBySymbolOrAddress.ts
@@ -1,9 +1,9 @@
-import { useAllTokens } from 'hooks/Tokens'
 import { Token } from '@uniswap/sdk-core'
 import { useMemo } from 'react'
+import { useAllTokensList } from 'cow-react/common/hooks/useAllTokensList'
 
 export function useTokenBySymbolOrAddress(symbolOrAddress?: string | null): Token | null {
-  const tokens = useAllTokens()
+  const tokens = useAllTokensList()
 
   return useMemo(() => {
     if (!symbolOrAddress) {
@@ -11,8 +11,8 @@ export function useTokenBySymbolOrAddress(symbolOrAddress?: string | null): Toke
     }
 
     return (
-      Object.values(tokens).find(
-        (item) => item.address.toLowerCase() === symbolOrAddress || item.symbol === symbolOrAddress
+      tokens.find(
+        (item) => item.address.toLowerCase() === symbolOrAddress.toLowerCase() || item.symbol === symbolOrAddress
       ) || null
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/cow-react/common/hooks/useTokenBySymbolOrAddress.ts
+++ b/src/cow-react/common/hooks/useTokenBySymbolOrAddress.ts
@@ -1,0 +1,20 @@
+import { useAllTokens } from 'hooks/Tokens'
+import { Token } from '@uniswap/sdk-core'
+import { useMemo } from 'react'
+
+export function useTokenBySymbolOrAddress(symbolOrAddress?: string | null): Token | null {
+  const tokens = useAllTokens()
+
+  return useMemo(() => {
+    if (!symbolOrAddress) {
+      return null
+    }
+
+    return (
+      Object.values(tokens).find(
+        (item) => item.address.toLowerCase() === symbolOrAddress || item.symbol === symbolOrAddress
+      ) || null
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tokens, symbolOrAddress])
+}

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -1,17 +1,31 @@
 import * as styledEl from './styled'
+import { useHistory } from 'react-router-dom'
 import { CurrencyInputPanel } from 'cow-react/common/pure/CurrencyInputPanel'
 import { CurrencyArrowSeparator } from 'cow-react/common/pure/CurrencyArrowSeparator'
 import { AddRecipient } from 'cow-react/common/pure/AddRecipient'
 import { ButtonPrimary } from 'components/Button'
 import { Trans } from '@lingui/macro'
-import React from 'react'
+import React, { useCallback } from 'react'
 import { BalanceAndSubsidy } from 'hooks/useCowBalanceAndSubsidy'
 import { CurrencyInfo } from 'cow-react/common/pure/CurrencyInputPanel/typings'
 import { Field } from 'state/swap/actions'
-import { GNO, USDC } from 'constants/tokens'
 import { ButtonSize } from 'theme'
+import { useLimitOrdersTradeState } from 'cow-react/modules/limitOrders/hooks/useLimitOrdersTradeState'
+import { Currency } from '@uniswap/sdk-core'
+import { parameterizeLimitOrdersRoute } from 'cow-react/modules/limitOrders/hooks/useParameterizeLimitOrdersRoute'
+import { useWeb3React } from '@web3-react/core'
+import { useSetupLimitOrdersState } from 'cow-react/modules/limitOrders/hooks/useSetupLimitOrdersState'
+import { useAtom } from 'jotai'
+import { limitOrdersAtom } from 'cow-react/modules/limitOrders/state/limitOrdersAtom'
 
 export function LimitOrdersWidget() {
+  useSetupLimitOrdersState()
+
+  const { chainId } = useWeb3React()
+  const { inputCurrency, outputCurrency, inputCurrencyAmount, outputCurrencyAmount } = useLimitOrdersTradeState()
+  const history = useHistory()
+  const [state, setState] = useAtom(limitOrdersAtom)
+
   const currenciesLoadingInProgress = false
   const allowsOffchainSigning = false
   const isTradePriceUpdating = false
@@ -26,35 +40,53 @@ export function LimitOrdersWidget() {
   }
   const inputCurrencyInfo: CurrencyInfo = {
     field: Field.INPUT,
-    currency: USDC[1],
-    rawAmount: null,
-    viewAmount: '1',
+    currency: inputCurrency,
+    rawAmount: inputCurrencyAmount,
+    viewAmount: inputCurrencyAmount?.toExact() || '',
     balance: null,
     fiatAmount: null,
     receiveAmountInfo: null,
   }
   const outputCurrencyInfo: CurrencyInfo = {
-    field: Field.INPUT,
-    currency: GNO[1],
-    rawAmount: null,
-    viewAmount: '2',
+    field: Field.OUTPUT,
+    currency: outputCurrency,
+    rawAmount: outputCurrencyAmount,
+    viewAmount: outputCurrencyAmount?.toExact() || '',
     balance: null,
     fiatAmount: null,
     receiveAmountInfo: null,
   }
-  const onCurrencySelection = () => {
-    //
-  }
-  const onUserInput = () => {
-    //
-  }
+  const onCurrencySelection = useCallback(
+    (field: Field, currency: Currency) => {
+      const inputCurrencyId = (field === Field.INPUT ? currency.symbol : inputCurrency?.symbol) || ''
+      const outputCurrencyId = (field === Field.OUTPUT ? currency.symbol : outputCurrency?.symbol) || ''
+      const route = parameterizeLimitOrdersRoute(chainId, inputCurrencyId, outputCurrencyId)
+
+      history.push(route)
+    },
+    [history, chainId, inputCurrency, outputCurrency]
+  )
+  const onUserInput = useCallback(
+    (field: Field, typedValue: string) => {
+      const inputCurrencyAmount = field === Field.INPUT ? typedValue : state.inputCurrencyAmount
+      const outputCurrencyAmount = field === Field.OUTPUT ? typedValue : state.outputCurrencyAmount
+
+      setState({ ...state, inputCurrencyAmount, outputCurrencyAmount })
+    },
+    [setState, state]
+  )
+
+  const onSwitchTokens = useCallback(() => {
+    const route = parameterizeLimitOrdersRoute(chainId, state.outputCurrencyId, state.inputCurrencyId)
+
+    history.push(route)
+  }, [history, state, chainId])
+
   const onChangeRecipient = () => {
     //
   }
 
-  const onSwitchTokens = () => {
-    //
-  }
+  console.log('RENDER LIMIT ORDERS WIDGET', { inputCurrencyInfo, outputCurrencyInfo })
 
   return (
     <styledEl.Container>

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -12,10 +12,11 @@ import { ButtonSize } from 'theme'
 import { useLimitOrdersTradeState } from 'cow-react/modules/limitOrders/hooks/useLimitOrdersTradeState'
 import { useWeb3React } from '@web3-react/core'
 import { useSetupLimitOrdersState } from 'cow-react/modules/limitOrders/hooks/useSetupLimitOrdersState'
-import { useLimitOrdersStateManager } from 'cow-react/modules/limitOrders/state/limitOrdersAtom'
+import { limitOrdersAtom, updateLimitOrdersAtom } from 'cow-react/modules/limitOrders/state/limitOrdersAtom'
 import { useOnCurrencySelection } from 'cow-react/modules/limitOrders/hooks/useOnCurrencySelection'
 import { useResetStateWithSymbolDuplication } from 'cow-react/modules/limitOrders/hooks/useResetStateWithSymbolDuplication'
 import { useLimitOrdersNavigate } from 'cow-react/modules/limitOrders/hooks/useLimitOrdersNavigate'
+import { useAtomValue, useUpdateAtom } from 'jotai/utils'
 
 // TODO: move the widget to Swap module
 export function LimitOrdersWidget() {
@@ -25,7 +26,8 @@ export function LimitOrdersWidget() {
   const { chainId } = useWeb3React()
   const { inputCurrency, outputCurrency, inputCurrencyAmount, outputCurrencyAmount, recipient } =
     useLimitOrdersTradeState()
-  const stateManager = useLimitOrdersStateManager()
+  const state = useAtomValue(limitOrdersAtom)
+  const updateLimitOrdersState = useUpdateAtom(updateLimitOrdersAtom)
   const onCurrencySelection = useOnCurrencySelection()
   const limitOrdersNavigate = useLimitOrdersNavigate()
 
@@ -62,24 +64,24 @@ export function LimitOrdersWidget() {
   const onUserInput = useCallback(
     (field: Field, typedValue: string) => {
       if (field === Field.INPUT) {
-        stateManager.setInputCurrencyAmount(typedValue)
+        updateLimitOrdersState({ inputCurrencyId: typedValue })
       } else {
-        stateManager.setOutputCurrencyAmount(typedValue)
+        updateLimitOrdersState({ outputCurrencyId: typedValue })
       }
     },
-    [stateManager]
+    [updateLimitOrdersState]
   )
 
   const onSwitchTokens = useCallback(() => {
-    const { inputCurrencyId, outputCurrencyId } = stateManager.state
+    const { inputCurrencyId, outputCurrencyId } = state
     limitOrdersNavigate(chainId, outputCurrencyId, inputCurrencyId)
-  }, [limitOrdersNavigate, stateManager, chainId])
+  }, [limitOrdersNavigate, state, chainId])
 
   const onChangeRecipient = useCallback(
     (recipient: string | null) => {
-      stateManager.setRecipient(recipient)
+      updateLimitOrdersState({ recipient })
     },
-    [stateManager]
+    [updateLimitOrdersState]
   )
 
   console.log('RENDER LIMIT ORDERS WIDGET', { inputCurrencyInfo, outputCurrencyInfo })

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -15,6 +15,7 @@ import { useSetupLimitOrdersState } from 'cow-react/modules/limitOrders/hooks/us
 import { useLimitOrdersStateManager } from 'cow-react/modules/limitOrders/state/limitOrdersAtom'
 import { useOnCurrencySelection } from 'cow-react/modules/limitOrders/hooks/useOnCurrencySelection'
 import { useResetStateWithSymbolDuplication } from 'cow-react/modules/limitOrders/hooks/useResetStateWithSymbolDuplication'
+import { useLimitOrdersNavigate } from 'cow-react/modules/limitOrders/hooks/useLimitOrdersNavigate'
 
 // TODO: move the widget to Swap module
 export function LimitOrdersWidget() {
@@ -26,6 +27,7 @@ export function LimitOrdersWidget() {
     useLimitOrdersTradeState()
   const stateManager = useLimitOrdersStateManager()
   const onCurrencySelection = useOnCurrencySelection()
+  const limitOrdersNavigate = useLimitOrdersNavigate()
 
   const currenciesLoadingInProgress = false
   const allowsOffchainSigning = false
@@ -70,8 +72,8 @@ export function LimitOrdersWidget() {
 
   const onSwitchTokens = useCallback(() => {
     const { inputCurrencyId, outputCurrencyId } = stateManager.state
-    stateManager.navigate(chainId, outputCurrencyId, inputCurrencyId)
-  }, [stateManager, chainId])
+    limitOrdersNavigate(chainId, outputCurrencyId, inputCurrencyId)
+  }, [limitOrdersNavigate, stateManager, chainId])
 
   const onChangeRecipient = useCallback(
     (recipient: string | null) => {

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -16,6 +16,7 @@ import { useLimitOrdersStateManager } from 'cow-react/modules/limitOrders/state/
 import { useOnCurrencySelection } from 'cow-react/modules/limitOrders/hooks/useOnCurrencySelection'
 import { useResetStateWithSymbolDuplication } from 'cow-react/modules/limitOrders/hooks/useResetStateWithSymbolDuplication'
 
+// TODO: move the widget to Swap module
 export function LimitOrdersWidget() {
   useSetupLimitOrdersState()
   useResetStateWithSymbolDuplication()

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -10,18 +10,21 @@ import { CurrencyInfo } from 'cow-react/common/pure/CurrencyInputPanel/typings'
 import { Field } from 'state/swap/actions'
 import { ButtonSize } from 'theme'
 import { useLimitOrdersTradeState } from 'cow-react/modules/limitOrders/hooks/useLimitOrdersTradeState'
-import { Currency } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
 import { useSetupLimitOrdersState } from 'cow-react/modules/limitOrders/hooks/useSetupLimitOrdersState'
 import { useLimitOrdersStateManager } from 'cow-react/modules/limitOrders/state/limitOrdersAtom'
+import { useOnCurrencySelection } from 'cow-react/modules/limitOrders/hooks/useOnCurrencySelection'
+import { useResetStateWithSymbolDuplication } from 'cow-react/modules/limitOrders/hooks/useResetStateWithSymbolDuplication'
 
 export function LimitOrdersWidget() {
   useSetupLimitOrdersState()
+  useResetStateWithSymbolDuplication()
 
   const { chainId } = useWeb3React()
   const { inputCurrency, outputCurrency, inputCurrencyAmount, outputCurrencyAmount, recipient } =
     useLimitOrdersTradeState()
   const stateManager = useLimitOrdersStateManager()
+  const onCurrencySelection = useOnCurrencySelection()
 
   const currenciesLoadingInProgress = false
   const allowsOffchainSigning = false
@@ -53,15 +56,6 @@ export function LimitOrdersWidget() {
     fiatAmount: null,
     receiveAmountInfo: null,
   }
-  const onCurrencySelection = useCallback(
-    (field: Field, currency: Currency) => {
-      const inputCurrencyId = (field === Field.INPUT ? currency.symbol : inputCurrency?.symbol) || ''
-      const outputCurrencyId = (field === Field.OUTPUT ? currency.symbol : outputCurrency?.symbol) || ''
-
-      stateManager.navigate(chainId, inputCurrencyId, outputCurrencyId)
-    },
-    [stateManager, chainId, inputCurrency, outputCurrency]
-  )
   const onUserInput = useCallback(
     (field: Field, typedValue: string) => {
       if (field === Field.INPUT) {

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/styled.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/styled.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components/macro'
 import { MEDIA_WIDTHS } from 'theme'
 import { Settings } from 'react-feather'
+import { RemoveRecipient } from 'cow-react/modules/swap/containers/RemoveRecipient'
 
 export const Container = styled.div`
   max-width: 460px;
@@ -62,4 +63,8 @@ export const SettingsIcon = styled(Settings)`
   > * {
     stroke: ${({ theme }) => theme.text1};
   }
+`
+
+export const StyledRemoveRecipient = styled(RemoveRecipient)`
+  margin: 15px 0;
 `

--- a/src/cow-react/modules/limitOrders/hooks/useAreThereTokensWithSameSymbol.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useAreThereTokensWithSameSymbol.ts
@@ -1,0 +1,18 @@
+import { isAddress } from 'utils'
+import { useCallback } from 'react'
+import { useAllTokensList } from 'cow-react/common/hooks/useAllTokensList'
+
+export function useAreThereTokensWithSameSymbol(): (tokenAddressOrSymbol: string | null | undefined) => boolean {
+  const allTokens = useAllTokensList()
+
+  return useCallback(
+    (tokenAddressOrSymbol: string | null | undefined) => {
+      if (!tokenAddressOrSymbol || isAddress(tokenAddressOrSymbol)) return false
+
+      const tokens = allTokens.filter((token) => token.symbol === tokenAddressOrSymbol)
+
+      return tokens.length > 1
+    },
+    [allTokens]
+  )
+}

--- a/src/cow-react/modules/limitOrders/hooks/useLimitOrdersNavigate.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useLimitOrdersNavigate.ts
@@ -1,0 +1,21 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { parameterizeLimitOrdersRoute } from 'cow-react/modules/limitOrders/hooks/useParameterizeLimitOrdersRoute'
+import { useHistory } from 'react-router-dom'
+import { useCallback } from 'react'
+
+interface UseLimitOrdersNavigateCallback {
+  (chainId: SupportedChainId | null | undefined, inputCurrencyId: string | null, outputCurrencyId: string | null): void
+}
+
+export function useLimitOrdersNavigate(): UseLimitOrdersNavigateCallback {
+  const history = useHistory()
+
+  return useCallback(
+    (chainId: SupportedChainId | null | undefined, inputCurrencyId: string | null, outputCurrencyId: string | null) => {
+      const route = parameterizeLimitOrdersRoute(chainId, inputCurrencyId, outputCurrencyId)
+
+      history.push(route)
+    },
+    [history]
+  )
+}

--- a/src/cow-react/modules/limitOrders/hooks/useLimitOrdersStateFromUrl.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useLimitOrdersStateFromUrl.ts
@@ -1,0 +1,36 @@
+import { useLocation, useParams } from 'react-router-dom'
+import { useMemo } from 'react'
+import { getDefaultLimitOrdersState, LimitOrdersState } from 'cow-react/modules/limitOrders/state/limitOrdersAtom'
+import { useWeb3React } from '@web3-react/core'
+
+interface LimitOrdersStateFromUrl {
+  readonly chainId: string | undefined
+  readonly inputCurrencyId: string | undefined
+  readonly outputCurrencyId: string | undefined
+}
+
+export function useLimitOrdersStateFromUrl(): LimitOrdersState {
+  const { chainId: currentChainId } = useWeb3React()
+  const params = useParams()
+  const location = useLocation()
+
+  return useMemo(() => {
+    const searchParams = new URLSearchParams(location.search)
+    const recipient = searchParams.get('recipient')
+    const { chainId, inputCurrencyId, outputCurrencyId } = params as LimitOrdersStateFromUrl
+    const chainIdAsNumber = chainId ? parseInt(chainId) : null
+
+    if (chainId && currentChainId && currentChainId !== chainIdAsNumber) {
+      return getDefaultLimitOrdersState(currentChainId)
+    }
+
+    return {
+      chainId: chainIdAsNumber || null,
+      inputCurrencyAmount: null,
+      outputCurrencyAmount: null,
+      inputCurrencyId: inputCurrencyId || null,
+      outputCurrencyId: outputCurrencyId || null,
+      recipient,
+    }
+  }, [location.search, params, currentChainId])
+}

--- a/src/cow-react/modules/limitOrders/hooks/useLimitOrdersStateFromUrl.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useLimitOrdersStateFromUrl.ts
@@ -20,12 +20,12 @@ export function useLimitOrdersStateFromUrl(): LimitOrdersState {
     const { chainId, inputCurrencyId, outputCurrencyId } = params as LimitOrdersStateFromUrl
     const chainIdAsNumber = chainId ? parseInt(chainId) : null
 
-    if (chainId && currentChainId && currentChainId !== chainIdAsNumber) {
+    if (currentChainId && currentChainId !== chainIdAsNumber) {
       return getDefaultLimitOrdersState(currentChainId)
     }
 
     return {
-      chainId: chainIdAsNumber || null,
+      chainId: chainIdAsNumber,
       inputCurrencyAmount: null,
       outputCurrencyAmount: null,
       inputCurrencyId: inputCurrencyId || null,

--- a/src/cow-react/modules/limitOrders/hooks/useLimitOrdersTradeState.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useLimitOrdersTradeState.ts
@@ -1,0 +1,36 @@
+import { useAtomValue } from 'jotai/utils'
+import { limitOrdersAtom } from 'cow-react/modules/limitOrders/state/limitOrdersAtom'
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
+import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
+import { useMemo } from 'react'
+import { useTokenBySymbolOrAddress } from 'cow-react/common/hooks/useTokenBySymbolOrAddress'
+
+export interface LimitOrdersTradeState {
+  readonly inputCurrency: Currency | null
+  readonly outputCurrency: Currency | null
+  readonly inputCurrencyAmount: CurrencyAmount<Currency> | null
+  readonly outputCurrencyAmount: CurrencyAmount<Currency> | null
+  readonly recipient: string | null
+}
+
+export function useLimitOrdersTradeState(): LimitOrdersTradeState {
+  const state = useAtomValue(limitOrdersAtom)
+
+  const recipient = state.recipient
+  const inputCurrency = useTokenBySymbolOrAddress(state.inputCurrencyId) || null
+  const outputCurrency = useTokenBySymbolOrAddress(state.outputCurrencyId) || null
+  const inputCurrencyAmount =
+    tryParseCurrencyAmount(state.inputCurrencyAmount || undefined, inputCurrency || undefined) || null
+  const outputCurrencyAmount =
+    tryParseCurrencyAmount(state.outputCurrencyAmount || undefined, outputCurrency || undefined) || null
+
+  return useMemo(() => {
+    return {
+      recipient,
+      inputCurrency,
+      outputCurrency,
+      inputCurrencyAmount,
+      outputCurrencyAmount,
+    }
+  }, [recipient, inputCurrency, outputCurrency, inputCurrencyAmount, outputCurrencyAmount])
+}

--- a/src/cow-react/modules/limitOrders/hooks/useOnCurrencySelection.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useOnCurrencySelection.ts
@@ -3,8 +3,8 @@ import { Field } from 'state/swap/actions'
 import { useWeb3React } from '@web3-react/core'
 import { Currency, Token } from '@uniswap/sdk-core'
 import { useAreThereTokensWithSameSymbol } from 'cow-react/modules/limitOrders/hooks/useAreThereTokensWithSameSymbol'
-import { useLimitOrdersStateManager } from 'cow-react/modules/limitOrders/state/limitOrdersAtom'
 import { useLimitOrdersTradeState } from 'cow-react/modules/limitOrders/hooks/useLimitOrdersTradeState'
+import { useLimitOrdersNavigate } from 'cow-react/modules/limitOrders/hooks/useLimitOrdersNavigate'
 
 /**
  * To avoid collisions of tokens with the same symbols we use a token address instead of token symbol
@@ -13,9 +13,9 @@ import { useLimitOrdersTradeState } from 'cow-react/modules/limitOrders/hooks/us
  */
 export function useOnCurrencySelection(): (field: Field, currency: Currency) => void {
   const { chainId } = useWeb3React()
-  const stateManager = useLimitOrdersStateManager()
   const areThereTokensWithSameSymbol = useAreThereTokensWithSameSymbol()
   const { inputCurrency, outputCurrency } = useLimitOrdersTradeState()
+  const limitOrdersNavigate = useLimitOrdersNavigate()
 
   const resolveCurrencyAddressOrSymbol = useCallback(
     (currency: Currency | null): string | null => {
@@ -31,11 +31,11 @@ export function useOnCurrencySelection(): (field: Field, currency: Currency) => 
       const tokenSymbolOrAddress = resolveCurrencyAddressOrSymbol(currency)
 
       if (field === Field.INPUT) {
-        stateManager.navigate(chainId, tokenSymbolOrAddress, resolveCurrencyAddressOrSymbol(outputCurrency))
+        limitOrdersNavigate(chainId, tokenSymbolOrAddress, resolveCurrencyAddressOrSymbol(outputCurrency))
       } else {
-        stateManager.navigate(chainId, resolveCurrencyAddressOrSymbol(inputCurrency), tokenSymbolOrAddress)
+        limitOrdersNavigate(chainId, resolveCurrencyAddressOrSymbol(inputCurrency), tokenSymbolOrAddress)
       }
     },
-    [stateManager, chainId, inputCurrency, outputCurrency, resolveCurrencyAddressOrSymbol]
+    [limitOrdersNavigate, chainId, inputCurrency, outputCurrency, resolveCurrencyAddressOrSymbol]
   )
 }

--- a/src/cow-react/modules/limitOrders/hooks/useOnCurrencySelection.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useOnCurrencySelection.ts
@@ -1,0 +1,41 @@
+import { useCallback } from 'react'
+import { Field } from 'state/swap/actions'
+import { useWeb3React } from '@web3-react/core'
+import { Currency, Token } from '@uniswap/sdk-core'
+import { useAreThereTokensWithSameSymbol } from 'cow-react/modules/limitOrders/hooks/useAreThereTokensWithSameSymbol'
+import { useLimitOrdersStateManager } from 'cow-react/modules/limitOrders/state/limitOrdersAtom'
+import { useLimitOrdersTradeState } from 'cow-react/modules/limitOrders/hooks/useLimitOrdersTradeState'
+
+/**
+ * To avoid collisions of tokens with the same symbols we use a token address instead of token symbol
+ * if there are more than one token with the same symbol
+ * @see useResetStateWithSymbolDuplication.ts
+ */
+export function useOnCurrencySelection(): (field: Field, currency: Currency) => void {
+  const { chainId } = useWeb3React()
+  const stateManager = useLimitOrdersStateManager()
+  const areThereTokensWithSameSymbol = useAreThereTokensWithSameSymbol()
+  const { inputCurrency, outputCurrency } = useLimitOrdersTradeState()
+
+  const resolveCurrencyAddressOrSymbol = useCallback(
+    (currency: Currency | null): string | null => {
+      if (!currency) return null
+
+      return areThereTokensWithSameSymbol(currency.symbol) ? (currency as Token).address : currency.symbol || null
+    },
+    [areThereTokensWithSameSymbol]
+  )
+
+  return useCallback(
+    (field: Field, currency: Currency) => {
+      const tokenSymbolOrAddress = resolveCurrencyAddressOrSymbol(currency)
+
+      if (field === Field.INPUT) {
+        stateManager.navigate(chainId, tokenSymbolOrAddress, resolveCurrencyAddressOrSymbol(outputCurrency))
+      } else {
+        stateManager.navigate(chainId, resolveCurrencyAddressOrSymbol(inputCurrency), tokenSymbolOrAddress)
+      }
+    },
+    [stateManager, chainId, inputCurrency, outputCurrency, resolveCurrencyAddressOrSymbol]
+  )
+}

--- a/src/cow-react/modules/limitOrders/hooks/useParameterizeLimitOrdersRoute.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useParameterizeLimitOrdersRoute.ts
@@ -13,12 +13,16 @@ export function useParameterizeLimitOrdersRoute(): string {
   }, [chainId, inputCurrencyId, outputCurrencyId])
 }
 
+/**
+ * When input currency is not set and user select output currency, we build a link like:
+ * /limit-orders/_/DAI
+ */
 export function parameterizeLimitOrdersRoute(
   chainId: number | null | undefined,
   inputCurrencyId: string | null,
   outputCurrencyId: string | null
 ): string {
   return Routes.LIMIT_ORDER.replace('/:chainId?', chainId ? `/${chainId}` : '')
-    .replace('/:inputCurrencyId?', inputCurrencyId ? `/${inputCurrencyId}` : '')
+    .replace('/:inputCurrencyId?', inputCurrencyId ? `/${inputCurrencyId}` : '/_')
     .replace('/:outputCurrencyId?', outputCurrencyId ? `/${outputCurrencyId}` : '')
 }

--- a/src/cow-react/modules/limitOrders/hooks/useParameterizeLimitOrdersRoute.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useParameterizeLimitOrdersRoute.ts
@@ -1,0 +1,24 @@
+import { Routes } from 'constants/routes'
+import { useWeb3React } from '@web3-react/core'
+import { useAtomValue } from 'jotai/utils'
+import { limitOrdersAtom } from 'cow-react/modules/limitOrders/state/limitOrdersAtom'
+import { useMemo } from 'react'
+
+export function useParameterizeLimitOrdersRoute(): string {
+  const { chainId } = useWeb3React()
+  const { inputCurrencyId, outputCurrencyId } = useAtomValue(limitOrdersAtom)
+
+  return useMemo(() => {
+    return parameterizeLimitOrdersRoute(chainId, inputCurrencyId, outputCurrencyId)
+  }, [chainId, inputCurrencyId, outputCurrencyId])
+}
+
+export function parameterizeLimitOrdersRoute(
+  chainId: number | null | undefined,
+  inputCurrencyId: string | null,
+  outputCurrencyId: string | null
+): string {
+  return Routes.LIMIT_ORDER.replace('/:chainId?', chainId ? `/${chainId}` : '')
+    .replace('/:inputCurrencyId?', inputCurrencyId ? `/${inputCurrencyId}` : '')
+    .replace('/:outputCurrencyId?', outputCurrencyId ? `/${outputCurrencyId}` : '')
+}

--- a/src/cow-react/modules/limitOrders/hooks/useResetStateWithSymbolDuplication.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useResetStateWithSymbolDuplication.ts
@@ -1,0 +1,47 @@
+import { useWeb3React } from '@web3-react/core'
+// eslint-disable-next-line no-restricted-imports
+import { t } from '@lingui/macro'
+import { useEffect } from 'react'
+import {
+  getDefaultLimitOrdersState,
+  limitOrdersAtom,
+  useLimitOrdersStateManager,
+} from 'cow-react/modules/limitOrders/state/limitOrdersAtom'
+import { useAreThereTokensWithSameSymbol } from 'cow-react/modules/limitOrders/hooks/useAreThereTokensWithSameSymbol'
+import { useAtomValue } from 'jotai/utils'
+
+const alertMessage = (
+  doubledSymbol: string
+) => t`There is more than one token in the list of tokens with the symbol: ${doubledSymbol}.
+Please select the token you need from the UI or use the address of the token instead of the symbol`
+
+/**
+ * Case: when user opened a link with a token symbol and there are more than one token with the same symbol
+ * Example: /limit-orders/UST/WETH
+ * https://etherscan.io/token/0xa47c8bf37f92abed4a126bda807a7b7498661acd - Symbol: UST
+ * https://etherscan.io/token/0xa693b19d2931d498c5b318df961919bb4aee87a5 - Symbol: UST
+ * In this case we just reset state to default, because:
+ * if user selected a token with symbol duplication from cowswap Dapp, then Dapp puts a token address in the URL
+ * Example: /limit-orders/0xa47c8bf37f92abed4a126bda807a7b7498661acd/WETH
+ * @see useOnCurrencySelection.ts
+ */
+export function useResetStateWithSymbolDuplication() {
+  const { chainId } = useWeb3React()
+  const { inputCurrencyId, outputCurrencyId } = useAtomValue(limitOrdersAtom)
+  const checkTokensWithSameSymbol = useAreThereTokensWithSameSymbol()
+  const stateManager = useLimitOrdersStateManager()
+
+  useEffect(() => {
+    const inputCurrencyIsDoubled = checkTokensWithSameSymbol(inputCurrencyId)
+    const outputCurrencyIsDoubled = checkTokensWithSameSymbol(outputCurrencyId)
+
+    if (chainId && (inputCurrencyIsDoubled || outputCurrencyIsDoubled)) {
+      const doubledSymbol = inputCurrencyIsDoubled ? inputCurrencyId : outputCurrencyId
+
+      alert(alertMessage(doubledSymbol || ''))
+
+      const defaultState = getDefaultLimitOrdersState(chainId)
+      stateManager.navigate(chainId, defaultState.inputCurrencyId, defaultState.outputCurrencyId)
+    }
+  }, [stateManager, checkTokensWithSameSymbol, chainId, inputCurrencyId, outputCurrencyId])
+}

--- a/src/cow-react/modules/limitOrders/hooks/useResetStateWithSymbolDuplication.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useResetStateWithSymbolDuplication.ts
@@ -2,13 +2,10 @@ import { useWeb3React } from '@web3-react/core'
 // eslint-disable-next-line no-restricted-imports
 import { t } from '@lingui/macro'
 import { useEffect } from 'react'
-import {
-  getDefaultLimitOrdersState,
-  limitOrdersAtom,
-  useLimitOrdersStateManager,
-} from 'cow-react/modules/limitOrders/state/limitOrdersAtom'
+import { getDefaultLimitOrdersState, limitOrdersAtom } from 'cow-react/modules/limitOrders/state/limitOrdersAtom'
 import { useAreThereTokensWithSameSymbol } from 'cow-react/modules/limitOrders/hooks/useAreThereTokensWithSameSymbol'
 import { useAtomValue } from 'jotai/utils'
+import { useLimitOrdersNavigate } from 'cow-react/modules/limitOrders/hooks/useLimitOrdersNavigate'
 
 const alertMessage = (
   doubledSymbol: string
@@ -29,7 +26,7 @@ export function useResetStateWithSymbolDuplication() {
   const { chainId } = useWeb3React()
   const { inputCurrencyId, outputCurrencyId } = useAtomValue(limitOrdersAtom)
   const checkTokensWithSameSymbol = useAreThereTokensWithSameSymbol()
-  const stateManager = useLimitOrdersStateManager()
+  const limitOrdersNavigate = useLimitOrdersNavigate()
 
   useEffect(() => {
     const inputCurrencyIsDoubled = checkTokensWithSameSymbol(inputCurrencyId)
@@ -41,7 +38,7 @@ export function useResetStateWithSymbolDuplication() {
       alert(alertMessage(doubledSymbol || ''))
 
       const defaultState = getDefaultLimitOrdersState(chainId)
-      stateManager.navigate(chainId, defaultState.inputCurrencyId, defaultState.outputCurrencyId)
+      limitOrdersNavigate(chainId, defaultState.inputCurrencyId, defaultState.outputCurrencyId)
     }
-  }, [stateManager, checkTokensWithSameSymbol, chainId, inputCurrencyId, outputCurrencyId])
+  }, [limitOrdersNavigate, checkTokensWithSameSymbol, chainId, inputCurrencyId, outputCurrencyId])
 }

--- a/src/cow-react/modules/limitOrders/hooks/useSetupLimitOrdersState.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useSetupLimitOrdersState.ts
@@ -8,7 +8,7 @@ import { useEffect } from 'react'
 
 export function useSetupLimitOrdersState() {
   const tradeStateFromUrl = useLimitOrdersStateFromUrl()
-  const { state, setState, navigate } = useLimitOrdersStateManager()
+  const { state, setState } = useLimitOrdersStateManager()
 
   const chainIdWasChanged = tradeStateFromUrl.chainId !== state.chainId
 
@@ -27,14 +27,11 @@ export function useSetupLimitOrdersState() {
           ...state,
           chainId: tradeStateFromUrl.chainId,
           recipient: tradeStateFromUrl.recipient || state.recipient,
-          inputCurrencyId: tradeStateFromUrl.inputCurrencyId || state.inputCurrencyId,
-          outputCurrencyId: tradeStateFromUrl.outputCurrencyId || state.outputCurrencyId,
+          inputCurrencyId: tradeStateFromUrl.inputCurrencyId,
+          outputCurrencyId: tradeStateFromUrl.outputCurrencyId,
         }
 
     console.log('UPDATE LIMIT ORDERS STATE:', newState)
     setState(newState)
-    setTimeout(() => {
-      navigate(newState.chainId, newState.inputCurrencyId, newState.outputCurrencyId)
-    }, 0)
-  }, [navigate, setState, state, tradeStateFromUrl, shouldSkipUpdate, chainIdWasChanged])
+  }, [setState, state, tradeStateFromUrl, shouldSkipUpdate, chainIdWasChanged])
 }

--- a/src/cow-react/modules/limitOrders/hooks/useSetupLimitOrdersState.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useSetupLimitOrdersState.ts
@@ -1,0 +1,42 @@
+import { useLimitOrdersStateFromUrl } from 'cow-react/modules/limitOrders/hooks/useLimitOrdersStateFromUrl'
+import { useAtom } from 'jotai'
+import {
+  getDefaultLimitOrdersState,
+  limitOrdersAtom,
+  LimitOrdersState,
+} from 'cow-react/modules/limitOrders/state/limitOrdersAtom'
+import { useHistory } from 'react-router-dom'
+import { parameterizeLimitOrdersRoute } from 'cow-react/modules/limitOrders/hooks/useParameterizeLimitOrdersRoute'
+import { useEffect } from 'react'
+
+export function useSetupLimitOrdersState() {
+  const history = useHistory()
+  const tradeStateFromUrl = useLimitOrdersStateFromUrl()
+  const [state, setState] = useAtom(limitOrdersAtom)
+
+  const chainIdWasChanged = tradeStateFromUrl.chainId !== state.chainId
+
+  const shouldSkipUpdate =
+    !chainIdWasChanged &&
+    tradeStateFromUrl.inputCurrencyId?.toLowerCase() === state.inputCurrencyId?.toLowerCase() &&
+    tradeStateFromUrl.outputCurrencyId?.toLowerCase() === state.outputCurrencyId?.toLowerCase()
+
+  useEffect(() => {
+    if (shouldSkipUpdate) return
+
+    const newState: LimitOrdersState = chainIdWasChanged
+      ? getDefaultLimitOrdersState(tradeStateFromUrl.chainId)
+      : {
+          ...state,
+          chainId: tradeStateFromUrl.chainId,
+          inputCurrencyId: tradeStateFromUrl.inputCurrencyId || state.inputCurrencyId,
+          outputCurrencyId: tradeStateFromUrl.outputCurrencyId || state.outputCurrencyId,
+        }
+
+    console.log('UPDATE LIMIT ORDERS STATE:', newState)
+    setState(newState)
+    setTimeout(() => {
+      history.push(parameterizeLimitOrdersRoute(newState.chainId, newState.inputCurrencyId, newState.outputCurrencyId))
+    }, 0)
+  }, [history, setState, state, tradeStateFromUrl, shouldSkipUpdate, chainIdWasChanged])
+}

--- a/src/cow-react/modules/limitOrders/hooks/useSetupLimitOrdersState.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useSetupLimitOrdersState.ts
@@ -1,14 +1,17 @@
 import { useLimitOrdersStateFromUrl } from 'cow-react/modules/limitOrders/hooks/useLimitOrdersStateFromUrl'
 import {
   getDefaultLimitOrdersState,
+  limitOrdersAtom,
   LimitOrdersState,
-  useLimitOrdersStateManager,
+  updateLimitOrdersAtom,
 } from 'cow-react/modules/limitOrders/state/limitOrdersAtom'
 import { useEffect } from 'react'
+import { useAtomValue, useUpdateAtom } from 'jotai/utils'
 
 export function useSetupLimitOrdersState() {
   const tradeStateFromUrl = useLimitOrdersStateFromUrl()
-  const { state, setState } = useLimitOrdersStateManager()
+  const state = useAtomValue(limitOrdersAtom)
+  const updateLimitOrdersState = useUpdateAtom(updateLimitOrdersAtom)
 
   const chainIdWasChanged = tradeStateFromUrl.chainId !== state.chainId
 
@@ -21,10 +24,9 @@ export function useSetupLimitOrdersState() {
   useEffect(() => {
     if (shouldSkipUpdate) return
 
-    const newState: LimitOrdersState = chainIdWasChanged
+    const newState: Partial<LimitOrdersState> = chainIdWasChanged
       ? getDefaultLimitOrdersState(tradeStateFromUrl.chainId)
       : {
-          ...state,
           chainId: tradeStateFromUrl.chainId,
           recipient: tradeStateFromUrl.recipient || state.recipient,
           inputCurrencyId: tradeStateFromUrl.inputCurrencyId,
@@ -32,6 +34,6 @@ export function useSetupLimitOrdersState() {
         }
 
     console.log('UPDATE LIMIT ORDERS STATE:', newState)
-    setState(newState)
-  }, [setState, state, tradeStateFromUrl, shouldSkipUpdate, chainIdWasChanged])
+    updateLimitOrdersState(newState)
+  }, [updateLimitOrdersState, state, tradeStateFromUrl, shouldSkipUpdate, chainIdWasChanged])
 }

--- a/src/cow-react/modules/limitOrders/hooks/useSetupLimitOrdersState.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useSetupLimitOrdersState.ts
@@ -1,23 +1,20 @@
 import { useLimitOrdersStateFromUrl } from 'cow-react/modules/limitOrders/hooks/useLimitOrdersStateFromUrl'
-import { useAtom } from 'jotai'
 import {
   getDefaultLimitOrdersState,
-  limitOrdersAtom,
   LimitOrdersState,
+  useLimitOrdersStateManager,
 } from 'cow-react/modules/limitOrders/state/limitOrdersAtom'
-import { useHistory } from 'react-router-dom'
-import { parameterizeLimitOrdersRoute } from 'cow-react/modules/limitOrders/hooks/useParameterizeLimitOrdersRoute'
 import { useEffect } from 'react'
 
 export function useSetupLimitOrdersState() {
-  const history = useHistory()
   const tradeStateFromUrl = useLimitOrdersStateFromUrl()
-  const [state, setState] = useAtom(limitOrdersAtom)
+  const { state, setState, navigate } = useLimitOrdersStateManager()
 
   const chainIdWasChanged = tradeStateFromUrl.chainId !== state.chainId
 
   const shouldSkipUpdate =
     !chainIdWasChanged &&
+    (!tradeStateFromUrl.recipient || tradeStateFromUrl.recipient === state.recipient) &&
     tradeStateFromUrl.inputCurrencyId?.toLowerCase() === state.inputCurrencyId?.toLowerCase() &&
     tradeStateFromUrl.outputCurrencyId?.toLowerCase() === state.outputCurrencyId?.toLowerCase()
 
@@ -29,6 +26,7 @@ export function useSetupLimitOrdersState() {
       : {
           ...state,
           chainId: tradeStateFromUrl.chainId,
+          recipient: tradeStateFromUrl.recipient || state.recipient,
           inputCurrencyId: tradeStateFromUrl.inputCurrencyId || state.inputCurrencyId,
           outputCurrencyId: tradeStateFromUrl.outputCurrencyId || state.outputCurrencyId,
         }
@@ -36,7 +34,7 @@ export function useSetupLimitOrdersState() {
     console.log('UPDATE LIMIT ORDERS STATE:', newState)
     setState(newState)
     setTimeout(() => {
-      history.push(parameterizeLimitOrdersRoute(newState.chainId, newState.inputCurrencyId, newState.outputCurrencyId))
+      navigate(newState.chainId, newState.inputCurrencyId, newState.outputCurrencyId)
     }, 0)
-  }, [history, setState, state, tradeStateFromUrl, shouldSkipUpdate, chainIdWasChanged])
+  }, [navigate, setState, state, tradeStateFromUrl, shouldSkipUpdate, chainIdWasChanged])
 }

--- a/src/cow-react/modules/limitOrders/hooks/useSetupLimitOrdersState.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useSetupLimitOrdersState.ts
@@ -35,5 +35,5 @@ export function useSetupLimitOrdersState() {
 
     console.log('UPDATE LIMIT ORDERS STATE:', newState)
     updateLimitOrdersState(newState)
-  }, [updateLimitOrdersState, state, tradeStateFromUrl, shouldSkipUpdate, chainIdWasChanged])
+  }, [updateLimitOrdersState, state.recipient, tradeStateFromUrl, shouldSkipUpdate, chainIdWasChanged])
 }

--- a/src/cow-react/modules/limitOrders/state/limitOrdersAtom.ts
+++ b/src/cow-react/modules/limitOrders/state/limitOrdersAtom.ts
@@ -1,0 +1,25 @@
+import { atomWithStorage } from 'jotai/utils'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { WRAPPED_NATIVE_CURRENCY as WETH } from 'constants/tokens'
+
+export interface LimitOrdersState {
+  readonly chainId: number | null
+  readonly inputCurrencyId: string | null
+  readonly outputCurrencyId: string | null
+  readonly inputCurrencyAmount: string | null
+  readonly outputCurrencyAmount: string | null
+  readonly recipient: string | null
+}
+
+export function getDefaultLimitOrdersState(chainId: SupportedChainId | null): LimitOrdersState {
+  return {
+    chainId,
+    inputCurrencyId: chainId ? WETH[chainId]?.symbol || null : null,
+    outputCurrencyId: null,
+    inputCurrencyAmount: null,
+    outputCurrencyAmount: null,
+    recipient: null,
+  }
+}
+
+export const limitOrdersAtom = atomWithStorage<LimitOrdersState>('limit-orders-atom', getDefaultLimitOrdersState(null))

--- a/src/cow-react/modules/limitOrders/state/limitOrdersAtom.ts
+++ b/src/cow-react/modules/limitOrders/state/limitOrdersAtom.ts
@@ -1,8 +1,7 @@
 import { atomWithStorage } from 'jotai/utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { WRAPPED_NATIVE_CURRENCY as WETH } from 'constants/tokens'
-import { useAtom } from 'jotai'
-import { useMemo } from 'react'
+import { atom } from 'jotai'
 
 export interface LimitOrdersState {
   readonly chainId: number | null
@@ -11,14 +10,6 @@ export interface LimitOrdersState {
   readonly inputCurrencyAmount: string | null
   readonly outputCurrencyAmount: string | null
   readonly recipient: string | null
-}
-
-export interface LimitOrdersStateManager {
-  state: LimitOrdersState
-  setState(state: LimitOrdersState): void
-  setInputCurrencyAmount(inputCurrencyAmount: string | null): void
-  setOutputCurrencyAmount(outputCurrencyAmount: string | null): void
-  setRecipient(recipient: string | null): void
 }
 
 export function getDefaultLimitOrdersState(chainId: SupportedChainId | null): LimitOrdersState {
@@ -34,24 +25,10 @@ export function getDefaultLimitOrdersState(chainId: SupportedChainId | null): Li
 
 export const limitOrdersAtom = atomWithStorage<LimitOrdersState>('limit-orders-atom', getDefaultLimitOrdersState(null))
 
-export const useLimitOrdersStateManager = (): LimitOrdersStateManager => {
-  const [state, setState] = useAtom(limitOrdersAtom)
+export const updateLimitOrdersAtom = atom(null, (get, set, nextState: Partial<LimitOrdersState>) => {
+  set(limitOrdersAtom, () => {
+    const prevState = get(limitOrdersAtom)
 
-  return useMemo(() => {
-    return {
-      state,
-      setState(state: LimitOrdersState) {
-        setState(state)
-      },
-      setInputCurrencyAmount(inputCurrencyAmount: string | null) {
-        setState({ ...state, inputCurrencyAmount })
-      },
-      setOutputCurrencyAmount(outputCurrencyAmount: string | null) {
-        setState({ ...state, outputCurrencyAmount })
-      },
-      setRecipient(recipient: string | null) {
-        setState({ ...state, recipient })
-      },
-    }
-  }, [state, setState])
-}
+    return { ...prevState, ...nextState }
+  })
+})

--- a/src/cow-react/modules/limitOrders/state/limitOrdersAtom.ts
+++ b/src/cow-react/modules/limitOrders/state/limitOrdersAtom.ts
@@ -3,8 +3,6 @@ import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { WRAPPED_NATIVE_CURRENCY as WETH } from 'constants/tokens'
 import { useAtom } from 'jotai'
 import { useMemo } from 'react'
-import { parameterizeLimitOrdersRoute } from 'cow-react/modules/limitOrders/hooks/useParameterizeLimitOrdersRoute'
-import { useHistory } from 'react-router-dom'
 
 export interface LimitOrdersState {
   readonly chainId: number | null
@@ -21,11 +19,6 @@ export interface LimitOrdersStateManager {
   setInputCurrencyAmount(inputCurrencyAmount: string | null): void
   setOutputCurrencyAmount(outputCurrencyAmount: string | null): void
   setRecipient(recipient: string | null): void
-  navigate(
-    chainId: SupportedChainId | null | undefined,
-    inputCurrencyId: string | null,
-    outputCurrencyId: string | null
-  ): void
 }
 
 export function getDefaultLimitOrdersState(chainId: SupportedChainId | null): LimitOrdersState {
@@ -42,7 +35,6 @@ export function getDefaultLimitOrdersState(chainId: SupportedChainId | null): Li
 export const limitOrdersAtom = atomWithStorage<LimitOrdersState>('limit-orders-atom', getDefaultLimitOrdersState(null))
 
 export const useLimitOrdersStateManager = (): LimitOrdersStateManager => {
-  const history = useHistory()
   const [state, setState] = useAtom(limitOrdersAtom)
 
   return useMemo(() => {
@@ -60,15 +52,6 @@ export const useLimitOrdersStateManager = (): LimitOrdersStateManager => {
       setRecipient(recipient: string | null) {
         setState({ ...state, recipient })
       },
-      navigate(
-        chainId: SupportedChainId | null | undefined,
-        inputCurrencyId: string | null,
-        outputCurrencyId: string | null
-      ) {
-        const route = parameterizeLimitOrdersRoute(chainId, inputCurrencyId, outputCurrencyId)
-
-        history.push(route)
-      },
     }
-  }, [history, state, setState])
+  }, [state, setState])
 }

--- a/src/cow-react/modules/limitOrders/state/limitOrdersAtom.ts
+++ b/src/cow-react/modules/limitOrders/state/limitOrdersAtom.ts
@@ -1,6 +1,10 @@
 import { atomWithStorage } from 'jotai/utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { WRAPPED_NATIVE_CURRENCY as WETH } from 'constants/tokens'
+import { useAtom } from 'jotai'
+import { useMemo } from 'react'
+import { parameterizeLimitOrdersRoute } from '@src/cow-react/modules/limitOrders/hooks/useParameterizeLimitOrdersRoute'
+import { useHistory } from 'react-router-dom'
 
 export interface LimitOrdersState {
   readonly chainId: number | null
@@ -9,6 +13,19 @@ export interface LimitOrdersState {
   readonly inputCurrencyAmount: string | null
   readonly outputCurrencyAmount: string | null
   readonly recipient: string | null
+}
+
+export interface LimitOrdersStateManager {
+  state: LimitOrdersState
+  setState(state: LimitOrdersState): void
+  setInputCurrencyAmount(inputCurrencyAmount: string | null): void
+  setOutputCurrencyAmount(outputCurrencyAmount: string | null): void
+  setRecipient(recipient: string | null): void
+  navigate(
+    chainId: SupportedChainId | null | undefined,
+    outputCurrencyId: string | null,
+    inputCurrencyId: string | null
+  ): void
 }
 
 export function getDefaultLimitOrdersState(chainId: SupportedChainId | null): LimitOrdersState {
@@ -23,3 +40,35 @@ export function getDefaultLimitOrdersState(chainId: SupportedChainId | null): Li
 }
 
 export const limitOrdersAtom = atomWithStorage<LimitOrdersState>('limit-orders-atom', getDefaultLimitOrdersState(null))
+
+export const useLimitOrdersStateManager = (): LimitOrdersStateManager => {
+  const history = useHistory()
+  const [state, setState] = useAtom(limitOrdersAtom)
+
+  return useMemo(() => {
+    return {
+      state,
+      setState(state: LimitOrdersState) {
+        setState(state)
+      },
+      setInputCurrencyAmount(inputCurrencyAmount: string | null) {
+        setState({ ...state, inputCurrencyAmount })
+      },
+      setOutputCurrencyAmount(outputCurrencyAmount: string | null) {
+        setState({ ...state, outputCurrencyAmount })
+      },
+      setRecipient(recipient: string | null) {
+        setState({ ...state, recipient })
+      },
+      navigate(
+        chainId: SupportedChainId | null | undefined,
+        outputCurrencyId: string | null,
+        inputCurrencyId: string | null
+      ) {
+        const route = parameterizeLimitOrdersRoute(chainId, outputCurrencyId, inputCurrencyId)
+
+        history.push(route)
+      },
+    }
+  }, [history, state, setState])
+}

--- a/src/cow-react/modules/limitOrders/state/limitOrdersAtom.ts
+++ b/src/cow-react/modules/limitOrders/state/limitOrdersAtom.ts
@@ -3,7 +3,7 @@ import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { WRAPPED_NATIVE_CURRENCY as WETH } from 'constants/tokens'
 import { useAtom } from 'jotai'
 import { useMemo } from 'react'
-import { parameterizeLimitOrdersRoute } from '@src/cow-react/modules/limitOrders/hooks/useParameterizeLimitOrdersRoute'
+import { parameterizeLimitOrdersRoute } from 'cow-react/modules/limitOrders/hooks/useParameterizeLimitOrdersRoute'
 import { useHistory } from 'react-router-dom'
 
 export interface LimitOrdersState {
@@ -23,8 +23,8 @@ export interface LimitOrdersStateManager {
   setRecipient(recipient: string | null): void
   navigate(
     chainId: SupportedChainId | null | undefined,
-    outputCurrencyId: string | null,
-    inputCurrencyId: string | null
+    inputCurrencyId: string | null,
+    outputCurrencyId: string | null
   ): void
 }
 
@@ -62,10 +62,10 @@ export const useLimitOrdersStateManager = (): LimitOrdersStateManager => {
       },
       navigate(
         chainId: SupportedChainId | null | undefined,
-        outputCurrencyId: string | null,
-        inputCurrencyId: string | null
+        inputCurrencyId: string | null,
+        outputCurrencyId: string | null
       ) {
-        const route = parameterizeLimitOrdersRoute(chainId, outputCurrencyId, inputCurrencyId)
+        const route = parameterizeLimitOrdersRoute(chainId, inputCurrencyId, outputCurrencyId)
 
         history.push(route)
       },

--- a/src/custom/components/Header/MenuTree/index.tsx
+++ b/src/custom/components/Header/MenuTree/index.tsx
@@ -2,15 +2,7 @@ import { HeaderLinks as Wrapper, StyledNavLink } from '../styled'
 import MenuDropdown from 'components/MenuDropdown'
 import { MenuTitle, MenuSection } from 'components/MenuDropdown/styled'
 import SVG from 'react-inlinesvg'
-import {
-  MAIN_MENU,
-  MenuTreeItem,
-  MenuItemKind,
-  InternalLink,
-  ExternalLink,
-  DropDownItem,
-  MenuLink,
-} from 'constants/mainMenu'
+import { MenuTreeItem, MenuItemKind, InternalLink, ExternalLink, DropDownItem, MenuLink } from 'constants/mainMenu'
 import { ExternalLink as ExternalLinkComponent } from 'theme/components'
 
 // Assets
@@ -150,14 +142,21 @@ function MenuItemWithDropDown(props: MenuItemWithDropDownProps) {
 }
 
 export interface MenuTreeProps extends ContextProps {
+  items: MenuTreeItem[]
   isMobileMenuOpen: boolean
 }
 
-export function MenuTree({ isMobileMenuOpen, darkMode, toggleDarkMode, handleMobileMenuOnClick }: MenuTreeProps) {
+export function MenuTree({
+  items,
+  isMobileMenuOpen,
+  darkMode,
+  toggleDarkMode,
+  handleMobileMenuOnClick,
+}: MenuTreeProps) {
   const context = { darkMode, toggleDarkMode, handleMobileMenuOnClick }
   return (
     <Wrapper isMobileMenuOpen={isMobileMenuOpen}>
-      {MAIN_MENU.map((menuItem, index) => (
+      {items.map((menuItem, index) => (
         <MenuItemWithDropDown key={index} menuItem={menuItem} context={context} />
       ))}
     </Wrapper>

--- a/src/custom/components/Header/NetworkSelector/NetworkSelectorMod.tsx
+++ b/src/custom/components/Header/NetworkSelector/NetworkSelectorMod.tsx
@@ -32,6 +32,7 @@ import { SUPPORTED_CHAIN_IDS, supportedChainId } from 'utils/supportedChainId'
 import useIsSmartContractWallet from 'hooks/useIsSmartContractWallet'
 import { css } from 'styled-components/macro'
 import { useRemovePopup, useAddPopup } from 'state/application/hooks'
+import { LIMIT_ORDERS_PATH } from 'constants/routes'
 
 /* const ActiveRowLinkList = styled.div`
   display: flex;
@@ -354,6 +355,19 @@ export default function NetworkSelector() {
 
   const info = getChainInfo(chainId)
 
+  const setChainIdToUrl = useCallback(
+    (chainId: SupportedChainId) => {
+      if (history.location.pathname.includes(LIMIT_ORDERS_PATH)) {
+        return
+      }
+
+      history.replace({
+        search: replaceURLParam(history.location.search, 'chain', getChainNameFromId(chainId)),
+      })
+    },
+    [history]
+  )
+
   const onSelectChain = useCallback(
     async (targetChain: SupportedChainId, skipClose?: boolean) => {
       if (!connector) return
@@ -365,8 +379,8 @@ export default function NetworkSelector() {
       try {
         dispatch(updateConnectionError({ connectionType, error: undefined }))
         await switchChain(connector, targetChain)
-        // Update URL right after network change
-        history.replace({ search: replaceURLParam(history.location.search, 'chain', getChainNameFromId(targetChain)) })
+
+        setChainIdToUrl(targetChain)
       } catch (error) {
         console.error('Failed to switch networks', error)
 
@@ -380,7 +394,7 @@ export default function NetworkSelector() {
 
       isSwitching.current = false
     },
-    [connector, dispatch, history, addPopup, closeModal]
+    [connector, dispatch, setChainIdToUrl, addPopup, closeModal]
   )
 
   useEffect(() => {
@@ -390,23 +404,23 @@ export default function NetworkSelector() {
     }
     if (account && chainId && chainId !== urlChainId) {
       // if wallet is connected and chainId already set, keep the url param in sync
-      history.replace({ search: replaceURLParam(history.location.search, 'chain', getChainNameFromId(chainId)) })
+      setChainIdToUrl(chainId)
     } else if (urlChainId && chainId && urlChainId !== chainId) {
       // if chain and url chainId are both set and differ, try to update chainid
       onSelectChain(urlChainId, true).catch(() => {
         // we want app network <-> chainId param to be in sync, so if user changes the network by changing the URL
         // but the request fails, revert the URL back to current chainId
-        history.replace({ search: replaceURLParam(history.location.search, 'chain', getChainNameFromId(chainId)) })
+        setChainIdToUrl(chainId)
       })
     }
-  }, [account, chainId, history, onSelectChain, urlChainId])
+  }, [account, chainId, setChainIdToUrl, onSelectChain, urlChainId])
 
   // set chain parameter on initial load if not there
   useEffect(() => {
     if (chainId && !urlChainId) {
-      history.replace({ search: replaceURLParam(history.location.search, 'chain', getChainNameFromId(chainId)) })
+      setChainIdToUrl(chainId)
     }
-  }, [chainId, history, urlChainId, urlChain])
+  }, [chainId, setChainIdToUrl, urlChainId, urlChain])
 
   // Mod: to show popup for unsupported network
   useEffect(() => {

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -34,6 +34,7 @@ import CowBalanceButton from 'components/CowBalanceButton'
 
 // Assets
 import { toggleDarkModeAnalytics } from 'components/analytics'
+import { useParameterizedMainMenu } from 'cow-react/common/hooks/useParameterizedMainMenu'
 
 export const NETWORK_LABELS: { [chainId in ChainId]?: string } = {
   [ChainId.RINKEBY]: 'Rinkeby',
@@ -86,6 +87,8 @@ export default function Header() {
     isUpToLarge && setIsMobileMenuOpen(!isMobileMenuOpen)
   }, [isUpToLarge, isMobileMenuOpen])
 
+  const parameterizedMainMenu = useParameterizedMainMenu()
+
   // Toggle the 'noScroll' class on body, whenever the mobile menu or orders panel is open.
   // This removes the inner scrollbar on the page body, to prevent showing double scrollbars.
   useEffect(() => {
@@ -102,6 +105,7 @@ export default function Header() {
             </UniIcon>
           </Title>
           <MenuTree
+            items={parameterizedMainMenu}
             isMobileMenuOpen={isMobileMenuOpen}
             darkMode={darkMode}
             toggleDarkMode={toggleDarkMode}

--- a/src/custom/constants/mainMenu.ts
+++ b/src/custom/constants/mainMenu.ts
@@ -48,6 +48,10 @@ export interface DropDownItem {
 
 export type MenuTreeItem = InternalLink | ExternalLink | DropDownItem
 
+export const isBasicMenuLink = (item: any): item is BasicMenuLink => {
+  return !!(item.title && item.url)
+}
+
 export const FAQ_MENU: InternalLink[] = [
   { title: 'Overview', url: Routes.FAQ },
   { title: 'Protocol', url: Routes.FAQ_PROTOCOL },

--- a/src/custom/constants/routes.ts
+++ b/src/custom/constants/routes.ts
@@ -1,9 +1,11 @@
+export const LIMIT_ORDERS_PATH = 'limit-orders'
+
 // ENUM with routes
 export enum Routes {
   HOME = '/',
   SWAP = '/swap',
   SWAP_OUTPUT_CURRENCY = '/swap/:outputCurrency',
-  LIMIT_ORDER = '/limit-order',
+  LIMIT_ORDER = '/:chainId?/limit-orders/:inputCurrencyId?/:outputCurrencyId?',
   SEND = '/send',
   ACCOUNT = '/account',
   ACCOUNT_TOKENS = '/account/tokens',

--- a/src/custom/hooks/Tokens/TokensMod.ts
+++ b/src/custom/hooks/Tokens/TokensMod.ts
@@ -14,7 +14,7 @@ import { useCombinedActiveList, /*TokenAddressMap,*/ useUnsupportedTokenList } f
 
 // MOD imports
 import { useTokensFromMap } from '@src/hooks/Tokens'
-import { useThrottle } from 'hooks/useThrottle'
+import { useMemo } from 'react'
 
 export * from '@src/hooks/Tokens'
 
@@ -182,6 +182,11 @@ export function useCurrency(currencyId?: string | null): Currency | null | undef
 export function useAllTokens(): { [address: string]: Token } {
   const allTokens = useCombinedActiveList()
   const tokensFromMap = useTokensFromMap(allTokens, true)
+  const tokensList = Object.values(tokensFromMap)
+  // This trick removes infinite hook cals
+  // TODO: useCombinedActiveList() - mustn't fire so frequently
+  const tokensListString = tokensList.map((item) => item.address + item.symbol + item.chainId + item.decimals).join('/')
 
-  return useThrottle(tokensFromMap, 1000)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useMemo(() => tokensFromMap, [tokensListString])
 }

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -100,7 +100,7 @@ export default function App() {
             <Redirect from="/claim" to={Routes.ACCOUNT} />
             <Redirect from="/profile" to={Routes.ACCOUNT} />
             <Route exact strict path={Routes.SWAP} component={isNewSwapEnabled ? NewSwapPage : Swap} />
-            <Route exact strict path={Routes.LIMIT_ORDER} component={LimitOrders} />
+            <Route path={Routes.LIMIT_ORDER} component={LimitOrders} />
             <Route exact strict path={Routes.SWAP_OUTPUT_CURRENCY} component={RedirectToSwap} />
             <Route exact strict path={Routes.SEND} component={RedirectPathToSwapOnly} />
             <Route exact strict path={Routes.ABOUT} component={About} />

--- a/src/custom/theme/cowSwapTheme.tsx
+++ b/src/custom/theme/cowSwapTheme.tsx
@@ -11,7 +11,7 @@ import {
 
 import { getTheme, MEDIA_WIDTHS as MEDIA_WIDTHS_UNISWAP } from '@src/theme'
 import { useIsDarkMode } from 'state/user/hooks'
-import { Routes } from 'constants/routes'
+import { LIMIT_ORDERS_PATH, Routes } from 'constants/routes'
 import { useLocation } from 'react-router-dom'
 
 export { MEDIA_WIDTHS, ThemedText } from '@src/theme'
@@ -56,7 +56,9 @@ export default function ThemeProvider({ children }: { children: React.ReactNode 
   const themeObject = useMemo(() => {
     // Page background must be blurred for all pages besides Swap page
     const shouldBlurBackground =
-      location.pathname.length > 1 && !([Routes.SWAP] as string[]).includes(location.pathname)
+      location.pathname.length > 1 &&
+      Routes.SWAP !== location.pathname &&
+      !location.pathname.includes(LIMIT_ORDERS_PATH)
 
     return theme(darkMode, shouldBlurBackground)
   }, [darkMode, location.pathname])


### PR DESCRIPTION
# Summary

**Features:**
 - `jotai` store with persisting in the localStorage
 - set input/output currency into URL from user input
 - set widget state from URL
 - set input/output amounts into the store from user input

**Fixes and improvements:**
 - `useAllTokens()` - added useMemo() to avoid looped updates
 - fixed blurred background in the Limit orders page
 - moved `chainId` from query params to location paths, only for Limit orders page (`/#/swap?chain=goerli` -> `/#/5/limit-orders/DAI/USDC`)
 - persist input/output currencies into URL (now you can change currency symbol in URL and in will be automatically applied in the widget)

**Important:**
We DON'T update input/output currencies directly in the store, only through URL.
For example, if you want to change input currency, you should update only URL (`history.push(...)`) and it will be automatically set into the store.

  # To Test
Skip please, should be tested later

  # Background
`localStorage.setItem('enableLimitOrders', '1')` - run it in the browser console to enable Limit orders 
