### PR TITLE
Fix for receipt status

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/OrdersReceiptModal/hooks.ts
+++ b/src/cow-react/modules/limitOrders/containers/OrdersReceiptModal/hooks.ts
@@ -1,14 +1,33 @@
-import { useUpdateAtom } from 'jotai/utils'
-import { updateReceiptAtom } from '@cow/modules/limitOrders/state/limitOrdersReceiptAtom'
-import { Order } from '@src/custom/state/orders/actions'
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
+import { useUpdateAtom, useAtomValue } from 'jotai/utils'
+import { updateReceiptAtom, receiptAtom } from '@cow/modules/limitOrders/state/limitOrdersReceiptAtom'
+import {
+  ParsedOrder,
+  useLimitOrdersList,
+} from '@cow/modules/limitOrders/containers/OrdersWidget/hooks/useLimitOrdersList'
 
 export function useCloseReceiptModal() {
   const updateReceiptState = useUpdateAtom(updateReceiptAtom)
-  return useCallback(() => updateReceiptState({ selected: null }), [updateReceiptState])
+  return useCallback(() => updateReceiptState({ orderId: null }), [updateReceiptState])
 }
 
 export function useSelectReceiptOrder() {
   const updateReceiptState = useUpdateAtom(updateReceiptAtom)
-  return useCallback((order: Order) => updateReceiptState({ selected: order }), [updateReceiptState])
+  return useCallback((orderId: string) => updateReceiptState({ orderId }), [updateReceiptState])
+}
+
+export function useSelectedOrder(): ParsedOrder | null {
+  const { orderId } = useAtomValue(receiptAtom)
+  const orders = useLimitOrdersList()
+
+  return useMemo(() => {
+    if (!orderId || !orders) {
+      return null
+    }
+
+    const allOrders = Object.values(orders).flat()
+    const order = allOrders.find(({ id }) => id === orderId) || null
+
+    return order
+  }, [orderId, orders])
 }

--- a/src/cow-react/modules/limitOrders/containers/OrdersReceiptModal/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/OrdersReceiptModal/index.tsx
@@ -1,18 +1,16 @@
 import JSBI from 'jsbi'
-import { useAtomValue } from 'jotai/utils'
 import { CurrencyAmount } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
 
-import { receiptAtom } from '@cow/modules/limitOrders/state/limitOrdersReceiptAtom'
 import { ReceiptModal } from '@cow/modules/limitOrders/pure/ReceiptModal'
 import { calculatePrice } from '@cow/modules/limitOrders/utils/calculatePrice'
 
 import { supportedChainId } from 'utils/supportedChainId'
-import { useCloseReceiptModal } from './hooks'
+import { useCloseReceiptModal, useSelectedOrder } from './hooks'
 
 export function OrdersReceiptModal() {
   // TODO: can we get selected order from URL by id?
-  const { selected: order } = useAtomValue(receiptAtom)
+  const order = useSelectedOrder()
   const { chainId: _chainId } = useWeb3React()
   const closeReceiptModal = useCloseReceiptModal()
   const chainId = supportedChainId(_chainId)

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
@@ -147,7 +147,7 @@ export function OrdersTable({
               isRateInversed={isRateInversed}
               isSmartContractWallet={isSmartContractWallet}
               showOrderCancelationModal={showOrderCancelationModal}
-              onClick={() => selectReceiptOrder(order)}
+              onClick={() => selectReceiptOrder(order.id)}
             />
           ))}
         </Rows>

--- a/src/cow-react/modules/limitOrders/state/limitOrdersReceiptAtom.ts
+++ b/src/cow-react/modules/limitOrders/state/limitOrdersReceiptAtom.ts
@@ -1,12 +1,11 @@
 import { atom } from 'jotai'
-import { ParsedOrder } from '@cow/modules/limitOrders/containers/OrdersWidget/hooks/useLimitOrdersList'
 
 export interface ReceiptState {
-  selected: ParsedOrder | null
+  orderId: string | null
 }
 
 export const receiptAtom = atom<ReceiptState>({
-  selected: null,
+  orderId: null,
 })
 
 export const updateReceiptAtom = atom(null, (get, set, nextState: Partial<ReceiptState>) => {


### PR DESCRIPTION
# Summary

Fixes #1534

Modifies the implementation to keep selected order id in state
And then in another hook we get selected order with the id from the state
So when the other hook updates the orders the selected order will also be updated.


# To test
- make a limit order with short expiration and some price that probably wont execute
- open receipt for that order and don't close it
- wait until the time expired and make sure that the status in updated