### PR TITLE
Fix for zero decimal tokens

### DIFF
--- a/src/cow-react/common/pure/RateInfo/index.tsx
+++ b/src/cow-react/common/pure/RateInfo/index.tsx
@@ -9,6 +9,7 @@ import { SupportedChainId } from 'constants/chains'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import { usePrice } from '@cow/common/hooks/usePrice'
 import { transparentize } from 'polished'
+import { DEFAULT_DECIMALS } from '@cowprotocol/cow-js'
 
 export interface RateInfoParams {
   chainId: SupportedChainId | undefined
@@ -155,7 +156,13 @@ export function RateInfo({
       )}
       <div>
         <RateWrapper onClick={() => setCurrentIsInversed((state) => !state)}>
-          <span title={currentActiveRate.toFixed(rateOutputCurrency.decimals) + ' ' + rateOutputCurrency.symbol}>
+          <span
+            title={
+              currentActiveRate.toFixed(rateOutputCurrency.decimals || DEFAULT_DECIMALS) +
+              ' ' +
+              rateOutputCurrency.symbol
+            }
+          >
             1 {rateInputCurrency.symbol} = {formatSmart(currentActiveRate)} {rateOutputCurrency.symbol}
           </span>{' '}
           {!!fiatAmount && <FiatRate>(≈${formatSmart(fiatAmount, 2)})</FiatRate>}

--- a/src/cow-react/modules/limitOrders/containers/RateInput/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/RateInput/index.tsx
@@ -76,7 +76,7 @@ export function RateInput() {
 
     if (!outputCurrencyId || !inputCurrencyId) return true
 
-    if (executionRate) {
+    if (executionRate && !executionRate.equalTo(0)) {
       return activeRate?.equalTo(executionRate)
     } else {
       return !!initialRate && activeRate?.equalTo(initialRate)

--- a/src/cow-react/modules/limitOrders/containers/TradeButtons/limitOrdersTradeButtonsMap.tsx
+++ b/src/cow-react/modules/limitOrders/containers/TradeButtons/limitOrdersTradeButtonsMap.tsx
@@ -46,7 +46,7 @@ export function SwapButton({
   onClick?: () => void
 }) {
   return (
-    <ButtonPrimary onClick={onClick} disabled={disabled} buttonSize={ButtonSize.BIG}>
+    <ButtonPrimary fontSize={'16px !important'} onClick={onClick} disabled={disabled} buttonSize={ButtonSize.BIG}>
       <Trans>{children}</Trans>
     </ButtonPrimary>
   )
@@ -103,6 +103,10 @@ export const limitOrdersTradeButtonsMap: { [key in LimitOrdersFormState]: Button
   [LimitOrdersFormState.CantLoadBalances]: {
     disabled: true,
     text: "Couldn't load balances",
+  },
+  [LimitOrdersFormState.ZeroPrice]: {
+    disabled: true,
+    text: 'Invalid price. Try increasing input/output amount.',
   },
   [LimitOrdersFormState.QuoteError]: ({ quote }: TradeButtonsParams) => {
     return (

--- a/src/cow-react/modules/limitOrders/hooks/useRateImpact.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useRateImpact.ts
@@ -6,7 +6,10 @@ export function useRateImpact(): number {
   const { activeRate, executionRate, isLoading, isLoadingExecutionRate } = useAtomValue(limitRateAtom)
 
   return useMemo(() => {
-    if (!activeRate || activeRate.equalTo(0) || !executionRate || isLoading || isLoadingExecutionRate) return 0
+    const noActiveRate = !activeRate || activeRate.equalTo(0)
+    const noExecutionRate = !executionRate || executionRate.equalTo(0)
+
+    if (noActiveRate || noExecutionRate || isLoading || isLoadingExecutionRate) return 0
 
     const ratePercent = +activeRate.divide(executionRate).multiply(100).subtract(100).toFixed(1)
 

--- a/src/cow-react/modules/limitOrders/utils/getDecimals.ts
+++ b/src/cow-react/modules/limitOrders/utils/getDecimals.ts
@@ -6,7 +6,7 @@ export function getDecimals(currency: Currency): number {
     ALI: 18,
   }
 
-  if (!currency.decimals) return DEFAULT_DECIMALS
+  if (currency.decimals === undefined) return DEFAULT_DECIMALS
   if (currency.symbol && currency.symbol in customMap) return customMap[currency.symbol]
 
   return currency.decimals


### PR DESCRIPTION
> Original PR from @nenadV91 #1771

# Summary

Fixes #1759
- There was an issue in our code where we used `DEFAULT_DECIMALS` (18) when the actual token decimals is 0 and that shouldn't happen

# To test
- check if the mentioned issue is fixed
- make sure prices for other tokens are correct (for example USDC, WBTC, USDT)
