### PR TITLE
[ETH] Stepper pure component

### DIFF
--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/StatusIcon.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/StatusIcon.tsx
@@ -37,7 +37,7 @@ const LABEL_COLOR: Record<StatusIconState, string> = {
   success: STATUS_ICON_STYLES['success'].color,
   pending: STATUS_ICON_STYLES['pending'].color,
   'not-started': 'gray',
-  error: STATUS_ICON_STYLES['error'].color,
+  error: STATUS_ICON_STYLES['error'].bgColor,
 }
 
 const StepIcon = styled.div<StepIconStyle>`
@@ -48,7 +48,7 @@ const StepIcon = styled.div<StepIconStyle>`
   justify-content: center;
   align-items: center;
   margin-bottom: 5px;
-  border: 1px solid;
+  border: 2px solid;
 
   ${({ bgColor, borderColor, color }) => css`
     background-color: ${bgColor};
@@ -73,7 +73,7 @@ export interface StatusIconProps {
   crossOut?: boolean
 }
 
-export function StatusIcon({ state, icon: CustomIcon, label, crossOut = true }: StatusIconProps) {
+export function StatusIcon({ state, icon: CustomIcon, label, crossOut = false }: StatusIconProps) {
   const styles = STATUS_ICON_STYLES[state]
 
   return (

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/StatusIcon.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/StatusIcon.tsx
@@ -1,0 +1,93 @@
+import React from 'react'
+import { Icon } from 'react-feather'
+import styled, { css } from 'styled-components/macro'
+
+export type StatusIconState = 'success' | 'pending' | 'not-started' | 'error'
+
+interface StepIconStyle {
+  bgColor: string
+  color: string
+  borderColor: string
+}
+
+const STATUS_ICON_STYLES: Record<StatusIconState, StepIconStyle> = {
+  success: {
+    bgColor: '#D5E5E3',
+    borderColor: '#D5E5E3',
+    color: '#017B28',
+  },
+  pending: {
+    bgColor: '#F8F9FD',
+    borderColor: '#F8F9FD',
+    color: '#0D5ED9',
+  },
+  'not-started': {
+    bgColor: 'none',
+    borderColor: '#D6DDE9',
+    color: '#D6DDE9',
+  },
+  error: {
+    bgColor: '#f25757',
+    borderColor: '#f25757',
+    color: 'white',
+  },
+}
+
+const LABEL_COLOR: Record<StatusIconState, string> = {
+  success: STATUS_ICON_STYLES['success'].color,
+  pending: STATUS_ICON_STYLES['pending'].color,
+  'not-started': 'gray',
+  error: STATUS_ICON_STYLES['error'].color,
+}
+
+const StepIcon = styled.div<StepIconStyle>`
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 5px;
+  border: 1px solid;
+
+  ${({ bgColor, borderColor, color }) => css`
+    background-color: ${bgColor};
+    border-color: ${borderColor};
+    color: ${color};
+  `}
+`
+
+const Label = styled.span<{ state: StatusIconState }>`
+  color: ${({ state }) => LABEL_COLOR[state]};
+`
+
+const LabelCrossOut = styled.span`
+  text-decoration: line-through;
+  color: ${LABEL_COLOR['not-started']};
+`
+
+export interface StatusIconProps {
+  state: StatusIconState
+  icon: Icon
+  label: string
+  crossOut?: boolean
+}
+
+export function StatusIcon({ state, icon: CustomIcon, label, crossOut = true }: StatusIconProps) {
+  const styles = STATUS_ICON_STYLES[state]
+
+  return (
+    <>
+      <StepIcon {...styles}>
+        <CustomIcon size="20" />
+      </StepIcon>
+      {crossOut ? <LabelCrossOut>{label}</LabelCrossOut> : <Label state={state}>{label}</Label>}
+    </>
+  )
+}
+
+export interface StepProps {
+  status: StatusIconState
+  details: React.ReactNode
+  icon: Icon
+}

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/Step.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/Step.tsx
@@ -15,7 +15,7 @@ const StepWrapper = styled.div`
 `
 
 export interface StepProps {
-  statusIconState: StatusIconState
+  state: StatusIconState
   icon: Icon
   label: string
   crossOut?: boolean
@@ -23,10 +23,10 @@ export interface StepProps {
 }
 
 export function Step(props: StepProps) {
-  const { label, crossOut, details, statusIconState, icon } = props
+  const { label, crossOut, details, state, icon } = props
   return (
     <StepWrapper>
-      <StatusIcon icon={icon} state={statusIconState} label={label} crossOut={crossOut} />
+      <StatusIcon icon={icon} state={state} label={label} crossOut={crossOut} />
       {details}
     </StepWrapper>
   )

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/Step.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/Step.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { Icon } from 'react-feather'
+import styled from 'styled-components/macro'
+import { StatusIcon, StatusIconState } from './StatusIcon'
+
+const StepWrapper = styled.div`
+  height: 100%;
+  padding: 10px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  /* min-height: 6rem; */
+`
+
+export interface StepProps {
+  statusIconState: StatusIconState
+  icon: Icon
+  label: string
+  crossOut?: boolean
+  details: React.ReactNode
+}
+
+export function Step(props: StepProps) {
+  const { label, crossOut, details, statusIconState, icon } = props
+  return (
+    <StepWrapper>
+      <StatusIcon icon={icon} state={statusIconState} label={label} crossOut={crossOut} />
+      {details}
+    </StepWrapper>
+  )
+}

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/Step.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/Step.tsx
@@ -11,7 +11,7 @@ const StepWrapper = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  /* min-height: 6rem; */
+  min-height: 6rem;
 `
 
 export interface StepProps {

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/Step.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/Step.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { PropsWithChildren } from 'react'
 import { Icon } from 'react-feather'
 import styled from 'styled-components/macro'
 import { StatusIcon, StatusIconState } from './StatusIcon'
@@ -14,20 +14,19 @@ const StepWrapper = styled.div`
   min-height: 6rem;
 `
 
-export interface StepProps {
+export type StepProps = PropsWithChildren<{
   state: StatusIconState
   icon: Icon
   label: string
   crossOut?: boolean
-  details?: React.ReactNode
-}
+}>
 
 export function Step(props: StepProps) {
-  const { label, crossOut, details, state, icon } = props
+  const { label, crossOut, children, state, icon } = props
   return (
     <StepWrapper>
       <StatusIcon icon={icon} state={state} label={label} crossOut={crossOut} />
-      {details}
+      {children}
     </StepWrapper>
   )
 }

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/Step.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/Step.tsx
@@ -19,7 +19,7 @@ export interface StepProps {
   icon: Icon
   label: string
   crossOut?: boolean
-  details: React.ReactNode
+  details?: React.ReactNode
 }
 
 export function Step(props: StepProps) {

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.cosmos.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.cosmos.tsx
@@ -108,7 +108,7 @@ const STEPS: Step[] = [
     },
   },
   {
-    description: `[REJECTED] If expires when also rejected, we don't care`,
+    description: `[REJECTED] Rejected+Expired: Rejected Wins`,
     props: {
       ...defaultProps,
       status: EthFlowStepperStatus.ETH_SENT,
@@ -145,13 +145,13 @@ const STEPS: Step[] = [
     },
   },
   {
-    description: '[CANCEL] Cancelled',
+    description: '[CANCEL] Cancelled+Expired: Cancelled wins',
     props: {
       ...defaultProps,
       status: EthFlowStepperStatus.ORDER_CANCELLED,
       order: {
         orderId: ORDER_ID,
-        isExpired: false,
+        isExpired: true,
       },
       cancelationTx: TX,
     },

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.cosmos.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.cosmos.tsx
@@ -1,0 +1,183 @@
+import { EthFlowStepper, EthFlowStepperProps, EthFlowStepperStatus } from '.'
+
+import { useSelect } from 'react-cosmos/fixture'
+
+const ORDER_ID =
+  '0xfc5646178d29fe6412c26aaa216dba86fedcf4ebb1e49d9e3a05c5e58d59cc6a9d98c4ff9724040269bdbe3eb2078fa2cb6a21f8636ecb32'
+
+const TX = '0x183fa3b48c676bf9c5613e3e20b67a7250acc94af8e65dbe57787f47e5e54c75'
+const ORDER_REJECTED_REASON = 'Price quote expired'
+
+const defaultProps = {
+  sendEtherTx: TX,
+  nativeTokenSymbol: 'xDAI',
+  tokenLabel: 'USDC',
+  isOrderExpired: false,
+}
+
+interface Step {
+  description: string
+  props: EthFlowStepperProps
+}
+
+const STEPS: Step[] = [
+  {
+    description: '1. User Send Order Creation Tx',
+    props: { ...defaultProps, status: EthFlowStepperStatus.ETH_SENDING },
+  },
+  {
+    description: '2. Order Creation Tx is Executed',
+    props: { ...defaultProps, status: EthFlowStepperStatus.ETH_SENT },
+  },
+  {
+    description: '3. Order is Created',
+    props: { ...defaultProps, status: EthFlowStepperStatus.ETH_SENT, order: { orderId: ORDER_ID, isExpired: false } },
+  },
+  {
+    description: '4. Order is Filled',
+    props: {
+      ...defaultProps,
+      status: EthFlowStepperStatus.ORDER_FILLED,
+      order: { orderId: ORDER_ID, isExpired: false },
+    },
+  },
+  {
+    description: '[EXPIRED] 1. Just Expired',
+    props: { ...defaultProps, status: EthFlowStepperStatus.ETH_SENT, order: { orderId: ORDER_ID, isExpired: true } },
+  },
+  {
+    description: '[EXPIRED] 2. Refunding',
+    props: {
+      ...defaultProps,
+      status: EthFlowStepperStatus.ETH_SENT,
+      order: {
+        orderId: ORDER_ID,
+        isExpired: true,
+      },
+      refundTx: TX,
+    },
+  },
+  {
+    description: '[EXPIRED] 3. Received Refund',
+    props: {
+      ...defaultProps,
+      status: EthFlowStepperStatus.ETH_REFUNDED,
+      order: {
+        orderId: ORDER_ID,
+        isExpired: true,
+      },
+      refundTx: TX,
+    },
+  },
+  {
+    description: '[REJECTED] 1. Just Rejected',
+    props: {
+      ...defaultProps,
+      status: EthFlowStepperStatus.ETH_SENT,
+      order: {
+        orderId: ORDER_ID,
+        isExpired: false,
+        rejectedReason: ORDER_REJECTED_REASON,
+      },
+    },
+  },
+  {
+    description: '[REJECTED] 2. Refunding',
+    props: {
+      ...defaultProps,
+      status: EthFlowStepperStatus.ETH_SENT,
+      order: {
+        orderId: ORDER_ID,
+        isExpired: false,
+        rejectedReason: ORDER_REJECTED_REASON,
+      },
+      refundTx: TX,
+    },
+  },
+  {
+    description: '[REJECTED] 3. Refunded',
+    props: {
+      ...defaultProps,
+      status: EthFlowStepperStatus.ETH_REFUNDED,
+      order: {
+        orderId: ORDER_ID,
+        isExpired: false,
+        rejectedReason: ORDER_REJECTED_REASON,
+      },
+      refundTx: TX,
+    },
+  },
+  {
+    description: `[REJECTED] If expires when also rejected, we don't care`,
+    props: {
+      ...defaultProps,
+      status: EthFlowStepperStatus.ETH_SENT,
+      order: {
+        orderId: ORDER_ID,
+        isExpired: true,
+        rejectedReason: ORDER_REJECTED_REASON,
+      },
+      refundTx: TX,
+    },
+  },
+  {
+    description: '[CANCEL] 1. Open and Canceling',
+    props: {
+      ...defaultProps,
+      status: EthFlowStepperStatus.ETH_SENT,
+      order: {
+        orderId: ORDER_ID,
+        isExpired: false,
+      },
+      cancelationTx: TX,
+    },
+  },
+  {
+    description: '[CANCEL] 2. Cancelled',
+    props: {
+      ...defaultProps,
+      status: EthFlowStepperStatus.ORDER_CANCELLED,
+      order: {
+        orderId: ORDER_ID,
+        isExpired: false,
+      },
+      cancelationTx: TX,
+    },
+  },
+  {
+    description: '[CANCEL] Cancelled',
+    props: {
+      ...defaultProps,
+      status: EthFlowStepperStatus.ORDER_CANCELLED,
+      order: {
+        orderId: ORDER_ID,
+        isExpired: false,
+      },
+      cancelationTx: TX,
+    },
+  },
+]
+
+const STEPS_BY_DESCRIPTION = STEPS.reduce<{ [description: string]: EthFlowStepperProps }>((acc, step) => {
+  acc[step.description] = step.props
+  return acc
+}, {})
+
+function Fixture() {
+  const [stepDescription] = useSelect('steps', {
+    options: STEPS.map((step) => step.description),
+  })
+  const props = STEPS_BY_DESCRIPTION[stepDescription]
+
+  return (
+    <>
+      <EthFlowStepper {...props} />
+      <h3>Params</h3>
+      <div style={{ fontSize: '0.8em' }}>
+        <pre>{JSON.stringify(props, null, 2)}</pre>
+      </div>
+    </>
+  )
+}
+
+export default Fixture

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.cosmos.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.cosmos.tsx
@@ -110,28 +110,6 @@ const STEPS: Step[] = [
     },
   },
   {
-    description: '[EXPIRED] Expired+Creating: ????',
-    props: {
-      ...defaultProps,
-      order: {
-        ...defaultOrderProps,
-        state: SmartOrderStatus.CREATING,
-        isExpired: true,
-      },
-    },
-  },
-  {
-    description: '[EXPIRED] Expired+Created: ????',
-    props: {
-      ...defaultProps,
-      order: {
-        ...defaultOrderProps,
-        state: SmartOrderStatus.CREATION_MINED,
-        isExpired: true,
-      },
-    },
-  },
-  {
     description: '[REJECTED] 1. Just Rejected',
     props: {
       ...defaultProps,
@@ -172,18 +150,7 @@ const STEPS: Step[] = [
       },
     },
   },
-  {
-    description: `[REJECTED] Rejected+Expired: Rejected Wins`,
-    props: {
-      ...defaultProps,
-      order: {
-        ...defaultOrderProps,
-        state: SmartOrderStatus.INDEXED,
-        rejectedReason: ORDER_REJECTED_REASON,
-        isExpired: true,
-      },
-    },
-  },
+
   {
     description: '[CANCEL] 1. Open and Canceling',
     props: {
@@ -191,7 +158,6 @@ const STEPS: Step[] = [
       order: {
         ...defaultOrderProps,
         state: SmartOrderStatus.INDEXED,
-        rejectedReason: ORDER_REJECTED_REASON,
       },
       cancelation: {
         cancelationTx: TX,
@@ -206,7 +172,6 @@ const STEPS: Step[] = [
       order: {
         ...defaultOrderProps,
         state: SmartOrderStatus.INDEXED,
-        rejectedReason: ORDER_REJECTED_REASON,
       },
       cancelation: {
         cancelationTx: TX,
@@ -215,13 +180,56 @@ const STEPS: Step[] = [
     },
   },
   {
-    description: '[CANCEL] Cancelling+Expired: Cancelled wins',
+    description: `[REJECTED+EXPIRED] 1. Just Rejected`,
     props: {
       ...defaultProps,
       order: {
         ...defaultOrderProps,
         state: SmartOrderStatus.INDEXED,
         rejectedReason: ORDER_REJECTED_REASON,
+        isExpired: true,
+      },
+    },
+  },
+  {
+    description: `[REJECTED+EXPIRED] 2. Refunding`,
+    props: {
+      ...defaultProps,
+      order: {
+        ...defaultOrderProps,
+        state: SmartOrderStatus.INDEXED,
+        rejectedReason: ORDER_REJECTED_REASON,
+        isExpired: true,
+      },
+      refund: {
+        refundTx: TX,
+        isRefunded: false,
+      },
+    },
+  },
+  {
+    description: `[REJECTED+EXPIRED] 3. Refunded`,
+    props: {
+      ...defaultProps,
+      order: {
+        ...defaultOrderProps,
+        state: SmartOrderStatus.INDEXED,
+        rejectedReason: ORDER_REJECTED_REASON,
+        isExpired: true,
+      },
+      refund: {
+        refundTx: TX,
+        isRefunded: true,
+      },
+    },
+  },
+  {
+    description: '[CANCEL+EXPIRED] 1. Expired and Canceling',
+    props: {
+      ...defaultProps,
+      order: {
+        ...defaultOrderProps,
+        state: SmartOrderStatus.INDEXED,
         isExpired: true,
       },
       cancelation: {
@@ -231,7 +239,22 @@ const STEPS: Step[] = [
     },
   },
   {
-    description: '[CANCEL+REFUND] Cancelling+Refunding',
+    description: '[CANCEL+EXPIRED] 2. Expired and Canceled',
+    props: {
+      ...defaultProps,
+      order: {
+        ...defaultOrderProps,
+        state: SmartOrderStatus.INDEXED,
+        isExpired: true,
+      },
+      cancelation: {
+        cancelationTx: TX,
+        isCanceled: true,
+      },
+    },
+  },
+  {
+    description: '[CANCEL+REFUND] Cancelling... + Refunding....',
     props: {
       ...defaultProps,
       order: {
@@ -251,7 +274,7 @@ const STEPS: Step[] = [
     },
   },
   {
-    description: '[CANCEL+REFUND] Cancelling+Refunded',
+    description: '[CANCEL+REFUND] Cancelling... + Refunded',
     props: {
       ...defaultProps,
       order: {
@@ -271,7 +294,7 @@ const STEPS: Step[] = [
     },
   },
   {
-    description: '[CANCEL+REFUND] Canceled+Refunding',
+    description: '[CANCEL+REFUND] Canceled + Refunding...',
     props: {
       ...defaultProps,
       order: {
@@ -291,7 +314,7 @@ const STEPS: Step[] = [
     },
   },
   {
-    description: '[CANCEL+REFUND] Canceled+Refunded',
+    description: '[CANCEL+REFUND] Canceled + Refunded',
     props: {
       ...defaultProps,
       order: {
@@ -307,6 +330,28 @@ const STEPS: Step[] = [
       refund: {
         refundTx: TX,
         isRefunded: true,
+      },
+    },
+  },
+  {
+    description: '[EXPIRED-BEFORE-CREATION] Expired before Create transaction is Mined',
+    props: {
+      ...defaultProps,
+      order: {
+        ...defaultOrderProps,
+        state: SmartOrderStatus.CREATING,
+        isExpired: true,
+      },
+    },
+  },
+  {
+    description: '[EXPIRED-BEFORE-CREATION] Expired when Create transaction is Mined (before indexing)',
+    props: {
+      ...defaultProps,
+      order: {
+        ...defaultOrderProps,
+        state: SmartOrderStatus.CREATION_MINED,
+        isExpired: true,
       },
     },
   },

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.cosmos.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.cosmos.tsx
@@ -260,7 +260,6 @@ const STEPS: Step[] = [
       order: {
         ...defaultOrderProps,
         state: SmartOrderStatus.INDEXED,
-        rejectedReason: ORDER_REJECTED_REASON,
         isExpired: true,
       },
       cancelation: {
@@ -280,7 +279,6 @@ const STEPS: Step[] = [
       order: {
         ...defaultOrderProps,
         state: SmartOrderStatus.INDEXED,
-        rejectedReason: ORDER_REJECTED_REASON,
         isExpired: true,
       },
       cancelation: {
@@ -300,7 +298,6 @@ const STEPS: Step[] = [
       order: {
         ...defaultOrderProps,
         state: SmartOrderStatus.INDEXED,
-        rejectedReason: ORDER_REJECTED_REASON,
         isExpired: true,
       },
       cancelation: {
@@ -320,7 +317,6 @@ const STEPS: Step[] = [
       order: {
         ...defaultOrderProps,
         state: SmartOrderStatus.INDEXED,
-        rejectedReason: ORDER_REJECTED_REASON,
         isExpired: true,
       },
       cancelation: {

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
@@ -1,0 +1,298 @@
+import { ExplorerLink } from '@src/custom/components/ExplorerLink'
+import React from 'react'
+import { Icon, Send, Flag, X, Plus, Check } from 'react-feather'
+import styled from 'styled-components/macro'
+
+export enum EthFlowStepperStatus {
+  ETH_SENDING = 'ETH_SENDING',
+  ETH_SENT = 'ETH_SENT',
+  ORDER_FILLED = 'ORDER_FILLED',
+
+  // ORDER_REJECTED = 'ORDER_REJECTED',
+  // ORDER_EXPIRED = 'ORDER_EXPIRED',
+  // ORDER_CANCELLING = 'ORDER_CANCELLING',
+  ORDER_CANCELLED = 'ORDER_CANCELLED',
+
+  ETH_REFUNDING = 'ETH_REFUNDING',
+  ETH_REFUNDED = 'ETH_REFUNDED',
+}
+
+export enum SendEthStatus {
+  ETH_SENDING = 'ETH_SENDING',
+  ETH_SENT = 'ETH_SENT',
+}
+
+export interface EthFlowStepperProps {
+  status: EthFlowStepperStatus
+  nativeTokenSymbol: string
+  tokenLabel: string
+
+  sendEtherTx: string
+  refundTx?: string
+  cancelationTx?: string
+
+  order?: {
+    orderId: string
+    isExpired: boolean
+    rejectedReason?: string
+  }
+}
+
+const Wrapper = styled.div`
+  padding: 15px;
+  background-color: #ecf1f8;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`
+
+const StepWrapper = styled.div`
+  padding: 10px;
+`
+
+type StepStatus = 'success' | 'pending' | 'not-started' | 'error'
+
+interface StepIcon {
+  bgColor: string
+  color: string
+  borderColor: string
+}
+
+const STATUS_COLORS: Record<StepStatus, StepIcon> = {
+  success: {
+    bgColor: '#D5E5E3',
+    borderColor: '£D5E5E3',
+    color: '#017B28',
+  },
+  pending: {
+    bgColor: '#F8F9FD',
+    borderColor: 'F8F9FD',
+    color: '#0D5ED9',
+  },
+  'not-started': {
+    bgColor: 'none',
+    borderColor: '#D6DDE9',
+    color: '#D6DDE9',
+  },
+  error: {
+    bgColor: '#D5E5E3',
+    borderColor: 'D5E5E3',
+    color: '#017B28',
+  },
+}
+
+export interface StepProps {
+  status: StepStatus
+  details: React.ReactNode
+  icon: Icon
+}
+
+const Circle = styled.div<StepIcon>`
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  background-color: ${(props) => props.bgColor};
+  border: solid 2px ${(props) => props.borderColor};
+  color: ${(props) => props.color};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`
+
+function Status({ status, icon: CustomIcon }: { status: StepStatus; icon: Icon }) {
+  const stepIcon = STATUS_COLORS[status]
+
+  return (
+    <Circle {...stepIcon}>
+      <CustomIcon size="20" />
+    </Circle>
+  )
+}
+
+function Step(props: StepProps) {
+  const { details, status, icon } = props
+  return (
+    <StepWrapper>
+      {/* {status} */}
+      <Status icon={icon} status={status} />
+      {details}
+    </StepWrapper>
+  )
+}
+
+const Divider = styled.progress`
+  height: 5px;
+  // background-color: #155ebe;
+  min-width: 100px;
+`
+
+// const DividerWrapper = styled.div`
+//   height: 3px;
+//   background-color: #155ebe;
+//   min-width: 100px;
+// `
+
+// export function Divider(props: EthFlowStepperProps) {
+//   return <DividerWrapper><div></></DividerWrapper>
+// }
+
+function Step1({ status, sendEtherTx, nativeTokenSymbol }: EthFlowStepperProps) {
+  let message: string, stepStatus: StepStatus, icon: Icon
+  if (status === EthFlowStepperStatus.ETH_SENDING) {
+    message = 'Sending ' + nativeTokenSymbol
+    stepStatus = 'pending'
+    icon = Send
+  } else {
+    message = 'Sending ' + nativeTokenSymbol
+    stepStatus = 'success'
+    icon = Check
+  }
+
+  const details = (
+    <>
+      {message}
+      <br />
+      {sendEtherTx && <ExplorerLink type="transaction" label="View Transaction" id={sendEtherTx} />}
+    </>
+  )
+  return <Step status={stepStatus} details={details} icon={icon} />
+}
+
+function Divider1({ status }: EthFlowStepperProps) {
+  let progress: number
+  if (status === EthFlowStepperStatus.ETH_SENDING) {
+    progress = 50
+  } else {
+    progress = 100
+  }
+
+  return <Divider value={progress} max={100} />
+}
+
+function Step2({ status, order }: EthFlowStepperProps) {
+  const rejectedReason = order?.rejectedReason
+  let message: string, stepStatus: StepStatus, icon: Icon
+  if (status === EthFlowStepperStatus.ETH_SENDING) {
+    message = 'Create Order'
+    stepStatus = 'not-started'
+    icon = Plus
+  } else if (status === EthFlowStepperStatus.ETH_SENT && order === undefined) {
+    message = 'Creating Order'
+    stepStatus = 'pending'
+    icon = Plus
+  } else if (rejectedReason) {
+    message = 'Order Creation Failed'
+    stepStatus = 'error'
+    icon = X
+  } else {
+    message = 'Order Created'
+    stepStatus = 'success'
+    icon = Check
+  }
+
+  const details = (
+    <>
+      {message}
+      <br />
+      {rejectedReason && (
+        <>
+          {rejectedReason}
+          <br />
+        </>
+      )}
+      {order && <ExplorerLink type="transaction" label="View details" id={order.orderId} />}
+    </>
+  )
+  return <Step status={stepStatus} details={details} icon={icon} />
+}
+
+function Divider2({ status, order, refundTx, cancelationTx }: EthFlowStepperProps) {
+  const isTerminalState =
+    status === EthFlowStepperStatus.ETH_REFUNDED ||
+    status === EthFlowStepperStatus.ORDER_CANCELLED ||
+    status === EthFlowStepperStatus.ORDER_FILLED
+  const isEthSent = status === EthFlowStepperStatus.ETH_SENT
+
+  let progress: number
+  if (isTerminalState) {
+    progress = 100
+  } else if (refundTx || cancelationTx) {
+    progress = 66
+  } else if (status === EthFlowStepperStatus.ETH_SENDING || (isEthSent && !order)) {
+    progress = 0
+    // } else if (order) {
+    //   progress = 33
+  } else if (isEthSent) {
+    if (refundTx || cancelationTx) {
+      progress = 66
+    } else {
+      progress = 33
+    }
+  } else {
+    progress = 90
+  }
+  return <Divider value={progress} max={100} />
+}
+
+function Step3({ status, nativeTokenSymbol, tokenLabel, order, refundTx, cancelationTx }: EthFlowStepperProps) {
+  const isRefunding = status === EthFlowStepperStatus.ETH_REFUNDING
+  const isOrderExpired = order && order.isExpired
+  const isOrderRejected = order && order.rejectedReason
+  const isCancelling = cancelationTx !== undefined
+  const isCancelled = status === EthFlowStepperStatus.ORDER_CANCELLED
+  const isRefunded = status === EthFlowStepperStatus.ETH_REFUNDED
+
+  let message: string, stepStatus: StepStatus, icon: Icon
+  if (status === EthFlowStepperStatus.ETH_SENT && order) {
+    message = 'Receive ' + tokenLabel
+    stepStatus = 'pending'
+    icon = Flag
+  } else if (status === EthFlowStepperStatus.ORDER_FILLED) {
+    message = 'Received ' + tokenLabel
+    stepStatus = 'success'
+    icon = Check
+  } else if (isCancelled || isRefunded) {
+    message = nativeTokenSymbol + ' Refunded'
+    stepStatus = 'success'
+    icon = Check
+  } else {
+    message = 'Receive ' + tokenLabel
+    stepStatus = 'not-started'
+    icon = Flag
+  }
+
+  const wontReceiveToken = isOrderExpired || isOrderRejected || isRefunding || isCancelling || isCancelled || isRefunded
+
+  const details = (
+    <>
+      <span style={wontReceiveToken ? { textDecoration: 'line-through' } : undefined}>{message}</span>
+      <br />
+      {isOrderExpired && (
+        <>
+          Order is Expired
+          <br />
+        </>
+      )}
+      {isRefunding && !refundTx && (
+        <>
+          Initiating ETH Refund...
+          <br />
+        </>
+      )}
+      {refundTx && <ExplorerLink type="transaction" label="ETH refunded successfully" id={refundTx} />}
+    </>
+  )
+  return <Step status={stepStatus} details={details} icon={icon} />
+}
+
+export function EthFlowStepper(props: EthFlowStepperProps) {
+  return (
+    <Wrapper>
+      <Step1 {...props} />
+      <Divider1 {...props} />
+      <Step2 {...props} />
+      <Divider2 {...props} />
+      <Step3 {...props} />
+    </Wrapper>
+  )
+}

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
@@ -57,6 +57,11 @@ export const Progress = styled.progress<ProgressProps>`
   min-width: 100px;
 
   // TODO: We might want to style differently the error status (see props!)
+  /* ::-moz-progress-bar,
+  ::-webkit-progress-value,
+  ::-webkit-progress-bar {
+    background-color: red;
+  } */
 `
 
 export const ExplorerLinkStyled = styled(ExplorerLink)`

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
@@ -45,18 +45,6 @@ const Wrapper = styled.div`
   align-items: center;
   font-size: 12px;
   line-height: 1.5;
-
-  p {
-    margin: 0;
-  }
-
-  // TODO: Figure out why this doesn't work https://stackoverflow.com/questions/18368202/how-can-i-set-the-color-for-the-progress-element
-  /* 
-  progress.error::-webkit-progress-value {
-    background: red;
-    color: red;
-  } 
-  */
 `
 
 export const Progress = styled.progress`

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
@@ -6,6 +6,7 @@ import { Progress1 } from './steps/Progress1'
 import { Step2 } from './steps/Step2'
 import { Progress2 } from './steps/Progress2'
 import { Step3 } from './steps/Step3'
+import { StatusIconState } from './StatusIcon'
 
 export enum SmartOrderStatus {
   CREATING = 'CREATING',
@@ -47,9 +48,15 @@ const Wrapper = styled.div`
   line-height: 1.5;
 `
 
-export const Progress = styled.progress`
+export interface ProgressProps {
+  status: StatusIconState
+  value: number
+}
+export const Progress = styled.progress<ProgressProps>`
   height: 5px;
   min-width: 100px;
+
+  // TODO: We might want to style differently the error status (see props!)
 `
 
 export const ExplorerLinkStyled = styled(ExplorerLink)`

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
@@ -1,17 +1,11 @@
-import { ExplorerLink } from '@src/custom/components/ExplorerLink'
 import React from 'react'
-import { Icon, Send, Flag, X, Plus, Check, AlertTriangle } from 'react-feather'
 import styled from 'styled-components/macro'
-
-// export enum EthFlowStepperStatus {
-//   ETH_SENDING = 'ETH_SENDING',
-//   ETH_SENT = 'ETH_SENT',
-//   ORDER_FILLED = 'ORDER_FILLED',
-
-//   ORDER_CANCELLED = 'ORDER_CANCELLED',
-//   ETH_REFUNDING = 'ETH_REFUNDING',
-//   ETH_REFUNDED = 'ETH_REFUNDED',
-// }
+import { ExplorerLink } from 'components/ExplorerLink'
+import { Step1 } from './steps/Step1'
+import { Progress1 } from './steps/Progress1'
+import { Step2 } from './steps/Step2'
+import { Progress2 } from './steps/Progress2'
+import { Step3 } from './steps/Step3'
 
 export enum SmartOrderStatus {
   CREATING = 'CREATING',
@@ -20,130 +14,7 @@ export enum SmartOrderStatus {
   FILLED = 'FILLED',
 }
 
-type StepStatus = 'success' | 'pending' | 'not-started' | 'error'
-
-interface StepIcon {
-  bgColor: string
-  color: string
-  borderColor: string
-}
-
-const STATUS_COLORS: Record<StepStatus, StepIcon> = {
-  success: {
-    bgColor: '#D5E5E3',
-    borderColor: '£D5E5E3',
-    color: '#017B28',
-  },
-  pending: {
-    bgColor: '#F8F9FD',
-    borderColor: 'F8F9FD',
-    color: '#0D5ED9',
-  },
-  'not-started': {
-    bgColor: 'none',
-    borderColor: '#D6DDE9',
-    color: '#D6DDE9',
-  },
-  error: {
-    bgColor: '#f25757',
-    borderColor: '#f25757',
-    color: 'white',
-  },
-}
-
-const Wrapper = styled.div`
-  padding: 15px;
-  background-color: #ecf1f8;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 12px;
-  line-height: 1.5;
-
-  p {
-    margin: 0;
-  }
-
-  .success {
-    color: #017b28;
-  }
-  .pending {
-    color: #0d5ed9;
-  }
-  .not-started {
-    color: gray;
-  }
-
-  .error {
-    color: #f25757;
-  }
-
-  .crossOut {
-    text-decoration: line-through;
-    color: gray;
-  }
-
-  .refund {
-    color: #0d5ed9;
-  }
-`
-
-const StepWrapper = styled.div`
-  height: 100%;
-  padding: 10px;
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  min-height: 6rem;
-`
-
-const Circle = styled.div<StepIcon>`
-  border-radius: 50%;
-  width: 40px;
-  height: 40px;
-  background-color: ${(props) => props.bgColor};
-  border: solid 2px ${(props) => props.borderColor};
-  color: ${(props) => props.color};
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-bottom: 5px;
-`
-
-function Status({ status, icon: CustomIcon }: { status: StepStatus; icon: Icon }) {
-  const stepIcon = STATUS_COLORS[status]
-
-  return (
-    <Circle {...stepIcon}>
-      <CustomIcon size="20" />
-    </Circle>
-  )
-}
-
-export interface StepProps {
-  status: StepStatus
-  details: React.ReactNode
-  icon: Icon
-}
-
-function Step(props: StepProps) {
-  const { details, status, icon } = props
-  return (
-    <StepWrapper>
-      <Status icon={icon} status={status} />
-      {details}
-    </StepWrapper>
-  )
-}
-
-const Progress = styled.progress`
-  height: 5px;
-  min-width: 100px;
-`
-
 export interface EthFlowStepperProps {
-  // status: EthFlowStepperStatus
   nativeTokenSymbol: string
   tokenLabel: string
 
@@ -166,197 +37,37 @@ export interface EthFlowStepperProps {
   }
 }
 
-function Step1({ nativeTokenSymbol, order }: EthFlowStepperProps) {
-  const { state, isExpired, createOrderTx } = order
-  const isCreating = state === SmartOrderStatus.CREATING
+const Wrapper = styled.div`
+  padding: 15px;
+  background-color: #ecf1f8;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 12px;
+  line-height: 1.5;
 
-  let message: string, stepStatus: StepStatus, icon: Icon
-  if (isCreating) {
-    message = 'Sending ' + nativeTokenSymbol
-    if (isExpired) {
-      stepStatus = 'error'
-      icon = AlertTriangle
-    } else {
-      stepStatus = 'pending'
-      icon = Send
-    }
-  } else {
-    message = 'Sent ' + nativeTokenSymbol
-    stepStatus = 'success'
-    icon = Check
+  p {
+    margin: 0;
   }
 
-  const details = (
-    <>
-      <p className={isExpired && isCreating ? 'error' : stepStatus}>{message}</p>
-      <CreateOrderTx tx={createOrderTx} />
-    </>
-  )
-  return <Step status={stepStatus} details={details} icon={icon} />
-}
+  // TODO: Figure out why this doesn't work https://stackoverflow.com/questions/18368202/how-can-i-set-the-color-for-the-progress-element
+  /* 
+  progress.error::-webkit-progress-value {
+    background: red;
+    color: red;
+  } 
+  */
+`
 
-function Progress1({ order }: EthFlowStepperProps) {
-  const { state, isExpired } = order
-  const isCreating = state === SmartOrderStatus.CREATING
+export const Progress = styled.progress`
+  height: 5px;
+  min-width: 100px;
+`
 
-  let progress: number
-  if (isCreating && !isExpired) {
-    progress = 50
-  } else {
-    progress = 100
-  }
-
-  return <Progress value={progress} max={100} />
-}
-
-function Step2({ order }: EthFlowStepperProps) {
-  const { state, isExpired, orderId } = order
-  let rejectedReason = order.rejectedReason
-  const isCreating = state === SmartOrderStatus.CREATING
-  const isIndexing = state === SmartOrderStatus.CREATION_MINED
-  const isOrderCreated = !(isCreating || isIndexing)
-
-  const expiredBeforeCreate = isExpired && (isCreating || isIndexing)
-
-  let message: string, stepStatus: StepStatus, icon: Icon
-  if (expiredBeforeCreate) {
-    message = 'Order Creation Failed'
-    rejectedReason = 'Expired before creation'
-    stepStatus = 'error'
-    icon = X
-  } else if (isCreating) {
-    message = 'Create Order'
-    stepStatus = 'not-started'
-    icon = Plus
-  } else if (isIndexing) {
-    message = 'Creating Order'
-    stepStatus = 'pending'
-    icon = Plus
-  } else if (rejectedReason) {
-    message = 'Order Creation Failed'
-    stepStatus = 'error'
-    icon = X
-  } else {
-    message = 'Order Created'
-    stepStatus = 'success'
-    icon = Check
-  }
-
-  const details = (
-    <>
-      <p className={stepStatus}>{message}</p>
-      {rejectedReason && <p className={stepStatus}>{rejectedReason}</p>}
-      {isOrderCreated && <ExplorerLinkStyled type="transaction" label="View details" id={orderId} />}
-    </>
-  )
-  return <Step status={stepStatus} details={details} icon={icon} />
-}
-
-function Progress2({ order, refund, cancelation }: EthFlowStepperProps) {
-  const { state } = order
-  const { isRefunded, refundTx } = refund
-  const { isCanceled, cancelationTx } = cancelation
-  const isIndexing = state === SmartOrderStatus.CREATION_MINED
-  const isFilled = state === SmartOrderStatus.FILLED
-  const isCreating = state === SmartOrderStatus.CREATING
-
-  const isTerminalState = isRefunded || isCanceled || isFilled
-  let progress: number
-  if (isTerminalState) {
-    progress = 100
-  } else if (refundTx || cancelationTx) {
-    progress = 66
-  } else if (isCreating || isIndexing) {
-    progress = 0
-  } else {
-    if (refundTx || cancelationTx) {
-      progress = 66
-    } else {
-      progress = 33
-    }
-  }
-  return <Progress value={progress} max={100} />
-}
-
-function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancelation }: EthFlowStepperProps) {
-  const { state, isExpired, rejectedReason } = order
-  const { isRefunded, refundTx } = refund
-  const { isCanceled, cancelationTx } = cancelation
-
-  const isIndexing = state === SmartOrderStatus.CREATION_MINED
-  const isCreating = state === SmartOrderStatus.CREATING
-  const isFilled = state === SmartOrderStatus.FILLED
-
-  const isRefunding = !!refundTx && !isRefunded
-  const isCanceling = !!cancelationTx && isCanceled
-
-  const expiredBeforeCreate = isExpired && (isCreating || isIndexing)
-
-  let message: string, stepStatus: StepStatus, icon: Icon
-  if (expiredBeforeCreate) {
-    message = 'Receive ' + tokenLabel
-    stepStatus = 'pending'
-    icon = Flag
-  } else if (isIndexing) {
-    message = 'Receive ' + tokenLabel
-    stepStatus = 'not-started'
-    icon = Flag
-  } else if (isFilled) {
-    message = 'Received ' + tokenLabel
-    stepStatus = 'success'
-    icon = Check
-  } else if (isCanceled || isRefunded) {
-    message = nativeTokenSymbol + ' Refunded'
-    stepStatus = 'success'
-    icon = Check
-  } else {
-    message = 'Receive ' + tokenLabel
-    stepStatus = 'not-started'
-    icon = Flag
-  }
-
-  const isOrderRejected = !!rejectedReason
-  const wontReceiveToken = isExpired || isOrderRejected || isRefunding || isCanceling || isCanceled || isRefunded
-  console.log({
-    isOrderExpired: isExpired,
-    isOrderRejected,
-    isRefunding,
-    isCancelling: isCanceling,
-    isCanceled,
-    isRefunded,
-  })
-  const isSuccess = stepStatus === 'success'
-  const details = (
-    <>
-      <p className={!isSuccess && wontReceiveToken ? 'crossOut' : stepStatus}>{message}</p>
-      {isExpired && !isSuccess && <p>Order is Expired</p>}
-
-      {wontReceiveToken && !refundTx && <p className="refund">Initiating ETH Refund...</p>}
-
-      {refundTx && !expiredBeforeCreate && (
-        <ExplorerLinkStyled
-          type="transaction"
-          label={isRefunding ? 'Receiving ETH Refund...' : 'ETH refunded successfully'}
-          id={refundTx}
-        />
-      )}
-    </>
-  )
-  return <Step status={stepStatus} details={details} icon={icon} />
-}
-
-const ExplorerLinkStyled = styled(ExplorerLink)`
+export const ExplorerLinkStyled = styled(ExplorerLink)`
   margin-top: 3px;
   display: block;
 `
-
-export function CreateOrderTx({ tx }: { tx?: string }) {
-  if (!tx) {
-    return null
-  }
-
-  return <ExplorerLinkStyled type="transaction" label="View Transaction" id={tx} />
-}
 
 export function EthFlowStepper(props: EthFlowStepperProps) {
   return (

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
@@ -8,18 +8,9 @@ export enum EthFlowStepperStatus {
   ETH_SENT = 'ETH_SENT',
   ORDER_FILLED = 'ORDER_FILLED',
 
-  // ORDER_REJECTED = 'ORDER_REJECTED',
-  // ORDER_EXPIRED = 'ORDER_EXPIRED',
-  // ORDER_CANCELLING = 'ORDER_CANCELLING',
   ORDER_CANCELLED = 'ORDER_CANCELLED',
-
   ETH_REFUNDING = 'ETH_REFUNDING',
   ETH_REFUNDED = 'ETH_REFUNDED',
-}
-
-export enum SendEthStatus {
-  ETH_SENDING = 'ETH_SENDING',
-  ETH_SENT = 'ETH_SENT',
 }
 
 export interface EthFlowStepperProps {
@@ -126,16 +117,6 @@ const Divider = styled.progress`
   min-width: 100px;
 `
 
-// const DividerWrapper = styled.div`
-//   height: 3px;
-//   background-color: #155ebe;
-//   min-width: 100px;
-// `
-
-// export function Divider(props: EthFlowStepperProps) {
-//   return <DividerWrapper><div></></DividerWrapper>
-// }
-
 function Step1({ status, sendEtherTx, nativeTokenSymbol }: EthFlowStepperProps) {
   let message: string, stepStatus: StepStatus, icon: Icon
   if (status === EthFlowStepperStatus.ETH_SENDING) {
@@ -235,6 +216,7 @@ function Divider2({ status, order, refundTx, cancelationTx }: EthFlowStepperProp
 }
 
 function Step3({ status, nativeTokenSymbol, tokenLabel, order, refundTx, cancelationTx }: EthFlowStepperProps) {
+  const isEthSent = status === EthFlowStepperStatus.ETH_SENT
   const isRefunding = status === EthFlowStepperStatus.ETH_REFUNDING
   const isOrderExpired = order && order.isExpired
   const isOrderRejected = order && order.rejectedReason
@@ -243,7 +225,7 @@ function Step3({ status, nativeTokenSymbol, tokenLabel, order, refundTx, cancela
   const isRefunded = status === EthFlowStepperStatus.ETH_REFUNDED
 
   let message: string, stepStatus: StepStatus, icon: Icon
-  if (status === EthFlowStepperStatus.ETH_SENT && order) {
+  if (isEthSent && order) {
     message = 'Receive ' + tokenLabel
     stepStatus = 'pending'
     icon = Flag
@@ -279,10 +261,26 @@ function Step3({ status, nativeTokenSymbol, tokenLabel, order, refundTx, cancela
           <br />
         </>
       )}
-      {refundTx && <ExplorerLink type="transaction" label="ETH refunded successfully" id={refundTx} />}
+      <RefundEthTx tx={refundTx} isPending={isEthSent} />
     </>
   )
   return <Step status={stepStatus} details={details} icon={icon} />
+}
+
+export function RefundEthTx(props: { isPending: boolean; tx?: string }) {
+  const { isPending, tx } = props
+
+  if (!tx) {
+    return null
+  }
+
+  return (
+    <ExplorerLink
+      type="transaction"
+      label={isPending ? 'Receiving ETH Refund...' : 'ETH refunded successfully'}
+      id={tx}
+    />
+  )
 }
 
 export function EthFlowStepper(props: EthFlowStepperProps) {

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Progress1.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Progress1.tsx
@@ -1,24 +1,30 @@
-import React from 'react'
-import { Progress, EthFlowStepperProps, SmartOrderStatus } from '..'
-import { StatusIconState } from '../StatusIcon'
+import React, { useMemo } from 'react'
+import { Progress, EthFlowStepperProps, SmartOrderStatus, ProgressProps } from '..'
 
 export function Progress1({ order }: EthFlowStepperProps) {
   const { state, isExpired } = order
   const isCreating = state === SmartOrderStatus.CREATING
 
-  let progress: number, status: StatusIconState
-  if (isCreating) {
-    if (isExpired) {
-      progress = 100
-      status = 'error'
-    } else {
-      progress = 50
-      status = 'pending'
-    }
-  } else {
-    progress = 100
-    status = 'pending'
-  }
+  const { status: progressStatus, value: progress } = useMemo<ProgressProps>(() => {
+    if (isCreating) {
+      if (isExpired) {
+        return {
+          value: 100,
+          status: 'error',
+        }
+      }
 
-  return <Progress className={status} value={progress} max={100} />
+      return {
+        value: 50,
+        status: 'pending',
+      }
+    }
+
+    return {
+      value: 100,
+      status: 'pending',
+    }
+  }, [isCreating, isExpired])
+
+  return <Progress status={progressStatus} value={progress} max={100} />
 }

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Progress1.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Progress1.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { Progress, EthFlowStepperProps, SmartOrderStatus } from '..'
+import { StatusIconState } from '../StatusIcon'
+
+export function Progress1({ order }: EthFlowStepperProps) {
+  const { state, isExpired } = order
+  const isCreating = state === SmartOrderStatus.CREATING
+
+  let progress: number, status: StatusIconState
+  if (isCreating) {
+    if (isExpired) {
+      progress = 100
+      status = 'error'
+    } else {
+      progress = 50
+      status = 'pending'
+    }
+  } else {
+    progress = 100
+    status = 'pending'
+  }
+
+  return <Progress className={status} value={progress} max={100} />
+}

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Progress2.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Progress2.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { Progress, EthFlowStepperProps, SmartOrderStatus } from '..'
+
+export function Progress2({ order, refund, cancelation }: EthFlowStepperProps) {
+  const { state } = order
+  const { isRefunded, refundTx } = refund
+  const { isCanceled, cancelationTx } = cancelation
+  const isIndexing = state === SmartOrderStatus.CREATION_MINED
+  const isFilled = state === SmartOrderStatus.FILLED
+  const isCreating = state === SmartOrderStatus.CREATING
+
+  const isTerminalState = isRefunded || isCanceled || isFilled
+  let progress: number
+  if (isTerminalState) {
+    progress = 100
+  } else if (refundTx || cancelationTx) {
+    progress = 66
+  } else if (isCreating || isIndexing) {
+    progress = 0
+  } else {
+    if (refundTx || cancelationTx) {
+      progress = 66
+    } else {
+      progress = 33
+    }
+  }
+  return <Progress value={progress} max={100} />
+}

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Progress2.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Progress2.tsx
@@ -1,28 +1,50 @@
-import React from 'react'
-import { Progress, EthFlowStepperProps, SmartOrderStatus } from '..'
+import React, { useMemo } from 'react'
+import { Progress, EthFlowStepperProps, SmartOrderStatus, ProgressProps } from '..'
 
 export function Progress2({ order, refund, cancelation }: EthFlowStepperProps) {
   const { state } = order
   const { isRefunded, refundTx } = refund
   const { isCanceled, cancelationTx } = cancelation
-  const isIndexing = state === SmartOrderStatus.CREATION_MINED
-  const isFilled = state === SmartOrderStatus.FILLED
-  const isCreating = state === SmartOrderStatus.CREATING
 
-  const isTerminalState = isRefunded || isCanceled || isFilled
-  let progress: number
-  if (isTerminalState) {
-    progress = 100
-  } else if (refundTx || cancelationTx) {
-    progress = 66
-  } else if (isCreating || isIndexing) {
-    progress = 0
-  } else {
-    if (refundTx || cancelationTx) {
-      progress = 66
-    } else {
-      progress = 33
+  const { status: progressStatus, value: progress } = useMemo<ProgressProps>(() => {
+    const isIndexing = state === SmartOrderStatus.CREATION_MINED
+    const isFilled = state === SmartOrderStatus.FILLED
+    const isCreating = state === SmartOrderStatus.CREATING
+    const isTerminalState = isRefunded || isCanceled || isFilled
+
+    if (isTerminalState) {
+      return {
+        status: 'success',
+        value: 100,
+      }
     }
-  }
-  return <Progress value={progress} max={100} />
+
+    if (refundTx || cancelationTx) {
+      return {
+        status: 'pending',
+        value: 66,
+      }
+    }
+
+    if (isCreating || isIndexing) {
+      return {
+        status: 'not-started',
+        value: 0,
+      }
+    }
+
+    if (refundTx || cancelationTx) {
+      return {
+        status: 'pending',
+        value: 66,
+      }
+    }
+
+    return {
+      status: 'pending',
+      value: 33,
+    }
+  }, [state, refundTx, cancelationTx, isCanceled, isRefunded])
+
+  return <Progress status={progressStatus} value={progress} max={100} />
 }

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step1.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step1.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Icon, Send, Check, AlertTriangle } from 'react-feather'
+import { ExplorerLinkStyled, EthFlowStepperProps, SmartOrderStatus } from '..'
+import { StatusIconState } from '../StatusIcon'
+import { Step } from '../Step'
+
+export function Step1({ nativeTokenSymbol, order }: EthFlowStepperProps) {
+  const { state, isExpired, createOrderTx } = order
+  const isCreating = state === SmartOrderStatus.CREATING
+
+  let message: string, stepStatus: StatusIconState, icon: Icon
+  if (isCreating) {
+    message = 'Sending ' + nativeTokenSymbol
+    if (isExpired) {
+      stepStatus = 'error'
+      icon = AlertTriangle
+    } else {
+      stepStatus = 'pending'
+      icon = Send
+    }
+  } else {
+    message = 'Sent ' + nativeTokenSymbol
+    stepStatus = 'success'
+    icon = Check
+  }
+
+  const details = (
+    <>
+      <p className={isExpired && isCreating ? 'error' : stepStatus}>{message}</p>
+      {createOrderTx && <ExplorerLinkStyled type="transaction" label="View Transaction" id={createOrderTx} />}
+    </>
+  )
+  return <Step statusIconState={stepStatus} details={details} icon={icon} />
+}

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step1.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step1.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Icon, Send, Check, AlertTriangle } from 'react-feather'
-import { ExplorerLinkStyled, EthFlowStepperProps, SmartOrderStatus } from '..'
+import { EthFlowStepperProps, ExplorerLinkStyled, SmartOrderStatus } from '..'
 import { StatusIconState } from '../StatusIcon'
 import { Step } from '../Step'
 
@@ -24,8 +24,9 @@ export function Step1({ nativeTokenSymbol, order }: EthFlowStepperProps) {
     icon = Check
   }
 
-  const details = (
-    <>{createOrderTx && <ExplorerLinkStyled type="transaction" label="View Transaction" id={createOrderTx} />}</>
+  return (
+    <Step state={stepState} icon={icon} label={label}>
+      {createOrderTx && <ExplorerLinkStyled type="transaction" label="View Transaction" id={createOrderTx} />}
+    </Step>
   )
-  return <Step state={stepState} details={details} icon={icon} label={label} />
 }

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step1.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step1.tsx
@@ -8,24 +8,24 @@ export function Step1({ nativeTokenSymbol, order }: EthFlowStepperProps) {
   const { state, isExpired, createOrderTx } = order
   const isCreating = state === SmartOrderStatus.CREATING
 
-  let label: string, stepStatus: StatusIconState, icon: Icon
+  let label: string, stepState: StatusIconState, icon: Icon
   if (isCreating) {
     label = 'Sending ' + nativeTokenSymbol
     if (isExpired) {
-      stepStatus = 'error'
+      stepState = 'error'
       icon = AlertTriangle
     } else {
-      stepStatus = 'pending'
+      stepState = 'pending'
       icon = Send
     }
   } else {
     label = 'Sent ' + nativeTokenSymbol
-    stepStatus = 'success'
+    stepState = 'success'
     icon = Check
   }
 
   const details = (
     <>{createOrderTx && <ExplorerLinkStyled type="transaction" label="View Transaction" id={createOrderTx} />}</>
   )
-  return <Step statusIconState={stepStatus} details={details} icon={icon} label={label} />
+  return <Step state={stepState} details={details} icon={icon} label={label} />
 }

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step1.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step1.tsx
@@ -8,9 +8,9 @@ export function Step1({ nativeTokenSymbol, order }: EthFlowStepperProps) {
   const { state, isExpired, createOrderTx } = order
   const isCreating = state === SmartOrderStatus.CREATING
 
-  let message: string, stepStatus: StatusIconState, icon: Icon
+  let label: string, stepStatus: StatusIconState, icon: Icon
   if (isCreating) {
-    message = 'Sending ' + nativeTokenSymbol
+    label = 'Sending ' + nativeTokenSymbol
     if (isExpired) {
       stepStatus = 'error'
       icon = AlertTriangle
@@ -19,16 +19,13 @@ export function Step1({ nativeTokenSymbol, order }: EthFlowStepperProps) {
       icon = Send
     }
   } else {
-    message = 'Sent ' + nativeTokenSymbol
+    label = 'Sent ' + nativeTokenSymbol
     stepStatus = 'success'
     icon = Check
   }
 
   const details = (
-    <>
-      <p className={isExpired && isCreating ? 'error' : stepStatus}>{message}</p>
-      {createOrderTx && <ExplorerLinkStyled type="transaction" label="View Transaction" id={createOrderTx} />}
-    </>
+    <>{createOrderTx && <ExplorerLinkStyled type="transaction" label="View Transaction" id={createOrderTx} />}</>
   )
-  return <Step statusIconState={stepStatus} details={details} icon={icon} />
+  return <Step statusIconState={stepStatus} details={details} icon={icon} label={label} />
 }

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step2.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step2.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useMemo } from 'react'
 import { X, Plus, Check } from 'react-feather'
 import styled from 'styled-components/macro'
 import { ExplorerLinkStyled, EthFlowStepperProps, SmartOrderStatus } from '..'
@@ -24,11 +24,11 @@ export function Step2({ order }: EthFlowStepperProps) {
     state: stepState,
     icon,
     error,
-  } = useCallback<() => Step2Config>(() => {
+  } = useMemo<Step2Config>(() => {
     if (expiredBeforeCreate) {
       return {
         label: 'Order Creation Failed',
-        errorMessage: 'Expired before creation',
+        error: 'Expired before creation',
         state: 'error',
         icon: X,
       }
@@ -63,14 +63,15 @@ export function Step2({ order }: EthFlowStepperProps) {
       state: 'success',
       icon: Check,
     }
-  }, [expiredBeforeCreate, isCreating, isIndexing, rejectedReason])()
+  }, [expiredBeforeCreate, isCreating, isIndexing, rejectedReason])
 
   const errorMessage = error || rejectedReason
-  const details = (
-    <>
-      {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
-      {isOrderCreated && <ExplorerLinkStyled type="transaction" label="View details" id={orderId} />}
-    </>
+  return (
+    <Step state={stepState} icon={icon} label={label}>
+      <>
+        {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
+        {isOrderCreated && <ExplorerLinkStyled type="transaction" label="View details" id={orderId} />}
+      </>
+    </Step>
   )
-  return <Step state={stepState} details={details} icon={icon} label={label} />
 }

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step2.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step2.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { Icon, X, Plus, Check } from 'react-feather'
+import { ExplorerLinkStyled, EthFlowStepperProps, SmartOrderStatus } from '..'
+import { StatusIconState } from '../StatusIcon'
+import { Step } from '../Step'
+
+export function Step2({ order }: EthFlowStepperProps) {
+  const { state, isExpired, orderId } = order
+  let rejectedReason = order.rejectedReason
+  const isCreating = state === SmartOrderStatus.CREATING
+  const isIndexing = state === SmartOrderStatus.CREATION_MINED
+  const isOrderCreated = !(isCreating || isIndexing)
+
+  const expiredBeforeCreate = isExpired && (isCreating || isIndexing)
+
+  let message: string, stepStatus: StatusIconState, icon: Icon
+  if (expiredBeforeCreate) {
+    message = 'Order Creation Failed'
+    rejectedReason = 'Expired before creation'
+    stepStatus = 'error'
+    icon = X
+  } else if (isCreating) {
+    message = 'Create Order'
+    stepStatus = 'not-started'
+    icon = Plus
+  } else if (isIndexing) {
+    message = 'Creating Order'
+    stepStatus = 'pending'
+    icon = Plus
+  } else if (rejectedReason) {
+    message = 'Order Creation Failed'
+    stepStatus = 'error'
+    icon = X
+  } else {
+    message = 'Order Created'
+    stepStatus = 'success'
+    icon = Check
+  }
+
+  const details = (
+    <>
+      <p className={stepStatus}>{message}</p>
+      {rejectedReason && <p className={stepStatus}>{rejectedReason}</p>}
+      {isOrderCreated && <ExplorerLinkStyled type="transaction" label="View details" id={orderId} />}
+    </>
+  )
+  return <Step statusIconState={stepStatus} details={details} icon={icon} />
+}

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step2.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step2.tsx
@@ -1,8 +1,13 @@
 import React from 'react'
 import { Icon, X, Plus, Check } from 'react-feather'
+import styled from 'styled-components/macro'
 import { ExplorerLinkStyled, EthFlowStepperProps, SmartOrderStatus } from '..'
 import { StatusIconState } from '../StatusIcon'
 import { Step } from '../Step'
+
+const RejectMessage = styled.span`
+  color: #f25757;
+`
 
 export function Step2({ order }: EthFlowStepperProps) {
   const { state, isExpired, orderId } = order
@@ -13,36 +18,35 @@ export function Step2({ order }: EthFlowStepperProps) {
 
   const expiredBeforeCreate = isExpired && (isCreating || isIndexing)
 
-  let message: string, stepStatus: StatusIconState, icon: Icon
+  let label: string, stepStatus: StatusIconState, icon: Icon
   if (expiredBeforeCreate) {
-    message = 'Order Creation Failed'
+    label = 'Order Creation Failed'
     rejectedReason = 'Expired before creation'
     stepStatus = 'error'
     icon = X
   } else if (isCreating) {
-    message = 'Create Order'
+    label = 'Create Order'
     stepStatus = 'not-started'
     icon = Plus
   } else if (isIndexing) {
-    message = 'Creating Order'
+    label = 'Creating Order'
     stepStatus = 'pending'
     icon = Plus
   } else if (rejectedReason) {
-    message = 'Order Creation Failed'
+    label = 'Order Creation Failed'
     stepStatus = 'error'
     icon = X
   } else {
-    message = 'Order Created'
+    label = 'Order Created'
     stepStatus = 'success'
     icon = Check
   }
 
   const details = (
     <>
-      <p className={stepStatus}>{message}</p>
-      {rejectedReason && <p className={stepStatus}>{rejectedReason}</p>}
+      {rejectedReason && <RejectMessage>{rejectedReason}</RejectMessage>}
       {isOrderCreated && <ExplorerLinkStyled type="transaction" label="View details" id={orderId} />}
     </>
   )
-  return <Step statusIconState={stepStatus} details={details} icon={icon} />
+  return <Step statusIconState={stepStatus} details={details} icon={icon} label={label} />
 }

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step2.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step2.tsx
@@ -19,12 +19,17 @@ export function Step2({ order }: EthFlowStepperProps) {
   const expiredBeforeCreate = isExpired && (isCreating || isIndexing)
 
   // Get config for Step 2
-  const { label, statusIconState, icon, error } = useCallback<() => Step2Config>(() => {
+  const {
+    label,
+    state: stepState,
+    icon,
+    error,
+  } = useCallback<() => Step2Config>(() => {
     if (expiredBeforeCreate) {
       return {
         label: 'Order Creation Failed',
         errorMessage: 'Expired before creation',
-        statusIconState: 'error',
+        state: 'error',
         icon: X,
       }
     }
@@ -32,7 +37,7 @@ export function Step2({ order }: EthFlowStepperProps) {
     if (isCreating) {
       return {
         label: 'Create Order',
-        statusIconState: 'not-started',
+        state: 'not-started',
         icon: Plus,
       }
     }
@@ -40,7 +45,7 @@ export function Step2({ order }: EthFlowStepperProps) {
     if (isIndexing) {
       return {
         label: 'Creating Order',
-        statusIconState: 'pending',
+        state: 'pending',
         icon: Plus,
       }
     }
@@ -48,14 +53,14 @@ export function Step2({ order }: EthFlowStepperProps) {
     if (rejectedReason) {
       return {
         label: 'Order Creation Failed',
-        statusIconState: 'error',
+        state: 'error',
         icon: X,
       }
     }
 
     return {
       label: 'Order Created',
-      statusIconState: 'success',
+      state: 'success',
       icon: Check,
     }
   }, [expiredBeforeCreate, isCreating, isIndexing, rejectedReason])()
@@ -67,5 +72,5 @@ export function Step2({ order }: EthFlowStepperProps) {
       {isOrderCreated && <ExplorerLinkStyled type="transaction" label="View details" id={orderId} />}
     </>
   )
-  return <Step statusIconState={statusIconState} details={details} icon={icon} label={label} />
+  return <Step state={stepState} details={details} icon={icon} label={label} />
 }

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useMemo } from 'react'
 import { Flag, Check } from 'react-feather'
 import styled from 'styled-components/macro'
 import { ExplorerLinkStyled, EthFlowStepperProps, SmartOrderStatus } from '..'
@@ -25,54 +25,58 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancelatio
 
   const expiredBeforeCreate = isExpired && (isCreating || isIndexing)
 
-  // Get the label, status and icon
-  const { label, statusIconState, icon } = useCallback<() => StepProps>(() => {
+  // Get the label, state and icon
+  const {
+    label,
+    state: stepState,
+    icon,
+  } = useMemo<StepProps>(() => {
     if (expiredBeforeCreate) {
       return {
         label: 'Receive ' + tokenLabel,
-        statusIconState: 'pending',
+        state: 'pending',
         icon: Flag,
       }
     }
     if (isIndexing) {
       return {
         label: 'Receive ' + tokenLabel,
-        statusIconState: 'not-started',
+        state: 'not-started',
         icon: Flag,
       }
     }
     if (isFilled) {
       return {
         label: 'Received ' + tokenLabel,
-        statusIconState: 'success',
+        state: 'success',
         icon: Check,
       }
     }
     if (isCanceled || isRefunded) {
       return {
         label: nativeTokenSymbol + ' Refunded',
-        statusIconState: 'success',
+        state: 'success',
         icon: Check,
       }
     }
     if (isIndexed) {
       return {
         label: 'Receive ' + tokenLabel,
-        statusIconState: 'pending',
+        state: 'pending',
         icon: Flag,
       }
     }
 
     return {
       label: 'Receive ' + tokenLabel,
-      statusIconState: 'not-started',
+      state: 'not-started',
       icon: Flag,
     }
-  }, [nativeTokenSymbol, tokenLabel, expiredBeforeCreate, isIndexing, isFilled, isCanceled, isRefunded, isIndexed])()
+  }, [nativeTokenSymbol, tokenLabel, expiredBeforeCreate, isIndexing, isFilled, isCanceled, isRefunded, isIndexed])
 
   const isOrderRejected = !!rejectedReason
   const wontReceiveToken = isExpired || isOrderRejected || isRefunding || isCanceling || isCanceled || isRefunded
-  const isSuccess = statusIconState === 'success'
+  const isSuccess = stepState === 'success'
 
   let refundLink: JSX.Element | undefined
   if (cancelationTx && !isRefunded) {
@@ -101,5 +105,5 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancelatio
       {refundLink}
     </>
   )
-  return <Step statusIconState={statusIconState} details={details} icon={icon} label={label} crossOut={crossOut} />
+  return <Step state={stepState} details={details} icon={icon} label={label} crossOut={crossOut} />
 }

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
@@ -79,10 +79,7 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancelatio
   const crossOut = !isSuccess && wontReceiveToken
   const details = (
     <>
-      {/* <p className={!isSuccess && wontReceiveToken ? 'crossOut' : stepStatus}>{label}</p> */}
-      {/* <StepLabel crossOut={!isSuccess && wontReceiveToken}>{message}</StepLabel> */}
       {isExpired && !(isSuccess || isOrderRejected) && <ExpiredMessage>Order is Expired</ExpiredMessage>}
-
       {wontReceiveToken && !(refundTx || cancelationTx) && <RefundMessage>Initiating ETH Refund...</RefundMessage>}
       {refundLink}
     </>

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import { Icon, Flag, Check } from 'react-feather'
+import styled from 'styled-components/macro'
+import { ExplorerLinkStyled, EthFlowStepperProps, SmartOrderStatus } from '..'
+import { StatusIconState } from '../StatusIcon'
+import { Step } from '../Step'
+
+const RefundMessage = styled.span`
+  color: #0d5ed9;
+`
+
+export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancelation }: EthFlowStepperProps) {
+  const { state, isExpired, rejectedReason } = order
+  const { isRefunded, refundTx } = refund
+  const { isCanceled, cancelationTx } = cancelation
+
+  const isIndexing = state === SmartOrderStatus.CREATION_MINED
+  const isIndexed = state === SmartOrderStatus.INDEXED
+  const isCreating = state === SmartOrderStatus.CREATING
+  const isFilled = state === SmartOrderStatus.FILLED
+
+  const isRefunding = !!refundTx && !isRefunded
+  const isCanceling = !!cancelationTx && !isCanceled
+
+  const expiredBeforeCreate = isExpired && (isCreating || isIndexing)
+
+  let label: string, stepStatus: StatusIconState, icon: Icon
+  if (expiredBeforeCreate) {
+    label = 'Receive ' + tokenLabel
+    stepStatus = 'pending'
+    icon = Flag
+  } else if (isIndexing) {
+    label = 'Receive ' + tokenLabel
+    stepStatus = 'not-started'
+    icon = Flag
+  } else if (isFilled) {
+    label = 'Received ' + tokenLabel
+    stepStatus = 'success'
+    icon = Check
+  } else if (isCanceled || isRefunded) {
+    label = nativeTokenSymbol + ' Refunded'
+    stepStatus = 'success'
+    icon = Check
+  } else if (isIndexed) {
+    label = 'Receive ' + tokenLabel
+    stepStatus = 'pending'
+    icon = Flag
+  } else {
+    label = 'Receive ' + tokenLabel
+    stepStatus = 'not-started'
+    icon = Flag
+  }
+
+  const isOrderRejected = !!rejectedReason
+  const wontReceiveToken = isExpired || isOrderRejected || isRefunding || isCanceling || isCanceled || isRefunded
+  const isSuccess = stepStatus === 'success'
+
+  let refundLink: JSX.Element | undefined
+  if (cancelationTx && !isRefunded) {
+    refundLink = (
+      <ExplorerLinkStyled
+        type="transaction"
+        label={isCanceling ? 'Initiating ETH Refund...' : 'ETH refunded successfully'}
+        id={cancelationTx}
+      />
+    )
+  } else if ((refundTx && !(expiredBeforeCreate || cancelationTx)) || (refundTx && isRefunded)) {
+    refundLink = (
+      <ExplorerLinkStyled
+        type="transaction"
+        label={isRefunding ? 'Receiving ETH Refund...' : 'ETH refunded successfully'}
+        id={refundTx}
+      />
+    )
+  }
+
+  const crossOut = !isSuccess && wontReceiveToken
+  const details = (
+    <>
+      {/* <p className={!isSuccess && wontReceiveToken ? 'crossOut' : stepStatus}>{label}</p> */}
+      {/* <StepLabel crossOut={!isSuccess && wontReceiveToken}>{message}</StepLabel> */}
+      {isExpired && !(isSuccess || isOrderRejected) && <p>Order is Expired</p>}
+
+      {wontReceiveToken && !(refundTx || cancelationTx) && <RefundMessage>Initiating ETH Refund...</RefundMessage>}
+      {refundLink}
+    </>
+  )
+  return <Step statusIconState={stepStatus} details={details} icon={icon} label={label} crossOut={crossOut} />
+}

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
@@ -10,8 +10,6 @@ const RefundMessage = styled.span`
 
 const ExpiredMessage = styled.span``
 
-type BasicStepProps = Pick<StepProps, 'label' | 'statusIconState' | 'icon'>
-
 export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancelation }: EthFlowStepperProps) {
   const { state, isExpired, rejectedReason } = order
   const { isRefunded, refundTx } = refund
@@ -28,7 +26,7 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancelatio
   const expiredBeforeCreate = isExpired && (isCreating || isIndexing)
 
   // Get the label, status and icon
-  const { label, statusIconState, icon } = useCallback<() => BasicStepProps>(() => {
+  const { label, statusIconState, icon } = useCallback<() => StepProps>(() => {
     if (expiredBeforeCreate) {
       return {
         label: 'Receive ' + tokenLabel,

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
@@ -77,7 +77,6 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancelatio
   const isSuccess = stepState === 'success'
 
   let refundLink: JSX.Element | undefined
-  console.log('cancelationTx && !isRefunded', { cancelationTx, isRefunded }, cancelationTx && !isRefunded)
   if (cancelationTx && !isRefunded) {
     refundLink = (
       <ExplorerLinkStyled

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
@@ -19,10 +19,6 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancelatio
   const isIndexed = state === SmartOrderStatus.INDEXED
   const isCreating = state === SmartOrderStatus.CREATING
   const isFilled = state === SmartOrderStatus.FILLED
-
-  const isRefunding = !!refundTx && !isRefunded
-  const isCanceling = !!cancelationTx && !isCanceled
-
   const expiredBeforeCreate = isExpired && (isCreating || isIndexing)
 
   // Get the label, state and icon
@@ -74,11 +70,14 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancelatio
     }
   }, [nativeTokenSymbol, tokenLabel, expiredBeforeCreate, isIndexing, isFilled, isCanceled, isRefunded, isIndexed])
 
+  const isRefunding = !!refundTx && !isRefunded
+  const isCanceling = !!cancelationTx && !isCanceled
   const isOrderRejected = !!rejectedReason
   const wontReceiveToken = isExpired || isOrderRejected || isRefunding || isCanceling || isCanceled || isRefunded
   const isSuccess = stepState === 'success'
 
   let refundLink: JSX.Element | undefined
+  console.log('cancelationTx && !isRefunded', { cancelationTx, isRefunded }, cancelationTx && !isRefunded)
   if (cancelationTx && !isRefunded) {
     refundLink = (
       <ExplorerLinkStyled
@@ -98,12 +97,13 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancelatio
   }
 
   const crossOut = !isSuccess && wontReceiveToken
-  const details = (
-    <>
-      {isExpired && !(isSuccess || isOrderRejected) && <ExpiredMessage>Order is Expired</ExpiredMessage>}
-      {wontReceiveToken && !(refundTx || cancelationTx) && <RefundMessage>Initiating ETH Refund...</RefundMessage>}
-      {refundLink}
-    </>
+  return (
+    <Step state={stepState} icon={icon} label={label} crossOut={crossOut}>
+      <>
+        {isExpired && !(isSuccess || isOrderRejected) && <ExpiredMessage>Order is Expired</ExpiredMessage>}
+        {wontReceiveToken && !(refundTx || cancelationTx) && <RefundMessage>Initiating ETH Refund...</RefundMessage>}
+        {refundLink}
+      </>
+    </Step>
   )
-  return <Step state={stepState} details={details} icon={icon} label={label} crossOut={crossOut} />
 }

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
@@ -9,6 +9,8 @@ const RefundMessage = styled.span`
   color: #0d5ed9;
 `
 
+const ExpiredMessage = styled.span``
+
 export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancelation }: EthFlowStepperProps) {
   const { state, isExpired, rejectedReason } = order
   const { isRefunded, refundTx } = refund
@@ -79,7 +81,7 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancelatio
     <>
       {/* <p className={!isSuccess && wontReceiveToken ? 'crossOut' : stepStatus}>{label}</p> */}
       {/* <StepLabel crossOut={!isSuccess && wontReceiveToken}>{message}</StepLabel> */}
-      {isExpired && !(isSuccess || isOrderRejected) && <p>Order is Expired</p>}
+      {isExpired && !(isSuccess || isOrderRejected) && <ExpiredMessage>Order is Expired</ExpiredMessage>}
 
       {wontReceiveToken && !(refundTx || cancelationTx) && <RefundMessage>Initiating ETH Refund...</RefundMessage>}
       {refundLink}

--- a/src/custom/components/ExplorerLink/index.tsx
+++ b/src/custom/components/ExplorerLink/index.tsx
@@ -26,7 +26,7 @@ export function ExplorerLink(props: Props) {
   const linkLabel = label || getExplorerLabel(chainId, id, type)
   return (
     <ExternalLink className={className} href={getEtherscanLink(chainId, id, type)}>
-      {linkLabel}
+      {linkLabel} <span style={{ fontSize: '0.8em' }}>↗</span>
     </ExternalLink>
   )
 }

--- a/src/custom/components/ExplorerLink/index.tsx
+++ b/src/custom/components/ExplorerLink/index.tsx
@@ -7,6 +7,7 @@ interface Props {
   id: string
   type?: BlockExplorerLinkType
   label?: string
+  className?: string
 }
 
 /**
@@ -14,7 +15,7 @@ interface Props {
  * @param props
  */
 export function ExplorerLink(props: Props) {
-  const { id, label, type = 'transaction' } = props
+  const { id, label, type = 'transaction', className } = props
   const { chainId: _chainId } = useWeb3React()
   const chainId = supportedChainId(_chainId)
 
@@ -23,5 +24,9 @@ export function ExplorerLink(props: Props) {
   }
 
   const linkLabel = label || getExplorerLabel(chainId, id, type)
-  return <ExternalLink href={getEtherscanLink(chainId, id, type)}>{linkLabel}</ExternalLink>
+  return (
+    <ExternalLink className={className} href={getEtherscanLink(chainId, id, type)}>
+      {linkLabel}
+    </ExternalLink>
+  )
 }


### PR DESCRIPTION
# Summary

This PR implements the pure component for the stepper. 

<img width="999" alt="image" src="https://user-images.githubusercontent.com/2352112/201962906-0634203e-7965-4555-a6f4-a33edbc0c971.png">

- Simple model for the parameters. Its easier to check in cosmos the parameters (its shown as a JSON in the fixture)
- Creates a component with the 3 steps, and 2 progress bars
- Step 1: Models the Send ETH tx state
- Step 2: Models the Order Creation state
- Step 3: Models the Receival of either the tokens or the refund

# Wireframes
- https://www.figma.com/proto/sUwumNFlcslHzShSZJHVsS/2022_COW-Native-ETH-Flow?page-id=1201%3A382&node-id=1232%3A1702&viewport=-96%2C1616%2C0.19&scaling=min-zoom&starting-point-node-id=1204%3A674
- Designs https://www.figma.com/proto/sUwumNFlcslHzShSZJHVsS/2022_COW-Native-ETH-Flow?page-id=1201%3A382&node-id=1298%3A382&viewport=-96%2C1616%2C0.19&scaling=min-zoom&starting-point-node-id=1298%3A382&show-proto-sidebar=1

## Cosmos cases
Cosmos allows to quickly check the happy path, but also many other not so obvious cases that can happen (i.e. the order expires before its creation).

<img width="650" alt="image" src="https://user-images.githubusercontent.com/2352112/201963261-a5eee71b-dd64-43a9-b386-f61f29ae205b.png">

## Not included
- I realised we don't have some global styles applied in the cosmos fixtures. I think we should. For example, to include the right fonts. This PR adds a hack to add the fonts in the fixture, but it should be done globally (follow up PR)
- Fine details and possible additional refactors, or restyling will be done by @fairlighteth 

# To Test

1. Go to Cosmos, open `EthFlowStepper` (`command + P` works best to find it)
     * https://pr1402--cowswap.review.gnosisdev.com/cosmos/?fixtureId=%7B%22path%22%3A%22src%2Fcow-react%2Fmodules%2Fswap%2Fpure%2FEthFlow%2FEthFlowStepper%2Findex.cosmos.tsx%22%7D 
2. Use the steps in the control to check how all the cases are handled


