### PR TITLE
Fix limit orders performance issues

### DIFF
--- a/src/custom/state/orders/consts.ts
+++ b/src/custom/state/orders/consts.ts
@@ -8,7 +8,9 @@ export const ContractDeploymentBlocks: Partial<Record<ChainId, number>> = {
   [ChainId.GNOSIS_CHAIN]: 13566914,
 }
 
-export const OPERATOR_API_POLL_INTERVAL = ms`2s` // in ms
-export const PENDING_ORDERS_PRICE_CHECK_POLL_INTERVAL = ms`15s` // in ms
+export const MARKET_OPERATOR_API_POLL_INTERVAL = ms`2s`
+// We can have lots of limit orders and it creates a high load, so we poll them no so ofter as market orders
+export const LIMIT_OPERATOR_API_POLL_INTERVAL = ms`15s`
+export const PENDING_ORDERS_PRICE_CHECK_POLL_INTERVAL = ms`15s`
 
 export const OUT_OF_MARKET_PRICE_DELTA_PERCENTAGE = new Percent(1, 100) // 1/100 => 0.01 => 1%

--- a/src/custom/state/orders/updaters/CancelledOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/CancelledOrdersUpdater.ts
@@ -5,7 +5,7 @@ import { useWeb3React } from '@web3-react/core'
 import { useCancelledOrders, useFulfillOrdersBatch } from 'state/orders/hooks'
 import { OrderTransitionStatus } from 'state/orders/utils'
 import { OrderFulfillmentData } from 'state/orders/actions'
-import { OPERATOR_API_POLL_INTERVAL } from 'state/orders/consts'
+import { MARKET_OPERATOR_API_POLL_INTERVAL } from 'state/orders/consts'
 
 import { SupportedChainId as ChainId } from 'constants/chains'
 import { CANCELLED_ORDERS_PENDING_TIME } from 'constants/index'
@@ -114,7 +114,7 @@ export function CancelledOrdersUpdater(): null {
       return
     }
 
-    const interval = setInterval(() => updateOrders(chainId, account), OPERATOR_API_POLL_INTERVAL)
+    const interval = setInterval(() => updateOrders(chainId, account), MARKET_OPERATOR_API_POLL_INTERVAL)
 
     return () => clearInterval(interval)
   }, [account, chainId, updateOrders])

--- a/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -3,7 +3,7 @@ import { timestamp } from '@cowprotocol/contracts'
 
 import { useWeb3React } from '@web3-react/core'
 import { usePendingOrders, useSetIsOrderUnfillable } from 'state/orders/hooks'
-import { Order } from 'state/orders/actions'
+import { Order, OrderClass } from 'state/orders/actions'
 import { PENDING_ORDERS_PRICE_CHECK_POLL_INTERVAL } from 'state/orders/consts'
 
 import { SupportedChainId as ChainId } from 'constants/chains'
@@ -118,7 +118,10 @@ export function UnfillableOrdersUpdater(): null {
 
       const lowerCaseAccount = account.toLowerCase()
       // Only check pending orders of the connected account
-      const pending = pendingRef.current.filter(({ owner }) => owner.toLowerCase() === lowerCaseAccount)
+      // Exclude limit orders because we don't need "unfillable" flag for them
+      const pending = pendingRef.current.filter(
+        (order) => order.owner.toLowerCase() === lowerCaseAccount && order.class !== OrderClass.LIMIT
+      )
 
       if (pending.length === 0) {
         return


### PR DESCRIPTION
# Summary

Fixes #1563

1. Removed `quote` requests for limit-orders to derive "unfillable" state
2. Reduced count of `order` requests for limit-orders (before - every 2 sec, now - every 15 sec)

![image](https://user-images.githubusercontent.com/7122625/205031648-2d62d381-f88a-411c-be36-4fc9eb51383a.png)
