### PR TITLE
Set pinned node 16.17.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v2
         with:
-          node-version: lts/*
+          node-version: 16.17.1
 
       - name: Set output of cache
         id: yarn-cache
@@ -82,7 +82,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v2
         with:
-          node-version: lts/*
+          node-version: 16.17.1
 
       - name: Load dependencies
         id: cache-node-modules
@@ -123,7 +123,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v2
         with:
-          node-version: lts/*
+          node-version: 16.17.1
 
       - name: Load dependencies
         id: cache-node-modules
@@ -169,7 +169,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v2
         with:
-          node-version: lts/*
+          node-version: 16.17.1
 
       - name: Load dependencies
         id: cache-node-modules
@@ -278,7 +278,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v2
         with:
-          node-version: lts/*
+          node-version: 16.17.1
 
       # - name: Download website
       #   uses: actions/download-artifact@v2


### PR DESCRIPTION
# Summary

We use LTS versions of node, seems like yesterday it auto updated to 18.12.0 LTS which gives us errors:

<img width="964" alt="image" src="https://user-images.githubusercontent.com/21335563/198137394-5d38abbb-40bc-4402-97f3-b71d6a8f49eb.png">

```bash
Creating an optimized production build...
Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
```

Using 16.17.1 fixes that.

I don't have too much time to debug this more as it's not a prio, but we should revert this change after eth-flow and/or others have had time to properly investigate this.