### PR TITLE
Use recursion to check props in genericPropsChecker()

### DIFF
--- a/src/cow-react/modules/swap/containers/NewSwapModals/index.tsx
+++ b/src/cow-react/modules/swap/containers/NewSwapModals/index.tsx
@@ -6,6 +6,7 @@ import CowSubsidyModal from 'components/CowSubsidyModal'
 import { useCloseModals } from 'state/application/hooks'
 import { TradeApproveWidget } from '@cow/common/containers/TradeApprove/TradeApproveWidget'
 import { useOnImportDismiss } from '@cow/modules/trade/hooks/useOnImportDismiss'
+import { genericPropsChecker } from '@cow/utils/genericPropsChecker'
 
 export interface NewSwapModalsProps {
   chainId: number | undefined
@@ -15,8 +16,7 @@ export interface NewSwapModalsProps {
   ethFlowProps: EthFlowProps
 }
 
-// FIXME: This component was memoized, but that was removed because it was catching the callback "directSwapCallback". ALthough the function was recreated, the NewModal was not re-rendering the component
-export const NewSwapModals = function (props: NewSwapModalsProps) {
+export const NewSwapModals = React.memo(function (props: NewSwapModalsProps) {
   const { chainId, showNativeWrapModal, showCowSubsidyModal, confirmSwapProps, ethFlowProps } = props
 
   const closeModals = useCloseModals()
@@ -33,4 +33,4 @@ export const NewSwapModals = function (props: NewSwapModalsProps) {
       <TradeApproveWidget />
     </>
   )
-}
+}, genericPropsChecker)

--- a/src/cow-react/utils/genericPropsChecker.ts
+++ b/src/cow-react/utils/genericPropsChecker.ts
@@ -13,6 +13,24 @@ export function genericPropsChecker(prev: any, next: any): boolean {
       const prevValue = prev[key]
       const nextValue = next[key]
 
+      /* In case when value is object we go into recursion.
+      For example:
+
+      props = {
+        id: 10,
+        options: {
+          option1: { foo: 'bar' },
+          keys: [5, 6],
+        },
+      }
+
+      When we get `options` key we detect that it's an object and check it through genericPropsChecker again recursively
+      And we do it until we met not object value (primitive, array, function)
+      */
+      if (typeof nextValue === 'object' && !Array.isArray(nextValue) && nextValue !== null) {
+        return genericPropsChecker(prevValue, nextValue)
+      }
+
       // We shouldn't check functions using JSON.stringify because it always returns true
       if (typeof prevValue === 'function' || typeof nextValue === 'function') {
         return prevValue === nextValue


### PR DESCRIPTION
# Summary

Reference:
https://cowservices.slack.com/archives/C0361CDG8GP/p1672911351963629


  # To Test

1. In Goerli. Go to SWAP, and select ETH/DAI
2. Send Quickly two orders with the same parameters that are the same
3. Open the devtools and filter the console by calculateOrderId (it will think that the second order, which should have the same order Id, is sent without detecting the collision)

  # Background

`genericPropsChecker` wrongly compared object values.

For example:
Before the fix, it compared object like this and of course got `true` as result
```
JSON.stringify({foo: function() {console.log('aa')}}) === JSON.stringify({foo: function() {console.log('bar')}})
```
