### PR TITLE
Adds SELL or BUY order type and updates labels accordingly

### DIFF
--- a/src/cow-react/common/pure/CurrencyInputPanel/index.tsx
+++ b/src/cow-react/common/pure/CurrencyInputPanel/index.tsx
@@ -28,6 +28,7 @@ export interface CurrencyInputPanelProps extends Partial<BuiltItProps> {
   subsidyAndBalance: BalanceAndSubsidy
   onCurrencySelection: (field: Field, currency: Currency) => void
   onUserInput: (field: Field, typedValue: string) => void
+  topLabel?: string
 }
 
 export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
@@ -42,6 +43,7 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
     onUserInput,
     allowsOffchainSigning,
     subsidyAndBalance,
+    topLabel,
   } = props
   const { priceImpact, loading: priceImpactLoading } = priceImpactParams || {}
   const { field, currency, balance, fiatAmount, viewAmount, receiveAmountInfo } = currencyInfo
@@ -78,6 +80,8 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
   return (
     <>
       <styledEl.Wrapper id={id} className={className} withReceiveAmountInfo={!!receiveAmountInfo}>
+        {topLabel && <styledEl.CurrencyTopLabel>{topLabel}</styledEl.CurrencyTopLabel>}
+
         <styledEl.CurrencyInputBox flexibleWidth={true}>
           <div>
             <CurrencySelectButton
@@ -95,6 +99,7 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
             />
           </div>
         </styledEl.CurrencyInputBox>
+
         <styledEl.CurrencyInputBox flexibleWidth={false}>
           <div>
             {balance && (

--- a/src/cow-react/common/pure/CurrencyInputPanel/styled.tsx
+++ b/src/cow-react/common/pure/CurrencyInputPanel/styled.tsx
@@ -40,6 +40,11 @@ export const CurrencyInputBox = styled.div<{ flexibleWidth: boolean }>`
   }
 `
 
+export const CurrencyTopLabel = styled.div`
+  font-size: 0.85rem;
+  margin-bottom: 12px;
+`
+
 export const NumericalInput = styled(Input)<{ $loading: boolean }>`
   width: 100%;
   background: none;

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -24,6 +24,7 @@ import { limitOrdersQuoteAtom } from '@cow/modules/limitOrders/state/limitOrders
 import { RateInput } from '@cow/modules/limitOrders/containers/RateInput'
 import { ExpiryDate } from '@cow/modules/limitOrders/containers/ExpiryDate'
 import { useUpdateCurrencyAmount } from '@cow/modules/limitOrders/hooks/useUpdateCurrencyAmount'
+import { useIsSellOrder } from '@cow/modules/limitOrders/hooks/useIsSellOrder'
 
 // TODO: move the widget to Swap module
 export function LimitOrdersWidget() {
@@ -39,6 +40,7 @@ export function LimitOrdersWidget() {
   const limitOrdersNavigate = useLimitOrdersNavigate()
   const limitOrdersQuote = useAtomValue(limitOrdersQuoteAtom)
   const updateCurrencyAmount = useUpdateCurrencyAmount()
+  const isSellOrder = useIsSellOrder()
 
   const currenciesLoadingInProgress = false
   const allowsOffchainSigning = false
@@ -120,6 +122,7 @@ export function LimitOrdersWidget() {
           allowsOffchainSigning={allowsOffchainSigning}
           currencyInfo={inputCurrencyInfo}
           showSetMax={showSetMax}
+          topLabel={isSellOrder ? 'You sell' : 'You sell at most'}
         />
         <styledEl.RateWrapper>
           <RateInput />
@@ -142,6 +145,7 @@ export function LimitOrdersWidget() {
           allowsOffchainSigning={allowsOffchainSigning}
           currencyInfo={outputCurrencyInfo}
           priceImpactParams={priceImpactParams}
+          topLabel={isSellOrder ? 'Your receive at least' : 'You receive exactly'}
         />
         {recipient !== null && (
           <styledEl.StyledRemoveRecipient recipient={recipient} onChangeRecipient={onChangeRecipient} />

--- a/src/cow-react/modules/limitOrders/hooks/useIsSellOrder.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useIsSellOrder.ts
@@ -1,0 +1,12 @@
+import { useMemo } from 'react'
+import { useAtomValue } from 'jotai'
+
+import { OrderKind } from '@cowprotocol/contracts'
+import { limitOrdersAtom } from '@cow/modules/limitOrders/state/limitOrdersAtom'
+
+// Returns boolean if the current order kind is SELL or BUY
+export function useIsSellOrder(): boolean {
+  const { orderKind } = useAtomValue(limitOrdersAtom)
+
+  return useMemo(() => orderKind === OrderKind.SELL, [orderKind])
+}

--- a/src/cow-react/modules/limitOrders/hooks/useLimitOrdersStateFromUrl.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useLimitOrdersStateFromUrl.ts
@@ -32,6 +32,7 @@ export function useLimitOrdersStateFromUrl(): LimitOrdersState {
       inputCurrencyId: inputCurrencyId || null,
       outputCurrencyId: outputCurrencyId || null,
       recipient,
+      orderKind: null,
     }
   }, [location.search, params, currentChainId])
 }

--- a/src/cow-react/modules/limitOrders/hooks/useUpdateCurrencyAmount.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useUpdateCurrencyAmount.ts
@@ -1,5 +1,7 @@
 import { useCallback } from 'react'
 import { useUpdateAtom } from 'jotai/utils'
+
+import { OrderKind } from '@cowprotocol/contracts'
 import { updateLimitOrdersAtom } from '@cow/modules/limitOrders/state/limitOrdersAtom'
 import { useApplyLimitRate } from '@cow/modules/limitOrders/hooks/useApplyLimitRate'
 import { Field } from 'state/swap/actions'
@@ -7,6 +9,7 @@ import { Field } from 'state/swap/actions'
 type CurrencyAmountProps = {
   inputCurrencyAmount?: string | null
   outputCurrencyAmount?: string | null
+  orderKind?: OrderKind
 }
 
 export function useUpdateCurrencyAmount() {
@@ -23,6 +26,7 @@ export function useUpdateCurrencyAmount() {
         // Calculate OUTPUT amount by applying the rate
         const outputWithRate = applyLimitRate(inputCurrencyAmount, Field.INPUT)
         update.outputCurrencyAmount = outputWithRate
+        update.orderKind = OrderKind.SELL
       }
 
       // Handle OUTPUT amount change
@@ -30,6 +34,7 @@ export function useUpdateCurrencyAmount() {
         // Calculate INPUT amount by applying the rate
         const inputWithRate = applyLimitRate(outputCurrencyAmount, Field.OUTPUT)
         update.inputCurrencyAmount = inputWithRate
+        update.orderKind = OrderKind.BUY
       }
 
       // Continue with the state update

--- a/src/cow-react/modules/limitOrders/state/limitOrdersAtom.ts
+++ b/src/cow-react/modules/limitOrders/state/limitOrdersAtom.ts
@@ -3,6 +3,7 @@ import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { WRAPPED_NATIVE_CURRENCY as WETH } from 'constants/tokens'
 import { atom } from 'jotai'
 import { TRADE_DEADLINE_DEFAULT } from '@cow/modules/limitOrders/const/trade'
+import { OrderKind } from '@cowprotocol/contracts'
 
 export interface LimitOrdersState {
   readonly chainId: number | null
@@ -12,6 +13,7 @@ export interface LimitOrdersState {
   readonly outputCurrencyAmount: string | null
   readonly recipient: string | null
   readonly deadline: number | null
+  readonly orderKind: OrderKind | null
 }
 
 export function getDefaultLimitOrdersState(chainId: SupportedChainId | null): LimitOrdersState {
@@ -23,6 +25,7 @@ export function getDefaultLimitOrdersState(chainId: SupportedChainId | null): Li
     outputCurrencyAmount: null,
     recipient: null,
     deadline: TRADE_DEADLINE_DEFAULT,
+    orderKind: OrderKind.SELL,
   }
 }
 


### PR DESCRIPTION
# Summary

This PR sets order types to SELL or BUY depending on what input field user changes
And also updates the input labels accordingly

Note: Label text might change but the functionality is important here

# To test
1. Go to limits page `1/limit-orders/DAI/USDC`
2. Update INPUT or OUTPUT amount and you should see the Currency input labels change

![Screenshot from 2022-10-19 15-27-16](https://user-images.githubusercontent.com/34926005/196705260-316c5366-aa26-47d6-9801-3f343607285f.png)
