### PR TITLE
Fix swap/limit container responsive styles

### DIFF
--- a/src/cow-react/common/pure/CurrencyArrowSeparator/index.tsx
+++ b/src/cow-react/common/pure/CurrencyArrowSeparator/index.tsx
@@ -8,10 +8,11 @@ export interface CurrencyArrowSeparatorProps {
   hasSeparatorLine?: boolean
   isCollapsed?: boolean
   onSwitchTokens(): void
+  border?: boolean
 }
 
 export function CurrencyArrowSeparator(props: CurrencyArrowSeparatorProps) {
-  const { isLoading, onSwitchTokens, withRecipient, isCollapsed = true, hasSeparatorLine } = props
+  const { isLoading, onSwitchTokens, withRecipient, isCollapsed = true, hasSeparatorLine, border } = props
 
   return (
     <styledEl.Box
@@ -20,7 +21,7 @@ export function CurrencyArrowSeparator(props: CurrencyArrowSeparatorProps) {
       onClick={onSwitchTokens}
       hasSeparatorLine={hasSeparatorLine}
     >
-      <styledEl.LoadingWrapper isLoading={isLoading}>
+      <styledEl.LoadingWrapper isLoading={isLoading} border={border}>
         {isLoading ? <styledEl.CowImg src={loadingCowWebp} alt="loading" /> : <styledEl.ArrowDownIcon />}
       </styledEl.LoadingWrapper>
     </styledEl.Box>

--- a/src/cow-react/common/pure/CurrencyArrowSeparator/styled.tsx
+++ b/src/cow-react/common/pure/CurrencyArrowSeparator/styled.tsx
@@ -4,12 +4,12 @@ import { loadingAnimationMixin } from './style-mixins'
 
 export const Box = styled.div<{ withRecipient: boolean; isCollapsed: boolean; hasSeparatorLine?: boolean }>`
   display: ${({ withRecipient }) => (withRecipient ? 'inline-flex' : 'block')};
-  margin: ${({ withRecipient, isCollapsed }) => (withRecipient ? '0' : isCollapsed ? '-12px auto' : '6px auto')};
+  margin: ${({ withRecipient, isCollapsed }) => (withRecipient ? '0' : isCollapsed ? '-12px auto' : '2px auto')};
   cursor: pointer;
   position: relative;
   z-index: 2;
-  width: ${({ withRecipient }) => (withRecipient ? '28px' : '100%')};
-  height: 28px;
+  width: ${({ withRecipient }) => (withRecipient ? '26px' : '100%')};
+  height: 26px;
   justify-content: ${({ withRecipient }) => (withRecipient ? 'intial' : 'center')};
   transition: width 0.3s ease-in-out;
 
@@ -28,7 +28,7 @@ export const Box = styled.div<{ withRecipient: boolean; isCollapsed: boolean; ha
     `}
 `
 
-export const LoadingWrapper = styled.div<{ isLoading: boolean }>`
+export const LoadingWrapper = styled.div<{ isLoading: boolean; border?: boolean }>`
   position: absolute;
   left: calc(50% - 14px);
   height: 100%;
@@ -36,11 +36,11 @@ export const LoadingWrapper = styled.div<{ isLoading: boolean }>`
   transform-style: preserve-3d;
   transform-origin: center right;
   transition: transform 0.25s;
-  border: 1px solid ${({ theme }) => theme.grey1};
+  border: ${({ border, theme }) => (border ? `1px solid ${theme.grey1}` : '0')};
   box-shadow: 0px 0px 0px 3px ${({ theme }) => theme.bg1};
   background: ${({ theme }) => (theme.darkMode ? theme.grey1 : theme.white)};
   border-radius: 8px;
-  width: 28px;
+  width: 26px;
   margin: 0 auto;
 
   ${({ isLoading }) => isLoading && loadingAnimationMixin}
@@ -49,9 +49,9 @@ export const LoadingWrapper = styled.div<{ isLoading: boolean }>`
 export const ArrowDownIcon = styled(ArrowDown)`
   stroke: ${({ theme }) => theme.text1};
   stroke-width: 2px;
-  width: 100%;
-  height: 100%;
   padding: 3px;
+  height: 100%;
+  width: 100%;
 `
 
 export const CowImg = styled.img`

--- a/src/cow-react/common/pure/CurrencyArrowSeparator/styled.tsx
+++ b/src/cow-react/common/pure/CurrencyArrowSeparator/styled.tsx
@@ -29,8 +29,11 @@ export const Box = styled.div<{ withRecipient: boolean; isCollapsed: boolean; ha
 `
 
 export const LoadingWrapper = styled.div<{ isLoading: boolean; border?: boolean }>`
+  --size: 26px;
   position: absolute;
-  left: calc(50% - 14px);
+  left: calc(50% - var(--size) / 2);
+  top: 0;
+  bottom: 0;
   height: 100%;
   text-align: center;
   transform-style: preserve-3d;
@@ -40,8 +43,12 @@ export const LoadingWrapper = styled.div<{ isLoading: boolean; border?: boolean 
   box-shadow: 0px 0px 0px 3px ${({ theme }) => theme.bg1};
   background: ${({ theme }) => (theme.darkMode ? theme.grey1 : theme.white)};
   border-radius: 8px;
-  width: 26px;
-  margin: 0 auto;
+  width: var(--size);
+  margin: auto;
+
+  &:hover {
+    transform: translateY(-2px);
+  }
 
   ${({ isLoading }) => isLoading && loadingAnimationMixin}
 `

--- a/src/cow-react/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
+++ b/src/cow-react/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
@@ -128,10 +128,10 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
               <>
                 <styledEl.BalanceText title={balance.toExact() + ' ' + currency?.symbol}>
                   <Trans>Balance</Trans>: {formatSmartAmount(balance) || '0'} {currency?.symbol}
+                  {showSetMax && balance.greaterThan(0) && (
+                    <styledEl.SetMaxBtn onClick={handleMaxInput}>Max</styledEl.SetMaxBtn>
+                  )}
                 </styledEl.BalanceText>
-                {showSetMax && balance.greaterThan(0) && (
-                  <styledEl.SetMaxBtn onClick={handleMaxInput}>(Max)</styledEl.SetMaxBtn>
-                )}
               </>
             )}
           </div>

--- a/src/cow-react/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
+++ b/src/cow-react/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
@@ -109,7 +109,7 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
       <styledEl.Wrapper id={id} className={className} withReceiveAmountInfo={!!receiveAmountInfo} disabled={disabled}>
         {topLabel && <styledEl.CurrencyTopLabel>{topLabel}</styledEl.CurrencyTopLabel>}
 
-        <styledEl.CurrencyInputBox flexibleWidth={true}>
+        <styledEl.CurrencyInputBox>
           <div>
             <CurrencySelectButton
               onClick={() => setCurrencySearchModalOpen(true)}
@@ -122,7 +122,7 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
           </div>
         </styledEl.CurrencyInputBox>
 
-        <styledEl.CurrencyInputBox flexibleWidth={false}>
+        <styledEl.CurrencyInputBox>
           <div>
             {balance && !disabled && (
               <>

--- a/src/cow-react/common/pure/CurrencyInputPanel/CurrencyPreview.tsx
+++ b/src/cow-react/common/pure/CurrencyInputPanel/CurrencyPreview.tsx
@@ -28,7 +28,7 @@ export function CurrencyPreview(props: CurrencyPreviewProps) {
       <styledEl.Wrapper id={id} className={className} withReceiveAmountInfo={false} disabled={false}>
         {topLabel && <styledEl.CurrencyTopLabel>{topLabel}</styledEl.CurrencyTopLabel>}
 
-        <styledEl.CurrencyInputBox flexibleWidth={true}>
+        <styledEl.CurrencyInputBox>
           <div>
             <CurrencySelectButton currency={currency || undefined} loading={false} readonlyMode={true} />
           </div>
@@ -44,7 +44,7 @@ export function CurrencyPreview(props: CurrencyPreviewProps) {
           </div>
         </styledEl.CurrencyInputBox>
 
-        <styledEl.CurrencyInputBox flexibleWidth={false}>
+        <styledEl.CurrencyInputBox>
           <div>
             {balance && (
               <>

--- a/src/cow-react/common/pure/CurrencyInputPanel/styled.tsx
+++ b/src/cow-react/common/pure/CurrencyInputPanel/styled.tsx
@@ -14,39 +14,36 @@ export const Wrapper = styled.div<{ withReceiveAmountInfo: boolean; disabled: bo
   border-radius: ${({ withReceiveAmountInfo }) => (withReceiveAmountInfo ? '16px 16px 0 0' : '16px')};
   min-height: 106px;
   pointer-events: ${({ disabled }) => (disabled ? 'none' : '')};
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    gap: 10px;
+    padding: 12px;
+  `}
 `
 
-export const CurrencyInputBox = styled.div<{ flexibleWidth: boolean }>`
+export const CurrencyInputBox = styled.div`
   display: grid;
   width: 100%;
-  grid-template-columns: ${({ flexibleWidth }) => (flexibleWidth ? 'min-content auto' : 'auto auto')};
+  grid-template-columns: auto auto;
   gap: 16px;
+  margin: 0;
   font-weight: 400;
   font-size: 13px;
 
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    gap: 8px;
+    grid-template-columns: minmax(auto, 50%) auto;
+  `}
+
   > div {
     display: flex;
+    flex-flow: row wrap;
     align-items: center;
   }
 
   > div:last-child {
     text-align: right;
     margin: 0 0 0 auto;
-  }
-
-  @media screen and (max-width: ${MEDIA_WIDTHS.upToSmall}px) {
-    ${({ flexibleWidth }) =>
-      flexibleWidth
-        ? `
-    display: block;
-    `
-        : `
-    display: flex;
-    flex-direction: column-reverse;
-    align-items: start;
-    margin: 0;
-    gap: 8px;
-    `}
   }
 `
 
@@ -67,14 +64,13 @@ export const NumericalInput = styled(Input)<{ $loading: boolean }>`
   font-weight: 500;
   color: ${({ theme }) => theme.text1};
 
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    font-size: 26px;
+  `}
+
   &::placeholder {
     color: ${({ theme }) => theme.text1};
     opacity: 0.5;
-  }
-
-  @media screen and (max-width: ${MEDIA_WIDTHS.upToSmall}px) {
-    margin: 20px 0 0 8px;
-    text-align: left;
   }
 
   ${loadingOpacityMixin}

--- a/src/cow-react/common/pure/CurrencyInputPanel/styled.tsx
+++ b/src/cow-react/common/pure/CurrencyInputPanel/styled.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components/macro'
 import { loadingOpacityMixin } from 'components/Loader/styled'
 import Input from 'components/NumericalInput'
-import { MEDIA_WIDTHS } from 'theme'
+import { transparentize } from 'polished'
 
 export const Wrapper = styled.div<{ withReceiveAmountInfo: boolean; disabled: boolean }>`
   display: flex;
@@ -29,10 +29,10 @@ export const CurrencyInputBox = styled.div`
   margin: 0;
   font-weight: 400;
   font-size: 13px;
+  color: ${({ theme }) => transparentize(0.3, theme.text1)};
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
     gap: 8px;
-    grid-template-columns: minmax(auto, 50%) auto;
   `}
 
   > div {
@@ -50,8 +50,8 @@ export const CurrencyInputBox = styled.div`
 export const CurrencyTopLabel = styled.div`
   font-size: 13px;
   font-weight: 400;
-  opacity: 0.8;
   margin: auto 0;
+  color: ${({ theme }) => transparentize(0.3, theme.text1)};
 `
 
 export const NumericalInput = styled(Input)<{ $loading: boolean }>`
@@ -69,8 +69,7 @@ export const NumericalInput = styled(Input)<{ $loading: boolean }>`
   `}
 
   &::placeholder {
-    color: ${({ theme }) => theme.text1};
-    opacity: 0.5;
+    color: ${({ theme }) => transparentize(0.3, theme.text1)};
   }
 
   ${loadingOpacityMixin}
@@ -79,10 +78,9 @@ export const NumericalInput = styled(Input)<{ $loading: boolean }>`
 export const BalanceText = styled.span`
   font-weight: inherit;
   font-size: inherit;
-
-  @media screen and (max-width: ${MEDIA_WIDTHS.upToSmall}px) {
-    opacity: 0.75;
-  }
+  gap: 5px;
+  display: flex;
+  align-items: center;
 `
 
 export const FiatAmountText = styled.span`
@@ -101,10 +99,15 @@ export const SetMaxBtn = styled.button`
   border: none;
   outline: none;
   color: ${({ theme }) => theme.text3};
-  font-weight: 500;
-  font-size: inherit;
+  font-weight: 600;
+  font-size: 11px;
+  background: ${({ theme }) => transparentize(0.9, theme.text3)};
+  border-radius: 6px;
+  padding: 3px 4px;
+  text-transform: uppercase;
+  transition: background 0.15s ease-in-out;
 
-  :hover {
-    opacity: 0.85;
+  &:hover {
+    background: ${({ theme }) => transparentize(0.7, theme.text3)};
   }
 `

--- a/src/cow-react/common/pure/RateInfo/index.tsx
+++ b/src/cow-react/common/pure/RateInfo/index.tsx
@@ -37,26 +37,32 @@ const Wrapper = styled.div<{ stylized: boolean }>`
 `
 
 const RateLabel = styled.div`
+  display: flex;
+  align-items: center;
   color: ${({ theme }) => transparentize(0.2, theme.text1)};
   font-weight: 400;
+  gap: 5px;
 `
 
 const InvertIcon = styled.div`
+  --size: 20px;
+  cursor: pointer;
   background: ${({ theme }) => theme.grey1};
   color: ${({ theme }) => theme.text1};
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  display: inline-block;
-  text-align: center;
-  line-height: 22px;
-  margin-left: 5px;
-  cursor: pointer;
+  width: var(--size);
+  height: var(--size);
+  border-radius: var(--size);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   transition: background 0.15s ease-in-out, color 0.15s ease-in-out;
 
   &:hover {
-    background: ${({ theme }) => theme.text1};
-    color: ${({ theme }) => theme.grey1};
+    background: ${({ theme }) => theme.bg2};
+
+    > svg {
+      stroke: ${({ theme }) => theme.white};
+    }
   }
 `
 
@@ -78,6 +84,7 @@ const RateWrapper = styled.button`
 export const FiatRate = styled.span`
   color: ${({ theme }) => transparentize(0.3, theme.text1)};
   font-weight: 400;
+  text-align: right;
 `
 
 export function InvertRateControl({ onClick }: { onClick(): void }) {

--- a/src/cow-react/modules/application/containers/App/styled.ts
+++ b/src/cow-react/modules/application/containers/App/styled.ts
@@ -36,7 +36,7 @@ export const BodyWrapper = styled.div`
   padding: 5vh 16px 0;
 
   ${({ theme }) => theme.mediaWidth.upToMedium`
-  padding: 0 16px 16px;
+  padding: 0 10px 16px;
   flex: none;
 `}
 `

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -183,6 +183,7 @@ export function LimitOrdersWidget() {
                   withRecipient={showRecipient}
                   isLoading={isTradePriceUpdating}
                   hasSeparatorLine={true}
+                  border={true}
                 />
                 {showRecipient && recipient === null && <AddRecipient onChangeRecipient={onChangeRecipient} />}
               </styledEl.CurrencySeparatorBox>

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/styled.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/styled.tsx
@@ -58,6 +58,11 @@ export const RateWrapper = styled.div`
   grid-template-columns: auto 150px;
   gap: 6px;
 
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    display: flex;
+    flex-flow: column wrap;
+  `}
+
   ${NumericalInput} {
     font-size: 21px;
   }
@@ -74,4 +79,13 @@ export const StyledRemoveRecipient = styled(RemoveRecipient)`
 export const StyledRateInfo = styled(RateInfo)`
   margin-top: 15px;
   font-size: 14px;
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    display: flex;
+    flex-flow: column wrap;
+    align-items: flex-start;
+    padding: 8px;
+    margin: 0;
+    gap: 4px;
+  `}
 `

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/styled.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/styled.tsx
@@ -57,6 +57,7 @@ export const RateWrapper = styled.div`
   display: grid;
   grid-template-columns: auto 150px;
   gap: 6px;
