### PR TITLE
Fixed logo position on mobile menu open

### DIFF
--- a/src/custom/components/Header/styled.ts
+++ b/src/custom/components/Header/styled.ts
@@ -114,7 +114,7 @@ export const Wrapper = styled.div<{ isMobileMenuOpen: boolean; isDarkMode: boole
       ${
         isMobileMenuOpen &&
         css`
-          position: absolute;
+          position: fixed;
           top: 0;
           z-index: 3;
 


### PR DESCRIPTION
# Summary

Fixes the logo position in the mobile menu, when the banner is present:

https://user-images.githubusercontent.com/31534717/194368865-ab87c3e6-f84e-42c1-abcb-80143957437a.mov

