### PR TITLE
Fix sell amount in orders table

### DIFF
--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow.tsx
@@ -8,6 +8,7 @@ import { MouseoverTooltipContent } from 'components/Tooltip'
 import { AlertTriangle, Trash2 } from 'react-feather'
 import { transparentize } from 'polished'
 import { OrderParams } from './utils/getOrderParams'
+import { getSellAmountWithFee } from '@cow/modules/limitOrders/utils/getSellAmountWithFee'
 
 export const orderStatusTitleMap: { [key in OrderStatus]: string } = {
   [OrderStatus.PENDING]: 'Open',
@@ -190,14 +191,14 @@ export function OrderRow({
   orderParams,
   onClick,
 }: OrderRowProps) {
-  const { sellAmount, buyAmount, rateInfoParams, hasEnoughAllowance, hasEnoughBalance } = orderParams
+  const { buyAmount, rateInfoParams, hasEnoughAllowance, hasEnoughBalance } = orderParams
 
   const withWarning = !hasEnoughBalance || !hasEnoughAllowance
 
   return (
     <RowElement onClick={onClick}>
       <div>
-        <CurrencyAmountItem amount={sellAmount} />
+        <CurrencyAmountItem amount={getSellAmountWithFee(order)} />
       </div>
       <div>
         <CurrencyAmountItem amount={buyAmount} />

--- a/src/cow-react/modules/limitOrders/pure/ReceiptModal/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/ReceiptModal/index.tsx
@@ -6,8 +6,9 @@ import { CloseIcon } from 'theme'
 import { CurrencyField } from './CurrencyField'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { ParsedOrder } from '@cow/modules/limitOrders/containers/OrdersWidget/hooks/useLimitOrdersList'
-import { FeeField } from './FeeField'
+import { getSellAmountWithFee } from '@cow/modules/limitOrders/utils/getSellAmountWithFee'
 import { StyledScrollarea } from 'components/SearchModal/CommonBases/CommonBasesMod'
+import { FeeField } from './FeeField'
 import { FieldLabel } from './FieldLabel'
 import { PriceField } from './PriceField'
 import { DateField } from './DateField'
@@ -58,8 +59,6 @@ export function ReceiptModal({
 
   const inputLabel = order.kind === OrderKind.SELL ? 'You sell' : 'You sell at most'
   const outputLabel = order.kind === OrderKind.SELL ? 'Your receive at least' : 'You receive exactly'
-  const feeAmountParsed = CurrencyAmount.fromRawAmount(order.inputToken, order.feeAmount.toString())
-  const sellAmountWithFee = sellAmount.add(feeAmountParsed)
 
   return (
     <GpModal onDismiss={onDismiss} isOpen={isOpen}>
@@ -71,7 +70,7 @@ export function ReceiptModal({
 
         <StyledScrollarea>
           <styledEl.Body>
-            <CurrencyField amount={sellAmountWithFee} token={order.inputToken} label={inputLabel} />
+            <CurrencyField amount={getSellAmountWithFee(order)} token={order.inputToken} label={inputLabel} />
             <CurrencyField amount={buyAmount} token={order.outputToken} label={outputLabel} />
 
             <styledEl.Field border="rounded-top">

--- a/src/cow-react/modules/limitOrders/utils/getSellAmountWithFee.ts
+++ b/src/cow-react/modules/limitOrders/utils/getSellAmountWithFee.ts
@@ -1,0 +1,8 @@
+import { Order } from '@src/custom/state/orders/actions'
+import { CurrencyAmount } from '@uniswap/sdk-core'
+
+export function getSellAmountWithFee(order: Order) {
+  const feeAmountParsed = CurrencyAmount.fromRawAmount(order.inputToken, order.feeAmount.toString())
+  const sellAmountParsed = CurrencyAmount.fromRawAmount(order.inputToken, order.sellAmount.toString())
+  return sellAmountParsed.add(feeAmountParsed)
+}


### PR DESCRIPTION
# Summary

Fixes the issue mentioned by @elena-zh in this comment https://github.com/cowprotocol/cowswap/pull/1537#issuecomment-1330740367

# To test
- go to limit orders page
- make sure that orders in the table have the same sell amount as in the explorer
- to open that order in explorer, open the order receipt, scroll down and you can click on a order id link