### PR TITLE
[ethflow] [refunder testing PR] reduced ethflow slippage

### DIFF
--- a/src/cow-react/modules/swap/state/EthFlow/updaters/EthFlowSlippageUpdater.tsx
+++ b/src/cow-react/modules/swap/state/EthFlow/updaters/EthFlowSlippageUpdater.tsx
@@ -5,7 +5,7 @@ import { useIsEthFlow } from '@cow/modules/swap/hooks/useIsEthFlow'
 import { loadJsonFromLocalStorage, setJsonToLocalStorage } from '@cow/utils/localStorage'
 import { SerializedSlippage, SerializedSlippageSettings, Slippage, SlippageSettings } from './types'
 
-export const ETH_FLOW_SLIPPAGE = new Percent(2, 100) // 2%
+export const ETH_FLOW_SLIPPAGE = new Percent(1, 1000) // 2%
 const LOCAL_STORAGE_KEY = 'UserSlippageSettings'
 
 export function EthFlowSlippageUpdater() {

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -103,7 +103,7 @@ export const PRICE_API_TIMEOUT_MS = 10000 // 10s
 export const GP_ORDER_UPDATE_INTERVAL = 30 * 1000 // 30s
 export const MINIMUM_ORDER_VALID_TO_TIME_SECONDS = 120
 // Minimum deadline for EthFlow orders. Like the default deadline, anything smaller will be replaced by this
-export const MINIMUM_ETH_FLOW_DEADLINE_SECONDS = 600 // 10 minutes in SECONDS
+export const MINIMUM_ETH_FLOW_DEADLINE_SECONDS = 60 // 10 minutes in SECONDS
 
 export const WETH_LOGO_URI =
   'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png'


### PR DESCRIPTION
Do not merge. only for testing the refunder

I reduced the slippage for ethflow, such that I get more unsettable tx.

How I test it:
-> Place a order in an illiquid token
-> Place a second order on the same pair quickly again.

usually, the slippage of the first order during the settlement will prevent the other order to be refunded.

@elena-zh maybe this is also helpful for you for testing certain scenarios, not sure.