### PR TITLE
Fix limit orders performance issues

### DIFF
--- a/src/cow-react/modules/limitOrders/hooks/useLimitOrdersDeadline.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useLimitOrdersDeadline.ts
@@ -1,0 +1,12 @@
+import { calculateValidTo } from '@cow/utils/time'
+import { useAtomValue } from 'jotai/utils'
+import { limitOrdersSettingsAtom } from '@cow/modules/limitOrders/state/limitOrdersSettingsAtom'
+import { Timestamp } from '@cow/types'
+
+export function useLimitOrdersDeadline(): Timestamp {
+  const settingsState = useAtomValue(limitOrdersSettingsAtom)
+
+  return settingsState.customDeadlineTimestamp
+    ? settingsState.customDeadlineTimestamp
+    : calculateValidTo(settingsState.deadlineMilliseconds / 1000)
+}

--- a/src/cow-react/modules/limitOrders/hooks/useLimitOrdersTradeState.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useLimitOrdersTradeState.ts
@@ -8,9 +8,6 @@ import { OrderKind } from '@cowprotocol/contracts'
 import useCurrencyBalance from 'lib/hooks/useCurrencyBalance'
 import { useHigherUSDValue } from 'hooks/useStablecoinPrice'
 import { useSafeMemoObject } from '@cow/common/hooks/useSafeMemo'
