### PR TITLE
Fix input in CurrencyInputPanel when value is zero

### DIFF
--- a/src/cow-react/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
+++ b/src/cow-react/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
@@ -82,7 +82,11 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
   )
   const handleMaxInput = useCallback(() => {
     const maxBalance = maxAmountSpend(balance || undefined)
-    maxBalance && onUserInputDispatch(maxBalance.toExact())
+    if (!maxBalance) {
+      return
+    }
+
+    onUserInputDispatch(maxBalance.toExact())
     setMaxSellTokensAnalytics()
   }, [balance, onUserInputDispatch])
 
@@ -93,7 +97,9 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
     }
 
     setTypedValue(viewAmount)
-  }, [typedValue, viewAmount])
+    // We don't need triggering from typedValue changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewAmount])
 
   const numericalInput = (
     <styledEl.NumericalInput

--- a/src/cow-react/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
+++ b/src/cow-react/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
@@ -67,10 +67,6 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
   const [isCurrencySearchModalOpen, setCurrencySearchModalOpen] = useState(false)
   const [typedValue, setTypedValue] = useState(viewAmount)
 
-  useEffect(() => {
-    setTypedValue(viewAmount)
-  }, [viewAmount])
-
   const onCurrencySelect = useCallback(
     (currency: Currency) => {
       onCurrencySelection(field, currency)
@@ -91,8 +87,13 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
   }, [balance, onUserInputDispatch])
 
   useEffect(() => {
+    // Don't override typedValue, when viewAmount from props and typedValue are zero (0 or 0. or 0.000)
+    if (!viewAmount && (!typedValue || parseFloat(typedValue) === 0)) {
+      return
+    }
+
     setTypedValue(viewAmount)
-  }, [viewAmount])
+  }, [typedValue, viewAmount])
 
   const numericalInput = (
     <styledEl.NumericalInput

--- a/src/cow-react/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
+++ b/src/cow-react/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
@@ -91,10 +91,13 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
   }, [balance, onUserInputDispatch])
 
   useEffect(() => {
+    const areValuesSame = parseFloat(viewAmount) === parseFloat(typedValue)
+
+    // Don't override typedValue when, for example: viewAmount = 5  and typedValue = 5.
+    if (areValuesSame) return
+
     // Don't override typedValue, when viewAmount from props and typedValue are zero (0 or 0. or 0.000)
-    if (!viewAmount && (!typedValue || parseFloat(typedValue) === 0)) {
-      return
-    }
+    if (!viewAmount && (!typedValue || parseFloat(typedValue) === 0)) return
 
     setTypedValue(viewAmount)
     // We don't need triggering from typedValue changes

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -212,7 +212,7 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
   }, [isRateLoading, isWrapOrUnwrap, inputCurrency, outputCurrency])
 
   const currenciesLoadingInProgress = false
