### PR TITLE
Fixed order price calculation

### DIFF
--- a/src/cow-react/common/hooks/usePrice.ts
+++ b/src/cow-react/common/hooks/usePrice.ts
@@ -1,0 +1,12 @@
+import { useSafeMemo } from '@cow/common/hooks/useSafeMemo'
+import { Currency, CurrencyAmount, Price } from '@uniswap/sdk-core'
+
+export function usePrice(
+  inputCurrencyAmount: CurrencyAmount<Currency> | null,
+  outputCurrencyAmount: CurrencyAmount<Currency> | null
+): Price<Currency, Currency> | null {
+  return useSafeMemo(() => {
+    if (!outputCurrencyAmount || !inputCurrencyAmount) return null
+    return new Price({ baseAmount: inputCurrencyAmount, quoteAmount: outputCurrencyAmount })
+  }, [inputCurrencyAmount, outputCurrencyAmount])
+}

--- a/src/cow-react/common/hooks/useRateInfoParams.ts
+++ b/src/cow-react/common/hooks/useRateInfoParams.ts
@@ -2,9 +2,10 @@ import { useHigherUSDValue } from 'hooks/useStablecoinPrice'
 import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
 import { useCallback } from 'react'
 import { useWeb3React } from '@web3-react/core'
-import { useSafeMemo, useSafeMemoObject } from '@cow/common/hooks/useSafeMemo'
+import { useSafeMemoObject } from '@cow/common/hooks/useSafeMemo'
 import { RateInfoParams } from '@cow/common/pure/RateInfo'
