### PR TITLE
Consistent fee/numbers layout for fee tooltip

### DIFF
--- a/src/cow-react/constants/format.ts
+++ b/src/cow-react/constants/format.ts
@@ -1,0 +1,1 @@
+export const DECIMAL_SEPARATOR = '.'

--- a/src/cow-react/modules/swap/pure/ReceiveAmountInfo/index.tsx
+++ b/src/cow-react/modules/swap/pure/ReceiveAmountInfo/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import * as styledEl from './styled'
+import { Box, GreenText, TextAmount, Column } from './styled'
 import { ReceiveAmountInfo } from '@cow/modules/swap/helpers/tradeReceiveAmount'
 import { Currency } from '@uniswap/sdk-core'
 import { BalanceAndSubsidy } from 'hooks/useCowBalanceAndSubsidy'
@@ -29,50 +29,62 @@ export function ReceiveAmountInfoTooltip(props: ReceiveAmountInfoTooltipProps) {
   )
 
   return (
-    <styledEl.Box>
-      <div>
+    <Box>
+      <Column>
         <span>
           <Trans>Before fee</Trans>
         </span>
-        <span>
-          {amountBeforeFees} {currency.symbol}
-        </span>
-      </div>
-      <div>
-        {discount ? <styledEl.GreenText>{FeePercent}</styledEl.GreenText> : FeePercent}
+        <TextAmount>
+          {/* // Split amountBeforeFees string into integers and decimals to style them differently (e.g. 1.2345 -> 1.23 45)  */}
+          <span>{amountBeforeFees.split('.')[0]}</span>
+          <span>.</span>
+          <span>{amountBeforeFees.split('.')[1]}</span>
+          <span>{currency.symbol}</span>
+        </TextAmount>
+      </Column>
+      <Column>
+        {discount ? <GreenText>{FeePercent}</GreenText> : FeePercent}
         {hasFee ? (
-          <span>
-            {typeString}
-            {feeAmount} {currency.symbol}
-          </span>
+          <TextAmount>
+            <span>
+              {typeString}
+              {feeAmount.split('.')[0]}
+            </span>
+            <span>.</span>
+            <span>{feeAmount.split('.')[1]}</span>
+            <span>{currency.symbol}</span>
+          </TextAmount>
         ) : (
-          <styledEl.GreenText>
+          <GreenText>
             <strong>
               <Trans>Free</Trans>
             </strong>
-          </styledEl.GreenText>
+          </GreenText>
         )}
-      </div>
+      </Column>
       {allowsOffchainSigning && (
-        <div>
+        <Column>
           <span>
             <Trans>Gas cost</Trans>
           </span>
-          <styledEl.GreenText>
+          <GreenText>
             <strong>
               <Trans>Free</Trans>
             </strong>
-          </styledEl.GreenText>
-        </div>
+          </GreenText>
+        </Column>
       )}
-      <styledEl.TotalAmount>
+      <Column isTotal={true}>
         <span>
           <Trans>{type === 'from' ? 'From' : 'To'}</Trans>
         </span>
-        <span>
-          {amountAfterFees} {currency.symbol}
-        </span>
-      </styledEl.TotalAmount>
-    </styledEl.Box>
+        <TextAmount>
+          <span>{amountAfterFees.split('.')[0]}</span>
+          <span>.</span>
+          <span>{amountAfterFees.split('.')[1]}</span>
+          <span>{currency.symbol}</span>
+        </TextAmount>
+      </Column>
+    </Box>
   )
 }

--- a/src/cow-react/modules/swap/pure/ReceiveAmountInfo/index.tsx
+++ b/src/cow-react/modules/swap/pure/ReceiveAmountInfo/index.tsx
@@ -4,6 +4,26 @@ import { ReceiveAmountInfo } from '@cow/modules/swap/helpers/tradeReceiveAmount'
 import { Currency } from '@uniswap/sdk-core'
 import { BalanceAndSubsidy } from 'hooks/useCowBalanceAndSubsidy'
 import { Trans } from '@lingui/macro'
