### PR TITLE
Replace useIsTradeUnsupported() by state from limitOrdersQuoteAtom for Limit orders

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/TradeButtons/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/TradeButtons/index.tsx
@@ -21,7 +21,7 @@ import OperatorError from '@cow/api/gnosisProtocol/errors/OperatorError'
 import { CompatibilityIssuesWarning } from '@cow/modules/trade/pure/CompatibilityIssuesWarning'
 import { useWalletInfo } from 'hooks/useWalletInfo'
 import styled from 'styled-components/macro'
-import { useIsTradeUnsupported } from 'state/lists/hooks/hooksMod'
+import { isUnsupportedTokenInQuote } from '@cow/modules/limitOrders/utils/isUnsupportedTokenInQuote'
 
 const CompatibilityIssuesWarningWrapper = styled.div`
   margin-top: -10px;
@@ -50,7 +50,7 @@ export function TradeButtons(props: TradeButtonsProps) {
   const { handleSetError, ErrorModal } = useErrorModal()
   const { isSupportedWallet } = useWalletInfo()
   const { inputCurrency, outputCurrency } = tradeState
-  const isSwapUnsupported = useIsTradeUnsupported(inputCurrency, outputCurrency)
+  const isSwapUnsupported = isUnsupportedTokenInQuote(quote)
 
   const wrapUnwrapParams: WrapUnwrapParams = {
     isNativeIn: !!inputCurrencyAmount?.currency.isNative,

--- a/src/cow-react/modules/limitOrders/hooks/useLimitOrdersFormState.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useLimitOrdersFormState.ts
@@ -14,7 +14,7 @@ import { useAtomValue } from 'jotai/utils'
 import { limitOrdersQuoteAtom, LimitOrdersQuoteState } from '@cow/modules/limitOrders/state/limitOrdersQuoteAtom'
 import { limitRateAtom } from '@cow/modules/limitOrders/state/limitRateAtom'
 import { useDetectNativeToken } from '@cow/modules/swap/hooks/useDetectNativeToken'
-import { useIsTradeUnsupported } from 'state/lists/hooks/hooksMod'
+import { isUnsupportedTokenInQuote } from '@cow/modules/limitOrders/utils/isUnsupportedTokenInQuote'
 
 export enum LimitOrdersFormState {
   NotApproved = 'NotApproved',
@@ -157,7 +157,7 @@ export function useLimitOrdersFormState(): LimitOrdersFormState {
   const { activeRate, isLoading } = useAtomValue(limitRateAtom)
   const { isWrapOrUnwrap } = useDetectNativeToken()
 
-  const { inputCurrency, outputCurrency, recipient } = tradeState
+  const { inputCurrency, recipient } = tradeState
   const sellAmount = tradeState.inputCurrencyAmount
   const buyAmount = tradeState.outputCurrencyAmount
   const sellToken = inputCurrency?.isToken ? inputCurrency : undefined
@@ -165,7 +165,7 @@ export function useLimitOrdersFormState(): LimitOrdersFormState {
 
   const currentAllowance = useTokenAllowance(sellToken, account ?? undefined, spender)
   const approvalState = useTradeApproveState(sellAmount)
-  const isSwapUnsupported = useIsTradeUnsupported(inputCurrency, outputCurrency)
+  const isSwapUnsupported = isUnsupportedTokenInQuote(quote)
   const { address: recipientEnsAddress } = useENSAddress(recipient)
 
   const params: LimitOrdersFormParams = {

--- a/src/cow-react/modules/limitOrders/utils/isUnsupportedTokenInQuote.ts
+++ b/src/cow-react/modules/limitOrders/utils/isUnsupportedTokenInQuote.ts
@@ -1,0 +1,6 @@
+import { LimitOrdersQuoteState } from '@cow/modules/limitOrders/state/limitOrdersQuoteAtom'
+import { GpQuoteErrorCodes } from '@cow/api/gnosisProtocol/errors/QuoteError'
+
+export function isUnsupportedTokenInQuote(state: LimitOrdersQuoteState): boolean {
+  return state.error?.type === GpQuoteErrorCodes.UnsupportedToken
+}


### PR DESCRIPTION
# Summary

Fixes #1872

`useIsTradeUnsupported()` is not appropriate to Limit orders, because it's coupled with `useRefetchQuoteCallback()` that in turn is unrelated to Limit orders.
Because of it, the unsupported check was changed and now it's based on `limitOrdersQuoteAtom`.

![image](https://user-images.githubusercontent.com/7122625/212457617-c700d271-a773-40f8-8e8c-b1c70bbae568.png)


  # To Test
1. Connect to a wallet on GC
2. Open Limit orders page
3. Select WXDAI-AST token pair
4. Fill in the amount
