### PR TITLE
Added enable limit orders screen

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -124,7 +124,7 @@ export function LimitOrdersWidget() {
         <styledEl.ContainerBox>
           <styledEl.Header>
             <TradeWidgetLinks />
-            <SettingsWidget />
+            {isUnlocked && <SettingsWidget />}
           </styledEl.Header>
 
           {isUnlocked ? (

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -29,6 +29,7 @@ import { limitRateAtom } from '../../state/limitRateAtom'
 import { useRateImpact } from '@cow/modules/limitOrders/hooks/useRateImpact'
 import { TradeWidgetLinks } from '@cow/modules/application/containers/TradeWidgetLinks'
 import { useDisableNativeTokenUsage } from '@cow/modules/limitOrders/hooks/useDisableNativeTokenUsage'
+import { UnlockLimitOrders } from '../../pure/UnlockLimitOrders'
 
 export function LimitOrdersWidget() {
   useSetupTradeState()
@@ -45,6 +46,7 @@ export function LimitOrdersWidget() {
     inputCurrencyFiatAmount,
     outputCurrencyFiatAmount,
     recipient,
+    isUnlocked,
   } = useLimitOrdersTradeState()
   const onCurrencySelection = useOnCurrencySelection()
   const onImportDismiss = useOnImportDismiss()
@@ -124,52 +126,59 @@ export function LimitOrdersWidget() {
             <TradeWidgetLinks />
             <SettingsWidget />
           </styledEl.Header>
-          <CurrencyInputPanel
-            id="swap-currency-input"
-            disableNonToken={true}
-            loading={currenciesLoadingInProgress}
-            onCurrencySelection={onCurrencySelection}
-            onUserInput={onUserInput}
-            subsidyAndBalance={subsidyAndBalance}
-            allowsOffchainSigning={allowsOffchainSigning}
-            currencyInfo={inputCurrencyInfo}
-            showSetMax={showSetMax}
-            topLabel={inputCurrencyInfo.label}
-          />
-          <styledEl.RateWrapper>
-            <RateInput />
-            <DeadlineInput />
-          </styledEl.RateWrapper>
-          <styledEl.CurrencySeparatorBox withRecipient={showRecipient}>
-            <CurrencyArrowSeparator
-              isCollapsed={false}
-              onSwitchTokens={onSwitchTokens}
-              withRecipient={showRecipient}
-              isLoading={isTradePriceUpdating}
-            />
-            {showRecipient && <AddRecipient onChangeRecipient={onChangeRecipient} />}
-          </styledEl.CurrencySeparatorBox>
-          <CurrencyInputPanel
-            id="swap-currency-output"
-            disableNonToken={true}
-            loading={currenciesLoadingInProgress}
-            isRateLoading={isRateLoading}
-            onCurrencySelection={onCurrencySelection}
-            onUserInput={onUserInput}
-            subsidyAndBalance={subsidyAndBalance}
-            allowsOffchainSigning={allowsOffchainSigning}
-            currencyInfo={outputCurrencyInfo}
-            priceImpactParams={priceImpactParams}
-            topLabel={outputCurrencyInfo.label}
-          />
-          {recipient !== null && (
-            <styledEl.StyledRemoveRecipient recipient={recipient} onChangeRecipient={onChangeRecipient} />
-          )}
-          <styledEl.TradeButtonBox>
-            <TradeButtons tradeContext={tradeContext} openConfirmScreen={() => setShowConfirmation(true)} />
-          </styledEl.TradeButtonBox>
-          {!!inputCurrency && (
-            <styledEl.StyledRateImpactWarning rateImpact={rateImpact} inputCurrency={inputCurrency} />
+
+          {isUnlocked ? (
+            <>
+              <CurrencyInputPanel
+                id="swap-currency-input"
+                disableNonToken={true}
+                loading={currenciesLoadingInProgress}
+                onCurrencySelection={onCurrencySelection}
+                onUserInput={onUserInput}
+                subsidyAndBalance={subsidyAndBalance}
+                allowsOffchainSigning={allowsOffchainSigning}
+                currencyInfo={inputCurrencyInfo}
+                showSetMax={showSetMax}
+                topLabel={inputCurrencyInfo.label}
+              />
+              <styledEl.RateWrapper>
+                <RateInput />
+                <DeadlineInput />
+              </styledEl.RateWrapper>
+              <styledEl.CurrencySeparatorBox withRecipient={showRecipient}>
+                <CurrencyArrowSeparator
+                  isCollapsed={false}
+                  onSwitchTokens={onSwitchTokens}
+                  withRecipient={showRecipient}
+                  isLoading={isTradePriceUpdating}
+                />
+                {showRecipient && <AddRecipient onChangeRecipient={onChangeRecipient} />}
+              </styledEl.CurrencySeparatorBox>
+              <CurrencyInputPanel
+                id="swap-currency-output"
+                disableNonToken={true}
+                loading={currenciesLoadingInProgress}
+                isRateLoading={isRateLoading}
+                onCurrencySelection={onCurrencySelection}
+                onUserInput={onUserInput}
+                subsidyAndBalance={subsidyAndBalance}
+                allowsOffchainSigning={allowsOffchainSigning}
+                currencyInfo={outputCurrencyInfo}
+                priceImpactParams={priceImpactParams}
+                topLabel={outputCurrencyInfo.label}
+              />
+              {recipient !== null && (
+                <styledEl.StyledRemoveRecipient recipient={recipient} onChangeRecipient={onChangeRecipient} />
+              )}
+              <styledEl.TradeButtonBox>
+                <TradeButtons tradeContext={tradeContext} openConfirmScreen={() => setShowConfirmation(true)} />
+              </styledEl.TradeButtonBox>
+              {!!inputCurrency && (
+                <styledEl.StyledRateImpactWarning rateImpact={rateImpact} inputCurrency={inputCurrency} />
+              )}
+            </>
+          ) : (
+            <UnlockLimitOrders handleUnlock={() => updateLimitOrdersState({ isUnlocked: true })} />
           )}
         </styledEl.ContainerBox>
       </styledEl.Container>

--- a/src/cow-react/modules/limitOrders/hooks/useLimitOrdersTradeState.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useLimitOrdersTradeState.ts
@@ -24,6 +24,7 @@ export interface LimitOrdersTradeState {
   readonly recipient: string | null
   readonly deadlineTimestamp: Timestamp | null
   readonly orderKind: OrderKind
+  readonly isUnlocked: boolean
 }
 
 export function useLimitOrdersTradeState(): LimitOrdersTradeState {
@@ -33,6 +34,7 @@ export function useLimitOrdersTradeState(): LimitOrdersTradeState {
 
   const recipient = state.recipient
   const orderKind = state.orderKind
+  const isUnlocked = state.isUnlocked
   const deadlineTimestamp = settingsState.customDeadlineTimestamp
     ? settingsState.customDeadlineTimestamp
     : calculateValidTo(settingsState.deadlineMilliseconds / 1000)
@@ -60,5 +62,6 @@ export function useLimitOrdersTradeState(): LimitOrdersTradeState {
     outputCurrencyBalance,
     inputCurrencyFiatAmount,
     outputCurrencyFiatAmount,
+    isUnlocked,
   })
 }

--- a/src/cow-react/modules/limitOrders/pure/UnlockLimitOrders/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/UnlockLimitOrders/index.tsx
@@ -50,6 +50,7 @@ export function UnlockLimitOrders({ handleUnlock }: { handleUnlock: () => void }
       </styledEl.BodySection>
 
       <styledEl.ControlSection>
+        {/* TODO: update href with a correct external link */}
         <ExternalLink href={'https://www.google.com'}>Learn more about limit orders ↗</ExternalLink>
         <ButtonPrimary onClick={handleUnlock}>Unlock limit orders (BETA)</ButtonPrimary>
       </styledEl.ControlSection>

--- a/src/cow-react/modules/limitOrders/pure/UnlockLimitOrders/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/UnlockLimitOrders/index.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import * as styledEl from './styled'
+import { CheckCircle, Activity } from 'react-feather'
+import { ExternalLink } from 'theme'
+import { ButtonPrimary } from 'components/Button'
+
+const iconMap = {
+  completed: CheckCircle,
+  pending: Activity,
+}
+
+interface ItemProps {
+  type: keyof typeof iconMap
+  children: React.ReactNode
+}
+
+function Item({ type, children }: ItemProps) {
+  const Icon = iconMap[type]
+
+  return (
+    <styledEl.Item>
+      <styledEl.Icon type={type}>
+        <Icon size={20} />
+      </styledEl.Icon>
+      <span>{children}</span>
+    </styledEl.Item>
+  )
+}
+
+export function UnlockLimitOrders({ handleUnlock }: { handleUnlock: () => void }) {
+  return (
+    <styledEl.Container>
+      <styledEl.TitleSection>
+        <styledEl.Title>Want to try out limit orders?</styledEl.Title>
+        <styledEl.SubTitle>Unlock the beta version!</styledEl.SubTitle>
+      </styledEl.TitleSection>
+
+      <styledEl.BodySection>
+        <styledEl.BodyColumn>
+          <Item type="completed">Set your limit price and CoW Protocol executes</Item>
+          <Item type="completed">FREE order placement and cancellations</Item>
+          <Item type="completed">Place unlimited orders: balances are not locked</Item>
+        </styledEl.BodyColumn>
+
+        <styledEl.BodyColumn>
+          <Item type="completed">Always receive 100% of the order surplus</Item>
+          <Item type="completed">Your order is protected from MEV by default!</Item>
+          <Item type="pending">Orders are Fill-or-Kill. Partial fills coming soon!</Item>
+        </styledEl.BodyColumn>
+      </styledEl.BodySection>
+
+      <styledEl.ControlSection>
+        <ExternalLink href={'https://www.google.com'}>Learn more about limit orders ↗</ExternalLink>
+        <ButtonPrimary onClick={handleUnlock}>Unlock limit orders (BETA)</ButtonPrimary>
+      </styledEl.ControlSection>
+    </styledEl.Container>
+  )
+}

--- a/src/cow-react/modules/limitOrders/pure/UnlockLimitOrders/styled.ts
+++ b/src/cow-react/modules/limitOrders/pure/UnlockLimitOrders/styled.ts
@@ -1,0 +1,64 @@
+import styled from 'styled-components/macro'
+
+export const Container = styled.div`
+  padding: 2rem 1.2rem;
+`
+
+export const TitleSection = styled.div`
+  text-align: center;
+
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    & h4 {
+      font-size: 1.2rem;
+    }
+  `};
+`
+
+export const Title = styled.h4`
+  font-weight: 600;
+  font-size: 1.6rem;
+  margin: 10px 0;
+`
+
+export const SubTitle = styled.h4`
+  font-weight: 400;
+  font-size: 1.6rem;
+  opacity: 0.8;
+  margin: 10px 0;
+`
+
+export const BodySection = styled.div`
+  display: flex;
+  padding: 1rem 0;
+
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    flex-direction: column;
+    max-width: 250px;
+    margin: 0 auto;
+  `};
+`
+
+export const BodyColumn = styled.div``
+export const ControlSection = styled.div`
+  text-align: center;
+
+  & a {
+    margin-bottom: 1.2rem;
+    display: block;
+  }
+`
+
+export const Item = styled.div`
+  display: flex;
+  padding: 10px 5px;
+  font-size: 0.8rem;
+`
+
+export const Icon = styled.div<{ type: string }>`
+  margin-right: 10px;
+  color: ${({ type, theme }) => {
+    if (type === 'completed') return theme.green1
+    if (type === 'pending') return theme.yellow1
+    return theme.primary1
+  }};
+`

--- a/src/cow-react/modules/limitOrders/state/limitOrdersAtom.ts
+++ b/src/cow-react/modules/limitOrders/state/limitOrdersAtom.ts
@@ -12,6 +12,7 @@ export interface LimitOrdersState {
   readonly outputCurrencyAmount: string | null
   readonly recipient: string | null
   readonly orderKind: OrderKind
+  readonly isUnlocked: boolean
 }
 
 export function getDefaultLimitOrdersState(chainId: SupportedChainId | null): LimitOrdersState {
@@ -23,6 +24,7 @@ export function getDefaultLimitOrdersState(chainId: SupportedChainId | null): Li
     outputCurrencyAmount: null,
     recipient: null,
     orderKind: OrderKind.SELL,
+    isUnlocked: false,
   }
 }
 


### PR DESCRIPTION
# Summary

This PR adds "Unlock limit orders" screen
This will be shown to a user first until he clicks on the enable button
From that point he will not see this screen
![Screenshot from 2022-11-14 17-40-39](https://user-images.githubusercontent.com/34926005/201716559-3041f5a8-8751-45c7-8576-b17ecbd53940.png)

# To test
1. go to limit orders page
2. you should see this screen
3. click on the Unlock button
4. the screen should be gone and if you refresh the page it should also be gone
