### PR TITLE
Display up to 100 limit-orders in the table

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/OrdersWidget/hooks/useLimitOrdersList.ts
+++ b/src/cow-react/modules/limitOrders/containers/OrdersWidget/hooks/useLimitOrdersList.ts
@@ -31,6 +31,7 @@ export interface ParsedOrder extends Order {
   parsedCreationtime?: Date
 }
 
+const ORDERS_LIMIT = 100
 const pendingOrderStatuses: OrderStatus[] = [OrderStatus.PRESIGNATURE_PENDING, OrderStatus.PENDING]
 
 export function useLimitOrdersList(): LimitOrdersList {
@@ -68,7 +69,7 @@ export function useLimitOrdersList(): LimitOrdersList {
   }, [allNonEmptyOrders, ordersFilter])
 
   return useMemo(() => {
-    return allSortedOrders.reduce(
+    const { pending, history } = allSortedOrders.reduce(
       (acc, order) => {
         if (pendingOrderStatuses.includes(order.status)) {
           acc.pending.push(order)
@@ -80,5 +81,7 @@ export function useLimitOrdersList(): LimitOrdersList {
       },
       { pending: [], history: [] } as LimitOrdersList
     )
+
+    return { pending: pending.slice(0, ORDERS_LIMIT), history: history.slice(0, ORDERS_LIMIT) }
   }, [allSortedOrders])
 }


### PR DESCRIPTION
# Summary

There are no reasons to display too many orders, so, the limit of up to 100 orders was added.

![image](https://user-images.githubusercontent.com/7122625/206092784-7fe34e26-e908-404f-9ac4-b0c2aeaa8654.png)


