### PR TITLE
Fix for zero decimal tokens

### DIFF
--- a/src/cow-react/modules/limitOrders/utils/getDecimals.ts
+++ b/src/cow-react/modules/limitOrders/utils/getDecimals.ts
@@ -6,7 +6,7 @@ export function getDecimals(currency: Currency): number {
     ALI: 18,
   }
 
-  if (!currency.decimals) return DEFAULT_DECIMALS
+  if (currency.decimals === undefined) return DEFAULT_DECIMALS
   if (currency.symbol && currency.symbol in customMap) return customMap[currency.symbol]
 
   return currency.decimals


### PR DESCRIPTION
# Summary

Fixes #1759
- There was an issue in our code where we used `DEFAULT_DECIMALS` (18) when the actual token decimals is 0 and that shouldn't happen

# To test
- check if the mentioned issue is fixed
- make sure prices for other tokens are correct (for example USDC, WBTC, USDT)