-import { Currency, CurrencyAmount, Price } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
+import { usePrice } from '@cow/common/hooks/usePrice'
 
 export function useRateInfoParams(
   inputCurrencyAmount: CurrencyAmount<Currency> | null,
@@ -12,10 +13,7 @@ export function useRateInfoParams(
 ): RateInfoParams {
   const { chainId } = useWeb3React()
 
-  const activeRate = useSafeMemo(() => {
-    if (!outputCurrencyAmount || !inputCurrencyAmount) return null
-    return new Price({ baseAmount: inputCurrencyAmount, quoteAmount: outputCurrencyAmount })
-  }, [inputCurrencyAmount, outputCurrencyAmount])
+  const activeRate = usePrice(inputCurrencyAmount, outputCurrencyAmount)
 
   const parseRate = useCallback(
     (invert: boolean) => {

--- a/src/cow-react/common/hooks/useRateInfoParams.ts
+++ b/src/cow-react/common/hooks/useRateInfoParams.ts
@@ -1,10 +1,10 @@
 import { useHigherUSDValue } from 'hooks/useStablecoinPrice'
 import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
-import { useCallback, useMemo } from 'react'
+import { useCallback } from 'react'
 import { useWeb3React } from '@web3-react/core'
-import { useSafeMemoObject } from '@cow/common/hooks/useSafeMemo'
+import { useSafeMemo, useSafeMemoObject } from '@cow/common/hooks/useSafeMemo'
 import { RateInfoParams } from '@cow/common/pure/RateInfo'
-import { Currency, CurrencyAmount, Fraction } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount, Price } from '@uniswap/sdk-core'
 
 export function useRateInfoParams(
   inputCurrencyAmount: CurrencyAmount<Currency> | null,
@@ -12,11 +12,10 @@ export function useRateInfoParams(
 ): RateInfoParams {
   const { chainId } = useWeb3React()
 
-  const activeRate = useMemo(() => {
-    if (!outputCurrencyAmount?.quotient || !inputCurrencyAmount?.quotient) return null
-
-    return new Fraction(outputCurrencyAmount.quotient, inputCurrencyAmount.quotient)
-  }, [outputCurrencyAmount?.quotient, inputCurrencyAmount?.quotient])
+  const activeRate = useSafeMemo(() => {
+    if (!outputCurrencyAmount || !inputCurrencyAmount) return null
+    return new Price({ baseAmount: inputCurrencyAmount, quoteAmount: outputCurrencyAmount })
+  }, [inputCurrencyAmount, outputCurrencyAmount])
 
   const parseRate = useCallback(
     (invert: boolean) => {

--- a/src/cow-react/common/pure/RateInfo/index.tsx
+++ b/src/cow-react/common/pure/RateInfo/index.tsx
@@ -6,8 +6,8 @@ import { Repeat } from 'react-feather'
 import { getQuoteCurrency } from '@cow/common/services/getQuoteCurrency'
 import { getAddress } from '@cow/modules/limitOrders/utils/getAddress'
 import { SupportedChainId } from 'constants/chains'
-import { Currency, CurrencyAmount, Price } from '@uniswap/sdk-core'
-import { useSafeMemo } from '@cow/common/hooks/useSafeMemo'
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
+import { usePrice } from '@cow/common/hooks/usePrice'
 
 export interface RateInfoParams {
   chainId: SupportedChainId | undefined
@@ -86,11 +86,7 @@ export function RateInfo({
   const { chainId, inputCurrencyAmount, outputCurrencyAmount, activeRateFiatAmount, inversedActiveRateFiatAmount } =
     rateInfoParams
 
-  const activeRate = useSafeMemo(() => {
-    if (!outputCurrencyAmount || !inputCurrencyAmount) return null
-    return new Price({ baseAmount: inputCurrencyAmount, quoteAmount: outputCurrencyAmount })
-  }, [inputCurrencyAmount, outputCurrencyAmount])
-
+  const activeRate = usePrice(inputCurrencyAmount, outputCurrencyAmount)
   const inputCurrency = inputCurrencyAmount?.currency
   const outputCurrency = outputCurrencyAmount?.currency
 

--- a/src/cow-react/common/pure/RateInfo/index.tsx
+++ b/src/cow-react/common/pure/RateInfo/index.tsx
@@ -6,7 +6,8 @@ import { Repeat } from 'react-feather'
 import { getQuoteCurrency } from '@cow/common/services/getQuoteCurrency'
 import { getAddress } from '@cow/modules/limitOrders/utils/getAddress'
 import { SupportedChainId } from 'constants/chains'
-import { Currency, CurrencyAmount, Fraction } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount, Price } from '@uniswap/sdk-core'
+import { useSafeMemo } from '@cow/common/hooks/useSafeMemo'
 
 export interface RateInfoParams {
   chainId: SupportedChainId | undefined
@@ -85,11 +86,10 @@ export function RateInfo({
   const { chainId, inputCurrencyAmount, outputCurrencyAmount, activeRateFiatAmount, inversedActiveRateFiatAmount } =
     rateInfoParams
 
-  const activeRate = useMemo(() => {
-    return outputCurrencyAmount?.quotient && inputCurrencyAmount?.quotient
-      ? new Fraction(outputCurrencyAmount.quotient, inputCurrencyAmount.quotient)
-      : null
-  }, [outputCurrencyAmount?.quotient, inputCurrencyAmount?.quotient])
+  const activeRate = useSafeMemo(() => {
+    if (!outputCurrencyAmount || !inputCurrencyAmount) return null
+    return new Price({ baseAmount: inputCurrencyAmount, quoteAmount: outputCurrencyAmount })
+  }, [inputCurrencyAmount, outputCurrencyAmount])
 
   const inputCurrency = inputCurrencyAmount?.currency
   const outputCurrency = outputCurrencyAmount?.currency


### PR DESCRIPTION
# Summary

![image](https://user-images.githubusercontent.com/7122625/204234929-6af24cbc-3d93-46ea-aba8-653248e49e83.png)

@nenadV91:
>Right now on dev in orders table I think we have an issue with price calculation because its not adjusting for the decimals. In the first order the actual price should be 1 WETH = 1125.7329 USDC

  # To Test

1. Create order with currencies with different decimals (for example: WETH -> USDC)
2. AR: The price on Limit orders form and in Orders table is wrong
3. ER: The price is actual

