### PR TITLE
[EthFlow]#1294 - updated backend return types

### DIFF
--- a/src/cow-react/api/gnosisProtocol/api.ts
+++ b/src/cow-react/api/gnosisProtocol/api.ts
@@ -121,12 +121,19 @@ export interface OrderMetaData {
   class: OrderClass
   // EthFlow related fields
   ethflowData: EthFlowData
-  onchainUser?: string
+  onchainOrderData?: OnChainOrderData
 }
 
 type EthFlowData = {
   userValidTo: number
-  isRefunded: boolean
+  isRefunded: boolean // TODO: remove once `isRefundable` is implemented
+  isRefundable?: boolean | null // TODO: not yet available from the API
+  refundTxHash?: string | null
+}
+
+type OnChainOrderData = {
+  sender: string
+  placementError?: string | null
 }
 
 export interface TradeMetaData {
@@ -601,7 +608,7 @@ function transformEthFlowOrder(order: OrderMetaData): OrderMetaData {
   }
 
   const { userValidTo: validTo } = ethflowData
-  const owner = order.onchainUser || order.owner
+  const owner = order.onchainOrderData?.sender || order.owner
   const sellToken = BUY_ETH_ADDRESS
 
   return { ...order, validTo, owner, sellToken }

--- a/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
+++ b/src/cow-react/modules/swap/containers/EthFlowStepper/index.tsx
@@ -55,7 +55,7 @@ export function EthFlowStepper(props: EthFlowStepperProps) {
       failed: creationTxFailed,
     },
     refund: {
-      // hash?: string // TODO: fill in when backend provides it
+      hash: order.refundHash,
       failed: didRefundFail(order),
     },
     cancellation: {
@@ -111,7 +111,7 @@ function didRefundFail(order: Order): boolean | undefined {
   if (order.isRefunded === undefined) {
     return undefined
   }
-  return !order.isRefunded
+  return !order.refundHash
 }
 
 // TODO: move this somewhere else?

--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step3.tsx
@@ -97,7 +97,7 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, creation, refund, 
     refundLink = (
       <ExplorerLinkStyled
         type="transaction"
-        label={isCanceling ? `Initiating ${nativeTokenSymbol} Refund...` : `${nativeTokenSymbol} refunded successfully`}
+        label={isCanceling ? `Initiating ${nativeTokenSymbol} Refund...` : 'View transaction'}
         id={cancellationHash}
       />
     )
@@ -105,7 +105,7 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, creation, refund, 
     refundLink = (
       <ExplorerLinkStyled
         type="transaction"
-        label={isRefunding ? `Receiving ${nativeTokenSymbol} Refund...` : `${nativeTokenSymbol} refunded successfully`}
+        label={isRefunding ? `Receiving ${nativeTokenSymbol} Refund...` : 'View transaction'}
         id={refundHash}
       />
     )

--- a/src/cow-react/pages/Faq/EthFlowFaq.tsx
+++ b/src/cow-react/pages/Faq/EthFlowFaq.tsx
@@ -289,8 +289,8 @@ export default function EthFlowFAQ() {
               How can I check I actually received the refund after my order expired?
             </h3>
             <p>
-              You can click on the hyperlink “ETH refunded successfully” on the progress modal which will redirect you
-              to etherscan.io to see the actual transaction on the blockchain.
+              You can click on the hyperlink “View transaction” on the progress modal which will redirect you to
+              etherscan.io to see the actual transaction on the blockchain.
             </p>
             <p>
               You can search for your wallet address on etherscan.io and see that the balance is right where it should

--- a/src/custom/components/Header/styled.ts
+++ b/src/custom/components/Header/styled.ts
@@ -227,7 +227,7 @@ export const HeaderLinks = styled(HeaderLinksMod)<{ isMobileMenuOpen: boolean }>
       gap 36px;
       opacity: 0.7;
     `};
-  }}
+  }
 
   ${MenuTitle} {
     ${({ theme }) => theme.mediaWidth.upToLarge`

--- a/src/custom/state/orders/actions.ts
+++ b/src/custom/state/orders/actions.ts
@@ -46,7 +46,7 @@ export interface BaseOrder extends Omit<OrderCreation, 'signingScheme'> {
   // EthFlow
   orderCreationHash?: string
   isRefunded?: boolean
-  // TODO: add refund hash here when working on that
+  refundHash?: string
 
   cancellationHash?: string // Filled when a hard cancellation is triggered. Be it ethflow or regular order
 
@@ -82,6 +82,7 @@ export type OrderInfoApi = Pick<
   | 'executedSurplusFee'
   | 'invalidated'
   | 'ethflowData'
+  | 'onchainOrderData'
 >
 
 /**
@@ -178,5 +179,6 @@ export type SetIsOrderUnfillableParams = {
 
 export const setIsOrderUnfillable = createAction<SetIsOrderUnfillableParams>('order/setIsOrderUnfillable')
 
-export type SetIsOrderRefundedBatch = { chainId: ChainId; ids: OrderID[] }
+type RefundItem = { id: OrderID; refundHash: string }
+export type SetIsOrderRefundedBatch = { chainId: ChainId; items: RefundItem[] }
 export const setIsOrderRefundedBatch = createAction<SetIsOrderRefundedBatch>('order/setIsOrderRefundedBatch')

--- a/src/custom/state/orders/reducer.ts
+++ b/src/custom/state/orders/reducer.ts
@@ -392,13 +392,14 @@ export default createReducer(initialState, (builder) =>
     .addCase(setIsOrderRefundedBatch, (state, action) => {
       prefillState(state, action)
 
-      const { chainId, ids } = action.payload
+      const { chainId, items } = action.payload
 
-      ids.forEach((id) => {
+      items.forEach(({ id, refundHash }) => {
         const orderObject = getOrderById(state, chainId, id)
 
         if (orderObject) {
           orderObject.order.isRefunded = true
+          orderObject.order.refundHash = refundHash
         }
       })
     })

--- a/src/custom/state/orders/updaters/GpOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/GpOrdersUpdater.ts
@@ -44,7 +44,16 @@ function _transformGpOrderToStoreOrder(
   chainId: ChainId,
   allTokens: { [address: string]: Token | null }
 ): Order | undefined {
-  const { uid: id, sellToken, buyToken, creationDate: creationTime, receiver, ethflowData, owner, onchainUser } = order
+  const {
+    uid: id,
+    sellToken,
+    buyToken,
+    creationDate: creationTime,
+    receiver,
+    ethflowData,
+    owner,
+    onchainOrderData,
+  } = order
 
   const isEthFlow = Boolean(ethflowData)
 
@@ -80,9 +89,10 @@ function _transformGpOrderToStoreOrder(
     apiAdditionalInfo: order,
     isCancelling: apiStatus === 'pending' && order.invalidated, // already cancelled in the API, not yet in the UI
     // EthFlow related
-    owner: onchainUser || owner,
+    owner: onchainOrderData?.sender || owner,
     validTo: ethflowData?.userValidTo || order.validTo,
-    isRefunded: ethflowData?.isRefunded,
+    isRefunded: ethflowData?.isRefunded, // TODO: this will be removed from the API
+    refundHash: ethflowData?.refundTxHash || undefined,
   }
   // The function to compute the summary needs the Order instance to exist already
   // That's why it's not used before and an empty string is set instead

--- a/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
@@ -105,6 +105,7 @@ async function _updateCreatingOrders(
             ...order,
             validTo: orderData.ethflowData?.userValidTo || order.validTo,
             isRefunded: orderData.ethflowData?.isRefunded,
+            refundHash: orderData.ethflowData?.refundTxHash || undefined,
           }
           addOrUpdateOrders({ chainId, orders: [updatedOrder] })
         })


### PR DESCRIPTION
# Summary

Part of #1294 

Wiring up refund tx hash

After the order expires and the automated refunder kicks in, the refund tx hash will be displayed at the bottom of the 3rd step
<img width="813" alt="Screenshot 2022-12-26 at 16 25 11" src="https://user-images.githubusercontent.com/43217/209567547-61dd3d47-8f86-4a48-9b74-c649b79dacd7.png">

  # To Test

Follow same test steps as https://github.com/cowprotocol/cowswap/pull/1756