### PR TITLE
[ETH-FLOW V2] - Allow force wrapping in Banner component

### DIFF
--- a/src/cow-react/modules/swap/containers/EthFlow/EthFlowBanner.tsx
+++ b/src/cow-react/modules/swap/containers/EthFlow/EthFlowBanner.tsx
@@ -5,8 +5,7 @@ import { useHasEnoughWrappedBalanceForSwap } from '@src/custom/hooks/useWrapCall
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
 export interface EthFlowBannerCallbacks {
-  wrapCallback: () => void
-  forceWrapCallback: () => void
+  wrapCallback: (forceWrap?: boolean) => void
   switchCurrencyCallback: () => void
 }
 

--- a/src/cow-react/modules/swap/containers/EthFlow/hooks/index.ts
+++ b/src/cow-react/modules/swap/containers/EthFlow/hooks/index.ts
@@ -1,0 +1,18 @@
+import { useState } from 'react'
+
+export * from './useEthFlowActions'
+export * from './useRemainingNativeTxsAndCosts'
+export * from './useSetupEthFlow'
+
+export function useOpenNativeWrapModal() {
+  // Native wrap modals
+  const [showNativeWrapModal, setOpenNativeWrapModal] = useState(false)
+  const openNativeWrapModal = () => setOpenNativeWrapModal(true)
+  const dismissNativeWrapModal = () => setOpenNativeWrapModal(false)
+
+  return {
+    showNativeWrapModal,
+    openNativeWrapModal,
+    dismissNativeWrapModal,
+  }
+}

--- a/src/cow-react/modules/swap/containers/EthFlow/hooks/useRemainingNativeTxsAndCosts.ts
+++ b/src/cow-react/modules/swap/containers/EthFlow/hooks/useRemainingNativeTxsAndCosts.ts
@@ -9,10 +9,10 @@ import { AVG_APPROVE_COST_GWEI } from 'constants/index'
 import { parseUnits } from 'ethers/lib/utils'
 // eslint-disable-next-line no-restricted-imports
 
-export const MINIMUM_TXS = '10'
-export const DEFAULT_GAS_FEE = parseUnits('50', 'gwei')
+const MINIMUM_TXS = '10'
+const DEFAULT_GAS_FEE = parseUnits('50', 'gwei')
 
