### PR TITLE
Remove duplicates from inactive tokens lists in Currency search modal

### DIFF
--- a/src/custom/components/SearchModal/CurrencyList/CurrencyListMod.tsx
+++ b/src/custom/components/SearchModal/CurrencyList/CurrencyListMod.tsx
@@ -121,6 +121,7 @@ function CurrencyRow({
   showCurrencyAmount,
   eventProperties,
   isUnsupported, // gp-swap added
+  allTokens,
   TokenTagsComponent = TokenTags, // gp-swap added
   BalanceComponent = Balance, // gp-swap added
 }: {
@@ -132,12 +133,12 @@ function CurrencyRow({
   showCurrencyAmount?: boolean
   eventProperties: Record<string, unknown>
   isUnsupported: boolean // gp-added
+  allTokens: { [address: string]: Token } // gp-added
   BalanceComponent?: (params: { balance: CurrencyAmount<Currency> }) => JSX.Element // gp-swap added
   TokenTagsComponent?: (params: { currency: Currency; isUnsupported: boolean }) => JSX.Element // gp-swap added
 }) {
   const { account } = useWeb3React()
   const key = currencyKey(currency)
-  const allTokens = useAllTokens()
   const isOnSelectedList = currency?.isToken && !!allTokens[currency.address.toLowerCase()]
   const customAdded = useIsUserAddedToken(currency)
   const balance = useCurrencyBalance(account ?? undefined, currency)
@@ -273,14 +274,19 @@ export default function CurrencyList({
   BalanceComponent?: (params: { balance: CurrencyAmount<Currency> }) => JSX.Element // gp-swap added
   TokenTagsComponent?: (params: { currency: Currency; isUnsupported: boolean }) => JSX.Element // gp-swap added
 }) {
+  const allTokens = useAllTokens()
   const isUnsupportedToken = useIsUnsupportedTokenGp()
 
   const itemData: (Currency | BreakLine)[] = useMemo(() => {
     if (otherListTokens && otherListTokens?.length > 0) {
-      return [...currencies, BREAK_LINE, ...otherListTokens]
+      const filteredOtherListTokens = otherListTokens.filter((token) =>
+        token.isToken ? !allTokens[token.address.toLowerCase()] : true
+      )
+
+      return [...currencies, BREAK_LINE, ...filteredOtherListTokens]
     }
     return currencies
-  }, [currencies, otherListTokens])
+  }, [currencies, otherListTokens, allTokens])
 
   const Row = useCallback(
     function TokenRow({ data, index, style }: TokenRowProps) {
@@ -318,6 +324,7 @@ export default function CurrencyList({
         return (
           <CurrencyRow
             style={style}
+            allTokens={allTokens}
             currency={currency}
             isSelected={isSelected}
             onSelect={handleSelect}
@@ -347,6 +354,7 @@ export default function CurrencyList({
       isUnsupportedToken,
       BalanceComponent,
       TokenTagsComponent,
+      allTokens,
     ]
   )
 


### PR DESCRIPTION
# Summary

Fixes #1864

Before the fix, `otherListTokens` included tokens from the main list and it created conflicts (because tokens have the same address and it used as a key in list)

<img width="543" alt="image" src="https://user-images.githubusercontent.com/7122625/212277374-3a39c266-6a48-4a53-badf-aae0f0ff064b.png">

