### PR TITLE
Fix e2e tests

### DIFF
--- a/cypress-custom/integration/swap.test.ts
+++ b/cypress-custom/integration/swap.test.ts
@@ -23,7 +23,7 @@ describe('Swap (custom)', () => {
   it('can swap ETH for DAI', () => {
     cy.visit(`/${CHAIN_ID}/swap/ETH/${DAI}`)
     cy.get('#swap-currency-input .token-amount-input').should('be.visible')
-    cy.get('#swap-currency-input .token-amount-input').type('0.001', { force: true, delay: 200 })
+    cy.get('#swap-currency-input .token-amount-input').type('0.1', { force: true, delay: 200 })
     cy.get('#swap-currency-output .token-amount-input').should('not.equal', '')
     cy.get('#swap-button > button').should('contain.text', 'Swap').click()
     cy.get('#confirm-swap-or-send').should('contain', 'Confirm Swap')


### PR DESCRIPTION
# Summary

Our e2e tests are red, because there is Fees exceed 30% of the swap amount!  banner for the trade.
e2e test doesn't expect it

![image](https://user-images.githubusercontent.com/7122625/210765374-63ada788-f83d-4533-a59f-f30dc7f5e553.png)

