### PR TITLE
1186 - Eth-Flow - Fix issues

### DIFF
--- a/src/custom/components/SearchModal/CommonBases/CommonBasesMod.tsx
+++ b/src/custom/components/SearchModal/CommonBases/CommonBasesMod.tsx
@@ -14,6 +14,8 @@ import { currencyId } from 'utils/currencyId'
 import QuestionHelper from 'components/QuestionHelper'
 import { BaseWrapper, CommonBasesRow, MobileWrapper } from '.' // mod
 import { useFavouriteOrCommonTokens } from 'hooks/useFavouriteOrCommonTokens'
+import { getOverriddenTokenLogoURI } from 'lib/hooks/useCurrencyLogoURIs/useCurrencyLogoURIsMod'
+import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
 
 /* const MobileWrapper = styled(AutoColumn)`
   ${({ theme }) => theme.mediaWidth.upToSmall`
@@ -149,5 +151,11 @@ export default function CommonBases({
 function CurrencyLogoFromList({ currency }: { currency: Currency }) {
   const token = useTokenInfoFromActiveList(currency)
 
-  return <CurrencyLogo currency={token} style={{ marginRight: 8 }} />
+  let tokenAux = token
+  if (token instanceof WrappedTokenInfo) {
+    const logoURI = getOverriddenTokenLogoURI(token)
+    tokenAux = logoURI ? new WrappedTokenInfo({ ...token.tokenInfo, logoURI }, token.list) : token
+  }
+
+  return <CurrencyLogo currency={tokenAux} style={{ marginRight: 8 }} />
 }

--- a/src/custom/components/swap/EthFlow/containers/EthFlowModal/index.tsx
+++ b/src/custom/components/swap/EthFlow/containers/EthFlowModal/index.tsx
@@ -71,6 +71,7 @@ function EthFlow({
   }
 
   useSetupEthFlow({
+    state,
     ethFlowActions,
     isExpertMode,
     hasEnoughWrappedBalanceForSwap,

--- a/src/custom/components/swap/EthFlow/pure/EthFlowModalContent/EthFlowModalBottomContent.tsx
+++ b/src/custom/components/swap/EthFlow/pure/EthFlowModalContent/EthFlowModalBottomContent.tsx
@@ -41,8 +41,14 @@ export function EthFlowModalBottomContent(params: BottomContentParams) {
     wrap: { txStatus: wrapTxStatus, txHash: wrapTxHash },
   } = ethFlowContext
 
+  const isFailedState = [
+    EthFlowState.WrapAndApproveFailed,
+    EthFlowState.WrapFailed,
+    EthFlowState.ApproveFailed,
+    EthFlowState.ApproveInsufficient,
+  ].includes(state)
   // The only case in Expert mode when we display the button is WrapAndApproveFailed, @see getDerivedEthFlowState()
-  const showButton = !isExpertMode || state === EthFlowState.WrapAndApproveFailed
+  const showButton = !isExpertMode || isFailedState
   const showWrapPreview = isExpertMode || ![EthFlowState.SwapReady, EthFlowState.ApproveNeeded].includes(state)
 
   const onClick = useCallback(() => {

--- a/src/custom/components/swap/EthFlow/pure/EthFlowModalContent/EthFlowModalTopContent.tsx
+++ b/src/custom/components/swap/EthFlow/pure/EthFlowModalContent/EthFlowModalTopContent.tsx
@@ -10,6 +10,10 @@ const ModalMessage = styled.div`
   padding: 0;
   width: 100%;
   color: ${({ theme }) => theme.wallet.color};
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    margin-top: 2rem;
+  `}
 `
 
 const LowBalanceMessage = styled(ModalMessage)`

--- a/src/custom/components/swap/EthFlow/pure/EthFlowModalContent/EthFlowModalTopContent.tsx
+++ b/src/custom/components/swap/EthFlow/pure/EthFlowModalContent/EthFlowModalTopContent.tsx
@@ -53,7 +53,7 @@ export function EthFlowModalTopContent({ descriptions, state, balanceChecks, nat
             ) : (
               <>
                 sufficient for{' '}
-                <strong>up to {balanceChecks.txsRemaining} wrapping, unwrapping, or approval operation(s)</strong>
+                <strong>up to {balanceChecks.txsRemaining} wrapping, unwrapping, or approval operation(s).</strong>
               </>
             )}
           </Trans>

--- a/src/custom/components/swap/EthFlow/pure/EthFlowModalContent/configs.ts
+++ b/src/custom/components/swap/EthFlow/pure/EthFlowModalContent/configs.ts
@@ -6,7 +6,7 @@ export interface EthFlowConfig {
   descriptions: string[]
 }
 
-const expertCommonDescription = 'Transaction signature required, please check your connected wallet'
+const expertCommonDescription = 'Transaction signature required, please check your connected wallet.'
 const ethFlowDescription = (nativeSymbol: string) =>
   `The current version of CoW Swap can’t yet use native ${nativeSymbol} to execute a trade (Look out for that feature coming soon!).`
 
@@ -26,7 +26,7 @@ export const ethFlowConfigs: {
     buttonText: 'Wrap and approve',
     descriptions: [
       'Both wrap and approve operations failed.',
-      `Check that you are providing a sufficient gas limit for both transactions in your wallet. Click "Wrap and approve" to try again`,
+      `Check that you are providing a sufficient gas limit for both transactions in your wallet. Click "Wrap and approve" to try again.`,
     ],
   }),
   [EthFlowState.WrapFailed]: ({ nativeSymbol }) => ({
@@ -34,15 +34,15 @@ export const ethFlowConfigs: {
     buttonText: `Wrap ${nativeSymbol}`,
     descriptions: [
       `Wrap operation failed.`,
-      `Check that you are providing a sufficient gas limit for the transaction in your wallet. Click "Wrap ${nativeSymbol}" to try again`,
+      `Check that you are providing a sufficient gas limit for the transaction in your wallet. Click "Wrap ${nativeSymbol}" to try again.`,
     ],
   }),
   [EthFlowState.ApproveFailed]: ({ wrappedSymbol }) => ({
     title: `Approve ${wrappedSymbol} failed!`,
     buttonText: `Approve ${wrappedSymbol}`,
     descriptions: [
-      `Approve operation failed. Check that you are providing a sufficient gas limit for the transaction in your wallet`,
-      `Click "Approve ${wrappedSymbol}" to try again`,
+      `Approve operation failed. Check that you are providing a sufficient gas limit for the transaction in your wallet.`,
+      `Click "Approve ${wrappedSymbol}" to try again.`,
     ],
   }),
   /**
@@ -52,24 +52,24 @@ export const ethFlowConfigs: {
   [EthFlowState.WrapAndApprovePending]: () => ({
     title: 'Wrap and approve',
     buttonText: '',
-    descriptions: ['Transactions in progress', 'See below for live status updates of each operation'],
+    descriptions: ['Transactions in progress.', 'See below for live status updates of each operation.'],
   }),
   [EthFlowState.WrapPending]: ({ nativeSymbol }) => ({
     title: `Swap with Wrapped ${nativeSymbol}`,
     buttonText: '',
-    descriptions: ['Transaction in progress. See below for live status updates'],
+    descriptions: ['Transaction in progress. See below for live status updates.'],
   }),
   [EthFlowState.ApprovePending]: ({ wrappedSymbol }) => ({
     title: `Approve ${wrappedSymbol}`,
     buttonText: '',
-    descriptions: ['Transaction in progress. See below for live status updates'],
+    descriptions: ['Transaction in progress. See below for live status updates.'],
   }),
   [EthFlowState.ApproveInsufficient]: ({ wrappedSymbol }) => ({
     title: 'Approval amount insufficient!',
     buttonText: `Approve ${wrappedSymbol}`,
     descriptions: [
-      'Approval amount insufficient for input amount',
-      'Check that you are approving an amount equal to or greater than the input amount',
+      'Approval amount insufficient for input amount.',
+      'Check that you are approving an amount equal to or greater than the input amount.',
     ],
   }),
   /**
@@ -80,7 +80,7 @@ export const ethFlowConfigs: {
     title: 'Wrap and approve',
     buttonText: '',
     descriptions: [
-      `2 pending on-chain transactions: ${nativeSymbol} wrap and approve. Please check your connected wallet for both signature requests`,
+      `2 pending on-chain transactions: ${nativeSymbol} wrap and approve. Please check your connected wallet for both signature requests.`,
     ],
   }),
   [EthFlowState.WrapNeeded]: ({ isExpertMode, nativeSymbol }) => ({

--- a/src/custom/components/swap/EthFlow/pure/EthFlowModalContent/configs.ts
+++ b/src/custom/components/swap/EthFlow/pure/EthFlowModalContent/configs.ts
@@ -7,8 +7,11 @@ export interface EthFlowConfig {
 }
 
 const expertCommonDescription = 'Transaction signature required, please check your connected wallet.'
+const commonSingularTxProgressDescription = 'Transaction in progress. See below for live status updates.'
+const commonFailedSingularTxGasLimitDescription =
+  'Check that you are providing a sufficient gas limit for the transaction in your wallet.'
 const ethFlowDescription = (nativeSymbol: string) =>
-  `The current version of CoW Swap can’t yet use native ${nativeSymbol} to execute a trade (Look out for that feature coming soon!).`
+  `CoW Swap does not currently support native ${nativeSymbol} trades. This will be supported very shortly, so stay tuned!`
 
 export const ethFlowConfigs: {
   [key in EthFlowState]: (context: {
@@ -26,22 +29,25 @@ export const ethFlowConfigs: {
     buttonText: 'Wrap and approve',
     descriptions: [
       'Both wrap and approve operations failed.',
-      `Check that you are providing a sufficient gas limit for both transactions in your wallet. Click "Wrap and approve" to try again.`,
+      'Check that you are providing a sufficient gas limit for both transactions in your wallet.',
+      'Click "Wrap and approve" to try again.',
     ],
   }),
   [EthFlowState.WrapFailed]: ({ nativeSymbol }) => ({
     title: `Wrap ${nativeSymbol} failed`,
     buttonText: `Wrap ${nativeSymbol}`,
     descriptions: [
-      `Wrap operation failed.`,
-      `Check that you are providing a sufficient gas limit for the transaction in your wallet. Click "Wrap ${nativeSymbol}" to try again.`,
+      'Wrap operation failed.',
+      commonFailedSingularTxGasLimitDescription,
+      `Click "Wrap ${nativeSymbol}" to try again.`,
     ],
   }),
   [EthFlowState.ApproveFailed]: ({ wrappedSymbol }) => ({
     title: `Approve ${wrappedSymbol} failed!`,
     buttonText: `Approve ${wrappedSymbol}`,
     descriptions: [
-      `Approve operation failed. Check that you are providing a sufficient gas limit for the transaction in your wallet.`,
+      'Approve operation failed.',
+      commonFailedSingularTxGasLimitDescription,
       `Click "Approve ${wrappedSymbol}" to try again.`,
     ],
   }),
@@ -52,17 +58,17 @@ export const ethFlowConfigs: {
   [EthFlowState.WrapAndApprovePending]: () => ({
     title: 'Wrap and approve',
     buttonText: '',
-    descriptions: ['Transactions in progress.', 'See below for live status updates of each operation.'],
+    descriptions: ['Transactions in progress. See below for live status updates of each operation.'],
   }),
   [EthFlowState.WrapPending]: ({ nativeSymbol }) => ({
     title: `Swap with Wrapped ${nativeSymbol}`,
     buttonText: '',
-    descriptions: ['Transaction in progress. See below for live status updates.'],
+    descriptions: [commonSingularTxProgressDescription],
   }),
   [EthFlowState.ApprovePending]: ({ wrappedSymbol }) => ({
     title: `Approve ${wrappedSymbol}`,
     buttonText: '',
-    descriptions: ['Transaction in progress. See below for live status updates.'],
+    descriptions: [commonSingularTxProgressDescription],
   }),
   [EthFlowState.ApproveInsufficient]: ({ wrappedSymbol }) => ({
     title: 'Approval amount insufficient!',
@@ -80,36 +86,43 @@ export const ethFlowConfigs: {
     title: 'Wrap and approve',
     buttonText: '',
     descriptions: [
+      ethFlowDescription(nativeSymbol),
+      `Continue this trade by wrapping your ${nativeSymbol}.`,
       `2 pending on-chain transactions: ${nativeSymbol} wrap and approve. Please check your connected wallet for both signature requests.`,
     ],
   }),
-  [EthFlowState.WrapNeeded]: ({ isExpertMode, nativeSymbol }) => ({
+  [EthFlowState.WrapNeeded]: ({ isExpertMode, nativeSymbol, wrappedSymbol }) => ({
     title: `Swap with Wrapped ${nativeSymbol}`,
     buttonText: `Wrap ${nativeSymbol}`,
     descriptions: isExpertMode
-      ? [expertCommonDescription]
-      : [ethFlowDescription(nativeSymbol), 'TODO: You dont have enough wrapped token...'],
+      ? [
+          ethFlowDescription(nativeSymbol),
+          `Continue this trade by wrapping your ${nativeSymbol}.`,
+          expertCommonDescription,
+        ]
+      : [
+          ethFlowDescription(nativeSymbol),
+          `To continue, click below to wrap your ${nativeSymbol} to ${wrappedSymbol} via an on-chain ERC20 transaction.`,
+        ],
   }),
   [EthFlowState.ApproveNeeded]: ({ isExpertMode, nativeSymbol, wrappedSymbol }) => ({
     title: `Approve ${wrappedSymbol}`,
     buttonText: `Approve ${wrappedSymbol}`,
-    descriptions: isExpertMode
-      ? [expertCommonDescription]
-      : [
-          ethFlowDescription(nativeSymbol),
-          `Additionally, it's also required to do a one-time approval of ${wrappedSymbol} via an on-chain ERC20 Approve transaction.`,
-        ],
+    descriptions: [
+      ethFlowDescription(nativeSymbol),
+      `For now, use your existing ${wrappedSymbol} balance to continue this trade.`,
+      isExpertMode
+        ? expertCommonDescription
+        : `Additionally, it is required to do a one-time approval of ${wrappedSymbol} via an on-chain ERC20 Approve transaction.`,
+    ],
   }),
-  [EthFlowState.SwapReady]: ({ isExpertMode, nativeSymbol, wrappedSymbol }) => ({
+  [EthFlowState.SwapReady]: ({ nativeSymbol, wrappedSymbol }) => ({
     title: `No need to wrap ${nativeSymbol}`,
     buttonText: 'Swap',
-    descriptions: isExpertMode
-      ? []
-      : [
-          `For now, use your existing ${wrappedSymbol} balance to continue this trade.`,
-          `You have enough ${wrappedSymbol} for this trade, so you don't need to wrap any more ${nativeSymbol} to continue with this trade.`,
-          `Press SWAP to use ${wrappedSymbol} and continue trading.`,
-        ],
+    descriptions: [
+      ethFlowDescription(nativeSymbol),
+      `To continue, click SWAP below to use your existing ${wrappedSymbol} balance and trade.`,
+    ],
   }),
   [EthFlowState.Loading]: () => ({
     title: 'Loading operation',

--- a/src/custom/lib/hooks/useCurrencyLogoURIs/useCurrencyLogoURIsMod.ts
+++ b/src/custom/lib/hooks/useCurrencyLogoURIs/useCurrencyLogoURIsMod.ts
@@ -1,4 +1,4 @@
-import { Currency } from '@uniswap/sdk-core'
+import { Currency, Token } from '@uniswap/sdk-core'
 import { SupportedChainId } from 'constants/chains'
 import useHttpLocations from 'hooks/useHttpLocations'
 import { useMemo } from 'react'
@@ -64,8 +64,7 @@ export default function useCurrencyLogoURIs(currency?: Currency | null): string[
         logoURIs.push(getNativeLogoURI(currency.chainId))
       } else if (currency.isToken) {
         // mod
-        const imageOverride = ADDRESS_IMAGE_OVERRIDE[currency.address]
-        const logoURI = imageOverride || getTokenLogoURI(currency.address, currency.chainId)
+        const logoURI = getOverriddenTokenLogoURI(currency)
         if (logoURI) {
           logoURIs.push(logoURI)
         }
@@ -73,4 +72,10 @@ export default function useCurrencyLogoURIs(currency?: Currency | null): string[
     }
     return logoURIs
   }, [currency, locations])
+}
+
+export function getOverriddenTokenLogoURI(currency: Token) {
+  const imageOverride = ADDRESS_IMAGE_OVERRIDE[currency.address]
+  const logoURI = imageOverride || getTokenLogoURI(currency.address, currency.chainId)
+  return logoURI
 }

--- a/src/custom/state/swap/hooks.tsx
+++ b/src/custom/state/swap/hooks.tsx
@@ -28,7 +28,8 @@ import { useGetQuoteAndStatus, useQuote } from '../price/hooks'
 import { registerOnWindow } from 'utils/misc'
 import { useTradeExactInWithFee, useTradeExactOutWithFee, stringToCurrency } from './extension'
 import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
-import { FEE_SIZE_THRESHOLD, INITIAL_ALLOWED_SLIPPAGE_PERCENT, WETH_LOGO_URI, XDAI_LOGO_URI } from 'constants/index'
+import { FEE_SIZE_THRESHOLD, INITIAL_ALLOWED_SLIPPAGE_PERCENT, WETH_LOGO_URI } from 'constants/index'
+import WXDAI_LOGO_URI from 'assets/cow-swap/wxdai.png'
 import TradeGp from './TradeGp'
 
 import { SupportedChainId, SupportedChainId as ChainId } from 'constants/chains'
@@ -488,7 +489,7 @@ export function useDetectNativeToken() {
     const wrappedToken: Token & { logoURI: string } = Object.assign(
       WETH[activeChainId || DEFAULT_NETWORK_FOR_LISTS].wrapped,
       {
-        logoURI: activeChainId === ChainId.GNOSIS_CHAIN ? XDAI_LOGO_URI : WETH_LOGO_URI,
+        logoURI: activeChainId === ChainId.GNOSIS_CHAIN ? WXDAI_LOGO_URI : WETH_LOGO_URI,
       }
     )
 


### PR DESCRIPTION
# Summary
Closes 1-4 (core issues) of #1186 

## Note
I see that the EthFlow code is currently in `src/custom` but according to the new guidelines it should be moved into `src/cow-react` correct? In that case I will do so after this PR

I also noticed the division of the folders inside `src/cow-react/modules`. Question: should EthFlow be it's own module to keep the `hooks`, `utils` etc separate from the `swap` stuff? @anxolin 

## Checklist and screenshots
1 & 2 & 4. Punctuation: 
- [X] add periods at end of sentences
- [X] no button to retry `Wrap`, `Approve`, or `Wrap and approve` in expert mode when tx fails
- [X] insufficient approval confirmed and moves to swap modal screen

### Wrap and approve
<img width="490" alt="image" src="https://user-images.githubusercontent.com/21335563/195409454-e342c778-9c83-415b-a40a-61fc0f3733de.png">

### Wrap failed
<img width="495" alt="image" src="https://user-images.githubusercontent.com/21335563/195409683-b44e6bd7-2acc-4318-9abe-d8324d8cbed6.png">

### Approve failed
<img width="497" alt="image" src="https://user-images.githubusercontent.com/21335563/195409997-b709feec-d890-4818-960a-16119d3fbbcb.png">

### Approve insufficient modal
<img width="529" alt="image" src="https://user-images.githubusercontent.com/21335563/195410571-43d195ec-7188-4fd7-9ea6-865320fd066e.png">

### Incomplete tasks (lower prio)
 - [ ] 3. 3-4 case, Expert mode: 'No need to wrap' modal blinks after the successful wrap before the Confirm Swap modal
- [x] 5. Progress bar modal appears in the Expert mode after signing transaction (however, should be fixed in https://github.com/cowprotocol/cowswap/pull/1167)
- [ ] 6. Order of transactions for the 4 case in the exprt mode is incorrect
- [x] 7. Fourth case, regular mode: 'Insufficient approved' modal blinks after successfully approved transaction before the 'No need to wrap' modal.
- [x] 8. Incorrect token icon: https://github.com/cowprotocol/cowswap/pull/1158#issuecomment-1273195270