### PR TITLE
Add expert mode for eth flow

### DIFF
--- a/src/cow-react/modules/swap/helpers/getSwapButtonState.ts
+++ b/src/cow-react/modules/swap/helpers/getSwapButtonState.ts
@@ -26,7 +26,8 @@ export enum SwapButtonState {
   ExpertModeSwap = 'ExpertModeSwap',
   RegularSwap = 'RegularSwap',
   SwapWithWrappedToken = 'SwapWithWrappedToken',
-  EthFlowSwap = 'EthFlowSwap',
+  RegularEthFlowSwap = 'EthFlowSwap',
+  ExpertModeEthFlowSwap = 'ExpertModeEthFlowSwap',
 }
 
 export interface SwapButtonStateParams {
@@ -123,7 +124,7 @@ export function getSwapButtonState(input: SwapButtonStateParams): SwapButtonStat
 
   if (input.isNativeIn) {
     if (getEthFlowEnabled(input.isSmartContractWallet)) {
-      return SwapButtonState.EthFlowSwap
+      return input.isExpertMode ? SwapButtonState.ExpertModeEthFlowSwap : SwapButtonState.RegularEthFlowSwap
     } else {
       return SwapButtonState.SwapWithWrappedToken
     }

--- a/src/cow-react/modules/swap/pure/SwapButtons/index.tsx
+++ b/src/cow-react/modules/swap/pure/SwapButtons/index.tsx
@@ -154,9 +154,18 @@ const swapButtonStateMap: { [key in SwapButtonState]: (props: SwapButtonsContext
       </styledEl.SwapButtonBox>
     </ButtonError>
   ),
-  [SwapButtonState.EthFlowSwap]: (props: SwapButtonsContext) => (
+  [SwapButtonState.RegularEthFlowSwap]: (props: SwapButtonsContext) => (
+    <EthFlowSwapButton isExpertMode={false} {...props} />
+  ),
+  [SwapButtonState.ExpertModeEthFlowSwap]: (props: SwapButtonsContext) => (
+    <EthFlowSwapButton isExpertMode={true} {...props} />
+  ),
+}
+
+function EthFlowSwapButton(props: SwapButtonsContext & { isExpertMode: boolean }) {
+  return (
     <>
-      <ButtonError buttonSize={ButtonSize.BIG} onClick={props.openSwapConfirm}>
+      <ButtonError buttonSize={ButtonSize.BIG} onClick={props.isExpertMode ? props.handleSwap : props.openSwapConfirm}>
         <styledEl.SwapButtonBox>
           <Trans>Swap</Trans>
         </styledEl.SwapButtonBox>
@@ -167,7 +176,7 @@ const swapButtonStateMap: { [key in SwapButtonState]: (props: SwapButtonsContext
         wrapCallback={props.onEthFlow}
       />
     </>
-  ),
+  )
 }
 
 export const SwapButtons = React.memo(function (props: SwapButtonsContext) {


### PR DESCRIPTION
# Summary

Closes #1747

Add expert mode for eth flow.

# To Test
Test to swap with and without expert mode 
Verify the confirmation only shows for normal mode