### PR TITLE
[EthFlow]#1299 Stepper state changes

### DIFF
--- a/src/cow-react/common/hooks/useCancelOrder/index.ts
+++ b/src/cow-react/common/hooks/useCancelOrder/index.ts
@@ -40,7 +40,7 @@ export function useCancelOrder(): (order: Order) => UseCancelOrderReturn {
     (order: Order) => {
       // Check the 'cancellability'
 
-      const isEthFlowOrder = !!getIsEthFlowOrder(order)
+      const isEthFlowOrder = getIsEthFlowOrder(order)
 
       // 1. EthFlow orders will never be able to be cancelled offChain
       // 2. The wallet must support offChain singing

--- a/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
@@ -73,6 +73,6 @@ function isEthFlowOrderExpired(order: Order | undefined): boolean {
 }
 
 // TODO: move this somewhere else?
-export function getIsEthFlowOrder(order: Order | undefined): boolean | undefined {
+export function getIsEthFlowOrder(order: Order | undefined): boolean {
   return order?.inputToken.address === NATIVE_CURRENCY_BUY_ADDRESS
 }

--- a/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
@@ -40,10 +40,10 @@ export function EthFlowStepper(props: EthFlowStepperProps) {
       // refundTx?: string
       isRefunded: false,
     },
-    // TODO: fill these in when dealing with cancellations
-    cancelation: {
-      // cancelationTx?: string
-      isCanceled: false,
+    cancellation: {
+      cancellationTx: order.cancellationHash,
+      //  TODO: wire this up also with the cancellation tx once that's implemented
+      isCancelled: order.status === 'cancelled',
     },
   }
 

--- a/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
@@ -7,6 +7,7 @@ import { useDetectNativeToken } from '@cow/modules/swap/hooks/useDetectNativeTok
 import { Order, OrderStatus } from 'state/orders/actions'
 import { NATIVE_CURRENCY_BUY_ADDRESS } from 'constants/index'
 import { safeTokenName } from '@cowprotocol/cow-js'
+import { isOrderExpired } from 'state/orders/utils'
 
 type EthFlowStepperProps = {
   order: Order | undefined
@@ -31,7 +32,7 @@ export function EthFlowStepper(props: EthFlowStepperProps) {
       createOrderTx: order.orderCreationHash || '',
       orderId: order.id,
       state,
-      isExpired: order.status === 'expired',
+      isExpired: isEthFlowOrderExpired(order),
       // rejectedReason?: TODO: address when dealing with rejections
     },
     // TODO: fill these in when dealing with rejections

--- a/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
@@ -68,6 +68,10 @@ function mapOrderToEthFlowStepperState(order: Order | undefined): SmartOrderStat
   return undefined
 }
 
+function isEthFlowOrderExpired(order: Order | undefined): boolean {
+  return order?.status === 'expired' || isOrderExpired({ validTo: order?.validTo as number })
+}
+
 // TODO: move this somewhere else?
 export function getIsEthFlowOrder(order: Order | undefined): boolean | undefined {
   return order?.inputToken.address === NATIVE_CURRENCY_BUY_ADDRESS

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.cosmos.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.cosmos.tsx
@@ -23,8 +23,8 @@ const defaultProps: EthFlowStepperProps = {
   refund: {
     isRefunded: false,
   },
-  cancelation: {
-    isCanceled: false,
+  cancellation: {
+    isCancelled: false,
   },
 }
 
@@ -159,9 +159,9 @@ const STEPS: Step[] = [
         ...defaultOrderProps,
         state: SmartOrderStatus.INDEXED,
       },
-      cancelation: {
-        cancelationTx: TX,
-        isCanceled: false,
+      cancellation: {
+        cancellationTx: TX,
+        isCancelled: false,
       },
     },
   },
@@ -173,9 +173,9 @@ const STEPS: Step[] = [
         ...defaultOrderProps,
         state: SmartOrderStatus.INDEXED,
       },
-      cancelation: {
-        cancelationTx: TX,
-        isCanceled: true,
+      cancellation: {
+        cancellationTx: TX,
+        isCancelled: true,
       },
     },
   },
@@ -232,9 +232,9 @@ const STEPS: Step[] = [
         state: SmartOrderStatus.INDEXED,
         isExpired: true,
       },
-      cancelation: {
-        cancelationTx: TX,
-        isCanceled: false,
+      cancellation: {
+        cancellationTx: TX,
+        isCancelled: false,
       },
     },
   },
@@ -247,9 +247,9 @@ const STEPS: Step[] = [
         state: SmartOrderStatus.INDEXED,
         isExpired: true,
       },
-      cancelation: {
-        cancelationTx: TX,
-        isCanceled: true,
+      cancellation: {
+        cancellationTx: TX,
+        isCancelled: true,
       },
     },
   },
@@ -262,9 +262,9 @@ const STEPS: Step[] = [
         state: SmartOrderStatus.INDEXED,
         isExpired: true,
       },
-      cancelation: {
-        cancelationTx: TX,
-        isCanceled: false,
+      cancellation: {
+        cancellationTx: TX,
+        isCancelled: false,
       },
       refund: {
         refundTx: TX,
@@ -281,9 +281,9 @@ const STEPS: Step[] = [
         state: SmartOrderStatus.INDEXED,
         isExpired: true,
       },
-      cancelation: {
-        cancelationTx: TX,
-        isCanceled: false,
+      cancellation: {
+        cancellationTx: TX,
+        isCancelled: false,
       },
       refund: {
         refundTx: TX,
@@ -300,9 +300,9 @@ const STEPS: Step[] = [
         state: SmartOrderStatus.INDEXED,
         isExpired: true,
       },
-      cancelation: {
-        cancelationTx: TX,
-        isCanceled: true,
+      cancellation: {
+        cancellationTx: TX,
+        isCancelled: true,
       },
       refund: {
         refundTx: TX,
@@ -319,9 +319,9 @@ const STEPS: Step[] = [
         state: SmartOrderStatus.INDEXED,
         isExpired: true,
       },
-      cancelation: {
-        cancelationTx: TX,
-        isCanceled: true,
+      cancellation: {
+        cancellationTx: TX,
+        isCancelled: true,
       },
       refund: {
         refundTx: TX,

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
@@ -32,9 +32,9 @@ export interface EthFlowStepperProps {
     isRefunded: boolean
   }
 
-  cancelation: {
-    cancelationTx?: string
-    isCanceled: boolean
+  cancellation: {
+    cancellationTx?: string
+    isCancelled: boolean
   }
 }
 

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Progress2.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Progress2.tsx
@@ -1,16 +1,16 @@
 import React, { useMemo } from 'react'
 import { Progress, EthFlowStepperProps, SmartOrderStatus, ProgressProps } from '..'
 
-export function Progress2({ order, refund, cancelation }: EthFlowStepperProps) {
+export function Progress2({ order, refund, cancellation }: EthFlowStepperProps) {
   const { state } = order
   const { isRefunded, refundTx } = refund
-  const { isCanceled, cancelationTx } = cancelation
+  const { isCancelled, cancellationTx } = cancellation
 
   const { status: progressStatus, value: progress } = useMemo<ProgressProps>(() => {
     const isIndexing = state === SmartOrderStatus.CREATION_MINED
     const isFilled = state === SmartOrderStatus.FILLED
     const isCreating = state === SmartOrderStatus.CREATING
-    const isTerminalState = isRefunded || isCanceled || isFilled
+    const isTerminalState = isRefunded || isCancelled || isFilled
 
     if (isTerminalState) {
       return {
@@ -19,7 +19,7 @@ export function Progress2({ order, refund, cancelation }: EthFlowStepperProps) {
       }
     }
 
-    if (refundTx || cancelationTx) {
+    if (refundTx || cancellationTx) {
       return {
         status: 'pending',
         value: 66,
@@ -33,7 +33,7 @@ export function Progress2({ order, refund, cancelation }: EthFlowStepperProps) {
       }
     }
 
-    if (refundTx || cancelationTx) {
+    if (refundTx || cancellationTx) {
       return {
         status: 'pending',
         value: 66,
@@ -44,7 +44,7 @@ export function Progress2({ order, refund, cancelation }: EthFlowStepperProps) {
       status: 'pending',
       value: 33,
     }
-  }, [state, refundTx, cancelationTx, isCanceled, isRefunded])
+  }, [state, refundTx, cancellationTx, isCancelled, isRefunded])
 
   return <Progress status={progressStatus} value={progress} />
 }

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
@@ -78,7 +78,8 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancellati
   const isRefunding = !!refundTx && !isRefunded
   const isCanceling = !!cancellationTx && !isCancelled
   const isOrderRejected = !!rejectedReason
-  const wontReceiveToken = isExpired || isOrderRejected || isRefunding || isCanceling || isCancelled || isRefunded
+  const wontReceiveToken =
+    !isFilled && (isExpired || isOrderRejected || isRefunding || isCanceling || isCancelled || isRefunded)
   const isSuccess = stepState === 'success'
 
   let refundLink: JSX.Element | undefined

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
@@ -15,10 +15,10 @@ const ExpiredMessage = styled.span`
   color: ${({ theme }) => theme.warning};
 `
 
-export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancelation }: EthFlowStepperProps) {
+export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancellation }: EthFlowStepperProps) {
   const { state, isExpired, rejectedReason } = order
   const { isRefunded, refundTx } = refund
-  const { isCanceled, cancelationTx } = cancelation
+  const { isCancelled, cancellationTx } = cancellation
 
   const isIndexing = state === SmartOrderStatus.CREATION_MINED
   const isIndexed = state === SmartOrderStatus.INDEXED
@@ -53,7 +53,7 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancelatio
         icon: Checkmark,
       }
     }
-    if (isCanceled || isRefunded) {
+    if (isCancelled || isRefunded) {
       return {
         label: nativeTokenSymbol + ' Refunded',
         state: 'success',
@@ -73,24 +73,24 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancelatio
       state: 'not-started',
       icon: Finish,
     }
-  }, [nativeTokenSymbol, tokenLabel, expiredBeforeCreate, isIndexing, isFilled, isCanceled, isRefunded, isIndexed])
+  }, [nativeTokenSymbol, tokenLabel, expiredBeforeCreate, isIndexing, isFilled, isCancelled, isRefunded, isIndexed])
 
   const isRefunding = !!refundTx && !isRefunded
-  const isCanceling = !!cancelationTx && !isCanceled
+  const isCanceling = !!cancellationTx && !isCancelled
   const isOrderRejected = !!rejectedReason
-  const wontReceiveToken = isExpired || isOrderRejected || isRefunding || isCanceling || isCanceled || isRefunded
+  const wontReceiveToken = isExpired || isOrderRejected || isRefunding || isCanceling || isCancelled || isRefunded
   const isSuccess = stepState === 'success'
 
   let refundLink: JSX.Element | undefined
-  if (cancelationTx && !isRefunded) {
+  if (cancellationTx && !isRefunded) {
     refundLink = (
       <ExplorerLinkStyled
         type="transaction"
         label={isCanceling ? 'Initiating ETH Refund...' : 'ETH refunded successfully'}
-        id={cancelationTx}
+        id={cancellationTx}
       />
     )
-  } else if ((refundTx && !(expiredBeforeCreate || cancelationTx)) || (refundTx && isRefunded)) {
+  } else if ((refundTx && !(expiredBeforeCreate || cancellationTx)) || (refundTx && isRefunded)) {
     refundLink = (
       <ExplorerLinkStyled
         type="transaction"
@@ -105,7 +105,7 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancelatio
     <Step state={stepState} icon={icon} label={label} crossOut={crossOut}>
       <>
         {isExpired && !(isSuccess || isOrderRejected) && <ExpiredMessage>Order has expired</ExpiredMessage>}
-        {wontReceiveToken && !(refundTx || cancelationTx) && <RefundMessage>Initiating ETH Refund...</RefundMessage>}
+        {wontReceiveToken && !(refundTx || cancellationTx) && <RefundMessage>Initiating ETH Refund...</RefundMessage>}
         {refundLink}
       </>
     </Step>

--- a/src/custom/state/orders/utils.ts
+++ b/src/custom/state/orders/utils.ts
@@ -53,8 +53,7 @@ function isOrderCancelled(order: Pick<OrderMetaData, 'creationDate' | 'invalidat
  * The buffer is used to take into account race conditions where a solver might
  * execute a transaction after the backend changed the order status.
  */
-function isOrderExpired(order: Pick<OrderMetaData, 'validTo'>): boolean {
-  // TODO: EthFlow expiration is different, make sure it's taken into account
+export function isOrderExpired(order: Pick<OrderMetaData, 'validTo'>): boolean {
   const validToTime = order.validTo * 1000 // validTo is in seconds
   return Date.now() - validToTime > PENDING_ORDERS_BUFFER
 }


### PR DESCRIPTION
# Summary

Part of #1299 

EthFlow stepper states

![Screenshot 2022-12-13 at 14 25 58](https://user-images.githubusercontent.com/43217/207361810-b1ca6365-385d-40f8-ada7-6ef285677750.png)
![Screenshot 2022-12-13 at 14 25 49](https://user-images.githubusercontent.com/43217/207361815-01c39cc6-a8cb-4ce5-bc18-ea10e2e00e9f.png)
![Screenshot 2022-12-13 at 14 25 41](https://user-images.githubusercontent.com/43217/207361820-3647d9ca-cb96-47b8-aa38-2e14b01087ac.png)

# To Test

1. Place orders in several contexts: expired, cancelled, cancelling

*Note*: Automatic refunds not yet supported
*Note*: Order creation/cancellation transactions not yet tracked. Will be part of next PR