### PR TITLE
Fix for lower-case letters in URL

### DIFF
--- a/src/cow-react/common/hooks/useTokenBySymbolOrAddress.ts
+++ b/src/cow-react/common/hooks/useTokenBySymbolOrAddress.ts
@@ -12,15 +12,17 @@ export function useTokenBySymbolOrAddress(symbolOrAddress?: string | null): Toke
       return null
     }
 
-    if (nativeCurrency.symbol === symbolOrAddress) {
+    const symbolOrAddressLowerCase = symbolOrAddress.toLowerCase()
+
+    if (nativeCurrency.symbol?.toLowerCase() === symbolOrAddressLowerCase) {
       return nativeCurrency
     }
 
     return (
       tokens.find(
         (item) =>
-          item.address.toLowerCase() === symbolOrAddress.toLowerCase() ||
-          item.symbol?.toLowerCase() === symbolOrAddress.toLowerCase()
+          item.address.toLowerCase() === symbolOrAddressLowerCase ||
+          item.symbol?.toLowerCase() === symbolOrAddressLowerCase
       ) || null
     )
   }, [symbolOrAddress, nativeCurrency, tokens])

--- a/src/cow-react/common/hooks/useTokenBySymbolOrAddress.ts
+++ b/src/cow-react/common/hooks/useTokenBySymbolOrAddress.ts
@@ -18,7 +18,9 @@ export function useTokenBySymbolOrAddress(symbolOrAddress?: string | null): Toke
 
     return (
       tokens.find(
-        (item) => item.address.toLowerCase() === symbolOrAddress.toLowerCase() || item.symbol === symbolOrAddress
+        (item) =>
+          item.address.toLowerCase() === symbolOrAddress.toLowerCase() ||
+          item.symbol?.toLowerCase() === symbolOrAddress.toLowerCase()
       ) || null
     )
   }, [symbolOrAddress, nativeCurrency, tokens])


### PR DESCRIPTION
# Summary

Fixes #1321

# To test
- type lower-case token symbols in URL
- make sure the correct tokens are selected