### PR TITLE
Fixed #20: JS and floats are not to be trusted

### DIFF
--- a/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
+++ b/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
@@ -152,7 +152,7 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
       slippageToleranceAnalytics('Default', isEthFlow ? MINIMUM_ETH_FLOW_SLIPPAGE_BIPS : DEFAULT_SLIPPAGE_BPS)
       setUserSlippageTolerance('auto')
     } else {
-      const parsed = Math.floor(Number.parseFloat(value) * 100)
+      const parsed = Math.round(Number.parseFloat(value) * 100)
 
       if (
         !Number.isInteger(parsed) ||

--- a/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
+++ b/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
@@ -152,7 +152,17 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
       slippageToleranceAnalytics('Default', isEthFlow ? MINIMUM_ETH_FLOW_SLIPPAGE_BIPS : DEFAULT_SLIPPAGE_BPS)
       setUserSlippageTolerance('auto')
     } else {
-      const parsed = Math.round(Number.parseFloat(value) * 100)
+      let v = value
+
+      // Prevent inserting more than 2 decimal precision
+      if (value.split('.')[1]?.length > 2) {
+        // indexOf + 3 because we are cutting it off at `.XX`
+        v = value.slice(0, value.indexOf('.') + 3)
+        // Update the input to remove the extra numbers from UI input
+        setSlippageInput(v)
+      }
+
+      const parsed = Math.round(Number.parseFloat(v) * 100)
 
       if (
         !Number.isInteger(parsed) ||
@@ -161,7 +171,7 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
       ) {
         slippageToleranceAnalytics('Default', isEthFlow ? MINIMUM_ETH_FLOW_SLIPPAGE_BIPS : DEFAULT_SLIPPAGE_BPS)
         setUserSlippageTolerance('auto')
-        if (value !== '.') {
+        if (v !== '.') {
           setSlippageError(SlippageError.InvalidInput)
         }
       } else {


### PR DESCRIPTION
# Summary

Closes #20 

## Edit 2022-12-29

Also preventing more than 2 decimals of precision on slippage input.

E.g.: 1.99 OK; 1.999 won't be possible to type

## Original

Funny business with JS and floats

  # To Test

1. Try slippage inputs: 5.02 and 5.06
* Slippage should be valid and remain 5.02 and 5.06
2. Of course, try other values and make sure there's nothing funny after this tiny change