### PR TITLE
[EthFlow]#1293 connect stepper happy path

### DIFF
--- a/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
@@ -1,17 +1,17 @@
 import {
   EthFlowStepper as Pure,
-  EthFlowStepperProps,
+  EthFlowStepperProps as PureProps,
   SmartOrderStatus,
 } from '@cow/modules/swap/pure/EthFlow/EthFlowStepper'
 import { useDetectNativeToken } from '@cow/modules/swap/hooks/useDetectNativeToken'
 import { Order } from 'state/orders/actions'
 import { NATIVE_CURRENCY_BUY_ADDRESS } from 'constants/index'
 
-type Props = {
+type EthFlowStepperProps = {
   storeOrder: Order | undefined
 }
 
-export function EthFlowStepper(props: Props) {
+export function EthFlowStepper(props: EthFlowStepperProps) {
   const { storeOrder } = props
   const { native } = useDetectNativeToken()
 
@@ -22,7 +22,7 @@ export function EthFlowStepper(props: Props) {
     return null
   }
 
-  const stepperProps: EthFlowStepperProps = {
+  const stepperProps: PureProps = {
     nativeTokenSymbol: native.symbol as string,
     tokenLabel: storeOrder.outputToken.symbol as string,
     order: {

--- a/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
@@ -6,6 +6,7 @@ import {
 import { useDetectNativeToken } from '@cow/modules/swap/hooks/useDetectNativeToken'
 import { Order } from 'state/orders/actions'
 import { NATIVE_CURRENCY_BUY_ADDRESS } from 'constants/index'
+import { safeTokenName } from '@cowprotocol/cow-js'
 
 type EthFlowStepperProps = {
   order: Order | undefined
@@ -24,7 +25,7 @@ export function EthFlowStepper(props: EthFlowStepperProps) {
 
   const stepperProps: PureProps = {
     nativeTokenSymbol: native.symbol as string,
-    tokenLabel: order.outputToken.symbol as string,
+    tokenLabel: safeTokenName(order.outputToken),
     order: {
       // The creation hash is only available in the device where the order is placed
       createOrderTx: order.orderCreationHash || '',

--- a/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
@@ -69,8 +69,5 @@ function mapOrderToEthFlowStepperState(order: Order | undefined): SmartOrderStat
 
 // TODO: move this somewhere else?
 function getIsEthFlowOrder(order: Order | undefined): boolean | undefined {
-  if (!order) {
-    return undefined
-  }
-  return order.inputToken.address === NATIVE_CURRENCY_BUY_ADDRESS
+  return order?.inputToken.address === NATIVE_CURRENCY_BUY_ADDRESS
 }

--- a/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
@@ -1,4 +1,8 @@
-import { EthFlowStepper as Pure, SmartOrderStatus } from '@cow/modules/swap/pure/EthFlow/EthFlowStepper'
+import {
+  EthFlowStepper as Pure,
+  EthFlowStepperProps,
+  SmartOrderStatus,
+} from '@cow/modules/swap/pure/EthFlow/EthFlowStepper'
 import { useDetectNativeToken } from '@cow/modules/swap/hooks/useDetectNativeToken'
 import { Order } from 'state/orders/actions'
 import { NATIVE_CURRENCY_BUY_ADDRESS } from 'constants/index'
@@ -18,39 +22,30 @@ export function EthFlowStepper(props: Props) {
     return null
   }
 
-  const nativeTokenSymbol = native.symbol as string
-  const tokenLabel = storeOrder.outputToken.symbol as string
-
-  const order = {
-    // The creation hash is only available in the device where the order is placed
-    createOrderTx: storeOrder.orderCreationHash || '',
-    orderId: storeOrder.id,
-    state,
-    isExpired: storeOrder.status === 'expired',
-    // rejectedReason?: TODO: address when dealing with rejections
+  const stepperProps: EthFlowStepperProps = {
+    nativeTokenSymbol: native.symbol as string,
+    tokenLabel: storeOrder.outputToken.symbol as string,
+    order: {
+      // The creation hash is only available in the device where the order is placed
+      createOrderTx: storeOrder.orderCreationHash || '',
+      orderId: storeOrder.id,
+      state,
+      isExpired: storeOrder.status === 'expired',
+      // rejectedReason?: TODO: address when dealing with rejections
+    },
+    // TODO: fill these in when dealing with rejections
+    refund: {
+      // refundTx?: string
+      isRefunded: false,
+    },
+    // TODO: fill these in when dealing with cancellations
+    cancelation: {
+      // cancelationTx?: string
+      isCanceled: false,
+    },
   }
 
-  // TODO: fill these in when dealing with rejections
-  const refund = {
-    // refundTx?: string
-    isRefunded: false,
-  }
-
-  // TODO: fill these in when dealing with cancellations
-  const cancelation = {
-    // cancelationTx?: string
-    isCanceled: false,
-  }
-
-  return (
-    <Pure
-      nativeTokenSymbol={nativeTokenSymbol}
-      tokenLabel={tokenLabel}
-      order={order}
-      refund={refund}
-      cancelation={cancelation}
-    />
-  )
+  return <Pure {...stepperProps} />
 }
 
 function mapOrderToEthFlowStepperState(order: Order | undefined): SmartOrderStatus | undefined {

--- a/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
@@ -60,7 +60,7 @@ function mapOrderToEthFlowStepperState(order: Order | undefined): SmartOrderStat
   } else if (order.status === 'fulfilled') {
     return SmartOrderStatus.FILLED
   }
-  return
+  return undefined
 }
 
 // TODO: move this somewhere else?

--- a/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
@@ -8,29 +8,29 @@ import { Order } from 'state/orders/actions'
 import { NATIVE_CURRENCY_BUY_ADDRESS } from 'constants/index'
 
 type EthFlowStepperProps = {
-  storeOrder: Order | undefined
+  order: Order | undefined
 }
 
 export function EthFlowStepper(props: EthFlowStepperProps) {
-  const { storeOrder } = props
+  const { order } = props
   const { native } = useDetectNativeToken()
 
-  const state = mapOrderToEthFlowStepperState(storeOrder)
-  const isEthFlowOrder = getIsEthFlowOrder(storeOrder)
+  const state = mapOrderToEthFlowStepperState(order)
+  const isEthFlowOrder = getIsEthFlowOrder(order)
 
-  if (!storeOrder || !state || !isEthFlowOrder) {
+  if (!order || !state || !isEthFlowOrder) {
     return null
   }
 
   const stepperProps: PureProps = {
     nativeTokenSymbol: native.symbol as string,
-    tokenLabel: storeOrder.outputToken.symbol as string,
+    tokenLabel: order.outputToken.symbol as string,
     order: {
       // The creation hash is only available in the device where the order is placed
-      createOrderTx: storeOrder.orderCreationHash || '',
-      orderId: storeOrder.id,
+      createOrderTx: order.orderCreationHash || '',
+      orderId: order.id,
       state,
-      isExpired: storeOrder.status === 'expired',
+      isExpired: order.status === 'expired',
       // rejectedReason?: TODO: address when dealing with rejections
     },
     // TODO: fill these in when dealing with rejections

--- a/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
@@ -1,0 +1,76 @@
+import { EthFlowStepper as Pure, SmartOrderStatus } from '@cow/modules/swap/pure/EthFlow/EthFlowStepper'
+import { useDetectNativeToken } from '@cow/modules/swap/hooks/useDetectNativeToken'
+import { Order } from 'state/orders/actions'
+import { NATIVE_CURRENCY_BUY_ADDRESS } from 'constants/index'
+
+type Props = {
+  storeOrder: Order | undefined
+}
+
+export function EthFlowStepper(props: Props) {
+  const { storeOrder } = props
+  const { native } = useDetectNativeToken()
+
+  const state = mapOrderToEthFlowStepperState(storeOrder)
+  const isEthFlowOrder = getIsEthFlowOrder(storeOrder)
+
+  if (!storeOrder || !state || !isEthFlowOrder) {
+    return null
+  }
+
+  const nativeTokenSymbol = native.symbol as string
+  const tokenLabel = storeOrder.outputToken.symbol as string
+
+  const order = {
+    // The creation hash is only available in the device where the order is placed
+    createOrderTx: storeOrder.orderCreationHash || '',
+    orderId: storeOrder.id,
+    state,
+    isExpired: storeOrder.status === 'expired',
+    // rejectedReason?: TODO: address when dealing with rejections
+  }
+
+  // TODO: fill these in when dealing with rejections
+  const refund = {
+    // refundTx?: string
+    isRefunded: false,
+  }
+
+  // TODO: fill these in when dealing with cancellations
+  const cancelation = {
+    // cancelationTx?: string
+    isCanceled: false,
+  }
+
+  return (
+    <Pure
+      nativeTokenSymbol={nativeTokenSymbol}
+      tokenLabel={tokenLabel}
+      order={order}
+      refund={refund}
+      cancelation={cancelation}
+    />
+  )
+}
+
+function mapOrderToEthFlowStepperState(order: Order | undefined): SmartOrderStatus | undefined {
+  // NOTE: not returning `CREATED` as we currently don't track the initial tx execution
+  if (!order) {
+    return
+  } else if (order.status === 'creating') {
+    return SmartOrderStatus.CREATING
+  } else if (order.status === 'pending') {
+    return SmartOrderStatus.INDEXED
+  } else if (order.status === 'fulfilled') {
+    return SmartOrderStatus.FILLED
+  }
+  return
+}
+
+// TODO: move this somewhere else?
+function getIsEthFlowOrder(order: Order | undefined): boolean | undefined {
+  if (!order) {
+    return undefined
+  }
+  return order.inputToken.address === NATIVE_CURRENCY_BUY_ADDRESS
+}

--- a/src/custom/components/AccountDetails/Transaction/ActivityDetails.tsx
+++ b/src/custom/components/AccountDetails/Transaction/ActivityDetails.tsx
@@ -298,7 +298,7 @@ export function ActivityDetails(props: {
           </ActivityLink>
         )}
         <GnosisSafeTxDetails chainId={chainId} activityDerivedState={activityDerivedState} />
-        <EthFlowStepper storeOrder={order} />
+        <EthFlowStepper order={order} />
         {showProgressBar && (
           <OrderProgressBar activityDerivedState={activityDerivedState} chainId={chainId} hideWhenFinished={true} />
         )}

--- a/src/custom/components/AccountDetails/Transaction/ActivityDetails.tsx
+++ b/src/custom/components/AccountDetails/Transaction/ActivityDetails.tsx
@@ -25,6 +25,7 @@ import { useToken } from 'hooks/Tokens'
 import { ActivityStatus } from 'hooks/useRecentActivity'
 import { getActivityState } from 'hooks/useActivityDerivedState'
 import { V_COW, COW } from 'constants/tokens'
+import { EthFlowStepper } from '@cow/modules/swap/containers/EthFlowStepper'
 
 const DEFAULT_ORDER_SUMMARY = {
   from: '',
@@ -151,6 +152,7 @@ export function ActivityDetails(props: {
   const tokenAddress =
     enhancedTransaction?.approval?.tokenAddress || (enhancedTransaction?.claim && V_COW_CONTRACT_ADDRESS[chainId])
   const singleToken = useToken(tokenAddress) || null
+
   const showProgressBar = (activityState === 'open' || activityState === 'filled') && order?.class !== 'limit'
 
   if (!order && !enhancedTransaction) return null
@@ -296,6 +298,7 @@ export function ActivityDetails(props: {
           </ActivityLink>
         )}
         <GnosisSafeTxDetails chainId={chainId} activityDerivedState={activityDerivedState} />
+        <EthFlowStepper storeOrder={order} />
         {showProgressBar && (
           <OrderProgressBar activityDerivedState={activityDerivedState} chainId={chainId} hideWhenFinished={true} />
         )}

--- a/src/custom/components/TransactionConfirmationModal/index.tsx
+++ b/src/custom/components/TransactionConfirmationModal/index.tsx
@@ -27,6 +27,7 @@ import AddToMetamask from 'components/AddToMetamask' // mod
 import { supportedChainId } from 'utils/supportedChainId'
 import { useOrder } from 'state/orders/hooks'
 import { OrderStatus } from 'state/orders/actions'
+import { EthFlowStepper } from '@cow/modules/swap/containers/EthFlowStepper'
 
 const Wrapper = styled.div`
   width: 100%;
@@ -527,6 +528,7 @@ export function TransactionSubmittedContent({
   const activityDerivedState = useActivityDerivedState({ chainId, activity: activities[0] })
   const activityState = activityDerivedState && getActivityState(activityDerivedState)
   const showProgressBar = activityState === 'open' || activityState === 'filled'
+  const { order } = activityDerivedState || {}
 
   if (!supportedChainId(chainId)) {
     return null
@@ -540,6 +542,7 @@ export function TransactionSubmittedContent({
           {getTitleStatus(activityDerivedState)}
         </Text>
         <DisplayLink id={hash} chainId={chainId} />
+        <EthFlowStepper storeOrder={order} />
         {activityDerivedState && showProgressBar && (
           <OrderProgressBar activityDerivedState={activityDerivedState} chainId={chainId} />
         )}

--- a/src/custom/components/TransactionConfirmationModal/index.tsx
+++ b/src/custom/components/TransactionConfirmationModal/index.tsx
@@ -542,7 +542,7 @@ export function TransactionSubmittedContent({
           {getTitleStatus(activityDerivedState)}
         </Text>
         <DisplayLink id={hash} chainId={chainId} />
-        <EthFlowStepper storeOrder={order} />
+        <EthFlowStepper order={order} />
         {activityDerivedState && showProgressBar && (
           <OrderProgressBar activityDerivedState={activityDerivedState} chainId={chainId} />
         )}


### PR DESCRIPTION
# Summary

Closes #1293 

Adding EthFlow stepper to Activity details and Confirmation modal

![Screen Shot 2022-11-22 at 15 05 06](https://user-images.githubusercontent.com/43217/203348455-235ce680-be5c-4297-a1f1-64027134f172.png)
![Screen Shot 2022-11-22 at 15 04 53](https://user-images.githubusercontent.com/43217/203348465-71a0ae11-557e-491d-b889-0ae3a6930504.png)

**Note:** Definitely NOT pretty! Out of the scope of this task
**Note:** Expiration and cancellation NOT yet supported!

# To Test

1. Turn on ethflow with `localStorage.setItem('enableEthFlow', '1')`
2. Place ETH sell order
* Confirmation modal should show stepper
* Activity details should show stepper

# Background

