### PR TITLE
[EthFlow]#1299 fix extra popups

### DIFF
--- a/src/cow-react/modules/application/containers/App/Updaters.tsx
+++ b/src/cow-react/modules/application/containers/App/Updaters.tsx
@@ -2,7 +2,6 @@ import { MulticallUpdater } from 'lib/state/multicall'
 import ApplicationUpdater from 'state/application/updater'
 import ListsUpdater from 'state/lists/updater'
 import LogsUpdater from 'state/logs/updater'
-import TransactionUpdater from 'state/transactions/updater'
 import UserUpdater from 'state/user/updater'
 import GnosisSafeUpdater from 'state/gnosisSafe/updater'
 import RadialGradientByChainUpdater from 'theme/RadialGradientByChainUpdater'
@@ -28,7 +27,6 @@ export function Updaters() {
       <ListsUpdater />
       <UserUpdater />
       <ApplicationUpdater />
-      <TransactionUpdater />
       <EnhancedTransactionUpdater />
       <MulticallUpdater />
       <PendingOrdersUpdater />


### PR DESCRIPTION
# Summary

Follow up to https://github.com/cowprotocol/cowswap/pull/1724

Fixes the issue where creation/cancellation ethflow transactions were displaying a pop-up when confirmed

# To Test

1. Place one ethflow tx
2. After the tx is confirmed, there should NOT be a pop-up displayed
3. Cancel the ethflow
4. After the cancellation tx is confirmed, there should NOT be a pop-up displayed