### PR TITLE
Fix user input handling in limit-orders

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -99,14 +99,14 @@ export function LimitOrdersWidget() {
     fiatAmount: outputCurrencyFiatAmount,
     receiveAmountInfo: null,
   }
+
   const onUserInput = useCallback(
     (field: Field, typedValue: string) => {
-      if (!inputCurrency || !outputCurrency) return
+      const currency = field === Field.INPUT ? inputCurrency : outputCurrency
 
-      const value = tryParseCurrencyAmount(
-        typedValue,
-        field === Field.INPUT ? inputCurrency : outputCurrency
-      )?.quotient.toString()
+      if (!currency) return
+
+      const value = tryParseCurrencyAmount(typedValue, currency)?.quotient.toString()
 
       if (isWrapOrUnwrap) {
         updateCurrencyAmount({


### PR DESCRIPTION
# Summary

Fixes #1684 #1683

`onUserInput()` callback wrongly handled an user input when one of the tokens is not set.