### PR TITLE
Updated env vars with domain regex

### DIFF
--- a/.env
+++ b/.env
@@ -36,11 +36,11 @@ REACT_APP_FORTMATIC_SITE_VERIFICATION="LzjrtdM7hqVJfvvA"
 
 # Domain regex (to detect environment)
 REACT_APP_DOMAIN_REGEX_LOCAL="^(:?localhost:\d{2,5}|(?:127|192)(?:\.[0-9]{1,3}){3})"
-REACT_APP_DOMAIN_REGEX_PR="^pr\d+--cowswap\.review"
-REACT_APP_DOMAIN_REGEX_DEV="^cowswap\.dev"
-REACT_APP_DOMAIN_REGEX_STAGING="^cowswap\.staging"
-REACT_APP_DOMAIN_REGEX_PROD="^(cowswap\.exchange|swap\.cow\.fi)$"
-REACT_APP_DOMAIN_REGEX_BARN="^barn\.(cowswap\.exchange|swap\.cow\.fi|cow\.fi)$"
+REACT_APP_DOMAIN_REGEX_PR="^pr\d+--cowswap\.review|^(swap-dev-git-[\w\d-]+|swap-\w{9}-)cowswap\.vercel\.app"
+REACT_APP_DOMAIN_REGEX_DEV="^(cowswap\.dev|dev\.swap\.cow\.fi|swap-develop\.vercel\.app)"
+REACT_APP_DOMAIN_REGEX_STAGING="^(cowswap\.staging|staging\.swap\.cow\.fi|swap-staging\.vercel\.app)"
+REACT_APP_DOMAIN_REGEX_PROD="^(swap\.cow\.fi|swap-prod\.vercel\.app)$"
+REACT_APP_DOMAIN_REGEX_BARN="^(barn\.cow\.fi|swap-barn\.vercel\.app)$"
 REACT_APP_DOMAIN_REGEX_ENS="(:?^cowswap\.eth|ipfs)"
 
 # Path regex (to detect environment)

--- a/.env.production
+++ b/.env.production
@@ -37,11 +37,11 @@ REACT_APP_FORTMATIC_KEY_PROD="pk_live_7BD8004CBBF5CDD6"
 
 # Domain regex (to detect environment)
 REACT_APP_DOMAIN_REGEX_LOCAL="^(:?localhost:\d{2,5}|(?:127|192)(?:\.[0-9]{1,3}){3})"
-REACT_APP_DOMAIN_REGEX_PR="^pr\d+--cowswap\.review"
-REACT_APP_DOMAIN_REGEX_DEV="^cowswap\.dev"
-REACT_APP_DOMAIN_REGEX_STAGING="^cowswap\.staging"
-REACT_APP_DOMAIN_REGEX_PROD="^(swap\.cow\.fi)$"
-REACT_APP_DOMAIN_REGEX_BARN="^(barn\.cow\.fi)$"
+REACT_APP_DOMAIN_REGEX_PR="^pr\d+--cowswap\.review|^(swap-dev-git-[\w\d-]+|swap-\w{9}-)cowswap\.vercel\.app"
+REACT_APP_DOMAIN_REGEX_DEV="^(cowswap\.dev|dev\.swap\.cow\.fi|swap-develop\.vercel\.app)"
+REACT_APP_DOMAIN_REGEX_STAGING="^(cowswap\.staging|staging\.swap\.cow\.fi|swap-staging\.vercel\.app)"
+REACT_APP_DOMAIN_REGEX_PROD="^(swap\.cow\.fi|swap-prod\.vercel\.app)$"
+REACT_APP_DOMAIN_REGEX_BARN="^(barn\.cow\.fi|swap-barn\.vercel\.app)$"
 REACT_APP_DOMAIN_REGEX_ENS="(:?^cowswap\.eth|ipfs)"
 
 # Path regex (to detect environment)


### PR DESCRIPTION
# Summary

- New staging and dev endpoints
- New preview URLs
- New temporary Vercel endpoints until our own are migrated

  # To Test

Needs deployment to each respective environment.
For develop it should already detect itself as being on develop, but then nothing changes there as it's already the default

Tested the regexes with https://regex101.com/

## PRs

Regex: `^pr\d+--cowswap\.review|^(swap-dev-git-[\w\d-]+|swap-\w{9}-)cowswap\.vercel\.app`
URLs:
```
swap-h3c4xsg7t-cowswap.vercel.app/
swap-dev-git-limit-orders-wrap-unwrap-cowswap.vercel.app/
pr1284--cowswap.review.gnosisdev.com/
```

## Develop

Regex: `^(cowswap\.dev|dev\.swap\.cow\.fi|swap-develop\.vercel\.app)`
URLs:
```
cowswap.dev.gnosisdev.com/
dev.swap.cow.fi
swap-develop.vercel.app
```


## Staging

Regex: `^(cowswap\.staging|staging\.swap\.cow\.fi|swap-staging\.vercel\.app)`
URLs:
```
cowswap.staging.gnosisdev.com/
staging.swap.cow.fi
swap-staging.vercel.app
```

## Barn

Regex: `^(barn\.cow\.fi|swap-barn\.vercel\.app)$`
URLs:
```
barn.cow.fi
swap-barn.vercel.app
```


## Production

Regex: `^(prod\.cow\.fi|swap-prod\.vercel\.app)$`
URLs:
```
prod.cow.fi
swap-prod.vercel.app
```