+  text-align: right;
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
     display: flex;

--- a/src/cow-react/modules/limitOrders/containers/RateInput/styled.ts
+++ b/src/cow-react/modules/limitOrders/containers/RateInput/styled.ts
@@ -12,6 +12,10 @@ export const Wrapper = styled.div`
   justify-content: space-between;
   display: flex;
   flex-flow: row wrap;
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    gap: 10px;
+  `}
 `
 
 export const Header = styled.div`
@@ -44,6 +48,7 @@ export const MarketPriceButton = styled.button`
 export const Body = styled.div`
   padding: 0;
   display: flex;
+  width: 100%;
 `
 
 export const NumericalInput = styled(Input)<{ $loading: boolean }>`

--- a/src/cow-react/modules/limitOrders/pure/DeadlineSelector/styled.tsx
+++ b/src/cow-react/modules/limitOrders/pure/DeadlineSelector/styled.tsx
@@ -40,6 +40,10 @@ export const Current = styled.button<{ isCustom: boolean }>`
   text-overflow: ellipsis;
   overflow: hidden;
 
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    font-size: 21px;
+  `}
+
   &:hover {
     text-decoration: underline;
   }

--- a/src/cow-react/modules/swap/containers/NewSwapWidget/styled.tsx
+++ b/src/cow-react/modules/swap/containers/NewSwapWidget/styled.tsx
@@ -14,10 +14,6 @@ export const ContainerBox = styled.div`
   box-shadow: ${({ theme }) => theme.boxShadow1};
   padding: 10px;
   max-width: ${({ theme }) => theme.appBody.maxWidth.swap};
-
-  ${({ theme }) => theme.mediaWidth.upToMedium`
-    padding: 16px;
-  `};
 `
 
 export const Header = styled.div`
@@ -36,7 +32,7 @@ export const SwapFormWrapper = styled.div`
 export const CurrencySeparatorBox = styled.div<{ withRecipient: boolean }>`
   display: flex;
   justify-content: space-between;
-  margin: ${({ withRecipient }) => (withRecipient ? '10px' : '0')};
+  margin: ${({ withRecipient }) => (withRecipient ? '10px' : '1px 0')};
 `
 
 export const SwapHeaderStyled = styled(SwapHeader)`

--- a/src/cow-react/modules/swap/containers/NewSwapWidget/styled.tsx
+++ b/src/cow-react/modules/swap/containers/NewSwapWidget/styled.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components/macro'
 import SwapHeader from 'components/swap/SwapHeader'
 import { RemoveRecipient } from '@cow/modules/swap/containers/RemoveRecipient'
+import { LoadingWrapper } from '@cow/common/pure/CurrencyArrowSeparator/styled'
 
 export const Container = styled.div`
   max-width: ${({ theme }) => theme.appBody.maxWidth.swap};
