### PR TITLE
Optimize yarn script execution time

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "contracts:compile:v3": "typechain --target ethers-v5 --out-dir src/types/v3 \"./node_modules/@uniswap/**/artifacts/contracts/**/*[!dbg].json\"",
     "contracts:compile": "yarn contracts:compile:abi && yarn contracts:compile:abi-ethflow && yarn contracts:add:export && yarn contracts:compile:abi-uniswap && yarn contracts:compile:v3",
     "prei18n:extract": "touch src/locales/en-US.po",
-    "postinstall": "npm-run-all -p contracts:compile i18n:compile patch-package",
+    "postinstall": "npm-run-all -p patch-package",
     "patch-package": "patch-package",
     "i18n:extract": "cross-env NODE_ENV=development lingui extract --locale en-US",
     "i18n:compile": "yarn i18n:extract && lingui compile",

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "contracts:compile:v3": "typechain --target ethers-v5 --out-dir src/types/v3 \"./node_modules/@uniswap/**/artifacts/contracts/**/*[!dbg].json\"",
     "contracts:compile": "yarn contracts:compile:abi && yarn contracts:compile:abi-ethflow && yarn contracts:add:export && yarn contracts:compile:abi-uniswap && yarn contracts:compile:v3",
     "prei18n:extract": "touch src/locales/en-US.po",
-    "postinstall": "npm-run-all -p patch-package",
+    "postinstall": "patch-package",
     "patch-package": "patch-package",
     "i18n:extract": "cross-env NODE_ENV=development lingui extract --locale en-US",
     "i18n:compile": "yarn i18n:extract && lingui compile",

--- a/src/cow-react/abis/types/index.ts
+++ b/src/cow-react/abis/types/index.ts
@@ -10,5 +10,5 @@ export { GPv2Settlement__factory } from "./factories/GPv2Settlement__factory";
 export { MerkleDrop__factory } from "./factories/MerkleDrop__factory";
 export { TokenDistro__factory } from "./factories/TokenDistro__factory";
 export { VCow__factory } from "./factories/VCow__factory";
-export * from "@cow/abis/types/ethflow";
 export * from "@src/abis/types";
+export * from "@cow/abis/types/ethflow";


### PR DESCRIPTION
# Summary

Remove `contracts:compile i18n:compile` scripts from `postinstall` because we also call them in `prepare`
This will reduce the build time