### PR TITLE
Manual prod deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,18 @@ jobs:
     with:
       env_name: ${{ matrix.env_name }}
 
+  vercel-prod:
+    # Deploys to Vercel prod environment
+    name: Vercel prod
+    needs: [test, lint]
+    if: |
+      github.event_name == 'workflow_dispatch' &&
+      contains(env.ALLOWED_TO_DEPLOY_TO_PROD, github.author)
+    uses: ./.github/workflows/vercel.yml
+    secrets: inherit
+    with:
+      env_name: prod
+
   deploy:
     name: Deploy
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
 env:
   REPO_NAME_SLUG: cowswap
   PR_NUMBER: ${{ github.event.number }}
+  ALLOWED_TO_DEPLOY_TO_PROD: [ahhda, fleupold, anxolin, josojo, alfetopito]
   NODE_VERSION: lts/gallium
   REACT_APP_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   REACT_APP_PINATA_API_KEY: ${{ secrets.REACT_APP_PINATA_API_KEY }}
@@ -205,6 +206,17 @@ jobs:
         with:
           name: website
           path: build
+
+  vercel-test:
+    name: Test deploy!!! Remove before publishing
+    #    needs: [test, lint] # only if these steps finish and succeed
+    if: |
+      github.event_name == 'pull_request' &&
+      contains(env.ALLOWED_TO_DEPLOY_TO_PROD, github.author)
+    uses: ./.github/workflows/vercel.yml
+    secrets: inherit
+    with:
+      env_name: dev
 
   vercel-dev:
     # Deploys to Vercel dev environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 env:
   REPO_NAME_SLUG: cowswap
   PR_NUMBER: ${{ github.event.number }}
