### PR TITLE
Migrate to the high-availability RPC for Gnosis chain

### DIFF
--- a/src/custom/constants/networks.ts
+++ b/src/custom/constants/networks.ts
@@ -26,5 +26,5 @@ export const RPC_URLS: { [key in SupportedChainId]: string } = {
   // [SupportedChainId.POLYGON_MUMBAI]: `https://polygon-mumbai.infura.io/v3/${INFURA_KEY}`,
   // [SupportedChainId.CELO]: `https://forno.celo.org`,
   // [SupportedChainId.CELO_ALFAJORES]: `https://alfajores-forno.celo-testnet.org`,
-  [SupportedChainId.GNOSIS_CHAIN]: `https://rpc.gnosischain.com`,
+  [SupportedChainId.GNOSIS_CHAIN]: `https://rpc.gnosis.gateway.fm`,
 }

--- a/src/custom/utils/switchChain.ts
+++ b/src/custom/utils/switchChain.ts
@@ -16,24 +16,6 @@ function getRpcUrls(chainId: SupportedChainId): [string] {
     case SupportedChainId.MAINNET:
     case SupportedChainId.GOERLI:
       return [RPC_URLS[chainId]]
-    // case SupportedChainId.ROPSTEN:
-    // case SupportedChainId.KOVAN:
-    // case SupportedChainId.OPTIMISM:
-    //   return ['https://mainnet.optimism.io']
-    // case SupportedChainId.OPTIMISTIC_KOVAN:
-    //   return ['https://kovan.optimism.io']
-    // case SupportedChainId.ARBITRUM_ONE:
-    //   return ['https://arb1.arbitrum.io/rpc']
-    // case SupportedChainId.ARBITRUM_RINKEBY:
-    //   return ['https://rinkeby.arbitrum.io/rpc']
-    // case SupportedChainId.POLYGON:
-    //   return ['https://polygon-rpc.com/']
-    // case SupportedChainId.POLYGON_MUMBAI:
-    //   return ['https://rpc-endpoints.superfluid.dev/mumbai']
-    // case SupportedChainId.CELO:
-    //   return ['https://forno.celo.org']
-    // case SupportedChainId.CELO_ALFAJORES:
-    //   return ['https://alfajores-forno.celo-testnet.org']
     case SupportedChainId.GNOSIS_CHAIN:
       return ['https://rpc.gnosischain.com/']
     default:


### PR DESCRIPTION
# Summary

![image](https://user-images.githubusercontent.com/7122625/211573604-a77e4807-6937-4b62-9ba5-6bb20d05a5a9.png)

The old (https://rpc.gnosischain.com/) Gnosis chain RPC endpoint is not stable and gets down sometimes.
Corresponding to https://docs.gnosischain.com/tools/rpc/#gateway we should https://rpc.gnosis.gateway.fm endpoint, because it provides a high-availability public RPC as part of their Core Contributor agreement in [GIP-70].


  # To Test

1. Connect any wallet to `Gnosis chain` via `Walletconnect`
2. Wait 1-2 minutes
3. AR: Balances disappears, lots of errors in the console
4. ER: No huge errors in the console, balances are displayed well
