### PR TITLE
[EthFlow]#1379 Storing ethFlow deadline and slippage

### DIFF
--- a/src/cow-react/modules/swap/containers/Row/RowDeadline/index.tsx
+++ b/src/cow-react/modules/swap/containers/Row/RowDeadline/index.tsx
@@ -11,7 +11,7 @@ export function RowDeadline() {
   const toggleSettings = useToggleSettingsMenu()
   const isEthFlow = useIsEthFlow()
   const isExpertMode = useIsExpertMode()
-  const { native: nativeCurrency } = useDetectNativeToken()
+  const { native: nativeCurrency, isWrapOrUnwrap } = useDetectNativeToken()
 
   const props = useMemo(() => {
     const displayDeadline = Math.floor(userDeadline / 60) + ' minutes'
@@ -21,10 +21,11 @@ export function RowDeadline() {
       displayDeadline,
       isEthFlow,
       isExpertMode,
+      isWrapOrUnwrap,
       toggleSettings,
       showSettingOnClick: true,
     }
-  }, [isEthFlow, isExpertMode, nativeCurrency.symbol, toggleSettings, userDeadline])
+  }, [isEthFlow, isExpertMode, isWrapOrUnwrap, nativeCurrency.symbol, toggleSettings, userDeadline])
 
   return <RowDeadlineContent {...props} />
 }

--- a/src/cow-react/modules/swap/containers/Row/RowDeadline/index.tsx
+++ b/src/cow-react/modules/swap/containers/Row/RowDeadline/index.tsx
@@ -27,5 +27,9 @@ export function RowDeadline() {
     }
   }, [isEthFlow, isExpertMode, isWrapOrUnwrap, nativeCurrency.symbol, toggleSettings, userDeadline])
 
+  if ((!isEthFlow && !isExpertMode) || isWrapOrUnwrap) {
+    return null
+  }
+
   return <RowDeadlineContent {...props} />
 }

--- a/src/cow-react/modules/swap/containers/Row/RowDeadline/index.tsx
+++ b/src/cow-react/modules/swap/containers/Row/RowDeadline/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 
 import { RowDeadlineContent } from '@cow/modules/swap/pure/Row/RowDeadline'
-import { useUserTransactionTTL } from 'state/user/hooks'
+import { useIsExpertMode, useUserTransactionTTL } from 'state/user/hooks'
 import { useIsEthFlow } from '@cow/modules/swap/hooks/useIsEthFlow'
 import { useToggleSettingsMenu } from 'state/application/hooks'
 import { useDetectNativeToken } from '@cow/modules/swap/hooks/useDetectNativeToken'
@@ -10,6 +10,7 @@ export function RowDeadline() {
   const [userDeadline] = useUserTransactionTTL()
   const toggleSettings = useToggleSettingsMenu()
   const isEthFlow = useIsEthFlow()
+  const isExpertMode = useIsExpertMode()
   const { native: nativeCurrency } = useDetectNativeToken()
 
   const props = useMemo(() => {
@@ -19,10 +20,11 @@ export function RowDeadline() {
       symbols: [nativeCurrency.symbol],
       displayDeadline,
       isEthFlow,
+      isExpertMode,
       toggleSettings,
       showSettingOnClick: true,
     }
-  }, [isEthFlow, nativeCurrency.symbol, toggleSettings, userDeadline])
+  }, [isEthFlow, isExpertMode, nativeCurrency.symbol, toggleSettings, userDeadline])
 
   return <RowDeadlineContent {...props} />
 }

--- a/src/cow-react/modules/swap/containers/Row/RowSlippage/index.tsx
+++ b/src/cow-react/modules/swap/containers/Row/RowSlippage/index.tsx
@@ -5,9 +5,9 @@ import { PERCENTAGE_PRECISION } from 'constants/index'
 import { useToggleSettingsMenu } from 'state/application/hooks'
 import { formatSmart } from 'utils/format'
 import { RowSlippageContent } from '@cow/modules/swap/pure/Row/RowSlippageContent'
-import { useWrapType, WrapType } from 'hooks/useWrapCallback'
 import { useIsEthFlow } from '@cow/modules/swap/hooks/useIsEthFlow'
 import { useDetectNativeToken } from '@cow/modules/swap/hooks/useDetectNativeToken'
