### PR TITLE
1186.3- fix token images further

### DIFF
--- a/src/custom/components/SearchModal/CommonBases/CommonBasesMod.tsx
+++ b/src/custom/components/SearchModal/CommonBases/CommonBasesMod.tsx
@@ -14,6 +14,8 @@ import { currencyId } from 'utils/currencyId'
 import QuestionHelper from 'components/QuestionHelper'
 import { BaseWrapper, CommonBasesRow, MobileWrapper } from '.' // mod
 import { useFavouriteOrCommonTokens } from 'hooks/useFavouriteOrCommonTokens'
+import { getOverriddenTokenLogoURI } from 'lib/hooks/useCurrencyLogoURIs/useCurrencyLogoURIsMod'
+import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
 
 /* const MobileWrapper = styled(AutoColumn)`
   ${({ theme }) => theme.mediaWidth.upToSmall`
@@ -149,5 +151,11 @@ export default function CommonBases({
 function CurrencyLogoFromList({ currency }: { currency: Currency }) {
   const token = useTokenInfoFromActiveList(currency)
 
-  return <CurrencyLogo currency={token} style={{ marginRight: 8 }} />
+  let tokenAux = token
+  if (token instanceof WrappedTokenInfo) {
+    const logoURI = getOverriddenTokenLogoURI(token)
+    tokenAux = logoURI ? new WrappedTokenInfo({ ...token.tokenInfo, logoURI }, token.list) : token
+  }
+
+  return <CurrencyLogo currency={tokenAux} style={{ marginRight: 8 }} />
 }

--- a/src/custom/lib/hooks/useCurrencyLogoURIs/useCurrencyLogoURIsMod.ts
+++ b/src/custom/lib/hooks/useCurrencyLogoURIs/useCurrencyLogoURIsMod.ts
@@ -1,4 +1,4 @@
-import { Currency } from '@uniswap/sdk-core'
+import { Currency, Token } from '@uniswap/sdk-core'
 import { SupportedChainId } from 'constants/chains'
 import useHttpLocations from 'hooks/useHttpLocations'
 import { useMemo } from 'react'
@@ -64,8 +64,7 @@ export default function useCurrencyLogoURIs(currency?: Currency | null): string[
         logoURIs.push(getNativeLogoURI(currency.chainId))
       } else if (currency.isToken) {
         // mod
-        const imageOverride = ADDRESS_IMAGE_OVERRIDE[currency.address]
-        const logoURI = imageOverride || getTokenLogoURI(currency.address, currency.chainId)
+        const logoURI = getOverriddenTokenLogoURI(currency)
         if (logoURI) {
           logoURIs.push(logoURI)
         }
@@ -73,4 +72,10 @@ export default function useCurrencyLogoURIs(currency?: Currency | null): string[
     }
     return logoURIs
   }, [currency, locations])
+}
+
+export function getOverriddenTokenLogoURI(currency: Token) {
+  const imageOverride = ADDRESS_IMAGE_OVERRIDE[currency.address]
+  const logoURI = imageOverride || getTokenLogoURI(currency.address, currency.chainId)
+  return logoURI
 }

--- a/src/custom/state/swap/hooks.tsx
+++ b/src/custom/state/swap/hooks.tsx
@@ -28,7 +28,8 @@ import { useGetQuoteAndStatus, useQuote } from '../price/hooks'
 import { registerOnWindow } from 'utils/misc'
 import { useTradeExactInWithFee, useTradeExactOutWithFee, stringToCurrency } from './extension'
 import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
-import { FEE_SIZE_THRESHOLD, INITIAL_ALLOWED_SLIPPAGE_PERCENT, WETH_LOGO_URI, XDAI_LOGO_URI } from 'constants/index'
+import { FEE_SIZE_THRESHOLD, INITIAL_ALLOWED_SLIPPAGE_PERCENT, WETH_LOGO_URI } from 'constants/index'
+import WXDAI_LOGO_URI from 'assets/cow-swap/wxdai.png'
 import TradeGp from './TradeGp'
 
 import { SupportedChainId, SupportedChainId as ChainId } from 'constants/chains'
@@ -488,7 +489,7 @@ export function useDetectNativeToken() {
     const wrappedToken: Token & { logoURI: string } = Object.assign(
       WETH[activeChainId || DEFAULT_NETWORK_FOR_LISTS].wrapped,
       {
-        logoURI: activeChainId === ChainId.GNOSIS_CHAIN ? XDAI_LOGO_URI : WETH_LOGO_URI,
+        logoURI: activeChainId === ChainId.GNOSIS_CHAIN ? WXDAI_LOGO_URI : WETH_LOGO_URI,
       }
     )
 


### PR DESCRIPTION
# Summary

Extends work done in https://github.com/cowprotocol/cowswap/pull/1152#issue-1395031158

### Explanation
This one was a bit tricky - @alfetopito 's work was not reflecting in the latest changes of #1149 in the token list, wrap card of eth flow, AND in the common bases.

Changes show that it was necessary to:
1. change the logo selected in the `useMemo` of `useDetectNativeToken` to use the local asset instead of the 1Hive URL for XDAI 
2. use the same modded logic in `useCurrencyLogoURIMod` (https://github.com/cowprotocol/cowswap/compare/1186/fix-commented-issues...1186.3/fix-token-images-further?expand=1#diff-87ebfc624cd00d5fc3d60a83d4020cab416fed914a48215706a98ebacb173e02) to override the token logo images in `CommonBasesMod` to override the token logo URI there as well, since it was being pulled from the active list (https://github.com/cowprotocol/cowswap/compare/1186/fix-commented-issues...1186.3/fix-token-images-further?expand=1#diff-ac462a5b2c2b70d1cbf7ee299146b76d5fc02bb33a0551338b510fefc4294267)