### PR TITLE
[EthFlow] Follow up to PR #1629 - Update cancellation state for EthFlow orders

### DIFF
--- a/src/cow-react/common/hooks/useCancelOrder/useEthFlowCancelOrder.ts
+++ b/src/cow-react/common/hooks/useCancelOrder/useEthFlowCancelOrder.ts
@@ -3,7 +3,7 @@ import { useWeb3React } from '@web3-react/core'
 
 import { useEthFlowContract } from 'hooks/useContract'
 import { Order } from 'state/orders/actions'
-import { useSetOrderCancellationHash } from 'state/orders/hooks'
+import { useRequestOrderCancellation, useSetOrderCancellationHash } from 'state/orders/hooks'
 import { calculateGasMargin } from 'utils/calculateGasMargin'
 import { logSwapFlowError } from '@cow/modules/swap/services/utils/logger'
 import { ETHFLOW_GAS_LIMIT_DEFAULT } from '@cow/modules/swap/services/ethFlow/const'
@@ -14,6 +14,7 @@ export function useEthFlowCancelOrder() {
   const { chainId } = useWeb3React()
   const cancelEthFlowCallback = getCancelEthFlowOrderCallback(useEthFlowContract())
   const setOrderCancellationHash = useSetOrderCancellationHash()
+  const cancelPendingOrder = useRequestOrderCancellation()
 
   return useCallback(
     async (order: Order) => {
@@ -23,11 +24,11 @@ export function useEthFlowCancelOrder() {
 
       const receipt = await cancelEthFlowCallback(order)
       if (receipt?.hash) {
-        // TODO: set cancelling as well?
+        cancelPendingOrder({ id: order.id, chainId })
         setOrderCancellationHash({ chainId, id: order.id, hash: receipt.hash })
       }
     },
-    [cancelEthFlowCallback, chainId, setOrderCancellationHash]
+    [cancelEthFlowCallback, cancelPendingOrder, chainId, setOrderCancellationHash]
   )
 }
 

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -140,10 +140,16 @@ function createActivityDescriptor(tx?: EnhancedTransactionDetails, order?: Order
     // setup variables accordingly...
     id = order.id
 
-    isPending = order.status === OrderStatus.PENDING
-    isPresignaturePending = order.status === OrderStatus.PRESIGNATURE_PENDING
+    isPresignaturePending = order.status === OrderStatus.PRESIGNATURE_PENDING // Smart contract orders only
+    isCreating = order.status === OrderStatus.CREATING // EthFlow orders only
+    isPending = order.status === OrderStatus.PENDING // All orders
     isConfirmed = !isPending && order.status === OrderStatus.FULFILLED
-    isCreating = order.status === OrderStatus.CREATING
+    // `order.isCancelling` is not enough to tell if the order should be shown as cancelling in the UI.
+    // We can only do so if the order is in a "pending" state.
+    // `isPending` is used for all orders when they are "OPEN".
+    // `isCreating` is only used for EthFlow orders from the moment the tx is sent until it's received from the API.
+    // After it's created in the backend the status changes to "OPEN", which ends up here as PENDING
+    // Thus, we add both here to tell if the order is being cancelled
     isCancelling = (order.isCancelling || false) && (isPending || isCreating)
     isCancelled = !isConfirmed && order.status === OrderStatus.CANCELLED
     isRefunding = false // TODO: wire up refunding state

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -143,9 +143,9 @@ function createActivityDescriptor(tx?: EnhancedTransactionDetails, order?: Order
     isPending = order.status === OrderStatus.PENDING
     isPresignaturePending = order.status === OrderStatus.PRESIGNATURE_PENDING
     isConfirmed = !isPending && order.status === OrderStatus.FULFILLED
-    isCancelling = (order.isCancelling || false) && isPending
-    isCancelled = !isConfirmed && order.status === OrderStatus.CANCELLED
     isCreating = order.status === OrderStatus.CREATING
+    isCancelling = (order.isCancelling || false) && (isPending || isCreating)
+    isCancelled = !isConfirmed && order.status === OrderStatus.CANCELLED
     isRefunding = false // TODO: wire up refunding state
     isRefunded = order.isRefunded || false
 


### PR DESCRIPTION
# Summary

Follow up to https://github.com/cowprotocol/cowswap/pull/1629#issuecomment-1339999184

This PR addresses (hopefully) points 1 to 3.

As for point 4, that is correct, the UI doesn't recognize when the tx is cancelled/sped up in the wallet directly.
