### PR TITLE
🎨 Rate impact styles

### DIFF
--- a/src/cow-react/common/pure/RateInfo/index.tsx
+++ b/src/cow-react/common/pure/RateInfo/index.tsx
@@ -41,6 +41,12 @@ const RateLabel = styled.div`
   align-items: center;
   font-weight: 400;
   gap: 5px;
+  transition: color 0.15s ease-in-out;
+  color: ${({ theme }) => transparentize(0.2, theme.text1)};
+
+  &:hover {
+    color: ${({ theme }) => theme.text1};
+  }
 `
 
 const InvertIcon = styled.div`

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/styled.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/styled.tsx
@@ -78,8 +78,8 @@ export const StyledRemoveRecipient = styled(RemoveRecipient)`
 `
 
 export const StyledRateInfo = styled(RateInfo)`
-  margin-top: 15px;
-  font-size: 14px;
+  padding: 8px 8px 0;
+  font-size: 13px;
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
     display: flex;

--- a/src/cow-react/modules/limitOrders/containers/RateInput/styled.ts
+++ b/src/cow-react/modules/limitOrders/containers/RateInput/styled.ts
@@ -69,6 +69,7 @@ export const ActiveCurrency = styled.button`
   background: none;
   cursor: pointer;
   padding: 0;
+  margin: 0 0 0 auto;
 `
 
 export const ActiveSymbol = styled.span`

--- a/src/cow-react/modules/limitOrders/pure/LimitOrdersDetails/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/LimitOrdersDetails/index.tsx
@@ -9,7 +9,10 @@ import { LimitOrdersSettingsState } from '@cow/modules/limitOrders/state/limitOr
 import { calculateLimitOrdersDeadline } from '@cow/modules/limitOrders/utils/calculateLimitOrdersDeadline'
 
 const Wrapper = styled.div`
-  margin: 10px 0;
+  font-size: 13px;
+  font-weight: 400;
+  color: ${({ theme }) => theme.text1};
+  padding: 8px;
 `
 export interface LimitOrdersDetailsProps {
   rateInfoParams: RateInfoParams

--- a/src/cow-react/modules/limitOrders/pure/LimitOrdersDetails/styled.tsx
+++ b/src/cow-react/modules/limitOrders/pure/LimitOrdersDetails/styled.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components/macro'
 import { RateInfo } from '@cow/common/pure/RateInfo'
+import { transparentize } from 'polished'
 
 export const DetailsRow = styled.div`
   display: flex;
@@ -7,9 +8,28 @@ export const DetailsRow = styled.div`
   justify-content: space-between;
   align-items: center;
   text-align: right;
+  min-height: 24px;
+  gap: 3px;
+
+  > div:first-child {
+    display: flex;
+    gap: 3px;
+  }
+
+  > div:first-child > span:first-child {
+    transition: color 0.15s ease-in-out;
+    color: ${({ theme }) => transparentize(0.2, theme.text1)};
+
+    &:hover {
+      color: ${({ theme }) => theme.text1};
+    }
+  }
 `
 
 export const StyledRateInfo = styled(RateInfo)`
-  margin-bottom: 5px;
-  font-size: 14px;
+  font-size: 13px;
+  font-weight: 400;
+  color: ${({ theme }) => theme.text1};
+  min-height: 24px;
+  gap: 3px;
 `

--- a/src/cow-react/modules/limitOrders/pure/RateInput/HeadingText.tsx
+++ b/src/cow-react/modules/limitOrders/pure/RateInput/HeadingText.tsx
@@ -1,5 +1,6 @@
 import { RateImpactIndicator } from '@cow/modules/limitOrders/pure/RateImpactIndicator'
 import { Currency } from '@uniswap/sdk-core'
