### PR TITLE
[Eth flow] Follow up 1239 - fix selltokenaddress

### DIFF
--- a/src/cow-react/modules/swap/services/utils/logger.ts
+++ b/src/cow-react/modules/swap/services/utils/logger.ts
@@ -1,7 +1,7 @@
 import { SwapFlowContext } from '@cow/modules/swap/services/common/types'
 
 export function logSwapFlow(label: string, ...args: any[]) {
-  console.debug(`%c [${label} ERROR] `, 'font-weight: bold; color: #1c5dbf', args)
+  console.debug(`%c [${label}] `, 'font-weight: bold; color: #1c5dbf', args)
 }
 
 export function logSwapFlowError(label: string, ...args: any[]) {

--- a/src/custom/utils/trade.ts
+++ b/src/custom/utils/trade.ts
@@ -6,7 +6,7 @@ import { AddUnserialisedPendingOrderParams } from 'state/orders/hooks'
 import { signOrder, signOrderCancellation, UnsignedOrder } from 'utils/signatures'
 import { sendSignedOrderCancellation, sendOrder as sendOrderApi, OrderID } from '@cow/api/gnosisProtocol'
 import { Signer } from '@ethersproject/abstract-signer'
-import { RADIX_DECIMAL, AMOUNT_PRECISION, NATIVE_CURRENCY_BUY_ADDRESS } from 'constants/index'
+import { RADIX_DECIMAL, AMOUNT_PRECISION } from 'constants/index'
 import { SupportedChainId as ChainId } from 'constants/chains'
 import { formatSmart } from 'utils/format'
 import { SigningScheme } from '@cowprotocol/contracts'
@@ -74,7 +74,7 @@ export function getOrderParams(params: PostOrderParams): {
 } {
   const { kind, inputAmount, outputAmount, sellToken, buyToken, feeAmount, validTo, recipient, appDataHash, quoteId } =
     params
-  const sellTokenAddress = sellToken instanceof Token ? sellToken.address : NATIVE_CURRENCY_BUY_ADDRESS
+  const sellTokenAddress = sellToken.address
 
   if (!sellTokenAddress) {
     throw new Error(`Order params invalid sellToken address for token: ${JSON.stringify(sellToken, undefined, 2)}`)


### PR DESCRIPTION
# Summary

Follow up to #1239 (https://github.com/cowprotocol/cowswap/pull/1239#discussion_r1019955645)

Using sellToken.address directly, as native token sell address is already set to 0xeee at this point

# To Test

1. Turn on eth flow `localStorage.setItem('enableEthFlow', '1')`
2. Select sell ETH for anything
3. Place order (no need to actually submit the tx)
* It should pop the onchain tx without issues
4. Repeat steps 2 and 3 with WETH and a different token pair
* It should show the wallet signature prompt without issues