### PR TITLE
[EthFlow]#1299 track tx states

### DIFF
--- a/src/cow-react/common/hooks/useCancelOrder/index.ts
+++ b/src/cow-react/common/hooks/useCancelOrder/index.ts
@@ -49,8 +49,11 @@ export function useCancelOrder(): (order: Order) => UseCancelOrderReturn {
 
       // 1. To be EthFlow cancellable the order must be an EthFlow order
       // 2. It can be cancelled when the order is CREATING or PENDING
+      // 3. It cannot be cancelled if there's a cancellationHash already
       const isEthFlowCancellable =
-        isEthFlowOrder && (order?.status === OrderStatus.CREATING || order?.status === OrderStatus.PENDING)
+        isEthFlowOrder &&
+        (order?.status === OrderStatus.CREATING || order?.status === OrderStatus.PENDING) &&
+        !order.cancellationHash
 
       // TODO: For now only ethflow orders are cancellable. Adjust when implementing general hard cancellations
       const isCancellable = !order.isCancelling && (isOffChainCancellable || isEthFlowCancellable)

--- a/src/cow-react/common/hooks/useCancelOrder/useEthFlowCancelOrder.ts
+++ b/src/cow-react/common/hooks/useCancelOrder/useEthFlowCancelOrder.ts
@@ -7,6 +7,7 @@ import { useRequestOrderCancellation, useSetOrderCancellationHash } from 'state/
 import { calculateGasMargin } from 'utils/calculateGasMargin'
 import { logSwapFlowError } from '@cow/modules/swap/services/utils/logger'
 import { ETHFLOW_GAS_LIMIT_DEFAULT } from '@cow/modules/swap/services/ethFlow/const'
+import { useTransactionAdder } from 'state/enhancedTransactions/hooks'
 
 const LOG_LABEL = 'CANCEL ETH FLOW ORDER'
 
@@ -15,6 +16,7 @@ export function useEthFlowCancelOrder() {
   const cancelEthFlowCallback = getCancelEthFlowOrderCallback(useEthFlowContract())
   const setOrderCancellationHash = useSetOrderCancellationHash()
   const cancelPendingOrder = useRequestOrderCancellation()
+  const addTransaction = useTransactionAdder()
 
   return useCallback(
     async (order: Order) => {
@@ -25,10 +27,11 @@ export function useEthFlowCancelOrder() {
       const receipt = await cancelEthFlowCallback(order)
       if (receipt?.hash) {
         cancelPendingOrder({ id: order.id, chainId })
+        addTransaction({ hash: receipt.hash, ethFlow: { orderId: order.id, subType: 'cancellation' } })
         setOrderCancellationHash({ chainId, id: order.id, hash: receipt.hash })
       }
     },
-    [cancelEthFlowCallback, cancelPendingOrder, chainId, setOrderCancellationHash]
+    [addTransaction, cancelEthFlowCallback, cancelPendingOrder, chainId, setOrderCancellationHash]
   )
 }
 

--- a/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
@@ -8,6 +8,8 @@ import { Order, OrderStatus } from 'state/orders/actions'
 import { NATIVE_CURRENCY_BUY_ADDRESS } from 'constants/index'
 import { safeTokenName } from '@cowprotocol/cow-js'
 import { isOrderExpired } from 'state/orders/utils'
+import { useAllTransactions } from 'state/enhancedTransactions/hooks'
+import { EnhancedTransactionDetails } from 'state/enhancedTransactions/reducer'
 
 type EthFlowStepperProps = {
   order: Order | undefined
@@ -17,7 +19,17 @@ export function EthFlowStepper(props: EthFlowStepperProps) {
   const { order } = props
   const { native } = useDetectNativeToken()
 
-  const state = mapOrderToEthFlowStepperState(order)
+  const allTxs = useAllTransactions()
+
+  const creationHash = order?.orderCreationHash
+  const cancellationHash = order?.cancellationHash
+  // TODO: add refund hash when available from API
+
+  const creationTx = creationHash ? allTxs[creationHash] : undefined
+  const cancellationTx = cancellationHash ? allTxs[cancellationHash] : undefined
+
+  const state = mapOrderToEthFlowStepperState(order, creationTx, cancellationTx)
+
   const isEthFlowOrder = getIsEthFlowOrder(order)
 
   if (!order || !state || !isEthFlowOrder) {
@@ -29,7 +41,7 @@ export function EthFlowStepper(props: EthFlowStepperProps) {
     tokenLabel: safeTokenName(order.outputToken),
     order: {
       // The creation hash is only available in the device where the order is placed
-      createOrderTx: order.orderCreationHash || '',
+      createOrderTx: creationHash || '',
       orderId: order.id,
       state,
       isExpired: isEthFlowOrderExpired(order),
@@ -42,9 +54,8 @@ export function EthFlowStepper(props: EthFlowStepperProps) {
       isRefunded: false,
     },
     cancellation: {
-      cancellationTx: order.cancellationHash,
-      //  TODO: wire this up also with the cancellation tx once that's implemented
-      isCancelled: order.status === 'cancelled',
+      cancellationTx: cancellationHash,
+      isCancelled: isEthFlowOrderCancelled(order, cancellationTx),
     },
   }
 
@@ -53,18 +64,23 @@ export function EthFlowStepper(props: EthFlowStepperProps) {
 
 const ORDER_INDEXED_STATUSES: OrderStatus[] = [OrderStatus.PENDING, OrderStatus.EXPIRED, OrderStatus.CANCELLED]
 
-function mapOrderToEthFlowStepperState(order: Order | undefined): SmartOrderStatus | undefined {
-  // NOTE: not returning `CREATED` as we currently don't track the initial tx execution
-
+function mapOrderToEthFlowStepperState(
+  order: Order | undefined,
+  creationTx: EnhancedTransactionDetails | undefined,
+  cancellationTx: EnhancedTransactionDetails | undefined
+): SmartOrderStatus | undefined {
   if (order) {
     const { status } = order
 
-    if (status === 'creating') {
-      return SmartOrderStatus.CREATING
-    } else if (ORDER_INDEXED_STATUSES.includes(status)) {
+    if (ORDER_INDEXED_STATUSES.includes(status) || cancellationTx?.receipt) {
       return SmartOrderStatus.INDEXED
     } else if (status === 'fulfilled') {
       return SmartOrderStatus.FILLED
+    } else if (status === 'creating') {
+      if (creationTx?.receipt) {
+        return SmartOrderStatus.CREATION_MINED
+      }
+      return SmartOrderStatus.CREATING
     }
   }
   return undefined
@@ -72,6 +88,10 @@ function mapOrderToEthFlowStepperState(order: Order | undefined): SmartOrderStat
 
 function isEthFlowOrderExpired(order: Order | undefined): boolean {
   return order?.status === 'expired' || isOrderExpired({ validTo: order?.validTo as number })
+}
+
+function isEthFlowOrderCancelled(order: Order, cancellationTx: EnhancedTransactionDetails | undefined): boolean {
+  return order.status === 'cancelled' || !!cancellationTx?.receipt
 }
 
 // TODO: move this somewhere else?

--- a/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
@@ -33,6 +33,7 @@ export function EthFlowStepper(props: EthFlowStepperProps) {
       orderId: order.id,
       state,
       isExpired: isEthFlowOrderExpired(order),
+      isCreated: !!order.apiAdditionalInfo,
       // rejectedReason?: TODO: address when dealing with rejections
     },
     // TODO: fill these in when dealing with rejections

--- a/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
@@ -72,10 +72,10 @@ function mapOrderToEthFlowStepperState(
   if (order) {
     const { status } = order
 
-    if (ORDER_INDEXED_STATUSES.includes(status) || cancellationTx?.receipt) {
-      return SmartOrderStatus.INDEXED
-    } else if (status === 'fulfilled') {
+    if (status === 'fulfilled') {
       return SmartOrderStatus.FILLED
+    } else if (ORDER_INDEXED_STATUSES.includes(status) || cancellationTx?.receipt) {
+      return SmartOrderStatus.INDEXED
     } else if (status === 'creating') {
       if (creationTx?.receipt) {
         return SmartOrderStatus.CREATION_MINED

--- a/src/cow-react/modules/swap/hooks/useEthFlowContext.ts
+++ b/src/cow-react/modules/swap/hooks/useEthFlowContext.ts
@@ -3,10 +3,12 @@ import { useEthFlowContract } from 'hooks/useContract'
 import { useBaseFlowContextSetup, getFlowContext } from '@cow/modules/swap/hooks/useFlowContext'
 import { EthFlowContext } from '@cow/modules/swap/services/common/types'
 import { NATIVE_CURRENCY_BUY_TOKEN } from 'constants/index'
+import { useTransactionAdder } from 'state/enhancedTransactions/hooks'
 
 export function useEthFlowContext(): EthFlowContext | null {
   const contract = useEthFlowContract()
   const baseProps = useBaseFlowContextSetup()
+  const addTransaction = useTransactionAdder()
 
   const baseContext = getFlowContext({
     baseProps,
@@ -19,5 +21,6 @@ export function useEthFlowContext(): EthFlowContext | null {
   return {
     ...baseContext,
     contract,
+    addTransaction,
   }
 }

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/StatusIcon.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/StatusIcon.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/macro'
 import { transparentize } from 'polished'
 import SVG from 'react-inlinesvg'
 
-export type StatusIconState = 'success' | 'pending' | 'not-started' | 'error'
+export type StatusIconState = 'success' | 'pending' | 'not-started' | 'error' | 'skipped'
 
 const Content = styled.span`
   display: flex;

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/StatusIcon.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/StatusIcon.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/macro'
 import { transparentize } from 'polished'
 import SVG from 'react-inlinesvg'
 
-export type StatusIconState = 'success' | 'pending' | 'not-started' | 'error' | 'skipped'
+export type StatusIconState = 'success' | 'pending' | 'not-started' | 'error' | 'cancelled'
 
 const Content = styled.span`
   display: flex;

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.cosmos.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.cosmos.tsx
@@ -15,6 +15,7 @@ const defaultOrderProps = {
   orderId: ORDER_ID,
   state: SmartOrderStatus.CREATING,
   isExpired: false,
+  isCreated: false,
 }
 const defaultProps: EthFlowStepperProps = {
   nativeTokenSymbol: 'xDAI',

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
@@ -24,6 +24,7 @@ export interface EthFlowStepperProps {
     orderId: string
     state: SmartOrderStatus
     isExpired: boolean
+    isCreated: boolean
     rejectedReason?: string
   }
 

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step2.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step2.tsx
@@ -61,7 +61,7 @@ export function Step2({ order, cancellation }: EthFlowStepperProps) {
     if (isCancelled && !isFilled) {
       return {
         label: 'Order Cancelled',
-        state: 'skipped',
+        state: 'cancelled',
         icon: Exclamation,
       }
     }

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step2.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step2.tsx
@@ -2,16 +2,18 @@ import React, { useMemo } from 'react'
 import Plus from 'assets/cow-swap/plus.svg'
 import X from 'assets/cow-swap/x.svg'
 import Checkmark from 'assets/cow-swap/checkmark.svg'
+import Exclamation from 'assets/cow-swap/exclamation.svg'
 import { EthFlowStepperProps, SmartOrderStatus } from '..'
 import { Step, StepProps, ExplorerLinkStyled } from '../Step'
 
 type Step2Config = StepProps & { error?: string }
 
-export function Step2({ order }: EthFlowStepperProps) {
+export function Step2({ order, cancellation }: EthFlowStepperProps) {
   const { state, isExpired, orderId, rejectedReason } = order
   const isCreating = state === SmartOrderStatus.CREATING
   const isIndexing = state === SmartOrderStatus.CREATION_MINED
   const isOrderCreated = !(isCreating || isIndexing)
+  const isCancelled = cancellation.isCancelled
 
   const expiredBeforeCreate = isExpired && (isCreating || isIndexing)
 
@@ -55,12 +57,20 @@ export function Step2({ order }: EthFlowStepperProps) {
       }
     }
 
+    if (isCancelled) {
+      return {
+        label: 'Order Cancelled',
+        state: 'skipped',
+        icon: Exclamation,
+      }
+    }
+
     return {
       label: 'Order Created',
       state: 'success',
       icon: Checkmark,
     }
-  }, [expiredBeforeCreate, isCreating, isIndexing, rejectedReason])
+  }, [expiredBeforeCreate, isCancelled, isCreating, isIndexing, rejectedReason])
 
   const errorMessage = error || rejectedReason
   return (

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step2.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step2.tsx
@@ -12,8 +12,8 @@ export function Step2({ order, cancellation }: EthFlowStepperProps) {
   const { state, isExpired, orderId, rejectedReason } = order
   const isCreating = state === SmartOrderStatus.CREATING
   const isIndexing = state === SmartOrderStatus.CREATION_MINED
-  const isOrderCreated = !(isCreating || isIndexing)
   const isCancelled = cancellation.isCancelled
+  const isOrderCreated = order.isCreated
 
   const expiredBeforeCreate = isExpired && (isCreating || isIndexing)
 

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step2.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step2.tsx
@@ -4,7 +4,7 @@ import X from 'assets/cow-swap/x.svg'
 import Checkmark from 'assets/cow-swap/checkmark.svg'
 import Exclamation from 'assets/cow-swap/exclamation.svg'
 import { EthFlowStepperProps, SmartOrderStatus } from '..'
-import { Step, StepProps, ExplorerLinkStyled } from '../Step'
+import { ExplorerLinkStyled, Step, StepProps } from '../Step'
 
 type Step2Config = StepProps & { error?: string }
 
@@ -14,6 +14,7 @@ export function Step2({ order, cancellation }: EthFlowStepperProps) {
   const isIndexing = state === SmartOrderStatus.CREATION_MINED
   const isCancelled = cancellation.isCancelled
   const isOrderCreated = order.isCreated
+  const isFilled = state === SmartOrderStatus.FILLED
 
   const expiredBeforeCreate = isExpired && (isCreating || isIndexing)
 
@@ -57,7 +58,7 @@ export function Step2({ order, cancellation }: EthFlowStepperProps) {
       }
     }
 
-    if (isCancelled) {
+    if (isCancelled && !isFilled) {
       return {
         label: 'Order Cancelled',
         state: 'skipped',
@@ -70,7 +71,7 @@ export function Step2({ order, cancellation }: EthFlowStepperProps) {
       state: 'success',
       icon: Checkmark,
     }
-  }, [expiredBeforeCreate, isCancelled, isCreating, isIndexing, rejectedReason])
+  }, [expiredBeforeCreate, isCancelled, isCreating, isFilled, isIndexing, rejectedReason])
 
   const errorMessage = error || rejectedReason
   return (

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
@@ -83,7 +83,7 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancellati
   const isSuccess = stepState === 'success'
 
   let refundLink: JSX.Element | undefined
-  if (cancellationTx && !isRefunded) {
+  if (cancellationTx && !isRefunded && !isFilled) {
     refundLink = (
       <ExplorerLinkStyled
         type="transaction"
@@ -106,7 +106,9 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancellati
     <Step state={stepState} icon={icon} label={label} crossOut={crossOut}>
       <>
         {isExpired && !(isSuccess || isOrderRejected) && <ExpiredMessage>Order has expired</ExpiredMessage>}
-        {wontReceiveToken && !(refundTx || cancellationTx) && <RefundMessage>Initiating ETH Refund...</RefundMessage>}
+        {wontReceiveToken && !(refundTx || cancellationTx) && !isCancelled && (
+          <RefundMessage>Initiating ETH Refund...</RefundMessage>
+        )}
         {refundLink}
       </>
     </Step>

--- a/src/cow-react/modules/swap/services/common/types.ts
+++ b/src/cow-react/modules/swap/services/common/types.ts
@@ -7,6 +7,7 @@ import { CoWSwapEthFlow, GPv2Settlement } from '@cow/abis/types'
 import { AppDispatch } from 'state'
 import { AddAppDataToUploadQueueParams, AppDataInfo } from 'state/appData/types'
 import { SwapFlowAnalyticsContext } from '@cow/modules/swap/services/common/steps/analytics'
+import { useTransactionAdder } from 'state/enhancedTransactions/hooks'
 
 export interface BaseFlowContext {
   context: {
@@ -36,4 +37,5 @@ export type SwapFlowContext = BaseFlowContext & {
 }
 export type EthFlowContext = BaseFlowContext & {
   contract: CoWSwapEthFlow
+  addTransaction: ReturnType<typeof useTransactionAdder>
 }

--- a/src/cow-react/modules/swap/services/ethFlow/index.ts
+++ b/src/cow-react/modules/swap/services/ethFlow/index.ts
@@ -18,7 +18,7 @@ export async function ethFlow(input: EthFlowContext, priceImpactParams: PriceImp
 
   try {
     logSwapFlow('ETH FLOW', 'STEP 3: sign order')
-    const { order, orderId } = await signEthFlowOrderStep(input.orderParams, input.contract).finally(() => {
+    const { order, orderId, txReceipt } = await signEthFlowOrderStep(input.orderParams, input.contract).finally(() => {
       input.callbacks.closeModals()
     })
 
@@ -31,6 +31,8 @@ export async function ethFlow(input: EthFlowContext, priceImpactParams: PriceImp
       },
       input.dispatch
     )
+    // TODO: maybe move this into addPendingOrderStep?
+    input.addTransaction({ hash: txReceipt.hash, ethFlow: { orderId: order.id, subType: 'creation' } })
 
     logSwapFlow('ETH FLOW', 'STEP 5: add app data to upload queue')
     input.callbacks.addAppDataToUploadQueue({ chainId: input.context.chainId, orderId, appData: input.appDataInfo })

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -87,6 +87,7 @@ export default function useRecentActivity() {
         .filter((tx) => tx.from.toLowerCase() === accountLowerCase)
         // Only recent transactions
         .filter(isTransactionRecent)
+        .filter(isNotEthFlowTx)
         .map((tx) => ({
           ...tx,
           // we need to adjust Transaction object and add "id" + "status" to match Orders type
@@ -299,4 +300,8 @@ export function useRecentActivityLastPendingOrder() {
     // Disabling hook to avoid unnecessary re-renders
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify(pending)])
+}
+
+export function isNotEthFlowTx(tx: EnhancedTransactionDetails): boolean {
+  return !tx.ethFlow
 }

--- a/src/custom/state/enhancedTransactions/actions.ts
+++ b/src/custom/state/enhancedTransactions/actions.ts
@@ -20,6 +20,7 @@ export type AddTransactionParams = WithChainId &
     | 'safeTransaction'
     | 'swapVCow'
     | 'swapLockedGNOvCow'
+    | 'ethFlow'
   >
 
 export const addTransaction = createAction<AddTransactionParams>('enhancedTransactions/addTransaction')

--- a/src/custom/state/enhancedTransactions/hooks/index.ts
+++ b/src/custom/state/enhancedTransactions/hooks/index.ts
@@ -24,26 +24,16 @@ export function useTransactionAdder(): TransactionAdder {
     (addTransactionParams: AddTransactionHookParams) => {
       if (!account || !chainId) return
 
-      const { hash, summary, data, claim, approval, presign, safeTransaction, swapVCow, swapLockedGNOvCow } =
-        addTransactionParams
       const hashType = isGnosisSafeWallet ? HashType.GNOSIS_SAFE_TX : HashType.ETHEREUM_TX
-      if (!hash) {
+      if (!addTransactionParams.hash) {
         throw Error('No transaction hash found')
       }
       dispatch(
         addTransaction({
-          hash,
           hashType,
           from: account,
           chainId,
-          approval,
-          summary,
-          claim,
-          data,
-          presign,
-          safeTransaction,
-          swapVCow,
-          swapLockedGNOvCow,
+          ...addTransactionParams,
         })
       )
     },

--- a/src/custom/state/enhancedTransactions/reducer.ts
+++ b/src/custom/state/enhancedTransactions/reducer.ts
@@ -39,6 +39,7 @@ export interface EnhancedTransactionDetails {
   claim?: { recipient: string; cowAmountRaw?: string; indices: number[] }
   swapVCow?: boolean
   swapLockedGNOvCow?: boolean
+  ethFlow?: { orderId: string; subType: 'creation' | 'cancellation' | 'refund' }
 
   // Wallet specific
   safeTransaction?: SafeMultisigTransactionResponse // Gnosis Safe transaction info
@@ -88,6 +89,7 @@ export default createReducer(initialState, (builder) =>
             data,
             swapVCow,
             swapLockedGNOvCow,
+            ethFlow,
           },
         }
       ) => {
@@ -113,6 +115,7 @@ export default createReducer(initialState, (builder) =>
           claim,
           swapVCow,
           swapLockedGNOvCow,
+          ethFlow,
         }
         transactions[chainId] = txs
       }

--- a/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
+++ b/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
@@ -81,16 +81,19 @@ function finalizeEthereumTransaction(
     })
   )
 
-  addPopup(
-    {
-      txn: {
-        hash: receipt.transactionHash,
-        success: receipt.status === 1 && transaction.replacementType !== 'cancel',
-        summary: transaction.summary,
+  if (!transaction.ethFlow) {
+    // Do NOT trigger the pop-ups when this is an EthFlow related tx
+    addPopup(
+      {
+        txn: {
+          hash: receipt.transactionHash,
+          success: receipt.status === 1 && transaction.replacementType !== 'cancel',
+          summary: transaction.summary,
+        },
       },
-    },
-    hash
-  )
+      hash
+    )
+  }
 }
 
 function checkEthereumTransactions(params: CheckEthereumTransactions): Cancel[] {

--- a/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
+++ b/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
@@ -16,6 +16,7 @@ import { TransactionReceipt } from '@ethersproject/abstract-provider'
 import { GetSafeInfo, useGetSafeInfo } from 'hooks/useGetSafeInfo'
 import { useWeb3React } from '@web3-react/core'
 import { supportedChainId } from 'utils/supportedChainId'
+import { cancelOrdersBatch } from 'state/orders/actions'
 
 type TxInterface = Pick<
   EnhancedTransactionDetails,
@@ -93,6 +94,14 @@ function finalizeEthereumTransaction(
       },
       hash
     )
+  } else {
+    // When it IS an EthFlow related tx, take action depending on the type
+    const { orderId, subType } = transaction.ethFlow
+
+    if (subType === 'cancellation') {
+      // For now, only handling the cancellation events
+      dispatch(cancelOrdersBatch({ chainId, ids: [orderId] }))
+    }
   }
 }
 


### PR DESCRIPTION
# Summary

Closes #1299 
Follow up to https://github.com/cowprotocol/cowswap/pull/1710

Keeping track of ethflow creation & cancellation txs

Also added a new sub-state to stepper on Step2: cancelled
![Screenshot 2022-12-13 at 18 29 59](https://user-images.githubusercontent.com/43217/207642964-60e40f7a-1410-4717-a760-4fd7e9a1e99c.png)


*Note*: Automatic refund states (when the order expires) are not yet returned by the backend, thus not tracked

# To Test

1. Place ethflow orders and test various states

# Pending

- [ ] There's a bug triggering a popup when creation/cancellation txs are mined. Working on it!