### PR TITLE
[EthFlow]#1787 failed sound on tx failure

### DIFF
--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step1.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowStepper/steps/Step1.tsx
@@ -35,7 +35,7 @@ export function Step1({ nativeTokenSymbol, order, creation }: EthFlowStepperProp
 
   return (
     <Step state={stepState} icon={icon} label={label}>
-      {hash && <ExplorerLinkStyled type="transaction" label="View Transaction" id={hash} />}
+      {hash && <ExplorerLinkStyled type="transaction" label="View transaction" id={hash} />}
     </Step>
   )
 }

--- a/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
+++ b/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
@@ -7,6 +7,7 @@ import { useAppDispatch } from 'state/hooks'
 // import { SupportedChainId } from 'constants/chains'
 import { useAddPopup } from 'state/application/hooks'
 import useBlockNumber from 'lib/hooks/useBlockNumber'
+import useNativeCurrency from 'lib/hooks/useNativeCurrency'
 import { checkedTransaction, finalizeTransaction, updateSafeTransaction } from '../actions'
 import { EnhancedTransactionDetails, HashType } from '../reducer'
 import { GetReceipt, useGetReceipt } from 'hooks/useGetReceipt'
@@ -55,6 +56,7 @@ interface CheckEthereumTransactions {
   dispatch: Dispatch
   addPopup: ReturnType<typeof useAddPopup>
   removeInFlightOrderId: (update: string) => void
+  nativeCurrency: ReturnType<typeof useNativeCurrency>
 }
 
 type Cancel = () => void
