### PR TITLE
New GH action workflow

### DIFF
--- a/.github/workflows/pr_comments.yml
+++ b/.github/workflows/pr_comments.yml
@@ -1,0 +1,18 @@
+name: PR comments
+
+on:
+  issue_comment:
+    types: [created, updated]
+
+jobs:
+  pr_commented:
+    name: PR comment
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Event log
+        run: |
+          echo $EVENT
+        env:
+          EVENT: ${{ github.event }}
+


### PR DESCRIPTION
# Summary

New GH action workflow

It'll trigger on every issue_comment
And run only on PR comments

This first workflow is only logging the whole workflow event context.

I intend to use this to create cosmos/storybook links from Vercel deployment comments.
Still not sure what's available, so the first step is just logging stuff.

Sadly, new workflows only run after they are deployed to the default branch, which is `develop`

So, nothing to see here in this PR