### PR TITLE
Eth flow/1647

### DIFF
--- a/src/cow-react/modules/swap/containers/Row/RowFee/index.tsx
+++ b/src/cow-react/modules/swap/containers/Row/RowFee/index.tsx
@@ -7,6 +7,7 @@ import { AMOUNT_PRECISION, FIAT_PRECISION } from 'constants/index'
 import { RowFeeContent } from '@cow/modules/swap/pure/Row/RowFeeContent'
 import { RowWithShowHelpersProps } from '@cow/modules/swap/pure/Row/types'
 import { useIsEthFlow } from '@cow/modules/swap/hooks/useIsEthFlow'
+import useNativeCurrency from 'lib/hooks/useNativeCurrency'
 
 export const GASLESS_FEE_TOOLTIP_MSG =
   'On CoW Swap you sign your order (hence no gas costs!). The fees are covering your gas costs already.'
@@ -14,8 +15,8 @@ export const GASLESS_FEE_TOOLTIP_MSG =
 export const PRESIGN_FEE_TOOLTIP_MSG =
   'These fees cover the gas costs for executing the order once it has been placed. However - since you are using a smart contract wallet - you will need to pay the gas for signing an on-chain tx in order to place it.'
 
-const ETHFLOW_FEE_TOOLTIP_MSG =
-  'Trades on CoW Swap usually don’t require you to pay gas in ETH. However, when selling ETH, you do have to pay a small gas fee to cover the cost of wrapping your ETH.'
+const getEthFlowFeeTooltipMsg = (native: string) =>
+  `Trades on CoW Swap usually don’t require you to pay gas in ${native}. However, when selling ${native}, you do have to pay a small gas fee to cover the cost of wrapping your ${native}.`
 
 // computes price breakdown for the trade
 export function computeTradePriceBreakdown(trade?: TradeGp | null): {
@@ -44,17 +45,19 @@ export interface RowFeeProps extends RowWithShowHelpersProps {
 
 export function RowFee({ trade, fee, feeFiatValue, allowsOffchainSigning, showHelpers }: RowFeeProps) {
   const { realizedFee } = useMemo(() => computeTradePriceBreakdown(trade), [trade])
+
   const isEthFLow = useIsEthFlow()
+  const native = useNativeCurrency()
 
   const tooltip = useMemo(() => {
     if (isEthFLow) {
-      return ETHFLOW_FEE_TOOLTIP_MSG
+      return getEthFlowFeeTooltipMsg(native.symbol || 'ETH')
     } else if (allowsOffchainSigning) {
       return GASLESS_FEE_TOOLTIP_MSG
     } else {
       return PRESIGN_FEE_TOOLTIP_MSG
     }
-  }, [allowsOffchainSigning, isEthFLow])
+  }, [allowsOffchainSigning, isEthFLow, native.symbol])
 
   // trades are null when there is a fee quote error e.g
   // so we can take both

--- a/src/cow-react/modules/swap/containers/Row/RowFee/index.tsx
+++ b/src/cow-react/modules/swap/containers/Row/RowFee/index.tsx
@@ -63,9 +63,10 @@ export function RowFee({ trade, fee, feeFiatValue, allowsOffchainSigning, showHe
     const feeCurrencySymbol = displayFee?.currency.symbol || '-'
     const smartFeeFiatValue = formatSmart(feeFiatValue, FIAT_PRECISION)
     const smartFeeTokenValue = formatSmart(displayFee, AMOUNT_PRECISION)
-    const feeToken = smartFeeTokenValue ? `${smartFeeTokenValue} ${feeCurrencySymbol}` : '🎉 Free!'
+    const feeAmountWithCurrency = `${smartFeeTokenValue} ${feeCurrencySymbol} ${isEthFLow ? ' + gas' : ''}`
+    const feeToken = smartFeeTokenValue ? feeAmountWithCurrency : '🎉 Free!'
     const fullDisplayFee = formatMax(displayFee, displayFee?.currency.decimals) || '-'
-    const includeGasMessage = allowsOffchainSigning ? ' (incl. gas costs)' : ''
+    const includeGasMessage = allowsOffchainSigning && !isEthFLow ? ' (incl. gas costs)' : ''
 
     return {
       showHelpers,
@@ -76,7 +77,7 @@ export function RowFee({ trade, fee, feeFiatValue, allowsOffchainSigning, showHe
       includeGasMessage,
       tooltip,
     }
-  }, [allowsOffchainSigning, fee, feeFiatValue, realizedFee, showHelpers, tooltip])
+  }, [allowsOffchainSigning, fee, feeFiatValue, isEthFLow, realizedFee, showHelpers, tooltip])
 
   return <RowFeeContent {...props} />
 }

--- a/src/cow-react/modules/swap/containers/Row/RowFee/index.tsx
+++ b/src/cow-react/modules/swap/containers/Row/RowFee/index.tsx
@@ -15,7 +15,7 @@ export const GASLESS_FEE_TOOLTIP_MSG =
 export const PRESIGN_FEE_TOOLTIP_MSG =
   'These fees cover the gas costs for executing the order once it has been placed. However - since you are using a smart contract wallet - you will need to pay the gas for signing an on-chain tx in order to place it.'
 
-const getEthFlowFeeTooltipMsg = (native: string) =>
+const getEthFlowFeeTooltipMsg = (native = 'a native currency') =>
   `Trades on CoW Swap usually don’t require you to pay gas in ${native}. However, when selling ${native}, you do have to pay a small gas fee to cover the cost of wrapping your ${native}.`
 
 // computes price breakdown for the trade
@@ -51,7 +51,7 @@ export function RowFee({ trade, fee, feeFiatValue, allowsOffchainSigning, showHe
 
   const tooltip = useMemo(() => {
     if (isEthFLow) {
-      return getEthFlowFeeTooltipMsg(native.symbol || 'ETH')
+      return getEthFlowFeeTooltipMsg(native.symbol)
     } else if (allowsOffchainSigning) {
       return GASLESS_FEE_TOOLTIP_MSG
     } else {

--- a/src/cow-react/modules/swap/pure/Row/RowSlippageContent/index.tsx
+++ b/src/cow-react/modules/swap/pure/Row/RowSlippageContent/index.tsx
@@ -28,12 +28,12 @@ export const ClickableText = styled.button`
 
 export const getNativeSlippageTooltip = (symbols: (string | undefined)[] | undefined) => (
   <Trans>
-    <p>Your slippage is MEV protected.</p>
     <p>
-      When swapping {symbols?.[0] || 'a native currency'}, the minimum slippage tolerance is set to{' '}
+      When selling {symbols?.[0] || 'a native currency'}, the minimum slippage tolerance is set to{' '}
       {ETH_FLOW_SLIPPAGE.toSignificant(PERCENTAGE_PRECISION)}% to ensure a high likelihood of order matching, even in
-      volatile market situations.
+      volatile market conditions.
     </p>
+    <p>Orders on CoW Swap are always protected from MEV, so your slippage tolerance cannot be exploited.</p>
   </Trans>
 )
 export const getNonNativeSlippageTooltip = () => (


### PR DESCRIPTION
# Summary

Fixes #1647

# This PR
- updates the Fee tooltip when ethflow
- updates the fee row when ethflow

# Question
- should the USD estimation for fee include the network gas fee?

# To test
- go to swap page
- select eth as a sell currency
- check fee row