### PR TITLE
Fix 1163: Show transaction confirm screen after order signing

### DIFF
--- a/src/cow-react/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
+++ b/src/cow-react/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
@@ -64,10 +64,12 @@ export function ConfirmSwapModalSetup(props: ConfirmSwapModalSetupProps) {
       />
 
       <TransactionConfirmationModal
-        attemptingTxn={true}
         isOpen={showTransactionConfirmationModal}
-        pendingText={pendingText}
         onDismiss={onDismiss}
+        attemptingTxn={swapConfirmState.attemptingTxn}
+        hash={swapConfirmState.txHash}
+        pendingText={pendingText}
+        currencyToAdd={trade?.outputAmount.currency}
         operationType={operationType}
       />
     </>

--- a/src/cow-react/modules/swap/hooks/useSwapConfirmManager.ts
+++ b/src/cow-react/modules/swap/hooks/useSwapConfirmManager.ts
@@ -2,6 +2,9 @@ import { swapConfirmAtom } from 'cow-react/modules/swap/state/swapConfirmAtom'
 import { useAtom } from 'jotai'
 import { useMemo } from 'react'
 import TradeGp from 'state/swap/TradeGp'
+import { useTransactionConfirmModal } from 'cow-react/modules/swap/hooks/useTransactionConfirmModal'
+import { OperationType } from 'components/TransactionConfirmationModal'
+import { useExpertModeManager } from 'state/user/hooks'
 
 export interface SwapConfirmManager {
   setSwapError(swapErrorMessage: string): void
@@ -14,6 +17,8 @@ export interface SwapConfirmManager {
 
 export function useSwapConfirmManager(): SwapConfirmManager {
   const [swapConfirmState, setSwapConfirmState] = useAtom(swapConfirmAtom)
+  const setTransactionConfirm = useTransactionConfirmModal()
+  const [isExpertMode] = useExpertModeManager()
 
   return useMemo(
     () => ({
@@ -58,8 +63,11 @@ export function useSwapConfirmManager(): SwapConfirmManager {
         const state = { ...swapConfirmState, attemptingTxn: false, swapErrorMessage: undefined, txHash }
         console.debug('[Swap confirm state] transactionSent: ', state)
         setSwapConfirmState(state)
+        if (!isExpertMode) {
+          setTransactionConfirm({ operationType: OperationType.ORDER_SIGN, pendingText: '' })
+        }
       },
     }),
-    [swapConfirmState, setSwapConfirmState]
+    [swapConfirmState, setSwapConfirmState, setTransactionConfirm, isExpertMode]
   )
 }


### PR DESCRIPTION
# Summary

Fixes #1163

<img width="995" alt="image" src="https://user-images.githubusercontent.com/7122625/194086971-ea42abb0-3716-4ef6-86d8-0b96c63b357c.png">

After Swap refactoring the "Order submitted" screen has been lost.
