### PR TITLE
Load fortmatic, coinbase, walletconnect and gnosis-safe wallets connectors asynchronously

### DIFF
--- a/src/custom/components/WalletModal/WalletModalMod.tsx
+++ b/src/custom/components/WalletModal/WalletModalMod.tsx
@@ -24,12 +24,12 @@ import { FortmaticOption } from 'components/WalletModal/FortmaticOption'
 import { InjectedOption, InstallMetaMaskOption, MetaMaskOption } from 'components/WalletModal/InjectedOption'
 import PendingView from 'components/WalletModal/PendingView'
 import { WalletConnectOption } from 'components/WalletModal/WalletConnectOption'
-import { WalletConnect } from '@web3-react/walletconnect'
 
 // MOD imports
 import ModalMod from '@src/components/Modal'
 import { changeWalletAnalytics } from 'components/analytics'
 import usePrevious from 'hooks/usePrevious'
+import type { WalletConnect } from '@web3-react/walletconnect'
 
 export const CloseIcon = styled.div`
   position: absolute;
@@ -215,8 +215,10 @@ export default function WalletModal({
 
         // MOD: Important for balances to load when connected to Gnosis-chain via WalletConnect
         if (getConnection(connector) === walletConnectConnection) {
-          if (connector instanceof WalletConnect) {
-            const { http, rpc, signer } = connector.provider
+          const provider: any = connector.provider
+
+          if (provider && provider.isWalletConnect) {
+            const { http, rpc, signer } = (connector as WalletConnect).provider
             const chainId = signer.connection.chainId
             // don't default to SupportedChainId.Mainnet - throw instead
             if (!chainId) throw new Error('[WalletModal::activation error: No chainId')

--- a/src/custom/connection/index.ts
+++ b/src/custom/connection/index.ts
@@ -1,13 +1,8 @@
-import { CoinbaseWallet } from '@web3-react/coinbase-wallet'
 import { initializeConnector, Web3ReactHooks } from '@web3-react/core'
-import { EIP1193 } from '@web3-react/eip1193'
-import { GnosisSafe } from '@web3-react/gnosis-safe'
 import { MetaMask } from '@web3-react/metamask'
 import { Network } from '@web3-react/network'
-import { Connector } from '@web3-react/types'
-import { WalletConnect } from '@web3-react/walletconnect'
+import { Actions, Connector } from '@web3-react/types'
 import { SupportedChainId } from 'constants/chains'
-import Fortmatic from 'fortmatic'
 
 import COWSWAP_LOGO_URL from 'assets/cow-swap/cow.svg'
 import { RPC_URLS } from 'constants/networks'
@@ -25,6 +20,24 @@ export interface Connection {
   connector: Connector
   hooks: Web3ReactHooks
   type: ConnectionType
+}
+
+/**
+ * To avoid including external libs for wallet connection in the bundle
+ * We load them in runtime by demand
+ */
+class AsyncConnector extends Connector {
+  constructor(private loader: () => Promise<Connector>, actions: Actions, onError?: (error: Error) => void) {
+    super(actions, onError)
+  }
+
+  activate(...args: unknown[]): Promise<void> | void {
+    return this.loader().then((connector) => {
+      // There is a magic - we change async-connector prototype to the loaded connector
+      ;(this as any).__proto__ = connector
+      return connector.activate(...args)
+    })
+  }
 }
 
 function onError(error: Error) {
@@ -47,52 +60,85 @@ export const injectedConnection: Connection = {
   type: ConnectionType.INJECTED,
 }
 
-const [web3GnosisSafe, web3GnosisSafeHooks] = initializeConnector<GnosisSafe>((actions) => new GnosisSafe({ actions }))
+const [web3GnosisSafe, web3GnosisSafeHooks] = initializeConnector<Connector>((actions) => {
+  return new AsyncConnector(
+    () => {
+      return import('@web3-react/gnosis-safe').then((module) => {
+        return new module.GnosisSafe({ actions })
+      })
+    },
+    actions,
+    onError
+  )
+})
+
 export const gnosisSafeConnection: Connection = {
   connector: web3GnosisSafe,
   hooks: web3GnosisSafeHooks,
   type: ConnectionType.GNOSIS_SAFE,
 }
 
-const [web3WalletConnect, web3WalletConnectHooks] = initializeConnector<WalletConnect>(
-  (actions) =>
-    new WalletConnect({
-      actions,
-      options: {
-        rpc: RPC_URLS,
-        qrcode: true,
-      },
-      onError,
-    })
-)
+const [web3WalletConnect, web3WalletConnectHooks] = initializeConnector<Connector>((actions) => {
+  return new AsyncConnector(
+    () => {
+      return import('@web3-react/walletconnect').then((module) => {
+        return new module.WalletConnect({
+          actions,
+          options: {
+            rpc: RPC_URLS,
+            qrcode: true,
+          },
+          onError,
+        })
+      })
+    },
+    actions,
+    onError
+  )
+})
 export const walletConnectConnection: Connection = {
   connector: web3WalletConnect,
   hooks: web3WalletConnectHooks,
   type: ConnectionType.WALLET_CONNECT,
 }
 
-const [web3Fortmatic, web3FortmaticHooks] = initializeConnector<EIP1193>(
-  (actions) => new EIP1193({ actions, provider: new Fortmatic(process.env.REACT_APP_FORTMATIC_KEY).getProvider() })
-)
+const [web3Fortmatic, web3FortmaticHooks] = initializeConnector<Connector>((actions) => {
+  return new AsyncConnector(
+    () => {
+      return Promise.all([import('fortmatic'), import('@web3-react/eip1193')]).then(([Fortmatic, { EIP1193 }]) => {
+        return new EIP1193({ actions, provider: new Fortmatic(process.env.REACT_APP_FORTMATIC_KEY).getProvider() })
+      })
+    },
+    actions,
+    onError
+  )
+})
 export const fortmaticConnection: Connection = {
   connector: web3Fortmatic,
   hooks: web3FortmaticHooks,
   type: ConnectionType.FORTMATIC,
 }
 
-const [web3CoinbaseWallet, web3CoinbaseWalletHooks] = initializeConnector<CoinbaseWallet>(
-  (actions) =>
-    new CoinbaseWallet({
-      actions,
-      options: {
-        url: RPC_URLS[SupportedChainId.MAINNET],
-        appName: 'CoW Swap',
-        appLogoUrl: COWSWAP_LOGO_URL,
-        reloadOnDisconnect: false,
-      },
-      onError,
-    })
-)
+const [web3CoinbaseWallet, web3CoinbaseWalletHooks] = initializeConnector<Connector>((actions) => {
+  return new AsyncConnector(
+    () => {
+      return import('@web3-react/coinbase-wallet').then((module) => {
+        return new module.CoinbaseWallet({
+          actions,
+          options: {
+            url: RPC_URLS[SupportedChainId.MAINNET],
+            appName: 'CoW Swap',
+            appLogoUrl: COWSWAP_LOGO_URL,
+            reloadOnDisconnect: false,
+          },
+          onError,
+        })
+      })
+    },
+    actions,
+    onError
+  )
+})
 export const coinbaseWalletConnection: Connection = {
   connector: web3CoinbaseWallet,
   hooks: web3CoinbaseWalletHooks,

--- a/src/custom/hooks/useWalletInfo.ts
+++ b/src/custom/hooks/useWalletInfo.ts
@@ -1,4 +1,3 @@
-import WalletConnectProvider from '@walletconnect/ethereum-provider'
 import { useWeb3React } from '@web3-react/core'
 import { Web3Provider } from '@ethersproject/providers'
 import useENSName from '@src/hooks/useENSName'
@@ -42,7 +41,7 @@ function checkIsSupportedWallet(walletName?: string): boolean {
   return true
 }
 
-function getWcPeerMetadata(provider: WalletConnectProvider | undefined): WalletMetaData {
+function getWcPeerMetadata(provider: any | undefined): WalletMetaData {
   // fix for this https://github.com/gnosis/cowswap/issues/1929
   const defaultOutput = { walletName: undefined, icon: undefined }
 
@@ -70,7 +69,7 @@ export function useWalletMetaData(): WalletMetaData {
     if (connectionType === ConnectionType.WALLET_CONNECT) {
       const wc = provider?.provider
 
-      if (wc instanceof WalletConnectProvider) {
+      if ((wc as any)?.isWalletConnect) {
         return getWcPeerMetadata(wc)
       }
     }


### PR DESCRIPTION
# Summary

To avoid including external libs for wallet connection in the bundle, we load them in runtime by demand.
The basic point here is `Connector` class from `@web3-react/types`.
This class has `activate` method that should activate the wallet and resolve a promise after activation.
I injected importing of a wallet package before activating and changed the connector prototype to a loaded one before activation.

  # To Test

1. Coinbase wallet (swap, limit order placement)
2. Fortmatic wallet (swap, limit order placement)
3. Walletconnect wallet (swap, limit order placement)
4. Gnosis-safe wallet (swap, limit order placement)
