### PR TITLE
Eth flow/remove feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,3 @@ The plan:
 2. Deploy a new version to production
 
 `emergency.js` is not cached by browser and loaded before all.
-
-## Feature flags
-
-`localStorage.setItem('enableEthFlow', '1')` - enable native EthFlow (WORK IN PROGRESS)
-`localStorage.setItem('enableLimitOrders', '1')` - enable limit orders page (WORK IN PROGRESS)

--- a/src/cow-react/modules/swap/helpers/getEthFlowEnabled.ts
+++ b/src/cow-react/modules/swap/helpers/getEthFlowEnabled.ts
@@ -1,7 +1,5 @@
 import { isProd } from 'utils/environments'
 
-const ETH_FLOW_ENABLED_LOCAL_STORAGE_KEY = 'enableEthFlow'
-
 export function getEthFlowEnabled(isSmartContractWallet: boolean): boolean {
-  return !isProd && !isSmartContractWallet && localStorage.getItem(ETH_FLOW_ENABLED_LOCAL_STORAGE_KEY) === '1'
+  return !isProd && !isSmartContractWallet
 }

--- a/src/cow-react/modules/swap/helpers/getEthFlowEnabled.ts
+++ b/src/cow-react/modules/swap/helpers/getEthFlowEnabled.ts
@@ -1,5 +1,3 @@
-import { isProd } from 'utils/environments'
-
 export function getEthFlowEnabled(isSmartContractWallet: boolean): boolean {
-  return !isProd && !isSmartContractWallet
+  return !isSmartContractWallet
 }


### PR DESCRIPTION
# Summary

Removing EthFlow feature flag

# To Test

1. Open app and pick ETH as sell token
* EthFlow should show up without needing to use the feature flag