### PR TITLE
Added widget links

### DIFF
--- a/src/cow-react/constants/featureFlags.ts
+++ b/src/cow-react/constants/featureFlags.ts
@@ -1,0 +1,1 @@
+export const LIMIT_ORDERS_ENABLED = 'enableLimitOrders'

--- a/src/cow-react/modules/application/containers/TradeWidgetLinks/index.tsx
+++ b/src/cow-react/modules/application/containers/TradeWidgetLinks/index.tsx
@@ -1,0 +1,45 @@
+import { Trans } from '@lingui/macro'
+import { Routes } from '@cow/constants/routes'
+
+import { ThemedText } from 'theme'
+import { RowFixed } from 'components/Row'
+import { LIMIT_ORDERS_ENABLED } from '@cow/constants/featureFlags'
+import { FeatureFlag } from '@cow/utils/featureFlags'
+import { useMemo } from 'react'
+import { useTradeState } from '@cow/modules/trade/hooks/useTradeState'
+import { parameterizeTradeRoute } from '@cow/modules/trade/utils/parameterizeTradeRoute'
+import * as styledEl from './styled'
+
+export function TradeWidgetLinks() {
+  const tradeState = useTradeState()
+
+  const tradeContext = useMemo(
+    () => ({
+      inputCurrencyId: tradeState?.state.inputCurrencyId || undefined,
+      outputCurrencyId: tradeState?.state.outputCurrencyId || undefined,
+      chainId: tradeState?.state.chainId?.toString(),
+    }),
+    [tradeState?.state]
+  )
+
+  return FeatureFlag.get(LIMIT_ORDERS_ENABLED) ? (
+    <RowFixed>
+      <styledEl.Link activeClassName="active" to={parameterizeTradeRoute(tradeContext, Routes.SWAP)}>
+        <ThemedText.Black fontWeight={500} fontSize={16} style={{ marginRight: '8px' }}>
+          <Trans>Swap</Trans>
+        </ThemedText.Black>
+      </styledEl.Link>
+      <styledEl.Link activeClassName="active" to={parameterizeTradeRoute(tradeContext, Routes.LIMIT_ORDER)}>
+        <ThemedText.Black fontWeight={500} fontSize={16} style={{ marginRight: '8px' }}>
+          <Trans>Limit</Trans>
+        </ThemedText.Black>
+      </styledEl.Link>
+    </RowFixed>
+  ) : (
+    <RowFixed>
+      <ThemedText.Black fontWeight={500} fontSize={16} style={{ marginRight: '8px' }}>
+        <Trans>Swap</Trans>
+      </ThemedText.Black>
+    </RowFixed>
+  )
+}

--- a/src/cow-react/modules/application/containers/TradeWidgetLinks/styled.ts
+++ b/src/cow-react/modules/application/containers/TradeWidgetLinks/styled.ts
@@ -1,0 +1,12 @@
+import styled from 'styled-components/macro'
+import { NavLink } from 'react-router-dom'
+
+export const Link = styled(NavLink)<{ isActive?: boolean }>`
+  text-decoration: none;
+  padding: 0 5px;
+  opacity: 0.5;
+
+  &.active {
+    opacity: 1;
+  }
+`

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -28,6 +28,7 @@ import { ImportTokenModal } from '@cow/modules/trade/containers/ImportTokenModal
 import { useOnImportDismiss } from '@cow/modules/trade/hooks/useOnImportDismiss'
 import { limitRateAtom } from '../../state/limitRateAtom'
 import { useRateImpact } from '@cow/modules/limitOrders/hooks/useRateImpact'
+import { TradeWidgetLinks } from '@cow/modules/application/containers/TradeWidgetLinks'
 
 export function LimitOrdersWidget() {
   useSetupTradeState()
@@ -120,7 +121,7 @@ export function LimitOrdersWidget() {
       <styledEl.Container>
         <styledEl.ContainerBox>
           <styledEl.Header>
-            <div>Limit orders</div>
+            <TradeWidgetLinks />
             <SettingsWidget />
           </styledEl.Header>
           <CurrencyInputPanel

--- a/src/cow-react/modules/mainMenu/constants/mainMenu.ts
+++ b/src/cow-react/modules/mainMenu/constants/mainMenu.ts
@@ -1,5 +1,7 @@
 import { Routes } from '@cow/constants/routes'
 import { CONTRACTS_CODE_LINK, DISCORD_LINK, DOCS_LINK, DUNE_DASHBOARD_LINK, TWITTER_LINK } from 'constants/index'
+import { LIMIT_ORDERS_ENABLED } from '@cow/constants/featureFlags'
+import { FeatureFlag } from '@cow/utils/featureFlags'
 import { BasicMenuLink, InternalLink, MainMenuItemId, MenuItemKind, MenuTreeItem } from '../types'
 
 // Assets
@@ -117,7 +119,7 @@ export const MAIN_MENU: MenuTreeItem[] = [
   },
 ]
 
-if (localStorage.getItem('enableLimitOrders')) {
+if (FeatureFlag.get(LIMIT_ORDERS_ENABLED)) {
   MAIN_MENU.splice(1, 0, {
     id: MainMenuItemId.LIMIT_ORDERS,
     kind: MenuItemKind.DYNAMIC_LINK,

--- a/src/cow-react/utils/featureFlags.ts
+++ b/src/cow-react/utils/featureFlags.ts
@@ -1,0 +1,9 @@
+export class FeatureFlag {
+  static get(name: string) {
+    return localStorage.getItem(name)
+  }
+
+  static set(name: string, value: string) {
+    localStorage.setItem(name, value)
+  }
+}

--- a/src/custom/components/swap/SwapHeader/SwapHeaderMod.tsx
+++ b/src/custom/components/swap/SwapHeader/SwapHeaderMod.tsx
@@ -1,10 +1,9 @@
-import { Trans } from '@lingui/macro'
 import { Percent } from '@uniswap/sdk-core'
 import styled from 'styled-components/macro'
 
-import { ThemedText } from 'theme'
 import { RowBetween, RowFixed } from 'components/Row'
 import SettingsTab from 'components/Settings'
+import { TradeWidgetLinks } from '@cow/modules/application/containers/TradeWidgetLinks'
 
 const StyledSwapHeader = styled.div`
   padding: 1rem 1.25rem 0.5rem 1.25rem;
@@ -16,11 +15,7 @@ export default function SwapHeader({ allowedSlippage, className }: { allowedSlip
   return (
     <StyledSwapHeader className={className}>
       <RowBetween>
-        <RowFixed>
-          <ThemedText.Black fontWeight={500} fontSize={16} style={{ marginRight: '8px' }}>
-            <Trans>Swap</Trans>
-          </ThemedText.Black>
-        </RowFixed>
+        <TradeWidgetLinks />
         <RowFixed>
           <SettingsTab placeholderSlippage={allowedSlippage} />
         </RowFixed>


### PR DESCRIPTION
# Summary

This PR does the following
- Adds Swap/Limit links on both swap and limit order widgets
- Moves these links in a separate component because its used in 2 places
- Adds feature-flag class and creates separate const file for feature-flags

![Screenshot from 2022-11-09 13-41-52](https://user-images.githubusercontent.com/34926005/200833138-d08a59af-3236-46ca-bbae-410e975bf30e.png)

# To test
- make sure you have `enableLimitOrders` value in local storage set to 1, if you want to disable it set it to 0 or remove value