### PR TITLE
Apply smart quote selection to RateInput

### DIFF
--- a/src/cow-react/common/services/getQuoteCurrency/index.ts
+++ b/src/cow-react/common/services/getQuoteCurrency/index.ts
@@ -33,6 +33,20 @@ export function getQuoteCurrency(
   const inputCurrency = inputCurrencyAmount.currency
   const outputCurrency = outputCurrencyAmount.currency
 
+  const quoteCurrencyByStableCoin = getQuoteCurrencyByStableCoin(chainId, inputCurrency, outputCurrency)
+
+  if (quoteCurrencyByStableCoin) return quoteCurrencyByStableCoin
+
+  return inputCurrencyAmount.lessThan(outputCurrencyAmount) ? inputCurrency : outputCurrency
+}
+
+export function getQuoteCurrencyByStableCoin(
+  chainId: SupportedChainId | undefined,
+  inputCurrency: Currency | null,
+  outputCurrency: Currency | null
+): Currency | null {
+  if (!chainId || !inputCurrency || !outputCurrency) return null
+
   const stableCoins = STABLE_COINS[chainId]
 
   const inputAddress = inputCurrency.isNative ? NATIVE_CURRENCY_BUY_ADDRESS : inputCurrency.address.toLowerCase()
@@ -44,5 +58,5 @@ export function getQuoteCurrency(
   if (isInputStableCoin) return outputCurrency
   if (isOutputStableCoin) return inputCurrency
 
-  return inputCurrencyAmount.lessThan(outputCurrencyAmount) ? inputCurrency : outputCurrency
+  return null
 }

--- a/src/cow-react/common/services/getQuoteCurrency/index.ts
+++ b/src/cow-react/common/services/getQuoteCurrency/index.ts
@@ -32,7 +32,6 @@ export function getQuoteCurrency(
 
   const inputCurrency = inputCurrencyAmount.currency
   const outputCurrency = outputCurrencyAmount.currency
-  const isInputAmountSmallerThatOutput = +inputCurrencyAmount.toExact() < +outputCurrencyAmount.toExact()
 
   const stableCoins = STABLE_COINS[chainId]
 
@@ -45,5 +44,5 @@ export function getQuoteCurrency(
   if (isInputStableCoin) return outputCurrency
   if (isOutputStableCoin) return inputCurrency
 
-  return isInputAmountSmallerThatOutput ? inputCurrency : outputCurrency
+  return inputCurrencyAmount.lessThan(outputCurrencyAmount) ? inputCurrency : outputCurrency
 }

--- a/src/cow-react/modules/limitOrders/containers/RateInput/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/RateInput/index.tsx
@@ -87,7 +87,13 @@ export function RateInput() {
   // use getQuoteCurrencyByStableCoin() first for cases when there are no amounts
   useEffect(() => {
     // Don't set quote currency until amounts are not set
-    if (isQuoteCurrencySet || isFractionFalsy(inputCurrencyAmount) || isFractionFalsy(outputCurrencyAmount)) {
+    if (
+      isQuoteCurrencySet ||
+      isFractionFalsy(inputCurrencyAmount) ||
+      isFractionFalsy(outputCurrencyAmount) ||
+      !inputCurrency ||
+      !outputCurrency
+    ) {
       return
     }
 

--- a/src/cow-react/modules/limitOrders/containers/RateInput/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/RateInput/index.tsx
@@ -10,7 +10,7 @@ import { toFraction } from '@cow/modules/limitOrders/utils/toFraction'
 import { useRateImpact } from '@cow/modules/limitOrders/hooks/useRateImpact'
 import { isFractionFalsy } from '@cow/utils/isFractionFalsy'
 import { formatSmart } from 'utils/format'
-import { getQuoteCurrency } from '@cow/common/services/getQuoteCurrency'
+import { getQuoteCurrency, getQuoteCurrencyByStableCoin } from '@cow/common/services/getQuoteCurrency'
 import { useWeb3React } from '@web3-react/core'
 import { getAddress } from '@cow/utils/getAddress'
 
@@ -83,8 +83,11 @@ export function RateInput() {
   }, [activeRate, executionRate, isLoadingExecutionRate, initialRate, inputCurrencyId, outputCurrencyId])
 
   // Apply smart quote selection
+  // use getQuoteCurrencyByStableCoin() first for cases when there are no amounts
   useEffect(() => {
-    const quoteCurrency = getQuoteCurrency(chainId, inputCurrencyAmount, outputCurrencyAmount)
+    const quoteCurrency =
+      getQuoteCurrencyByStableCoin(chainId, inputCurrency, outputCurrency) ||
+      getQuoteCurrency(chainId, inputCurrencyAmount, outputCurrencyAmount)
     const [quoteCurrencyAddress, inputCurrencyAddress] = [getAddress(quoteCurrency), getAddress(inputCurrency)]
 
     updateLimitRateState({ isInversed: quoteCurrencyAddress !== inputCurrencyAddress })

--- a/src/cow-react/modules/limitOrders/updaters/MarketPriceUpdater/index.tsx
+++ b/src/cow-react/modules/limitOrders/updaters/MarketPriceUpdater/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useLayoutEffect, useState } from 'react'
 import { useAtomValue, useUpdateAtom } from 'jotai/utils'
 import { limitRateAtom, updateLimitRateAtom } from '@cow/modules/limitOrders/state/limitRateAtom'
 import { useGetInitialPrice } from '@cow/modules/limitOrders/hooks/useGetInitialPrice'
@@ -16,7 +16,7 @@ export function MarketPriceUpdater() {
   const { price, isLoading } = useGetInitialPrice()
   const prevPrice = usePrevious(price)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     updateLimitRateState({
       // Don't change isLoading flag when price is already set
       isLoading: isInitialPriceSet ? false : isLoading,
@@ -25,7 +25,7 @@ export function MarketPriceUpdater() {
     })
   }, [isInitialPriceSet, price, isLoading, updateLimitRateState])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     // Remove current execution rate on empty fields or zero value
     if (isFractionFalsy(inputCurrencyAmount) || isFractionFalsy(outputCurrencyAmount)) {
       updateLimitRateState({ executionRate: null })
@@ -33,7 +33,7 @@ export function MarketPriceUpdater() {
   }, [inputCurrencyAmount, outputCurrencyAmount, executionRate, updateLimitRateState])
 
   // Set initial price once
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!price || isInitialPriceSet || isLoading || prevPrice?.equalTo(price)) return
 
     setIsInitialPriceSet(true)
@@ -41,7 +41,7 @@ export function MarketPriceUpdater() {
   }, [isInitialPriceSet, updateLimitRateState, price, isLoading, prevPrice])
 
   // Reset initial price set flag when any token was changed
-  useEffect(() => {
+  useLayoutEffect(() => {
     setIsInitialPriceSet(false)
   }, [inputCurrency, outputCurrency])
 

--- a/src/cow-react/modules/limitOrders/updaters/QuoteUpdater/hooks/useFetchMarketPrice/index.ts
+++ b/src/cow-react/modules/limitOrders/updaters/QuoteUpdater/hooks/useFetchMarketPrice/index.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useLayoutEffect } from 'react'
 import { useWeb3React } from '@web3-react/core'
 import { useUpdateAtom } from 'jotai/utils'
 
@@ -32,7 +32,7 @@ export function useFetchMarketPrice() {
   const handleResponse = useHandleResponse()
 
   // Main hook updater
-  useEffect(() => {
+  useLayoutEffect(() => {
     const handleFetchQuote = () => {
       if (!feeQuoteParams || isWrapOrUnwrap) {
         return
@@ -56,7 +56,7 @@ export function useFetchMarketPrice() {
   }, [feeQuoteParams, handleResponse, updateLimitRateState, setLimitOrdersQuote, isWrapOrUnwrap])
 
   // Turn on the loading if some of these dependencies have changed and remove execution rate
-  useEffect(() => {
+  useLayoutEffect(() => {
     updateLimitRateState({ isLoadingExecutionRate: true, executionRate: null })
   }, [chainId, inputCurrency, outputCurrency, orderKind, account, updateLimitRateState])
 


### PR DESCRIPTION
# Summary

Fixes #1656

1. When one of the tokens is stable-coin, then another token is `quote` (should be displayed in `Price per TOKEN`)
2. When there are no stable-coins in trade, then consider a token with the smallest amount as `quote`. (for 0.0005 WETH -> 3000 COW, WETH is quote)

https://user-images.githubusercontent.com/7122625/206747578-fff03901-0dec-4c1d-8ab6-8fecb6a147e2.mov

