### PR TITLE
Tooltip styles fix

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/styled.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/styled.tsx
@@ -23,7 +23,7 @@ export const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 4px 10px;
+  padding: 8px;
   margin: 0;
   font-weight: 500;
   font-size: 16px;

--- a/src/cow-react/modules/limitOrders/pure/Settings/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Settings/index.tsx
@@ -21,7 +21,7 @@ function SettingsBox({ title, tooltip, value, toggle, disabled = false }: Settin
     <styledEl.SettingsBox disabled={disabled}>
       <styledEl.SettingsBoxTitle>
         <Trans>{title}</Trans>
-        <QuestionHelper bgColor={theme.bg3} color={theme.text1} text={<Trans>{tooltip}</Trans>} />
+        <QuestionHelper bgColor={theme.grey1} color={theme.text1} text={<Trans>{tooltip}</Trans>} />
       </styledEl.SettingsBoxTitle>
       <Toggle isActive={value} toggle={toggle} />
     </styledEl.SettingsBox>

--- a/src/cow-react/modules/limitOrders/pure/Settings/styled.ts
+++ b/src/cow-react/modules/limitOrders/pure/Settings/styled.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components/macro'
+import { transparentize } from 'polished'
 
 export const SettingsTitle = styled.h3`
   font-weight: 600;
@@ -8,12 +9,13 @@ export const SettingsTitle = styled.h3`
 `
 
 export const SettingsContainer = styled.div`
-  margin-top: 12px;
-  background: ${({ theme }) => theme.bg5};
-  padding: 1rem;
+  margin: 12px 0 0;
+  padding: 16px;
   border-radius: 12px;
-  box-shadow: 0 0 0 rgb(0 0 0 / 1%), 0 4px 8px rgb(0 0 0 / 0%), 0 16px 24px rgb(0 0 0 / 60%),
-    0 24px 32px rgb(0 0 0 / 20%);
+  box-shadow: ${({ theme }) => theme.boxShadow2};
+  border: 1px solid ${({ theme }) => transparentize(0.95, theme.white)};
+  background: ${({ theme }) => theme.bg1};
+  color: ${({ theme }) => theme.text1};
 `
 
 export const SettingsBox = styled.div<{ disabled: boolean }>`

--- a/src/cow-react/modules/limitOrders/pure/UnlockLimitOrders/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/UnlockLimitOrders/index.tsx
@@ -27,7 +27,10 @@ export function UnlockLimitOrders({ handleUnlock }: { handleUnlock: () => void }
         <styledEl.List>
           {BULLET_LIST_CONTENT.map(({ id, iconType, content }) => (
             <li key={id} data-icon={iconType || null}>
-              <SVG src={iconType && iconType === 'progress' ? iconProgress : iconCompleted} /> {content}
+              <span>
+                <SVG src={iconType && iconType === 'progress' ? iconProgress : iconCompleted} />
+              </span>{' '}
+              {content}
             </li>
           ))}
         </styledEl.List>

--- a/src/cow-react/modules/limitOrders/pure/UnlockLimitOrders/styled.ts
+++ b/src/cow-react/modules/limitOrders/pure/UnlockLimitOrders/styled.ts
@@ -49,17 +49,24 @@ export const List = styled.ul`
     padding: 0;
   }
 
-  > li > svg {
-    --size: 17px;
+  > li > span {
+    --size: 18px;
     width: var(--size);
     height: var(--size);
+    display: block;
   }
 
-  > li > svg > path {
+  > li > span > svg {
+    width: var(--size);
+    height: var(--size);
+    display: block;
+  }
+
+  > li > span > svg > path {
     fill: ${({ theme }) => theme.success};
   }
 
-  > li[data-icon='progress'] > svg > path {
+  > li[data-icon='progress'] > span > svg > path {
     fill: ${({ theme }) => theme.warning};
   }
 `

--- a/src/cow-react/modules/swap/containers/FeesDiscount/index.tsx
+++ b/src/cow-react/modules/swap/containers/FeesDiscount/index.tsx
@@ -35,7 +35,7 @@ export const FeesDiscount: React.FC<FeesDiscountProps> = ({ onClick, theme, ...b
           <Trans>Fees discount</Trans>{' '}
           <MouseoverTooltipContent
             content={SUBSIDY_INFO_MESSAGE + '. Click on the discount button on the right for more info.'}
-            bgColor={theme.bg1}
+            bgColor={theme.grey1}
             color={theme.text1}
             wrap
           >

--- a/src/custom/components/Popover/index.tsx
+++ b/src/custom/components/Popover/index.tsx
@@ -12,11 +12,11 @@ export interface PopoverContainerProps {
 }
 
 const PopoverContainer = styled(PopoverContainerMod)<PopoverContainerProps>`
-  background: ${({ theme, bgColor }) => bgColor || theme.bg1};
+  background: ${({ theme, bgColor }) => bgColor || theme.grey1};
   color: ${({ theme, color }) => color || theme.text1};
-  box-shadow: 0 4px 16px 0 ${({ theme }) => transparentize(0.8, theme.shadow1)};
+  box-shadow: ${({ theme }) => theme.boxShadow2};
+  border: 1px solid ${({ theme }) => transparentize(0.95, theme.white)};
   border-radius: 12px;
-  border: 0;
   padding: 6px 3px;
   z-index: 10;
   font-size: 13px;
@@ -28,7 +28,7 @@ const PopoverContainer = styled(PopoverContainerMod)<PopoverContainerProps>`
 
 const Arrow = styled(ArrowMod)<Omit<PopoverContainerProps, 'color' | 'show'>>`
   ::before {
-    background: ${({ theme, bgColor }) => bgColor || theme.bg1};
+    background: ${({ theme, bgColor }) => bgColor || theme.grey1};
   }
 `
 

--- a/src/custom/components/Settings/SettingsMod.tsx
+++ b/src/custom/components/Settings/SettingsMod.tsx
@@ -269,7 +269,8 @@ export default function SettingsTab({ className, placeholderSlippage, SettingsBu
                   <Trans>Expert Mode</Trans>
                 </ThemedText.Black>
                 <QuestionHelper
-                  bgColor={theme.bg3}
+                  // bgColor={theme.bg3}
+                  bgColor={theme.grey1} // mod
                   color={theme.text1}
                   text={
                     <Trans>Allow high price impact trades and skip the confirm screen. Use at your own risk.</Trans>
@@ -301,7 +302,8 @@ export default function SettingsTab({ className, placeholderSlippage, SettingsBu
                   <Trans>Toggle Recipient</Trans>
                 </ThemedText.Black>
                 <QuestionHelper
-                  bgColor={theme.bg3}
+                  // bgColor={theme.bg3}
+                  bgColor={theme.grey1} // mod
                   color={theme.text1}
                   text={
                     <Trans>Allows you to choose a destination address for the swap other than the connected one.</Trans>

--- a/src/custom/components/Settings/index.tsx
+++ b/src/custom/components/Settings/index.tsx
@@ -12,6 +12,11 @@ const Settings = styled(SettingsMod)`
     border: 1px solid ${({ theme }) => transparentize(0.95, theme.white)};
     background-color: ${({ theme }) => theme.bg1};
     color: ${({ theme }) => theme.text1};
+    padding: 0;
+    margin: 0;
+    top: 36px;
+    right: 0;
+    width: 280px;
   }
 
   ${RowFixed} {

--- a/src/custom/components/SwapWarnings/index.tsx
+++ b/src/custom/components/SwapWarnings/index.tsx
@@ -155,7 +155,7 @@ export const HighFeeWarning = (props: WarningProps) => {
         <AlertTriangle size={24} />
         Fees exceed {level}% of the swap amount!{' '}
         <MouseoverTooltipContent
-          bgColor={theme.bg1}
+          bgColor={theme.bg3}
           color={theme.text1}
           wrap
           content={<HighFeeWarningMessage feePercentage={feePercentage} />}

--- a/src/custom/components/Tooltip/TooltipMod.tsx
+++ b/src/custom/components/Tooltip/TooltipMod.tsx
@@ -9,7 +9,6 @@ const TooltipContainer = styled.div`
   padding: 0.6rem 1rem;
   font-weight: 400;
   word-break: break-word;
-  font-size: smaller; //  mod
 
   /* background: ${({ theme }) => theme.bg0};
   border-radius: 12px;

--- a/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
+++ b/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
@@ -215,7 +215,8 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
             <Trans>MEV protected slippage</Trans>
           </ThemedText.Black>
           <QuestionHelper
-            bgColor={theme.bg3}
+            // bgColor={theme.bg3}
+            bgColor={theme.grey1} // mod
             color={theme.text1}
             text={
               // <Trans>Your transaction will revert if the price changes unfavorably by more than this percentage.</Trans>
@@ -291,7 +292,8 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
               <Trans>Swap deadline</Trans>
             </ThemedText.Black>
             <QuestionHelper
-              bgColor={theme.bg3}
+              // bgColor={theme.bg3}
+              bgColor={theme.grey1} // mod
               color={theme.text1}
               text={
                 <Trans>

--- a/src/custom/components/swap/FeeInformationTooltip.tsx
+++ b/src/custom/components/swap/FeeInformationTooltip.tsx
@@ -129,7 +129,7 @@ export default function FeeInformationTooltip(props: FeeInformationTooltipProps)
       <span>
         {label}{' '}
         <WrappedQuestionHelper
-          bgColor={theme.bg1}
+          bgColor={theme.grey1}
           color={theme.text1}
           text={
             <FeeInnerWrapper>

--- a/src/custom/components/swap/SwapHeader/SwapHeaderMod.tsx
+++ b/src/custom/components/swap/SwapHeader/SwapHeaderMod.tsx
@@ -6,7 +6,6 @@ import SettingsTab from 'components/Settings'
 import { TradeWidgetLinks } from '@cow/modules/application/containers/TradeWidgetLinks'
 
 const StyledSwapHeader = styled.div`
-  padding: 1rem 1.25rem 0.5rem 1.25rem;
   width: 100%;
   color: ${({ theme }) => theme.text2};
 `


### PR DESCRIPTION
# Summary

- Addresses https://github.com/cowprotocol/cowswap/issues/1637 

https://user-images.githubusercontent.com/31534717/207121569-7da440b5-8e9f-48b1-88a5-c339f02ede27.mov

- Consistent header padding on switch between SWAP and LIMIT tab

https://user-images.githubusercontent.com/31534717/207123080-8e04fc92-4adf-4d3b-8b1e-349a6e78911c.mov


- Fix the blinking issue on the limit order UNLOCK screen. The issue was related to the SVG's needing to load. In the future we need to re-consider if inline SVG is performant enough vs. just having plain IMAGE imports.

https://user-images.githubusercontent.com/31534717/207125993-6d17f885-7a8a-4786-9465-2904430d3c53.mov