-import { limitOrdersSettingsAtom } from '@cow/modules/limitOrders/state/limitOrdersSettingsAtom'
-import { calculateValidTo } from '@cow/utils/time'
-import { Timestamp } from '@cow/types'
 
 export interface LimitOrdersTradeState {
   readonly inputCurrency: Currency | null
@@ -22,20 +19,15 @@ export interface LimitOrdersTradeState {
   readonly inputCurrencyFiatAmount: CurrencyAmount<Currency> | null
   readonly outputCurrencyFiatAmount: CurrencyAmount<Currency> | null
   readonly recipient: string | null
-  readonly deadlineTimestamp: Timestamp | null
   readonly orderKind: OrderKind
 }
 
 export function useLimitOrdersTradeState(): LimitOrdersTradeState {
   const { account } = useWeb3React()
   const state = useAtomValue(limitOrdersAtom)
-  const settingsState = useAtomValue(limitOrdersSettingsAtom)
 
   const recipient = state.recipient
   const orderKind = state.orderKind
-  const deadlineTimestamp = settingsState.customDeadlineTimestamp
-    ? settingsState.customDeadlineTimestamp
-    : calculateValidTo(settingsState.deadlineMilliseconds / 1000)
 
   const inputCurrency = useTokenBySymbolOrAddress(state.inputCurrencyId)
   const outputCurrency = useTokenBySymbolOrAddress(state.outputCurrencyId)
@@ -50,7 +42,6 @@ export function useLimitOrdersTradeState(): LimitOrdersTradeState {
 
   return useSafeMemoObject({
     orderKind,
-    deadlineTimestamp,
     recipient,
     inputCurrency,
     outputCurrency,

--- a/src/cow-react/modules/limitOrders/hooks/useTradeFlowContext.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useTradeFlowContext.ts
@@ -1,7 +1,6 @@
 import { TradeFlowContext } from '@cow/modules/limitOrders/services/tradeFlow'
 import { useWeb3React } from '@web3-react/core'
 import { OrderKind } from '@cowprotocol/contracts'
-import { useLimitOrdersTradeState } from '@cow/modules/limitOrders/hooks/useLimitOrdersTradeState'
 import { CurrencyAmount, Token } from '@uniswap/sdk-core'
 import { useWalletInfo } from 'hooks/useWalletInfo'
 import { useGP2SettlementContract } from 'hooks/useContract'
@@ -10,10 +9,13 @@ import { AppDispatch } from 'state'
 import { useAppData } from 'hooks/useAppData'
 import { LIMIT_ORDER_SLIPPAGE } from '@cow/modules/limitOrders/const/trade'
 import useENSAddress from 'hooks/useENSAddress'
+import { useLimitOrdersTradeState } from './useLimitOrdersTradeState'
+import { useLimitOrdersDeadline } from './useLimitOrdersDeadline'
 
 export function useTradeFlowContext(): TradeFlowContext | null {
   const { chainId, account, provider } = useWeb3React()
   const state = useLimitOrdersTradeState()
+  const deadlineTimestamp = useLimitOrdersDeadline()
   const { allowsOffchainSigning, gnosisSafeInfo } = useWalletInfo()
   const settlementContract = useGP2SettlementContract()
   const dispatch = useDispatch<AppDispatch>()
@@ -27,7 +29,6 @@ export function useTradeFlowContext(): TradeFlowContext | null {
     !state.outputCurrencyAmount ||
     !state.inputCurrency ||
     !state.outputCurrency ||
-    !state.deadlineTimestamp ||
     !provider ||
     !settlementContract ||
     !appData
@@ -54,7 +55,7 @@ export function useTradeFlowContext(): TradeFlowContext | null {
       chainId,
       sellToken,
       buyToken,
-      validTo: state.deadlineTimestamp,
+      validTo: deadlineTimestamp,
       recipient,
       recipientAddressOrName,
       allowsOffchainSigning,

--- a/src/cow-react/modules/limitOrders/updaters/QuoteUpdater/hooks/useQuoteRequestParams.ts
+++ b/src/cow-react/modules/limitOrders/updaters/QuoteUpdater/hooks/useQuoteRequestParams.ts
@@ -7,9 +7,11 @@ import { useMemo } from 'react'
 import { useTypedValue } from '@cow/modules/limitOrders/hooks/useTypedValue'
 import { getAddress } from '@cow/modules/limitOrders/utils/getAddress'
 import useENSAddress from 'hooks/useENSAddress'
+import { useLimitOrdersDeadline } from '@cow/modules/limitOrders/hooks/useLimitOrdersDeadline'
 
 export function useQuoteRequestParams(): FeeQuoteParams | null {
-  const { inputCurrency, outputCurrency, recipient, orderKind, deadlineTimestamp } = useLimitOrdersTradeState()
+  const { inputCurrency, outputCurrency, recipient, orderKind } = useLimitOrdersTradeState()
+  const deadlineTimestamp = useLimitOrdersDeadline()
   const { chainId, account } = useWeb3React()
   const { exactTypedValue } = useTypedValue()
   const { address: recipientEnsAddress } = useENSAddress(recipient)

--- a/src/cow-react/modules/trade/hooks/useTradeNavigate.ts
+++ b/src/cow-react/modules/trade/hooks/useTradeNavigate.ts
@@ -1,5 +1,5 @@
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { useHistory } from 'react-router-dom'
+import { useHistory, useLocation } from 'react-router-dom'
 import { useCallback } from 'react'
 import { useTradeTypeInfo } from '@cow/modules/trade/hooks/useTradeTypeInfo'
 import { TradeCurrenciesIds } from '@cow/modules/trade/types/TradeState'
@@ -11,6 +11,7 @@ interface UseTradeNavigateCallback {
 
 export function useTradeNavigate(): UseTradeNavigateCallback {
   const history = useHistory()
+  const location = useLocation()
   const tradeTypeInfo = useTradeTypeInfo()
 
   return useCallback(
@@ -26,8 +27,10 @@ export function useTradeNavigate(): UseTradeNavigateCallback {
         tradeTypeInfo.route
       )
 
+      if (location.pathname === route) return
+
       history.push(route)
     },
-    [tradeTypeInfo, history]
+    [tradeTypeInfo, history, location.pathname]
   )
 }

--- a/src/cow-react/modules/trade/hooks/useTradeTypeInfo.ts
+++ b/src/cow-react/modules/trade/hooks/useTradeTypeInfo.ts
@@ -18,8 +18,12 @@ export interface TradeTypeInfo {
 export function useTradeTypeInfo(): TradeTypeInfo | null {
   const location = useLocation()
 
-  const swapMatch = matchPath<TradeStateFromUrl>(location.pathname, Routes.SWAP)
-  const limitOrderMatch = matchPath<TradeStateFromUrl>(location.pathname, Routes.LIMIT_ORDER)
+  const [swapMatch, limitOrderMatch] = useMemo(() => {
+    return [
+      matchPath<TradeStateFromUrl>(location.pathname, Routes.SWAP),
+      matchPath<TradeStateFromUrl>(location.pathname, Routes.LIMIT_ORDER),
+    ]
+  }, [location.pathname])
 
   return useMemo(() => {
     if (!swapMatch && !limitOrderMatch) return null


### PR DESCRIPTION
# Summary

 - moved `useLimitOrdersDeadline()` from `useLimitOrdersTradeState()` because deadline updates every second
 - avoided redundant navigations from `useTradeNavigate()`
 - added memoization to `useTradeTypeInfo()`

  # To Test

1. Open limit orders in Gnosis safe
2. AR: https://www.loom.com/share/d37f4e9017564d59bcbd67bda9ea0d9e
3. ER: no blinking UI
