### PR TITLE
[ETH-FLOW V2] - Modified slippage label and popover

### DIFF
--- a/src/cow-react/modules/swap/containers/TradeBasicDetails/index.tsx
+++ b/src/cow-react/modules/swap/containers/TradeBasicDetails/index.tsx
@@ -42,7 +42,7 @@ export function TradeBasicDetails(props: TradeBasicDetailsProp) {
       {isExpertMode && trade && (
         <>
           {/* Slippage */}
-          <RowSlippage allowedSlippage={allowedSlippagePercent} />
+          <RowSlippage trade={trade} allowedSlippage={allowedSlippagePercent} />
 
           {/* Min/Max received */}
           <RowReceivedAfterSlippage

--- a/src/cow-react/pages/Swap/SwapMod.tsx
+++ b/src/cow-react/pages/Swap/SwapMod.tsx
@@ -366,7 +366,13 @@ export default function Swap({ history, location, className }: RouteComponentPro
                     {trade && <Price trade={trade} />}
 
                     {!isExpertMode && !allowedSlippage.equalTo(INITIAL_ALLOWED_SLIPPAGE_PERCENT) && (
-                      <RowSlippage allowedSlippage={allowedSlippage} fontSize={12} fontWeight={400} rowHeight={24} />
+                      <RowSlippage
+                        trade={trade}
+                        allowedSlippage={allowedSlippage}
+                        fontSize={12}
+                        fontWeight={400}
+                        rowHeight={24}
+                      />
                     )}
                     {(isFeeGreater || trade) && fee && (
                       <TradeBasicDetails

--- a/src/custom/components/swap/TradeSummary/index.tsx
+++ b/src/custom/components/swap/TradeSummary/index.tsx
@@ -43,6 +43,7 @@ export default function TradeSummary({ trade, allowedSlippage, showHelpers, show
 
         {/* Slippage */}
         <RowSlippage
+          trade={trade}
           allowedSlippage={allowedSlippage}
           fontSize={12}
           fontWeight={400}

--- a/src/custom/theme/baseTheme.tsx
+++ b/src/custom/theme/baseTheme.tsx
@@ -67,6 +67,7 @@ export function colors(darkMode: boolean): Colors {
     blue2: darkMode ? '#a3beff' : '#0c40bf',
     purple: '#8958FF',
     yellow: '#fff6dc',
+    yellow1: '#ebd6a2',
     orange: '#FF784A',
     greenShade: '#376c57',
     blueShade: '#0f2644',

--- a/src/custom/theme/index.tsx
+++ b/src/custom/theme/index.tsx
@@ -1,3 +1,8 @@
+import styled from 'styled-components/macro'
+import { Text } from 'rebass'
+import { ThemedText as ThemedTextUni, TextProps as TextPropsUni } from '@src/theme'
+import { Colors } from './styled'
+
 export enum ButtonSize {
   SMALL,
   DEFAULT,
@@ -15,6 +20,30 @@ export enum Z_INDEX {
   modal = 1060,
   popover = 1070,
   tooltip = 1080,
+}
+
+type TextProps = TextPropsUni & { override?: boolean }
+
+export const TextWrapper = styled(Text)<{ color: keyof Colors; override?: boolean }>`
+  color: ${({ color, theme, override }) => {
+    const colour = (theme as any)[color]
+    if (colour && override) {
+      return colour + '!important'
+    } else {
+      return colour
+    }
+  }};
+`
+
+/**
+ * Preset styles of the Rebass Text component
+ * MOD of UNI's in @src/theme/index.ts
+ */
+export const ThemedText = {
+  ...ThemedTextUni,
+  Warn(props: TextProps) {
+    return <TextWrapper fontWeight={500} color={'yellow1'} {...props} />
+  },
 }
 
 // Cow theme

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -11,7 +11,7 @@ import { Colors } from './styled'
 
 export * from './components'
 
-type TextProps = Omit<TextPropsOriginal, 'css'>
+export type TextProps = Omit<TextPropsOriginal, 'css'>
 
 export const MEDIA_WIDTHS = {
   upToExtraSmall: 500,
@@ -153,7 +153,7 @@ export function getTheme(darkMode: boolean): DefaultTheme {
 //   return <StyledComponentsThemeProvider theme={themeObject}>{children}</StyledComponentsThemeProvider>
 // }
 
-const TextWrapper = styled(Text)<{ color: keyof Colors }>`
+export const TextWrapper = styled(Text)<{ color: keyof Colors }>`
   color: ${({ color, theme }) => (theme as any)[color]};
 `
 


### PR DESCRIPTION
Since changes in #1158 this replaces #901

# Summary

Additionally adds changes required to the `RowSlippage` component which is shown to users (currently only in non-expert mode) under the swap currency selectors as part of the trade information.

Following PR #902 will add the modified 2% slippage where necessary using the `isUserNativeEthFlow` prop

# Testing
The slippage won't change to 2% here, just the `modified` slippage message and popover appears when native trade detected

Following PR will have slippage updates
