### PR TITLE
Wrap/unwrap for limit-orders

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/TradeButtons/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/TradeButtons/index.tsx
@@ -6,21 +6,26 @@ import { tradeFlow, TradeFlowContext } from '@cow/modules/limitOrders/services/t
 import { limitOrdersSettingsAtom } from '@cow/modules/limitOrders/state/limitOrdersSettingsAtom'
 import { useLimitOrdersTradeState } from '@cow/modules/limitOrders/hooks/useLimitOrdersTradeState'
 import { useLimitOrdersFormState } from '../../hooks/useLimitOrdersFormState'
-import { limitOrdersTradeButtonsMap, SwapButton } from './limitOrdersTradeButtonsMap'
+import { limitOrdersTradeButtonsMap, SwapButton, WrapUnwrapParams } from './limitOrdersTradeButtonsMap'
 import { limitOrdersConfirmState } from '../LimitOrdersConfirmModal/state'
-import { useToggleWalletModal } from 'state/application/hooks'
+import { useCloseModals, useModalIsOpen, useToggleWalletModal } from 'state/application/hooks'
 import { limitOrdersQuoteAtom } from '@cow/modules/limitOrders/state/limitOrdersQuoteAtom'
 import { useLimitOrdersWarningsAccepted } from '@cow/modules/limitOrders/hooks/useLimitOrdersWarningsAccepted'
 import { PriceImpact } from 'hooks/usePriceImpact'
