### PR TITLE
No pagination when orders.length is lower than LIMIT_ORDERS_PAGE_SIZE

### DIFF
--- a/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
@@ -109,11 +109,15 @@ export function OrdersTable({
           ))}
         </Rows>
       </TableBox>
-      <OrdersTablePagination
-        pageSize={LIMIT_ORDERS_PAGE_SIZE}
-        totalCount={orders.length}
-        currentPage={currentPageNumber}
-      />
+
+      {/* Only show pagination if more than 1 page available */}
+      {orders.length > LIMIT_ORDERS_PAGE_SIZE && (
+        <OrdersTablePagination
+          pageSize={LIMIT_ORDERS_PAGE_SIZE}
+          totalCount={orders.length}
+          currentPage={currentPageNumber}
+        />
+      )}
     </>
   )
 }


### PR DESCRIPTION
# Summary

Only shows pagination when `orders.length > LIMIT_ORDERS_PAGE_SIZE`