### PR TITLE
Additionally compare chainId in URL and in provider for trade state updates

### DIFF
--- a/src/cow-react/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
+++ b/src/cow-react/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
@@ -48,7 +48,7 @@ function shouldSkipUpdate(tradeStateFromUrl: TradeState, tradeStateFromStore: Tr
   return chainIdIsNotChanged && recipientIsNotChanged && inputCurrencyIsNotChanged && outputCurrencyIsNotChanged
 }
 
-function compareChainIds(aChainId: Nullish<number>, bChainId: Nullish<number>): boolean {
+function areChainIdsTheSame(aChainId: Nullish<number>, bChainId: Nullish<number>): boolean {
   return !!aChainId && !!bChainId && aChainId !== bChainId
 }
 
@@ -63,9 +63,9 @@ export function useSetupTradeState(): void {
   const prevChainIdFromUrl = usePrevious(chainIdFromUrl)
   const prevCurrentChainId = usePrevious(currentChainId)
 
-  const chainIdFromUrlWasChanged = compareChainIds(chainIdFromUrl, prevChainIdFromUrl)
+  const chainIdFromUrlWasChanged = areChainIdsTheSame(chainIdFromUrl, prevChainIdFromUrl)
   const chainIdFromProviderWasChanged =
-    compareChainIds(currentChainId, prevCurrentChainId) || compareChainIds(currentChainId, chainIdFromUrl)
+    areChainIdsTheSame(currentChainId, prevCurrentChainId) || areChainIdsTheSame(currentChainId, chainIdFromUrl)
 
   const skipUpdate = useMemo(() => {
     if (areCurrenciesTheSame(tradeStateFromUrl)) return false

--- a/src/cow-react/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
+++ b/src/cow-react/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
@@ -9,6 +9,7 @@ import { switchChain } from 'utils/switchChain'
 import usePrevious from 'hooks/usePrevious'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { isSupportedChainId } from 'lib/hooks/routing/clientSideSmartOrderRouter'
+import { Nullish } from '@cow/types'
 
 function areCurrenciesTheSame({ inputCurrencyId, outputCurrencyId }: TradeState): boolean {
   if (!inputCurrencyId && !outputCurrencyId) return false
@@ -47,6 +48,10 @@ function shouldSkipUpdate(tradeStateFromUrl: TradeState, tradeStateFromStore: Tr
   return chainIdIsNotChanged && recipientIsNotChanged && inputCurrencyIsNotChanged && outputCurrencyIsNotChanged
 }
 
+function compareChainIds(aChainId: Nullish<number>, bChainId: Nullish<number>): boolean {
+  return !!aChainId && !!bChainId && aChainId !== bChainId
+}
+
 export function useSetupTradeState(): void {
   const { chainId: currentChainId, connector, account } = useWeb3React()
   const [isChainIdSet, setIsChainIdSet] = useState(false)
@@ -58,18 +63,19 @@ export function useSetupTradeState(): void {
   const prevChainIdFromUrl = usePrevious(chainIdFromUrl)
   const prevCurrentChainId = usePrevious(currentChainId)
 
-  const chainIdFromUrlWasChanged = !!chainIdFromUrl && chainIdFromUrl !== prevChainIdFromUrl
-  const providerChainIdWasChanged = !!currentChainId && !!prevCurrentChainId && currentChainId !== prevCurrentChainId
+  const chainIdFromUrlWasChanged = compareChainIds(chainIdFromUrl, prevChainIdFromUrl)
+  const chainIdFromProviderWasChanged =
+    compareChainIds(currentChainId, prevCurrentChainId) || compareChainIds(currentChainId, chainIdFromUrl)
 
   const skipUpdate = useMemo(() => {
     if (areCurrenciesTheSame(tradeStateFromUrl)) return false
 
     if (chainIdFromUrlWasChanged && !!account) return true
 
-    if (providerChainIdWasChanged) return false
+    if (chainIdFromProviderWasChanged) return false
 
     return tradeState ? shouldSkipUpdate(tradeStateFromUrl, tradeState.state) : true
-  }, [tradeState, tradeStateFromUrl, providerChainIdWasChanged, chainIdFromUrlWasChanged, account])
+  }, [tradeState, tradeStateFromUrl, chainIdFromProviderWasChanged, chainIdFromUrlWasChanged, account])
 
   const newChainId = useMemo(() => {
     const providerChainId = currentChainId || SupportedChainId.MAINNET
@@ -79,7 +85,7 @@ export function useSetupTradeState(): void {
 
     if (!account) {
       // When wallet is not connected and network was changed in the provider, then use chainId from provider
-      if (providerChainIdWasChanged) {
+      if (chainIdFromProviderWasChanged) {
         return providerChainId
       } else {
         // When wallet is not connected, then use chainId from URL by priority and fallback to provider's value
@@ -89,13 +95,13 @@ export function useSetupTradeState(): void {
       // When wallet is connected, then always use chainId from provider
       return providerChainId
     }
-  }, [account, providerChainIdWasChanged, chainIdFromUrl, currentChainId])
+  }, [account, chainIdFromProviderWasChanged, chainIdFromUrl, currentChainId])
 
   const updateStateAndNavigate = useCallback(() => {
     if (!tradeState) return
 
     // Reset state to default when chainId was changed in the provider
-    const newState: TradeState = providerChainIdWasChanged
+    const newState: TradeState = chainIdFromProviderWasChanged
       ? getDefaultTradeState(newChainId)
       : {
           chainId: newChainId,
@@ -111,7 +117,7 @@ export function useSetupTradeState(): void {
       inputCurrencyId: newState.inputCurrencyId || null,
       outputCurrencyId: newState.outputCurrencyId || null,
     })
-  }, [tradeNavigate, newChainId, providerChainIdWasChanged, tradeState, tradeStateFromUrl])
+  }, [tradeNavigate, newChainId, chainIdFromProviderWasChanged, tradeState, tradeStateFromUrl])
 
   /**
    * STEP 1

--- a/src/cow-react/types.ts
+++ b/src/cow-react/types.ts
@@ -3,3 +3,5 @@ export type Timestamp = number // Example: 1667981900 === Nov 09 2022 14:18:20
 export type Milliseconds = number // Example: 30000 === 30 sec
 
 export type Writeable<T> = { -readonly [P in keyof T]: T[P] }
+
+export type Nullish<T> = T | null | undefined


### PR DESCRIPTION
# Summary

Fixes #1391, #1717

`useSetupTradeState()` didn't check the case, when `chainId` was changed while changing wallet

  # To Test

1. Connect to Metamask on Gnosis chain
2. Click `Change wallet` in the Account modal
3. Connect via Walletconnect to a wallet that doesn't support Gnosis chain (Trust for example)
- [ ] AR: Wallet provider uses Mainnet, but the URL still contain Gnosis chain id
- [ ] ER: ChainId in the URL was changed corresponding to provider's chainId