### PR TITLE
[Eth flow]#1289 Feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,5 +167,5 @@ The plan:
 
 ## Feature flags
 
-`localStorage.setItem('enableNewSwap', '1')` - enable refactored swap interface
+`localStorage.setItem('enableEthFlow', '1')` - enable native EthFlow (WORK IN PROGRESS)
 `localStorage.setItem('enableLimitOrders', '1')` - enable limit orders page (WORK IN PROGRESS)

--- a/src/cow-react/modules/swap/helpers/getEthFlowEnabled.ts
+++ b/src/cow-react/modules/swap/helpers/getEthFlowEnabled.ts
@@ -1,0 +1,5 @@
+const ETH_FLOW_ENABLED_LOCAL_STORAGE_KEY = 'enableEthFlow'
+
+export function getEthFlowEnabled(): boolean {
+  return localStorage.getItem(ETH_FLOW_ENABLED_LOCAL_STORAGE_KEY) === '1'
+}

--- a/src/cow-react/modules/swap/helpers/getEthFlowEnabled.ts
+++ b/src/cow-react/modules/swap/helpers/getEthFlowEnabled.ts
@@ -1,5 +1,7 @@
+import { isProd } from 'utils/environments'
+
 const ETH_FLOW_ENABLED_LOCAL_STORAGE_KEY = 'enableEthFlow'
 
 export function getEthFlowEnabled(): boolean {
-  return localStorage.getItem(ETH_FLOW_ENABLED_LOCAL_STORAGE_KEY) === '1'
+  return !isProd && localStorage.getItem(ETH_FLOW_ENABLED_LOCAL_STORAGE_KEY) === '1'
 }

--- a/src/cow-react/modules/swap/helpers/getSwapButtonState.ts
+++ b/src/cow-react/modules/swap/helpers/getSwapButtonState.ts
@@ -24,6 +24,7 @@ export enum SwapButtonState {
   SwapError = 'SwapError',
   ExpertModeSwap = 'ExpertModeSwap',
   RegularSwap = 'RegularSwap',
+  SwapWithWrappedToken = 'SwapWithWrappedToken',
   EthFlowSwap = 'EthFlowSwap',
 }
 

--- a/src/cow-react/modules/swap/helpers/getSwapButtonState.ts
+++ b/src/cow-react/modules/swap/helpers/getSwapButtonState.ts
@@ -3,6 +3,7 @@ import { WrapType } from 'hooks/useWrapCallback'
 import { QuoteError } from 'state/price/actions'
 import { ApprovalState } from 'hooks/useApproveCallback'
 import TradeGp from 'state/swap/TradeGp'
+import { getEthFlowEnabled } from '@cow/modules/swap/helpers/getEthFlowEnabled'
 
 export enum SwapButtonState {
   SwapIsUnsupported = 'SwapIsUnsupported',
@@ -120,7 +121,11 @@ export function getSwapButtonState(input: SwapButtonStateParams): SwapButtonStat
   }
 
   if (input.isNativeIn) {
-    return SwapButtonState.EthFlowSwap
+    if (getEthFlowEnabled()) {
+      return SwapButtonState.EthFlowSwap
+    } else {
+      return SwapButtonState.SwapWithWrappedToken
+    }
   }
 
   if (input.isExpertMode) {

--- a/src/cow-react/modules/swap/hooks/useIsEthFlow.ts
+++ b/src/cow-react/modules/swap/hooks/useIsEthFlow.ts
@@ -1,7 +1,9 @@
 import { useDetectNativeToken } from '@cow/modules/swap/hooks/useDetectNativeToken'
+import { getEthFlowEnabled } from '@cow/modules/swap/helpers/getEthFlowEnabled'
 
 export function useIsEthFlow(): boolean {
   const { isNativeIn, isWrapOrUnwrap } = useDetectNativeToken()
+  const isEnabled = getEthFlowEnabled()
 
-  return isNativeIn && !isWrapOrUnwrap
+  return isEnabled && isNativeIn && !isWrapOrUnwrap
 }

--- a/src/cow-react/modules/swap/pure/SwapButtons/index.tsx
+++ b/src/cow-react/modules/swap/pure/SwapButtons/index.tsx
@@ -64,6 +64,13 @@ const swapButtonStateMap: { [key in SwapButtonState]: (props: SwapButtonsContext
       <Trans>Unwrap</Trans>
     </ButtonPrimary>
   ),
+  [SwapButtonState.SwapWithWrappedToken]: (props: SwapButtonsContext) => (
+    <ButtonError buttonSize={ButtonSize.BIG} onClick={props.onEthFlow}>
+      <styledEl.SwapButtonBox>
+        <Trans>Swap with {props.wrappedToken.symbol}</Trans>
+      </styledEl.SwapButtonBox>
+    </ButtonError>
+  ),
   [SwapButtonState.FeesExceedFromAmount]: () => <styledEl.FeesExceedFromAmountMessage />,
   [SwapButtonState.InsufficientLiquidity]: () => (
     <GreyCard style={{ textAlign: 'center' }}>


### PR DESCRIPTION
# Summary

Closes #1289 

Added feature flag for toggling Native Eth Flow

To enabled it, on the console type if: `localStorage.setItem('enableEthFlow', '1')`
To disabled it: `localStorage.setItem('enableEthFlow', 0)`

# To Test

1. Load the page and try to sell ETH
2. Test a few flows with varying amounts of ETH and WETH in your wallet
* The behaviour should be identical to the one currently in dev.swap.cow.fi

![Screen Shot 2022-11-10 at 14 55 50](https://user-images.githubusercontent.com/43217/201124724-75600af4-8708-4b35-ade1-b86293c87d1e.png)

3. Enable the EthFlow with `localStorage.setItem('enableEthFlow', '1')`
4. Try to sell ETH (if ETH was selected before you might need to switch the token pair to reset it)
* It should now use the native Eth Flow

![Screen Shot 2022-11-10 at 14 55 36](https://user-images.githubusercontent.com/43217/201124743-33b1ea1b-fff6-4769-93cc-8ef42d428512.png)


**Note**: Native Eth Flow is not fully working yet. The change here is just the feature flag