@@ -27,6 +28,16 @@ export const Header = styled.div`
 
 export const SwapFormWrapper = styled.div`
   margin: 0 0 10px;
+
+  ${LoadingWrapper} {
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      --size: 24px;
+      height: var(--size);
+      width: var(--size);
+      left: calc(50% - var(--size)/2);
+      border-radius: var(--size);
+  `};
+  }
 `
 
 export const CurrencySeparatorBox = styled.div<{ withRecipient: boolean }>`

--- a/src/cow-react/modules/swap/pure/CurrencySelectButton/styled.tsx
+++ b/src/cow-react/modules/swap/pure/CurrencySelectButton/styled.tsx
@@ -40,14 +40,14 @@ export const ArrowDown = styled(DropDown)<{ stubbed?: boolean }>`
 `
 
 export const CurrencySymbol = styled.div<{ stubbed: boolean }>`
-  font-size: 20px;
+  font-size: 19px;
   font-weight: 500;
   white-space: nowrap;
   color: ${({ stubbed, theme }) => (stubbed ? theme.white : theme.text1)};
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
-    font-size: 17px;
-    word-break: break-all;
+    font-size: 16px;
+    word-break: break-word;
     white-space: normal;
     text-align: left;
   `};

--- a/src/cow-react/modules/swap/pure/CurrencySelectButton/styled.tsx
+++ b/src/cow-react/modules/swap/pure/CurrencySelectButton/styled.tsx
@@ -24,11 +24,6 @@ export const CurrencySelectWrapper = styled.button<{ isLoading: boolean; stubbed
     background-color: ${({ readonlyMode, stubbed, theme }) =>
       readonlyMode ? 'red' : stubbed ? lighten(0.1, theme.bg2) : lighten(0.1, theme.bg1)};
   }
-
-  ${({ theme }) => theme.mediaWidth.upToSmall`
-    width: 100%;
-    justify-content: start;
-  `};
 `
 
 export const ArrowDown = styled(DropDown)<{ stubbed?: boolean }>`
@@ -49,4 +44,11 @@ export const CurrencySymbol = styled.div<{ stubbed: boolean }>`
   font-weight: 500;
   white-space: nowrap;
   color: ${({ stubbed, theme }) => (stubbed ? theme.white : theme.text1)};
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    font-size: 17px;
+    word-break: break-all;
+    white-space: normal;
+    text-align: left;
+  `};
 `

--- a/src/cow-react/modules/swap/pure/Row/styled.ts
+++ b/src/cow-react/modules/swap/pure/Row/styled.ts
@@ -10,7 +10,7 @@ const StyledMouseoverTooltipContent = styled(MouseoverTooltipContent)``
 export const TextWrapper = styled(Text)``
 
 export const StyledRowBetween = styled(RowBetween)<RowStyleProps>`
-  height: ${({ rowHeight = 24 }) => rowHeight}px;
+  min-height: 24px;
 
   ${TextWrapper} {
     color: ${({ theme }) => theme.text1};
@@ -24,6 +24,10 @@ export const StyledRowBetween = styled(RowBetween)<RowStyleProps>`
       &:hover {
         color: ${({ theme }) => theme.text1};
       }
+    }
+
+    &:last-child {
+      text-align: right;
     }
   }
 

