### PR TITLE
[EthFlow]#1300 cancellation toast notifications

### DIFF
--- a/src/custom/components/AccountDetails/Transaction/styled.ts
+++ b/src/custom/components/AccountDetails/Transaction/styled.ts
@@ -379,42 +379,6 @@ export const CancellationSummary = styled.span`
   background: ${({ theme }) => theme.bg1};
 `
 
-export const TransactionAlertMessage = styled.div<{ type?: string }>`
-  display: flex;
-  justify-content: center;
-  color: ${({ theme, type }) => (type === 'attention' ? theme.attention : theme.danger)};
-  margin: 24px 0 0;
-  padding: 8px 12px;
-  border-radius: 8px;
-  display: flex;
-  align-items: center;
-  line-height: 1.4;
-  background: ${({ theme, type }) =>
-    type === 'attention' ? transparentize(0.9, theme.attention) : transparentize(0.9, theme.danger)};
-  width: 100%;
-  height: auto;
-
-  ${({ theme }) => theme.mediaWidth.upToSmall`
-    grid-column: 1 / -1;
-    flex-flow: column wrap;
-    justify-content: flex-start;
-    align-items: center;
-    text-align: center;
-    padding: 16px 32px;
-    margin: 12px 0 0;
-  `};
-
-  > svg,
-  > img {
-    margin: 0 6px 0 0;
-    fill: ${({ theme, type }) => (type === 'attention' ? theme.attention : theme.danger)};
-
-    ${({ theme }) => theme.mediaWidth.upToSmall`
-      margin: 0 0 12px;
-    `};
-  }
-`
-
 export const TransactionInnerDetail = styled.div`
   display: flex;
   flex-flow: column wrap;

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -51,12 +51,12 @@ export const COWSWAP_ETHFLOW_CONTRACT_ADDRESS: Record<Env, Partial<Record<number
   prod: {
     [ChainId.MAINNET]: EthFlowProd[ChainId.MAINNET].address,
     [ChainId.GNOSIS_CHAIN]: EthFlowProd[ChainId.GNOSIS_CHAIN].address,
-    [ChainId.GOERLI]: EthFlowProd[ChainId.GOERLI].address,
+    [ChainId.GOERLI]: '0xF55E40061fe3dFfB7aE166B46A008dfc2aDA510f',
   },
   barn: {
     [ChainId.MAINNET]: EthFlowBarn[ChainId.MAINNET].address,
     [ChainId.GNOSIS_CHAIN]: EthFlowBarn[ChainId.GNOSIS_CHAIN].address,
-    [ChainId.GOERLI]: EthFlowBarn[ChainId.GOERLI].address,
+    [ChainId.GOERLI]: '0xF55E40061fe3dFfB7aE166B46A008dfc2aDA510f',
   },
 }
 

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -51,12 +51,12 @@ export const COWSWAP_ETHFLOW_CONTRACT_ADDRESS: Record<Env, Partial<Record<number
   prod: {
     [ChainId.MAINNET]: EthFlowProd[ChainId.MAINNET].address,
     [ChainId.GNOSIS_CHAIN]: EthFlowProd[ChainId.GNOSIS_CHAIN].address,
-    [ChainId.GOERLI]: '0xF55E40061fe3dFfB7aE166B46A008dfc2aDA510f',
+    [ChainId.GOERLI]: EthFlowProd[ChainId.GOERLI].address,
   },
   barn: {
     [ChainId.MAINNET]: EthFlowBarn[ChainId.MAINNET].address,
     [ChainId.GNOSIS_CHAIN]: EthFlowBarn[ChainId.GNOSIS_CHAIN].address,
-    [ChainId.GOERLI]: '0xF55E40061fe3dFfB7aE166B46A008dfc2aDA510f',
+    [ChainId.GOERLI]: EthFlowBarn[ChainId.GOERLI].address,
   },
 }
 

--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -1,12 +1,13 @@
-import { Middleware, isAnyOf, MiddlewareAPI, Dispatch, AnyAction } from '@reduxjs/toolkit'
+import { AnyAction, Dispatch, isAnyOf, Middleware, MiddlewareAPI } from '@reduxjs/toolkit'
 
 import { addPopup } from 'state/application/reducer'
 import { AppState } from 'state'
 import * as OrderActions from './actions'
+import { OrderClass, SerializedOrder } from './actions'
 
 import { SupportedChainId as ChainId } from 'constants/chains'
 
-import { OrderIDWithPopup, OrderTxTypes, PopupPayload, buildCancellationPopupSummary, setPopupData } from './helpers'
+import { buildCancellationPopupSummary, OrderIDWithPopup, OrderTxTypes, PopupPayload, setPopupData } from './helpers'
 import { registerOnWindow } from 'utils/misc'
 import { getCowSoundError, getCowSoundSend, getCowSoundSuccess } from 'utils/sound'
 // import ReactGA from 'react-ga4'
@@ -15,7 +16,6 @@ import { isOrderInPendingTooLong, openNpsAppziSometimes } from 'utils/appzi'
 import { OrderObject, OrdersStateNetwork } from 'state/orders/reducer'
 import { timeSinceInSeconds } from '@cow/utils/time'
 import { getExplorerOrderLink } from 'utils/explorer'
-import { OrderClass } from './actions'
 
 // action syntactic sugar
 const isSingleOrderChangeAction = isAnyOf(OrderActions.addPendingOrder)
@@ -76,11 +76,7 @@ export const popupMiddleware: Middleware<Record<string, unknown>, AppState> = (s
     } else if (isCancelOrderAction(action)) {
       // action is order/cancelOrder
       // Cancelled Order Popup
-      popup = setPopupData(OrderTxTypes.METATXN, {
-        success: true,
-        summary: buildCancellationPopupSummary(id, summary),
-        id,
-      })
+      popup = _buildCancellationPopup(orderObject.order)
       orderAnalytics('Canceled', orderClass)
     } else {
       // action is order/expireOrder
@@ -143,13 +139,7 @@ export const popupMiddleware: Middleware<Record<string, unknown>, AppState> = (s
         if (orderObject) {
           const { order } = orderObject
 
-          const summary = order.summary
-
-          const popup = setPopupData(OrderTxTypes.METATXN, {
-            success: true,
-            summary: buildCancellationPopupSummary(id, summary),
-            id,
-          })
+          const popup = _buildCancellationPopup(order)
           orderAnalytics('Canceled', order.class)
 
           idsAndPopups.push({ id, popup })
@@ -298,4 +288,27 @@ function _getOrderById(orders: OrdersStateNetwork | undefined, id: string): Orde
     refunding?.[id] ||
     refunded?.[id]
   )
+}
+
+function _buildCancellationPopup(order: SerializedOrder) {
+  const { cancellationHash, apiAdditionalInfo, id, summary } = order
+
+  if (cancellationHash && !apiAdditionalInfo) {
+    // EthFlow order which has been cancelled and does not exist on the backend
+    // Use the `tx` popup
+    return setPopupData(OrderTxTypes.TXN, {
+      success: true,
+      summary: buildCancellationPopupSummary(id, summary),
+      hash: cancellationHash,
+      id,
+    })
+  } else {
+    // Regular order being cancelled
+    // Use `metatx` popup
+    return setPopupData(OrderTxTypes.METATXN, {
+      success: true,
+      summary: buildCancellationPopupSummary(id, summary),
+      id,
+    })
+  }
 }

--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -108,7 +108,7 @@ export const popupMiddleware: Middleware<Record<string, unknown>, AppState> = (s
       return result
     }
 
-    const { pending, fulfilled, expired, cancelled } = orders
+    const { pending, fulfilled, expired, cancelled, creating } = orders
 
     if (isBatchFulfillOrderAction(action)) {
       // construct Fulfilled Order Popups for each Order
@@ -158,7 +158,7 @@ export const popupMiddleware: Middleware<Record<string, unknown>, AppState> = (s
     } else {
       // construct Expired Order Popups for each Order
       action.payload.ids.forEach((id) => {
-        const orderObject = pending?.[id] || fulfilled?.[id] || expired?.[id]
+        const orderObject = pending?.[id] || fulfilled?.[id] || expired?.[id] || creating?.[id]
         if (orderObject) {
           const { summary, class: orderClass } = orderObject.order
 


### PR DESCRIPTION
# Summary

Closes #1300 
Built on top of https://github.com/cowprotocol/cowswap/pull/1732

Cancellation pop-ups are already displayed for ethflow cancellations, but there is one edge case.
When the order is not created on the backend, the notification will still point to Explorer.
That will lead nowhere as the order doesn't exist.

This PR makes the link in that case point to etherscan with the cancellation tx hash

⚠️ **Note** ⚠️ This PR is intentionally pointing to the wrong contract so the order is never created in the backend to test this behaviour. The contract change SHOULD BE REVERTED before merging this PR!!!

# To Test

1. Place order
2. Cancel it
* The toast notification will show `View on Etherscan` instead of `View on Explorer`