### PR TITLE
[EthFlow]follow up #1732 double cancellation toasts

### DIFF
--- a/src/custom/state/orders/updaters/CancelledOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/CancelledOrdersUpdater.ts
@@ -57,11 +57,18 @@ export function CancelledOrdersUpdater(): null {
         // Filter orders:
         // - Owned by the current connected account
         // - Created in the last 5 min, no further
-        const pending = cancelledRef.current.filter(({ owner, creationTime: creationTimeString }) => {
-          const creationTime = new Date(creationTimeString).getTime()
+        // - Not EthFlow orders already cancelled
+        const pending = cancelledRef.current.filter(
+          ({ owner, creationTime: creationTimeString, status, cancellationHash }) => {
+            const creationTime = new Date(creationTimeString).getTime()
 
-          return owner.toLowerCase() === lowerCaseAccount && now - creationTime < CANCELLED_ORDERS_PENDING_TIME
-        })
+            return (
+              owner.toLowerCase() === lowerCaseAccount &&
+              now - creationTime < CANCELLED_ORDERS_PENDING_TIME &&
+              !(cancellationHash && status === 'cancelled')
+            )
+          }
+        )
 
         if (pending.length === 0) {
           // console.debug(`[CancelledOrdersUpdater] No orders are being cancelled`)

--- a/src/custom/state/orders/updaters/GpOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/GpOrdersUpdater.ts
@@ -88,6 +88,14 @@ function _transformGpOrderToStoreOrder(
   // That's why it's not used before and an empty string is set instead
   storeOrder.summary = computeOrderSummary({ orderFromStore: storeOrder, orderFromApi: order }) || ''
 
+  // EthFlow adjustments
+  // It can happen that EthFlow cancellation is identified in the app before the API is aware
+  // In that case
+  if (order.ethflowData && order.status === 'cancelled') {
+    storeOrder.status = OrderStatus.CANCELLED
+    storeOrder.isCancelling = false
+  }
+
   return storeOrder
 }
 


### PR DESCRIPTION
# Summary

Fixes issue where the cancellation pop-up was triggered twice for ethflow orders
Issue was reported here https://github.com/cowprotocol/cowswap/pull/1732#issuecomment-1353154225

  # To Test

1. Place ethflow order
2. Cancel it
* There should be 1 pop-up when cancellation tx is mined
3. Wait for a few minutes
* No other cancellation pop-up should be triggered