### PR TITLE
[ETH-FLOW-v2] Show ETH Flow Description in expertMode

### DIFF
--- a/src/custom/components/swap/EthFlow/containers/EthFlowModal/hooks/useSetupEthFlow.ts
+++ b/src/custom/components/swap/EthFlow/containers/EthFlowModal/hooks/useSetupEthFlow.ts
@@ -41,6 +41,7 @@ export function useSetupEthFlow({
 
   const [isExpertModeRunning, setExpertModeRunning] = useState(false)
   const [isContextInited, setContextInited] = useState(false)
+  const [isExpertModeNeedsSwapConfirm, setIsExpertModeNeedsSwapConfirm] = useState(false)
 
   const {
     approve: { isNeeded: isApproveNeeded, txStatus: approveTxStatus },
@@ -76,7 +77,9 @@ export function useSetupEthFlow({
       setExpertModeRunning(true)
 
       if (!isWrapNeeded && !isApproveNeeded) {
-        ethFlowActions.directSwap()
+        // initially "swap ready" user in expertMode
+        // still needs to confirm that they are swapping wrapped native
+        setIsExpertModeNeedsSwapConfirm(true)
       } else {
         ethFlowActions.expertModeFlow()
       }
@@ -100,8 +103,9 @@ export function useSetupEthFlow({
       : true
     const isWrapPassed = isWrapNeeded ? wrapTxStatus === ActivityStatus.CONFIRMED : true
 
-    if (isExpertMode && isExpertModeRunning && isApprovePassed && isWrapPassed) {
-      delay(MODAL_CLOSE_DELAY).then(ethFlowActions.swap)
+    // automatically go to swap when user has gone thru wrap/approve steps in expertMode
+    if (isExpertMode && isExpertModeRunning && isApprovePassed && isWrapPassed && !isExpertModeNeedsSwapConfirm) {
+      delay(MODAL_CLOSE_DELAY).then(ethFlowActions.directSwap)
     }
   }, [
     state,
@@ -112,5 +116,6 @@ export function useSetupEthFlow({
     isWrapNeeded,
     wrapTxStatus,
     isExpertModeRunning,
+    isExpertModeNeedsSwapConfirm,
   ])
 }


### PR DESCRIPTION
# Summary

Based on https://github.com/cowprotocol/cowswap/pull/1192#issuecomment-1278823485

Adds the same warning modal in regular mode about the inability to swap native ETH to expert mode

### Note for reviewer and specifically QA
@elena-zh I noticed this later in this comment: https://github.com/cowprotocol/cowswap/pull/1197#issuecomment-1281306939

Let's revisit this.

This PR does what is intended regarding showing the warning modal pre-swap in expert mode, but it _may_ introduce new bugs (flashing other modals from other states)

I would recommend we don't implement this now because of the relatively low impact of the change and the time crunch with the latest release. We can revisit this later.

## Screenshot
<img width="504" alt="image" src="https://user-images.githubusercontent.com/21335563/196251541-4a64ecd8-c01e-47e5-819f-fff56dab1d8d.png">

