### PR TITLE
1.26.0-RC.0 version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "types": "./dist/widgets.d.ts",
   "private": true,
-  "version": "1.26.0-alpha.2",
+  "version": "1.26.0-RC.0",
   "engines": {
     "node": ">=16.0.0 <17.0.0"
   },


### PR DESCRIPTION
# Summary

- Bump version `1.26.0-RC.0`
