### PR TITLE
Fix vercel project

### DIFF
--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -22,16 +22,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set VERCEL_PROJECT_ID env var
-        run: >
-          if [[ ${{ inputs.env_name == 'dev' }} ]]; then
-            echo "VERCEL_PROJECT_ID=${{ secrets.VERCEL_PROJECT_ID_DEV }}" >> $GITHUB_ENV
-          elif [[ ${{ inputs.env_name == 'staging' }} ]]; then
-            echo "VERCEL_PROJECT_ID=${{ secrets.VERCEL_PROJECT_ID_STAGING }}" >> $GITHUB_ENV
-          elif [[ ${{ inputs.env_name == 'barn' }} ]]; then
-            echo "VERCEL_PROJECT_ID=${{ secrets.VERCEL_PROJECT_ID_BARN }}" >> $GITHUB_ENV
-          elif [[ ${{ inputs.env_name == 'prod' }} ]]; then
-            echo "VERCEL_PROJECT_ID=${{ secrets.VERCEL_PROJECT_ID_PROD }}" >> $GITHUB_ENV
-          fi
+        # It's set in each env's config on https://github.com/cowprotocol/cowswap/settings/environments
+        run: echo "VERCEL_PROJECT_ID=${{ secrets.VERCEL_PROJECT_ID }}" >> $GITHUB_ENV
 
       - name: Install Vercel CLI
         run: npm install --global vercel@latest

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -32,7 +32,15 @@ jobs:
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build Project Artifacts
-        run: vercel build -t ${{ secrets.VERCEL_TOKEN }} --prod
+        run: >
+          REACT_APP_SENTRY_DSN=${{ secrets.SENTRY_DSN }}
+          REACT_APP_SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+          REACT_APP_PINATA_API_KEY=${{ secrets.REACT_APP_PINATA_API_KEY }}
+          REACT_APP_PINATA_SECRET_API_KEY=${{ secrets.REACT_APP_PINATA_SECRET_API_KEY }}
+          REACT_APP_BLOCKNATIVE_API_KEY=${{ secrets.REACT_APP_BLOCKNATIVE_API_KEY }}
+          REACT_APP_GOOGLE_ANALYTICS_ID=${{ secrets.REACT_APP_GOOGLE_ANALYTICS_ID }}
+          REACT_APP_AMPLITUDE_KEY=${{ secrets.REACT_APP_AMPLITUDE_KEY }}
+          vercel build -t ${{ secrets.VERCEL_TOKEN }} --prod
 
       - name: Get the version
         id: get_version
@@ -42,12 +50,5 @@ jobs:
         run: >
           vercel deploy --prebuilt --prod
           -t ${{ secrets.VERCEL_TOKEN }}
-          -b REACT_APP_SENTRY_DSN=${{ secrets.SENTRY_DSN }}
-          -b REACT_APP_SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
-          -b REACT_APP_PINATA_API_KEY=${{ secrets.REACT_APP_PINATA_API_KEY }}
-          -b REACT_APP_PINATA_SECRET_API_KEY=${{ secrets.REACT_APP_PINATA_SECRET_API_KEY }}
-          -b REACT_APP_BLOCKNATIVE_API_KEY=${{ secrets.REACT_APP_BLOCKNATIVE_API_KEY }}
-          -b REACT_APP_GOOGLE_ANALYTICS_ID=${{ secrets.REACT_APP_GOOGLE_ANALYTICS_ID }}
-          -b REACT_APP_AMPLITUDE_KEY=${{ secrets.REACT_APP_AMPLITUDE_KEY }}
           -m VERSION=${{ steps.get_version.outputs.VERSION }}
           -m COMMIT=${{ github.sha }}


### PR DESCRIPTION
# Summary

RELEASE!

(another RC, not intended for deployment neither changes any code other that CI)

---

This change removes the local envvar mapping that for some reason wasn't working.
Only the `dev` env var was being picked which means `barn` and `staging` steps were deploying to `dev` environment.

Now the `VERCEL_PROJECT_ID` env var is set individually in each GH environment
![Screen Shot 2022-11-03 at 13 47 48](https://user-images.githubusercontent.com/43217/199737876-27f49206-d263-48d5-a435-d673f0fbabfc.png)

![Screen Shot 2022-11-03 at 13 47 59](https://user-images.githubusercontent.com/43217/199737864-924abc46-76fd-4577-b324-41812d6f7353.png)

There is also a fix for the envvars, which need to be set at build time but were not being passed.

# Test

1. I have temporarily forced `staging` and `barn` to be deployed in this branch to check the respective projects are deployed on Vercel
2. Change will be reverted before the merge
3. Example working build https://github.com/cowprotocol/cowswap/actions/runs/3386498114
4. Staging and barn created in the previous deployment https://swap-staging.vercel.app/ and https://swap-barn.vercel.app/
