### PR TITLE
Cosmos ci build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,8 +232,8 @@ jobs:
         uses: mshick/add-pr-comment@v1
         with:
           message: |
-            * **🔭 [GP Swap](${{ env.REVIEW_FEATURE_URL }})**: CoW Protocol v2 Swap UI
-            * **🌌 [GP Swap](${{ env.REVIEW_FEATURE_URL }}/cosmos/)**: Cosmos
+            * **🔭 [CoW Swap preview](${{ env.REVIEW_FEATURE_URL }})**: CoW Swap UI
+            * **🌌 [Cosmos](${{ env.REVIEW_FEATURE_URL }}/cosmos/)**: Cosmos
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]'
         if: env.PR_NUMBER

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
         with:
           message: |
             * **🔭 [GP Swap](${{ env.REVIEW_FEATURE_URL }})**: CoW Protocol v2 Swap UI
-            * **🌌 [GP Swap](${{ env.REVIEW_FEATURE_URL/cosmos/ }})**: Cosmos
+            * **🌌 [GP Swap](${{ env.REVIEW_FEATURE_URL }}/cosmos/)**: Cosmos
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]'
         if: env.PR_NUMBER

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,11 @@ jobs:
             src/locales
           key: ${{ runner.os }}-generatedFiles-${{ hashFiles('**/yarn.lock') }}
 
+      - name: Build Cosmos
+        id: build-cosmos
+        if: env.PR_NUMBER # only build cosmos on PRs
+        run: yarn cosmos:export
+
       - name: Build Web Apps
         run: yarn build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,7 @@ jobs:
         with:
           message: |
             * **🔭 [GP Swap](${{ env.REVIEW_FEATURE_URL }})**: CoW Protocol v2 Swap UI
+            * **🌌 [GP Swap](${{ env.REVIEW_FEATURE_URL/cosmos/ }})**: Cosmos
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]'
         if: env.PR_NUMBER


### PR DESCRIPTION
# Summary

Adding Cosmos build step to CI

It'll be deployed alongside the website on PRs and accessible at <pr url>/cosmos/

  # To Test

1. Watch this PR's build step
* Should contain `Build Cosmos` withing the `Build apps` CI workflow
2. Watch PR comments
* The same one where the app link is available should have another link pointing straight to /cosmos/ url
![Screen Shot 2022-10-24 at 18 09 23](https://user-images.githubusercontent.com/43217/197585052-076764a4-578c-469f-aa6e-d4568ad9960b.png)
