### PR TITLE
Fix detection of network changes from provider

### DIFF
--- a/src/cow-react/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
+++ b/src/cow-react/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
@@ -54,7 +54,7 @@ export function useSetupTradeState(): void {
   const prevCurrentChainId = usePrevious(currentChainId)
 
   const chainIdFromUrlWasChanged = !!chainIdFromUrl && chainIdFromUrl !== prevChainIdFromUrl
-  const providerChainIdWasChanged = !!currentChainId && currentChainId !== prevCurrentChainId
+  const providerChainIdWasChanged = !!currentChainId && !!prevCurrentChainId && currentChainId !== prevCurrentChainId
 
   const skipUpdate = useMemo(() => {
     if (chainIdFromUrlWasChanged && !!account) return true


### PR DESCRIPTION
# Summary

Fix for e2e tests.
In the Cypress environment we have a little different setup of provider, so, we have a case when the provider returns `chainId` as `undefined` and we shouldn't consider that case as network change.
