### PR TITLE
Fix SwapButtons props changes check

### DIFF
--- a/src/cow-react/modules/swap/containers/NewSwapWidget/propsChecker.ts
+++ b/src/cow-react/modules/swap/containers/NewSwapWidget/propsChecker.ts
@@ -2,23 +2,10 @@ import { SwapFormProps } from 'cow-react/modules/swap/containers/NewSwapWidget/t
 import { PriceImpact } from 'hooks/usePriceImpact'
 import { Fraction } from '@uniswap/sdk-core'
 import { ReceiveAmountInfo } from 'cow-react/modules/swap/helpers/tradeReceiveAmount'
-import { SwapButtonsContext } from 'cow-react/modules/swap/containers/SwapButtons'
 import { CurrencyInfo } from 'cow-react/common/pure/CurrencyInputPanel/typings'
 
 function isFractionEqual(prev?: Fraction | null, next?: Fraction | null): boolean {
   return prev && next ? prev.equalTo(next) : prev === next
-}
-
-export function isSwapButtonPropsEqual(prev: SwapButtonsContext, next: SwapButtonsContext): boolean {
-  return (
-    prev.swapButtonState === next.swapButtonState &&
-    prev.chainId === next.chainId &&
-    prev.wrappedToken.address === next.wrappedToken.address &&
-    prev.swapInputError === next.swapInputError &&
-    prev.wrapInputError === next.wrapInputError &&
-    isFractionEqual(prev.wrapUnwrapAmount, next.wrapUnwrapAmount) &&
-    prev.approveButtonProps.approvalState === next.approveButtonProps.approvalState
-  )
 }
 
 function isReceiveAmountInfoEqual(prev: ReceiveAmountInfo | null, next: ReceiveAmountInfo | null): boolean {

--- a/src/cow-react/modules/swap/containers/SwapButtons/index.tsx
+++ b/src/cow-react/modules/swap/containers/SwapButtons/index.tsx
@@ -12,7 +12,7 @@ import { SupportedChainId } from 'constants/chains'
 import { AutoColumn } from 'components/Column'
 import * as styledEl from './styled'
 import { HandleSwapCallback } from 'cow-react/modules/swap/hooks/useHandleSwap'
-import { isSwapButtonPropsEqual } from 'cow-react/modules/swap/containers/NewSwapWidget/propsChecker'
+import { genericPropsChecker } from 'cow-react/modules/swap/containers/NewSwapWidget/propsChecker'
 
 import { ApproveButtons, ApproveButtonsProps } from './ApproveButtons'
 
@@ -158,4 +158,4 @@ export const SwapButtons = React.memo(function (props: SwapButtonsContext) {
   console.debug('RENDER SWAP BUTTON: ', props)
 
   return <div id="swap-button">{swapButtonStateMap[props.swapButtonState](props)}</div>
-}, isSwapButtonPropsEqual)
+}, genericPropsChecker)

--- a/src/cow-react/modules/swap/helpers/getSwapButtonState.ts
+++ b/src/cow-react/modules/swap/helpers/getSwapButtonState.ts
@@ -1,6 +1,5 @@
 import { Token } from '@uniswap/sdk-core'
 import { WrapType } from 'hooks/useWrapCallback'
-import { ReactNode } from 'react'
 import { QuoteError } from 'state/price/actions'
 import { ApprovalState } from 'hooks/useApproveCallback'
 import TradeGp from 'state/swap/TradeGp'
@@ -38,7 +37,7 @@ export interface SwapButtonStateParams {
   wrapType: WrapType
   wrapInputError: string | undefined
   quoteError: QuoteError | undefined | null
-  inputError?: ReactNode
+  inputError?: string
   approvalState: ApprovalState
   approvalSubmitted: boolean
   feeWarningAccepted: boolean

--- a/src/custom/state/swap/hooks.tsx
+++ b/src/custom/state/swap/hooks.tsx
@@ -1,11 +1,12 @@
-import { Trans } from '@lingui/macro'
+// eslint-disable-next-line no-restricted-imports
+import { t } from '@lingui/macro'
 import { Currency, CurrencyAmount, NativeCurrency, Percent, Token /* TradeType, */ } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
 // import useAutoSlippageTolerance from 'hooks/useAutoSlippageTolerance'
 // import { useBestTrade } from 'hooks/useBestTrade'
 import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
 import { ParsedQs } from 'qs'
-import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useAppDispatch, useAppSelector } from 'state/hooks'
 // import { InterfaceTrade, TradeState } from 'state/routing/types'
 import { useIsExpertMode, useUserSlippageToleranceWithDefault } from 'state/user/hooks'
@@ -64,7 +65,7 @@ interface DerivedSwapInfo {
   currencies: Currencies
   currencyBalances: { [field in Field]?: CurrencyAmount<Currency> }
   parsedAmount: CurrencyAmount<Currency> | undefined
-  inputError?: ReactNode
+  inputError?: string
   v2Trade: TradeGp | undefined
   allowedSlippage: Percent
 }
@@ -292,26 +293,26 @@ export function useDerivedSwapInfo(): DerivedSwapInfo {
   const allowedSlippage = useUserSlippageToleranceWithDefault(INITIAL_ALLOWED_SLIPPAGE_PERCENT) // mod
 
   const inputError = useMemo(() => {
-    let inputError: ReactNode | undefined
+    let inputError: string | undefined
 
     if (!account) {
-      inputError = <Trans>Connect Wallet</Trans>
+      inputError = t`Connect Wallet`
     }
 
     if (!currencies[Field.INPUT] || !currencies[Field.OUTPUT]) {
-      inputError = inputError ?? <Trans>Select a token</Trans>
+      inputError = inputError ?? t`Select a token`
     }
 
     if (!parsedAmount) {
-      inputError = inputError ?? <Trans>Enter an amount</Trans>
+      inputError = inputError ?? t`Enter an amount`
     }
 
     const formattedTo = isAddress(to)
     if (!to || !formattedTo) {
-      inputError = inputError ?? <Trans>Enter a recipient</Trans>
+      inputError = inputError ?? t`Enter a recipient`
     } else {
       if (BAD_RECIPIENT_ADDRESSES[formattedTo]) {
-        inputError = inputError ?? <Trans>Invalid recipient</Trans>
+        inputError = inputError ?? t`Invalid recipient`
       }
     }
 
@@ -321,11 +322,11 @@ export function useDerivedSwapInfo(): DerivedSwapInfo {
 
     // Balance not loaded - fix for https://github.com/cowprotocol/cowswap/issues/451
     if (!balanceIn && inputCurrency) {
-      inputError = <Trans>Couldn&apos;t load balances</Trans>
+      inputError = t`Couldn't load balances`
     }
 
     if (balanceIn && amountIn && balanceIn.lessThan(amountIn)) {
-      inputError = <Trans>Insufficient {amountIn.currency.symbol} balance</Trans>
+      inputError = t`Insufficient ${amountIn.currency.symbol} balance`
     }
 
     return inputError


### PR DESCRIPTION
# Summary

#1142

`SwapButtons` component had the wrong props checker `isSwapButtonPropsEqual`.
This checker didn't check all props properly and therefore we had an outdated trade data on the confirmation screen.

[swap/hooks.tsx](https://github.com/cowprotocol/cowswap/pull/1143/files#diff-9f3a1b6697e3fe27f8e496a5224658fd212db2e0dbc93eb58c79b6256c966a66) - `inputError` type was changed from `ReactNode` to `string` to have an opportunity to use `genericPropsChecker`. Because `ReactNode` cannot be used in the `JSON.stringify()`