### PR TITLE
Persist current orders tab to the URL query

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/OrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/OrdersWidget/index.tsx
@@ -1,5 +1,5 @@
 import { Orders } from '../../pure/Orders'
-import { LIMIT_ORDERS_TAB_KEY, limitOrdersTabUrl, OrderTab } from '@cow/modules/limitOrders/pure/Orders/OrdersTabs'
+import { LIMIT_ORDERS_TAB_KEY, buildLimitOrdersTabUrl, OrderTab } from '@cow/modules/limitOrders/pure/Orders/OrdersTabs'
 import { LimitOrdersList, useLimitOrdersList } from './hooks/useLimitOrdersList'
 import { useEffect, useMemo } from 'react'
 import { Order } from 'state/orders/actions'
@@ -43,7 +43,7 @@ export function OrdersWidget() {
   }, [currentTabId, ordersList])
 
   useEffect(() => {
-    history.push(limitOrdersTabUrl(location.pathname, location.search, currentTabId))
+    history.push(buildLimitOrdersTabUrl(location.pathname, location.search, currentTabId))
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return <Orders tabs={tabs} orders={orders} isWalletConnected={!!account} />

--- a/src/cow-react/modules/limitOrders/containers/OrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/OrdersWidget/index.tsx
@@ -1,10 +1,10 @@
 import { Orders } from '../../pure/Orders'
-import { LIMIT_ORDERS_TAB_KEY, OrderTab } from '@cow/modules/limitOrders/pure/Orders/OrdersTabs'
+import { LIMIT_ORDERS_TAB_KEY, limitOrdersTabUrl, OrderTab } from '@cow/modules/limitOrders/pure/Orders/OrdersTabs'
 import { LimitOrdersList, useLimitOrdersList } from './hooks/useLimitOrdersList'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { Order } from 'state/orders/actions'
 import { useWeb3React } from '@web3-react/core'
-import { useLocation } from 'react-router-dom'
+import { useHistory, useLocation } from 'react-router-dom'
 
 const openTab: OrderTab = {
   id: 'open',
@@ -24,6 +24,7 @@ function getOrdersListByIndex(ordersList: LimitOrdersList, id: string): Order[] 
 
 export function OrdersWidget() {
   const location = useLocation()
+  const history = useHistory()
   const ordersList = useLimitOrdersList()
   const { account } = useWeb3React()
 
@@ -40,6 +41,10 @@ export function OrdersWidget() {
       return { ...tab, isActive: tab.id === currentTabId, count: getOrdersListByIndex(ordersList, tab.id).length }
     })
   }, [currentTabId, ordersList])
+
+  useEffect(() => {
+    history.push(limitOrdersTabUrl(location.pathname, location.search, currentTabId))
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return <Orders tabs={tabs} orders={orders} isWalletConnected={!!account} />
 }

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrdersTabs.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrdersTabs.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom'
 
 export const LIMIT_ORDERS_TAB_KEY = 'tab'
 
-export const limitOrdersTabUrl = (pathname: string, search: string, tabId: string) => {
+export const buildLimitOrdersTabUrl = (pathname: string, search: string, tabId: string) => {
   const query = new URLSearchParams(search)
   query.delete(LIMIT_ORDERS_TAB_KEY)
   query.append(LIMIT_ORDERS_TAB_KEY, tabId)
@@ -61,7 +61,7 @@ export function OrdersTabs({ tabs }: OrdersTabsProps) {
         <TabButton
           key={index}
           active={index === activeTabIndex}
-          to={(location) => limitOrdersTabUrl(location.pathname, location.search, tab.id)}
+          to={(location) => buildLimitOrdersTabUrl(location.pathname, location.search, tab.id)}
         >
           <Trans>{tab.title}</Trans> <span>({tab.count})</span>
         </TabButton>

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrdersTabs.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrdersTabs.tsx
@@ -4,6 +4,14 @@ import { Link } from 'react-router-dom'
 
 export const LIMIT_ORDERS_TAB_KEY = 'tab'
 
+export const limitOrdersTabUrl = (pathname: string, search: string, tabId: string) => {
+  const query = new URLSearchParams(search)
+  query.delete(LIMIT_ORDERS_TAB_KEY)
+  query.append(LIMIT_ORDERS_TAB_KEY, tabId)
+
+  return pathname + '?' + query
+}
+
 const Tabs = styled.div`
   display: inline-block;
   border-radius: 8px;
@@ -47,21 +55,13 @@ export function OrdersTabs({ tabs }: OrdersTabsProps) {
     0
   )
 
-  const tabUrl = (pathname: string, search: string, tab: OrderTab) => {
-    const query = new URLSearchParams(search)
-    query.delete(LIMIT_ORDERS_TAB_KEY)
-    query.append(LIMIT_ORDERS_TAB_KEY, tab.id)
-
-    return pathname + '?' + query
-  }
-
   return (
     <Tabs>
       {tabs.map((tab, index) => (
         <TabButton
           key={index}
           active={index === activeTabIndex}
-          to={(location) => tabUrl(location.pathname, location.search, tab)}
+          to={(location) => limitOrdersTabUrl(location.pathname, location.search, tab.id)}
         >
           <Trans>{tab.title}</Trans> <span>({tab.count})</span>
         </TabButton>

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrdersTabs.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrdersTabs.tsx
@@ -27,6 +27,7 @@ const TabButton = styled.button<{ active?: boolean }>`
 `
 
 export interface OrderTab {
+  id: string
   title: string
   count: number
   isActive?: boolean
@@ -34,7 +35,7 @@ export interface OrderTab {
 
 export interface OrdersTabsProps {
   tabs: OrderTab[]
-  onTabChange(tab: OrderTab, index: number): void
+  onTabChange(tab: OrderTab): void
 }
 
 export function OrdersTabs({ tabs, onTabChange }: OrdersTabsProps) {
@@ -48,7 +49,7 @@ export function OrdersTabs({ tabs, onTabChange }: OrdersTabsProps) {
   const changeTab = useCallback(
     (tab: OrderTab, index: number) => {
       setActiveTabIndex(index)
-      onTabChange(tab, index)
+      onTabChange(tab)
     },
     [setActiveTabIndex, onTabChange]
   )

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrdersTabs.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrdersTabs.tsx
@@ -1,6 +1,8 @@
 import styled from 'styled-components/macro'
-import { useCallback, useState } from 'react'
 import { Trans } from '@lingui/macro'
+import { Link } from 'react-router-dom'
+
+export const LIMIT_ORDERS_TAB_KEY = 'tab'
 
 const Tabs = styled.div`
   display: inline-block;
@@ -10,10 +12,12 @@ const Tabs = styled.div`
   border: 2px solid ${({ theme }) => theme.border2};
 `
 
-const TabButton = styled.button<{ active?: boolean }>`
+const TabButton = styled(Link)<{ active?: boolean }>`
+  display: inline-block;
   background: ${({ theme, active }) => (active ? theme.bg2 : theme.bg1)};
   color: ${({ theme, active }) => (active ? theme.text2 : theme.text1)};
   font-weight: ${({ active }) => (active ? '600' : '400')};
+  text-decoration: none;
   font-size: 14px;
   padding: 12px 24px;
   border: 0;
@@ -35,29 +39,30 @@ export interface OrderTab {
 
 export interface OrdersTabsProps {
   tabs: OrderTab[]
-  onTabChange(tab: OrderTab): void
 }
 
-export function OrdersTabs({ tabs, onTabChange }: OrdersTabsProps) {
-  const [activeTabIndex, setActiveTabIndex] = useState(
-    Math.max(
-      tabs.findIndex((i) => i.isActive),
-      0
-    )
+export function OrdersTabs({ tabs }: OrdersTabsProps) {
+  const activeTabIndex = Math.max(
+    tabs.findIndex((i) => i.isActive),
+    0
   )
 
-  const changeTab = useCallback(
-    (tab: OrderTab, index: number) => {
-      setActiveTabIndex(index)
-      onTabChange(tab)
-    },
-    [setActiveTabIndex, onTabChange]
-  )
+  const tabUrl = (pathname: string, search: string, tab: OrderTab) => {
+    const query = new URLSearchParams(search)
+    query.delete(LIMIT_ORDERS_TAB_KEY)
+    query.append(LIMIT_ORDERS_TAB_KEY, tab.id)
+
+    return pathname + '?' + query
+  }
 
   return (
     <Tabs>
       {tabs.map((tab, index) => (
-        <TabButton key={index} active={index === activeTabIndex} onClick={() => changeTab(tab, index)}>
+        <TabButton
+          key={index}
+          active={index === activeTabIndex}
+          to={(location) => tabUrl(location.pathname, location.search, tab)}
+        >
           <Trans>{tab.title}</Trans> <span>({tab.count})</span>
         </TabButton>
       ))}

--- a/src/cow-react/modules/limitOrders/pure/Orders/index.cosmos.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/index.cosmos.tsx
@@ -4,10 +4,12 @@ import { ordersMock } from './orders.mock'
 
 const tabs: OrderTab[] = [
   {
+    id: 'open',
     title: 'Open orders',
     count: 5,
   },
   {
+    id: 'history',
     title: 'Orders history',
     count: 0,
     isActive: false,

--- a/src/cow-react/modules/limitOrders/pure/Orders/index.cosmos.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/index.cosmos.tsx
@@ -16,4 +16,4 @@ const tabs: OrderTab[] = [
   },
 ]
 
-export default <Orders orders={ordersMock} tabs={tabs} onTabChange={() => void 0} isWalletConnected={true} />
+export default <Orders orders={ordersMock} tabs={tabs} isWalletConnected={true} />

--- a/src/cow-react/modules/limitOrders/pure/Orders/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/index.tsx
@@ -6,7 +6,7 @@ export interface OrdersProps extends OrdersTabsProps, OrdersTableProps {
   isWalletConnected: boolean
 }
 
-export function Orders({ orders, tabs, onTabChange, isWalletConnected }: OrdersProps) {
+export function Orders({ orders, tabs, isWalletConnected }: OrdersProps) {
   const content = () => {
     if (!isWalletConnected) {
       return <styledEl.EmptyOrdersMessage>Please connect your wallet to view orders</styledEl.EmptyOrdersMessage>
@@ -23,7 +23,7 @@ export function Orders({ orders, tabs, onTabChange, isWalletConnected }: OrdersP
     <>
       <styledEl.Orders>
         <styledEl.OrdersTitle>Orders</styledEl.OrdersTitle>
-        <OrdersTabs tabs={tabs} onTabChange={onTabChange} />
+        <OrdersTabs tabs={tabs} />
         {content()}
       </styledEl.Orders>
     </>


### PR DESCRIPTION
# Summary

To get better UX we persist selected tab id to the URL.

<img width="370" alt="image" src="https://user-images.githubusercontent.com/7122625/202403230-cb4283c8-403e-4100-8dc9-ae3e7a40c872.png">

 - `/limit-orders/WETH/DAI?tab=open`
 - `/limit-orders/WETH/DAI?tab=history`