### PR TITLE
[EthFlow]#1294 handle failed txs

### DIFF
--- a/src/cow-react/api/gnosisProtocol/api.ts
+++ b/src/cow-react/api/gnosisProtocol/api.ts
@@ -91,7 +91,7 @@ const ENABLED = process.env.REACT_APP_PRICE_FEED_GP_ENABLED !== 'false'
  * where orderDigest = keccak256(orderStruct). bytes32.
  */
 export type OrderID = string
-export type ApiOrderStatus = 'fulfilled' | 'expired' | 'cancelled' | 'presignaturePending' | 'open'
+export type ApiOrderStatus = 'fulfilled' | 'expired' | 'cancelled' | 'invalid' | 'presignaturePending' | 'open'
 
 // TODO: replace it by import from SDK
 export interface OrderMetaData {

--- a/src/cow-react/common/hooks/useCategorizeRecentActivity.ts
+++ b/src/cow-react/common/hooks/useCategorizeRecentActivity.ts
@@ -2,22 +2,11 @@ import { useMemo } from 'react'
 import useRecentActivity, { TransactionAndOrder } from 'hooks/useRecentActivity'
 import { OrderStatus, OrderClass } from 'state/orders/actions'
 
-const PENDING_STATES = [
-  OrderStatus.PENDING,
-  OrderStatus.PRESIGNATURE_PENDING,
-  OrderStatus.CREATING,
-  OrderStatus.REFUNDING,
-]
+const PENDING_STATES = [OrderStatus.PENDING, OrderStatus.PRESIGNATURE_PENDING, OrderStatus.CREATING]
 
 const isPending = (data: TransactionAndOrder) => PENDING_STATES.includes(data.status)
 
-const CONFIRMED_STATES = [
-  OrderStatus.FULFILLED,
-  OrderStatus.EXPIRED,
-  OrderStatus.CANCELLED,
-  OrderStatus.REJECTED,
-  OrderStatus.REFUNDED,
-]
+const CONFIRMED_STATES = [OrderStatus.FULFILLED, OrderStatus.EXPIRED, OrderStatus.CANCELLED, OrderStatus.INVALID]
 
 const isConfirmed = (data: TransactionAndOrder) => CONFIRMED_STATES.includes(data.status)
 

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow.tsx
@@ -20,9 +20,7 @@ export const orderStatusTitleMap: { [key in OrderStatus]: string } = {
   [OrderStatus.EXPIRED]: 'Expired',
   [OrderStatus.CANCELLED]: 'Cancelled',
   [OrderStatus.CREATING]: 'Creating',
-  [OrderStatus.REFUNDED]: 'Expired',
-  [OrderStatus.REFUNDING]: 'Expired',
-  [OrderStatus.REJECTED]: 'Expired',
+  [OrderStatus.INVALID]: 'Invalid',
 }
 
 const RateValue = styled.span``
@@ -45,11 +43,11 @@ export const StatusItem = styled.div<{ status: OrderStatus; cancelling: boolean;
       ? theme.success
       : status === OrderStatus.EXPIRED
       ? theme.warning
-      : status === (OrderStatus.CANCELLED || OrderStatus.REJECTED)
+      : status === OrderStatus.CANCELLED
       ? theme.danger
-      : status === OrderStatus.REFUNDED
+      : status === OrderStatus.INVALID
       ? theme.text3
-      : status === (OrderStatus.CREATING || OrderStatus.PRESIGNATURE_PENDING || OrderStatus.REFUNDING)
+      : status === (OrderStatus.CREATING || OrderStatus.PRESIGNATURE_PENDING || OrderStatus)
       ? theme.text1
       : theme.text1};
 

--- a/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
@@ -74,6 +74,8 @@ function mapOrderToEthFlowStepperState(
 
     if (status === 'fulfilled') {
       return SmartOrderStatus.FILLED
+    } else if (status === 'invalid' || isTxFailed(creationTx)) {
+      return SmartOrderStatus.INVALID
     } else if (ORDER_INDEXED_STATUSES.includes(status) || cancellationTx?.receipt) {
       return SmartOrderStatus.INDEXED
     } else if (status === 'creating') {
@@ -92,6 +94,10 @@ function isEthFlowOrderExpired(order: Order | undefined): boolean {
 
 function isEthFlowOrderCancelled(order: Order, cancellationTx: EnhancedTransactionDetails | undefined): boolean {
   return order.status === 'cancelled' || !!cancellationTx?.receipt
+}
+
+function isTxFailed(tx: EnhancedTransactionDetails | undefined): boolean {
+  return tx?.receipt?.status !== undefined && tx?.receipt?.status !== 1
 }
 
 // TODO: move this somewhere else?

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.cosmos.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.cosmos.tsx
@@ -336,11 +336,24 @@ const STEPS: Step[] = [
       order: {
         ...defaultOrderProps,
         state: SmartOrderStatus.INDEXED,
-        isExpired: false,
+        isExpired: true,
       },
       creation: { ...defaultProps.creation, failed: false },
       cancellation: { hash: TX, failed: true },
       refund: { failed: false },
+    },
+  },
+  {
+    description: '[TX-FAILED-CANCELLATION] Cancellation tx failed - order filled',
+    props: {
+      ...defaultProps,
+      order: {
+        ...defaultOrderProps,
+        state: SmartOrderStatus.FILLED,
+        isExpired: false,
+      },
+      creation: { ...defaultProps.creation, failed: false },
+      cancellation: { hash: TX, failed: true },
     },
   },
   {
@@ -350,7 +363,7 @@ const STEPS: Step[] = [
       order: {
         ...defaultOrderProps,
         state: SmartOrderStatus.INDEXED,
-        isExpired: false,
+        isExpired: true,
       },
       creation: { ...defaultProps.creation, failed: false },
       refund: { hash: TX, failed: true },

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.cosmos.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.cosmos.tsx
@@ -11,7 +11,6 @@ const TX = '0x183fa3b48c676bf9c5613e3e20b67a7250acc94af8e65dbe57787f47e5e54c75'
 const ORDER_REJECTED_REASON = 'Price quote expired'
 
 const defaultOrderProps = {
-  createOrderTx: TX,
   orderId: ORDER_ID,
   state: SmartOrderStatus.CREATING,
   isExpired: false,
@@ -21,12 +20,9 @@ const defaultProps: EthFlowStepperProps = {
   nativeTokenSymbol: 'xDAI',
   tokenLabel: 'USDC',
   order: defaultOrderProps,
-  refund: {
-    isRefunded: false,
-  },
-  cancellation: {
-    isCancelled: false,
-  },
+  creation: { hash: TX },
+  refund: {},
+  cancellation: {},
 }
 
 interface Step {
@@ -47,6 +43,7 @@ const STEPS: Step[] = [
         ...defaultOrderProps,
         state: SmartOrderStatus.CREATION_MINED,
       },
+      creation: { ...defaultProps.creation, failed: false },
     },
   },
   {
@@ -57,6 +54,7 @@ const STEPS: Step[] = [
         ...defaultOrderProps,
         state: SmartOrderStatus.INDEXED,
       },
+      creation: { ...defaultProps.creation, failed: false },
     },
   },
   {
@@ -67,6 +65,7 @@ const STEPS: Step[] = [
         ...defaultOrderProps,
         state: SmartOrderStatus.FILLED,
       },
+      creation: { ...defaultProps.creation, failed: false },
     },
   },
   {
@@ -78,6 +77,7 @@ const STEPS: Step[] = [
         state: SmartOrderStatus.INDEXED,
         isExpired: true,
       },
+      creation: { ...defaultProps.creation, failed: false },
     },
   },
   {
@@ -89,10 +89,8 @@ const STEPS: Step[] = [
         state: SmartOrderStatus.INDEXED,
         isExpired: true,
       },
-      refund: {
-        refundTx: TX,
-        isRefunded: false,
-      },
+      creation: { ...defaultProps.creation, failed: false },
+      refund: { hash: TX },
     },
   },
   {
@@ -104,10 +102,8 @@ const STEPS: Step[] = [
         state: SmartOrderStatus.INDEXED,
         isExpired: true,
       },
-      refund: {
-        refundTx: TX,
-        isRefunded: true,
-      },
+      creation: { ...defaultProps.creation, failed: false },
+      refund: { hash: TX, failed: false },
     },
   },
   {
@@ -119,6 +115,7 @@ const STEPS: Step[] = [
         state: SmartOrderStatus.INDEXED,
         rejectedReason: ORDER_REJECTED_REASON,
       },
+      creation: { ...defaultProps.creation, failed: false },
     },
   },
   {
@@ -130,10 +127,8 @@ const STEPS: Step[] = [
         state: SmartOrderStatus.INDEXED,
         rejectedReason: ORDER_REJECTED_REASON,
       },
-      refund: {
-        refundTx: TX,
-        isRefunded: false,
-      },
+      creation: { ...defaultProps.creation, failed: false },
+      refund: { hash: TX },
     },
   },
   {
@@ -145,10 +140,8 @@ const STEPS: Step[] = [
         state: SmartOrderStatus.INDEXED,
         rejectedReason: ORDER_REJECTED_REASON,
       },
-      refund: {
-        refundTx: TX,
-        isRefunded: true,
-      },
+      creation: { ...defaultProps.creation, failed: false },
+      refund: { hash: TX, failed: false },
     },
   },
 
