### PR TITLE
Store amounts using precise values in limit-orders

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -22,7 +22,6 @@ import { TradeButtons } from '@cow/modules/limitOrders/containers/TradeButtons'
 import { TradeApproveWidget } from '@cow/common/containers/TradeApprove/TradeApproveWidget'
 import { useSetupTradeState } from '@cow/modules/trade'
 import { useTradeNavigate } from '@cow/modules/trade/hooks/useTradeNavigate'
-import { useOnCurrencySelection } from '@cow/modules/trade/hooks/useOnCurrencySelection'
 import { ImportTokenModal } from '@cow/modules/trade/containers/ImportTokenModal'
 import { useOnImportDismiss } from '@cow/modules/trade/hooks/useOnImportDismiss'
 import { limitRateAtom } from '../../state/limitRateAtom'
@@ -39,6 +38,7 @@ import { useWalletInfo } from 'hooks/useWalletInfo'
 import { useDetectNativeToken } from '@cow/modules/swap/hooks/useDetectNativeToken'
 import { LimitOrdersProps, limitOrdersPropsChecker } from './limitOrdersPropsChecker'
 import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
+import { useOnCurrencySelection } from '@cow/modules/limitOrders/hooks/useOnCurrencySelection'
 
 export function LimitOrdersWidget() {
   useSetupTradeState()

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -39,6 +39,7 @@ import { useDetectNativeToken } from '@cow/modules/swap/hooks/useDetectNativeTok
 import { LimitOrdersProps, limitOrdersPropsChecker } from './limitOrdersPropsChecker'
 import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
 import { useOnCurrencySelection } from '@cow/modules/limitOrders/hooks/useOnCurrencySelection'
+import { formatSmart } from 'utils/format'
 
 export function LimitOrdersWidget() {
   useSetupTradeState()
@@ -83,7 +84,7 @@ export function LimitOrdersWidget() {
     label: isWrapOrUnwrap ? undefined : isSellOrder ? 'You sell' : 'You sell at most',
     currency: inputCurrency,
     rawAmount: inputCurrencyAmount,
-    viewAmount: inputCurrencyAmount?.toSignificant(6) || '',
+    viewAmount: formatSmart(inputCurrencyAmount) || '',
     balance: inputCurrencyBalance,
     fiatAmount: inputCurrencyFiatAmount,
     receiveAmountInfo: null,
@@ -93,9 +94,7 @@ export function LimitOrdersWidget() {
     label: isWrapOrUnwrap ? undefined : isSellOrder ? 'Your receive at least' : 'You receive exactly',
     currency: outputCurrency,
     rawAmount: isWrapOrUnwrap ? inputCurrencyAmount : outputCurrencyAmount,
-    viewAmount: isWrapOrUnwrap
-      ? inputCurrencyAmount?.toSignificant(6) || ''
-      : outputCurrencyAmount?.toSignificant(6) || '',
+    viewAmount: formatSmart(isWrapOrUnwrap ? inputCurrencyAmount : outputCurrencyAmount) || '',
     balance: outputCurrencyBalance,
     fiatAmount: outputCurrencyFiatAmount,
     receiveAmountInfo: null,

--- a/src/cow-react/modules/limitOrders/containers/RateInput/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/RateInput/index.tsx
@@ -9,6 +9,7 @@ import { useLimitOrdersTradeState } from '@cow/modules/limitOrders/hooks/useLimi
 import { toFraction } from '@cow/modules/limitOrders/utils/toFraction'
 import { useRateImpact } from '@cow/modules/limitOrders/hooks/useRateImpact'
 import { isFractionFalsy } from '@cow/utils/isFractionFalsy'
+import { formatSmart } from 'utils/format'
 
 export function RateInput() {
   // Rate state
@@ -41,7 +42,7 @@ export function RateInput() {
 
     const rate = isInversed ? activeRate.invert() : activeRate
 
-    return rate.toSignificant(6)
+    return formatSmart(rate) || ''
   }, [activeRate, areBothCurrencies, isInversed, isTypedValue, typedValue])
 
   // Handle set market price

--- a/src/cow-react/modules/limitOrders/hooks/useApplyLimitRate.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useApplyLimitRate.ts
@@ -11,25 +11,22 @@ export function useApplyLimitRate() {
   const { activeRate } = useAtomValue(limitRateAtom)
 
   return useCallback(
-    (value: string | null, field: Field): string | null | undefined => {
+    (value: string | null, field: Field): Fraction | null => {
       if (!value || !Number(value) || !activeRate || activeRate.equalTo(0)) {
         return null
       }
 
-      let output: Fraction | null = null
       const parsedValue = toFraction(value)
 
-      // If the field is INPUT we will MULTIPLY passed value and rate
       if (field === Field.INPUT) {
-        output = parsedValue.multiply(activeRate)
-
-        // If the field is OUTPUT we will DIVIDE passed value and rate
-      } else if (field === Field.OUTPUT) {
-        output = parsedValue.divide(activeRate)
+        return parsedValue.multiply(activeRate)
       }
 
-      // We need to return string and we also limit the decimals
-      return output?.toSignificant(6)
+      if (field === Field.OUTPUT) {
+        return parsedValue.divide(activeRate)
+      }
+
+      return null
     },
     [activeRate]
   )

--- a/src/cow-react/modules/limitOrders/hooks/useApplyLimitRate.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useApplyLimitRate.ts
@@ -6,7 +6,7 @@ import { limitRateAtom } from '@cow/modules/limitOrders/state/limitRateAtom'
 import { Fraction } from '@uniswap/sdk-core'
 import { toFraction } from '@cow/modules/limitOrders/utils/toFraction'
 import { useLimitOrdersTradeState } from '@cow/modules/limitOrders/hooks/useLimitOrdersTradeState'
-import JSBI from 'jsbi'
+import { adjustDecimals } from '@cow/modules/limitOrders/utils/adjustDecimals'
 
 // Applies rate to provided value which can be INPUT or OUTPUT
 export function useApplyLimitRate() {
@@ -22,27 +22,11 @@ export function useApplyLimitRate() {
       const { decimals: inputDecimals } = inputCurrency
       const { decimals: outputDecimals } = outputCurrency
 
-      /**
-       * Consider a trade DAI (decimals 18) <-> USDC (decimals 6)
-       * 1. When input is 9 DAI, the value equals 9000000000000000000
-       * Then we should divide it to get value for USDC = 9000000 (6 decimals)
-       *
-       * 2. When input is 9 USDC, the value equals 9000000
-       * Then we should multiply to get value for DAI = 9000000000000000000 (18 decimals)
-       */
-      const shouldMultiplyInput = field === Field.INPUT && inputDecimals < outputDecimals
-      const shouldMultiplyOutput = field === Field.OUTPUT && outputDecimals < inputDecimals
-      const decimalsShift = JSBI.BigInt(10 ** Math.abs(inputDecimals - outputDecimals))
-
-      const parsedValue = ((fraction) => {
-        if (inputDecimals === outputDecimals) return fraction
-
-        if (shouldMultiplyInput || shouldMultiplyOutput) {
-          return fraction.multiply(decimalsShift)
-        }
-
-        return fraction.divide(decimalsShift)
-      })(toFraction(value))
+      const parsedValue = adjustDecimals(
+        toFraction(value),
+        field === Field.INPUT ? inputDecimals : outputDecimals,
+        field === Field.INPUT ? outputDecimals : inputDecimals
+      )
 
       if (field === Field.INPUT) {
         return parsedValue.multiply(activeRate)

--- a/src/cow-react/modules/limitOrders/hooks/useApplyLimitRate.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useApplyLimitRate.ts
@@ -23,17 +23,20 @@ export function useApplyLimitRate() {
       const { decimals: outputDecimals } = outputCurrency
 
       /**
-       * Consider a trade DAI (decimals 18) -> USDC (decimals 6)
-       * 1. When input 9 DAI, the value equals 9000000000000000000
-       * Then we should divide it until 6 decimals to get value for USDC = 9000000
-       * 2. When input 9 USDC, the value equals 9000000
-       * Then we should multiply it until 18 decimals to get value for DAI = 9000000000000000000
+       * Consider a trade DAI (decimals 18) <-> USDC (decimals 6)
+       * 1. When input is 9 DAI, the value equals 9000000000000000000
+       * Then we should divide it to get value for USDC = 9000000 (6 decimals)
+       *
+       * 2. When input is 9 USDC, the value equals 9000000
+       * Then we should multiply to get value for DAI = 9000000000000000000 (18 decimals)
        */
       const shouldMultiplyInput = field === Field.INPUT && inputDecimals < outputDecimals
       const shouldMultiplyOutput = field === Field.OUTPUT && outputDecimals < inputDecimals
       const decimalsShift = JSBI.BigInt(10 ** Math.abs(inputDecimals - outputDecimals))
 
       const parsedValue = ((fraction) => {
+        if (inputDecimals === outputDecimals) return fraction
+
         if (shouldMultiplyInput || shouldMultiplyOutput) {
           return fraction.multiply(decimalsShift)
         }

--- a/src/cow-react/modules/limitOrders/hooks/useApplyLimitRate.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useApplyLimitRate.ts
@@ -5,18 +5,41 @@ import { Field } from 'state/swap/actions'
 import { limitRateAtom } from '@cow/modules/limitOrders/state/limitRateAtom'
 import { Fraction } from '@uniswap/sdk-core'
 import { toFraction } from '@cow/modules/limitOrders/utils/toFraction'
+import { useLimitOrdersTradeState } from '@cow/modules/limitOrders/hooks/useLimitOrdersTradeState'
+import JSBI from 'jsbi'
 
 // Applies rate to provided value which can be INPUT or OUTPUT
 export function useApplyLimitRate() {
   const { activeRate } = useAtomValue(limitRateAtom)
+  const { inputCurrency, outputCurrency } = useLimitOrdersTradeState()
 
   return useCallback(
     (value: string | null, field: Field): Fraction | null => {
-      if (!value || !Number(value) || !activeRate || activeRate.equalTo(0)) {
+      if (!value || !Number(value) || !activeRate || activeRate.equalTo(0) || !inputCurrency || !outputCurrency) {
         return null
       }
 
-      const parsedValue = toFraction(value)
+      const { decimals: inputDecimals } = inputCurrency
+      const { decimals: outputDecimals } = outputCurrency
+
+      /**
+       * Consider a trade DAI (decimals 18) -> USDC (decimals 6)
+       * 1. When input 9 DAI, the value equals 9000000000000000000
+       * Then we should divide it until 6 decimals to get value for USDC = 9000000
+       * 2. When input 9 USDC, the value equals 9000000
+       * Then we should multiply it until 18 decimals to get value for DAI = 9000000000000000000
+       */
+      const shouldMultiplyInput = field === Field.INPUT && inputDecimals < outputDecimals
+      const shouldMultiplyOutput = field === Field.OUTPUT && outputDecimals < inputDecimals
+      const decimalsShift = JSBI.BigInt(10 ** Math.abs(inputDecimals - outputDecimals))
+
+      const parsedValue = ((fraction) => {
+        if (shouldMultiplyInput || shouldMultiplyOutput) {
+          return fraction.multiply(decimalsShift)
+        }
+
+        return fraction.divide(decimalsShift)
+      })(toFraction(value))
 
       if (field === Field.INPUT) {
         return parsedValue.multiply(activeRate)
@@ -28,6 +51,6 @@ export function useApplyLimitRate() {
 
       return null
     },
-    [activeRate]
+    [activeRate, inputCurrency, outputCurrency]
   )
 }

--- a/src/cow-react/modules/limitOrders/hooks/useLimitOrdersTradeState.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useLimitOrdersTradeState.ts
@@ -2,7 +2,6 @@ import { useWeb3React } from '@web3-react/core'
 import { useAtomValue } from 'jotai/utils'
 import { limitOrdersAtom } from '@cow/modules/limitOrders/state/limitOrdersAtom'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
-import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
 import { useTokenBySymbolOrAddress } from '@cow/common/hooks/useTokenBySymbolOrAddress'
 import { OrderKind } from '@cowprotocol/contracts'
 import useCurrencyBalance from 'lib/hooks/useCurrencyBalance'
@@ -23,6 +22,16 @@ export interface LimitOrdersTradeState {
   readonly isUnlocked: boolean
 }
 
+function tryParseFractionalAmount(currency: Currency | null, amount: string | null): CurrencyAmount<Currency> | null {
+  if (!amount || !currency) return null
+
+  try {
+    return currency ? CurrencyAmount.fromFractionalAmount(currency, amount, 1) : null
+  } catch (e) {
+    return null
+  }
+}
+
 export function useLimitOrdersTradeState(): LimitOrdersTradeState {
   const { account } = useWeb3React()
   const state = useAtomValue(limitOrdersAtom)
@@ -33,10 +42,8 @@ export function useLimitOrdersTradeState(): LimitOrdersTradeState {
 
   const inputCurrency = useTokenBySymbolOrAddress(state.inputCurrencyId)
   const outputCurrency = useTokenBySymbolOrAddress(state.outputCurrencyId)
-  const inputCurrencyAmount =
-    tryParseCurrencyAmount(state.inputCurrencyAmount || undefined, inputCurrency || undefined) || null
-  const outputCurrencyAmount =
-    tryParseCurrencyAmount(state.outputCurrencyAmount || undefined, outputCurrency || undefined) || null
+  const inputCurrencyAmount = tryParseFractionalAmount(inputCurrency, state.inputCurrencyAmount)
+  const outputCurrencyAmount = tryParseFractionalAmount(outputCurrency, state.outputCurrencyAmount)
   const inputCurrencyBalance = useCurrencyBalance(account, inputCurrency) || null
   const outputCurrencyBalance = useCurrencyBalance(account, outputCurrency) || null
   const inputCurrencyFiatAmount = useHigherUSDValue(inputCurrencyAmount || undefined)

--- a/src/cow-react/modules/limitOrders/hooks/useLimitOrdersTradeState.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useLimitOrdersTradeState.ts
@@ -23,7 +23,7 @@ export interface LimitOrdersTradeState {
 }
 
 function tryParseFractionalAmount(currency: Currency | null, amount: string | null): CurrencyAmount<Currency> | null {
-  if (!amount || !currency) return null
+  if (!amount || !currency || !+amount) return null
 
   try {
     return currency ? CurrencyAmount.fromFractionalAmount(currency, amount, 1) : null

--- a/src/cow-react/modules/limitOrders/hooks/useOnCurrencySelection.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useOnCurrencySelection.ts
@@ -1,0 +1,51 @@
+import { useCallback } from 'react'
+import { Field } from 'state/swap/actions'
+import { Currency } from '@uniswap/sdk-core'
+import { adjustDecimals } from '@cow/modules/limitOrders/utils/adjustDecimals'
+import { useOnCurrencySelection as useOnCurrencySelectionCommon } from '@cow/modules/trade/hooks/useOnCurrencySelection'
+import { useLimitOrdersTradeState } from '@cow/modules/limitOrders/hooks/useLimitOrdersTradeState'
+import { useUpdateAtom } from 'jotai/utils'
+import { updateLimitOrdersAtom } from '@cow/modules/limitOrders'
+
+export function useOnCurrencySelection(): (field: Field, currency: Currency | null) => void {
+  const { inputCurrency, outputCurrency, inputCurrencyAmount, outputCurrencyAmount } = useLimitOrdersTradeState()
+  const onCurrencySelectionCommon = useOnCurrencySelectionCommon()
+  const updateLimitOrdersState = useUpdateAtom(updateLimitOrdersAtom)
+
+  return useCallback(
+    (field: Field, currency: Currency | null) => {
+      /**
+       * Since we store quotient value in the store, we must adjust the value regarding a currency decimals
+       * For example, we selected USDC (6 decimals) as input currency and entered "6" as amount
+       * Then we change the input currency from USDC to WETH (18 decimals)
+       * In the store we have inputCurrencyAmount = 6000000
+       * Before changing the input currency we must adjust the inputCurrencyAmount for the new currency decimals
+       * 6000000 must be converted to 6000000000000000000
+       */
+      if (currency) {
+        const amountField = field === Field.INPUT ? 'inputCurrencyAmount' : 'outputCurrencyAmount'
+        const amount = field === Field.INPUT ? inputCurrencyAmount : outputCurrencyAmount
+        const targetCurrency = field === Field.INPUT ? inputCurrency : outputCurrency
+
+        if (targetCurrency && amount) {
+          const prevDecimals = targetCurrency.decimals
+          const newDecimals = currency.decimals
+
+          updateLimitOrdersState({
+            [amountField]: adjustDecimals(amount, prevDecimals, newDecimals).quotient.toString(),
+          })
+        }
+      }
+
+      return onCurrencySelectionCommon(field, currency)
+    },
+    [
+      onCurrencySelectionCommon,
+      updateLimitOrdersState,
+      inputCurrency,
+      inputCurrencyAmount,
+      outputCurrency,
+      outputCurrencyAmount,
+    ]
+  )
+}

--- a/src/cow-react/modules/limitOrders/hooks/useUpdateCurrencyAmount.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useUpdateCurrencyAmount.ts
@@ -26,7 +26,7 @@ export function useUpdateCurrencyAmount() {
       if (inputCurrencyAmount !== undefined) {
         // Calculate OUTPUT amount by applying the rate
         const outputWithRate = applyLimitRate(inputCurrencyAmount, Field.INPUT)
-        update.outputCurrencyAmount = outputWithRate
+        update.outputCurrencyAmount = outputWithRate?.quotient.toString()
 
         // Update order type only if keeOrderKind param is not true
         if (!keepOrderKind) {
@@ -38,7 +38,7 @@ export function useUpdateCurrencyAmount() {
       if (outputCurrencyAmount !== undefined) {
         // Calculate INPUT amount by applying the rate
         const inputWithRate = applyLimitRate(outputCurrencyAmount, Field.OUTPUT)
-        update.inputCurrencyAmount = inputWithRate
+        update.inputCurrencyAmount = inputWithRate?.quotient.toString()
 
         // Update order type only if keeOrderKind param is not true
         if (!keepOrderKind) {

--- a/src/cow-react/modules/limitOrders/state/limitOrdersAtom.ts
+++ b/src/cow-react/modules/limitOrders/state/limitOrdersAtom.ts
@@ -27,7 +27,7 @@ export function getDefaultLimitOrdersState(chainId: SupportedChainId | null): Li
 }
 
 export const limitOrdersAtom = atomWithStorage<LimitOrdersState>(
-  'limit-orders-atom:v1',
+  'limit-orders-atom:v2',
   getDefaultLimitOrdersState(null),
   /**
    * atomWithStorage() has build-in feature to persist state between all tabs

--- a/src/cow-react/modules/limitOrders/updaters/ActiveRateUpdater/index.ts
+++ b/src/cow-react/modules/limitOrders/updaters/ActiveRateUpdater/index.ts
@@ -27,7 +27,7 @@ export function ActiveRateUpdater() {
       const field = orderKind === OrderKind.SELL ? 'inputCurrencyAmount' : 'outputCurrencyAmount'
 
       updateCurrencyAmount({
-        [field]: limitState[field]?.toExact(),
+        [field]: limitState[field]?.quotient.toString(),
         keepOrderKind: true,
       })
     }

--- a/src/cow-react/modules/limitOrders/utils/adjustDecimals.ts
+++ b/src/cow-react/modules/limitOrders/utils/adjustDecimals.ts
@@ -1,0 +1,12 @@
+import JSBI from 'jsbi'
+import { Fraction } from '@uniswap/sdk-core'
+
+export function adjustDecimals(value: Fraction, prevDecimals: number, nextDecimals: number): Fraction {
+  const decimalsShift = JSBI.BigInt(10 ** Math.abs(prevDecimals - nextDecimals))
+
+  if (!JSBI.equal(decimalsShift, JSBI.BigInt(0))) {
+    return prevDecimals < nextDecimals ? value.multiply(decimalsShift) : value.divide(decimalsShift)
+  }
+
+  return value
+}

--- a/src/cow-react/modules/limitOrders/utils/adjustDecimals.ts
+++ b/src/cow-react/modules/limitOrders/utils/adjustDecimals.ts
@@ -1,6 +1,14 @@
 import JSBI from 'jsbi'
 import { Fraction } from '@uniswap/sdk-core'
 
+/**
+ * Consider a trade DAI (decimals 18) <-> USDC (decimals 6)
+ * 1. When input is 9 DAI, the value equals 9000000000000000000
+ * Then we should divide it to get value for USDC = 9000000 (6 decimals)
+ *
+ * 2. When input is 9 USDC, the value equals 9000000
+ * Then we should multiply to get value for DAI = 9000000000000000000 (18 decimals)
+ */
 export function adjustDecimals(value: Fraction, prevDecimals: number, nextDecimals: number): Fraction {
   const decimalsShift = JSBI.BigInt(10 ** Math.abs(prevDecimals - nextDecimals))
 


### PR DESCRIPTION
# Summary

Fixes #1595

1. Store amounts using precise values instead of view values (view value = 5 USDC, unit value = 5000000 USDC)
2. Adjust decimals on switch token places
3. Adjust decimals on select currency