### PR TITLE
[TokenLists] Prioritise explicit logoURI over fallback path

### DIFF
--- a/src/custom/components/SearchModal/CommonBases/CommonBasesMod.tsx
+++ b/src/custom/components/SearchModal/CommonBases/CommonBasesMod.tsx
@@ -14,7 +14,7 @@ import { currencyId } from 'utils/currencyId'
 import QuestionHelper from 'components/QuestionHelper'
 import { BaseWrapper, CommonBasesRow, MobileWrapper } from '.' // mod
 import { useFavouriteOrCommonTokens } from 'hooks/useFavouriteOrCommonTokens'
-import { getOverriddenTokenLogoURI } from 'lib/hooks/useCurrencyLogoURIs/useCurrencyLogoURIsMod'
+import useCurrencyLogoURIs from 'lib/hooks/useCurrencyLogoURIs'
 import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
 
 /* const MobileWrapper = styled(AutoColumn)`
@@ -151,11 +151,11 @@ export default function CommonBases({
 /** helper component to retrieve a base currency from the active token lists */
 function CurrencyLogoFromList({ currency }: { currency: Currency }) {
   const token = useTokenInfoFromActiveList(currency)
+  const logoUris = useCurrencyLogoURIs(currency)
 
   let tokenAux = token
-  if (token instanceof WrappedTokenInfo) {
-    const logoURI = getOverriddenTokenLogoURI(token)
-    tokenAux = logoURI ? new WrappedTokenInfo({ ...token.tokenInfo, logoURI }, token.list) : token
+  if (token instanceof WrappedTokenInfo && logoUris.length > 0) {
+    tokenAux = new WrappedTokenInfo({ ...token.tokenInfo, logoURI: logoUris[0] }, token.list)
   }
 
   return <CurrencyLogo currency={tokenAux} style={{ marginRight: 8 }} />

--- a/src/custom/lib/hooks/useCurrencyLogoURIs/useCurrencyLogoURIsMod.ts
+++ b/src/custom/lib/hooks/useCurrencyLogoURIs/useCurrencyLogoURIsMod.ts
@@ -1,4 +1,4 @@
-import { Currency, Token } from '@uniswap/sdk-core'
+import { Currency } from '@uniswap/sdk-core'
 import { SupportedChainId } from 'constants/chains'
 import useHttpLocations from 'hooks/useHttpLocations'
 import { useMemo } from 'react'
@@ -67,8 +67,11 @@ export default function useCurrencyLogoURIs(currency?: Currency | null): string[
         // Explicit overrides should take priority, otherwise append potential other logoURIs to existing candidates
         const imageOverride = ADDRESS_IMAGE_OVERRIDE[currency.address]
         if (imageOverride) {
-          return [imageOverride]
+          // Add image override with higher priority
+          logoURIs.unshift(imageOverride)
         }
+
+        // Last resource, we get the logo from @Uniswap/assets
         const logoURI = getTokenLogoURI(currency.address, currency.chainId)
         if (logoURI) {
           logoURIs.push(logoURI)
@@ -77,10 +80,4 @@ export default function useCurrencyLogoURIs(currency?: Currency | null): string[
     }
     return logoURIs
   }, [currency, locations])
-}
-
-export function getOverriddenTokenLogoURI(currency: Token) {
-  const imageOverride = ADDRESS_IMAGE_OVERRIDE[currency.address]
-  const logoURI = imageOverride || getTokenLogoURI(currency.address, currency.chainId)
-  return logoURI
 }

--- a/src/custom/lib/hooks/useCurrencyLogoURIs/useCurrencyLogoURIsMod.ts
+++ b/src/custom/lib/hooks/useCurrencyLogoURIs/useCurrencyLogoURIsMod.ts
@@ -64,6 +64,7 @@ export default function useCurrencyLogoURIs(currency?: Currency | null): string[
         logoURIs.push(getNativeLogoURI(currency.chainId))
       } else if (currency.isToken) {
         // mod
+        // Explicit overrides should take priority, otherwise append potential other logoURIs to existing candidates
         const imageOverride = ADDRESS_IMAGE_OVERRIDE[currency.address]
         if (imageOverride) {
           return [imageOverride]

--- a/src/custom/lib/hooks/useCurrencyLogoURIs/useCurrencyLogoURIsMod.ts
+++ b/src/custom/lib/hooks/useCurrencyLogoURIs/useCurrencyLogoURIsMod.ts
@@ -64,9 +64,13 @@ export default function useCurrencyLogoURIs(currency?: Currency | null): string[
         logoURIs.push(getNativeLogoURI(currency.chainId))
       } else if (currency.isToken) {
         // mod
-        const logoURI = getOverriddenTokenLogoURI(currency)
+        const imageOverride = ADDRESS_IMAGE_OVERRIDE[currency.address]
+        if (imageOverride) {
+          return [imageOverride]
+        }
+        const logoURI = getTokenLogoURI(currency.address, currency.chainId)
         if (logoURI) {
-          return [logoURI]
+          logoURIs.push(logoURI)
         }
       }
     }


### PR DESCRIPTION
# Summary

Currently we override the explicit tokenURL as provided in the token list by either an explicit (hardcoded) override or the Uniswap generated fallback link (https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/${networkName}/assets/${address}/logo.png).

This means we never load the URLs from the actual token list (cf. e.g. in prod right now ACX and icETH don't have a logo despite having one specified in the list.

This PR changes the logic of the override to use the following priority:
1. Explicit hardcoded overrides (this ensures that e.g. we show a nice WETH symbol)
2. Explicit URLs as specified on the token list
3. Autogenerated Uniswap link only as a fallback

Before:

<img width="1006" alt="image (1)" src="https://user-images.githubusercontent.com/1200333/206691809-f984a6e0-16a4-4d24-919d-537a6ecd328b.png">


After:

<img width="518" alt="image" src="https://user-images.githubusercontent.com/1200333/206691912-800c00cb-ada5-44f7-bbc6-8bf7220b15f8.png">

  # To Test

1. Open the token picker, type ACX
    - [ ] See the token loads with an image
    - [ ] All other tokens still show the same image
2. Select Token
    - [ ] See icon displayed in sell token field

  # Background

Context: https://cowservices.slack.com/archives/C04DV3TL1MH/p1670522808765189