@@ -160,10 +153,8 @@ const STEPS: Step[] = [
         ...defaultOrderProps,
         state: SmartOrderStatus.INDEXED,
       },
-      cancellation: {
-        cancellationTx: TX,
-        isCancelled: false,
-      },
+      creation: { ...defaultProps.creation, failed: false },
+      cancellation: { hash: TX },
     },
   },
   {
@@ -174,10 +165,8 @@ const STEPS: Step[] = [
         ...defaultOrderProps,
         state: SmartOrderStatus.INDEXED,
       },
-      cancellation: {
-        cancellationTx: TX,
-        isCancelled: true,
-      },
+      creation: { ...defaultProps.creation, failed: false },
+      cancellation: { hash: TX, failed: false },
     },
   },
   {
@@ -190,6 +179,7 @@ const STEPS: Step[] = [
         rejectedReason: ORDER_REJECTED_REASON,
         isExpired: true,
       },
+      creation: { ...defaultProps.creation, failed: false },
     },
   },
   {
@@ -202,10 +192,8 @@ const STEPS: Step[] = [
         rejectedReason: ORDER_REJECTED_REASON,
         isExpired: true,
       },
-      refund: {
-        refundTx: TX,
-        isRefunded: false,
-      },
+      creation: { ...defaultProps.creation, failed: false },
+      refund: { hash: TX },
     },
   },
   {
@@ -218,10 +206,8 @@ const STEPS: Step[] = [
         rejectedReason: ORDER_REJECTED_REASON,
         isExpired: true,
       },
-      refund: {
-        refundTx: TX,
-        isRefunded: true,
-      },
+      creation: { ...defaultProps.creation, failed: false },
+      refund: { hash: TX, failed: false },
     },
   },
   {
@@ -233,10 +219,8 @@ const STEPS: Step[] = [
         state: SmartOrderStatus.INDEXED,
         isExpired: true,
       },
-      cancellation: {
-        cancellationTx: TX,
-        isCancelled: false,
-      },
+      creation: { ...defaultProps.creation, failed: false },
+      cancellation: { hash: TX },
     },
   },
   {
@@ -248,10 +232,8 @@ const STEPS: Step[] = [
         state: SmartOrderStatus.INDEXED,
         isExpired: true,
       },
-      cancellation: {
-        cancellationTx: TX,
-        isCancelled: true,
-      },
+      creation: { ...defaultProps.creation, failed: false },
+      cancellation: { hash: TX, failed: false },
     },
   },
   {
@@ -263,14 +245,9 @@ const STEPS: Step[] = [
         state: SmartOrderStatus.INDEXED,
         isExpired: true,
       },
-      cancellation: {
-        cancellationTx: TX,
-        isCancelled: false,
-      },
-      refund: {
-        refundTx: TX,
-        isRefunded: false,
-      },
+      creation: { ...defaultProps.creation, failed: false },
+      cancellation: { hash: TX },
+      refund: { hash: TX },
     },
   },
   {
@@ -282,14 +259,9 @@ const STEPS: Step[] = [
         state: SmartOrderStatus.INDEXED,
         isExpired: true,
       },
-      cancellation: {
-        cancellationTx: TX,
-        isCancelled: false,
-      },
-      refund: {
-        refundTx: TX,
-        isRefunded: true,
-      },
+      creation: { ...defaultProps.creation, failed: false },
+      cancellation: { hash: TX },
+      refund: { hash: TX, failed: false },
     },
   },
   {
@@ -301,14 +273,9 @@ const STEPS: Step[] = [
         state: SmartOrderStatus.INDEXED,
         isExpired: true,
       },
-      cancellation: {
-        cancellationTx: TX,
-        isCancelled: true,
-      },
-      refund: {
-        refundTx: TX,
-        isRefunded: false,
-      },
+      creation: { ...defaultProps.creation, failed: false },
+      cancellation: { hash: TX, failed: false },
+      refund: { hash: TX },
     },
   },
   {
@@ -320,14 +287,9 @@ const STEPS: Step[] = [
         state: SmartOrderStatus.INDEXED,
         isExpired: true,
       },
-      cancellation: {
-        cancellationTx: TX,
-        isCancelled: true,
-      },
-      refund: {
-        refundTx: TX,
-        isRefunded: true,
-      },
+      creation: { ...defaultProps.creation, failed: false },
+      cancellation: { hash: TX, failed: false },
+      refund: { hash: TX, failed: false },
     },
   },
   {
@@ -339,6 +301,7 @@ const STEPS: Step[] = [
         state: SmartOrderStatus.CREATING,
         isExpired: true,
       },
+      creation: { ...defaultProps.creation, failed: false },
     },
   },
   {
@@ -350,6 +313,47 @@ const STEPS: Step[] = [
         state: SmartOrderStatus.CREATION_MINED,
         isExpired: true,
       },
+      creation: { ...defaultProps.creation, failed: false },
+    },
+  },
+  {
+    description: '[TX-FAILED-CREATION] Creation tx failed',
+    props: {
+      ...defaultProps,
+      order: {
+        ...defaultOrderProps,
+        state: SmartOrderStatus.CREATING,
+        isExpired: false,
+        rejectedReason: 'Transaction failed',
+      },
+      creation: { ...defaultProps.creation, failed: true },
+    },
+  },
+  {
+    description: '[TX-FAILED-CANCELLATION] Cancellation tx failed - refund succeeded',
+    props: {
+      ...defaultProps,
+      order: {
+        ...defaultOrderProps,
+        state: SmartOrderStatus.INDEXED,
+        isExpired: false,
+      },
+      creation: { ...defaultProps.creation, failed: false },
+      cancellation: { hash: TX, failed: true },
+      refund: { failed: false },
+    },
+  },
+  {
+    description: '[TX-FAILED-REFUND] Refund tx failed (can it?)',
+    props: {
+      ...defaultProps,
+      order: {
+        ...defaultOrderProps,
+        state: SmartOrderStatus.INDEXED,
+        isExpired: false,
+      },
+      creation: { ...defaultProps.creation, failed: false },
+      refund: { hash: TX, failed: true },
     },
   },
 ]

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
@@ -13,7 +13,20 @@ export enum SmartOrderStatus {
   CREATION_MINED = 'CREATED',
   INDEXED = 'INDEXED',
   FILLED = 'FILLED',
-  INVALID = 'INVALID',
+}
+
+type TxState = {
+  /**
+   * undefined: there's no tx to track
+   * string: tx was created and can be tracked
+   */
+  hash?: string
+  /**
+   * undefined: not started/mining
+   * true: transaction failed
+   * false: transaction succeeded
+   */
+  failed?: boolean
 }
 
 export interface EthFlowStepperProps {
@@ -21,23 +34,33 @@ export interface EthFlowStepperProps {
   tokenLabel: string
 
   order: {
-    createOrderTx: string
     orderId: string
     state: SmartOrderStatus
+    /**
+     * To track if the order is past the expiration date
+     */
     isExpired: boolean
+    /**
+     * To track if the order has been created on the backend
+     */
     isCreated: boolean
     rejectedReason?: string
   }
 
-  refund: {
-    refundTx?: string
-    isRefunded: boolean
-  }
+  /**
+   * To track smart order tx creation
+   */
+  creation: TxState
 
-  cancellation: {
-    cancellationTx?: string
-    isCancelled: boolean
-  }
+  /**
+   * To track refund tx
+   */
+  refund: TxState
+
+  /**
+   * To track cancellation tx
+   */
+  cancellation: TxState
 }
 
 const Wrapper = styled.div`

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
@@ -13,6 +13,7 @@ export enum SmartOrderStatus {
   CREATION_MINED = 'CREATED',
   INDEXED = 'INDEXED',
   FILLED = 'FILLED',
+  INVALID = 'INVALID',
 }
 
 export interface EthFlowStepperProps {

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Progress1.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Progress1.tsx
@@ -1,11 +1,15 @@
 import React, { useMemo } from 'react'
-import { Progress, EthFlowStepperProps, SmartOrderStatus, ProgressProps } from '..'
+import { EthFlowStepperProps, Progress, ProgressProps, SmartOrderStatus } from '..'
 
 export function Progress1({ order }: EthFlowStepperProps) {
   const { state, isExpired } = order
   const isCreating = state === SmartOrderStatus.CREATING
+  const isInvalid = state === SmartOrderStatus.INVALID
 
   const { status: progressStatus, value: progress } = useMemo<ProgressProps>(() => {
+    if (isInvalid) {
+      return { value: 0, status: 'error' }
+    }
     if (isCreating) {
       if (isExpired) {
         return {
@@ -24,7 +28,7 @@ export function Progress1({ order }: EthFlowStepperProps) {
       value: 100,
       status: 'pending',
     }
-  }, [isCreating, isExpired])
+  }, [isCreating, isExpired, isInvalid])
 
   return <Progress status={progressStatus} value={progress} />
 }

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Progress1.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Progress1.tsx
@@ -1,34 +1,25 @@
 import React, { useMemo } from 'react'
 import { EthFlowStepperProps, Progress, ProgressProps, SmartOrderStatus } from '..'
 
-export function Progress1({ order }: EthFlowStepperProps) {
+export function Progress1({ order, creation }: EthFlowStepperProps) {
   const { state, isExpired } = order
   const isCreating = state === SmartOrderStatus.CREATING
-  const isInvalid = state === SmartOrderStatus.INVALID
+  const { failed } = creation
 
   const { status: progressStatus, value: progress } = useMemo<ProgressProps>(() => {
-    if (isInvalid) {
+    if (failed) {
       return { value: 0, status: 'error' }
     }
     if (isCreating) {
       if (isExpired) {
-        return {
-          value: 100,
-          status: 'error',
-        }
+        return { value: 100, status: 'error' }
       }
 
-      return {
-        value: 50,
-        status: 'pending',
-      }
+      return { value: 50, status: 'pending' }
     }
 
-    return {
-      value: 100,
-      status: 'pending',
-    }
-  }, [isCreating, isExpired, isInvalid])
+    return { value: 100, status: 'pending' }
+  }, [failed, isCreating, isExpired])
 
   return <Progress status={progressStatus} value={progress} />
 }

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Progress2.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Progress2.tsx
@@ -1,19 +1,19 @@
 import React, { useMemo } from 'react'
 import { Progress, EthFlowStepperProps, SmartOrderStatus, ProgressProps } from '..'
 
-export function Progress2({ order, refund, cancellation }: EthFlowStepperProps) {
+export function Progress2({ order, creation, refund, cancellation }: EthFlowStepperProps) {
   const { state } = order
-  const { isRefunded, refundTx } = refund
-  const { isCancelled, cancellationTx } = cancellation
+  const { failed: creationFailed } = creation
+  const { hash: refundHash, failed: refundFailed } = refund
+  const { hash: cancellationHash, failed: cancellationFailed } = cancellation
 
   const { status: progressStatus, value: progress } = useMemo<ProgressProps>(() => {
     const isIndexing = state === SmartOrderStatus.CREATION_MINED
     const isFilled = state === SmartOrderStatus.FILLED
     const isCreating = state === SmartOrderStatus.CREATING
-    const isTerminalState = isRefunded || isCancelled || isFilled
-    const isInvalid = state === SmartOrderStatus.INVALID
+    const isTerminalState = refundFailed !== undefined || cancellationFailed !== undefined || isFilled
 
-    if (isInvalid) {
+    if (creationFailed) {
       return { status: 'error', value: 0 }
     }
 
@@ -21,7 +21,7 @@ export function Progress2({ order, refund, cancellation }: EthFlowStepperProps) 
       return { status: 'success', value: 100 }
     }
 
-    if (refundTx || cancellationTx) {
+    if (refundHash || cancellationHash) {
       return { status: 'pending', value: 66 }
     }
 
@@ -30,7 +30,7 @@ export function Progress2({ order, refund, cancellation }: EthFlowStepperProps) 
     }
 
     return { status: 'pending', value: 33 }
-  }, [state, isRefunded, isCancelled, refundTx, cancellationTx])
+  }, [cancellationFailed, cancellationHash, creationFailed, refundFailed, refundHash, state])
 
   return <Progress status={progressStatus} value={progress} />
 }

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Progress2.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Progress2.tsx
@@ -11,40 +11,26 @@ export function Progress2({ order, refund, cancellation }: EthFlowStepperProps) 
     const isFilled = state === SmartOrderStatus.FILLED
     const isCreating = state === SmartOrderStatus.CREATING
     const isTerminalState = isRefunded || isCancelled || isFilled
+    const isInvalid = state === SmartOrderStatus.INVALID
+
+    if (isInvalid) {
+      return { status: 'error', value: 0 }
+    }
 
     if (isTerminalState) {
-      return {
-        status: 'success',
-        value: 100,
-      }
+      return { status: 'success', value: 100 }
     }
 
     if (refundTx || cancellationTx) {
-      return {
-        status: 'pending',
-        value: 66,
-      }
+      return { status: 'pending', value: 66 }
     }
 
     if (isCreating || isIndexing) {
-      return {
-        status: 'not-started',
-        value: 0,
-      }
+      return { status: 'not-started', value: 0 }
     }
 
-    if (refundTx || cancellationTx) {
-      return {
-        status: 'pending',
-        value: 66,
-      }
-    }
-
-    return {
-      status: 'pending',
-      value: 33,
-    }
-  }, [state, refundTx, cancellationTx, isCancelled, isRefunded])
+    return { status: 'pending', value: 33 }
+  }, [state, isRefunded, isCancelled, refundTx, cancellationTx])
 
   return <Progress status={progressStatus} value={progress} />
 }

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step1.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step1.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import Send from 'assets/cow-swap/send.svg'
 import Exclamation from 'assets/cow-swap/exclamation.svg'
 import Checkmark from 'assets/cow-swap/checkmark.svg'
+import X from 'assets/cow-swap/x.svg'
 import { EthFlowStepperProps, SmartOrderStatus } from '..'
 import { StatusIconState } from '../StatusIcon'
 import { Step, ExplorerLinkStyled } from '../Step'
@@ -9,6 +10,7 @@ import { Step, ExplorerLinkStyled } from '../Step'
 export function Step1({ nativeTokenSymbol, order }: EthFlowStepperProps) {
   const { state, isExpired, createOrderTx } = order
   const isCreating = state === SmartOrderStatus.CREATING
+  const isInvalid = state === SmartOrderStatus.INVALID
 
   let label: string, stepState: StatusIconState, icon: string
   if (isCreating) {
@@ -20,6 +22,10 @@ export function Step1({ nativeTokenSymbol, order }: EthFlowStepperProps) {
       stepState = 'pending'
       icon = Send
     }
+  } else if (isInvalid) {
+    label = 'Transaction failed'
+    stepState = 'error'
+    icon = X
   } else {
     label = 'Sent ' + nativeTokenSymbol
     stepState = 'success'

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step1.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step1.tsx
@@ -7,13 +7,18 @@ import { EthFlowStepperProps, SmartOrderStatus } from '..'
 import { StatusIconState } from '../StatusIcon'
 import { Step, ExplorerLinkStyled } from '../Step'
 
-export function Step1({ nativeTokenSymbol, order }: EthFlowStepperProps) {
-  const { state, isExpired, createOrderTx } = order
+export function Step1({ nativeTokenSymbol, order, creation }: EthFlowStepperProps) {
+  const { state, isExpired } = order
   const isCreating = state === SmartOrderStatus.CREATING
-  const isInvalid = state === SmartOrderStatus.INVALID
+  const { hash, failed } = creation
 
   let label: string, stepState: StatusIconState, icon: string
-  if (isCreating) {
+
+  if (failed) {
+    label = 'Transaction failed'
+    stepState = 'error'
+    icon = X
+  } else if (isCreating) {
     label = 'Sending ' + nativeTokenSymbol
     if (isExpired) {
       stepState = 'error'
@@ -22,10 +27,6 @@ export function Step1({ nativeTokenSymbol, order }: EthFlowStepperProps) {
       stepState = 'pending'
       icon = Send
     }
-  } else if (isInvalid) {
-    label = 'Transaction failed'
-    stepState = 'error'
-    icon = X
   } else {
     label = 'Sent ' + nativeTokenSymbol
     stepState = 'success'
@@ -34,7 +35,7 @@ export function Step1({ nativeTokenSymbol, order }: EthFlowStepperProps) {
 
   return (
     <Step state={stepState} icon={icon} label={label}>
-      {createOrderTx && <ExplorerLinkStyled type="transaction" label="View Transaction" id={createOrderTx} />}
+      {hash && <ExplorerLinkStyled type="transaction" label="View Transaction" id={hash} />}
     </Step>
   )
 }

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step2.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step2.tsx
@@ -15,6 +15,7 @@ export function Step2({ order, cancellation }: EthFlowStepperProps) {
   const isCancelled = cancellation.isCancelled
   const isOrderCreated = order.isCreated
   const isFilled = state === SmartOrderStatus.FILLED
+  const isInvalid = state === SmartOrderStatus.INVALID
 
   const expiredBeforeCreate = isExpired && (isCreating || isIndexing)
 
@@ -50,7 +51,7 @@ export function Step2({ order, cancellation }: EthFlowStepperProps) {
       }
     }
 
-    if (rejectedReason) {
+    if (rejectedReason || isInvalid) {
       return {
         label: 'Order Creation Failed',
         state: 'error',
@@ -71,7 +72,7 @@ export function Step2({ order, cancellation }: EthFlowStepperProps) {
       state: 'success',
       icon: Checkmark,
     }
-  }, [expiredBeforeCreate, isCancelled, isCreating, isFilled, isIndexing, rejectedReason])
+  }, [expiredBeforeCreate, isCancelled, isCreating, isFilled, isIndexing, isInvalid, rejectedReason])
 
   const errorMessage = error || rejectedReason
   return (

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step2.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step2.tsx
@@ -76,7 +76,7 @@ export function Step2({ order, cancellation }: EthFlowStepperProps) {
   const errorMessage = error || rejectedReason
   return (
     <Step state={stepState} icon={icon} label={label} errorMessage={errorMessage}>
-      <>{isOrderCreated && <ExplorerLinkStyled type="transaction" label="View details" id={orderId} />}</>
+      {isOrderCreated && <ExplorerLinkStyled type="transaction" label="View details" id={orderId} />}
     </Step>
   )
 }

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step2.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step2.tsx
@@ -12,10 +12,9 @@ export function Step2({ order, cancellation }: EthFlowStepperProps) {
   const { state, isExpired, orderId, rejectedReason } = order
   const isCreating = state === SmartOrderStatus.CREATING
   const isIndexing = state === SmartOrderStatus.CREATION_MINED
-  const isCancelled = cancellation.isCancelled
+  const isCancelled = cancellation.failed === false // if undefined: not cancelled, if true: cancellation failed
   const isOrderCreated = order.isCreated
   const isFilled = state === SmartOrderStatus.FILLED
-  const isInvalid = state === SmartOrderStatus.INVALID
 
   const expiredBeforeCreate = isExpired && (isCreating || isIndexing)
 
@@ -26,6 +25,14 @@ export function Step2({ order, cancellation }: EthFlowStepperProps) {
     icon,
     error,
   } = useMemo<Step2Config>(() => {
+    if (rejectedReason) {
+      return {
+        label: 'Order Creation Failed',
+        error: rejectedReason,
+        state: 'error',
+        icon: X,
+      }
+    }
     if (expiredBeforeCreate) {
       return {
         label: 'Order Creation Failed',
@@ -51,14 +58,6 @@ export function Step2({ order, cancellation }: EthFlowStepperProps) {
       }
     }
 
-    if (rejectedReason || isInvalid) {
-      return {
-        label: 'Order Creation Failed',
-        state: 'error',
-        icon: X,
-      }
-    }
-
     if (isCancelled && !isFilled) {
       return {
         label: 'Order Cancelled',
@@ -72,11 +71,10 @@ export function Step2({ order, cancellation }: EthFlowStepperProps) {
       state: 'success',
       icon: Checkmark,
     }
-  }, [expiredBeforeCreate, isCancelled, isCreating, isFilled, isIndexing, isInvalid, rejectedReason])
+  }, [expiredBeforeCreate, isCancelled, isCreating, isFilled, isIndexing, rejectedReason])
 
-  const errorMessage = error || rejectedReason
   return (
-    <Step state={stepState} icon={icon} label={label} errorMessage={errorMessage}>
+    <Step state={stepState} icon={icon} label={label} errorMessage={error}>
       {isOrderCreated && <ExplorerLinkStyled type="transaction" label="View details" id={orderId} />}
     </Step>
   )

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react'
 import Finish from 'assets/cow-swap/finish.svg'
 import Checkmark from 'assets/cow-swap/checkmark.svg'
 import Refund from 'assets/cow-swap/refund.svg'
+import Exclamation from 'assets/cow-swap/exclamation.svg'
 import styled from 'styled-components/macro'
 import { EthFlowStepperProps, SmartOrderStatus } from '..'
 import { Step, StepProps, ExplorerLinkStyled } from '../Step'
@@ -25,6 +26,7 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancellati
   const isCreating = state === SmartOrderStatus.CREATING
   const isFilled = state === SmartOrderStatus.FILLED
   const expiredBeforeCreate = isExpired && (isCreating || isIndexing)
+  const isInvalid = state === SmartOrderStatus.INVALID
 
   // Get the label, state and icon
   const {
@@ -60,6 +62,13 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancellati
         icon: Refund,
       }
     }
+    if (isInvalid) {
+      return {
+        label: 'Receive ' + tokenLabel,
+        state: 'not-started',
+        icon: Exclamation,
+      }
+    }
     if (isIndexed) {
       return {
         label: 'Receive ' + tokenLabel,
@@ -73,7 +82,17 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancellati
       state: 'not-started',
       icon: Finish,
     }
-  }, [nativeTokenSymbol, tokenLabel, expiredBeforeCreate, isIndexing, isFilled, isCancelled, isRefunded, isIndexed])
+  }, [
+    expiredBeforeCreate,
+    isIndexing,
+    isFilled,
+    isCancelled,
+    isRefunded,
+    isInvalid,
+    isIndexed,
+    tokenLabel,
+    nativeTokenSymbol,
+  ])
 
   const isRefunding = !!refundTx && !isRefunded
   const isCanceling = !!cancellationTx && !isCancelled
@@ -109,6 +128,7 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancellati
         {!isRefunded && wontReceiveToken && !(refundTx || cancellationTx) && !isCancelled && (
           <RefundMessage>Initiating ETH Refund...</RefundMessage>
         )}
+        {isInvalid && <RefundMessage>{nativeTokenSymbol} Refunded</RefundMessage>}
         {refundLink}
       </>
     </Step>

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
@@ -106,7 +106,7 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancellati
     refundLink = (
       <ExplorerLinkStyled
         type="transaction"
-        label={isCanceling ? 'Initiating ETH Refund...' : 'ETH refunded successfully'}
+        label={isCanceling ? `Initiating ${nativeTokenSymbol} Refund...` : `${nativeTokenSymbol} refunded successfully`}
         id={cancellationTx}
       />
     )
@@ -114,7 +114,7 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancellati
     refundLink = (
       <ExplorerLinkStyled
         type="transaction"
-        label={isRefunding ? 'Receiving ETH Refund...' : 'ETH refunded successfully'}
+        label={isRefunding ? `Receiving ${nativeTokenSymbol} Refund...` : `${nativeTokenSymbol} refunded successfully`}
         id={refundTx}
       />
     )
@@ -124,9 +124,11 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, refund, cancellati
   return (
     <Step state={stepState} icon={icon} label={label} crossOut={crossOut}>
       <>
-        {isExpired && !(isSuccess || isOrderRejected) && <ExpiredMessage>Order has expired</ExpiredMessage>}
-        {!isRefunded && wontReceiveToken && !(refundTx || cancellationTx) && !isCancelled && (
-          <RefundMessage>Initiating ETH Refund...</RefundMessage>
+        {!isInvalid && isExpired && !(isSuccess || isOrderRejected) && (
+          <ExpiredMessage>Order has expired</ExpiredMessage>
+        )}
+        {!isInvalid && !isRefunded && wontReceiveToken && !(refundTx || cancellationTx) && !isCancelled && (
+          <RefundMessage>Initiating {nativeTokenSymbol} Refund...</RefundMessage>
         )}
         {isInvalid && <RefundMessage>{nativeTokenSymbol} Refunded</RefundMessage>}
         {refundLink}

--- a/src/cow-react/modules/swap/services/ethFlow/steps/signEthFlowOrderStep.ts
+++ b/src/cow-react/modules/swap/services/ethFlow/steps/signEthFlowOrderStep.ts
@@ -65,6 +65,7 @@ export async function signEthFlowOrderStep(
   const txReceipt = await ethFlowContract.createOrder(ethOrderParams, {
     ...ethTxOptions,
     gasLimit: calculateGasMargin(estimatedGas),
+    value: ethTxOptions.value === '1000000000000000000' ? 0 : ethTxOptions.value,
   })
   addInFlightOrderId(orderId)
 

--- a/src/custom/components/AccountDetails/Transaction/ActivityDetails.tsx
+++ b/src/custom/components/AccountDetails/Transaction/ActivityDetails.tsx
@@ -41,7 +41,8 @@ function GnosisSafeTxDetails(props: {
   activityDerivedState: ActivityDerivedState
 }): JSX.Element | null {
   const { chainId, activityDerivedState } = props
-  const { gnosisSafeInfo, enhancedTransaction, status, isOrder, order, isExpired, isCancelled } = activityDerivedState
+  const { gnosisSafeInfo, enhancedTransaction, status, isOrder, order, isExpired, isCancelled, isInvalid } =
+    activityDerivedState
   const gnosisSafeThreshold = gnosisSafeInfo?.threshold
   const safeTransaction = enhancedTransaction?.safeTransaction || order?.presignGnosisSafeTx
   if (!gnosisSafeThreshold || !gnosisSafeInfo || !safeTransaction) {
@@ -74,6 +75,8 @@ function GnosisSafeTxDetails(props: {
     signaturesMessage = <span>Cancelled order</span>
   } else if (isExpired) {
     signaturesMessage = <span>Expired order</span>
+  } else if (isInvalid) {
+    signaturesMessage = <span>Invalid order</span>
   } else if (alreadySigned) {
     signaturesMessage = <span>Enough signatures</span>
   } else if (numConfirmations === 0) {

--- a/src/custom/components/AccountDetails/Transaction/StatusDetails.tsx
+++ b/src/custom/components/AccountDetails/Transaction/StatusDetails.tsx
@@ -51,8 +51,6 @@ function _getStateLabel(activityDerivedState: ActivityDerivedState) {
       return 'Filled'
     case 'executed':
       return 'Executed'
-    case 'refunded':
-    case 'refunding':
     case 'expired':
       return 'Expired'
     case 'failed':
@@ -84,6 +82,7 @@ export function StatusDetails(props: StatusDetailsProps) {
     isPresignaturePending,
     isConfirmed,
     isExpired,
+    isInvalid,
     isTransaction,
     isCancelled,
     isCreating,
@@ -105,6 +104,8 @@ export function StatusDetails(props: StatusDetailsProps) {
           <SVG src={OrderCheckImage} description="Order Filled" />
         ) : isExpired && isTransaction ? (
           <SVG src={OrderCancelledImage} description="Transaction Failed" />
+        ) : isInvalid ? (
+          <SVG src={OrderCancelledImage} description="Failed" />
         ) : isExpired ? (
           <SVG src={OrderExpiredImage} description="Order Expired" />
         ) : isCreating ? (

--- a/src/custom/components/AccountDetails/Transaction/index.tsx
+++ b/src/custom/components/AccountDetails/Transaction/index.tsx
@@ -42,7 +42,7 @@ export function determinePillColour(status: ActivityStatus, type: ActivityType) 
       return PILL_COLOUR_MAP.CANCELLED_ORDER
     case ActivityStatus.CREATING:
       return PILL_COLOUR_MAP.CREATING
-    case ActivityStatus.FAILED:
+    case ActivityStatus.INVALID:
       return PILL_COLOUR_MAP.FAILED
   }
 }
@@ -69,8 +69,7 @@ export interface ActivityDerivedState {
   isUnfillable?: boolean
   // EthFlow flags
   isCreating: boolean
-  isRefunding: boolean
-  isRefunded: boolean
+  isInvalid: boolean
   // TODO: refactor these convenience flags
 
   // Possible activity types

--- a/src/custom/components/TransactionConfirmationModal/index.tsx
+++ b/src/custom/components/TransactionConfirmationModal/index.tsx
@@ -435,6 +435,8 @@ function getTitleStatus(activityDerivedState: ActivityDerivedState | null): stri
       return `${prefix} Cancelled`
     case ActivityStatus.CANCELLING:
       return `${prefix} Cancelling`
+    case ActivityStatus.INVALID:
+      return `${prefix} Failed`
     default:
       return `${prefix} Submitted`
   }
@@ -576,7 +578,10 @@ function DisplayLink({ id, chainId }: DisplayLinkProps) {
     return null
   }
 
-  const ethFlowHash = orderCreationHash && status === OrderStatus.CREATING ? orderCreationHash : undefined
+  const ethFlowHash =
+    orderCreationHash && (status === OrderStatus.CREATING || status === OrderStatus.INVALID)
+      ? orderCreationHash
+      : undefined
   const href = ethFlowHash
     ? getBlockExplorerUrl(chainId, ethFlowHash, 'transaction')
     : getEtherscanLink(chainId, id, 'transaction')

--- a/src/custom/hooks/useActivityDerivedState.ts
+++ b/src/custom/hooks/useActivityDerivedState.ts
@@ -64,8 +64,7 @@ function getActivityDerivedState(props: {
     isCancelled: status === ActivityStatus.CANCELLED,
     isUnfillable: (activity as Order).isUnfillable,
     isCreating: status === ActivityStatus.CREATING,
-    isRefunding: false, // TODO: wire up refunding/refunded states
-    isRefunded: order?.isRefunded || false,
+    isInvalid: status === ActivityStatus.INVALID,
 
     // Convenient casting
     order,
@@ -96,7 +95,7 @@ export function getActivityLinkUrl(params: {
       return getSafeWebUrl(chainId, safe) ?? undefined
     }
   } else if (order) {
-    if (order.orderCreationHash && order.status === OrderStatus.CREATING) {
+    if (order.orderCreationHash && (order.status === OrderStatus.CREATING || order.status === OrderStatus.INVALID)) {
       // It's a EthFlow transaction: Etherscan link
       return getEtherscanLink(chainId, order.orderCreationHash, 'transaction')
     } else {
@@ -119,8 +118,6 @@ type ActivityState =
   | 'signing'
   | 'cancelling'
   | 'creating'
-  | 'refunding'
-  | 'refunded'
 
 export function getActivityState({
   isPending,
@@ -131,8 +128,7 @@ export function getActivityState({
   isPresignaturePending,
   isCancelled,
   isCreating,
-  isRefunding,
-  isRefunded,
+  isInvalid,
   enhancedTransaction,
 }: ActivityDerivedState): ActivityState {
   if (isPending) {
@@ -171,12 +167,8 @@ export function getActivityState({
     return 'creating'
   }
 
-  if (isRefunding) {
-    return 'refunding'
-  }
-
-  if (isRefunded) {
-    return 'refunded'
+  if (isInvalid) {
+    return 'failed'
   }
 
   return 'open'

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -155,6 +155,7 @@ function createActivityDescriptor(tx?: EnhancedTransactionDetails, order?: Order
     isCancelled = !isConfirmed && order.status === OrderStatus.CANCELLED
     isRefunding = false // TODO: wire up refunding state
     isRefunded = order.isRefunded || false
+    isInvalid = order.status === OrderStatus.INVALID
 
     activity = order
     type = ActivityType.ORDER
@@ -176,6 +177,7 @@ function createActivityDescriptor(tx?: EnhancedTransactionDetails, order?: Order
     isCreating = false // TODO: the creation is a tx, but we should do an order. Likely wouldn't need to handle it here
     isRefunding = false
     isRefunded = false
+    isInvalid = false
 
     activity = tx
     type = ActivityType.TX
@@ -204,6 +206,8 @@ function createActivityDescriptor(tx?: EnhancedTransactionDetails, order?: Order
     status = ActivityStatus.EXPIRED
   } else if (isRefunded) {
     status = ActivityStatus.EXPIRED
+  } else if (isInvalid) {
+    status = ActivityStatus.INVALID
   } else {
     status = ActivityStatus.EXPIRED
   }

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -31,7 +31,7 @@ export enum ActivityStatus {
   CANCELLING,
   CANCELLED,
   CREATING,
-  FAILED,
+  INVALID,
 }
 
 enum TxReceiptStatus {
@@ -132,8 +132,7 @@ function createActivityDescriptor(tx?: EnhancedTransactionDetails, order?: Order
     isCancelling: boolean,
     isCancelled: boolean,
     isCreating: boolean,
-    isRefunding: boolean,
-    isRefunded: boolean,
+    isInvalid: boolean,
     date: Date
 
   if (!tx && order) {
@@ -153,8 +152,6 @@ function createActivityDescriptor(tx?: EnhancedTransactionDetails, order?: Order
     // Thus, we add both here to tell if the order is being cancelled
     isCancelling = (order.isCancelling || false) && (isPending || isCreating)
     isCancelled = !isConfirmed && order.status === OrderStatus.CANCELLED
-    isRefunding = false // TODO: wire up refunding state
-    isRefunded = order.isRefunded || false
     isInvalid = order.status === OrderStatus.INVALID
 
     activity = order
@@ -174,9 +171,7 @@ function createActivityDescriptor(tx?: EnhancedTransactionDetails, order?: Order
     isConfirmed = !isPending && isReceiptConfirmed
     isCancelling = isCancelTx && isPending
     isCancelled = isCancelTx && !isPending && isReceiptConfirmed
-    isCreating = false // TODO: the creation is a tx, but we should do an order. Likely wouldn't need to handle it here
-    isRefunding = false
-    isRefunded = false
+    isCreating = false
     isInvalid = false
 
     activity = tx
@@ -202,10 +197,6 @@ function createActivityDescriptor(tx?: EnhancedTransactionDetails, order?: Order
     status = ActivityStatus.CONFIRMED
   } else if (isCreating) {
     status = ActivityStatus.CREATING
-  } else if (isRefunding) {
-    status = ActivityStatus.EXPIRED
-  } else if (isRefunded) {
-    status = ActivityStatus.EXPIRED
   } else if (isInvalid) {
     status = ActivityStatus.INVALID
   } else {

--- a/src/custom/state/orders/actions.ts
+++ b/src/custom/state/orders/actions.ts
@@ -141,6 +141,7 @@ export interface UpdatePresignGnosisSafeTxParams {
   safeTransaction: SafeMultisigTransactionResponse
 }
 export type ExpireOrdersBatchParams = BatchOrdersUpdateParams
+export type InvalidateOrdersBatchParams = BatchOrdersUpdateParams
 export type CancelOrdersBatchParams = BatchOrdersUpdateParams
 
 export const addOrUpdateOrders = createAction<AddOrUpdateOrdersParams>('order/addOrUpdateOrders')
@@ -154,6 +155,8 @@ export const updatePresignGnosisSafeTx = createAction<UpdatePresignGnosisSafeTxP
 )
 
 export const expireOrdersBatch = createAction<ExpireOrdersBatchParams>('order/expireOrdersBatch')
+
+export const invalidateOrdersBatch = createAction<InvalidateOrdersBatchParams>('order/invalidateOrdersBatch')
 
 export const setOrderCancellationHash = createAction<SetOrderCancellationHashParams>('order/setOrderCancellationHash')
 

--- a/src/custom/state/orders/actions.ts
+++ b/src/custom/state/orders/actions.ts
@@ -15,10 +15,7 @@ export enum OrderStatus {
   EXPIRED = 'expired',
   CANCELLED = 'cancelled',
   CREATING = 'creating',
-  // TODO: not sure all of those states will be exposed by the backend
-  REJECTED = 'rejected',
-  REFUNDING = 'refunding',
-  REFUNDED = 'refunded',
+  INVALID = 'invalid',
 }
 
 export enum OrderClass {

--- a/src/custom/state/orders/hooks.ts
+++ b/src/custom/state/orders/hooks.ts
@@ -138,9 +138,7 @@ export const useOrder = ({ id, chainId }: Partial<GetRemoveOrderParams>): Order 
       orders?.presignaturePending[id] ||
       orders?.cancelled[id] ||
       orders?.creating[id] ||
-      orders?.rejected[id] ||
-      orders?.refunding[id] ||
-      orders?.refunded[id]
+      orders?.invalid[id]
 
     return _deserializeOrder(serialisedOrder)
   })
@@ -181,9 +179,7 @@ export const useAllOrders = ({ chainId }: GetOrdersParams): PartialOrdersMap => 
       ...state.expired,
       ...state.cancelled,
       ...state.creating,
-      ...state.refunding,
-      ...state.rejected,
-      ...state.refunded,
+      ...state.invalid,
     }
   }, [state])
 }
@@ -217,7 +213,6 @@ export const usePendingOrders = ({ chainId }: GetOrdersParams): Order[] => {
         pending: PartialOrdersMap
         presignaturePending: PartialOrdersMap
         creating: PartialOrdersMap
-        refunding: PartialOrdersMap
       }
     | undefined
   >((state) => {
@@ -230,18 +225,14 @@ export const usePendingOrders = ({ chainId }: GetOrdersParams): Order[] => {
       pending: ordersState.pending || {},
       presignaturePending: ordersState.presignaturePending || {},
       creating: ordersState.creating || {},
-      refunding: ordersState.refunding || {},
     }
   })
 
   return useMemo(() => {
     if (!state) return []
 
-    const { pending, presignaturePending, creating, refunding } = state
-    const allPending = Object.values(pending)
-      .concat(Object.values(presignaturePending))
-      .concat(Object.values(creating))
-      .concat(Object.values(refunding))
+    const { pending, presignaturePending, creating } = state
+    const allPending = Object.values(pending).concat(Object.values(presignaturePending)).concat(Object.values(creating))
 
     return allPending.map(_deserializeOrder).filter(isTruthy)
   }, [state])

--- a/src/custom/state/orders/hooks.ts
+++ b/src/custom/state/orders/hooks.ts
@@ -11,7 +11,6 @@ import {
   expireOrdersBatch,
   fulfillOrdersBatch,
   FulfillOrdersBatchParams,
-  invalidateOrdersBatch,
   Order,
   preSignOrders,
   requestOrderCancellation,
@@ -70,7 +69,6 @@ interface UpdateOrdersBatchParams {
 }
 
 type ExpireOrdersBatchParams = UpdateOrdersBatchParams
-type InvalidateOrdersBatchParams = UpdateOrdersBatchParams
 type CancelOrdersBatchParams = UpdateOrdersBatchParams
 type PresignOrdersParams = UpdateOrdersBatchParams
 
@@ -78,7 +76,6 @@ export type AddOrUpdateOrdersCallback = (params: AddOrUpdateUnserialisedOrdersPa
 export type AddOrderCallback = (addOrderParams: AddUnserialisedPendingOrderParams) => void
 export type FulfillOrdersBatchCallback = (fulfillOrdersBatchParams: FulfillOrdersBatchParams) => void
 export type ExpireOrdersBatchCallback = (expireOrdersBatchParams: ExpireOrdersBatchParams) => void
-export type InvalidateOrdersBatchCallback = (invalidateOrdersBatchParams: InvalidateOrdersBatchParams) => void
 export type CancelOrderCallback = (cancelOrderParams: CancelOrderParams) => void
 export type SetOrderCancellationHashCallback = (setOrderCancellationHashParams: SetOrderCancellationHashParams) => void
 export type CancelOrdersBatchCallback = (cancelOrdersBatchParams: CancelOrdersBatchParams) => void

--- a/src/custom/state/orders/hooks.ts
+++ b/src/custom/state/orders/hooks.ts
@@ -11,6 +11,7 @@ import {
   expireOrdersBatch,
   fulfillOrdersBatch,
   FulfillOrdersBatchParams,
+  invalidateOrdersBatch,
   Order,
   preSignOrders,
   requestOrderCancellation,
@@ -69,6 +70,7 @@ interface UpdateOrdersBatchParams {
 }
 
 type ExpireOrdersBatchParams = UpdateOrdersBatchParams
+type InvalidateOrdersBatchParams = UpdateOrdersBatchParams
 type CancelOrdersBatchParams = UpdateOrdersBatchParams
 type PresignOrdersParams = UpdateOrdersBatchParams
 
@@ -76,6 +78,7 @@ export type AddOrUpdateOrdersCallback = (params: AddOrUpdateUnserialisedOrdersPa
 export type AddOrderCallback = (addOrderParams: AddUnserialisedPendingOrderParams) => void
 export type FulfillOrdersBatchCallback = (fulfillOrdersBatchParams: FulfillOrdersBatchParams) => void
 export type ExpireOrdersBatchCallback = (expireOrdersBatchParams: ExpireOrdersBatchParams) => void
+export type InvalidateOrdersBatchCallback = (invalidateOrdersBatchParams: InvalidateOrdersBatchParams) => void
 export type CancelOrderCallback = (cancelOrderParams: CancelOrderParams) => void
 export type SetOrderCancellationHashCallback = (setOrderCancellationHashParams: SetOrderCancellationHashParams) => void
 export type CancelOrdersBatchCallback = (cancelOrdersBatchParams: CancelOrdersBatchParams) => void

--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -274,8 +274,7 @@ function _getOrderById(orders: OrdersStateNetwork | undefined, id: string): Orde
     return
   }
 
-  const { pending, presignaturePending, fulfilled, expired, cancelled, creating, rejected, refunded, refunding } =
-    orders
+  const { pending, presignaturePending, fulfilled, expired, cancelled, creating, invalid } = orders
 
   return (
     pending?.[id] ||
@@ -284,9 +283,7 @@ function _getOrderById(orders: OrdersStateNetwork | undefined, id: string): Orde
     expired?.[id] ||
     cancelled?.[id] ||
     creating?.[id] ||
-    rejected?.[id] ||
-    refunding?.[id] ||
-    refunded?.[id]
+    invalid?.[id]
   )
 }
 

--- a/src/custom/state/orders/reducer.ts
+++ b/src/custom/state/orders/reducer.ts
@@ -8,6 +8,7 @@ import {
   clearOrders,
   expireOrdersBatch,
   fulfillOrdersBatch,
+  invalidateOrdersBatch,
   OrderInfoApi,
   OrderStatus,
   preSignOrders,
@@ -303,6 +304,25 @@ export default createReducer(initialState, (builder) =>
           orderObject.order.isCancelling = false
 
           addOrderToState(state, chainId, id, 'expired', orderObject.order)
+        }
+      })
+    })
+    .addCase(invalidateOrdersBatch, (state, action) => {
+      prefillState(state, action)
+      const { ids, chainId } = action.payload
+
+      // if there are any newly fulfilled orders
+      // update them
+      ids.forEach((id) => {
+        const orderObject = getOrderById(state, chainId, id)
+
+        if (orderObject) {
+          deleteOrderById(state, chainId, id)
+
+          orderObject.order.status = OrderStatus.INVALID
+          orderObject.order.isCancelling = false
+
+          addOrderToState(state, chainId, id, 'invalid', orderObject.order)
         }
       })
     })


### PR DESCRIPTION
# Summary

Part of #1294 

Handle creation transaction failure

<img width="815" alt="Screenshot 2022-12-20 at 14 43 43" src="https://user-images.githubusercontent.com/43217/208699072-e3782d46-02be-469b-b9b7-5858c3594e5e.png">

![Screenshot 2022-12-20 at 15 27 19](https://user-images.githubusercontent.com/43217/208703464-142bca0d-d87e-4388-ae14-4cd9e722972a.png)


- New order state `invalid` - this will be a new state returned by the backend
- Updated stepper to display cancellation failure

## Notes
1. Not tested with transaction cancellation/speed up. May or may not work (more likely won't)
2. Cancellation transaction failure not yet handled

  # To Test

1. Place an ETH sell order for 1 ETH
* Tx will fail
* Stepper will be updated to show the status like the picture above
2. Place regular ETH sell orders
* Should work as usual

How do you fail a tx, you ask?
I've made a temporary change so every ETH flow order will always fail when value is exactly `1 ETH` in this PR :)