### PR TITLE
Handle Unknown WETH for current network

### DIFF
--- a/src/cow-react/pages/NewSwap/index.tsx
+++ b/src/cow-react/pages/NewSwap/index.tsx
@@ -19,7 +19,7 @@ export function NewSwapPageRedirect({ location }: RouteComponentProps) {
 
   const defaultState = getDefaultTradeState(chainId)
   const searchParams = new URLSearchParams(location.search)
-  const inputCurrencyId = searchParams.get('inputCurrency') || defaultState.inputCurrencyId || WETH[chainId].symbol
+  const inputCurrencyId = searchParams.get('inputCurrency') || defaultState.inputCurrencyId || WETH[chainId]?.symbol
   const outputCurrencyId = searchParams.get('outputCurrency') || defaultState.outputCurrencyId || undefined
 
   searchParams.delete('inputCurrency')


### PR DESCRIPTION
# Summary
Fixes #1458

Basically, the new Swap redirection was making the assumption we have defined the WETH address for all networks. 


# To Test
- Reproduce the steps from Elena described in #1458
- No crash now