### PR TITLE
Update the header navigation for limit-orders

### DIFF
--- a/src/cow-react/modules/mainMenu/constants/mainMenu.ts
+++ b/src/cow-react/modules/mainMenu/constants/mainMenu.ts
@@ -32,7 +32,25 @@ export const ACCOUNT_MENU: InternalLink[] = [
 ]
 
 export const MAIN_MENU: MenuTreeItem[] = [
-  { id: MainMenuItemId.SWAP, kind: MenuItemKind.DYNAMIC_LINK, title: 'Swap', url: Routes.SWAP },
+  FeatureFlag.get(LIMIT_ORDERS_ENABLED)
+    ? {
+        kind: MenuItemKind.DROP_DOWN,
+        title: 'Trade',
+        items: [
+          {
+            links: [
+              { id: MainMenuItemId.SWAP, kind: MenuItemKind.DYNAMIC_LINK, title: 'Swap', url: Routes.SWAP },
+              {
+                id: MainMenuItemId.LIMIT_ORDERS,
+                kind: MenuItemKind.DYNAMIC_LINK,
+                title: 'Limit orders',
+                url: Routes.LIMIT_ORDER,
+              },
+            ],
+          },
+        ],
+      }
+    : { id: MainMenuItemId.SWAP, kind: MenuItemKind.DYNAMIC_LINK, title: 'Swap', url: Routes.SWAP },
   {
     kind: MenuItemKind.DROP_DOWN,
     title: 'Account',
@@ -118,12 +136,3 @@ export const MAIN_MENU: MenuTreeItem[] = [
     ],
   },
 ]
-
-if (FeatureFlag.get(LIMIT_ORDERS_ENABLED)) {
-  MAIN_MENU.splice(1, 0, {
-    id: MainMenuItemId.LIMIT_ORDERS,
-    kind: MenuItemKind.DYNAMIC_LINK,
-    title: 'Limit orders',
-    url: Routes.LIMIT_ORDER,
-  })
-}


### PR DESCRIPTION
# Summary

This PR updates the header so if the flag `enableLimitOrders` **is set** in local storage then we show this 
![Screenshot from 2022-11-30 14-53-08](https://user-images.githubusercontent.com/34926005/204814430-e7da66e6-4e38-4b4d-ab69-e34e10744a61.png)

if **not** then we show this
![Screenshot from 2022-11-30 14-52-34](https://user-images.githubusercontent.com/34926005/204814482-f1bcb44b-90ad-4805-a8f0-2a4c2c1ce869.png)