+import { useWrapCallback } from 'hooks/useWrapCallback'
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
+import { transactionConfirmAtom } from '@cow/modules/swap/state/transactionConfirmAtom'
+import { ApplicationModal } from '@src/state/application/reducer'
 
 export interface TradeButtonsProps {
   tradeContext: TradeFlowContext | null
   priceImpact: PriceImpact
+  inputCurrencyAmount: CurrencyAmount<Currency> | null
   openConfirmScreen(): void
 }
 
 export function TradeButtons(props: TradeButtonsProps) {
-  const { tradeContext, openConfirmScreen, priceImpact } = props
+  const { tradeContext, openConfirmScreen, priceImpact, inputCurrencyAmount } = props
   const { expertMode } = useAtomValue(limitOrdersSettingsAtom)
   const formState = useLimitOrdersFormState()
   const tradeState = useLimitOrdersTradeState()
@@ -28,6 +33,18 @@ export function TradeButtons(props: TradeButtonsProps) {
   const toggleWalletModal = useToggleWalletModal()
   const quote = useAtomValue(limitOrdersQuoteAtom)
   const warningsAccepted = useLimitOrdersWarningsAccepted(false)
+  const wrapUnwrapCallback = useWrapCallback(inputCurrencyAmount || undefined)
+  const transactionConfirmState = useAtomValue(transactionConfirmAtom)
+  const closeModals = useCloseModals()
+  const showTransactionConfirmationModal = useModalIsOpen(ApplicationModal.TRANSACTION_CONFIRMATION)
+
+  const wrapUnwrapParams: WrapUnwrapParams = {
+    isNativeIn: !!inputCurrencyAmount?.currency.isNative,
+    wrapUnwrapCallback,
+    transactionConfirmState,
+    closeModals,
+    showTransactionConfirmationModal,
+  }
 
   const doTrade = useCallback(() => {
     if (expertMode && tradeContext) {
@@ -48,7 +65,7 @@ export function TradeButtons(props: TradeButtonsProps) {
   const button = limitOrdersTradeButtonsMap[formState]
 
   if (typeof button === 'function') {
-    return button({ tradeState, toggleWalletModal, quote })
+    return button({ tradeState, toggleWalletModal, quote, wrapUnwrapParams })
   }
 
   const isButtonDisabled = button.disabled || !warningsAccepted

--- a/src/cow-react/modules/limitOrders/containers/TradeButtons/limitOrdersTradeButtonsMap.tsx
+++ b/src/cow-react/modules/limitOrders/containers/TradeButtons/limitOrdersTradeButtonsMap.tsx
@@ -7,11 +7,23 @@ import { ButtonSize } from 'theme'
 import { TradeApproveButton } from '@cow/common/containers/TradeApprove/TradeApproveButton'
 import { LimitOrdersQuoteState } from '@cow/modules/limitOrders/state/limitOrdersQuoteAtom'
 import { GpQuoteErrorCodes } from '@cow/api/gnosisProtocol/errors/QuoteError'
+import { WrapUnwrapCallback } from 'hooks/useWrapCallback'
+import TransactionConfirmationModal from 'components/TransactionConfirmationModal'
+import { TransactionConfirmState } from '@cow/modules/swap/state/transactionConfirmAtom'
+
+export interface WrapUnwrapParams {
+  isNativeIn: boolean
+  wrapUnwrapCallback: WrapUnwrapCallback | null
+  transactionConfirmState: TransactionConfirmState
+  closeModals(): void
+  showTransactionConfirmationModal: boolean
+}
 
 export interface TradeButtonsParams {
   tradeState: LimitOrdersTradeState
   quote: LimitOrdersQuoteState
   toggleWalletModal: () => void
+  wrapUnwrapParams: WrapUnwrapParams
 }
 
 interface ButtonConfig {
@@ -119,6 +131,30 @@ export const limitOrdersTradeButtonsMap: { [key in LimitOrdersFormState]: Button
             </SwapButton>
           </TradeApproveButton>
         )}
+      </>
+    )
+  },
+  [LimitOrdersFormState.Unwrap]: ({ wrapUnwrapParams }: TradeButtonsParams) => {
+    const {
+      isNativeIn,
+      wrapUnwrapCallback,
+      transactionConfirmState: { pendingText, operationType },
+      closeModals,
+      showTransactionConfirmationModal,
+    } = wrapUnwrapParams
+
+    return (
+      <>
+        <SwapButton disabled={false} onClick={() => wrapUnwrapCallback?.({ useModals: true })}>
+          <Trans>{isNativeIn ? 'Wrap' : 'Unwrap'}</Trans>
+        </SwapButton>
+        <TransactionConfirmationModal
+          attemptingTxn={true}
+          isOpen={showTransactionConfirmationModal}
+          pendingText={pendingText}
+          onDismiss={closeModals}
+          operationType={operationType}
+        />
       </>
     )
   },

--- a/src/cow-react/modules/limitOrders/hooks/useDisableNativeTokenSelling.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useDisableNativeTokenSelling.ts
@@ -5,28 +5,32 @@ import { useEffect } from 'react'
 import { NATIVE_CURRENCY_BUY_TOKEN } from 'constants/index'
 import { useTradeNavigate } from '@cow/modules/trade/hooks/useTradeNavigate'
 import { getDefaultTradeState } from '@cow/modules/trade/types/TradeState'
+import { WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
 
 /**
- * To avoid WRAP/UNWRAP/ETH-flow cases in the Limit orders page
- * We disable selecting of native currency as input currency
- * We set `disableNonToken` as true to input currency `CurrencyInputPanel` component as well
+ * Since the selling of ETH is not supported in limit orders
+ * We automatically replace it by WETH
  */
-export function useDisableNativeTokenUsage() {
+export function useDisableNativeTokenSelling() {
   const { chainId } = useWeb3React()
   const { inputCurrencyId, outputCurrencyId } = useAtomValue(limitOrdersAtom)
   const limitOrdersNavigate = useTradeNavigate()
 
   useEffect(() => {
     const nativeToken = chainId ? NATIVE_CURRENCY_BUY_TOKEN[chainId] : null
+    const wrappedToken = chainId ? WRAPPED_NATIVE_CURRENCY[chainId] : null
 
-    if (!chainId || !nativeToken) return
+    if (!chainId || !nativeToken || !wrappedToken) return
 
     const nativeIds = [nativeToken.address, nativeToken.symbol].map((value) => value?.toLowerCase())
+    const wrappedIds = [wrappedToken.address, wrappedToken.symbol].map((value) => value?.toLowerCase())
 
     const isInputNative = !!inputCurrencyId && nativeIds.includes(inputCurrencyId?.toLowerCase())
+    const isOutputWrappedNative = !!outputCurrencyId && wrappedIds.includes(outputCurrencyId?.toLowerCase())
+
     const defaultInputCurrencyId = getDefaultTradeState(chainId).inputCurrencyId
 
-    if (isInputNative) {
+    if (isInputNative && !isOutputWrappedNative) {
       limitOrdersNavigate(chainId, {
         inputCurrencyId: isInputNative ? defaultInputCurrencyId : inputCurrencyId,
         outputCurrencyId,

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrdersTabs.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrdersTabs.tsx
@@ -12,11 +12,11 @@ const Tabs = styled.div`
   border: 1px solid ${({ theme }) => transparentize(0.8, theme.text3)};
 `
 
-const TabButton = styled(Link)<{ active?: boolean }>`
+const TabButton = styled(Link)<{ active: string }>`
   display: inline-block;
-  background: ${({ theme, active }) => (active ? transparentize(0.88, theme.text3) : 'transparent')};
-  color: ${({ theme, active }) => (active ? theme.text1 : transparentize(0.2, theme.text1))};
-  font-weight: ${({ active }) => (active ? '600' : '400')};
+  background: ${({ theme, active }) => (active === 'true' ? transparentize(0.88, theme.text3) : 'transparent')};
+  color: ${({ theme, active }) => (active === 'true' ? theme.text1 : transparentize(0.2, theme.text1))};
+  font-weight: ${({ active }) => (active === 'true' ? '600' : '400')};
   text-decoration: none;
   font-size: 13px;
   padding: 10px 24px;
@@ -53,7 +53,7 @@ export function OrdersTabs({ tabs }: OrdersTabsProps) {
       {tabs.map((tab, index) => (
         <TabButton
           key={index}
-          active={index === activeTabIndex}
+          active={(index === activeTabIndex).toString()}
           to={(location) => buildLimitOrdersUrl(location, { tabId: tab.id, pageNumber: 1 })}
         >
           <Trans>{tab.title}</Trans> <span>({tab.count})</span>

--- a/src/cow-react/modules/swap/hooks/useDetectNativeToken.ts
+++ b/src/cow-react/modules/swap/hooks/useDetectNativeToken.ts
@@ -5,19 +5,17 @@ import { Token } from '@uniswap/sdk-core'
 import { WETH_LOGO_URI } from 'constants/index'
 import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
 import { WRAPPED_NATIVE_CURRENCY as WETH, GpEther as ETHER } from 'constants/tokens'
-import { useSwapState } from 'state/swap/hooks'
 import { supportedChainId } from 'utils/supportedChainId'
-import { Field } from 'state/swap/actions'
 import WXDAI_LOGO_URI from 'assets/cow-swap/wxdai.png'
 import { useTokenBySymbolOrAddress } from '@cow/common/hooks/useTokenBySymbolOrAddress'
 import { SupportedChainId as ChainId } from 'constants/chains'
+import { useTradeState } from '@cow/modules/trade/hooks/useTradeState'
 
+// TODO: move it to `modules/trade`
 export function useDetectNativeToken() {
   const { chainId } = useWeb3React()
-  const {
-    [Field.INPUT]: { currencyId: inputCurrencyId },
-    [Field.OUTPUT]: { currencyId: outputCurrencyId },
-  } = useSwapState()
+  const tradeState = useTradeState()
+  const { inputCurrencyId, outputCurrencyId } = tradeState?.state || {}
 
   const input = useTokenBySymbolOrAddress(inputCurrencyId)
   const output = useTokenBySymbolOrAddress(outputCurrencyId)


### PR DESCRIPTION
# Summary

Fixes #1431

<img width="497" alt="image" src="https://user-images.githubusercontent.com/7122625/204534844-db8703a0-0289-43c2-b0c1-b062f7701ae1.png">

1. Now you can select ETH/WETH in the limit orders widget
2. Wrap/unwrap operations should be the same as in Swap
3. If you have ETH -> WETH state and change the output currency to any token, then the input token will be automatically changed to WETH