### PR TITLE
[do-not-merge] Test banner mergeability

### DIFF
--- a/config/announcements/announcements-4.md
+++ b/config/announcements/announcements-4.md
@@ -1,0 +1,1 @@
+Test alert. Rinkeby does not have any unexpected issue.


### PR DESCRIPTION
# **DO NOT MERGE**

# Background

We want to make sure whoever is oncall can always add a banner in the frontend without further approval if need be.  This PR only serves to test that I would be able to merge it if I wanted (and I won't actually merge it).

# **DO NOT MERGE**
