### PR TITLE
Use Blocknative as source for Mainet gas-prices and update implementation

### DIFF
--- a/src/cow-react/api/gasPrices/index.ts
+++ b/src/cow-react/api/gasPrices/index.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
-import { SupportedChainId as ChainId } from 'constants/chains'
+import { SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
 import { GAS_FEE_ENDPOINTS, GAS_API_KEYS } from 'constants/index'
 
 // Values are returned as floats in gwei
@@ -38,6 +38,10 @@ class GasFeeApi {
     }
 
     return baseUrl
+  }
+
+  supportedChain(chainId: ChainId): boolean {
+    return !!GAS_FEE_ENDPOINTS[chainId]
   }
 
   getHeaders(chainId: ChainId): { headers?: Headers } {
@@ -102,11 +106,9 @@ class GasFeeApi {
   async fetchData(chainId: ChainId) {
     const url = this.getUrl(chainId)
     const headers = this.getHeaders(chainId)
-
     const response = await fetch(url, headers)
-    const json = await response.json()
 
-    return json
+    return response.json()
   }
 
   async getGasPrices(chainId: ChainId = DEFAULT_NETWORK_FOR_LISTS): Promise<GasFeeEndpointResponse> {

--- a/src/cow-react/api/gnosisProtocol/api.ts
+++ b/src/cow-react/api/gnosisProtocol/api.ts
@@ -32,7 +32,6 @@ import { getAppDataHash } from 'constants/appDataHash'
 import { Context } from '@sentry/types'
 import { PriceInformation, SimpleGetQuoteResponse } from '@cowprotocol/cow-sdk'
 import { GpPriceStrategy } from 'state/gas/atoms'
-import { BigNumber } from '@ethersproject/bignumber'
 
 function getGnosisProtocolUrl(): Partial<Record<ChainId, string>> {
   if (isLocal || isDev || isPr || isBarn) {
@@ -581,7 +580,6 @@ export async function getNativePrice(chainId: ChainId, address: string): Promise
 
 // Register some globals for convenience
 registerOnWindow({
-  BigNumber,
   operator: {
     getQuote,
     getTrades,

--- a/src/cow-react/api/gnosisProtocol/api.ts
+++ b/src/cow-react/api/gnosisProtocol/api.ts
@@ -8,7 +8,7 @@ import {
   SigningSchemeValue,
   UnsignedOrder,
 } from 'utils/signatures'
-import { APP_DATA_HASH, GAS_FEE_ENDPOINTS, RAW_CODE_LINK } from 'constants/index'
+import { APP_DATA_HASH, RAW_CODE_LINK } from 'constants/index'
 import { getProviderErrorMessage, registerOnWindow } from 'utils/misc'
 import { environmentName, isBarn, isDev, isLocal, isPr } from 'utils/environments'
 import OperatorError, {
@@ -25,7 +25,6 @@ import QuoteError, {
 import { toErc20Address, toNativeBuyAddress } from 'utils/tokens'
 import { LegacyFeeQuoteParams as FeeQuoteParams, LegacyPriceQuoteParams as PriceQuoteParams } from './legacy/types'
 
-import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
 import * as Sentry from '@sentry/browser'
 import { checkAndThrowIfJsonSerialisableError, constructSentryError } from 'utils/logging'
 import { ZERO_ADDRESS } from 'constants/misc'
@@ -33,6 +32,7 @@ import { getAppDataHash } from 'constants/appDataHash'
 import { Context } from '@sentry/types'
 import { PriceInformation, SimpleGetQuoteResponse } from '@cowprotocol/cow-sdk'
 import { GpPriceStrategy } from 'state/gas/atoms'
+import { BigNumber } from '@ethersproject/bignumber'
 
 function getGnosisProtocolUrl(): Partial<Record<ChainId, string>> {
   if (isLocal || isDev || isPr || isBarn) {
@@ -556,37 +556,6 @@ export interface GChainFeeEndpointResponse {
   fast: number
   slow: number
 }
-// Values are returned as floats in gwei
-const ONE_GWEI = 1_000_000_000
-
-export interface GasFeeEndpointResponse {
-  lastUpdate: string
-  lowest: string
-  safeLow?: string
-  standard: string
-  fast: string
-  fastest?: string
-}
-
-export async function getGasPrices(chainId: ChainId = DEFAULT_NETWORK_FOR_LISTS): Promise<GasFeeEndpointResponse> {
-  const response = await fetch(GAS_FEE_ENDPOINTS[chainId])
-  const json = await response.json()
-
-  if (chainId === ChainId.GNOSIS_CHAIN) {
-    // Different endpoint for GChain with a different format. Need to transform it
-    return _transformGChainGasPrices(json)
-  }
-  return json
-}
-
-function _transformGChainGasPrices({ slow, average, fast }: GChainFeeEndpointResponse): GasFeeEndpointResponse {
-  return {
-    lastUpdate: new Date().toISOString(),
-    lowest: Math.floor(slow * ONE_GWEI).toString(),
-    standard: Math.floor(average * ONE_GWEI).toString(),
-    fast: Math.floor(fast * ONE_GWEI).toString(),
-  }
-}
 
 export interface NativePrice {
   price: number
@@ -612,6 +581,7 @@ export async function getNativePrice(chainId: ChainId, address: string): Promise
 
 // Register some globals for convenience
 registerOnWindow({
+  BigNumber,
   operator: {
     getQuote,
     getTrades,

--- a/src/cow-react/api/gnosisProtocol/gasFeeApi.ts
+++ b/src/cow-react/api/gnosisProtocol/gasFeeApi.ts
@@ -1,0 +1,120 @@
+import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
+import { SupportedChainId as ChainId } from 'constants/chains'
+import { GAS_FEE_ENDPOINTS, GAS_API_KEYS } from 'constants/index'
+
+// Values are returned as floats in gwei
+const ONE_GWEI = 1_000_000_000
+
+export type GasFeeEndpointResponse = {
+  lastUpdate: string
+  average: number | null
+  fast: number | null
+  slow: number | null
+}
+
+export interface EstimatedPrice {
+  confidence: number
+  price: number
+  maxFeePerGas: number
+  maxPriorityFeePerGas: number
+}
+
+type GasPrices = Omit<GasFeeEndpointResponse, 'lastUpdate'>
+
+// Here the key is what we use in gas state and the value is confidence level
+// coming from the Blockscout api, so we map state values with confidence lvls
+const priceMap: GasPrices = {
+  fast: 99,
+  average: 90,
+  slow: 70,
+}
+
+class GasFeeApi {
+  getUrl(chainId: ChainId) {
+    const baseUrl = GAS_FEE_ENDPOINTS[chainId]
+
+    if (chainId !== ChainId.GNOSIS_CHAIN) {
+      return `${baseUrl}?chainId=${chainId}`
+    }
+
+    return baseUrl
+  }
+
+  getHeaders(chainId: ChainId) {
+    const headers: any = {}
+    const apiKey = GAS_API_KEYS[chainId] || ''
+
+    if (chainId !== ChainId.GNOSIS_CHAIN) {
+      headers.headers = new Headers({
+        Authorization: apiKey,
+      })
+    }
+
+    return headers
+  }
+
+  toWei(input: number | null) {
+    if (!input) {
+      return null
+    }
+
+    return Math.floor(input * ONE_GWEI).toString()
+  }
+
+  getBlocknativePrice(data: EstimatedPrice[], lvl: number | null) {
+    if (!data || !lvl) {
+      return null
+    }
+
+    const price = data.find(({ confidence }: EstimatedPrice) => lvl === confidence)?.price
+
+    return price || null
+  }
+
+  parseData(json: any, chainId: ChainId) {
+    const output: any = {
+      lastUpdate: new Date().toISOString(),
+      fast: null,
+      average: null,
+      slow: null,
+    }
+
+    // Parse data for Gnosis chain (from Blockscout)
+    if (chainId === ChainId.GNOSIS_CHAIN) {
+      for (const key of Object.keys(priceMap)) {
+        output[key] = this.toWei(json[key])
+      }
+    } else {
+      // Parse data for other chains (from Blocknative)
+      const prices = json?.blockPrices[0]?.estimatedPrices
+
+      if (prices) {
+        for (const [key, value] of Object.entries(priceMap)) {
+          const price = this.getBlocknativePrice(prices, value)
+          output[key] = this.toWei(price)
+        }
+      }
+    }
+
+    return output
+  }
+
+  async fetchData(chainId: ChainId) {
+    const url = this.getUrl(chainId)
+    const headers = this.getHeaders(chainId)
+
+    const response = await fetch(url, headers)
+    const json = await response.json()
+
+    return json
+  }
+
+  async getGasPrices(chainId: ChainId = DEFAULT_NETWORK_FOR_LISTS) {
+    const data = await this.fetchData(chainId)
+    const parsed = this.parseData(data, chainId)
+
+    return parsed
+  }
+}
+
+export const gasFeeApi = new GasFeeApi()

--- a/src/cow-react/modules/swap/containers/EthFlow/hooks/useRemainingNativeTxsAndCosts.ts
+++ b/src/cow-react/modules/swap/containers/EthFlow/hooks/useRemainingNativeTxsAndCosts.ts
@@ -18,7 +18,7 @@ export function _estimateTxCost(gasPrice: ReturnType<typeof useGasPrices>, nativ
   }
   // TODO: should use DEFAULT_GAS_FEE from backup source
   // when/if implemented
-  const gas = gasPrice?.standard || DEFAULT_GAS_FEE
+  const gas = gasPrice?.average || DEFAULT_GAS_FEE
 
   const amount = BigNumber.from(gas).mul(MINIMUM_TXS).mul(AVG_APPROVE_COST_GWEI)
 

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -124,23 +124,18 @@ export const GNOSIS_FORUM_ROADTODECENT_LINK = 'https://forum.gnosis.io/t/gpv2-ro
 export const MEV_TOTAL = '606 Million'
 export const FLASHBOTS_LINK = 'https://explore.flashbots.net/'
 
-//  10 seconds
-export const GAS_PRICE_UPDATE_THRESHOLD = 10 * 1000
+export const GAS_PRICE_UPDATE_THRESHOLD = ms`5s`
 export const GAS_FEE_ENDPOINTS = {
   [ChainId.MAINNET]: 'https://api.blocknative.com/gasprices/blockprices',
-  // No ropsten = main
-  // [ChainId.ROPSTEN]: 'https://safe-relay.gnosis.io/api/v1/gas-station/',
-  [ChainId.RINKEBY]: 'https://api.blocknative.com/gasprices/blockprices', // not actually supported
-  [ChainId.GOERLI]: 'https://api.blocknative.com/gasprices/blockprices', // not actually supported
-  // no kovan = main
-  // [ChainId.KOVAN]: 'https://safe-relay.kovan.gnosis.io/api/v1/gas-station/',
   [ChainId.GNOSIS_CHAIN]: 'https://blockscout.com/xdai/mainnet/api/v1/gas-price-oracle',
+  [ChainId.RINKEBY]: '',
+  [ChainId.GOERLI]: '',
 }
 export const GAS_API_KEYS = {
   [ChainId.MAINNET]: process.env.REACT_APP_BLOCKNATIVE_API_KEY,
-  [ChainId.RINKEBY]: process.env.REACT_APP_BLOCKNATIVE_API_KEY,
-  [ChainId.GOERLI]: process.env.REACT_APP_BLOCKNATIVE_API_KEY,
   [ChainId.GNOSIS_CHAIN]: '',
+  [ChainId.RINKEBY]: '',
+  [ChainId.GOERLI]: '',
 }
 
 export const UNSUPPORTED_TOKENS_FAQ_URL = '/faq/trading#what-token-pairs-does-cowswap-allow-to-trade'

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -124,17 +124,23 @@ export const GNOSIS_FORUM_ROADTODECENT_LINK = 'https://forum.gnosis.io/t/gpv2-ro
 export const MEV_TOTAL = '606 Million'
 export const FLASHBOTS_LINK = 'https://explore.flashbots.net/'
 
-// 30 minutes
-export const GAS_PRICE_UPDATE_THRESHOLD = 30 * 60 * 1000
+//  10 seconds
+export const GAS_PRICE_UPDATE_THRESHOLD = 10 * 1000
 export const GAS_FEE_ENDPOINTS = {
-  [ChainId.MAINNET]: 'https://safe-relay.gnosis.io/api/v1/gas-station/',
+  [ChainId.MAINNET]: 'https://api.blocknative.com/gasprices/blockprices',
   // No ropsten = main
   // [ChainId.ROPSTEN]: 'https://safe-relay.gnosis.io/api/v1/gas-station/',
-  [ChainId.RINKEBY]: 'https://safe-relay.rinkeby.gnosis.io/api/v1/gas-station/',
-  [ChainId.GOERLI]: 'https://safe-relay.goerli.gnosis.io/api/v1/gas-station/',
+  [ChainId.RINKEBY]: 'https://api.blocknative.com/gasprices/blockprices', // not actually supported
+  [ChainId.GOERLI]: 'https://api.blocknative.com/gasprices/blockprices', // not actually supported
   // no kovan = main
   // [ChainId.KOVAN]: 'https://safe-relay.kovan.gnosis.io/api/v1/gas-station/',
   [ChainId.GNOSIS_CHAIN]: 'https://blockscout.com/xdai/mainnet/api/v1/gas-price-oracle',
+}
+export const GAS_API_KEYS = {
+  [ChainId.MAINNET]: process.env.REACT_APP_BLOCKNATIVE_API_KEY,
+  [ChainId.RINKEBY]: process.env.REACT_APP_BLOCKNATIVE_API_KEY,
+  [ChainId.GOERLI]: process.env.REACT_APP_BLOCKNATIVE_API_KEY,
+  [ChainId.GNOSIS_CHAIN]: '',
 }
 
 export const UNSUPPORTED_TOKENS_FAQ_URL = '/faq/trading#what-token-pairs-does-cowswap-allow-to-trade'

--- a/src/custom/state/gas/actions.ts
+++ b/src/custom/state/gas/actions.ts
@@ -1,6 +1,6 @@
 import { createAction } from '@reduxjs/toolkit'
 import { WithChainId } from '../lists/actions'
-import { GasFeeEndpointResponse } from '@cow/api/gnosisProtocol/gasFeeApi'
+import { GasFeeEndpointResponse } from '@cow/api/gasPrices'
 
 export type UpdateGasPrices = GasFeeEndpointResponse & WithChainId
 

--- a/src/custom/state/gas/actions.ts
+++ b/src/custom/state/gas/actions.ts
@@ -1,6 +1,6 @@
 import { createAction } from '@reduxjs/toolkit'
 import { WithChainId } from '../lists/actions'
-import { GasFeeEndpointResponse } from '@cow/api/gnosisProtocol/api'
+import { GasFeeEndpointResponse } from '@cow/api/gnosisProtocol/gasFeeApi'
 
 export type UpdateGasPrices = GasFeeEndpointResponse & WithChainId
 

--- a/src/custom/state/gas/reducer.ts
+++ b/src/custom/state/gas/reducer.ts
@@ -15,8 +15,6 @@ export default createReducer(initialState, (builder) =>
     if (chainId) {
       state[chainId] = {
         ...rest,
-        // We don't use the last update of the endpoint, we use the one of the client time
-        lastUpdate: new Date().toISOString(),
       }
     }
   })

--- a/src/custom/state/gas/updater.tsx
+++ b/src/custom/state/gas/updater.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { useGasPrices, useUpdateGasPrices } from './hooks'
 import { useWeb3React } from '@web3-react/core'
 import { GAS_PRICE_UPDATE_THRESHOLD } from 'constants/index'
-import { gasFeeApi } from '@cow/api/gnosisProtocol/gasFeeApi'
+import { gasFeeApi } from '@cow/api/gasPrices'
 import useBlockNumber from '@src/lib/hooks/useBlockNumber'
 
 function needsGasUpdate(now: number, lastUpdated: number, threshold: number) {
@@ -22,7 +22,7 @@ export default function GasUpdater(): null {
 
     // if no gas in local/redux state OR time threshold has passed
     // since last update, and there is a chainId, then update the gas prices
-    if (shouldUpdate && chainId) {
+    if (shouldUpdate && chainId && gasFeeApi.supportedChain(chainId)) {
       gasFeeApi
         .getGasPrices(chainId)
         .then((gas) => {

--- a/src/custom/state/gas/updater.tsx
+++ b/src/custom/state/gas/updater.tsx
@@ -2,7 +2,8 @@ import { useEffect } from 'react'
 import { useGasPrices, useUpdateGasPrices } from './hooks'
 import { useWeb3React } from '@web3-react/core'
 import { GAS_PRICE_UPDATE_THRESHOLD } from 'constants/index'
-import { getGasPrices } from '@cow/api/gnosisProtocol/api'
+import { gasFeeApi } from '@cow/api/gnosisProtocol/gasFeeApi'
+import useBlockNumber from '@src/lib/hooks/useBlockNumber'
 
 function needsGasUpdate(now: number, lastUpdated: number, threshold: number) {
   return now - lastUpdated > threshold
@@ -12,15 +13,18 @@ export default function GasUpdater(): null {
   const { chainId } = useWeb3React()
   const gas = useGasPrices(chainId)
   const updateGasPrices = useUpdateGasPrices()
+  const blockNumber = useBlockNumber()
 
   useEffect(() => {
     const now = Date.now()
     const updated = gas ? Date.parse(gas.lastUpdate) : null
+    const shouldUpdate = !updated || needsGasUpdate(now, updated, GAS_PRICE_UPDATE_THRESHOLD)
 
     // if no gas in local/redux state OR time threshold has passed
-    // since last update, then:
-    if (!updated || needsGasUpdate(now, updated, GAS_PRICE_UPDATE_THRESHOLD)) {
-      getGasPrices(chainId)
+    // since last update, and there is a chainId, then update the gas prices
+    if (shouldUpdate && chainId) {
+      gasFeeApi
+        .getGasPrices(chainId)
         .then((gas) => {
           updateGasPrices({
             ...gas,
@@ -30,7 +34,7 @@ export default function GasUpdater(): null {
         // on error we log and keep state as it was
         .catch(console.error)
     }
-  }, [chainId, gas, updateGasPrices])
+  }, [chainId, gas, blockNumber, updateGasPrices])
 
   return null
 }


### PR DESCRIPTION
# Summary

In this PR
- we change gas prices API to use **Blocknative** for **Mainnet**
- the gas state structure will now have "fast, average, slow" properties same as response from **Blockscout** for **GC**
- we map the gas price confidence levels from Blocknative to our gas state properties `fast: 99, average: 90, slow: 70,`
- the gas price should now be updated every 10 seconds (if that is ok?)