### PR TITLE
[EthFlow]#1445 highligh invalid slippage

### DIFF
--- a/src/cow-react/modules/swap/pure/EthFlow/EthFlowBanner/index.tsx
+++ b/src/cow-react/modules/swap/pure/EthFlow/EthFlowBanner/index.tsx
@@ -2,8 +2,7 @@ import { Trans } from '@lingui/macro'
 import { ChevronUp, ChevronDown } from 'react-feather'
 import { Currency, Token } from '@uniswap/sdk-core'
 
-import { ETH_FLOW_SLIPPAGE } from '@cow/modules/swap/state/EthFlow/updaters/EthFlowSlippageUpdater'
-import { PERCENTAGE_PRECISION } from 'constants/index'
+import { MINIMUM_ETH_FLOW_SLIPPAGE, PERCENTAGE_PRECISION } from 'constants/index'
 import { EthFlowBannerCallbacks } from '@cow/modules/swap/containers/EthFlow/EthFlowBanner'
 import savingsIcon from 'assets/cow-swap/savings.svg'
 import SVG from 'react-inlinesvg'
@@ -59,7 +58,8 @@ export function EthFlowBannerContent(props: EthFlowBannerContentProps) {
             <ul>
               <li>Lower overall fees</li>
               <li>
-                Lower default slippage (instead of {ETH_FLOW_SLIPPAGE.toSignificant(PERCENTAGE_PRECISION)}% minimum)
+                Lower default slippage (instead of {MINIMUM_ETH_FLOW_SLIPPAGE.toSignificant(PERCENTAGE_PRECISION)}%
+                minimum)
               </li>
               <li>No fees for failed transactions</li>
             </ul>

--- a/src/cow-react/modules/swap/pure/Row/RowSlippageContent/index.tsx
+++ b/src/cow-react/modules/swap/pure/Row/RowSlippageContent/index.tsx
@@ -4,11 +4,10 @@ import { Trans } from '@lingui/macro'
 import { RowFixed } from 'components/Row'
 import { MouseoverTooltipContent } from 'components/Tooltip'
 import { RowStyleProps } from '@cow/modules/swap/pure/Row/types'
-import { INPUT_OUTPUT_EXPLANATION, PERCENTAGE_PRECISION } from 'constants/index'
+import { INPUT_OUTPUT_EXPLANATION, MINIMUM_ETH_FLOW_SLIPPAGE, PERCENTAGE_PRECISION } from 'constants/index'
 import { RowSlippageProps } from '@cow/modules/swap/containers/Row/RowSlippage'
 import { StyledRowBetween, TextWrapper } from '@cow/modules/swap/pure/Row/styled'
 import { ThemedText } from 'theme/index'
-import { ETH_FLOW_SLIPPAGE } from '@cow/modules/swap/state/EthFlow/updaters/EthFlowSlippageUpdater'
 import { StyledInfoIcon } from '@cow/modules/swap/pure/styled'
 
 export const ClickableText = styled.button`
@@ -30,8 +29,8 @@ export const getNativeSlippageTooltip = (symbols: (string | undefined)[] | undef
   <Trans>
     <p>
       When selling {symbols?.[0] || 'a native currency'}, the minimum slippage tolerance is set to{' '}
-      {ETH_FLOW_SLIPPAGE.toSignificant(PERCENTAGE_PRECISION)}% to ensure a high likelihood of order matching, even in
-      volatile market conditions.
+      {MINIMUM_ETH_FLOW_SLIPPAGE.toSignificant(PERCENTAGE_PRECISION)}% to ensure a high likelihood of order matching,
+      even in volatile market conditions.
     </p>
     <p>Orders on CoW Swap are always protected from MEV, so your slippage tolerance cannot be exploited.</p>
   </Trans>

--- a/src/cow-react/modules/swap/state/EthFlow/updaters/EthFlowSlippageUpdater.tsx
+++ b/src/cow-react/modules/swap/state/EthFlow/updaters/EthFlowSlippageUpdater.tsx
@@ -4,8 +4,8 @@ import { useSetUserSlippageTolerance, useUserSlippageTolerance } from 'state/use
 import { useIsEthFlow } from '@cow/modules/swap/hooks/useIsEthFlow'
 import { loadJsonFromLocalStorage, setJsonToLocalStorage } from '@cow/utils/localStorage'
 import { SerializedSlippage, SerializedSlippageSettings, Slippage, SlippageSettings } from './types'
+import { MINIMUM_ETH_FLOW_SLIPPAGE } from 'constants/index'
 
-export const ETH_FLOW_SLIPPAGE = new Percent(2, 100) // 2%
 const LOCAL_STORAGE_KEY = 'UserSlippageSettings'
 
 export function EthFlowSlippageUpdater() {
@@ -44,13 +44,15 @@ export function EthFlowSlippageUpdater() {
 
       if (
         currentSlippage === 'auto' ||
-        (!currentSlippage.greaterThan(ETH_FLOW_SLIPPAGE) && !currentSlippage.equalTo(ETH_FLOW_SLIPPAGE))
+        (!currentSlippage.greaterThan(MINIMUM_ETH_FLOW_SLIPPAGE) && !currentSlippage.equalTo(MINIMUM_ETH_FLOW_SLIPPAGE))
       ) {
         // If current slippage is auto or if it's smaller than ETH flow slippage, update it
 
         // If the former ethFlow slippage was saved, use that. Otherwise pick the minimum
         const newSlippage =
-          ethFlow !== 'auto' && ethFlow && ethFlow.greaterThan(ETH_FLOW_SLIPPAGE) ? ethFlow : ETH_FLOW_SLIPPAGE
+          ethFlow !== 'auto' && ethFlow && ethFlow.greaterThan(MINIMUM_ETH_FLOW_SLIPPAGE)
+            ? ethFlow
+            : MINIMUM_ETH_FLOW_SLIPPAGE
 
         // Update the global state
         setUserSlippageTolerance(newSlippage)

--- a/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
+++ b/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
@@ -23,6 +23,9 @@ import {
   HIGH_SLIPPAGE_BPS,
   DEFAULT_SLIPPAGE_BPS,
   MINIMUM_ETH_FLOW_DEADLINE_SECONDS,
+  MINIMUM_ETH_FLOW_SLIPPAGE_BIPS,
+  HIGH_ETH_FLOW_SLIPPAGE_BIPS,
+  MINIMUM_ETH_FLOW_SLIPPAGE,
 } from 'constants/index'
 import { slippageToleranceAnalytics, orderExpirationTimeAnalytics } from 'components/analytics'
 import { useIsEthFlow } from '@cow/modules/swap/hooks/useIsEthFlow'
@@ -146,13 +149,17 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
     setSlippageError(false)
 
     if (value.length === 0) {
-      slippageToleranceAnalytics('Default', DEFAULT_SLIPPAGE_BPS)
+      slippageToleranceAnalytics('Default', isEthFlow ? MINIMUM_ETH_FLOW_SLIPPAGE_BIPS : DEFAULT_SLIPPAGE_BPS)
       setUserSlippageTolerance('auto')
     } else {
       const parsed = Math.floor(Number.parseFloat(value) * 100)
 
-      if (!Number.isInteger(parsed) || parsed < MIN_SLIPPAGE_BPS || parsed > MAX_SLIPPAGE_BPS) {
-        slippageToleranceAnalytics('Default', DEFAULT_SLIPPAGE_BPS)
+      if (
+        !Number.isInteger(parsed) ||
+        parsed < (isEthFlow ? MINIMUM_ETH_FLOW_SLIPPAGE_BIPS : MIN_SLIPPAGE_BPS) ||
+        parsed > MAX_SLIPPAGE_BPS
+      ) {
+        slippageToleranceAnalytics('Default', isEthFlow ? MINIMUM_ETH_FLOW_SLIPPAGE_BIPS : DEFAULT_SLIPPAGE_BPS)
         setUserSlippageTolerance('auto')
         if (value !== '.') {
           setSlippageError(SlippageError.InvalidInput)
@@ -165,13 +172,11 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
   }
 
   const tooLow =
-    !isEthFlow &&
     userSlippageTolerance !== 'auto' &&
-    userSlippageTolerance.lessThan(new Percent(LOW_SLIPPAGE_BPS, 10_000))
+    userSlippageTolerance.lessThan(new Percent(isEthFlow ? MINIMUM_ETH_FLOW_SLIPPAGE_BIPS : LOW_SLIPPAGE_BPS, 10_000))
   const tooHigh =
-    !isEthFlow &&
     userSlippageTolerance !== 'auto' &&
-    userSlippageTolerance.greaterThan(new Percent(HIGH_SLIPPAGE_BPS, 10_000))
+    userSlippageTolerance.greaterThan(new Percent(isEthFlow ? HIGH_ETH_FLOW_SLIPPAGE_BIPS : HIGH_SLIPPAGE_BPS, 10_000))
 
   function parseCustomDeadline(value: string) {
     // populate what the user typed and clear the error
@@ -275,7 +280,11 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
             }}
           >
             {slippageError ? (
-              <Trans>Enter a valid slippage percentage</Trans>
+              <Trans>
+                Enter slippage percentage between{' '}
+                {isEthFlow ? MINIMUM_ETH_FLOW_SLIPPAGE.toFixed(0) : MIN_SLIPPAGE_BPS / 100}% and{' '}
+                {MAX_SLIPPAGE_BPS / 100}%
+              </Trans>
             ) : tooLow ? (
               <Trans>Your transaction may expire</Trans>
             ) : (

--- a/src/custom/components/TransactionSettings/index.tsx
+++ b/src/custom/components/TransactionSettings/index.tsx
@@ -1,24 +1,7 @@
-import SlippageTabsMod, {
-  TransactionSettingsProps as TransactionSettingsPropsMod,
-  FancyButton as FancyButtonUni,
-  OptionCustom,
-} from './TransactionSettingsMod'
+import SlippageTabsMod, { TransactionSettingsProps, OptionCustom } from './TransactionSettingsMod'
 import { RowBetween, RowFixed } from 'components/Row'
 import styled from 'styled-components/macro'
 import { darken } from 'polished'
-
-// TODO: option was restyled in v3, review if this change is necessary
-export const Option = styled(FancyButtonUni)<{ active: boolean }>`
-  margin-right: 8px;
-  border: 0;
-  background-color: ${({ theme }) => theme.grey1};
-  color: ${({ theme }) => theme.text1};
-  border: ${({ active, theme }) => active && `1px solid ${theme.primary1}`};
-
-  &:hover {
-    cursor: pointer;
-  }
-`
 
 const Wrapper = styled.div`
   ${RowBetween} > button, ${OptionCustom} {
@@ -69,13 +52,10 @@ const Wrapper = styled.div`
   }
 `
 
-export type TransactionSettingsProps = Omit<TransactionSettingsPropsMod, 'Option'>
-
 export default function SlippageTabs(params: TransactionSettingsProps) {
   return (
     <Wrapper>
-      {/* TODO: v3 option prop merge issue, review */}
-      <SlippageTabsMod {...params} /* Option={Option} */ />
+      <SlippageTabsMod {...params} />
     </Wrapper>
   )
 }

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -104,6 +104,9 @@ export const GP_ORDER_UPDATE_INTERVAL = ms`30s` // 30s
 export const MINIMUM_ORDER_VALID_TO_TIME_SECONDS = 120
 // Minimum deadline for EthFlow orders. Like the default deadline, anything smaller will be replaced by this
 export const MINIMUM_ETH_FLOW_DEADLINE_SECONDS = 600 // 10 minutes in SECONDS
+export const MINIMUM_ETH_FLOW_SLIPPAGE_BIPS = 200 // 2%
+export const MINIMUM_ETH_FLOW_SLIPPAGE = new Percent(MINIMUM_ETH_FLOW_SLIPPAGE_BIPS, 10_000) // 2%
+export const HIGH_ETH_FLOW_SLIPPAGE_BIPS = 1_000 // 10%
 
 export const WETH_LOGO_URI =
   'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png'


### PR DESCRIPTION
# Summary

Closes #1445 

More info about invalid slippage, both for regular and ethflow orders

- Regular orders have high slippage warning set to `1%`. Added the same for ethflow orders when above `10%`
- Showing error when ethflow slippage is < `2%`

## Regular

**Invalid: too high**: same for both types; > `50%`
![Screenshot 2022-12-28 at 14 22 34](https://user-images.githubusercontent.com/43217/209827527-668a428a-09c1-475c-b45b-b98a9e9529af.png)

**High**: > `1%`
![Screenshot 2022-12-28 at 14 22 12](https://user-images.githubusercontent.com/43217/209827531-dd5ef3ca-823c-4f74-8931-ae372b862dc3.png)

**Low**: < `0.05%`
![Screenshot 2022-12-28 at 14 21 59](https://user-images.githubusercontent.com/43217/209827535-267065de-1b00-4983-99be-e914ee9ddc1f.png)

**Invalid**: < `0%`
![Screenshot 2022-12-28 at 14 21 18](https://user-images.githubusercontent.com/43217/209827536-c358ef5d-e362-4b0a-b167-22822053fb70.png)

## EthFlow

**High**: > `10%`
![Screenshot 2022-12-28 at 14 20 51](https://user-images.githubusercontent.com/43217/209827546-ea5d3737-4762-4a7c-a849-660580fc2acf.png)

**Invalid**: < `2%`
![Screenshot 2022-12-28 at 14 20 30](https://user-images.githubusercontent.com/43217/209827548-00f6a470-a7db-4cba-9d96-70ea4d8be127.png)

  # To Test

1. On regular, check the slippages -1, 0, 1.1, 50, 50.1
* Make sure the behaviour matches what's described in the images above
2. On ethflow, check the slippages 1, 2, 10, 10.1, 50, 50.1
* Make sure the behaviour matches what's described in the images above