### PR TITLE
#874/Changed gchain explorer path from older `xdai` to current `gc`

### DIFF
--- a/src/custom/utils/explorer.ts
+++ b/src/custom/utils/explorer.ts
@@ -18,7 +18,7 @@ function _getExplorerUrlByEnvironment() {
   return {
     [ChainId.MAINNET]: baseUrl,
     [ChainId.GOERLI]: `${baseUrl}/goerli`,
-    [ChainId.GNOSIS_CHAIN]: `${baseUrl}/xdai`,
+    [ChainId.GNOSIS_CHAIN]: `${baseUrl}/gc`,
   }
 }
 


### PR DESCRIPTION
# Summary

Closes #874

# To Test

1. Connect wallet to gchain
2. Check the explorer links
* It should point to `<<explorer>>/gc` instead of `<<explorer>>/xdai`