### PR TITLE
Refactor preparing for unique order Id checks

### DIFF
--- a/src/cow-react/modules/swap/services/ethFlow/index.ts
+++ b/src/cow-react/modules/swap/services/ethFlow/index.ts
@@ -1,51 +1,68 @@
 import { EthFlowContext } from '@cow/modules/swap/services/common/types'
 import { swapFlowAnalytics } from '@cow/modules/swap/services/common/steps/analytics'
-import { signEthFlowOrderStep } from '@cow/modules/swap/services/ethFlow/steps/signEthFlowOrderStep'
 import confirmPriceImpactWithoutFee from 'components/swap/confirmPriceImpactWithoutFee'
 import { logSwapFlow } from '@cow/modules/swap/services/utils/logger'
 import { getSwapErrorMessage } from '@cow/modules/swap/services/common/steps/swapErrorHelper'
 import { PriceImpact } from 'hooks/usePriceImpact'
 import { addPendingOrderStep } from '@cow/modules/swap/services/common/steps/addPendingOrderStep'
+import { signEthFlowOrderStep } from './steps/signEthFlowOrderStep'
+import { calculateUniqueOrderId } from './steps/calculateUniqueOrderId'
 
 export async function ethFlow(input: EthFlowContext, priceImpactParams: PriceImpact): Promise<void> {
+  const {
+    swapFlowAnalyticsContext,
+    context,
+    swapConfirmManager,
+    contract,
+    callbacks,
+    appDataInfo,
+    dispatch,
+    orderParams: orderParamsOriginal,
+  } = input
+
   logSwapFlow('ETH FLOW', 'STEP 1: confirm price impact')
-  if (priceImpactParams?.priceImpact && !confirmPriceImpactWithoutFee(priceImpactParams.priceImpact)) return
+  if (priceImpactParams?.priceImpact && !confirmPriceImpactWithoutFee(priceImpactParams.priceImpact)) {
+    return undefined
+  }
 
   logSwapFlow('ETH FLOW', 'STEP 2: send transaction')
   // TODO: check if we need own eth flow analytics or more generic
-  swapFlowAnalytics.swap(input.swapFlowAnalyticsContext)
-  input.swapConfirmManager.sendTransaction(input.context.trade)
+  swapFlowAnalytics.swap(swapFlowAnalyticsContext)
+  swapConfirmManager.sendTransaction(context.trade)
+
+  logSwapFlow('ETH FLOW', 'STEP 3: Get Unique Order Id (prevent collisions)')
+  const { orderId, orderParams } = await calculateUniqueOrderId(orderParamsOriginal, contract)
 
   try {
     logSwapFlow('ETH FLOW', 'STEP 3: sign order')
-    const { order, orderId, txReceipt } = await signEthFlowOrderStep(input.orderParams, input.contract).finally(() => {
-      input.callbacks.closeModals()
+    const { order, txReceipt } = await signEthFlowOrderStep(orderId, orderParams, contract).finally(() => {
+      callbacks.closeModals()
     })
 
     logSwapFlow('ETH FLOW', 'STEP 4: add pending order step')
     addPendingOrderStep(
       {
         id: orderId,
-        chainId: input.context.chainId,
+        chainId: context.chainId,
         order,
       },
-      input.dispatch
+      dispatch
     )
     // TODO: maybe move this into addPendingOrderStep?
     input.addTransaction({ hash: txReceipt.hash, ethFlow: { orderId: order.id, subType: 'creation' } })
 
     logSwapFlow('ETH FLOW', 'STEP 5: add app data to upload queue')
-    input.callbacks.addAppDataToUploadQueue({ chainId: input.context.chainId, orderId, appData: input.appDataInfo })
+    callbacks.addAppDataToUploadQueue({ chainId: context.chainId, orderId, appData: appDataInfo })
 
     logSwapFlow('ETH FLOW', 'STEP 6: show UI of the successfully sent transaction', orderId)
-    input.swapConfirmManager.transactionSent(orderId)
-    swapFlowAnalytics.sign(input.swapFlowAnalyticsContext)
+    swapConfirmManager.transactionSent(orderId)
+    swapFlowAnalytics.sign(swapFlowAnalyticsContext)
   } catch (error) {
     logSwapFlow('ETH FLOW', 'STEP 7: ERROR: ', error)
     const swapErrorMessage = getSwapErrorMessage(error)
 
-    swapFlowAnalytics.error(error, swapErrorMessage, input.swapFlowAnalyticsContext)
+    swapFlowAnalytics.error(error, swapErrorMessage, swapFlowAnalyticsContext)
 
-    input.swapConfirmManager.setSwapError(swapErrorMessage)
+    swapConfirmManager.setSwapError(swapErrorMessage)
   }
 }

--- a/src/cow-react/modules/swap/services/ethFlow/index.ts
+++ b/src/cow-react/modules/swap/services/ethFlow/index.ts
@@ -34,12 +34,12 @@ export async function ethFlow(input: EthFlowContext, priceImpactParams: PriceImp
   const { orderId, orderParams } = await calculateUniqueOrderId(orderParamsOriginal, contract)
 
   try {
-    logSwapFlow('ETH FLOW', 'STEP 3: sign order')
+    logSwapFlow('ETH FLOW', 'STEP 4: sign order')
     const { order, txReceipt } = await signEthFlowOrderStep(orderId, orderParams, contract).finally(() => {
       callbacks.closeModals()
     })
 
-    logSwapFlow('ETH FLOW', 'STEP 4: add pending order step')
+    logSwapFlow('ETH FLOW', 'STEP 5: add pending order step')
     addPendingOrderStep(
       {
         id: orderId,
@@ -51,14 +51,14 @@ export async function ethFlow(input: EthFlowContext, priceImpactParams: PriceImp
     // TODO: maybe move this into addPendingOrderStep?
     input.addTransaction({ hash: txReceipt.hash, ethFlow: { orderId: order.id, subType: 'creation' } })
 
-    logSwapFlow('ETH FLOW', 'STEP 5: add app data to upload queue')
+    logSwapFlow('ETH FLOW', 'STEP 6: add app data to upload queue')
     callbacks.addAppDataToUploadQueue({ chainId: context.chainId, orderId, appData: appDataInfo })
 
-    logSwapFlow('ETH FLOW', 'STEP 6: show UI of the successfully sent transaction', orderId)
+    logSwapFlow('ETH FLOW', 'STEP 7: show UI of the successfully sent transaction', orderId)
     swapConfirmManager.transactionSent(orderId)
     swapFlowAnalytics.sign(swapFlowAnalyticsContext)
   } catch (error) {
-    logSwapFlow('ETH FLOW', 'STEP 7: ERROR: ', error)
+    logSwapFlow('ETH FLOW', 'STEP 8: ERROR: ', error)
     const swapErrorMessage = getSwapErrorMessage(error)
 
     swapFlowAnalytics.error(error, swapErrorMessage, swapFlowAnalyticsContext)

--- a/src/cow-react/modules/swap/services/ethFlow/steps/calculateUniqueOrderId.ts
+++ b/src/cow-react/modules/swap/services/ethFlow/steps/calculateUniqueOrderId.ts
@@ -1,0 +1,53 @@
+import { hashOrder, packOrderUidParams } from '@cowprotocol/contracts'
+import { CoWSwapEthFlow } from '@cow/abis/types'
+import { logSwapFlow } from '@cow/modules/swap/services/utils/logger'
+import { getOrderParams, PostOrderParams } from 'utils/trade'
+import { getDomain, UnsignedOrder } from 'utils/signatures'
+import { MAX_VALID_TO_EPOCH } from '@cow/utils/time'
+import { WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
+
+export type EthFlowCreateOrderParams = Omit<UnsignedOrder, 'quoteId' | 'appData' | 'validTo' | 'orderId'> & {
+  quoteId: number
+  appData: string
+  validTo: string
+  summary: string
+}
+export interface UniqueOrderIdResult {
+  orderId: string
+  orderParams: PostOrderParams // most cases, will be the same as the ones in the parameter, but it might be modified to make the order unique
+}
+
+export async function calculateUniqueOrderId(
+  orderParams: PostOrderParams,
+  ethFlowContract: CoWSwapEthFlow
+): Promise<UniqueOrderIdResult> {
+  logSwapFlow('ETH FLOW', '[EthFlow::calculateUniqueOrderId] - Calculate unique order Id', orderParams)
+  const { chainId } = orderParams
+
+  const { order } = getOrderParams(orderParams)
+
+  const domain = getDomain(chainId)
+  // Different validTo when signing because EthFlow contract expects it to be max for all orders
+  const orderDigest = hashOrder(domain, {
+    ...order,
+    validTo: MAX_VALID_TO_EPOCH,
+    sellToken: WRAPPED_NATIVE_CURRENCY[chainId].address,
+  })
+  // Generate the orderId from owner, orderDigest, and max validTo
+  const orderId = packOrderUidParams({
+    orderDigest,
+    owner: ethFlowContract.address,
+    validTo: MAX_VALID_TO_EPOCH,
+  })
+
+  logSwapFlow('ETH FLOW', '[EthFlow::calculateOrderId] Calculate Order Id', orderId)
+
+  // TODO: Detect if there's another order that has been created with the same order Id
+  // TODO: Detect collisions using the API (orderId exists)
+  // TODO: Do recursive call: calculateUniqueOrderId(incrementFee(orderParams), ethFlowContract)
+
+  return {
+    orderId,
+    orderParams,
+  }
+}

--- a/src/cow-react/modules/swap/services/ethFlow/steps/calculateUniqueOrderId.ts
+++ b/src/cow-react/modules/swap/services/ethFlow/steps/calculateUniqueOrderId.ts
@@ -2,16 +2,10 @@ import { hashOrder, packOrderUidParams } from '@cowprotocol/contracts'
 import { CoWSwapEthFlow } from '@cow/abis/types'
 import { logSwapFlow } from '@cow/modules/swap/services/utils/logger'
 import { getOrderParams, PostOrderParams } from 'utils/trade'
-import { getDomain, UnsignedOrder } from 'utils/signatures'
+import { getDomain } from 'utils/signatures'
 import { MAX_VALID_TO_EPOCH } from '@cow/utils/time'
 import { WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
 
-export type EthFlowCreateOrderParams = Omit<UnsignedOrder, 'quoteId' | 'appData' | 'validTo' | 'orderId'> & {
-  quoteId: number
-  appData: string
-  validTo: string
-  summary: string
-}
 export interface UniqueOrderIdResult {
   orderId: string
   orderParams: PostOrderParams // most cases, will be the same as the ones in the parameter, but it might be modified to make the order unique


### PR DESCRIPTION
# Summary

Small preparation/refactor for detection of collisions.

I removed the responsibility of calculating the order id from the step that signs the transaction.

I made the new step's function signature so it could call itself in a recursive fashion to find the first orderId without collisions. 

I briefly explained in this PR's TODO which checks we could implement and how to do the recustive all.

# To Test

Nothing should change in this PR behaviour. The app should work as before. You can check ETH flow is not broken :) 