### PR TITLE
Show different text on the stub for open/history orders

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/OrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/OrdersWidget/index.tsx
@@ -85,6 +85,7 @@ export function OrdersWidget() {
         chainId={chainId}
         tabs={tabs}
         orders={orders}
+        isOpenOrdersTab={isOpenOrdersTab}
         balancesAndAllowances={pendingBalancesAndAllowances}
         isWalletConnected={!!account}
         showOrderCancelationModal={showOrderCancelationModal}

--- a/src/cow-react/modules/limitOrders/pure/Orders/index.cosmos.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/index.cosmos.tsx
@@ -28,6 +28,7 @@ export default (
     chainId={1}
     orders={ordersMock}
     tabs={tabs}
+    isOpenOrdersTab={true}
     isWalletConnected={true}
     balancesAndAllowances={balancesAndAllowances}
     showOrderCancelationModal={() => console.log('showOrderCancelationModal')}

--- a/src/cow-react/modules/limitOrders/pure/Orders/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/index.tsx
@@ -111,7 +111,7 @@ export function Orders({
             <img src={cowMeditatingV2} alt="Cow meditating ..." />
           </span>
           <h3>
-            <Trans>{isOpenOrdersTab ? 'No open orders' : 'No orders history'}</Trans>
+            <Trans>{isOpenOrdersTab ? 'No open orders' : 'No order history'}</Trans>
           </h3>
           <p>
             <Trans>

--- a/src/cow-react/modules/limitOrders/pure/Orders/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/index.tsx
@@ -4,6 +4,7 @@ import { OrdersTable, OrdersTableProps } from './OrdersTable'
 import { Widget } from '../Widget'
 import { transparentize } from 'polished'
 import cowMeditatingV2 from 'assets/cow-swap/meditating-cow-v2.svg'
+import { Trans } from '@lingui/macro'
 
 const OrdersBox = styled(Widget)`
   min-height: 200px;
@@ -82,6 +83,7 @@ const Header = styled.span`
 `
 export interface OrdersProps extends OrdersTabsProps, OrdersTableProps {
   isWalletConnected: boolean
+  isOpenOrdersTab: boolean
 }
 
 export function Orders({
@@ -89,6 +91,7 @@ export function Orders({
   orders,
   tabs,
   isWalletConnected,
+  isOpenOrdersTab,
   balancesAndAllowances,
   showOrderCancelationModal,
 }: OrdersProps) {
@@ -101,17 +104,20 @@ export function Orders({
       )
     }
 
-    // TODO: Check if no orders + order history tab is active. To show a different icon & message.
     if (orders.length === 0) {
       return (
         <Content>
           <span>
             <img src={cowMeditatingV2} alt="Cow meditating ..." />
           </span>
-          <h3>No open orders</h3>
+          <h3>
+            <Trans>{isOpenOrdersTab ? 'No open orders' : 'No orders history'}</Trans>
+          </h3>
           <p>
-            You don&apos;t have any open orders at the moment. <br />
-            Create one for free!
+            <Trans>
+              You don&apos;t have any {isOpenOrdersTab ? 'open' : ''} orders at the moment. <br />
+              Create one for free!
+            </Trans>
           </p>
         </Content>
       )


### PR DESCRIPTION
# Summary

Fixes #1507

<img width="525" alt="image" src="https://user-images.githubusercontent.com/7122625/204294757-7fffa51d-8c97-4723-bbc2-5c70ce34371f.png">

<img width="523" alt="image" src="https://user-images.githubusercontent.com/7122625/204294797-4e59c227-94ab-446c-8db2-e1f1c6b36cff.png">