+import { DECIMAL_SEPARATOR } from '@cow/constants/format'
+import { decomposeDecimal } from '@cow/utils/number'
+
+const EXACT_DECIMALS = 4
+
+function DecimalAmount(props: { prefix?: string; value: string; symbol?: string }) {
+  const { prefix, value, symbol } = props
+  const [integerPart, decimalPart] = decomposeDecimal(value, EXACT_DECIMALS)
+  return (
+    <TextAmount>
+      <span>
+        {prefix ? prefix + ' ' : ''}
+        {integerPart}
+      </span>
+      <span>{DECIMAL_SEPARATOR}</span>
+      <span>{decimalPart}</span>
+      <span>{symbol}</span>
+    </TextAmount>
+  )
+}
 
 export interface ReceiveAmountInfoTooltipProps {
   receiveAmountInfo: ReceiveAmountInfo
@@ -34,26 +54,12 @@ export function ReceiveAmountInfoTooltip(props: ReceiveAmountInfoTooltipProps) {
         <span>
           <Trans>Before fee</Trans>
         </span>
-        <TextAmount>
-          {/* // Split amountBeforeFees string into integers and decimals to style them differently (e.g. 1.2345 -> 1.23 45)  */}
-          <span>{amountBeforeFees.split('.')[0]}</span>
-          <span>.</span>
-          <span>{amountBeforeFees.split('.')[1]}</span>
-          <span>{currency.symbol}</span>
-        </TextAmount>
+        <DecimalAmount value={amountBeforeFees} symbol={currency.symbol} />
       </Column>
       <Column>
         {discount ? <GreenText>{FeePercent}</GreenText> : FeePercent}
         {hasFee ? (
-          <TextAmount>
-            <span>
-              {typeString}
-              {feeAmount.split('.')[0]}
-            </span>
-            <span>.</span>
-            <span>{feeAmount.split('.')[1]}</span>
-            <span>{currency.symbol}</span>
-          </TextAmount>
+          <DecimalAmount prefix={typeString} value={feeAmount} symbol={currency.symbol} />
         ) : (
           <GreenText>
             <strong>
@@ -78,12 +84,7 @@ export function ReceiveAmountInfoTooltip(props: ReceiveAmountInfoTooltipProps) {
         <span>
           <Trans>{type === 'from' ? 'From' : 'To'}</Trans>
         </span>
-        <TextAmount>
-          <span>{amountAfterFees.split('.')[0]}</span>
-          <span>.</span>
-          <span>{amountAfterFees.split('.')[1]}</span>
-          <span>{currency.symbol}</span>
-        </TextAmount>
+        <DecimalAmount value={amountAfterFees} symbol={currency.symbol} />
       </Column>
     </Box>
   )

--- a/src/cow-react/modules/swap/pure/ReceiveAmountInfo/styled.tsx
+++ b/src/cow-react/modules/swap/pure/ReceiveAmountInfo/styled.tsx
@@ -38,7 +38,7 @@ export const GreenText = styled.span`
 export const Column = styled.div<{ isTotal?: boolean }>`
   display: grid;
   grid-template-columns: auto max-content;
-  gap: 16px;
+  gap: 24px;
   border-top: ${({ theme, isTotal }) => (isTotal ? `1px solid ${transparentize(0.7, theme.text1)}` : 'none')};
   font-weight: ${({ theme, isTotal }) => (isTotal ? `bold` : 'normal')};
   padding: ${({ theme, isTotal }) => (isTotal ? `calc(var(--gap) * 2) 0 0` : '0')};

--- a/src/cow-react/modules/swap/pure/ReceiveAmountInfo/styled.tsx
+++ b/src/cow-react/modules/swap/pure/ReceiveAmountInfo/styled.tsx
@@ -1,26 +1,46 @@
 import styled from 'styled-components/macro'
+import { transparentize } from 'polished'
 
 export const Box = styled.div`
-  > div {
-    display: flex;
-    justify-content: space-between;
-    gap: 0.5rem;
-    margin-bottom: 5px;
+  --gap: 4px;
+  display: flex;
+  flex-flow: column wrap;
+  gap: var(--gap);
+`
 
-    > :last-child {
-      text-align: right;
-      margin-bottom: 0;
-    }
+export const TextAmount = styled.span`
+  display: grid;
+  grid-template-columns: 1fr 5px max-content max-content;
+  align-items: center;
+
+  > span {
+    text-align: left;
+  }
+
+  > span:nth-child(1) {
+    text-align: right;
+  }
+
+  > span:nth-child(2) {
+    text-align: center;
+  }
+
+  > span:nth-child(4) {
+    padding: 0 0 0 4px;
   }
 `
 
 export const GreenText = styled.span`
   color: ${({ theme }) => theme.green1};
+  text-align: right;
 `
 
-export const TotalAmount = styled.div`
-  border-top: 1px solid #9191912e;
-  font-weight: bold;
-  margin-top: 8px;
-  padding-top: 8px;
+export const Column = styled.div<{ isTotal?: boolean }>`
+  display: grid;
+  grid-template-columns: auto max-content;
+  gap: 16px;
+  border-top: ${({ theme, isTotal }) => (isTotal ? `1px solid ${transparentize(0.7, theme.text1)}` : 'none')};
+  font-weight: ${({ theme, isTotal }) => (isTotal ? `bold` : 'normal')};
+  padding: ${({ theme, isTotal }) => (isTotal ? `calc(var(--gap) * 2) 0 0` : '0')};
+  margin: ${({ theme, isTotal }) => (isTotal ? `calc(var(--gap) * 2) 0 0` : '0')};
 `

--- a/src/cow-react/utils/number.ts
+++ b/src/cow-react/utils/number.ts
@@ -1,0 +1,18 @@
+import { DECIMAL_SEPARATOR } from '@cow/constants/format'
+
+export function decomposeDecimal(decimal: string, exactDecimals?: number): [string, string] {
+  const [integerPart, decimalPart] = decimal.split(DECIMAL_SEPARATOR)
+
+  // If we asked for the exactDecimals and the decimal part does not match that...
+  if (exactDecimals && decimalPart && decimalPart.length !== exactDecimals) {
+    const dPart =
+      decimalPart.length > exactDecimals
+        ? // If there are more than expected, cut it out
+          decimalPart.slice(0, exactDecimals)
+        : // If there are less than expected, pad it with 0s
+          decimalPart + '0'.repeat(exactDecimals - decimalPart.length)
+    return [integerPart, dPart]
+  }
+
+  return [integerPart, decimalPart]
+}

--- a/src/custom/components/QuestionHelper/QuestionHelperMod.tsx
+++ b/src/custom/components/QuestionHelper/QuestionHelperMod.tsx
@@ -48,7 +48,7 @@ export default function QuestionHelper({ text, className, QuestionMark, ...toolt
   const [show, setShow] = useState<boolean>(false)
 
   const open = useCallback(() => setShow(true), [setShow])
-  const close = useCallback(() => setShow(false), [setShow])
+  const close = useCallback(() => setShow(true), [setShow])
 
   return (
     <QuestionHelperContainer className={className}>

--- a/src/custom/components/QuestionHelper/QuestionHelperMod.tsx
+++ b/src/custom/components/QuestionHelper/QuestionHelperMod.tsx
@@ -48,7 +48,7 @@ export default function QuestionHelper({ text, className, QuestionMark, ...toolt
   const [show, setShow] = useState<boolean>(false)
 
   const open = useCallback(() => setShow(true), [setShow])
-  const close = useCallback(() => setShow(true), [setShow])
+  const close = useCallback(() => setShow(false), [setShow])
 
   return (
     <QuestionHelperContainer className={className}>

--- a/src/custom/components/Tooltip/TooltipMod.tsx
+++ b/src/custom/components/Tooltip/TooltipMod.tsx
@@ -6,7 +6,8 @@ import Popover, { PopoverProps } from 'components/Popover'
 
 const TooltipContainer = styled.div`
   max-width: 256px;
-  padding: 0.6rem 1rem;
+  /* padding: 0.6rem 1rem; */
+  padding: 6px 10px; // MOD
   font-weight: 400;
   word-break: break-word;
 

--- a/src/custom/lib/utils/tryParseCurrencyAmount.ts
+++ b/src/custom/lib/utils/tryParseCurrencyAmount.ts
@@ -1,3 +1,5 @@
+import { DECIMAL_SEPARATOR } from '@cow/constants/format'
+import { decomposeDecimal } from '@cow/utils/number'
 import { parseUnits } from '@ethersproject/units'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import JSBI from 'jsbi'
@@ -14,8 +16,8 @@ export default function tryParseCurrencyAmount<T extends Currency>(
     return undefined
   }
   try {
-    const [quotient, remainder] = value.split('.')
-    const fixedNumber = remainder ? quotient + '.' + remainder.slice(0, currency.decimals) : quotient
+    const [quotient, remainder] = decomposeDecimal(value)
+    const fixedNumber = remainder ? quotient + DECIMAL_SEPARATOR + remainder.slice(0, currency.decimals) : quotient
     const typedValueParsed = parseUnits(fixedNumber, currency.decimals).toString()
     if (typedValueParsed !== '0') {
       return CurrencyAmount.fromRawAmount(currency, JSBI.BigInt(typedValueParsed))

--- a/src/state/mint/v3/utils.ts
+++ b/src/state/mint/v3/utils.ts
@@ -1,3 +1,4 @@
+import { decomposeDecimal } from '@cow/utils/number'
 import { Price, Token } from '@uniswap/sdk-core'
 import {
   encodeSqrtRatioX96,
@@ -18,7 +19,7 @@ export function tryParsePrice(baseToken?: Token, quoteToken?: Token, value?: str
     return undefined
   }
 
-  const [whole, fraction] = value.split('.')
+  const [whole, fraction] = decomposeDecimal(value)
 
   const decimals = fraction?.length ?? 0
   const withoutDecimals = JSBI.BigInt((whole ?? '') + (fraction ?? ''))


### PR DESCRIPTION
# Summary

- Addresses https://github.com/cowprotocol/cowswap/issues/1794


## Some important notes:
 - Currently the integer and decimals are retrieved by using `.split('.')` on the `string`. I think it would be better to pass it as a prop. Need a review here.
- The current layout will not work if the decimal count are NOT consistently the same. E.g. we need to have the same amount of decimals for all decimals. Need some assistance here.


## Demo

https://user-images.githubusercontent.com/31534717/212090327-c0e849ca-f685-407b-891b-75eac0a9647b.mov




