### PR TITLE
[EFV2] Fix order digest

### DIFF
--- a/src/cow-react/modules/swap/services/ethFlow/steps/signEthFlowOrderStep.ts
+++ b/src/cow-react/modules/swap/services/ethFlow/steps/signEthFlowOrderStep.ts
@@ -9,6 +9,7 @@ import { calculateGasMargin } from 'utils/calculateGasMargin'
 import { getOrderParams, mapUnsignedOrderToOrder, PostOrderParams } from 'utils/trade'
 import { getDomain, UnsignedOrder } from 'utils/signatures'
 import { Order } from 'state/orders/actions'
+import { MAX_VALID_TO_EPOCH } from 'hooks/useSwapCallback'
 
 type EthFlowOrderParams = Omit<PostOrderParams, 'sellToken'> & {
   sellToken: NativeCurrency
@@ -62,13 +63,13 @@ export async function signEthFlowOrderStep(
     value: orderParams.sellAmountBeforeFee.quotient.toString(),
   })
 
-  const orderDigest = hashOrder(getDomain(orderParams.chainId), order)
+  const domain = getDomain(orderParams.chainId)
+  const orderDigest = hashOrder(domain, order)
   // Generate the orderId from owner and validTo
   const orderId = packOrderUidParams({
     orderDigest,
     owner: ethFlowContract.address,
-    // TODO: check this, do we set MAX here or is that in contract?
-    validTo: order.validTo,
+    validTo: MAX_VALID_TO_EPOCH,
   })
 
   logSwapFlow('ETH FLOW', '[EthFlow::SignEthFlowOrderStep] Sent transaction onchain', orderId, txReceipt)

--- a/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -16,6 +16,8 @@ import { PriceInformation } from '@cowprotocol/cow-sdk'
 import { priceOutOfRangeAnalytics } from 'components/analytics'
 import { GpPriceStrategy } from 'state/gas/atoms'
 import { supportedChainId } from 'utils/supportedChainId'
+import { NATIVE_CURRENCY_BUY_ADDRESS } from 'constants/index'
+import { WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
 
 /**
  * Thin wrapper around `getBestPrice` that builds the params and returns null on failure
@@ -38,11 +40,17 @@ async function _getOrderPrice(chainId: ChainId, order: Order, strategy: GpPriceS
     quoteToken = order.sellToken
   }
 
+  const isNativeSellSwap = order.sellToken === NATIVE_CURRENCY_BUY_ADDRESS
+  if (isNativeSellSwap) {
+    console.debug('[UnfillableOrderUpdater] - Native sell swap detected. Using wrapped token address for quotes')
+  }
+
   const quoteParams = {
     chainId,
     amount,
     kind: order.kind,
-    sellToken: order.sellToken,
+    // we need to get wrapped token quotes (native quotes will fail)
+    sellToken: isNativeSellSwap ? WRAPPED_NATIVE_CURRENCY[chainId].address : order.sellToken,
     buyToken: order.buyToken,
     baseToken,
     quoteToken,

--- a/src/custom/utils/signatures.ts
+++ b/src/custom/utils/signatures.ts
@@ -94,7 +94,7 @@ export function getSigningSchemeLibValue(ecdaSigningScheme: SigningScheme): numb
 }
 // ---------------- end of the TODO:
 
-function _getDomain(chainId: ChainId): TypedDataDomain {
+export function getDomain(chainId: ChainId): TypedDataDomain {
   // Get settlement contract address
   const settlementContract = GP_SETTLEMENT_CONTRACT_ADDRESS[chainId]
 
@@ -108,7 +108,7 @@ function _getDomain(chainId: ChainId): TypedDataDomain {
 async function _signOrder(params: SignOrderParams): Promise<Signature> {
   const { chainId, signer, order, signingScheme } = params
 
-  const domain = _getDomain(chainId)
+  const domain = getDomain(chainId)
   console.log('[utils:signature] signOrder', {
     domain,
     order,
@@ -121,7 +121,7 @@ async function _signOrder(params: SignOrderParams): Promise<Signature> {
 async function _signOrderCancellation(params: SingOrderCancellationParams): Promise<Signature> {
   const { chainId, signer, signingScheme, orderId } = params
 
-  const domain = _getDomain(chainId)
+  const domain = getDomain(chainId)
 
   console.log('[utils:signature] signOrderCancellation', {
     domain,
@@ -218,4 +218,4 @@ export async function signOrderCancellation(orderId: string, chainId: ChainId, s
   return _signPayload({ orderId, chainId }, _signOrderCancellation, signer)
 }
 
-registerOnWindow({ signature: { signOrder: _signOrder, getDomain: _getDomain } })
+registerOnWindow({ signature: { signOrder: _signOrder, getDomain } })


### PR DESCRIPTION
# Summary

1. Fixes order digest in eth flow signing step
2. use wrapped address inside `UnfillableOrdersUpdater` when getting new quotes and checking out-of-market prices