### PR TITLE
Limit orders bug fixes 1

### DIFF
--- a/src/cow-react/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
+++ b/src/cow-react/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
@@ -21,6 +21,7 @@ interface BuiltItProps {
 export interface CurrencyInputPanelProps extends Partial<BuiltItProps> {
   id: string
   loading: boolean
+  isRateLoading?: boolean
   showSetMax?: boolean
   allowsOffchainSigning: boolean
   currencyInfo: CurrencyInfo
@@ -44,6 +45,7 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
     allowsOffchainSigning,
     subsidyAndBalance,
     topLabel,
+    isRateLoading,
   } = props
   const { priceImpact, loading: priceImpactLoading } = priceImpactParams || {}
   const { field, currency, balance, fiatAmount, viewAmount, receiveAmountInfo } = currencyInfo
@@ -115,7 +117,12 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
           </div>
           <div>
             <styledEl.FiatAmountText>
-              <FiatValue priceImpactLoading={priceImpactLoading} fiatValue={fiatAmount} priceImpact={priceImpact} />
+              <FiatValue
+                isLoading={isRateLoading}
+                priceImpactLoading={priceImpactLoading}
+                fiatValue={fiatAmount}
+                priceImpact={priceImpact}
+              />
             </styledEl.FiatAmountText>
           </div>
         </styledEl.CurrencyInputBox>

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -26,6 +26,7 @@ import { useTradeNavigate } from '@cow/modules/trade/hooks/useTradeNavigate'
 import { useOnCurrencySelection } from '@cow/modules/trade/hooks/useOnCurrencySelection'
 import { ImportTokenModal } from '@cow/modules/trade/containers/ImportTokenModal'
 import { useOnImportDismiss } from '@cow/modules/trade/hooks/useOnImportDismiss'
+import { limitRateAtom } from '../../state/limitRateAtom'
 
 export function LimitOrdersWidget() {
   useSetupTradeState()
@@ -52,6 +53,7 @@ export function LimitOrdersWidget() {
   const tradeContext = useTradeFlowContext(limitOrdersQuote)
   const state = useAtomValue(limitOrdersAtom)
   const updateLimitOrdersState = useUpdateAtom(updateLimitOrdersAtom)
+  const { isLoading: isRateLoading } = useAtomValue(limitRateAtom)
 
   const [showConfirmation, setShowConfirmation] = useState(false)
 
@@ -145,6 +147,7 @@ export function LimitOrdersWidget() {
           <CurrencyInputPanel
             id="swap-currency-output"
             loading={currenciesLoadingInProgress}
+            isRateLoading={isRateLoading}
             onCurrencySelection={onCurrencySelection}
             onUserInput={onUserInput}
             subsidyAndBalance={subsidyAndBalance}

--- a/src/cow-react/modules/limitOrders/updaters/ActiveRateUpdater/index.ts
+++ b/src/cow-react/modules/limitOrders/updaters/ActiveRateUpdater/index.ts
@@ -6,36 +6,50 @@ import usePrevious from 'hooks/usePrevious'
 import { useUpdateCurrencyAmount } from '@cow/modules/limitOrders/hooks/useUpdateCurrencyAmount'
 import { limitRateAtom, updateLimitRateAtom } from '@cow/modules/limitOrders/state/limitRateAtom'
 import { useLimitOrdersTradeState } from '@cow/modules/limitOrders/hooks/useLimitOrdersTradeState'
+import { updateLimitOrdersAtom } from '@cow/modules/limitOrders/state/limitOrdersAtom'
 
 // Observe the activeRate value changes
 // Re-trigger the input field to apply the new rate to output
 export function ActiveRateUpdater() {
   const { chainId } = useWeb3React()
   const { inputCurrencyAmount } = useLimitOrdersTradeState()
-  const { isInversed, activeRate } = useAtomValue(limitRateAtom)
+  const { isInversed, activeRate, isLoading } = useAtomValue(limitRateAtom)
 
+  const updateLimitOrdersState = useUpdateAtom(updateLimitOrdersAtom)
   const updateLimitRateState = useUpdateAtom(updateLimitRateAtom)
   const updateCurrencyAmount = useUpdateCurrencyAmount()
   const prevIsInversed = usePrevious(isInversed)
   const prevChainId = usePrevious(chainId)
 
-  // Handle activeRate changes
   useEffect(() => {
+    // Handle active rate change
     if (isInversed === prevIsInversed && activeRate && inputCurrencyAmount) {
       updateCurrencyAmount({
         inputCurrencyAmount: inputCurrencyAmount?.toExact(),
         keepOrderKind: true,
       })
     }
+
+    // Clear output amount when there is no active rate
+    if (!activeRate) {
+      updateLimitOrdersState({
+        outputCurrencyAmount: null,
+      })
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeRate])
 
-  // Clear active rate on network change
   useEffect(() => {
+    // Clear active rate on network change
     if (prevChainId && prevChainId !== chainId) {
       updateLimitRateState({ activeRate: null })
     }
-  }, [chainId, prevChainId, updateLimitRateState])
+
+    // Clear active rate when its loading (currency changed)
+    if (isLoading) {
+      updateLimitRateState({ activeRate: null })
+    }
+  }, [chainId, isLoading, prevChainId, updateLimitRateState])
 
   return null
 }

--- a/src/custom/components/CurrencyInputPanel/FiatValue/FiatValueMod.tsx
+++ b/src/custom/components/CurrencyInputPanel/FiatValue/FiatValueMod.tsx
@@ -20,11 +20,13 @@ export function FiatValue({
   priceImpact,
   priceImpactLoading, // mod
   className, // mod
+  isLoading, // mod
 }: {
   fiatValue: CurrencyAmount<Currency> | null | undefined
   priceImpact?: Percent
   priceImpactLoading?: boolean
   className?: string // mod
+  isLoading?: boolean // mod
 }) {
   const theme = useTheme()
   const priceImpactColor = useMemo(() => {
@@ -38,7 +40,7 @@ export function FiatValue({
 
   return (
     <ThemedText.Body className={className} fontSize={14} color={fiatValue ? theme.text1 : theme.text4}>
-      {fiatValue ? (
+      {fiatValue && !isLoading ? (
         <Trans>
           ≈ $
           <HoverInlineText


### PR DESCRIPTION
# Summary

This PR fixes some smaller UI/UX issues
- when the currency changes, the output amount is removed while the new rate is loaded
- when the currency changes, until the new rate is loaded, we hide the USD amount of output value, otherwise there will be some point where the wrong value is showed

# To test
1. go to limit orders widget
2. change the currencies
3. make sure everything looks ok