### PR TITLE
Fix: don't reset network to mainnet after page reload

### DIFF
--- a/src/cow-react/modules/limitOrders/hooks/useLimitOrdersStateFromUrl.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useLimitOrdersStateFromUrl.ts
@@ -1,8 +1,7 @@
 import { useLocation, useParams } from 'react-router-dom'
 import { useMemo } from 'react'
-import { getDefaultLimitOrdersState, LimitOrdersState } from '@cow/modules/limitOrders/state/limitOrdersAtom'
-import { useWeb3React } from '@web3-react/core'
 import { OrderKind } from '@cowprotocol/contracts'
+import { LimitOrdersState } from '../state/limitOrdersAtom'
 
 interface LimitOrdersStateFromUrl {
   readonly chainId: string | undefined
@@ -11,7 +10,6 @@ interface LimitOrdersStateFromUrl {
 }
 
 export function useLimitOrdersStateFromUrl(): LimitOrdersState {
-  const { chainId: currentChainId } = useWeb3React()
   const params = useParams()
   const location = useLocation()
 
@@ -21,10 +19,6 @@ export function useLimitOrdersStateFromUrl(): LimitOrdersState {
     const { chainId, inputCurrencyId, outputCurrencyId } = params as LimitOrdersStateFromUrl
     const chainIdAsNumber = chainId ? parseInt(chainId) : null
     const orderKind = OrderKind.SELL
-
-    if (currentChainId && currentChainId !== chainIdAsNumber) {
-      return getDefaultLimitOrdersState(currentChainId)
-    }
 
     return {
       chainId: chainIdAsNumber,
@@ -36,5 +30,5 @@ export function useLimitOrdersStateFromUrl(): LimitOrdersState {
       recipient,
       orderKind,
     }
-  }, [location.search, params, currentChainId])
+  }, [location.search, params])
 }

--- a/src/cow-react/modules/limitOrders/hooks/useSetupLimitOrdersState.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useSetupLimitOrdersState.ts
@@ -1,21 +1,26 @@
-import { useLimitOrdersStateFromUrl } from '@cow/modules/limitOrders/hooks/useLimitOrdersStateFromUrl'
+import { useCallback, useEffect, useState } from 'react'
+import { useAtomValue, useUpdateAtom } from 'jotai/utils'
+import { useWeb3React } from '@web3-react/core'
+import { switchChain } from 'utils/switchChain'
+import { useLimitOrdersStateFromUrl } from '../hooks/useLimitOrdersStateFromUrl'
 import {
   getDefaultLimitOrdersState,
   limitOrdersAtom,
   LimitOrdersState,
   updateLimitOrdersAtom,
-} from '@cow/modules/limitOrders/state/limitOrdersAtom'
-import { useEffect } from 'react'
-import { useAtomValue, useUpdateAtom } from 'jotai/utils'
-import { useLimitOrdersNavigate } from '@cow/modules/limitOrders/hooks/useLimitOrdersNavigate'
+} from '../state/limitOrdersAtom'
+import { useLimitOrdersNavigate } from '../hooks/useLimitOrdersNavigate'
 
 export function useSetupLimitOrdersState(): void {
-  const tradeStateFromUrl = useLimitOrdersStateFromUrl()
+  const { chainId: currentChainId, connector } = useWeb3React()
   const state = useAtomValue(limitOrdersAtom)
   const updateLimitOrdersState = useUpdateAtom(updateLimitOrdersAtom)
   const limitOrdersNavigate = useLimitOrdersNavigate()
+  const [isChainIdSet, setIsChainIdSet] = useState(false)
+  const tradeStateFromUrl = useLimitOrdersStateFromUrl()
 
-  const chainIdWasChanged = tradeStateFromUrl.chainId !== state.chainId
+  const chainIdFromUrl = tradeStateFromUrl.chainId
+  const chainIdWasChanged = !!currentChainId && chainIdFromUrl !== currentChainId
 
   const shouldSkipUpdate =
     !chainIdWasChanged &&
@@ -23,9 +28,7 @@ export function useSetupLimitOrdersState(): void {
     tradeStateFromUrl.inputCurrencyId?.toLowerCase() === state.inputCurrencyId?.toLowerCase() &&
     tradeStateFromUrl.outputCurrencyId?.toLowerCase() === state.outputCurrencyId?.toLowerCase()
 
-  useEffect(() => {
-    if (shouldSkipUpdate) return
-
+  const updateStateAndNavigate = useCallback(() => {
     // Case: we have WETH/COW tokens pair
     // User decided to select WETH as output currency, and navigated to WETH/WETH
     // In this case, we reverse tokens pair and the result willbe: COW/WETH
@@ -34,7 +37,7 @@ export function useSetupLimitOrdersState(): void {
     const outputCurrencyId = areCurrenciesTheSame ? state.inputCurrencyId : tradeStateFromUrl.outputCurrencyId
 
     const newState: Partial<LimitOrdersState> = chainIdWasChanged
-      ? getDefaultLimitOrdersState(tradeStateFromUrl.chainId)
+      ? getDefaultLimitOrdersState(currentChainId)
       : {
           chainId: tradeStateFromUrl.chainId,
           recipient: tradeStateFromUrl.recipient || state.recipient,
@@ -43,7 +46,23 @@ export function useSetupLimitOrdersState(): void {
         }
 
     console.log('UPDATE LIMIT ORDERS STATE:', newState)
+
     updateLimitOrdersState(newState)
-    limitOrdersNavigate(tradeStateFromUrl.chainId, newState.inputCurrencyId || null, newState.outputCurrencyId || null)
-  }, [limitOrdersNavigate, updateLimitOrdersState, state, tradeStateFromUrl, shouldSkipUpdate, chainIdWasChanged])
+    limitOrdersNavigate(currentChainId, newState.inputCurrencyId || null, newState.outputCurrencyId || null)
+  }, [limitOrdersNavigate, updateLimitOrdersState, state, tradeStateFromUrl, chainIdWasChanged, currentChainId])
+
+  // Set chainId from URL into wallet provider once on page load
+  useEffect(() => {
+    if (isChainIdSet || !chainIdFromUrl || !currentChainId) return
+
+    setIsChainIdSet(true)
+    switchChain(connector, chainIdFromUrl).finally(updateStateAndNavigate)
+  }, [isChainIdSet, setIsChainIdSet, chainIdFromUrl, connector, currentChainId, updateStateAndNavigate])
+
+  // Update state when something was changed (chainId or URL params)
+  useEffect(() => {
+    if (!isChainIdSet || shouldSkipUpdate) return
+
+    updateStateAndNavigate()
+  }, [shouldSkipUpdate, isChainIdSet, updateStateAndNavigate])
 }


### PR DESCRIPTION
# Summary

https://www.loom.com/share/fda1f0e2ecdf4a5f92aa8e18aa5d3ee2

  # To Test

1. Open Limit orders page and don't connect wallet
2. Select `Gnosis chain` network
3. Reload page
- [x] ER: Current network is `Gnosis chain`
- [x] AR: Current network is `Mainnet`
