### PR TITLE
Fix offline issue

### DIFF
--- a/src/cow-react/utils/request.ts
+++ b/src/cow-react/utils/request.ts
@@ -1,0 +1,5 @@
+export const getTimeoutAbortController = (timeMilliseconds: number) => {
+  const controller = new AbortController()
+  setTimeout(() => controller.abort(), timeMilliseconds)
+  return controller
+}

--- a/src/custom/hooks/useIsOnline.ts
+++ b/src/custom/hooks/useIsOnline.ts
@@ -2,8 +2,8 @@ import { useCallback, useEffect, useState } from 'react'
 import { getTimeoutAbortController } from '@cow/utils/request'
 import ms from 'ms.macro'
 
-const CONNECTIVITY_CHECK_POLLING_TIME = ms`5s`
-const CONNECTIVITY_CHECK_TIMEOUT = ms`10s`
+const CONNECTIVITY_CHECK_POLLING_TIME = ms`30s`
+const CONNECTIVITY_CHECK_TIMEOUT = ms`15s`
 const IS_SUPPORTED = navigator.onLine !== undefined
 
 export function isOnline() {

--- a/src/custom/hooks/useIsOnline.ts
+++ b/src/custom/hooks/useIsOnline.ts
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useState } from 'react'
+import { getTimeoutAbortController } from '@cow/utils/request'
+import ms from 'ms.macro'
 
+const CONNECTIVITY_CHECK_POLLING_TIME = ms`5s`
+const CONNECTIVITY_CHECK_TIMEOUT = ms`10s`
 const IS_SUPPORTED = navigator.onLine !== undefined
 
 export function isOnline() {
@@ -7,15 +11,70 @@ export function isOnline() {
 }
 
 /**
+ * Checks if there is network connectivity.
+ * Relying on navigator.onLine is not enough, as empirically saw with some user complaints.
+ * There's some threads with Chrome experiencing this issue, see https://dev.to/maxmonteil/is-your-app-online-here-s-how-to-reliably-know-in-just-10-lines-of-js-guide-3in7
+ *
+ * This method runs a test of doing a HEAD HTTP request
+ *
+ *
+ * @returns true if we have connectivity, false otherwise
+ */
+export async function hasConnectivity(): Promise<boolean> {
+  try {
+    const response = await fetch(window.location.origin, {
+      method: 'HEAD',
+      signal: getTimeoutAbortController(CONNECTIVITY_CHECK_TIMEOUT).signal,
+    })
+    return response.ok
+  } catch {
+    return false
+  }
+}
+
+/**
  * Returns whether the window is currently visible to the user.
  */
 export default function useIsOnline(): boolean {
   const [online, setOnline] = useState<boolean>(isOnline())
+
+  // Double-check if we REALLY don't have connectivity when the browser says so (There's cases where `online = false` flag might be not true)
+  useEffect(() => {
+    let isCancelled = false
+
+    async function checkConnectivity() {
+      const connected = await hasConnectivity()
+
+      if (isCancelled) {
+        // Discard theconnectivity check result
+        return
+      }
+
+      if (connected) {
+        // The browser reports offline, but we observe we are online
+        setOnline(true)
+      } else {
+        // Schedule a test for later
+        setTimeout(checkConnectivity, CONNECTIVITY_CHECK_POLLING_TIME)
+      }
+    }
+
+    if (!online) {
+      checkConnectivity()
+    }
+
+    return function cleanup() {
+      isCancelled = true
+    }
+  }, [online])
+
+  // Update the online status purely base on the browser info
   const updateOnlineState = useCallback(() => {
     const onlineNew = isOnline()
     setOnline(onlineNew)
   }, [setOnline])
 
+  // Subscribe to changes of online/offline status
   useEffect(() => {
     window.addEventListener('online', updateOnlineState)
     window.addEventListener('offline', updateOnlineState)


### PR DESCRIPTION
# Summary

Fix to the false claims we get sometimes from the browser saying is offline.

Before this PR we relied only on `window.navigator.onLine`

This PR introduces:
- A check of connectivity when the browser says is offline
- This check is basically a HEAD HTTP request
- The request has a timeout of 15s (after this time, it assumes is offline)
- It will do re-attempts to check the network state every 30s if the browser is still offline

# To Test
TODO, I will add more details