### PR TITLE
[EthFlow]#1445 more slippage business

### DIFF
--- a/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
+++ b/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
@@ -150,7 +150,7 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
 
     if (value.length === 0) {
       slippageToleranceAnalytics('Default', isEthFlow ? MINIMUM_ETH_FLOW_SLIPPAGE_BIPS : DEFAULT_SLIPPAGE_BPS)
-      setUserSlippageTolerance('auto')
+      setUserSlippageTolerance(isEthFlow ? MINIMUM_ETH_FLOW_SLIPPAGE : 'auto')
     } else {
       let v = value
 

--- a/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
+++ b/src/custom/components/TransactionSettings/TransactionSettingsMod.tsx
@@ -272,7 +272,15 @@ export default function TransactionSettings({ placeholderSlippage }: Transaction
                 onChange={(e) => parseSlippageInput(e.target.value)}
                 onBlur={() => {
                   setSlippageInput('')
-                  setSlippageError(false)
+                  setSlippageError((curr) => {
+                    // When ethFlow and there was an error
+                    // Set the slippage to minimum allowed
+                    // Otherwise it'll default to last value used
+                    if (curr && isEthFlow) {
+                      setUserSlippageTolerance(MINIMUM_ETH_FLOW_SLIPPAGE)
+                    }
+                    return false
+                  })
                 }}
                 color={slippageError ? 'red' : ''}
               />


### PR DESCRIPTION
# Summary

A bit more of #1445 for ethflow

- Allow slippage input to be cleared -> then replace it with minimum (`2%`)

https://user-images.githubusercontent.com/43217/209933992-e927d86f-5bed-4001-9a01-14fdf15af9cc.mov

- When Input is an error (< `2%`) and focus moves away, set value to minimum rather than last used value

https://user-images.githubusercontent.com/43217/209934013-bd41f815-aebb-4792-b5a9-5db28ff9dc3f.mov

Somewhat addressing https://github.com/cowprotocol/cowswap/issues/1806 but not quite.
Clearing the field completely for ethflow is not trivial and I don't think it's worth the effort.

# To Test

1. Select eth flow order
2. Set slippage to something valid other than default and move the focus away
3. Go back to the input and remove everything
* It should be set to minimum (`2%`)
4. Insert a valid value other than the minimum and chance focus
5. Go back to the input and input 1
* It should show you the error about the slippage range
6. Move focus away from input
* It should set the value to the minimum (`2%`) rather than the previous valid input