### PR TITLE
Limit order responsive styles 1

### DIFF
--- a/src/cow-react/modules/limitOrders/pure/Orders/OrdersTabs.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrdersTabs.tsx
@@ -10,6 +10,12 @@ const Tabs = styled.div`
   overflow: hidden;
   margin: 0;
   border: 1px solid ${({ theme }) => transparentize(0.8, theme.text3)};
+
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+    width: 100%;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  `};
 `
 
 const TabButton = styled(Link)<{ active?: boolean }>`
@@ -24,6 +30,10 @@ const TabButton = styled(Link)<{ active?: boolean }>`
   outline: none;
   cursor: pointer;
   transition: background 0.15s ease-in-out, color 0.2s ease-in-out;
+
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+    text-align: center;
+  `};
 
   &:hover {
     background: ${({ theme }) => theme.bg1};

--- a/src/cow-react/modules/limitOrders/pure/Orders/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/index.tsx
@@ -76,6 +76,11 @@ const Header = styled.span`
   width: 100%;
   margin: 0 0 24px;
 
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+    flex-flow: column wrap;
+    margin: 0 0 16px;
+  `};
+
   > h2 {
     font-size: 24px;
     margin: 0;

--- a/src/cow-react/pages/LimitOrders/styled.ts
+++ b/src/cow-react/pages/LimitOrders/styled.ts
@@ -11,10 +11,6 @@ export const PageWrapper = styled.div<{ isUnlocked: boolean }>`
   ${({ theme }) => theme.mediaWidth.upToMedium`
     display: flex;
     flex-flow: column wrap;
-
-    > div:last-child {
-      margin: 20px;
-    }
   `};
 
   > div:last-child {
@@ -33,4 +29,9 @@ export const PrimaryWrapper = styled.div`
 // Graph + orders table
 export const SecondaryWrapper = styled.div`
   display: flex;
+
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+    flex-flow: column wrap;
+    margin: 56px 0;
+  `};
 `


### PR DESCRIPTION
# Summary

Fixes: #1543

- Adds responsive styles for the limit order, orders table.

https://user-images.githubusercontent.com/31534717/204773164-5e90aa44-f1db-4846-99c7-5999dbc3e2cc.mov



## Note
- Styling the rest of the table (responsive) is a WIP (next PR)