### PR TITLE
DIsplay orders list and styles fixes

### DIFF
--- a/src/cow-react/common/pure/CurrencyInputPanel/styled.tsx
+++ b/src/cow-react/common/pure/CurrencyInputPanel/styled.tsx
@@ -7,6 +7,7 @@ export const Wrapper = styled.div<{ withReceiveAmountInfo: boolean; disabled: bo
   display: flex;
   flex-flow: row wrap;
   align-content: space-between;
+  gap: 10px;
   padding: 16px;
   background: ${({ theme }) => theme.input.bg1};
   border: none;

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.styled.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.styled.tsx
@@ -27,6 +27,7 @@ export const Header = styled.div`
   display: grid;
   grid-gap: 10px;
   grid-template-columns: repeat(4, minmax(0, 1fr));
+  align-items: center;
   border-bottom: 2px solid ${({ theme }) => theme.border2};
 
   > div {

--- a/src/cow-react/modules/limitOrders/pure/Orders/styled.ts
+++ b/src/cow-react/modules/limitOrders/pure/Orders/styled.ts
@@ -3,6 +3,7 @@ import { Widget } from '../Widget'
 
 export const Orders = styled(Widget)`
   min-height: 200px;
+  width: 100%;
 `
 
 export const OrdersTitle = styled.h3`

--- a/src/cow-react/pages/LimitOrders/index.tsx
+++ b/src/cow-react/pages/LimitOrders/index.tsx
@@ -5,24 +5,29 @@ import {
   InfoPopup,
   MarketPriceUpdater,
   ActiveRateUpdater,
+  OrdersWidget,
+  limitOrdersAtom,
 } from '@cow/modules/limitOrders'
+import { useAtomValue } from 'jotai/utils'
+
 export default function LimitOrderPage() {
+  const { isUnlocked } = useAtomValue(limitOrdersAtom)
+
   return (
     <>
       <QuoteUpdater />
       <MarketPriceUpdater />
       <ActiveRateUpdater />
-      <styledEl.PageWrapper>
+      <styledEl.PageWrapper isUnlocked={isUnlocked}>
         <styledEl.PrimaryWrapper>
           <LimitOrdersWidget />
-          <InfoPopup />
+          {isUnlocked && <InfoPopup />}
         </styledEl.PrimaryWrapper>
 
-        {/*TODO: temporary hidden right part of the page until it's ready*/}
-        {/* <styledEl.SecondaryWrapper>
-          <ChartWidget />
-          <Orders />
-        </styledEl.SecondaryWrapper> */}
+        <styledEl.SecondaryWrapper>
+          {/*<ChartWidget />*/}
+          <OrdersWidget />
+        </styledEl.SecondaryWrapper>
       </styledEl.PageWrapper>
     </>
   )

--- a/src/cow-react/pages/LimitOrders/styled.ts
+++ b/src/cow-react/pages/LimitOrders/styled.ts
@@ -1,16 +1,25 @@
 import styled from 'styled-components/macro'
-export const PageWrapper = styled.div`
+
+export const PageWrapper = styled.div<{ isUnlocked: boolean }>`
   width: 100%;
   display: grid;
   max-width: ${({ theme }) => theme.appBody.maxWidth.limit};
   margin: 0 auto;
-  /* grid-template-columns: ${({ theme }) => theme.appBody.maxWidth.swap} 1fr; */
+  grid-template-columns: ${({ theme, isUnlocked }) => (isUnlocked ? theme.appBody.maxWidth.swap : '')} 1fr;
   grid-column-gap: 20px;
 
   ${({ theme }) => theme.mediaWidth.upToMedium`
     display: flex;
     flex-flow: column wrap;
+
+    > div:last-child {
+      margin: 20px;
+    }
   `};
+
+  > div:last-child {
+    display: ${({ isUnlocked }) => (isUnlocked ? '' : 'none')};
+  }
 `
 // Form + banner
 export const PrimaryWrapper = styled.div`


### PR DESCRIPTION
# Summary

1. Vertical alignment of content in the orders table:

<img width="848" alt="image" src="https://user-images.githubusercontent.com/7122625/202671867-d343b932-f0f0-4381-b490-8431760ede3c.png">

2. Fix the currency panel layout

![image](https://user-images.githubusercontent.com/7122625/202674049-01f112e6-fa08-4d55-9125-308b279ba7ee.png)

3. Display the orders table when Limit orders page is unlocked
4. Fix the orders list width for mobile view