### PR TITLE
Show Appzi nps for limit orders only when an order was filled before 5 min since creating

### DIFF
--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -11,10 +11,11 @@ import { registerOnWindow } from 'utils/misc'
 import { getCowSoundError, getCowSoundSend, getCowSoundSuccess } from 'utils/sound'
 // import ReactGA from 'react-ga4'
 import { orderAnalytics } from 'components/analytics'
-import { openNpsAppziSometimes } from 'utils/appzi'
+import { isOrderInPendingTooLong, openNpsAppziSometimes } from 'utils/appzi'
 import { OrderObject, OrdersStateNetwork } from 'state/orders/reducer'
 import { timeSinceInSeconds } from '@cow/utils/time'
 import { getExplorerOrderLink } from 'utils/explorer'
+import { OrderClass } from './actions'
 
 // action syntactic sugar
 const isSingleOrderChangeAction = isAnyOf(OrderActions.addPendingOrder)
@@ -266,8 +267,14 @@ function _triggerNps(
   npsParams: Parameters<typeof openNpsAppziSometimes>[0]
 ) {
   const orders = store.getState().orders[chainId]
-  const openSince = _getOrderById(orders, orderId)?.order?.openSince
+  const order = _getOrderById(orders, orderId)?.order
+  const openSince = order?.openSince
   const explorerUrl = getExplorerOrderLink(chainId, orderId)
+
+  // Don't open Appzi nps for limit orders that were filled after `PENDING_TOO_LONG_TIME` since creating
+  if (order?.class === OrderClass.LIMIT && isOrderInPendingTooLong(openSince)) {
+    return
+  }
 
   openNpsAppziSometimes({ ...npsParams, secondsSinceOpen: timeSinceInSeconds(openSince), explorerUrl, chainId })
 }

--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -271,8 +271,8 @@ function _triggerNps(
   const openSince = order?.openSince
   const explorerUrl = getExplorerOrderLink(chainId, orderId)
 
-  // Don't open Appzi nps for limit orders that were filled after `PENDING_TOO_LONG_TIME` since creating
-  if (order?.class === OrderClass.LIMIT && isOrderInPendingTooLong(openSince)) {
+  // Open Appzi NPS for limit orders only if they were filled before `PENDING_TOO_LONG_TIME` since creating
+  if (order?.class === OrderClass.LIMIT && npsParams?.traded && isOrderInPendingTooLong(openSince)) {
     return
   }
 

--- a/src/custom/utils/appzi.ts
+++ b/src/custom/utils/appzi.ts
@@ -2,6 +2,7 @@ import EventEmitter from 'events'
 import ReactAppzi from 'react-appzi'
 import { userAgent, majorBrowserVersion, isImTokenBrowser } from 'utils/userAgent'
 import { environmentName, isProdLike } from 'utils/environments'
+import ms from 'ms.macro'
 
 // Metamask IOS app uses a version from July 2019 which causes problems in appZi
 const OLD_CHROME_FROM_METAMASK_IOS_APP = 76
@@ -23,6 +24,8 @@ export const NPS_KEY = process.env.REACT_APP_APPZI_NPS_KEY || isProdLike ? PROD_
 
 const APPZI_TOKEN = process.env.REACT_APP_APPZI_TOKEN || '5ju0G'
 const EVENT = 'message'
+
+const PENDING_TOO_LONG_TIME = ms`5 min`
 
 type EventCallback = (event: any) => void
 
@@ -118,6 +121,12 @@ function restyleAppziNps(event: any) {
 export function openNpsAppzi() {
   applyOnceRestyleAppziNps()
   window.appzi?.openWidget(NPS_KEY)
+}
+
+export function isOrderInPendingTooLong(openSince: number | undefined): boolean {
+  const now = Date.now()
+
+  return !!openSince && now - openSince > PENDING_TOO_LONG_TIME
 }
 
 // Different triggers for each NPS survey.


### PR DESCRIPTION
# Summary

Fixes #1602

1. Don't show Appzi NPS for limit orders that in pending for a long time (>5mins)
2. Show Appzi NPS for limit orders only if they were filled before 5 mins since creating
