### PR TITLE
Disable limit-orders state persistence between browser tabs

### DIFF
--- a/src/cow-react/modules/limitOrders/state/limitOrdersAtom.ts
+++ b/src/cow-react/modules/limitOrders/state/limitOrdersAtom.ts
@@ -27,7 +27,7 @@ export function getDefaultLimitOrdersState(chainId: SupportedChainId | null): Li
 }
 
 export const limitOrdersAtom = atomWithStorage<LimitOrdersState>(
-  'limit-orders-atom',
+  'limit-orders-atom:v1',
   getDefaultLimitOrdersState(null),
   /**
    * atomWithStorage() has build-in feature to persist state between all tabs

--- a/src/cow-react/modules/limitOrders/state/limitOrdersAtom.ts
+++ b/src/cow-react/modules/limitOrders/state/limitOrdersAtom.ts
@@ -1,4 +1,4 @@
-import { atomWithStorage } from 'jotai/utils'
+import { atomWithStorage, createJSONStorage } from 'jotai/utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { atom } from 'jotai'
 import { OrderKind } from '@cowprotocol/contracts'
@@ -26,7 +26,16 @@ export function getDefaultLimitOrdersState(chainId: SupportedChainId | null): Li
   }
 }
 
-export const limitOrdersAtom = atomWithStorage<LimitOrdersState>('limit-orders-atom', getDefaultLimitOrdersState(null))
+export const limitOrdersAtom = atomWithStorage<LimitOrdersState>(
+  'limit-orders-atom',
+  getDefaultLimitOrdersState(null),
+  /**
+   * atomWithStorage() has build-in feature to persist state between all tabs
+   * To disable this feature we pass our own instance of storage
+   * https://github.com/pmndrs/jotai/pull/1004/files
+   */
+  createJSONStorage(() => localStorage)
+)
 
 export const updateLimitOrdersAtom = atom(null, (get, set, nextState: Partial<LimitOrdersState>) => {
   set(limitOrdersAtom, () => {


### PR DESCRIPTION
# Summary

Fixes #1415

The root of the problem is here: https://github.com/pmndrs/jotai/pull/1004

How it works:
1. Open a tab with the limit orders page with state: `2 WETH -> DAI`
2. Open one more tab with state: `3 WETH -> DAI`
3. After opening the second tab, the first one receives `storage` event with the state from the second tab
4. `useSetupTradeState()` hook detects changes and rewrites the state
5. Second tab receives state from the first tab and we go to the loop