### PR TITLE
🎨 Order table alignment: status labels

### DIFF
--- a/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
@@ -34,7 +34,7 @@ const TableBox = styled.div`
 const Header = styled.div`
   display: grid;
   grid-gap: 10px;
-  grid-template-columns: repeat(2, minmax(150px, 1fr)) minmax(150px, 1.5fr) minmax(85px, 0.65fr) 36px;
+  grid-template-columns: repeat(2, minmax(150px, 1fr)) minmax(150px, 1.5fr) 120px 36px;
   align-items: center;
   border-top: 1px solid transparent;
   border-bottom: 1px solid ${({ theme }) => transparentize(0.8, theme.text3)};
@@ -42,7 +42,6 @@ const Header = styled.div`
 
   > div {
     padding: 12px 0;
-    overflow: hidden;
     font-size: 13px;
     font-weight: 400;
   }

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
@@ -34,7 +34,7 @@ const TableBox = styled.div`
 const Header = styled.div`
   display: grid;
   grid-gap: 10px;
-  grid-template-columns: repeat(2, minmax(150px, 1fr)) minmax(150px, 1.5fr) minmax(85px, 0.5fr) 36px;
+  grid-template-columns: repeat(2, minmax(150px, 1fr)) minmax(150px, 1.5fr) minmax(85px, 0.65fr) 36px;
   align-items: center;
   border-top: 1px solid transparent;
   border-bottom: 1px solid ${({ theme }) => transparentize(0.8, theme.text3)};

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
@@ -34,7 +34,7 @@ const TableBox = styled.div`
 const Header = styled.div`
   display: grid;
   grid-gap: 10px;
-  grid-template-columns: repeat(2, minmax(150px, 1fr)) minmax(150px, 1.5fr) minmax(85px, min-content) 36px;
+  grid-template-columns: repeat(2, minmax(150px, 1fr)) minmax(150px, 1.5fr) minmax(85px, 0.7fr) 36px;
   align-items: center;
   border-top: 1px solid transparent;
   border-bottom: 1px solid ${({ theme }) => transparentize(0.8, theme.text3)};

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
@@ -34,7 +34,7 @@ const TableBox = styled.div`
 const Header = styled.div`
   display: grid;
   grid-gap: 10px;
-  grid-template-columns: repeat(2, minmax(150px, 1fr)) minmax(150px, 1.5fr) minmax(85px, 0.7fr) 36px;
+  grid-template-columns: repeat(2, minmax(150px, 1fr)) minmax(150px, 1.5fr) minmax(85px, 0.5fr) 36px;
   align-items: center;
   border-top: 1px solid transparent;
   border-bottom: 1px solid ${({ theme }) => transparentize(0.8, theme.text3)};


### PR DESCRIPTION
# Summary

- Addresses https://github.com/cowprotocol/cowswap/issues/1783
<img width="370" alt="Screenshot 2022-12-21 at 17 21 58" src="https://user-images.githubusercontent.com/31534717/208966178-12af3627-68d5-4b83-b375-7cf1d2d09654.png">
<img width="886" alt="Screenshot 2022-12-21 at 17 21 34" src="https://user-images.githubusercontent.com/31534717/208966180-5fe75ecf-17b6-4d40-b793-52e4ca300ae7.png">
<img width="887" alt="Screenshot 2022-12-21 at 17 21 18" src="https://user-images.githubusercontent.com/31534717/208966182-3550b734-7bdc-463a-bdd3-adff86ecf0a5.png">



# Test
- Open the order table with some orders, make sure there's a 'Cancelling...' order.
- All the status labels should be equally aligned