### PR TITLE
[ETH-FLOW V2] - Slippage updater

### DIFF
--- a/src/cow-react/modules/application/containers/App/Updaters.tsx
+++ b/src/cow-react/modules/application/containers/App/Updaters.tsx
@@ -19,6 +19,7 @@ import {
 
 import { UploadToIpfsUpdater } from 'state/appData/updater'
 import { GasPriceStrategyUpdater } from 'state/gas/gas-price-strategy-updater'
+import EthFlowSlippageUpdater from 'state/ethFlow/updater'
 
 export function Updaters() {
   return (
@@ -41,6 +42,7 @@ export function Updaters() {
       <UploadToIpfsUpdater />
       <GnosisSafeUpdater />
       <GasPriceStrategyUpdater />
+      <EthFlowSlippageUpdater />
     </>
   )
 }

--- a/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
+++ b/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
@@ -116,7 +116,7 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
   const { chainId } = useWeb3React()
   const theme = useContext(ThemeContext)
 
-  const shouldShowEthFlowSlippage = useShowNativeEthFlowSlippageWarning()
+  const { showWarning: shouldShowEthFlowSlippage } = useShowNativeEthFlowSlippageWarning()
 
   const userSlippageTolerance = useUserSlippageTolerance()
   const setUserSlippageTolerance = useSetUserSlippageTolerance()

--- a/src/custom/components/swap/TradeSummary/RowSlippage.tsx
+++ b/src/custom/components/swap/TradeSummary/RowSlippage.tsx
@@ -14,6 +14,8 @@ import TradeGp from 'state/swap/TradeGp'
 import { ClickableText } from 'pages/Pool/styleds'
 import { WrapType } from 'hooks/useWrapCallback'
 import { useWrapType } from 'hooks/useWrapCallback'
+import { ETH_FLOW_SLIPPAGE } from 'state/ethFlow/updater'
+import { useShowNativeEthFlowSlippageWarning } from 'state/ethFlow/hooks'
 
 export interface RowSlippageProps {
   trade?: TradeGp
@@ -36,13 +38,14 @@ export function RowSlippage({
   const toggleSettings = useToggleSettingsMenu()
   const displaySlippage = `${formatSmart(allowedSlippage, PERCENTAGE_PRECISION)}%`
 
+  // should we show the warning?
+  const { showWarning: showEthFlowSlippageWarning, native } = useShowNativeEthFlowSlippageWarning()
+
   // if is wrap/unwrap operation return null
   const wrapType = useWrapType()
   if (wrapType !== WrapType.NOT_APPLICABLE) return null
 
-  // should we show the warning?
-  const showEthFlowSlippageWarning = !!trade?.inputAmount.currency.isNative
-  const [nativeSymbol, wrappedSymbol] = [trade?.inputAmount.currency.symbol, trade?.inputAmount.currency.wrapped.symbol]
+  const nativeSymbol = native.symbol || 'a native currency'
 
   return (
     <RowBetween height={rowHeight}>
@@ -71,12 +74,9 @@ export function RowSlippage({
             showEthFlowSlippageWarning ? (
               <Trans>
                 <p>
-                  You are currently swapping {nativeSymbol || 'a native token'} with the classic{' '}
-                  {wrappedSymbol || 'wrapped currency'} experience disabled.
-                </p>
-                <p>
-                  Slippage tolerance is defaulted to 2% to ensure a high likelihood of order matching, even in volatile
-                  market situations.
+                  When swapping {nativeSymbol}, slippage tolerance is defaulted to{' '}
+                  {ETH_FLOW_SLIPPAGE.toSignificant(PERCENTAGE_PRECISION)}% to ensure a high likelihood of order
+                  matching, even in volatile market situations.
                 </p>
               </Trans>
             ) : (

--- a/src/custom/state/ethFlow/hooks.ts
+++ b/src/custom/state/ethFlow/hooks.ts
@@ -1,0 +1,7 @@
+import { useDetectNativeToken } from '../swap/hooks'
+
+export function useShowNativeEthFlowSlippageWarning() {
+  const { isNativeIn, isWrapOrUnwrap } = useDetectNativeToken()
+
+  return isNativeIn && !isWrapOrUnwrap
+}

--- a/src/custom/state/ethFlow/hooks.ts
+++ b/src/custom/state/ethFlow/hooks.ts
@@ -1,7 +1,7 @@
 import { useDetectNativeToken } from '../swap/hooks'
 
 export function useShowNativeEthFlowSlippageWarning() {
-  const { isNativeIn, isWrapOrUnwrap } = useDetectNativeToken()
+  const { isNativeIn, isWrapOrUnwrap, native } = useDetectNativeToken()
 
-  return isNativeIn && !isWrapOrUnwrap
+  return { showWarning: isNativeIn && !isWrapOrUnwrap, native }
 }

--- a/src/custom/state/ethFlow/updater.tsx
+++ b/src/custom/state/ethFlow/updater.tsx
@@ -1,0 +1,36 @@
+import { Percent } from '@uniswap/sdk-core'
+import { useEffect, useState } from 'react'
+import { useSetUserSlippageTolerance, useUserSlippageTolerance } from 'state/user/hooks'
+import { useShowNativeEthFlowSlippageWarning } from './hooks'
+
+export const ETH_FLOW_SLIPPAGE = new Percent(2, 100) // 2%
+
+export default function Updater() {
+  // use previous slippage for when user is not in native swap and set to native flow
+  const currentSlippage = useUserSlippageTolerance()
+
+  // save the last non eth-flow slippage amount to reset when user switches back to normal erc20 flow
+  const [erc20Slippage, setErc20Slippage] = useState<Percent | 'auto' | undefined>(currentSlippage)
+
+  const shouldShowEthFlowSlippage = useShowNativeEthFlowSlippageWarning()
+
+  const setUserSlippageTolerance = useSetUserSlippageTolerance()
+
+  // change slippage set to 2% when detected eth swap and option is set to use native flow
+  useEffect(() => {
+    if (shouldShowEthFlowSlippage) {
+      // user switched back to erc20, we need to reset their previous slippage back to what it was
+      if (currentSlippage instanceof Percent && !currentSlippage.equalTo(ETH_FLOW_SLIPPAGE)) {
+        // do sth
+        setErc20Slippage(currentSlippage)
+      }
+      setUserSlippageTolerance(ETH_FLOW_SLIPPAGE)
+    } else {
+      setUserSlippageTolerance(erc20Slippage ?? 'auto')
+    }
+    // we only want to depend on shouldShowEthFlowSlippage
+    // to avoid re-renders
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [setUserSlippageTolerance, shouldShowEthFlowSlippage])
+  return null
+}

--- a/src/custom/state/ethFlow/updater.tsx
+++ b/src/custom/state/ethFlow/updater.tsx
@@ -12,7 +12,7 @@ export default function Updater() {
   // save the last non eth-flow slippage amount to reset when user switches back to normal erc20 flow
   const [erc20Slippage, setErc20Slippage] = useState<Percent | 'auto' | undefined>(currentSlippage)
 
-  const shouldShowEthFlowSlippage = useShowNativeEthFlowSlippageWarning()
+  const { showWarning: shouldShowEthFlowSlippage } = useShowNativeEthFlowSlippageWarning()
 
   const setUserSlippageTolerance = useSetUserSlippageTolerance()
 


### PR DESCRIPTION
Replaces #902 and is built on top of the updated eth flow in develop

Adds the eth flow slippage updater that detects a native currency swap and sets the slippage to 2% 
When native currency swap detected:
- disables 'Auto' choice in settings
- disables changing the slippage input
- switches slippage to fixed 2%

When switching back to erc20 <> erc20
- returns to previous selected non-native swap slippage
- reenables the slippage settings

NATIVE SWAP DETECTED:
(slippage showing modified and @ 2%)
<img width="481" alt="image" src="https://user-images.githubusercontent.com/21335563/195191783-ac06bc4d-cd43-4536-a977-1de2752e7ac6.png">
(transaction settings showing disabled input/auto select option)
<img width="354" alt="image" src="https://user-images.githubusercontent.com/21335563/195191912-5f4a5d10-b5e9-48bf-bb61-23c775567ed6.png">
