### PR TITLE
Change uri logic

### DIFF
--- a/src/custom/components/SearchModal/CommonBases/CommonBasesMod.tsx
+++ b/src/custom/components/SearchModal/CommonBases/CommonBasesMod.tsx
@@ -14,7 +14,7 @@ import { currencyId } from 'utils/currencyId'
 import QuestionHelper from 'components/QuestionHelper'
 import { BaseWrapper, CommonBasesRow, MobileWrapper } from '.' // mod
 import { useFavouriteOrCommonTokens } from 'hooks/useFavouriteOrCommonTokens'
-import { getOverriddenTokenLogoURI } from 'lib/hooks/useCurrencyLogoURIs/useCurrencyLogoURIsMod'
+import useCurrencyLogoURIs from 'lib/hooks/useCurrencyLogoURIs'
 import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
 
 /* const MobileWrapper = styled(AutoColumn)`
@@ -151,11 +151,11 @@ export default function CommonBases({
 /** helper component to retrieve a base currency from the active token lists */
 function CurrencyLogoFromList({ currency }: { currency: Currency }) {
   const token = useTokenInfoFromActiveList(currency)
+  const logoUris = useCurrencyLogoURIs(currency)
 
   let tokenAux = token
-  if (token instanceof WrappedTokenInfo) {
-    const logoURI = getOverriddenTokenLogoURI(token)
-    tokenAux = logoURI ? new WrappedTokenInfo({ ...token.tokenInfo, logoURI }, token.list) : token
+  if (token instanceof WrappedTokenInfo && logoUris.length > 0) {
+    tokenAux = new WrappedTokenInfo({ ...token.tokenInfo, logoURI: logoUris[0] }, token.list)
   }
 
   return <CurrencyLogo currency={tokenAux} style={{ marginRight: 8 }} />

--- a/src/custom/lib/hooks/useCurrencyLogoURIs/useCurrencyLogoURIsMod.ts
+++ b/src/custom/lib/hooks/useCurrencyLogoURIs/useCurrencyLogoURIsMod.ts
@@ -1,4 +1,4 @@
-import { Currency, Token } from '@uniswap/sdk-core'
+import { Currency } from '@uniswap/sdk-core'
 import { SupportedChainId } from 'constants/chains'
 import useHttpLocations from 'hooks/useHttpLocations'
 import { useMemo } from 'react'
@@ -67,8 +67,11 @@ export default function useCurrencyLogoURIs(currency?: Currency | null): string[
         // Explicit overrides should take priority, otherwise append potential other logoURIs to existing candidates
         const imageOverride = ADDRESS_IMAGE_OVERRIDE[currency.address]
         if (imageOverride) {
-          return [imageOverride]
+          // Add image override with higher priority
+          logoURIs.unshift(imageOverride)
         }
+
+        // Last resource, we get the logo from @Uniswap/assets
         const logoURI = getTokenLogoURI(currency.address, currency.chainId)
         if (logoURI) {
           logoURIs.push(logoURI)
@@ -77,10 +80,4 @@ export default function useCurrencyLogoURIs(currency?: Currency | null): string[
     }
     return logoURIs
   }, [currency, locations])
-}
-
-export function getOverriddenTokenLogoURI(currency: Token) {
-  const imageOverride = ADDRESS_IMAGE_OVERRIDE[currency.address]
-  const logoURI = imageOverride || getTokenLogoURI(currency.address, currency.chainId)
-  return logoURI
 }


### PR DESCRIPTION
# Summary

Suggestion on some small modification for #1669

It doesn't change anything fundamentally, but it:
- Deletes the `getOverriddenTokenLogoURI` which I believe we don't need anymore.
- Adapts `CommonBases` so it uses `useCurrencyLogoURIs` hook instead.
- Changes slightly the logic. Respect the precedence, but returns the full list of uris so we have fallbacks even for the overrides tokens.