-  const showSetMax = inputCurrencyInfo.rawAmount?.toExact() !== inputCurrencyInfo.balance?.toExact()
+  const showSetMax = !!inputCurrencyInfo.balance && inputCurrencyInfo.rawAmount?.equalTo(inputCurrencyInfo.balance)
 
   const subsidyAndBalance: BalanceAndSubsidy = {
     subsidy: {

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -40,6 +40,7 @@ import { LimitOrdersProps, limitOrdersPropsChecker } from './limitOrdersPropsChe
 import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
 import { useOnCurrencySelection } from '@cow/modules/limitOrders/hooks/useOnCurrencySelection'
 import { tokenViewAmount } from '@cow/modules/trade/utils/tokenViewAmount'
+import { maxAmountSpend } from '@src/utils/maxAmountSpend'
 
 export function LimitOrdersWidget() {
   useSetupTradeState()
@@ -78,13 +79,14 @@ export function LimitOrdersWidget() {
     [settingState.showRecipient, isWrapOrUnwrap]
   )
   const priceImpact = usePriceImpact(useLimitOrdersPriceImpactParams())
+  const inputViewAmount = tokenViewAmount(inputCurrencyAmount, inputCurrencyBalance, orderKind === OrderKind.SELL)
 
   const inputCurrencyInfo: CurrencyInfo = {
     field: Field.INPUT,
     label: isWrapOrUnwrap ? undefined : isSellOrder ? 'You sell' : 'You sell at most',
     currency: inputCurrency,
     rawAmount: inputCurrencyAmount,
-    viewAmount: tokenViewAmount(inputCurrencyAmount, inputCurrencyBalance, orderKind === OrderKind.SELL),
+    viewAmount: inputViewAmount,
     balance: inputCurrencyBalance,
     fiatAmount: inputCurrencyFiatAmount,
     receiveAmountInfo: null,
@@ -94,11 +96,9 @@ export function LimitOrdersWidget() {
     label: isWrapOrUnwrap ? undefined : isSellOrder ? 'You receive at least' : 'You receive exactly',
     currency: outputCurrency,
     rawAmount: isWrapOrUnwrap ? inputCurrencyAmount : outputCurrencyAmount,
-    viewAmount: tokenViewAmount(
-      isWrapOrUnwrap ? inputCurrencyAmount : outputCurrencyAmount,
-      outputCurrencyBalance,
-      orderKind === OrderKind.BUY
-    ),
+    viewAmount: isWrapOrUnwrap
+      ? inputViewAmount
+      : tokenViewAmount(outputCurrencyAmount, outputCurrencyBalance, orderKind === OrderKind.BUY),
     balance: outputCurrencyBalance,
     fiatAmount: outputCurrencyFiatAmount,
     receiveAmountInfo: null,
@@ -212,7 +212,8 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
   }, [isRateLoading, isWrapOrUnwrap, inputCurrency, outputCurrency])
 
   const currenciesLoadingInProgress = false
-  const showSetMax = !!inputCurrencyInfo.balance && !inputCurrencyInfo.rawAmount?.equalTo(inputCurrencyInfo.balance)
+  const maxBalance = maxAmountSpend(inputCurrencyInfo.balance || undefined)
+  const showSetMax = !!maxBalance && !inputCurrencyInfo.rawAmount?.equalTo(maxBalance)
 
   const subsidyAndBalance: BalanceAndSubsidy = {
     subsidy: {

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -212,7 +212,7 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
   }, [isRateLoading, isWrapOrUnwrap, inputCurrency, outputCurrency])
 
   const currenciesLoadingInProgress = false
-  const showSetMax = !!inputCurrencyInfo.balance && inputCurrencyInfo.rawAmount?.equalTo(inputCurrencyInfo.balance)
+  const showSetMax = !!inputCurrencyInfo.balance && !inputCurrencyInfo.rawAmount?.equalTo(inputCurrencyInfo.balance)
 
   const subsidyAndBalance: BalanceAndSubsidy = {
     subsidy: {

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -105,12 +105,11 @@ export function LimitOrdersWidget() {
   }
   const onUserInput = useCallback(
     (field: Field, typedValue: string) => {
-      if (!inputCurrency || !outputCurrency) return
+      const currency = field === Field.INPUT ? inputCurrency : outputCurrency
 
-      const value = tryParseCurrencyAmount(
-        typedValue,
-        field === Field.INPUT ? inputCurrency : outputCurrency
-      )?.quotient.toString()
+      if (!currency) return
+
+      const value = tryParseCurrencyAmount(typedValue, currency)?.quotient.toString()
 
       if (isWrapOrUnwrap || field === Field.INPUT) {
         updateCurrencyAmount({

--- a/src/cow-react/modules/swap/containers/NewSwapWidget/index.tsx
+++ b/src/cow-react/modules/swap/containers/NewSwapWidget/index.tsx
@@ -20,7 +20,7 @@ import { useTradePricesUpdate } from '@cow/modules/swap/hooks/useTradePricesUpda
 import { useCurrencyBalance } from 'state/connection/hooks'
 import { CurrencyInfo } from '@cow/common/pure/CurrencyInputPanel/types'
 import { Field } from 'state/swap/actions'
-import { tokenViewAmount } from '@cow/modules/swap/helpers/tokenViewAmount'
+import { tokenViewAmount } from '@cow/modules/trade/utils/tokenViewAmount'
 import { useHigherUSDValue } from 'hooks/useStablecoinPrice'
 import { getInputReceiveAmountInfo, getOutputReceiveAmountInfo } from '@cow/modules/swap/helpers/tradeReceiveAmount'
 import React, { useState } from 'react'

--- a/src/cow-react/modules/trade/utils/tokenViewAmount.ts
+++ b/src/cow-react/modules/trade/utils/tokenViewAmount.ts
@@ -3,7 +3,7 @@ import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import { maxAmountSpend } from 'utils/maxAmountSpend'
 
 export function tokenViewAmount(
-  amount: CurrencyAmount<Currency> | undefined,
+  amount: CurrencyAmount<Currency> | undefined | null,
   balance: CurrencyAmount<Currency> | null,
   isIndependentField: boolean
 ): string {


### PR DESCRIPTION
# Summary

Fixes #1658 #1677

In `CurrencyInputPanel` there was a wrong overriding of `typed value` for zero values (`0` or `0.` or `0.0`).