### PR TITLE
#1841/Do not reset page number if there are no orders to be loaded

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/OrdersWidget/hooks/useValidatePageUrlParams.ts
+++ b/src/cow-react/modules/limitOrders/containers/OrdersWidget/hooks/useValidatePageUrlParams.ts
@@ -14,7 +14,9 @@ export function useValidatePageUrlParams(orders: Order[], currentTabId: string, 
     const params = parseLimitOrdersPageParams(location.search)
 
     const shouldResetPageNumber =
-      currentPageNumber > pagesCount || currentPageNumber < 1 || currentPageNumber !== params.pageNumber
+      (pagesCount > 0 && currentPageNumber > pagesCount) ||
+      currentPageNumber < 1 ||
+      currentPageNumber !== params.pageNumber
     const shouldResetTabId = currentTabId !== params.tabId
 
     if (shouldResetPageNumber || shouldResetTabId) {


### PR DESCRIPTION
# Summary

Closes #1841 

  # To Test

1. On limit orders, load token https://etherscan.io/token/0x2E2A42fbE7C7E2FfC031BAF7442dBE1F8957770a
* The app should NOT crash