### PR TITLE
Add open in metamask option on mobile

### DIFF
--- a/src/custom/components/WalletModal/InjectedOption.tsx
+++ b/src/custom/components/WalletModal/InjectedOption.tsx
@@ -23,8 +23,16 @@ const METAMASK_PROPS = {
   id: 'metamask',
 }
 
+const METAMASK_DEEP_LINK = 'https://metamask.app.link/dapp/'
+
 export function InstallMetaMaskOption() {
   return <Option {...METAMASK_PROPS} header={<Trans>Install MetaMask</Trans>} link={'https://metamask.io/'} />
+}
+
+export function OpenMetaMaskOption() {
+  return (
+    <Option {...METAMASK_PROPS} header={<Trans>Open MetaMask</Trans>} link={METAMASK_DEEP_LINK + window.location} />
+  )
 }
 
 export function MetaMaskOption({ tryActivation }: { tryActivation: (connector: Connector) => void }) {

--- a/src/custom/components/WalletModal/InjectedOption.tsx
+++ b/src/custom/components/WalletModal/InjectedOption.tsx
@@ -30,9 +30,7 @@ export function InstallMetaMaskOption() {
 }
 
 export function OpenMetaMaskMobileOption() {
-  return (
-    <Option {...METAMASK_PROPS} header={<Trans>Open MetaMask</Trans>} link={METAMASK_DEEP_LINK + window.location} />
-  )
+  return <Option {...METAMASK_PROPS} header={<Trans>MetaMask</Trans>} link={METAMASK_DEEP_LINK + window.location} />
 }
 
 export function MetaMaskOption({ tryActivation }: { tryActivation: (connector: Connector) => void }) {

--- a/src/custom/components/WalletModal/InjectedOption.tsx
+++ b/src/custom/components/WalletModal/InjectedOption.tsx
@@ -29,7 +29,7 @@ export function InstallMetaMaskOption() {
   return <Option {...METAMASK_PROPS} header={<Trans>Install MetaMask</Trans>} link={'https://metamask.io/'} />
 }
 
-export function OpenMetaMaskOption() {
+export function OpenMetaMaskMobileOption() {
   return (
     <Option {...METAMASK_PROPS} header={<Trans>Open MetaMask</Trans>} link={METAMASK_DEEP_LINK + window.location} />
   )

--- a/src/custom/components/WalletModal/WalletModalMod.tsx
+++ b/src/custom/components/WalletModal/WalletModalMod.tsx
@@ -25,7 +25,7 @@ import {
   InjectedOption,
   InstallMetaMaskOption,
   MetaMaskOption,
-  OpenMetaMaskOption,
+  OpenMetaMaskMobileOption,
 } from 'components/WalletModal/InjectedOption'
 import PendingView from 'components/WalletModal/PendingView'
 import { WalletConnectOption } from 'components/WalletModal/WalletConnectOption'
@@ -252,7 +252,7 @@ export default function WalletModal({
       if (!isMobile) {
         injectedOption = <InstallMetaMaskOption />
       } else {
-        injectedOption = <OpenMetaMaskOption />
+        injectedOption = <OpenMetaMaskMobileOption />
       }
     } else if (!isCoinbaseWallet) {
       if (isMetaMask) {

--- a/src/custom/components/WalletModal/WalletModalMod.tsx
+++ b/src/custom/components/WalletModal/WalletModalMod.tsx
@@ -21,7 +21,12 @@ import { /*Card,*/ LightCard } from 'components/Card'
 // import Modal from '../Modal'
 import { CoinbaseWalletOption /*, OpenCoinbaseWalletOption */ } from 'components/WalletModal/CoinbaseWalletOption'
 import { FortmaticOption } from 'components/WalletModal/FortmaticOption'
-import { InjectedOption, InstallMetaMaskOption, MetaMaskOption } from 'components/WalletModal/InjectedOption'
+import {
+  InjectedOption,
+  InstallMetaMaskOption,
+  MetaMaskOption,
+  OpenMetaMaskOption,
+} from 'components/WalletModal/InjectedOption'
 import PendingView from 'components/WalletModal/PendingView'
 import { WalletConnectOption } from 'components/WalletModal/WalletConnectOption'
 import { WalletConnect } from '@web3-react/walletconnect'
@@ -246,6 +251,8 @@ export default function WalletModal({
     if (!isInjected) {
       if (!isMobile) {
         injectedOption = <InstallMetaMaskOption />
+      } else {
+        injectedOption = <OpenMetaMaskOption />
       }
     } else if (!isCoinbaseWallet) {
       if (isMetaMask) {


### PR DESCRIPTION
# Summary

Fixes #1332

Adds an option on mobile to open Dapp in Metamask Browser.

# Demo:
https://user-images.githubusercontent.com/5501872/210831517-69256270-3240-4716-be59-9bab036bd0f0.mov


 # To Test

1. Tap `Connect Wallet` on mobile device
- [ ] Should have `Open Metamask` option
- [ ] Clicking it should open Metamask Browser on the current page
2. Tap `Connect Wallet` on Metamask Browser
- [ ] Should have `Metamask` option
- [ ] Selecting `Metamask` connects the wallet
