### PR TITLE
Refactor limit orders hooks and components

### DIFF
--- a/src/cow-react/common/hooks/useTokensAllowances.ts
+++ b/src/cow-react/common/hooks/useTokensAllowances.ts
@@ -16,6 +16,7 @@ export interface TokensAllowancesResult {
   isLoading: boolean
 }
 
+// TODO: add calls batching (max 100 requests per batch for example)
 export function useTokensAllowances(
   account: string | undefined,
   spender: string | undefined,

--- a/src/cow-react/common/hooks/useTokensAllowances.ts
+++ b/src/cow-react/common/hooks/useTokensAllowances.ts
@@ -5,6 +5,7 @@ import { Interface } from '@ethersproject/abi'
 import ERC20ABI from 'abis/erc20.json'
 import { Erc20Interface } from 'abis/types/Erc20'
 import JSBI from 'jsbi'
+import { ListenerOptions } from '@uniswap/redux-multicall'
 
 const ERC20Interface = new Interface(ERC20ABI) as Erc20Interface
 
@@ -18,7 +19,8 @@ export interface TokensAllowancesResult {
 export function useTokensAllowances(
   account: string | undefined,
   spender: string | undefined,
-  tokens: Token[]
+  tokens: Token[],
+  listenerOptions?: ListenerOptions
 ): TokensAllowancesResult {
   const tokensAddresses = useMemo(() => tokens.map((token) => token.address), [tokens])
 
@@ -26,15 +28,14 @@ export function useTokensAllowances(
     tokensAddresses,
     ERC20Interface,
     'allowance',
-    useMemo(() => [account, spender], [account, spender])
+    useMemo(() => [account, spender], [account, spender]),
+    listenerOptions
   )
 
   const isLoading = useMemo(() => allowancesRequests.some((callState) => callState.loading), [allowancesRequests])
 
-  return useMemo(() => {
-    if (!account) return { allowances: {}, isLoading: false }
-
-    const allowances = tokensAddresses.reduce((acc, tokenAddress, i) => {
+  const allowances = useMemo(() => {
+    return tokensAddresses.reduce((acc, tokenAddress, i) => {
       const allowance = allowancesRequests?.[i].result?.[0]
       const token = tokens[i]
 
@@ -42,7 +43,11 @@ export function useTokensAllowances(
 
       return acc
     }, {} as Allowances)
+  }, [tokensAddresses, allowancesRequests, tokens])
+
+  return useMemo(() => {
+    if (!account) return { allowances: {}, isLoading: false }
 
     return { allowances, isLoading }
-  }, [tokens, account, tokensAddresses, isLoading, allowancesRequests])
+  }, [account, allowances, isLoading])
 }

--- a/src/cow-react/modules/limitOrders/containers/OrdersWidget/hooks/useOrdersBalancesAndAllowances.ts
+++ b/src/cow-react/modules/limitOrders/containers/OrdersWidget/hooks/useOrdersBalancesAndAllowances.ts
@@ -23,8 +23,9 @@ export function useOrdersBalancesAndAllowances(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [orders.map((order) => order.sellToken).join('')])
 
+  // TODO: refactor useTokenBalancesWithLoadingIndicator() hook and add ListenerOptions
   const [balances] = useTokenBalancesWithLoadingIndicator(account, tokens)
-  const { allowances } = useTokensAllowances(account, spender, tokens)
+  const { allowances } = useTokensAllowances(account, spender, tokens, { blocksPerFetch: 25 })
 
   return useMemo(() => ({ balances, allowances }), [balances, allowances])
 }

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
@@ -8,6 +8,7 @@ import { InvertRateControl } from '@cow/common/pure/RateInfo'
 import { BalancesAndAllowances } from '../../containers/OrdersWidget/hooks/useOrdersBalancesAndAllowances'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { transparentize } from 'polished'
+import { getOrderParams } from './utils/getOrderParams'
 
 const TableBox = styled.div`
   display: block;
@@ -98,11 +99,10 @@ export function OrdersTable({ chainId, orders, balancesAndAllowances, showOrderC
           {ordersPage.map((order) => (
             <OrderRow
               key={order.id}
-              chainId={chainId}
               order={order}
+              orderParams={getOrderParams(chainId, balancesAndAllowances, order)}
               RowElement={RowElement}
               isRateInversed={isRateInversed}
-              balancesAndAllowances={balancesAndAllowances}
               showOrderCancelationModal={showOrderCancelationModal}
             />
           ))}

--- a/src/cow-react/modules/limitOrders/pure/Orders/utils/getOrderParams.ts
+++ b/src/cow-react/modules/limitOrders/pure/Orders/utils/getOrderParams.ts
@@ -1,0 +1,56 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { BalancesAndAllowances } from '@cow/modules/limitOrders/containers/OrdersWidget/hooks/useOrdersBalancesAndAllowances'
+import { Order } from 'state/orders/actions'
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
+import { RateInfoParams } from '@cow/common/pure/RateInfo'
+
+export interface OrderParams {
+  sellAmount: CurrencyAmount<Currency>
+  buyAmount: CurrencyAmount<Currency>
+  rateInfoParams: RateInfoParams
+  hasEnoughBalance: boolean
+  hasEnoughAllowance: boolean
+}
+
+export function getOrderParams(
+  chainId: SupportedChainId | undefined,
+  balancesAndAllowances: BalancesAndAllowances,
+  order: Order
+): OrderParams {
+  const sellAmount = CurrencyAmount.fromRawAmount(order.inputToken, order.sellAmount.toString())
+  const buyAmount = CurrencyAmount.fromRawAmount(order.outputToken, order.buyAmount.toString())
+
+  const rateInfoParams: RateInfoParams = {
+    chainId,
+    inputCurrencyAmount: sellAmount,
+    outputCurrencyAmount: buyAmount,
+    activeRateFiatAmount: null,
+    inversedActiveRateFiatAmount: null,
+  }
+
+  const { balances, allowances } = balancesAndAllowances
+  const balance = balances[order.inputToken.address]
+  const allowance = allowances[order.inputToken.address]
+
+  const hasEnoughBalance = isEnoughAmount(sellAmount, balance)
+  const hasEnoughAllowance = isEnoughAmount(sellAmount, allowance)
+
+  return {
+    sellAmount,
+    buyAmount,
+    rateInfoParams,
+    hasEnoughBalance,
+    hasEnoughAllowance,
+  }
+}
+
+function isEnoughAmount(
+  sellAmount: CurrencyAmount<Currency>,
+  targetAmount: CurrencyAmount<Currency> | undefined
+): boolean {
+  if (!targetAmount) return true
+
+  if (targetAmount.equalTo(sellAmount)) return true
+
+  return sellAmount.lessThan(targetAmount)
+}


### PR DESCRIPTION
# Summary

 Post-merge review fixes: https://github.com/cowprotocol/cowswap/pull/1437
 
 1. Added `TODO` to add batching for useTokensAllowances() 
 2. Added `ListenerOptions` for useTokensAllowances()
 3. Added `{ blocksPerFetch: 25 }` for allowances request in `useOrdersBalancesAndAllowances()`
 4. Refactored `useTokensAllowances()` hook to simplify `useMemo()` usage
 5. Added `TODO` for `useTokenBalancesWithLoadingIndicator()` refactoring
 6. Refactored `OrderRow` component and extracted logic to `getOrderParams` util

  # To Test

1. Recheck #1354 
