### PR TITLE
Fix 1794c

### DIFF
--- a/src/cow-react/modules/swap/pure/ReceiveAmountInfo/index.tsx
+++ b/src/cow-react/modules/swap/pure/ReceiveAmountInfo/index.tsx
@@ -57,7 +57,7 @@ export function ReceiveAmountInfoTooltip(props: ReceiveAmountInfoTooltipProps) {
       <Column>
         {discount ? <GreenText>{FeePercent}</GreenText> : FeePercent}
         {hasFee ? (
-          <DecimalAmount prefix={typeString} value={amountBeforeFees} symbol={currency.symbol} />
+          <DecimalAmount prefix={typeString} value={feeAmount} symbol={currency.symbol} />
         ) : (
           <GreenText>
             <strong>

--- a/src/cow-react/modules/swap/pure/ReceiveAmountInfo/index.tsx
+++ b/src/cow-react/modules/swap/pure/ReceiveAmountInfo/index.tsx
@@ -7,9 +7,11 @@ import { Trans } from '@lingui/macro'
 import { DECIMAL_SEPARATOR } from '@cow/constants/format'
 import { decomposeDecimal } from '@cow/utils/number'
 
+const EXACT_DECIMALS = 4
+
 function DecimalAmount(props: { prefix?: string; value: string; symbol?: string }) {
   const { prefix, value, symbol } = props
-  const [integerPart, decimalPart] = decomposeDecimal(value)
+  const [integerPart, decimalPart] = decomposeDecimal(value, EXACT_DECIMALS)
   return (
     <TextAmount>
       <span>

--- a/src/cow-react/utils/number.ts
+++ b/src/cow-react/utils/number.ts
@@ -1,7 +1,18 @@
 import { DECIMAL_SEPARATOR } from '@cow/constants/format'
 
-export function decomposeDecimal(decimal: string): [string, string] {
+export function decomposeDecimal(decimal: string, exactDecimals?: number): [string, string] {
   const [integerPart, decimalPart] = decimal.split(DECIMAL_SEPARATOR)
+
+  // If we asked for the exactDecimals and the decimal part does not match that...
+  if (exactDecimals && decimalPart && decimalPart.length !== exactDecimals) {
+    const dPart =
+      decimalPart.length > exactDecimals
+        ? // If there are more than expected, cut it out
+          decimalPart.slice(0, exactDecimals)
+        : // If there are less than expected, pad it with 0s
+          decimalPart + '0'.repeat(exactDecimals - decimalPart.length)
+    return [integerPart, dPart]
+  }
 
   return [integerPart, decimalPart]
 }


### PR DESCRIPTION
# Summary

Fix on top of https://github.com/cowprotocol/cowswap/pull/1862

1. Forcing 4 decimals for fee tooltip, padding with `0` when less than 4
2. Fixing bug with fee amount display

![Screenshot 2023-01-13 at 15 37 41](https://user-images.githubusercontent.com/43217/212360227-f18cfbb4-b441-4f0a-972c-cc0133f6fe3d.png)
