### PR TITLE
[analytics] Differentiate between Post Orders for Swaps and Limit Orders

### DIFF
--- a/src/cow-react/modules/swap/services/common/steps/analytics.ts
+++ b/src/cow-react/modules/swap/services/common/steps/analytics.ts
@@ -1,6 +1,7 @@
 import { signSwapAnalytics, swapAnalytics } from 'components/analytics'
 import TradeGp from 'state/swap/TradeGp'
 import { USER_SWAP_REJECTED_ERROR } from '@cow/modules/swap/services/common/steps/swapErrorHelper'
+import { OrderClass } from 'state/orders/actions'
 
 function getMarketLabel(trade: TradeGp): string {
   return [trade.inputAmount.currency.symbol, trade.outputAmount.currency.symbol].join(',')
@@ -15,27 +16,32 @@ export interface SwapFlowAnalyticsContext {
 
 export const swapFlowAnalytics = {
   swap(context: SwapFlowAnalyticsContext) {
-    swapAnalytics('Send', getMarketLabel(context.trade))
+    swapAnalytics('Send', OrderClass.MARKET, getMarketLabel(context.trade))
   },
   sign(context: SwapFlowAnalyticsContext) {
     const { account, recipient, recipientAddress, trade } = context
     const marketLabel = getMarketLabel(trade)
 
     if (recipient === null) {
-      signSwapAnalytics('Sign', marketLabel)
+      signSwapAnalytics('Sign', OrderClass.MARKET, marketLabel)
     } else {
       ;(recipientAddress ?? recipient) === account
-        ? signSwapAnalytics('SignAndSend', marketLabel)
-        : signSwapAnalytics('SignToSelf', marketLabel)
+        ? signSwapAnalytics('SignAndSend', OrderClass.MARKET, marketLabel)
+        : signSwapAnalytics('SignToSelf', OrderClass.MARKET, marketLabel)
     }
   },
   error(error: any, errorMessage: string, context: SwapFlowAnalyticsContext) {
     const marketLabel = getMarketLabel(context.trade)
 
     if (errorMessage === USER_SWAP_REJECTED_ERROR) {
-      swapAnalytics('Reject', marketLabel)
+      swapAnalytics('Reject', OrderClass.MARKET, marketLabel)
     } else {
-      swapAnalytics('Error', marketLabel, error.code && typeof error.code === 'number' ? error.code : undefined)
+      swapAnalytics(
+        'Error',
+        OrderClass.MARKET,
+        marketLabel,
+        error.code && typeof error.code === 'number' ? error.code : undefined
+      )
     }
   },
 }

--- a/src/custom/components/analytics/events/transactionEvents.ts
+++ b/src/custom/components/analytics/events/transactionEvents.ts
@@ -1,4 +1,10 @@
+import { OrderClass } from 'state/orders/actions'
 import { Category, sendEvent } from '../index'
+
+const LABEL_FROM_CLASS: Record<OrderClass, string> = {
+  limit: 'Limit Order',
+  market: 'Market Order',
+}
 
 type ExpirationType = 'Default' | 'Custom'
 export function orderExpirationTimeAnalytics(type: ExpirationType, value: number) {
@@ -38,35 +44,34 @@ export function approvalAnalytics(action: ApprovalAction, label?: string, value?
 }
 
 export type SwapAction = 'Send' | 'Error' | 'Reject'
-export function swapAnalytics(action: SwapAction, label?: string, value?: number) {
+export function swapAnalytics(action: SwapAction, orderClass: OrderClass, label?: string, value?: number) {
+  const classLabel = LABEL_FROM_CLASS[orderClass]
+
   sendEvent({
     category: Category.SWAP,
-    action: `${action} Swap Order`,
+    action: `${action} ${classLabel}`,
     label,
     value,
   })
 }
 
-const signSwapActions = {
-  Sign: 'Signed: Swap',
-  SignAndSend: 'Signed: Swap and send',
-  SignToSelf: 'Signed: Swap and send to self',
-}
+export type SignSwapAction = 'Sign' | 'SignAndSend' | 'SignToSelf' // TODO: Does it make sense to differenciate these options?
+export function signSwapAnalytics(action: SignSwapAction, orderClass: OrderClass, label?: string) {
+  const classLabel = LABEL_FROM_CLASS[orderClass]
 
-export type SignSwapAction = 'Sign' | 'SignAndSend' | 'SignToSelf'
-export function signSwapAnalytics(action: SignSwapAction, label?: string) {
   sendEvent({
     category: Category.SWAP,
-    action: signSwapActions[action],
+    action: `${action} ${classLabel}`,
     label,
   })
 }
 
 export type OrderType = 'Posted' | 'Executed' | 'Canceled' | 'Expired'
-export function orderAnalytics(action: OrderType, label?: string) {
+export function orderAnalytics(action: OrderType, orderClass: OrderClass, label?: string) {
+  const classLabel = LABEL_FROM_CLASS[orderClass]
   sendEvent({
     category: Category.SWAP,
-    action: `${action} Swap Order`,
+    action: `${action} ${classLabel}`,
     label,
   })
 }

--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -37,7 +37,7 @@ const isCancelOrderAction = isAnyOf(OrderActions.cancelOrdersBatch)
 export const popupMiddleware: Middleware<Record<string, unknown>, AppState> = (store) => (next) => (action) => {
   const result = next(action)
 
-  let idsAndPopups: OrderIDWithPopup[] = []
+  const idsAndPopups: OrderIDWithPopup[] = []
   //  is it a singular action with {chainId, id} payload
   if (isSingleOrderChangeAction(action)) {
     const { id, chainId } = action.payload
@@ -50,7 +50,7 @@ export const popupMiddleware: Middleware<Record<string, unknown>, AppState> = (s
       return result
     }
     // look up Order.summary for Popup
-    const summary = orderObject.order.summary
+    const { summary, class: orderClass } = orderObject.order
 
     let popup: PopupPayload
     if (isPendingOrderAction(action)) {
@@ -63,15 +63,15 @@ export const popupMiddleware: Middleware<Record<string, unknown>, AppState> = (s
           id: hash,
           hash,
         })
-        orderAnalytics('Posted', 'EthFlow')
+        orderAnalytics('Posted', orderClass, 'EthFlow')
       } else {
         // Pending Order Popup
         popup = setPopupData(OrderTxTypes.METATXN, { summary, status: 'submitted', id })
-        orderAnalytics('Posted', 'Offchain')
+        orderAnalytics('Posted', orderClass, 'Offchain')
       }
     } else if (isPresignOrders(action)) {
       popup = setPopupData(OrderTxTypes.METATXN, { summary, status: 'presigned', id })
-      orderAnalytics('Posted', 'Pre-Signed')
+      orderAnalytics('Posted', orderClass, 'Pre-Signed')
     } else if (isCancelOrderAction(action)) {
       // action is order/cancelOrder
       // Cancelled Order Popup
@@ -80,7 +80,7 @@ export const popupMiddleware: Middleware<Record<string, unknown>, AppState> = (s
         summary: buildCancellationPopupSummary(id, summary),
         id,
       })
-      orderAnalytics('Canceled')
+      orderAnalytics('Canceled', orderClass)
     } else {
       // action is order/expireOrder
       // Expired Order Popup
@@ -90,7 +90,7 @@ export const popupMiddleware: Middleware<Record<string, unknown>, AppState> = (s
         id,
         status: OrderActions.OrderStatus.EXPIRED,
       })
-      orderAnalytics('Expired')
+      orderAnalytics('Expired', orderClass)
     }
 
     idsAndPopups.push({
@@ -112,18 +112,22 @@ export const popupMiddleware: Middleware<Record<string, unknown>, AppState> = (s
     if (isBatchFulfillOrderAction(action)) {
       // construct Fulfilled Order Popups for each Order
 
-      idsAndPopups = action.payload.ordersData.map(({ id, summary }) => {
-        // it's an OrderTxTypes.TXN, yes, but we still want to point to the explorer
-        // because it's nicer there
-        const popup = setPopupData(OrderTxTypes.METATXN, {
-          summary,
-          id,
-          status: OrderActions.OrderStatus.FULFILLED,
-          descriptor: 'was traded',
-        })
-        orderAnalytics('Executed')
+      action.payload.ordersData.forEach(({ id, summary }) => {
+        const orderObject = _getOrderById(orders, id)
+        if (orderObject) {
+          const { class: orderClass } = orderObject.order
+          // it's an OrderTxTypes.TXN, yes, but we still want to point to the explorer
+          // because it's nicer there
+          const popup = setPopupData(OrderTxTypes.METATXN, {
+            summary,
+            id,
+            status: OrderActions.OrderStatus.FULFILLED,
+            descriptor: 'was traded',
+          })
+          orderAnalytics('Executed', orderClass)
 
-        return { id, popup }
+          idsAndPopups.push({ id, popup })
+        }
       })
     } else if (action.type === 'order/cancelOrdersBatch') {
       // Why is this condition not using a `isAnyOf` like the others?
@@ -132,36 +136,41 @@ export const popupMiddleware: Middleware<Record<string, unknown>, AppState> = (s
       // If you know how to fix it, let me know.
 
       // construct Cancelled Order Popups for each Order
-      idsAndPopups = action.payload.ids.map((id) => {
+      action.payload.ids.forEach((id) => {
         const orderObject = cancelled?.[id]
 
-        const summary = orderObject?.order.summary
+        if (orderObject) {
+          const { order } = orderObject
 
-        const popup = setPopupData(OrderTxTypes.METATXN, {
-          success: true,
-          summary: buildCancellationPopupSummary(id, summary),
-          id,
-        })
-        orderAnalytics('Canceled')
+          const summary = order.summary
 
-        return { id, popup }
+          const popup = setPopupData(OrderTxTypes.METATXN, {
+            success: true,
+            summary: buildCancellationPopupSummary(id, summary),
+            id,
+          })
+          orderAnalytics('Canceled', order.class)
+
+          idsAndPopups.push({ id, popup })
+        }
       })
     } else {
       // construct Expired Order Popups for each Order
-      idsAndPopups = action.payload.ids.map((id) => {
+      action.payload.ids.forEach((id) => {
         const orderObject = pending?.[id] || fulfilled?.[id] || expired?.[id]
+        if (orderObject) {
+          const { summary, class: orderClass } = orderObject.order
 
-        const summary = orderObject?.order.summary
+          const popup = setPopupData(OrderTxTypes.METATXN, {
+            success: false,
+            summary,
+            id,
+            status: OrderActions.OrderStatus.EXPIRED,
+          })
+          orderAnalytics('Expired', orderClass)
 
-        const popup = setPopupData(OrderTxTypes.METATXN, {
-          success: false,
-          summary,
-          id,
-          status: OrderActions.OrderStatus.EXPIRED,
-        })
-        orderAnalytics('Expired')
-
-        return { id, popup }
+          idsAndPopups.push({ id, popup })
+        }
       })
     }
   }


### PR DESCRIPTION
Fixes: #1371

# Summary

Base to differentiate between some order events for limit orders and swaps. 

Adds the class into the parameters for analytics. Also modifies the middleware so they can pass the required param

## Not included
This PR doesn't add any new event for limit orders. For example, there's no event for when the order is filled (is not handled in the middleware as for swaps)

The PR scope is just to parameterized the analytics, and for the post order event (which we were already sending), now it specifies if its a swap or a limit order.

<img width="1211" alt="image" src="https://user-images.githubusercontent.com/2352112/205149832-d578d678-c59b-4989-8ac1-6809d7bfdf9e.png">

Follow up PRs should handle the execution, cancelation, expiration of orders and report to analytics. 

# To Test

1. Install Google Analytics Debugger
2. Make sure 