### PR TITLE
Conditional display of the rate warning banner

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
@@ -45,6 +45,8 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
   const showPriceImpactWarning =
     !!chainId && !expertMode && !!account && !!priceImpact.error && formState === LimitOrdersFormState.CanTrade
 
+  const isVisible = showPriceImpactWarning || rateImpact < 0
+
   // Reset price impact flag when there is no price impact
   useEffect(() => {
     updateLimitOrdersWarnings({ isPriceImpactAccepted: !showPriceImpactWarning })
@@ -68,7 +70,7 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
     [updateLimitOrdersWarnings]
   )
 
-  return (
+  return isVisible ? (
     <div className={className}>
       {showPriceImpactWarning && (
         <StyledNoImpactWarning
@@ -87,5 +89,5 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
         />
       )}
     </div>
-  )
+  ) : null
 }


### PR DESCRIPTION
# Summary

- Prevents the output of an empty <div> when this condition is false:

`const isVisible = showPriceImpactWarning || rateImpact < 0`


https://user-images.githubusercontent.com/31534717/207928448-b836dbc3-ec2c-4bd6-805a-0c889f61f0b7.mov