-export function _estimateTxCost(gasPrice: ReturnType<typeof useGasPrices>, native: Currency | undefined) {
+function _estimateTxCost(gasPrice: ReturnType<typeof useGasPrices>, native: Currency | undefined) {
   if (!native) {
     return {}
   }
@@ -28,7 +28,7 @@ export function _estimateTxCost(gasPrice: ReturnType<typeof useGasPrices>, nativ
   }
 }
 
-export const _getAvailableTransactions = ({
+const _getAvailableTransactions = ({
   nativeBalance,
   nativeInput,
   singleTxCost,
@@ -46,7 +46,7 @@ export const _getAvailableTransactions = ({
   return txsAvailable.lessThan('1') ? null : txsAvailable.quotient.toString()
 }
 
-export function _isLowBalanceCheck({
+function _isLowBalanceCheck({
   threshold,
   txCost,
   nativeInput,

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowBanner/index.cosmos.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowBanner/index.cosmos.tsx
@@ -19,9 +19,6 @@ const defaultProps: EthFlowBannerContentProps = {
   wrapCallback() {
     return console.log('Eth flow banner wrap callback called!')
   },
-  forceWrapCallback() {
-    return console.log('Eth flow banner force wrap callback called!')
-  },
 }
 
 export default <EthFlowBannerContent {...defaultProps} />

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowBanner/index.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowBanner/index.tsx
@@ -135,7 +135,7 @@ export function EthFlowBannerContent(props: EthFlowBannerContentProps) {
                 </SpanCta>
               </>
             ) : (
-              <SpanCta onClick={wrapCallback}>Wrap my {native.symbol} and swap</SpanCta>
+              <SpanCta onClick={() => wrapCallback()}>Wrap my {native.symbol} and swap</SpanCta>
             )}
           </WrapEthCta>
         </BannerInnerWrapper>

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowBanner/index.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowBanner/index.tsx
@@ -87,7 +87,6 @@ export function EthFlowBannerContent(props: EthFlowBannerContentProps) {
     showBannerCallback,
     switchCurrencyCallback,
     wrapCallback,
-    forceWrapCallback,
   } = props
   return (
     <BannerWrapper onClick={showBannerCallback}>
@@ -129,13 +128,20 @@ export function EthFlowBannerContent(props: EthFlowBannerContentProps) {
                     or{' '}
                     <u>
                       {' '}
-                      <SpanCta onClick={forceWrapCallback}>wrap my {native.symbol} and swap</SpanCta>
+                      <SpanCta
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          wrapCallback(true)
+                        }}
+                      >
+                        wrap my {native.symbol} and swap
+                      </SpanCta>
                     </u>
                   </small>
                 </SpanCta>
               </>
             ) : (
-              <SpanCta onClick={wrapCallback}>Wrap my {native.symbol} and swap</SpanCta>
+              <SpanCta onClick={() => wrapCallback()}>Wrap my {native.symbol} and swap</SpanCta>
             )}
           </WrapEthCta>
         </BannerInnerWrapper>

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowBanner/index.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowBanner/index.tsx
@@ -135,7 +135,7 @@ export function EthFlowBannerContent(props: EthFlowBannerContentProps) {
                 </SpanCta>
               </>
             ) : (
-              <SpanCta onClick={() => wrapCallback()}>Wrap my {native.symbol} and swap</SpanCta>
+              <SpanCta onClick={wrapCallback}>Wrap my {native.symbol} and swap</SpanCta>
             )}
           </WrapEthCta>
         </BannerInnerWrapper>

--- a/src/cow-react/pages/Swap/SwapMod.tsx
+++ b/src/cow-react/pages/Swap/SwapMod.tsx
@@ -408,8 +408,6 @@ export default function Swap({ history, location, className }: RouteComponentPro
                 nativeInAmount={nativeInput}
                 switchCurrencyCallback={() => onCurrencySelection(Field.INPUT, nativeInput.wrapped.currency)}
                 wrapCallback={openNativeWrapModal}
-                // TODO: is removed in next PR
-                forceWrapCallback={console.log}
               />
             )}
           </Wrapper>

--- a/src/cow-react/pages/Swap/SwapMod.tsx
+++ b/src/cow-react/pages/Swap/SwapMod.tsx
@@ -408,6 +408,8 @@ export default function Swap({ history, location, className }: RouteComponentPro
                 nativeInAmount={nativeInput}
                 switchCurrencyCallback={() => onCurrencySelection(Field.INPUT, nativeInput.wrapped.currency)}
                 wrapCallback={openNativeWrapModal}
+                // TODO: is removed in next PR
+                forceWrapCallback={console.log}
               />
             )}
           </Wrapper>


### PR DESCRIPTION
# Summary

Banner component has 2 states: 
1. `SUFFICIENT WRAPPED TOKEN BALANCE`
2. `INSUFFICIENT WRAPPED TOKEN BALANCE`

State `1` requires 2 buttons: 
1. Switch to wrapped token
2. Wrap amt input (even tho balance sufficient), which opens native wrap flow

State `2` requires 1 button:
1. Wrap amount input via native wrap flow


### Note: right now the Swap button will only open the native wrap flow. Subsequent PRs (soon) will include the initial contract api stuff. Thanks!

## Screenshots
### Banner - CLOSED
<img width="443" alt="image" src="https://user-images.githubusercontent.com/21335563/197054914-86e9b314-f1e2-4905-bdd2-e6134b77896a.png">

### Banner - OPEN & SUFFICIENT WRAPPED TOKEN BALANCE
When the user has enough wrapped balance for the input native amount, we show 1 title and 2 buttons:
#### Title:
- Switch to the classic Wrapped Native Token experience and benefit!
#### Buttons:
1. Switch to Wrapped Native Token
4. or wrap my Native Token and swap (allows user to force wrap)
<img width="441" alt="image" src="https://user-images.githubusercontent.com/21335563/197055028-5d705099-7345-4f7b-b1ed-55b4af5952b2.png">

### Banner - OPEN & INSUFFICIENT WRAPPED TOKEN BALANCE
When the user does NOT have enough wrapped balance for the input native amount, we show 1 title and 1 button:
#### Title:
- Wrap your Native Token and use the classic Wrapped Token experience!
#### Button:
1. Wrap my native token and swap
<img width="451" alt="image" src="https://user-images.githubusercontent.com/21335563/197055839-f827f858-9efb-44ac-af89-b7aa96c0e88f.png">

# To Test
### States:
1. SUFFICIENT WRAPPED TOKEN BALANCE
2. INSUFFICIENT WRAPPED TOKEN BALANCE

### Steps
##### SUFFICIENT WRAPPED TOKEN BALANCE
1. select native token
2. select erc20
5. input sell amt GREATER than wrapped token balance
6. open banner
5a. Button CTA1: `Switch to native token` - switches swap page to wrapped token <> erc20
5b. Button CTA2: `or wrap my Native Token and swap` - opens native wrap modal and requires wrap (maybe also approve)

##### INSUFFICIENT WRAPPED TOKEN BALANCE 
1. select native token
2. select erc20
3. input sell amt LESS THAN than wrapped token balance
4. open banner
7. Button CTA opens native wrap modal and requires wrap (maybe also approve)