### PR TITLE
Don't use token's logo from HTTP when there is an override

### DIFF
--- a/src/custom/lib/hooks/useCurrencyLogoURIs/useCurrencyLogoURIsMod.ts
+++ b/src/custom/lib/hooks/useCurrencyLogoURIs/useCurrencyLogoURIsMod.ts
@@ -66,7 +66,7 @@ export default function useCurrencyLogoURIs(currency?: Currency | null): string[
         // mod
         const logoURI = getOverriddenTokenLogoURI(currency)
         if (logoURI) {
-          logoURIs.push(logoURI)
+          return [logoURI]
         }
       }
     }


### PR DESCRIPTION
# Summary

Fixes #1366