--- a/src/cow-react/modules/swap/pure/Row/types.ts
+++ b/src/cow-react/modules/swap/pure/Row/types.ts
@@ -1,7 +1,6 @@
 export interface RowStyleProps {
   fontWeight?: number
   fontSize?: number
-  rowHeight?: number
 }
 
 export interface RowWithShowHelpersProps {

--- a/src/cow-react/modules/swap/pure/Row/typings.ts
+++ b/src/cow-react/modules/swap/pure/Row/typings.ts
@@ -1,7 +1,6 @@
 export interface RowStyleProps {
   fontWeight?: number
   fontSize?: number
-  rowHeight?: number
 }
 
 export interface RowWithShowHelpersProps {

--- a/src/cow-react/modules/swap/pure/TradeRates/styled.tsx
+++ b/src/cow-react/modules/swap/pure/TradeRates/styled.tsx
@@ -65,7 +65,7 @@ export const Discount = styled.span`
   transition: background 0.2s ease-in-out, color 0.2s ease-in-out;
 
   &:hover {
-    background-color: ${({ theme }) => theme.bg2};
+    background: ${({ theme }) => theme.bg2};
     color: ${({ theme }) => theme.white};
   }
 `

--- a/src/cow-react/pages/Claim/styled.ts
+++ b/src/cow-react/pages/Claim/styled.ts
@@ -344,10 +344,6 @@ export const ClaimTable = styled.div`
     font-size: 16px;
     grid-template-columns: min-content auto auto 240px;
 
-    ${({ theme }) => theme.mediaWidth.upToSmall`
-      display: block;
-    `};
-
     input[type='checkbox'] {
       ${({ theme }) => theme.mediaWidth.upToSmall`
       width: 42px;

--- a/src/custom/components/Header/styled.ts
+++ b/src/custom/components/Header/styled.ts
@@ -69,7 +69,7 @@ export const HeaderElement = styled(HeaderElementUni)`
     width: 100%;
     border-radius: 0;
     height: 64px;
-    background-color: ${({ theme }) => transparentize(0.75, theme.bg1)};
+    background-color: ${({ theme }) => theme.bg1};
     border-top: 1px solid ${({ theme }) => theme.grey1};
     backdrop-filter: blur(21px);
     padding: 10px 16px;

--- a/src/custom/components/Popover/PopoverMod.tsx
+++ b/src/custom/components/Popover/PopoverMod.tsx
@@ -14,8 +14,9 @@ export const PopoverContainer = styled.div<{ show: boolean }>`
   visibility: ${(props) => (props.show ? 'visible' : 'hidden')};
   opacity: ${(props) => (props.show ? 1 : 0)};
   transition: visibility 150ms linear, opacity 150ms linear;
-  color: ${({ theme }) => theme.text2};
+  /* color: ${({ theme }) => theme.text2}; */
   /* MOD */
+  color: ${({ theme }) => theme.text1};
   background: ${({ theme }) => theme.bg1};
   border: 1px solid ${({ theme }) => theme.bg3};
   box-shadow: 0 4px 8px 0 ${({ theme }) => transparentize(0.9, theme.shadow1)};

--- a/src/custom/components/Popover/index.tsx
+++ b/src/custom/components/Popover/index.tsx
@@ -19,9 +19,10 @@ const PopoverContainer = styled(PopoverContainerMod)<PopoverContainerProps>`
   border: 0;
   padding: 6px 3px;
   z-index: 10;
+  font-size: 13px;
 
   > div div {
-    font-size: 14px;
+    font-size: inherit;
   }
 `
 


### PR DESCRIPTION
# Summary

- Adds responsive styles for the swap/limit container

Left = this PR
Right = current `develop` 

<img width="1006" alt="Screenshot 2022-11-30 at 17 30 08" src="https://user-images.githubusercontent.com/31534717/204867253-38b5ba11-c9e0-4ff8-aa94-feb38888ecef.png">

<img width="943" alt="Screenshot 2022-11-30 at 17 35 14" src="https://user-images.githubusercontent.com/31534717/204868332-f1bbaaa9-6fee-4c6d-837f-a4cf6746ee83.png">
