### PR TITLE
[1186 - ETH-FLOW-V2] Fix and standardise descriptions

### DIFF
--- a/src/custom/components/swap/EthFlow/pure/EthFlowModalContent/EthFlowModalTopContent.tsx
+++ b/src/custom/components/swap/EthFlow/pure/EthFlowModalContent/EthFlowModalTopContent.tsx
@@ -10,6 +10,10 @@ const ModalMessage = styled.div`
   padding: 0;
   width: 100%;
   color: ${({ theme }) => theme.wallet.color};
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    margin-top: 2rem;
+  `}
 `
 
 const LowBalanceMessage = styled(ModalMessage)`

--- a/src/custom/components/swap/EthFlow/pure/EthFlowModalContent/configs.ts
+++ b/src/custom/components/swap/EthFlow/pure/EthFlowModalContent/configs.ts
@@ -7,8 +7,11 @@ export interface EthFlowConfig {
 }
 
 const expertCommonDescription = 'Transaction signature required, please check your connected wallet.'
+const commonSingularTxProgressDescription = 'Transaction in progress. See below for live status updates.'
+const commonFailedSingularTxGasLimitDescription =
+  'Check that you are providing a sufficient gas limit for the transaction in your wallet.'
 const ethFlowDescription = (nativeSymbol: string) =>
