### PR TITLE
[EthFlow]#1586 progress bar starts not from 0

### DIFF
--- a/src/custom/components/OrderProgressBar/index.tsx
+++ b/src/custom/components/OrderProgressBar/index.tsx
@@ -47,11 +47,14 @@ type ExecutionState = 'cow' | 'amm' | 'confirmed' | 'unfillable' | 'delayed'
 export function OrderProgressBar(props: OrderProgressBarProps) {
   const { activityDerivedState, chainId, hideWhenFinished = false } = props
   const { order, isConfirmed, isUnfillable = false } = activityDerivedState
+
+  const orderOpenTime = order?.openSince || order?.creationTime || order?.apiAdditionalInfo?.creationDate
+
   const { validTo, creationTime } = useMemo(() => {
-    if (order?.creationTime && order?.validTo) {
+    if (orderOpenTime && order?.validTo) {
       return {
         validTo: new Date((order?.validTo as number) * 1000),
-        creationTime: new Date(order?.apiAdditionalInfo?.creationDate ?? order?.creationTime),
+        creationTime: new Date(orderOpenTime),
       }
     }
 
@@ -59,7 +62,7 @@ export function OrderProgressBar(props: OrderProgressBarProps) {
       validTo: null,
       creationTime: null,
     }
-  }, [order?.apiAdditionalInfo, order?.creationTime, order?.validTo])
+  }, [order?.validTo, orderOpenTime])
   const { elapsedSeconds, expirationInSeconds, isPending } = useGetProgressBarInfo({
     activityDerivedState,
     validTo,

--- a/src/custom/state/orders/reducer.ts
+++ b/src/custom/state/orders/reducer.ts
@@ -258,6 +258,7 @@ export default createReducer(initialState, (builder) =>
               apiAdditionalInfo: newOrder.apiAdditionalInfo,
               isCancelling: newOrder.isCancelling,
               class: newOrder.class,
+              openSince: newOrder.openSince || orderObj.order.openSince,
               status,
             }
           : { ...newOrder, validTo }

--- a/src/custom/state/orders/reducer.ts
+++ b/src/custom/state/orders/reducer.ts
@@ -181,7 +181,10 @@ export default createReducer(initialState, (builder) =>
       prefillState(state, action)
       const { order, id, chainId } = action.payload
 
-      order.openSince = order.status === OrderStatus.PRESIGNATURE_PENDING ? undefined : Date.now()
+      order.openSince =
+        order.status === OrderStatus.PRESIGNATURE_PENDING || order.status === OrderStatus.CREATING
+          ? undefined
+          : Date.now()
 
       switch (order.status) {
         // EthFlow or PreSign orders have their respective buckets

--- a/src/custom/state/orders/reducer.ts
+++ b/src/custom/state/orders/reducer.ts
@@ -169,6 +169,8 @@ function popOrder(state: OrdersState, chainId: ChainId, status: OrderStatus, id:
   return orderObj
 }
 
+const STATES_FOR_ORDERS_NOT_YET_OPEN = [OrderStatus.PRESIGNATURE_PENDING, OrderStatus.CREATING]
+
 function getValidTo(apiAdditionalInfo: OrderInfoApi | undefined, order: SerializedOrder): number {
   return (apiAdditionalInfo?.ethflowData?.userValidTo || order.validTo) as number
 }
@@ -181,10 +183,7 @@ export default createReducer(initialState, (builder) =>
       prefillState(state, action)
       const { order, id, chainId } = action.payload
 
-      order.openSince =
-        order.status === OrderStatus.PRESIGNATURE_PENDING || order.status === OrderStatus.CREATING
-          ? undefined
-          : Date.now()
+      order.openSince = STATES_FOR_ORDERS_NOT_YET_OPEN.includes(order.status) ? undefined : Date.now()
 
       switch (order.status) {
         // EthFlow or PreSign orders have their respective buckets

--- a/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
@@ -106,6 +106,7 @@ async function _updateCreatingOrders(
             validTo: orderData.ethflowData?.userValidTo || order.validTo,
             isRefunded: orderData.ethflowData?.isRefunded,
             refundHash: orderData.ethflowData?.refundTxHash || undefined,
+            openSince: Date.now(),
           }
           addOrUpdateOrders({ chainId, orders: [updatedOrder] })
         })

--- a/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
@@ -107,6 +107,8 @@ async function _updateCreatingOrders(
             isRefunded: orderData.ethflowData?.isRefunded,
             refundHash: orderData.ethflowData?.refundTxHash || undefined,
             openSince: Date.now(),
+            status: OrderStatus.PENDING, // seen once, can be moved to pending bucket
+            apiAdditionalInfo: orderData,
           }
           addOrUpdateOrders({ chainId, orders: [updatedOrder] })
         })


### PR DESCRIPTION
# Summary

Closes #1586 

Progress bar now starts from 0 for ethflow orders


https://user-images.githubusercontent.com/43217/210795533-b50ddf5a-7d06-449d-bb0e-8ba61a07d019.mov

# To Test

1. On regular mode (non-expert), place an ethflow order
2. Keep the modal open and observe
* When the order becomes pending, the progress bar should start from the very left
3. Repeat same process for non-ethflow orders, as well as smart contract wallets
* The behaviour should be the same