@@ -66,7 +68,7 @@ function finalizeEthereumTransaction(
   transaction: EnhancedTransactionDetails,
   params: CheckEthereumTransactions
 ) {
-  const { chainId, addPopup, dispatch } = params
+  const { chainId, addPopup, dispatch, nativeCurrency } = params
   const { hash } = transaction
 
   console.log(`[FinalizeTxUpdater] Transaction ${receipt.transactionHash} has been mined`, receipt)
@@ -204,6 +206,7 @@ export default function Updater(): null {
   const getSafeInfo = useGetSafeInfo()
   const addPopup = useAddPopup()
   const removeInFlightOrderId = useSetAtom(removeInFlightOrderIdAtom)
+  const nativeCurrency = useNativeCurrency()
 
   // Get, from the pending transaction, the ones that we should re-check
   const shouldCheckFilter = useMemo(() => {
@@ -227,6 +230,7 @@ export default function Updater(): null {
       addPopup,
       dispatch,
       removeInFlightOrderId,
+      nativeCurrency,
     })
 
     return () => {
@@ -243,6 +247,7 @@ export default function Updater(): null {
     getReceipt,
     getSafeInfo,
     removeInFlightOrderId,
+    nativeCurrency,
   ])
 
   return null

--- a/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
+++ b/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
@@ -114,6 +114,16 @@ function finalizeEthereumTransaction(
       // If creation failed, mark order as invalid
       if (receipt.status !== 1) {
         dispatch(invalidateOrdersBatch({ chainId, ids: [orderId] }))
+        addPopup(
+          {
+            txn: {
+              hash,
+              success: false,
+              summary: `Failed to place order selling ${nativeCurrency.symbol}`,
+            },
+          },
+          hash
+        )
       }
     }
 

--- a/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
+++ b/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
@@ -56,7 +56,7 @@ interface CheckEthereumTransactions {
   dispatch: Dispatch
   addPopup: ReturnType<typeof useAddPopup>
   removeInFlightOrderId: (update: string) => void
-  nativeCurrency: ReturnType<typeof useNativeCurrency>
+  nativeCurrencySymbol: string
 }
 
 type Cancel = () => void
@@ -68,7 +68,7 @@ function finalizeEthereumTransaction(
   transaction: EnhancedTransactionDetails,
   params: CheckEthereumTransactions
 ) {
-  const { chainId, addPopup, dispatch, nativeCurrency } = params
+  const { chainId, addPopup, dispatch, nativeCurrencySymbol } = params
   const { hash } = transaction
 
   console.log(`[FinalizeTxUpdater] Transaction ${receipt.transactionHash} has been mined`, receipt)
@@ -119,7 +119,7 @@ function finalizeEthereumTransaction(
             txn: {
               hash,
               success: false,
-              summary: `Failed to place order selling ${nativeCurrency.symbol}`,
+              summary: `Failed to place order selling ${nativeCurrencySymbol}`,
             },
           },
           hash
@@ -216,7 +216,7 @@ export default function Updater(): null {
   const getSafeInfo = useGetSafeInfo()
   const addPopup = useAddPopup()
   const removeInFlightOrderId = useSetAtom(removeInFlightOrderIdAtom)
-  const nativeCurrency = useNativeCurrency()
+  const nativeCurrencySymbol = useNativeCurrency().symbol || 'ETH'
 
   // Get, from the pending transaction, the ones that we should re-check
   const shouldCheckFilter = useMemo(() => {
@@ -240,7 +240,7 @@ export default function Updater(): null {
       addPopup,
       dispatch,
       removeInFlightOrderId,
-      nativeCurrency,
+      nativeCurrencySymbol,
     })
 
     return () => {
@@ -257,7 +257,7 @@ export default function Updater(): null {
     getReceipt,
     getSafeInfo,
     removeInFlightOrderId,
-    nativeCurrency,
+    nativeCurrencySymbol,
   ])
 
   return null

--- a/src/custom/state/orders/actions.ts
+++ b/src/custom/state/orders/actions.ts
@@ -124,6 +124,11 @@ export interface AddOrUpdateOrdersParams {
   orders: SerializedOrder[]
 }
 
+export interface UpdateOrderParams {
+  chainId: ChainId
+  order: Partial<Omit<SerializedOrder, 'id'>> & Pick<SerializedOrder, 'id'>
+}
+
 export interface FulfillOrdersBatchParams {
   ordersData: OrderFulfillmentData[]
   chainId: ChainId
@@ -145,6 +150,8 @@ export type InvalidateOrdersBatchParams = BatchOrdersUpdateParams
 export type CancelOrdersBatchParams = BatchOrdersUpdateParams
 
 export const addOrUpdateOrders = createAction<AddOrUpdateOrdersParams>('order/addOrUpdateOrders')
+
+export const updateOrder = createAction<UpdateOrderParams>('order/updateOrder')
 
 export const fulfillOrdersBatch = createAction<FulfillOrdersBatchParams>('order/fullfillOrdersBatch')
 

--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -217,6 +217,8 @@ export const soundMiddleware: Middleware<Record<string, unknown>, AppState> = (s
     cowSound = getCowSoundError()
   } else if (isCancelOrderAction(action)) {
     cowSound = getCowSoundError()
+  } else if (isFailedTxAction(action)) {
+    cowSound = getCowSoundError()
   }
 
   if (cowSound) {
@@ -226,6 +228,15 @@ export const soundMiddleware: Middleware<Record<string, unknown>, AppState> = (s
   }
 
   return result
+}
+
+const isAddPopup = isAnyOf(addPopup)
+
+/**
+ * Checks whether the action is `addPopup` for a `txn` which failed
+ */
+function isFailedTxAction(action: unknown): boolean {
+  return isAddPopup(action) && action.payload?.content?.txn?.success === false
 }
 
 export const appziMiddleware: Middleware<Record<string, unknown>, AppState> = (store) => (next) => (action) => {

--- a/src/custom/state/orders/reducer.ts
+++ b/src/custom/state/orders/reducer.ts
@@ -18,6 +18,7 @@ import {
   setIsOrderUnfillable,
   setOrderCancellationHash,
   updateLastCheckedBlock,
+  updateOrder,
   updatePresignGnosisSafeTx,
 } from './actions'
 import { ContractDeploymentBlocks } from './consts'
@@ -261,6 +262,17 @@ export default createReducer(initialState, (builder) =>
         // add order to respective state
         addOrderToState(state, chainId, id, status, order)
       })
+    })
+    .addCase(updateOrder, (state, action) => {
+      prefillState(state, action)
+
+      const { chainId, order } = action.payload
+
+      const orderObj = getOrderById(state, chainId, order.id)
+
+      if (orderObj) {
+        orderObj.order = { ...orderObj.order, ...order }
+      }
     })
     .addCase(fulfillOrdersBatch, (state, action) => {
       prefillState(state, action)


### PR DESCRIPTION
# Summary

Fixes #1787

- Displaying error pop when order creation tx fails
![Screenshot 2022-12-27 at 08 05 06](https://user-images.githubusercontent.com/43217/209645585-5c9b80d8-ae7b-4fa3-82d8-d29c8f157521.png)

- Displaying error pop when order cancellation tx fails
![Screenshot 2022-12-27 at 09 11 34](https://user-images.githubusercontent.com/43217/209645500-e23ae194-4c14-4275-b5a1-fc59997279b4.png)


- Tiny fix also for https://github.com/cowprotocol/cowswap/issues/1798

# To Test

## Creation failure
1. Following steps on #1787 , when placing the sell ETH order, tweak the `gas limit` in a way that the tx fails right away
* The order should be displayed as failed in the activity descriptor
* The failure sound should be emitted
* The failure pop-up should be displayed

## Cancellation failure
1. Place a valid ETH sell order
2. Right away request a cancellation, tweaking the `gas limit`  in a way that the tx fails right away
* The stepper should change from `eth refund initiated` etc to regular pending order flow
* The failure sound should be emitted
* The failure pop-up should be displayed