### PR TITLE
[EthFlow]#1293 stepper expired orders

### DIFF
--- a/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
@@ -53,16 +53,17 @@ const STEPPER_INDEXED_ORDER_STATUS: OrderStatus[] = [OrderStatus.PENDING, OrderS
 
 function mapOrderToEthFlowStepperState(order: Order | undefined): SmartOrderStatus | undefined {
   // NOTE: not returning `CREATED` as we currently don't track the initial tx execution
-  const { status } = order || {}
 
-  if (!status) {
-    return
-  } else if (status === 'creating') {
-    return SmartOrderStatus.CREATING
-  } else if (STEPPER_INDEXED_ORDER_STATUS.includes(status)) {
-    return SmartOrderStatus.INDEXED
-  } else if (status === 'fulfilled') {
-    return SmartOrderStatus.FILLED
+  if (order) {
+    const { status } = order
+
+    if (status === 'creating') {
+      return SmartOrderStatus.CREATING
+    } else if (STEPPER_INDEXED_ORDER_STATUS.includes(status)) {
+      return SmartOrderStatus.INDEXED
+    } else if (status === 'fulfilled') {
+      return SmartOrderStatus.FILLED
+    }
   }
   return undefined
 }

--- a/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
@@ -49,7 +49,7 @@ export function EthFlowStepper(props: EthFlowStepperProps) {
   return <Pure {...stepperProps} />
 }
 
-const STEPPER_INDEXED_ORDER_STATUS: OrderStatus[] = [OrderStatus.PENDING, OrderStatus.EXPIRED, OrderStatus.CANCELLED]
+const ORDER_INDEXED_STATUSES: OrderStatus[] = [OrderStatus.PENDING, OrderStatus.EXPIRED, OrderStatus.CANCELLED]
 
 function mapOrderToEthFlowStepperState(order: Order | undefined): SmartOrderStatus | undefined {
   // NOTE: not returning `CREATED` as we currently don't track the initial tx execution
@@ -59,7 +59,7 @@ function mapOrderToEthFlowStepperState(order: Order | undefined): SmartOrderStat
 
     if (status === 'creating') {
       return SmartOrderStatus.CREATING
-    } else if (STEPPER_INDEXED_ORDER_STATUS.includes(status)) {
+    } else if (ORDER_INDEXED_STATUSES.includes(status)) {
       return SmartOrderStatus.INDEXED
     } else if (status === 'fulfilled') {
       return SmartOrderStatus.FILLED

--- a/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
@@ -4,7 +4,7 @@ import {
   SmartOrderStatus,
 } from '@cow/modules/swap/pure/EthFlow/EthFlowStepper'
 import { useDetectNativeToken } from '@cow/modules/swap/hooks/useDetectNativeToken'
-import { Order } from 'state/orders/actions'
+import { Order, OrderStatus } from 'state/orders/actions'
 import { NATIVE_CURRENCY_BUY_ADDRESS } from 'constants/index'
 import { safeTokenName } from '@cowprotocol/cow-js'
 
@@ -49,15 +49,19 @@ export function EthFlowStepper(props: EthFlowStepperProps) {
   return <Pure {...stepperProps} />
 }
 
+const STEPPER_INDEXED_ORDER_STATUS: OrderStatus[] = [OrderStatus.PENDING, OrderStatus.EXPIRED, OrderStatus.CANCELLED]
+
 function mapOrderToEthFlowStepperState(order: Order | undefined): SmartOrderStatus | undefined {
   // NOTE: not returning `CREATED` as we currently don't track the initial tx execution
-  if (!order) {
+  const { status } = order || {}
+
+  if (!status) {
     return
-  } else if (order.status === 'creating') {
+  } else if (status === 'creating') {
     return SmartOrderStatus.CREATING
-  } else if (order.status === 'pending') {
+  } else if (STEPPER_INDEXED_ORDER_STATUS.includes(status)) {
     return SmartOrderStatus.INDEXED
-  } else if (order.status === 'fulfilled') {
+  } else if (status === 'fulfilled') {
     return SmartOrderStatus.FILLED
   }
   return undefined

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowBanner/index.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowBanner/index.tsx
@@ -57,7 +57,9 @@ export function EthFlowBannerContent(props: EthFlowBannerContentProps) {
             </p>
             <ul>
               <li>Lower overall fees</li>
-              <li>Lower default slippage (instead of {ETH_FLOW_SLIPPAGE.toSignificant(PERCENTAGE_PRECISION)}%)</li>
+              <li>
+                Lower default slippage (instead of {ETH_FLOW_SLIPPAGE.toSignificant(PERCENTAGE_PRECISION)}% minimum)
+              </li>
               <li>No fees for failed transactions</li>
             </ul>
             <Separator />


### PR DESCRIPTION
# Summary

Follow up to https://github.com/cowprotocol/cowswap/pull/1465
Closes #1293 

(Partially) handling expiration

You can now see the stepper for expired orders, but there's no action possible

![Screen Shot 2022-11-23 at 16 50 56](https://user-images.githubusercontent.com/43217/203606269-bc41da25-303a-4e28-afb0-67c689ae0bf3.png)

The refunding will never complete.

# To Test

1. Turn on ethflow with localStorage.setItem('enableEthFlow', '1')
2. Place ETH sell order
3. Make it expire - not very straight forward. See notes at the bottom
* Order will be seen as expired like screenshot above

Alternatively, you can use impersonator.xyz/ to impersonate my account (check [this](https://protocol-explorer.dev.gnosisdev.com/goerli/orders/0xdfe9b9ca80c54d655ac68121c04e0bfac9bf01d3a631fa71a9e051b9d6a6071976aaf674848311c7f21fc691b0b952f016da49f3ffffffff) expired order)

## Expire order
1. In two browser windows, connect with the same account
2. In one window, place and order to buy token X with another ERC20
3. VERY quickly in another window, place an order to buy same token X with ETH
* The first order should match first - hopefully - moving the price making the ETH order unfillable
* Wait (at least) 10 min for the order to expire

# Bonus

Updated classic ETH banner to reflect the fact that now slippage can be set to more than 2%
![Screen Shot 2022-11-23 at 17 11 00](https://user-images.githubusercontent.com/43217/203607925-18e84b3f-e89d-48e6-9d17-8959fa361265.png)
(The `minimum` word after 2%)