-  `The current version of CoW Swap can’t yet use native ${nativeSymbol} to execute a trade (Look out for that feature coming soon!).`
+  `CoW Swap does not currently support native ${nativeSymbol} trades. This will be supported very shortly, so stay tuned!`
 
 export const ethFlowConfigs: {
   [key in EthFlowState]: (context: {
@@ -26,22 +29,25 @@ export const ethFlowConfigs: {
     buttonText: 'Wrap and approve',
     descriptions: [
       'Both wrap and approve operations failed.',
-      `Check that you are providing a sufficient gas limit for both transactions in your wallet. Click "Wrap and approve" to try again.`,
+      'Check that you are providing a sufficient gas limit for both transactions in your wallet.',
+      'Click "Wrap and approve" to try again.',
     ],
   }),
   [EthFlowState.WrapFailed]: ({ nativeSymbol }) => ({
     title: `Wrap ${nativeSymbol} failed`,
     buttonText: `Wrap ${nativeSymbol}`,
     descriptions: [
-      `Wrap operation failed.`,
-      `Check that you are providing a sufficient gas limit for the transaction in your wallet. Click "Wrap ${nativeSymbol}" to try again.`,
+      'Wrap operation failed.',
+      commonFailedSingularTxGasLimitDescription,
+      `Click "Wrap ${nativeSymbol}" to try again.`,
     ],
   }),
   [EthFlowState.ApproveFailed]: ({ wrappedSymbol }) => ({
     title: `Approve ${wrappedSymbol} failed!`,
     buttonText: `Approve ${wrappedSymbol}`,
     descriptions: [
-      `Approve operation failed. Check that you are providing a sufficient gas limit for the transaction in your wallet.`,
+      'Approve operation failed.',
+      commonFailedSingularTxGasLimitDescription,
       `Click "Approve ${wrappedSymbol}" to try again.`,
     ],
   }),
@@ -52,17 +58,17 @@ export const ethFlowConfigs: {
   [EthFlowState.WrapAndApprovePending]: () => ({
     title: 'Wrap and approve',
     buttonText: '',
-    descriptions: ['Transactions in progress.', 'See below for live status updates of each operation.'],
+    descriptions: ['Transactions in progress. See below for live status updates of each operation.'],
   }),
   [EthFlowState.WrapPending]: ({ nativeSymbol }) => ({
     title: `Swap with Wrapped ${nativeSymbol}`,
     buttonText: '',
-    descriptions: ['Transaction in progress. See below for live status updates.'],
+    descriptions: [commonSingularTxProgressDescription],
   }),
   [EthFlowState.ApprovePending]: ({ wrappedSymbol }) => ({
     title: `Approve ${wrappedSymbol}`,
     buttonText: '',
-    descriptions: ['Transaction in progress. See below for live status updates.'],
+    descriptions: [commonSingularTxProgressDescription],
   }),
   [EthFlowState.ApproveInsufficient]: ({ wrappedSymbol }) => ({
     title: 'Approval amount insufficient!',
@@ -80,24 +86,28 @@ export const ethFlowConfigs: {
     title: 'Wrap and approve',
     buttonText: '',
     descriptions: [
+      ethFlowDescription(nativeSymbol),
       `2 pending on-chain transactions: ${nativeSymbol} wrap and approve. Please check your connected wallet for both signature requests.`,
     ],
   }),
-  [EthFlowState.WrapNeeded]: ({ isExpertMode, nativeSymbol }) => ({
+  [EthFlowState.WrapNeeded]: ({ isExpertMode, nativeSymbol, wrappedSymbol }) => ({
     title: `Swap with Wrapped ${nativeSymbol}`,
     buttonText: `Wrap ${nativeSymbol}`,
     descriptions: isExpertMode
-      ? [expertCommonDescription]
-      : [ethFlowDescription(nativeSymbol), 'TODO: You dont have enough wrapped token...'],
+      ? [ethFlowDescription(nativeSymbol), expertCommonDescription]
+      : [
+          ethFlowDescription(nativeSymbol),
+          `To continue, click below to wrap your ${nativeSymbol} to ${wrappedSymbol} via an on-chain ERC20 transaction.`,
+        ],
   }),
   [EthFlowState.ApproveNeeded]: ({ isExpertMode, nativeSymbol, wrappedSymbol }) => ({
     title: `Approve ${wrappedSymbol}`,
     buttonText: `Approve ${wrappedSymbol}`,
     descriptions: isExpertMode
-      ? [expertCommonDescription]
+      ? [ethFlowDescription(nativeSymbol), expertCommonDescription]
       : [
           ethFlowDescription(nativeSymbol),
-          `Additionally, it's also required to do a one-time approval of ${wrappedSymbol} via an on-chain ERC20 Approve transaction.`,
+          `Additionally, it is required to do a one-time approval of ${wrappedSymbol} via an on-chain ERC20 Approve transaction.`,
         ],
   }),
   [EthFlowState.SwapReady]: ({ isExpertMode, nativeSymbol, wrappedSymbol }) => ({
@@ -106,9 +116,8 @@ export const ethFlowConfigs: {
     descriptions: isExpertMode
       ? []
       : [
-          `For now, use your existing ${wrappedSymbol} balance to continue this trade.`,
-          `You have enough ${wrappedSymbol} for this trade, so you don't need to wrap any more ${nativeSymbol} to continue with this trade.`,
-          `Press SWAP to use ${wrappedSymbol} and continue trading.`,
+          ethFlowDescription(nativeSymbol),
+          `To continue, click SWAP below to use your existing ${wrappedSymbol} balance and trade.`,
         ],
   }),
   [EthFlowState.Loading]: () => ({

--- a/src/custom/components/swap/EthFlow/pure/EthFlowModalContent/configs.ts
+++ b/src/custom/components/swap/EthFlow/pure/EthFlowModalContent/configs.ts
@@ -87,6 +87,7 @@ export const ethFlowConfigs: {
     buttonText: '',
     descriptions: [
       ethFlowDescription(nativeSymbol),
+      `Continue this trade by wrapping your ${nativeSymbol}.`,
       `2 pending on-chain transactions: ${nativeSymbol} wrap and approve. Please check your connected wallet for both signature requests.`,
     ],
   }),
@@ -94,7 +95,11 @@ export const ethFlowConfigs: {
     title: `Swap with Wrapped ${nativeSymbol}`,
     buttonText: `Wrap ${nativeSymbol}`,
     descriptions: isExpertMode
-      ? [ethFlowDescription(nativeSymbol), expertCommonDescription]
+      ? [
+          ethFlowDescription(nativeSymbol),
+          `Continue this trade by wrapping your ${nativeSymbol}.`,
+          expertCommonDescription,
+        ]
       : [
           ethFlowDescription(nativeSymbol),
           `To continue, click below to wrap your ${nativeSymbol} to ${wrappedSymbol} via an on-chain ERC20 transaction.`,
@@ -104,9 +109,14 @@ export const ethFlowConfigs: {
     title: `Approve ${wrappedSymbol}`,
     buttonText: `Approve ${wrappedSymbol}`,
     descriptions: isExpertMode
-      ? [ethFlowDescription(nativeSymbol), expertCommonDescription]
+      ? [
+          ethFlowDescription(nativeSymbol),
+          `For now, use your existing ${wrappedSymbol} balance to continue this trade.`,
+          expertCommonDescription,
+        ]
       : [
           ethFlowDescription(nativeSymbol),
+          `For now, use your existing ${wrappedSymbol} balance to continue this trade.`,
           `Additionally, it is required to do a one-time approval of ${wrappedSymbol} via an on-chain ERC20 Approve transaction.`,
         ],
   }),

--- a/src/custom/components/swap/EthFlow/pure/EthFlowModalContent/configs.ts
+++ b/src/custom/components/swap/EthFlow/pure/EthFlowModalContent/configs.ts
@@ -108,27 +108,21 @@ export const ethFlowConfigs: {
   [EthFlowState.ApproveNeeded]: ({ isExpertMode, nativeSymbol, wrappedSymbol }) => ({
     title: `Approve ${wrappedSymbol}`,
     buttonText: `Approve ${wrappedSymbol}`,
-    descriptions: isExpertMode
-      ? [
-          ethFlowDescription(nativeSymbol),
-          `For now, use your existing ${wrappedSymbol} balance to continue this trade.`,
-          expertCommonDescription,
-        ]
-      : [
-          ethFlowDescription(nativeSymbol),
-          `For now, use your existing ${wrappedSymbol} balance to continue this trade.`,
-          `Additionally, it is required to do a one-time approval of ${wrappedSymbol} via an on-chain ERC20 Approve transaction.`,
-        ],
+    descriptions: [
+      ethFlowDescription(nativeSymbol),
+      `For now, use your existing ${wrappedSymbol} balance to continue this trade.`,
+      isExpertMode
+        ? expertCommonDescription
+        : `Additionally, it is required to do a one-time approval of ${wrappedSymbol} via an on-chain ERC20 Approve transaction.`,
+    ],
   }),
-  [EthFlowState.SwapReady]: ({ isExpertMode, nativeSymbol, wrappedSymbol }) => ({
+  [EthFlowState.SwapReady]: ({ nativeSymbol, wrappedSymbol }) => ({
     title: `No need to wrap ${nativeSymbol}`,
     buttonText: 'Swap',
-    descriptions: isExpertMode
-      ? []
-      : [
-          ethFlowDescription(nativeSymbol),
-          `To continue, click SWAP below to use your existing ${wrappedSymbol} balance and trade.`,
-        ],
+    descriptions: [
+      ethFlowDescription(nativeSymbol),
+      `To continue, click SWAP below to use your existing ${wrappedSymbol} balance and trade.`,
+    ],
   }),
   [EthFlowState.Loading]: () => ({
     title: 'Loading operation',


### PR DESCRIPTION
# Summary

Part of #1186 

Addresses @elena-zh 's comment on descriptions: https://github.com/cowprotocol/cowswap/pull/1187#issuecomment-1277712327

## Screenshots (in cosmos)

#### Regular Mode
@elena-zh made the comment that the description was a little redundant, so i cleaned it up:
##### Swap Ready base modal text
<img width="428" alt="image" src="https://user-images.githubusercontent.com/21335563/195654834-75e484c8-4d76-4d16-bc86-94e5ba755088.png">

#### Expert Mode
@elena-zh made the point that it is unclear even in expert mode why users are wrapping native currency. I opted for using the ethFlowDescription base text:

##### Approve/Wrap pending
<img width="437" alt="image" src="https://user-images.githubusercontent.com/21335563/196202909-24840502-3441-4a06-964d-179f06b93072.png">
<img width="439" alt="image" src="https://user-images.githubusercontent.com/21335563/196202988-d5839619-6486-4471-b44d-0992dfecf5eb.png">