+import styled from 'styled-components/macro'
 
 type Props = {
   currency: string | undefined
@@ -7,15 +8,24 @@ type Props = {
   rateImpact: number
 }
 
+const Wrapper = styled.span`
+  display: flex;
+  flex-flow: row wrap;
+  align-items: flex-start;
+  justify-content: flex-start;
+  text-align: left;
+  gap: 0 3px;
+`
+
 export function HeadingText({ inputCurrency, currency, rateImpact }: Props) {
   if (!currency) {
-    return <span>Select input and output</span>
+    return <Wrapper>Select input and output</Wrapper>
   }
 
   return (
-    <span>
+    <Wrapper>
       Price per {currency}
       {<RateImpactIndicator inputCurrency={inputCurrency} rateImpact={rateImpact} />}
-    </span>
+    </Wrapper>
   )
 }

--- a/src/cow-react/modules/swap/pure/Row/styled.ts
+++ b/src/cow-react/modules/swap/pure/Row/styled.ts
@@ -1,6 +1,6 @@
 import { Text } from 'rebass'
 import styled from 'styled-components/macro'
-import { RowBetween } from 'components/Row'
+import { RowBetween, RowFixed } from 'components/Row'
 import { MouseoverTooltipContent } from 'components/Tooltip'
 import { RowStyleProps } from './types'
 import { transparentize } from 'polished'
@@ -11,6 +11,11 @@ export const TextWrapper = styled(Text)``
 
 export const StyledRowBetween = styled(RowBetween)<RowStyleProps>`
   min-height: 24px;
+  gap: 3px;
+
+  ${RowFixed} {
+    gap: 3px;
+  }
 
   ${TextWrapper} {
     color: ${({ theme }) => theme.text1};

--- a/src/cow-react/modules/swap/pure/TradeRates/styled.tsx
+++ b/src/cow-react/modules/swap/pure/TradeRates/styled.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components/macro'
 import { Repeat } from 'react-feather'
 import QuestionHelper from 'components/QuestionHelper'
 import { RateInfo } from '@cow/common/pure/RateInfo'
+import { transparentize } from 'polished'
 
 export const Box = styled.div`
   margin: 12px 8px;
@@ -13,6 +14,8 @@ export const Row = styled.div`
   font-size: 13px;
   font-weight: 400;
   color: ${({ theme }) => theme.text1};
+  min-height: 24px;
+  gap: 3px;
 
   > div {
     display: flex;
@@ -24,17 +27,16 @@ export const Row = styled.div`
     }
 
     &:first-child > span {
-      opacity: 0.8;
+      color: ${({ theme }) => transparentize(0.2, theme.text1)};
+      transition: color 0.15s ease-in-out;
+
+      &:hover {
+        color: ${({ theme }) => theme.text1};
+      }
     }
 
     &:last-child {
       text-align: right;
-    }
-  }
-
-  &:hover {
-    > div {
-      opacity: 1;
     }
   }
 `

--- a/src/cow-react/modules/swap/pure/TradeRates/styled.tsx
+++ b/src/cow-react/modules/swap/pure/TradeRates/styled.tsx
@@ -20,6 +20,7 @@ export const Row = styled.div`
 
     &:first-child {
       font-weight: 400;
+      gap: 3px;
     }
 
     &:first-child > span {

--- a/src/custom/components/Tooltip/TooltipMod.tsx
+++ b/src/custom/components/Tooltip/TooltipMod.tsx
@@ -65,7 +65,7 @@ export function MouseoverTooltipContent({
   return (
     <TooltipContent {...rest} show={show} content={disableHover ? null : content}>
       <div
-        style={{ display: 'inline-block', lineHeight: 0, padding: '0.25rem' }}
+        // style={{ display: 'inline-block', lineHeight: 0, padding: '0.25rem' }}
         onMouseEnter={open}
         onMouseLeave={close}
       >


### PR DESCRIPTION
# Summary

- Addresses https://github.com/cowprotocol/cowswap/issues/1675
- Addresses https://github.com/cowprotocol/cowswap/issues/1528

The issue with the shifted rate impact is due to larger token symbols (e.g. FRACTION).

**BEFORE**
<img width="350" alt="Screenshot 2022-12-15 at 14 41 49" src="https://user-images.githubusercontent.com/31534717/207896674-82313f0b-8e0a-4146-a260-fc2f674b8a5e.png">

**AFTER**
<img width="350" alt="Screenshot 2022-12-15 at 14 54 55" src="https://user-images.githubusercontent.com/31534717/207896846-d37ee369-58b8-4cd1-8522-2d0a410f2113.png"><img width="350" alt="Screenshot 2022-12-15 at 14 52 39" src="https://user-images.githubusercontent.com/31534717/207896879-5812cd4f-8862-4f23-981f-2feead3c56d4.png">

**Example with very large token symbol/name:**
<img width="350" alt="Screenshot 2022-12-15 at 14 53 29" src="https://user-images.githubusercontent.com/31534717/207896867-fb381238-4420-4a6b-9fae-4f10005ec53d.png">

**Fixed token symbol on load**

https://user-images.githubusercontent.com/31534717/207896629-fdbec2b6-eb61-47e3-b2b2-fff5681bee0b.mov

