### PR TITLE
Don't crash app when user rejected tx for wrap/unwrap

### DIFF
--- a/src/custom/hooks/useWrapCallback.ts
+++ b/src/custom/hooks/useWrapCallback.ts
@@ -33,7 +33,7 @@ export interface WrapUnwrapCallbackParams {
   useModals?: boolean
 }
 
-export type WrapUnwrapCallback = (params?: WrapUnwrapCallbackParams) => Promise<TransactionResponse>
+export type WrapUnwrapCallback = (params?: WrapUnwrapCallbackParams) => Promise<TransactionResponse | null>
 
 type TransactionAdder = ReturnType<typeof useTransactionAdder>
 
@@ -151,7 +151,7 @@ export function useWrapCallback(inputAmount: CurrencyAmount<Currency> | null | u
 export async function wrapUnwrapCallback(
   context: WrapUnwrapContext,
   params: WrapUnwrapCallbackParams = { useModals: true }
-): Promise<TransactionResponse> {
+): Promise<TransactionResponse | null> {
   const { useModals } = params
   const {
     wrapType,
@@ -191,6 +191,10 @@ export async function wrapUnwrapCallback(
 
     const errorMessage = (isRejected ? 'Reject' : 'Error') + ' Signing transaction'
     console.error(errorMessage, error)
+
+    if (isRejected) {
+      return null
+    }
 
     throw typeof error === 'string' ? new Error(error) : error
   }

--- a/src/custom/utils/misc.ts
+++ b/src/custom/utils/misc.ts
@@ -4,7 +4,11 @@ import { OrderKind } from '@cowprotocol/contracts'
 import { Percent } from '@uniswap/sdk-core'
 
 const PROVIDER_REJECT_REQUEST_CODE = 4001 // See https://eips.ethereum.org/EIPS/eip-1193
-const PROVIDER_REJECT_REQUEST_ERROR_MESSAGES = ['User denied message signature', 'User rejected the transaction']
+const PROVIDER_REJECT_REQUEST_ERROR_MESSAGES = [
+  'User denied message signature',
+  'User rejected the transaction',
+  'user rejected transaction',
+]
 
 export const isTruthy = <T>(value: T | null | undefined | false): value is T => !!value
 

--- a/workbox.config.js
+++ b/workbox.config.js
@@ -9,6 +9,7 @@ module.exports = {
     // e.g. options.maximumFileSizeToCacheInBytes = 10 * 1024 * 1024;
     return {
       ...options,
+      maximumFileSizeToCacheInBytes: 10 * 1024 * 1024,
       exclude: [...options.exclude, /emergency\.js$/],
     }
   },


### PR DESCRIPTION
# Summary

1. Init tx signing for Wrap/Unwrap
2. Reject signing in the wallet

AR: The app crashes
ER: Nothing happened 

![image](https://user-images.githubusercontent.com/7122625/206180390-0dae5944-3e20-4387-a762-7639940870e5.png)

