### PR TITLE
[ETH-FLOW-V2] 1243 - Insufficient balance NATIVE/WRAPPED

### DIFF
--- a/src/custom/hooks/useWrapCallback.ts
+++ b/src/custom/hooks/useWrapCallback.ts
@@ -57,7 +57,7 @@ export function useHasEnoughWrappedBalanceForSwap(inputAmount?: CurrencyAmount<C
   const wrappedBalance = useCurrencyBalance(account ?? undefined, currencies.INPUT?.wrapped)
 
   // is an native currency trade but wrapped token has enough balance
-  return !!(wrappedBalance && inputAmount && wrappedBalance.greaterThan(inputAmount))
+  return !!(wrappedBalance && inputAmount && !wrappedBalance.lessThan(inputAmount))
 }
 
 export function useWrapType(): WrapType {


### PR DESCRIPTION
# Summary

Closes #1243

Fixes issue with NATIVE / WRAPPED balances showing insufficient when balance === wrappedBalance

Fix was switching from greaterThan to not less than (uni lib doesn't have greaterThanOrEqualTo)