### PR TITLE
[EthFlow] Show `creating/cancelling` EthFlow orders on limit orders history

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/OrdersReceiptModal/hooks.ts
+++ b/src/cow-react/modules/limitOrders/containers/OrdersReceiptModal/hooks.ts
@@ -26,8 +26,7 @@ export function useSelectedOrder(): ParsedOrder | null {
     }
 
     const allOrders = Object.values(orders).flat()
-    const order = allOrders.find(({ id }) => id === orderId) || null
 
-    return order
+    return allOrders.find(({ id }) => id === orderId) || null
   }, [orderId, orders])
 }

--- a/src/cow-react/modules/limitOrders/containers/OrdersWidget/hooks/useLimitOrdersList.ts
+++ b/src/cow-react/modules/limitOrders/containers/OrdersWidget/hooks/useLimitOrdersList.ts
@@ -33,7 +33,11 @@ export interface ParsedOrder extends Order {
 }
 
 const ORDERS_LIMIT = 100
-const pendingOrderStatuses: OrderStatus[] = [OrderStatus.PRESIGNATURE_PENDING, OrderStatus.PENDING]
+const pendingOrderStatuses: OrderStatus[] = [
+  OrderStatus.PRESIGNATURE_PENDING,
+  OrderStatus.PENDING,
+  OrderStatus.CREATING,
+]
 
 export function useLimitOrdersList(): LimitOrdersList {
   const { chainId, account } = useWeb3React()

--- a/src/cow-react/modules/limitOrders/pure/ReceiptModal/IdField.tsx
+++ b/src/cow-react/modules/limitOrders/pure/ReceiptModal/IdField.tsx
@@ -1,21 +1,20 @@
 import * as styledEl from './styled'
 import { ExternalLink } from 'theme'
-import { ParsedOrder } from '@cow/modules/limitOrders/containers/OrdersWidget/hooks/useLimitOrdersList'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { getEtherscanLink } from 'utils'
 
 export type Props = {
-  order: ParsedOrder
   chainId: SupportedChainId
+  id: string
 }
 
-export function OrderIDField({ order, chainId }: Props) {
-  const activityUrl = getEtherscanLink(chainId, order.id, 'transaction')
+export function IdField({ id, chainId }: Props) {
+  const activityUrl = getEtherscanLink(chainId, id, 'transaction')
 
   return (
     <styledEl.Value>
       <ExternalLink href={activityUrl || ''}>
-        <span>{order.id.slice(0, 8)}</span>
+        <span>{id.slice(0, 8)}</span>
         <span>↗</span>
       </ExternalLink>
     </styledEl.Value>

--- a/src/cow-react/modules/limitOrders/pure/ReceiptModal/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/ReceiptModal/index.tsx
@@ -1,7 +1,7 @@
 import { GpModal } from 'components/Modal'
 import { CurrencyAmount, Fraction, Token } from '@uniswap/sdk-core'
 import * as styledEl from './styled'
-import { OrderKind } from 'state/orders/actions'
+import { OrderKind, OrderStatus } from 'state/orders/actions'
 import { CloseIcon } from 'theme'
 import { CurrencyField } from './CurrencyField'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
@@ -13,7 +13,7 @@ import { PriceField } from './PriceField'
 import { DateField } from './DateField'
 import { FilledField } from './FilledField'
 import { SurplusField } from './SurplusField'
-import { OrderIDField } from './OrderIdField'
+import { IdField } from './IdField'
 import { StatusField } from './StatusField'
 import { OrderTypeField } from './OrderTypeField'
 
@@ -66,6 +66,8 @@ export function ReceiptModal({
 
   const inputLabel = order.kind === OrderKind.SELL ? 'You sell' : 'You sell at most'
   const outputLabel = order.kind === OrderKind.SELL ? 'You receive at least' : 'You receive exactly'
+
+  const showCreationTxLink = order.status === OrderStatus.CREATING && order.orderCreationHash
 
   return (
     <GpModal onDismiss={onDismiss} isOpen={isOpen}>
@@ -126,8 +128,17 @@ export function ReceiptModal({
             </styledEl.Field>
 
             <styledEl.Field>
-              <FieldLabel label="Order ID" />
-              <OrderIDField order={order} chainId={chainId} />
+              {showCreationTxLink ? (
+                <>
+                  <FieldLabel label="Creation transaction" />
+                  <IdField id={order.orderCreationHash as string} chainId={chainId} />
+                </>
+              ) : (
+                <>
+                  <FieldLabel label="Order ID" />
+                  <IdField id={order.id} chainId={chainId} />
+                </>
+              )}
             </styledEl.Field>
           </styledEl.FieldsWrapper>
         </styledEl.Body>


### PR DESCRIPTION
# Summary

Show creating EthFlow orders on limit orders history
![Screenshot 2022-12-12 at 18 12 52](https://user-images.githubusercontent.com/43217/207122326-85c8eb7f-de26-47f5-bbcf-237106a912d7.png)


  # To Test

1. Place ethflow order
2. Go to limit orders history
* EthFlow order should show up there

# Edit 2022/12/13

Limit orders view receipt now hides the orderId when the ethflow order is in creating state and shows the creation transaction instead:

![Screenshot 2022-12-13 at 09 43 25](https://user-images.githubusercontent.com/43217/207285214-e21ed00f-a0a9-4245-8fdc-695ac503aea6.png)
![Screenshot 2022-12-13 at 09 43 14](https://user-images.githubusercontent.com/43217/207285219-199e67df-7c93-4ed6-983a-214e07775c48.png)