+import { useIsExpertMode } from '@src/state/user/hooks'
 
 export interface RowSlippageProps {
   allowedSlippage: Percent
@@ -17,10 +17,9 @@ export interface RowSlippageProps {
 export function RowSlippage({ allowedSlippage, showSettingOnClick = true }: RowSlippageProps) {
   const toggleSettings = useToggleSettingsMenu()
 
-  // if is wrap/unwrap operation return null
-  const wrapType = useWrapType()
   const isEthFlow = useIsEthFlow()
-  const { native: nativeCurrency } = useDetectNativeToken()
+  const isExpertMode = useIsExpertMode()
+  const { native: nativeCurrency, isWrapOrUnwrap } = useDetectNativeToken()
 
   const props = useMemo(
     () => ({
@@ -33,5 +32,9 @@ export function RowSlippage({ allowedSlippage, showSettingOnClick = true }: RowS
     [allowedSlippage, nativeCurrency, isEthFlow, showSettingOnClick]
   )
 
-  return wrapType !== WrapType.NOT_APPLICABLE ? null : <RowSlippageContent {...props} toggleSettings={toggleSettings} />
+  if ((!isEthFlow && !isExpertMode) || isWrapOrUnwrap) {
+    return null
+  }
+
+  return <RowSlippageContent {...props} toggleSettings={toggleSettings} />
 }

--- a/src/cow-react/modules/swap/pure/Row/RowDeadline/index.cosmos.tsx
+++ b/src/cow-react/modules/swap/pure/Row/RowDeadline/index.cosmos.tsx
@@ -4,8 +4,6 @@ import { MINIMUM_ETH_FLOW_DEADLINE_SECONDS } from 'constants/index'
 const defaultProps: RowDeadlineProps = {
   toggleSettings: console.log,
   isEthFlow: true,
-  isExpertMode: true,
-  isWrapOrUnwrap: false,
   displayDeadline: Math.floor(MINIMUM_ETH_FLOW_DEADLINE_SECONDS / 60) + ' minutes',
   symbols: ['ETH', 'WETH'],
   userDeadline: 600,

--- a/src/cow-react/modules/swap/pure/Row/RowDeadline/index.cosmos.tsx
+++ b/src/cow-react/modules/swap/pure/Row/RowDeadline/index.cosmos.tsx
@@ -4,6 +4,7 @@ import { MINIMUM_ETH_FLOW_DEADLINE_SECONDS } from 'constants/index'
 const defaultProps: RowDeadlineProps = {
   toggleSettings: console.log,
   isEthFlow: true,
+  isExpertMode: true,
   displayDeadline: Math.floor(MINIMUM_ETH_FLOW_DEADLINE_SECONDS / 60) + ' minutes',
   symbols: ['ETH', 'WETH'],
   userDeadline: 600,

--- a/src/cow-react/modules/swap/pure/Row/RowDeadline/index.cosmos.tsx
+++ b/src/cow-react/modules/swap/pure/Row/RowDeadline/index.cosmos.tsx
@@ -5,6 +5,7 @@ const defaultProps: RowDeadlineProps = {
   toggleSettings: console.log,
   isEthFlow: true,
   isExpertMode: true,
+  isWrapOrUnwrap: false,
   displayDeadline: Math.floor(MINIMUM_ETH_FLOW_DEADLINE_SECONDS / 60) + ' minutes',
   symbols: ['ETH', 'WETH'],
   userDeadline: 600,

--- a/src/cow-react/modules/swap/pure/Row/RowDeadline/index.tsx
+++ b/src/cow-react/modules/swap/pure/Row/RowDeadline/index.tsx
@@ -35,8 +35,6 @@ export function getNonNativeOrderDeadlineTooltip() {
 export interface RowDeadlineProps extends Omit<RowSlippageProps, 'allowedSlippage'> {
   toggleSettings: () => void
   isEthFlow: boolean
-  isExpertMode: boolean
-  isWrapOrUnwrap: boolean
   symbols?: (string | undefined)[]
   displayDeadline: string
   styleProps?: RowStyleProps
@@ -44,20 +42,7 @@ export interface RowDeadlineProps extends Omit<RowSlippageProps, 'allowedSlippag
 }
 
 export function RowDeadlineContent(props: RowDeadlineProps) {
-  const {
-    showSettingOnClick,
-    toggleSettings,
-    displayDeadline,
-    isEthFlow,
-    isExpertMode,
-    isWrapOrUnwrap,
-    symbols,
-    styleProps,
-  } = props
-
-  if ((!isEthFlow && !isExpertMode) || isWrapOrUnwrap) {
-    return null
-  }
+  const { showSettingOnClick, toggleSettings, displayDeadline, isEthFlow, symbols, styleProps } = props
 
   return (
     <StyledRowBetween {...styleProps}>

--- a/src/cow-react/modules/swap/pure/Row/RowDeadline/index.tsx
+++ b/src/cow-react/modules/swap/pure/Row/RowDeadline/index.tsx
@@ -42,20 +42,26 @@ export interface RowDeadlineProps extends Omit<RowSlippageProps, 'allowedSlippag
 }
 
 export function RowDeadlineContent(props: RowDeadlineProps) {
-  const { userDeadline, showSettingOnClick, toggleSettings, displayDeadline, isEthFlow, symbols, styleProps } = props
-
-  if (!isEthFlow || userDeadline > MINIMUM_ETH_FLOW_DEADLINE_SECONDS) return null
+  const { showSettingOnClick, toggleSettings, displayDeadline, isEthFlow, symbols, styleProps } = props
 
   return (
     <StyledRowBetween {...styleProps}>
       <RowFixed>
         <TextWrapper>
-          <Trans>
-            Transaction expiration{' '}
-            <ThemedText.Warn display="inline-block" override>
-              (modified)
-            </ThemedText.Warn>
-          </Trans>
+          {isEthFlow ? (
+            <Trans>
+              Transaction expiration{' '}
+              <ThemedText.Warn display="inline-block" override>
+                (modified)
+              </ThemedText.Warn>
+            </Trans>
+          ) : showSettingOnClick ? (
+            <ClickableText onClick={toggleSettings}>
+              <Trans>Transaction expiration</Trans>
+            </ClickableText>
+          ) : (
+            <Trans>Transaction expiration</Trans>
+          )}
         </TextWrapper>
         <MouseoverTooltipContent wrap content={getNativeOrderDeadlineTooltip(symbols)}>
           <StyledInfoIcon size={16} />

--- a/src/cow-react/modules/swap/pure/Row/RowDeadline/index.tsx
+++ b/src/cow-react/modules/swap/pure/Row/RowDeadline/index.tsx
@@ -36,6 +36,7 @@ export interface RowDeadlineProps extends Omit<RowSlippageProps, 'allowedSlippag
   toggleSettings: () => void
   isEthFlow: boolean
   isExpertMode: boolean
+  isWrapOrUnwrap: boolean
   symbols?: (string | undefined)[]
   displayDeadline: string
   styleProps?: RowStyleProps
@@ -43,9 +44,18 @@ export interface RowDeadlineProps extends Omit<RowSlippageProps, 'allowedSlippag
 }
 
 export function RowDeadlineContent(props: RowDeadlineProps) {
-  const { showSettingOnClick, toggleSettings, displayDeadline, isEthFlow, isExpertMode, symbols, styleProps } = props
+  const {
+    showSettingOnClick,
+    toggleSettings,
+    displayDeadline,
+    isEthFlow,
+    isExpertMode,
+    isWrapOrUnwrap,
+    symbols,
+    styleProps,
+  } = props
 
-  if (!isEthFlow && !isExpertMode) {
+  if ((!isEthFlow && !isExpertMode) || isWrapOrUnwrap) {
     return null
   }
 

--- a/src/cow-react/modules/swap/pure/Row/RowDeadline/index.tsx
+++ b/src/cow-react/modules/swap/pure/Row/RowDeadline/index.tsx
@@ -41,6 +41,8 @@ export interface RowDeadlineProps extends Omit<RowSlippageProps, 'allowedSlippag
   userDeadline: number
 }
 
+// TODO: RowDeadlineContent and RowSlippageContent are very similar. Refactor and extract base component?
+
 export function RowDeadlineContent(props: RowDeadlineProps) {
   const { showSettingOnClick, toggleSettings, displayDeadline, isEthFlow, symbols, styleProps } = props
 
@@ -48,19 +50,12 @@ export function RowDeadlineContent(props: RowDeadlineProps) {
     <StyledRowBetween {...styleProps}>
       <RowFixed>
         <TextWrapper>
-          {isEthFlow ? (
-            <Trans>
-              Transaction expiration{' '}
-              <ThemedText.Warn display="inline-block" override>
-                (modified)
-              </ThemedText.Warn>
-            </Trans>
-          ) : showSettingOnClick ? (
+          {showSettingOnClick ? (
             <ClickableText onClick={toggleSettings}>
-              <Trans>Transaction expiration</Trans>
+              <DeadlineTextContents isEthFlow={isEthFlow} />
             </ClickableText>
           ) : (
-            <Trans>Transaction expiration</Trans>
+            <DeadlineTextContents isEthFlow={isEthFlow} />
           )}
         </TextWrapper>
         <MouseoverTooltipContent wrap content={getNativeOrderDeadlineTooltip(symbols)}>
@@ -75,5 +70,23 @@ export function RowDeadlineContent(props: RowDeadlineProps) {
         )}
       </TextWrapper>
     </StyledRowBetween>
+  )
+}
+
+type DeadlineTextContentsProps = { isEthFlow: boolean }
+
+function DeadlineTextContents({ isEthFlow }: DeadlineTextContentsProps) {
+  return (
+    <>
+      <Trans>Transaction expiration</Trans>
+      {isEthFlow && (
+        <>
+          {' '}
+          <ThemedText.Warn display="inline-block" override>
+            (modified)
+          </ThemedText.Warn>
+        </>
+      )}
+    </>
   )
 }

--- a/src/cow-react/modules/swap/pure/Row/RowDeadline/index.tsx
+++ b/src/cow-react/modules/swap/pure/Row/RowDeadline/index.tsx
@@ -35,6 +35,7 @@ export function getNonNativeOrderDeadlineTooltip() {
 export interface RowDeadlineProps extends Omit<RowSlippageProps, 'allowedSlippage'> {
   toggleSettings: () => void
   isEthFlow: boolean
+  isExpertMode: boolean
   symbols?: (string | undefined)[]
   displayDeadline: string
   styleProps?: RowStyleProps
@@ -42,7 +43,11 @@ export interface RowDeadlineProps extends Omit<RowSlippageProps, 'allowedSlippag
 }
 
 export function RowDeadlineContent(props: RowDeadlineProps) {
-  const { showSettingOnClick, toggleSettings, displayDeadline, isEthFlow, symbols, styleProps } = props
+  const { showSettingOnClick, toggleSettings, displayDeadline, isEthFlow, isExpertMode, symbols, styleProps } = props
+
+  if (!isEthFlow && !isExpertMode) {
+    return null
+  }
 
   return (
     <StyledRowBetween {...styleProps}>

--- a/src/cow-react/modules/swap/pure/Row/RowSlippageContent/index.tsx
+++ b/src/cow-react/modules/swap/pure/Row/RowSlippageContent/index.tsx
@@ -50,6 +50,8 @@ export interface RowSlippageContentProps extends RowSlippageProps {
   styleProps?: RowStyleProps
 }
 
+// TODO: RowDeadlineContent and RowSlippageContent are very similar. Refactor and extract base component?
+
 export function RowSlippageContent(props: RowSlippageContentProps) {
   const { showSettingOnClick, toggleSettings, displaySlippage, isEthFlow, symbols, styleProps } = props
 
@@ -57,19 +59,12 @@ export function RowSlippageContent(props: RowSlippageContentProps) {
     <StyledRowBetween {...styleProps}>
       <RowFixed>
         <TextWrapper>
-          {isEthFlow ? (
-            <Trans>
-              Slippage tolerance{' '}
-              <ThemedText.Warn display="inline-block" override>
-                (modified)
-              </ThemedText.Warn>
-            </Trans>
-          ) : showSettingOnClick ? (
+          {showSettingOnClick ? (
             <ClickableText onClick={toggleSettings}>
-              <Trans>Slippage tolerance</Trans>
+              <SlippageTextContents isEthFlow={isEthFlow} />
             </ClickableText>
           ) : (
-            <Trans>Slippage tolerance</Trans>
+            <SlippageTextContents isEthFlow={isEthFlow} />
           )}
         </TextWrapper>
         <MouseoverTooltipContent
@@ -87,5 +82,23 @@ export function RowSlippageContent(props: RowSlippageContentProps) {
         )}
       </TextWrapper>
     </StyledRowBetween>
+  )
+}
+
+type SlippageTextContentsProps = { isEthFlow: boolean }
+
+function SlippageTextContents({ isEthFlow }: SlippageTextContentsProps) {
+  return (
+    <>
+      <Trans>Slippage tolerance</Trans>
+      {isEthFlow && (
+        <>
+          {' '}
+          <ThemedText.Warn display="inline-block" override>
+            (modified)
+          </ThemedText.Warn>
+        </>
+      )}
+    </>
   )
 }

--- a/src/cow-react/modules/swap/pure/Row/RowSlippageContent/index.tsx
+++ b/src/cow-react/modules/swap/pure/Row/RowSlippageContent/index.tsx
@@ -26,7 +26,7 @@ export const getNativeSlippageTooltip = (symbols: (string | undefined)[] | undef
   <Trans>
     <p>Your slippage is MEV protected.</p>
     <p>
-      When swapping {symbols?.[0] || 'a native currency'}, slippage tolerance is defaulted to{' '}
+      When swapping {symbols?.[0] || 'a native currency'}, the minimum slippage tolerance is set to{' '}
       {ETH_FLOW_SLIPPAGE.toSignificant(PERCENTAGE_PRECISION)}% to ensure a high likelihood of order matching, even in
       volatile market situations.
     </p>

--- a/src/cow-react/modules/swap/state/EthFlow/updaters/EthFlowDeadlineUpdater.tsx
+++ b/src/cow-react/modules/swap/state/EthFlow/updaters/EthFlowDeadlineUpdater.tsx
@@ -1,70 +1,92 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef } from 'react'
 import { useUserTransactionTTL } from 'state/user/hooks'
 import { useIsEthFlow } from '@cow/modules/swap/hooks/useIsEthFlow'
 import { loadJsonFromLocalStorage, setJsonToLocalStorage } from '@cow/utils/localStorage'
 import { MINIMUM_ETH_FLOW_DEADLINE_SECONDS } from 'constants/index'
 
-const LOCAL_STORAGE_KEY = 'UserPreviousDeadline'
+const LOCAL_STORAGE_KEY = 'UserDeadlineSettings'
 
 export function EthFlowDeadlineUpdater() {
-  const [mounted, setMounted] = useState(false)
-
   // user deadline (in seconds)
   const [userDeadline, setUserDeadline] = useUserTransactionTTL()
   const isEthFlow = useIsEthFlow()
 
-  // on updater mount, load previous deadline from localStorage and set it, if it exists
+  // On updater mount, load previous deadline from localStorage and set it
   useEffect(() => {
-    const previousDeadline = _loadDeadline()
+    const { regular, ethFlow } = _loadDeadline() || {}
 
-    // only update if some storage amt exists
-    if (previousDeadline) {
-      setUserDeadline(previousDeadline)
+    // Depending on where whether we are on EthFlow, set a different deadline (if it exists)
+    if (ethFlow && isEthFlow) {
+      setUserDeadline(ethFlow)
+    } else if (regular) {
+      setUserDeadline(regular)
     }
 
-    setMounted(true)
     // we only want this on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  // ref used to track when EthFlow is disabled
+  const wasEthFlowActive = useRef(false)
+
   useEffect(() => {
     if (isEthFlow) {
-      // if EthFlow and deadline < than minimum, set it to minimum
-      const deadlineLessThanThreshold = MINIMUM_ETH_FLOW_DEADLINE_SECONDS > userDeadline
-      if (deadlineLessThanThreshold) {
-        console.log(
-          `[EthFlowDeadlineUpdater] - Setting user deadline to minimum threshold of ${
-            MINIMUM_ETH_FLOW_DEADLINE_SECONDS / 60
-          } minutes`,
-          isEthFlow,
-          userDeadline,
-          deadlineLessThanThreshold
-        )
-        _saveDeadline(userDeadline)
-        setUserDeadline(MINIMUM_ETH_FLOW_DEADLINE_SECONDS)
+      // Load what's stored
+      const { regular, ethFlow } = _loadDeadline() || {}
+      // Set the flag
+      wasEthFlowActive.current = true
+
+      if (userDeadline >= MINIMUM_ETH_FLOW_DEADLINE_SECONDS) {
+        // Valid deadline for ethflow. No need to update global state
+        // But do update local storage with new ethflow value
+        _saveDeadline({
+          // Re-use the value stored or use current deadline if nothing is stored
+          regular: regular || userDeadline,
+          // Store it as ethflow deadline
+          ethFlow: userDeadline,
+        })
+      } else {
+        // Current deadline is too short
+        // Use what's stored. If that's not valid, use the minimum value
+        const newDeadline =
+          ethFlow && ethFlow > MINIMUM_ETH_FLOW_DEADLINE_SECONDS ? ethFlow : MINIMUM_ETH_FLOW_DEADLINE_SECONDS
+        // Set that on global state
+        setUserDeadline(newDeadline)
+        // Update local storage
+        _saveDeadline({
+          // Store previous value as regular
+          regular: userDeadline,
+          // Use new value as ethflow
+          ethFlow: newDeadline,
+        })
       }
-    } else if (mounted) {
-      // if we are leaving EthFlow context, reset deadline to previous value
+    } else if (wasEthFlowActive.current) {
+      // Only when disabling EthFlow, reset to previous regular value
       _resetDeadline(setUserDeadline)
+      // Disable the flag
+      wasEthFlowActive.current = false
     }
-    // we only want to depend on isEthFlow
-    // to avoid re-renders
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isEthFlow])
+  }, [isEthFlow, setUserDeadline, userDeadline])
 
   return null
 }
 
-function _saveDeadline(currentUserDeadline: number): void {
+type DeadlineSettings = {
+  regular: number
+  ethFlow: number
+}
+
+function _saveDeadline(currentUserDeadline: DeadlineSettings): void {
+  console.log(`EthFlowDeadlineUpdater:_saveDeadline`, currentUserDeadline)
   setJsonToLocalStorage(LOCAL_STORAGE_KEY, currentUserDeadline)
 }
 
-function _loadDeadline(): number | null {
+function _loadDeadline(): DeadlineSettings | null {
   return loadJsonFromLocalStorage(LOCAL_STORAGE_KEY)
 }
 
-function _resetDeadline(setUserDeadline: (slippage: number) => void): void {
-  const parsedDeadline = _loadDeadline()
+function _resetDeadline(setUserDeadline: (deadline: number) => void): void {
+  const { regular } = _loadDeadline() || {}
   // user switched back to non-native swap, set deadline back to previous value
-  parsedDeadline && setUserDeadline(parsedDeadline)
+  regular && setUserDeadline(regular)
 }

--- a/src/cow-react/modules/swap/state/EthFlow/updaters/EthFlowDeadlineUpdater.tsx
+++ b/src/cow-react/modules/swap/state/EthFlow/updaters/EthFlowDeadlineUpdater.tsx
@@ -3,6 +3,7 @@ import { useUserTransactionTTL } from 'state/user/hooks'
 import { useIsEthFlow } from '@cow/modules/swap/hooks/useIsEthFlow'
 import { loadJsonFromLocalStorage, setJsonToLocalStorage } from '@cow/utils/localStorage'
 import { MINIMUM_ETH_FLOW_DEADLINE_SECONDS } from 'constants/index'
+import { DeadlineSettings } from './types'
 
 const LOCAL_STORAGE_KEY = 'UserDeadlineSettings'
 
@@ -67,11 +68,6 @@ export function EthFlowDeadlineUpdater() {
   }, [isEthFlow, setUserDeadline, userDeadline])
 
   return null
-}
-
-type DeadlineSettings = {
-  regular: number
-  ethFlow: number
 }
 
 function _saveDeadline(currentUserDeadline: DeadlineSettings): void {

--- a/src/cow-react/modules/swap/state/EthFlow/updaters/EthFlowDeadlineUpdater.tsx
+++ b/src/cow-react/modules/swap/state/EthFlow/updaters/EthFlowDeadlineUpdater.tsx
@@ -77,7 +77,6 @@ type DeadlineSettings = {
 }
 
 function _saveDeadline(currentUserDeadline: DeadlineSettings): void {
-  console.log(`EthFlowDeadlineUpdater:_saveDeadline`, currentUserDeadline)
   setJsonToLocalStorage(LOCAL_STORAGE_KEY, currentUserDeadline)
 }
 

--- a/src/cow-react/modules/swap/state/EthFlow/updaters/EthFlowDeadlineUpdater.tsx
+++ b/src/cow-react/modules/swap/state/EthFlow/updaters/EthFlowDeadlineUpdater.tsx
@@ -13,13 +13,11 @@ export function EthFlowDeadlineUpdater() {
 
   // On updater mount, load previous deadline from localStorage and set it
   useEffect(() => {
-    const { regular, ethFlow } = _loadDeadline() || {}
+    const { ethFlow } = _loadDeadline() || {}
 
     // Depending on where whether we are on EthFlow, set a different deadline (if it exists)
     if (ethFlow && isEthFlow) {
       setUserDeadline(ethFlow)
-    } else if (regular) {
-      setUserDeadline(regular)
     }
 
     // we only want this on mount

--- a/src/cow-react/modules/swap/state/EthFlow/updaters/EthFlowDeadlineUpdater.tsx
+++ b/src/cow-react/modules/swap/state/EthFlow/updaters/EthFlowDeadlineUpdater.tsx
@@ -16,7 +16,7 @@ export function EthFlowDeadlineUpdater() {
   useEffect(() => {
     const { ethFlow } = _loadDeadline() || {}
 
-    // Depending on where whether we are on EthFlow, set a different deadline (if it exists)
+    // If on load there's an efhFlow deadline stored and it's ethFlow, use it
     if (ethFlow && isEthFlow) {
       setUserDeadline(ethFlow)
     }

--- a/src/cow-react/modules/swap/state/EthFlow/updaters/EthFlowSlippageUpdater.tsx
+++ b/src/cow-react/modules/swap/state/EthFlow/updaters/EthFlowSlippageUpdater.tsx
@@ -42,7 +42,10 @@ export function EthFlowSlippageUpdater() {
       // Set the flag
       wasEthFlowActive.current = true
 
-      if (currentSlippage === 'auto' || !currentSlippage.greaterThan(ETH_FLOW_SLIPPAGE)) {
+      if (
+        currentSlippage === 'auto' ||
+        (!currentSlippage.greaterThan(ETH_FLOW_SLIPPAGE) && !currentSlippage.equalTo(ETH_FLOW_SLIPPAGE))
+      ) {
         // If current slippage is auto or if it's smaller than ETH flow slippage, update it
 
         // If the former ethFlow slippage was saved, use that. Otherwise pick the minimum

--- a/src/cow-react/modules/swap/state/EthFlow/updaters/EthFlowSlippageUpdater.tsx
+++ b/src/cow-react/modules/swap/state/EthFlow/updaters/EthFlowSlippageUpdater.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react'
 import { useSetUserSlippageTolerance, useUserSlippageTolerance } from 'state/user/hooks'
 import { useIsEthFlow } from '@cow/modules/swap/hooks/useIsEthFlow'
 import { loadJsonFromLocalStorage, setJsonToLocalStorage } from '@cow/utils/localStorage'
+import { SerializedSlippage, SerializedSlippageSettings, Slippage, SlippageSettings } from './types'
 
 export const ETH_FLOW_SLIPPAGE = new Percent(2, 100) // 2%
 const LOCAL_STORAGE_KEY = 'UserSlippageSettings'
@@ -65,17 +66,6 @@ export function EthFlowSlippageUpdater() {
 
   return null
 }
-
-type StoredSettings<T> = {
-  regular: T
-  ethFlow: T
-}
-
-type SerializedSlippage = 'auto' | [string, string]
-type Slippage = Percent | 'auto'
-
-type SerializedSlippageSettings = StoredSettings<SerializedSlippage>
-type SlippageSettings = StoredSettings<Slippage>
 
 function _saveSlippage(slippageSettings: SlippageSettings): void {
   setJsonToLocalStorage(LOCAL_STORAGE_KEY, _serialize(slippageSettings))

--- a/src/cow-react/modules/swap/state/EthFlow/updaters/EthFlowSlippageUpdater.tsx
+++ b/src/cow-react/modules/swap/state/EthFlow/updaters/EthFlowSlippageUpdater.tsx
@@ -1,70 +1,118 @@
 import { Percent } from '@uniswap/sdk-core'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef } from 'react'
 import { useSetUserSlippageTolerance, useUserSlippageTolerance } from 'state/user/hooks'
 import { useIsEthFlow } from '@cow/modules/swap/hooks/useIsEthFlow'
 import { loadJsonFromLocalStorage, setJsonToLocalStorage } from '@cow/utils/localStorage'
 
 export const ETH_FLOW_SLIPPAGE = new Percent(2, 100) // 2%
-const LOCAL_STORAGE_KEY = 'UserPreviousSlippage'
+const LOCAL_STORAGE_KEY = 'UserSlippageSettings'
 
 export function EthFlowSlippageUpdater() {
-  const [mounted, setMounted] = useState(false)
-  // use previous slippage for when user is not in native swap and set to native flow
   const currentSlippage = useUserSlippageTolerance()
-  // save the last non eth-flow slippage amount to reset when user switches back to normal erc20 flow
-  const previousSlippage = _loadSlippage()
-  const isEthFlow = useIsEthFlow()
   const setUserSlippageTolerance = useSetUserSlippageTolerance()
+  const isEthFlow = useIsEthFlow()
 
+  // On updater mount, load previous slippage from localStorage and set it
   useEffect(() => {
-    // only update if the current slippage is the ethflow slippage amt
-    if (currentSlippage !== 'auto' && currentSlippage.equalTo(ETH_FLOW_SLIPPAGE)) {
-      setUserSlippageTolerance(previousSlippage)
+    const { ethFlow } = _loadSlippage()
+
+    if (
+      isEthFlow &&
+      ((currentSlippage === 'auto' && ethFlow !== 'auto') ||
+        (currentSlippage instanceof Percent && ethFlow instanceof Percent && !currentSlippage.equalTo(ethFlow)))
+    ) {
+      // If ethFlow and there's an enflow stored which is not auto
+      setUserSlippageTolerance(ethFlow)
     }
 
-    setMounted(true)
     // we only want this on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // change slippage set to 2% when detected eth swap and option is set to use native flow
+  // ref used to track when EthFlow is disabled
+  const wasEthFlowActive = useRef(false)
+
   useEffect(() => {
     if (isEthFlow) {
-      // save the previous slippage to set back if users switches out of native swap
-      _saveSlippage(currentSlippage)
+      // Load what's stored
+      const { regular, ethFlow } = _loadSlippage()
 
-      setUserSlippageTolerance(ETH_FLOW_SLIPPAGE)
-      // only after it's run the effect once
-    } else if (mounted) {
+      // Set the flag
+      wasEthFlowActive.current = true
+
+      if (currentSlippage === 'auto' || !currentSlippage.greaterThan(ETH_FLOW_SLIPPAGE)) {
+        // If current slippage is auto or if it's smaller than ETH flow slippage, update it
+
+        // If the former ethFlow slippage was saved, use that. Otherwise pick the minimum
+        const newSlippage = ethFlow !== 'auto' && ethFlow.greaterThan(ETH_FLOW_SLIPPAGE) ? ethFlow : ETH_FLOW_SLIPPAGE
+
+        // Update the global state
+        setUserSlippageTolerance(newSlippage)
+
+        // Update local storage
+        _saveSlippage({ regular: currentSlippage, ethFlow: newSlippage })
+      } else {
+        // If current slippage is NOT auto and it's greater than minimum, store that locally
+        _saveSlippage({ regular, ethFlow: currentSlippage })
+      }
+    } else if (wasEthFlowActive.current) {
+      // Only when disabling EthFlow, reset to previous regular value
       _resetSlippage(setUserSlippageTolerance)
+      // Disable the flag
+      wasEthFlowActive.current = false
     }
-    // we only want to depend on isEthFlow
-    // to avoid re-renders
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [setUserSlippageTolerance, isEthFlow])
+  }, [setUserSlippageTolerance, isEthFlow, currentSlippage])
 
   return null
 }
 
-type SerializedSlippage = 'auto' | [string, string]
-
-function _saveSlippage(currentSlippage: Percent | 'auto'): void {
-  setJsonToLocalStorage(
-    LOCAL_STORAGE_KEY,
-    currentSlippage instanceof Percent
-      ? [currentSlippage.numerator.toString(), currentSlippage.denominator.toString()]
-      : currentSlippage
-  )
+type StoredSettings<T> = {
+  regular: T
+  ethFlow: T
 }
 
-function _loadSlippage(): 'auto' | Percent {
-  const slippage = loadJsonFromLocalStorage<SerializedSlippage>(LOCAL_STORAGE_KEY)
+type SerializedSlippage = 'auto' | [string, string]
+type Slippage = Percent | 'auto'
 
+type SerializedSlippageSettings = StoredSettings<SerializedSlippage>
+type SlippageSettings = StoredSettings<Slippage>
+
+function _saveSlippage(slippageSettings: SlippageSettings): void {
+  setJsonToLocalStorage(LOCAL_STORAGE_KEY, _serialize(slippageSettings))
+}
+
+function _serialize({ regular, ethFlow }: SlippageSettings): SerializedSlippageSettings {
+  return {
+    regular: _serializeSlippage(regular),
+    ethFlow: _serializeSlippage(ethFlow),
+  }
+}
+
+function _serializeSlippage(slippage: Slippage): SerializedSlippage {
+  return slippage instanceof Percent ? [slippage.numerator.toString(), slippage.denominator.toString()] : slippage
+}
+
+function _loadSlippage(): SlippageSettings {
+  const slippageSettings = loadJsonFromLocalStorage<SerializedSlippageSettings>(LOCAL_STORAGE_KEY)
+
+  return _deserialize(slippageSettings)
+}
+
+function _deserialize(settings: SerializedSlippageSettings | null): SlippageSettings {
+  const { regular, ethFlow } = settings || {}
+
+  return {
+    regular: _deserializeSlippage(regular),
+    ethFlow: _deserializeSlippage(ethFlow),
+  }
+}
+
+function _deserializeSlippage(slippage?: SerializedSlippage): Slippage {
   return slippage === 'auto' || !slippage ? 'auto' : new Percent(slippage[0], slippage[1])
 }
 
-function _resetSlippage(setUserSlippageTolerance: (slippageTolerance: Percent | 'auto') => void): void {
-  const parsedSlippage = _loadSlippage()
+function _resetSlippage(setUserSlippageTolerance: (slippageTolerance: Slippage) => void): void {
+  const { regular } = _loadSlippage()
   // user switched back to non-native swap, set slippage back to previous value
-  setUserSlippageTolerance(parsedSlippage)
+  setUserSlippageTolerance(regular)
 }

--- a/src/cow-react/modules/swap/state/EthFlow/updaters/types.ts
+++ b/src/cow-react/modules/swap/state/EthFlow/updaters/types.ts
@@ -1,8 +1,8 @@
 import { Percent } from '@uniswap/sdk-core'
 
 type StoredSettings<T> = {
-  regular: T
-  ethFlow: T
+  regular?: T
+  ethFlow?: T
 }
 
 export type SerializedSlippage = 'auto' | [string, string]

--- a/src/cow-react/modules/swap/state/EthFlow/updaters/types.ts
+++ b/src/cow-react/modules/swap/state/EthFlow/updaters/types.ts
@@ -1,0 +1,14 @@
+import { Percent } from '@uniswap/sdk-core'
+
+type StoredSettings<T> = {
+  regular: T
+  ethFlow: T
+}
+
+export type SerializedSlippage = 'auto' | [string, string]
+export type Slippage = Percent | 'auto'
+
+export type SerializedSlippageSettings = StoredSettings<SerializedSlippage>
+export type SlippageSettings = StoredSettings<Slippage>
+
+export type DeadlineSettings = StoredSettings<number>

--- a/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
+++ b/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
@@ -22,12 +22,10 @@ import {
   LOW_SLIPPAGE_BPS,
   HIGH_SLIPPAGE_BPS,
   DEFAULT_SLIPPAGE_BPS,
-  PERCENTAGE_PRECISION,
   MINIMUM_ETH_FLOW_DEADLINE_SECONDS,
 } from 'constants/index'
 import { slippageToleranceAnalytics, orderExpirationTimeAnalytics } from 'components/analytics'
 import { useIsEthFlow } from '@cow/modules/swap/hooks/useIsEthFlow'
-import { ETH_FLOW_SLIPPAGE } from '@cow/modules/swap/state/EthFlow/updaters/EthFlowSlippageUpdater'
 import { getNativeSlippageTooltip, getNonNativeSlippageTooltip } from '@cow/modules/swap/pure/Row/RowSlippageContent'
 import { useDetectNativeToken } from '@cow/modules/swap/hooks/useDetectNativeToken'
 import { getNativeOrderDeadlineTooltip, getNonNativeOrderDeadlineTooltip } from '@cow/modules/swap/pure/Row/RowDeadline'
@@ -237,12 +235,7 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
           >
             <Trans>Auto</Trans>
           </Option>
-          <OptionCustom
-            disabled={isEthFlow}
-            active={userSlippageTolerance !== 'auto' && !isEthFlow}
-            warning={!!slippageError}
-            tabIndex={-1}
-          >
+          <OptionCustom active={userSlippageTolerance !== 'auto'} warning={!!slippageError} tabIndex={-1}>
             <RowBetween>
               {tooLow || tooHigh ? (
                 <SlippageEmojiContainer>
@@ -252,12 +245,9 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
                 </SlippageEmojiContainer>
               ) : null}
               <Input
-                disabled={isEthFlow}
                 placeholder={placeholderSlippage.toFixed(2)}
                 value={
-                  isEthFlow
-                    ? ETH_FLOW_SLIPPAGE.toSignificant(PERCENTAGE_PRECISION)
-                    : slippageInput.length > 0
+                  slippageInput.length > 0
                     ? slippageInput
                     : userSlippageTolerance === 'auto'
                     ? ''


### PR DESCRIPTION
# Summary

Closes #1379

1. Storing both Deadline and Slippage settings for EthFlow
2. Allowing Slippage to be updated for EthFlow

# To Test

1. Turn on EthFlow flag with `localStorage.setItem('enableEthFlow', '1')`
2. Pick as sell token any ERC20, pick as buy token `ETH` (or xDAI, if on xDAI)
3. Open settings and set slippage to 1% and deadline to 4 minutes
4. Refresh the page
* Values should be kept
5. Click on the arrow to switch the tokens
* `ETH` should now be the sell token and the ERC20 the buy token
6. Open the settings
* The slippage should be set to `2%`
* The deadline should be set to 10min
7. Try to update slippage to a value < 2%
* You should not be able to
8. Try to update deadline to a value < 10 min
* You should not be able to
9. Update the values to slippage > 2% and deadline > 10 min
* You should be able to
10. Refresh the page
* Values should be kept
11. Repeat step `5`
* Values should be back to original (1% and 4min)
11. Repeat step `11`
* Values should be back to whatever was set on step `9`

You could play with more combinations of slippage and deadline.
The important thing is that the min for ethFlow for Slippage is 2% and Deadline is 10min.
You shouldn't be able to use less than that for those settings while selling ETH