### PR TITLE
[Hotfix] Fix Import token modal blinking on network switching

### DIFF
--- a/src/cow-react/modules/swap/containers/ImportTokenModal/index.tsx
+++ b/src/cow-react/modules/swap/containers/ImportTokenModal/index.tsx
@@ -3,7 +3,7 @@ import { Field } from 'state/swap/actions'
 import { Token } from '@uniswap/sdk-core'
 import { useCallback, useMemo, useState } from 'react'
 import { supportedChainId } from 'utils/supportedChainId'
-import { TOKEN_SHORTHANDS } from 'constants/tokens'
+import { TOKEN_SHORTHANDS, WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
 import { useDefaultsFromURLSearch } from 'state/swap/hooks'
 import TokenWarningModal from 'components/TokenWarningModal'
 
@@ -46,10 +46,16 @@ export function ImportTokenModal(props: ImportTokenModalProps) {
           // Any token addresses that are loaded from the shorthands map do not need to show the import URL
           const supported = supportedChainId(chainId)
           if (!supported) return true
-          return !Object.keys(TOKEN_SHORTHANDS).some((shorthand) => {
+
+          const isTokenInShorthands = Object.keys(TOKEN_SHORTHANDS).some((shorthand) => {
             const shorthandTokenAddress = TOKEN_SHORTHANDS[shorthand][supported]
-            return shorthandTokenAddress && shorthandTokenAddress === token.address
+            return shorthandTokenAddress && shorthandTokenAddress.toLowerCase() === token.address.toLowerCase()
           })
+
+          const isTokenInWrapped =
+            WRAPPED_NATIVE_CURRENCY[supported].address.toLowerCase() === token.address.toLowerCase()
+
+          return !isTokenInShorthands && !isTokenInWrapped
         })
     )
   }, [chainId, defaultTokens, urlLoadedTokens])

--- a/src/custom/tokens/goerli-token-list.json
+++ b/src/custom/tokens/goerli-token-list.json
@@ -5,12 +5,7 @@
     "minor": 0,
     "patch": 0
   },
-  "keywords": [
-    "CowSwap",
-    "Goerli",
-    "tokens",
-    "trusted"
-  ],
+  "keywords": ["CowSwap", "Goerli", "tokens", "trusted"],
   "logoURI": "https://gnosis.mypinata.cloud/ipfs/Qme9B6jRpGtZsRFcPjHvA5T4ugFuL4c3SzWfxyMPa59AMo",
   "timestamp": "2022-05-26T10:45:01.151Z",
   "tokens": [

--- a/src/custom/tokens/rinkeby-token-list.json
+++ b/src/custom/tokens/rinkeby-token-list.json
@@ -5,12 +5,7 @@
     "minor": 1,
     "patch": 0
   },
-  "keywords": [
-    "CowSwap",
-    "Rinkeby",
-    "tokens",
-    "trusted"
-  ],
+  "keywords": ["CowSwap", "Rinkeby", "tokens", "trusted"],
   "logoURI": "https://gnosis.mypinata.cloud/ipfs/Qme9B6jRpGtZsRFcPjHvA5T4ugFuL4c3SzWfxyMPa59AMo",
   "timestamp": "2021-02-22T13:09:54.363Z",
   "tokens": [


### PR DESCRIPTION
# Summary

<img width="309" alt="image" src="https://user-images.githubusercontent.com/7122625/196903653-f78b3461-a2f7-405e-8495-546e96dabe42.png">

Import token modal is blinking on network switching

  # To Test

1. Connect wallet to Ethereum Mainnet
2. Switch network to Gnosis Chain from UI
**ER:** UI updated without opening the Import token modal
**AR:** Import token modal appears for ~1sec and disappears