-  ALLOWED_TO_DEPLOY_TO_PROD: [ahhda, fleupold, anxolin, josojo, alfetopito]
+  ALLOWED_TO_DEPLOY_TO_PROD: "ahhda, fleupold, anxolin, josojo, alfetopito"
   NODE_VERSION: lts/gallium
   REACT_APP_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   REACT_APP_PINATA_API_KEY: ${{ secrets.REACT_APP_PINATA_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
       #   uses: coverallsapp/github-action@v1.1.2
       #   with:
       #     github-token: ${{ secrets.GITHUB_TOKEN }}
+
   lint:
     name: Lint
     needs: setup
@@ -205,14 +206,6 @@ jobs:
         with:
           name: website
           path: build
-
-  vercel-test:
-    name: Test deploy!!! Remove before publishing
-    if: github.event_name == 'pull_request'
-    uses: ./.github/workflows/vercel.yml
-    secrets: inherit
-    with:
-      env_name: dev
 
   vercel-dev:
     # Deploys to Vercel dev environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,10 @@ jobs:
     environment: test environment
     concurrency: test environment
 
+    steps:
+      - name: Approval workflow
+        run: echo "Workflow approved by ${{ github.author }}"
+
   vercel-test:
     name: Test deploy!!! Remove before publishing
     needs: pre-vercel-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
     #    needs: [test, lint] # only if these steps finish and succeed
     if: |
       github.event_name == 'pull_request' &&
-      ${{ contains([ahhda, fleupold, anxolin, josojo, alfetopito], github.author) }}
+      ${{ contains(fromJSON([ahhda, fleupold, anxolin, josojo, alfetopito]), github.author) }}
     uses: ./.github/workflows/vercel.yml
     secrets: inherit
     with:
@@ -247,7 +247,7 @@ jobs:
     needs: [test, lint]
     if: |
       github.event_name == 'workflow_dispatch' &&
-      ${{ contains([ahhda, fleupold, anxolin, josojo, alfetopito], github.author) }}
+      ${{ contains(fromJSON([ahhda, fleupold, anxolin, josojo, alfetopito]), github.author) }}
     uses: ./.github/workflows/vercel.yml
     secrets: inherit
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
     #    needs: [test, lint] # only if these steps finish and succeed
     if: |
       github.event_name == 'pull_request' &&
-      ${{ contains(fromJSON('["ahhda", "fleupold", "anxolin", "josojo", "alfetopito"]'), github.author) }}
+      ${{ contains(fromJSON('["ahhda", "fleupold", "anxolin", "josojo"]'), github.author) }}
     uses: ./.github/workflows/vercel.yml
     secrets: inherit
     with:
@@ -247,7 +247,7 @@ jobs:
     needs: [test, lint]
     if: |
       github.event_name == 'workflow_dispatch' &&
-      ${{ contains(fromJSON('["ahhda", "fleupold", "anxolin", "josojo", "alfetopito"]'), github.author) }}
+      ${{ contains(fromJSON('["ahhda", "fleupold", "anxolin", "josojo"]'), github.author) }}
     uses: ./.github/workflows/vercel.yml
     secrets: inherit
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,17 +207,6 @@ jobs:
           name: website
           path: build
 
-#  pre-vercel-test:
-#    name: Test step, remove me!
-#    if: github.event_name == 'pull_request'
-#    environment: test environment
-#    concurrency: test environment
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#      - name: Approval workflow
-#        run: echo "Workflow run by ${{ github.actor }} triggered by ${{ github.triggering_actor }}"
-
   vercel-test:
     name: Test deploy!!! Remove before publishing
     if: github.event_name == 'pull_request'
@@ -255,8 +244,6 @@ jobs:
     needs: [test, lint]
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/vercel.yml
-#    environment: production
-#    concurrency: production
     secrets: inherit
     with:
       env_name: prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,10 +210,10 @@ jobs:
   vercel-test:
     name: Test deploy!!! Remove before publishing
     #    needs: [test, lint] # only if these steps finish and succeed
-    if: |
-      github.event_name == 'pull_request' &&
-      ${{ contains(fromJSON('["ahhda", "fleupold", "anxolin", "josojo"]'), github.author) }}
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/vercel.yml
+    environment: test environment
+    concurrency: test environment
     secrets: inherit
     with:
       env_name: dev
@@ -245,10 +245,10 @@ jobs:
     # Deploys to Vercel prod environment
     name: Vercel prod
     needs: [test, lint]
-    if: |
-      github.event_name == 'workflow_dispatch' &&
-      ${{ contains(fromJSON('["ahhda", "fleupold", "anxolin", "josojo"]'), github.author) }}
+    if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/vercel.yml
+    environment: production
+    concurrency: production
     secrets: inherit
     with:
       env_name: prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
     #    needs: [test, lint] # only if these steps finish and succeed
     if: |
       github.event_name == 'pull_request' &&
-      contains(env.ALLOWED_TO_DEPLOY_TO_PROD, github.author)
+      ${{ contains(env.ALLOWED_TO_DEPLOY_TO_PROD, github.author) }}
     uses: ./.github/workflows/vercel.yml
     secrets: inherit
     with:
@@ -247,7 +247,7 @@ jobs:
     needs: [test, lint]
     if: |
       github.event_name == 'workflow_dispatch' &&
-      contains(env.ALLOWED_TO_DEPLOY_TO_PROD, github.author)
+      ${{ contains(env.ALLOWED_TO_DEPLOY_TO_PROD, github.author) }}
     uses: ./.github/workflows/vercel.yml
     secrets: inherit
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
 
     steps:
       - name: Approval workflow
-        run: echo "Workflow approved by ${{ github.author }}"
+        run: echo "Workflow run by ${{ github.actor }} triggered by ${{ github.triggering_actor }}"
 
   vercel-test:
     name: Test deploy!!! Remove before publishing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,7 @@ jobs:
     if: github.event_name == 'pull_request'
     environment: test environment
     concurrency: test environment
+    runs-on: ubuntu-latest
 
     steps:
       - name: Approval workflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
     #    needs: [test, lint] # only if these steps finish and succeed
     if: |
       github.event_name == 'pull_request' &&
-      ${{ contains("ahhda, fleupold, anxolin, josojo, alfetopito", github.author) }}
+      ${{ contains([ahhda, fleupold, anxolin, josojo, alfetopito], github.author) }}
     uses: ./.github/workflows/vercel.yml
     secrets: inherit
     with:
@@ -247,7 +247,7 @@ jobs:
     needs: [test, lint]
     if: |
       github.event_name == 'workflow_dispatch' &&
-      ${{ contains("ahhda, fleupold, anxolin, josojo, alfetopito", github.author) }}
+      ${{ contains([ahhda, fleupold, anxolin, josojo, alfetopito], github.author) }}
     uses: ./.github/workflows/vercel.yml
     secrets: inherit
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [main, develop]
     tags: [v*]
-
+  workflow_dispatch: # Manually trigger it via UI/CLI/API
 
 env:
   REPO_NAME_SLUG: cowswap

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,13 +207,17 @@ jobs:
           name: website
           path: build
 
-  vercel-test:
-    name: Test deploy!!! Remove before publishing
-    #    needs: [test, lint] # only if these steps finish and succeed
+  pre-vercel-test:
+    name: Test step, remove me!
     if: github.event_name == 'pull_request'
-    uses: ./.github/workflows/vercel.yml
     environment: test environment
     concurrency: test environment
+
+  vercel-test:
+    name: Test deploy!!! Remove before publishing
+    needs: pre-vercel-test
+    if: ${{ success() }}
+    uses: ./.github/workflows/vercel.yml
     secrets: inherit
     with:
       env_name: dev
@@ -247,8 +251,8 @@ jobs:
     needs: [test, lint]
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/vercel.yml
-    environment: production
-    concurrency: production
+#    environment: production
+#    concurrency: production
     secrets: inherit
     with:
       env_name: prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,21 +207,20 @@ jobs:
           name: website
           path: build
 
-  pre-vercel-test:
-    name: Test step, remove me!
-    if: github.event_name == 'pull_request'
-    environment: test environment
-    concurrency: test environment
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Approval workflow
-        run: echo "Workflow run by ${{ github.actor }} triggered by ${{ github.triggering_actor }}"
+#  pre-vercel-test:
+#    name: Test step, remove me!
+#    if: github.event_name == 'pull_request'
+#    environment: test environment
+#    concurrency: test environment
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#      - name: Approval workflow
+#        run: echo "Workflow run by ${{ github.actor }} triggered by ${{ github.triggering_actor }}"
 
   vercel-test:
     name: Test deploy!!! Remove before publishing
-    needs: pre-vercel-test
-    if: ${{ success() }}
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/vercel.yml
     secrets: inherit
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ on:
 env:
   REPO_NAME_SLUG: cowswap
   PR_NUMBER: ${{ github.event.number }}
-  ALLOWED_TO_DEPLOY_TO_PROD: "ahhda, fleupold, anxolin, josojo, alfetopito"
   NODE_VERSION: lts/gallium
   REACT_APP_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   REACT_APP_PINATA_API_KEY: ${{ secrets.REACT_APP_PINATA_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
     #    needs: [test, lint] # only if these steps finish and succeed
     if: |
       github.event_name == 'pull_request' &&
-      ${{ contains(fromJSON([ahhda, fleupold, anxolin, josojo, alfetopito]), github.author) }}
+      ${{ contains(fromJSON('["ahhda", "fleupold", "anxolin", "josojo", "alfetopito"]'), github.author) }}
     uses: ./.github/workflows/vercel.yml
     secrets: inherit
     with:
@@ -247,7 +247,7 @@ jobs:
     needs: [test, lint]
     if: |
       github.event_name == 'workflow_dispatch' &&
-      ${{ contains(fromJSON([ahhda, fleupold, anxolin, josojo, alfetopito]), github.author) }}
+      ${{ contains(fromJSON('["ahhda", "fleupold", "anxolin", "josojo", "alfetopito"]'), github.author) }}
     uses: ./.github/workflows/vercel.yml
     secrets: inherit
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
     #    needs: [test, lint] # only if these steps finish and succeed
     if: |
       github.event_name == 'pull_request' &&
-      ${{ contains(env.ALLOWED_TO_DEPLOY_TO_PROD, github.author) }}
+      ${{ contains("ahhda, fleupold, anxolin, josojo, alfetopito", github.author) }}
     uses: ./.github/workflows/vercel.yml
     secrets: inherit
     with:
@@ -247,7 +247,7 @@ jobs:
     needs: [test, lint]
     if: |
       github.event_name == 'workflow_dispatch' &&
-      ${{ contains(env.ALLOWED_TO_DEPLOY_TO_PROD, github.author) }}
+      ${{ contains("ahhda, fleupold, anxolin, josojo, alfetopito", github.author) }}
     uses: ./.github/workflows/vercel.yml
     secrets: inherit
     with:

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -23,12 +23,16 @@ jobs:
         run: >
           if [[ ${{ inputs.env_name == 'dev' }} ]]; then
             echo "VERCEL_PROJECT_ID=${{ secrets.VERCEL_PROJECT_ID_DEV }}" >> $GITHUB_ENV
+            echo "DOMAIN=${{ dev.swap.cow.fi }}" >> $GITHUB_ENV
           elif [[ ${{ inputs.env_name == 'staging' }} ]]; then
             echo "VERCEL_PROJECT_ID=${{ secrets.VERCEL_PROJECT_ID_STAGING }}" >> $GITHUB_ENV
+            echo "DOMAIN=${{ staging.swap.cow.fi }}" >> $GITHUB_ENV
           elif [[ ${{ inputs.env_name == 'barn' }} ]]; then
             echo "VERCEL_PROJECT_ID=${{ secrets.VERCEL_PROJECT_ID_BARN }}" >> $GITHUB_ENV
+            echo "DOMAIN=${{ barn.cow.fi }}" >> $GITHUB_ENV
           elif [[ ${{ inputs.env_name == 'prod' }} ]]; then
             echo "VERCEL_PROJECT_ID=${{ secrets.VERCEL_PROJECT_ID_PROD }}" >> $GITHUB_ENV
+            echo "DOMAIN=${{ swap.cow.fi }}" >> $GITHUB_ENV
           fi
 
       - name: Install Vercel CLI
@@ -45,6 +49,9 @@ jobs:
         run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
 
       - name: Deploy Project Artifacts to Vercel
+        environment:
+          name: ${{ inputs.env_name }}
+          url: https://${{ env.DOMAIN }}
         run: >
           vercel deploy --prebuilt --prod
           -t ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -14,9 +14,7 @@ env:
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
-    environment: # Environment rules defined on GH UI
-      name: ${{ inputs.env_name }}
-      url: https://${{ env.DOMAIN }}
+    environment: ${{ inputs.env_name }} # Environment rules defined on GH UI
 
     steps:
       - name: Checkout code
@@ -26,16 +24,12 @@ jobs:
         run: >
           if [[ ${{ inputs.env_name == 'dev' }} ]]; then
             echo "VERCEL_PROJECT_ID=${{ secrets.VERCEL_PROJECT_ID_DEV }}" >> $GITHUB_ENV
-            echo "DOMAIN=dev.swap.cow.fi" >> $GITHUB_ENV
           elif [[ ${{ inputs.env_name == 'staging' }} ]]; then
             echo "VERCEL_PROJECT_ID=${{ secrets.VERCEL_PROJECT_ID_STAGING }}" >> $GITHUB_ENV
-            echo "DOMAIN=staging.swap.cow.fi" >> $GITHUB_ENV
           elif [[ ${{ inputs.env_name == 'barn' }} ]]; then
             echo "VERCEL_PROJECT_ID=${{ secrets.VERCEL_PROJECT_ID_BARN }}" >> $GITHUB_ENV
-            echo "DOMAIN=barn.cow.fi" >> $GITHUB_ENV
           elif [[ ${{ inputs.env_name == 'prod' }} ]]; then
             echo "VERCEL_PROJECT_ID=${{ secrets.VERCEL_PROJECT_ID_PROD }}" >> $GITHUB_ENV
-            echo "DOMAIN=swap.cow.fi" >> $GITHUB_ENV
           fi
 
       - name: Install Vercel CLI

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
-    environment:
+    environment: # Environment rules defined on GH UI
       name: ${{ inputs.env_name }}
       url: https://${{ env.DOMAIN }}
 

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -23,16 +23,16 @@ jobs:
         run: >
           if [[ ${{ inputs.env_name == 'dev' }} ]]; then
             echo "VERCEL_PROJECT_ID=${{ secrets.VERCEL_PROJECT_ID_DEV }}" >> $GITHUB_ENV
-            echo "DOMAIN=${{ dev.swap.cow.fi }}" >> $GITHUB_ENV
+            echo "DOMAIN=dev.swap.cow.fi" >> $GITHUB_ENV
           elif [[ ${{ inputs.env_name == 'staging' }} ]]; then
             echo "VERCEL_PROJECT_ID=${{ secrets.VERCEL_PROJECT_ID_STAGING }}" >> $GITHUB_ENV
-            echo "DOMAIN=${{ staging.swap.cow.fi }}" >> $GITHUB_ENV
+            echo "DOMAIN=staging.swap.cow.fi" >> $GITHUB_ENV
           elif [[ ${{ inputs.env_name == 'barn' }} ]]; then
             echo "VERCEL_PROJECT_ID=${{ secrets.VERCEL_PROJECT_ID_BARN }}" >> $GITHUB_ENV
-            echo "DOMAIN=${{ barn.cow.fi }}" >> $GITHUB_ENV
+            echo "DOMAIN=barn.cow.fi" >> $GITHUB_ENV
           elif [[ ${{ inputs.env_name == 'prod' }} ]]; then
             echo "VERCEL_PROJECT_ID=${{ secrets.VERCEL_PROJECT_ID_PROD }}" >> $GITHUB_ENV
-            echo "DOMAIN=${{ swap.cow.fi }}" >> $GITHUB_ENV
+            echo "DOMAIN=swap.cow.fi" >> $GITHUB_ENV
           fi
 
       - name: Install Vercel CLI

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -15,6 +15,7 @@ jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     environment: ${{ inputs.env_name }} # Environment rules defined on GH UI
+    concurrency: ${{ inputs.env_name }} # Only one run per env at a time
 
     steps:
       - name: Checkout code

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -14,6 +14,9 @@ env:
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.env_name }}
+      url: https://${{ env.DOMAIN }}
 
     steps:
       - name: Checkout code
@@ -49,9 +52,6 @@ jobs:
         run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
 
       - name: Deploy Project Artifacts to Vercel
-        environment:
-          name: ${{ inputs.env_name }}
-          url: https://${{ env.DOMAIN }}
         run: >
           vercel deploy --prebuilt --prod
           -t ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
# Summary

- Added manual step to deploy to Vercel prod
Anyone can trigger it, but it'll stop before the actual deployment is started

- Added deployment environments
![Screen Shot 2022-11-02 at 15 33 18](https://user-images.githubusercontent.com/43217/199532518-bb671f6a-c5b4-4ae4-8732-2bff22c3252f.png)

Right now only these accounts will be allowed to publish to production
![Screen Shot 2022-11-02 at 15 33 33](https://user-images.githubusercontent.com/43217/199532515-bebaf615-3205-42d0-83e6-778235d1298a.png)

Only after the approval is give the env var `VERCEL_PROJECT_ID_PROD` will be available.
Otherwise it's not possible to deploy to production environment

Another cool thing about environments is that we can see all deployments per environment [here](https://github.com/cowprotocol/cowswap/deployments)
![Screen Shot 2022-11-02 at 15 36 14](https://user-images.githubusercontent.com/43217/199533182-82b212cc-cb6b-4bb7-8fc3-d2a35d137941.png)

# To Test

1. Check the deployment steps
2. There's one step that temporarily requires my permission to deploy to `dev`
3. I also tested with Anxo's approval

Otherwise, this needs to be first added to the default branch (I guess `develop`), then we can test the manual trigger. I have not tested that yet