### PR TITLE
Make tap area of CurrencyArrowSeparator smaller

### DIFF
--- a/src/cow-react/common/pure/CurrencyArrowSeparator/index.tsx
+++ b/src/cow-react/common/pure/CurrencyArrowSeparator/index.tsx
@@ -14,14 +14,13 @@ export function CurrencyArrowSeparator(props: CurrencyArrowSeparatorProps) {
   const { isLoading, onSwitchTokens, withRecipient, isCollapsed = true, hasSeparatorLine } = props
 
   return (
-    <styledEl.Box
-      withRecipient={withRecipient}
-      isCollapsed={isCollapsed}
-      onClick={onSwitchTokens}
-      hasSeparatorLine={hasSeparatorLine}
-    >
+    <styledEl.Box withRecipient={withRecipient} isCollapsed={isCollapsed} hasSeparatorLine={hasSeparatorLine}>
       <styledEl.LoadingWrapper isLoading={isLoading}>
-        {isLoading ? <styledEl.CowImg src={loadingCowWebp} alt="loading" /> : <styledEl.ArrowDownIcon />}
+        {isLoading ? (
+          <styledEl.CowImg src={loadingCowWebp} alt="loading" />
+        ) : (
+          <styledEl.ArrowDownIcon onClick={onSwitchTokens} />
+        )}
       </styledEl.LoadingWrapper>
     </styledEl.Box>
   )

--- a/src/cow-react/common/pure/CurrencyArrowSeparator/styled.tsx
+++ b/src/cow-react/common/pure/CurrencyArrowSeparator/styled.tsx
@@ -5,7 +5,6 @@ import { loadingAnimationMixin } from './style-mixins'
 export const Box = styled.div<{ withRecipient: boolean; isCollapsed: boolean; hasSeparatorLine?: boolean }>`
   display: ${({ withRecipient }) => (withRecipient ? 'inline-flex' : 'block')};
   margin: ${({ withRecipient, isCollapsed }) => (withRecipient ? '0' : isCollapsed ? '-12px auto' : '6px auto')};
-  cursor: pointer;
   position: relative;
   z-index: 2;
   width: ${({ withRecipient }) => (withRecipient ? '28px' : '100%')};
@@ -52,6 +51,7 @@ export const ArrowDownIcon = styled(ArrowDown)`
   width: 100%;
   height: 100%;
   padding: 3px;
+  cursor: pointer;
 `
 
 export const CowImg = styled.img`


### PR DESCRIPTION
# Summary

Fixes #1540

![image](https://user-images.githubusercontent.com/7122625/204986901-2807b723-f706-4733-96e0-717681e24afa.png)
