### PR TITLE
Long token symbols layout updates

### DIFF
--- a/src/cow-react/common/containers/TradeApprove/TradeApproveWidget.tsx
+++ b/src/cow-react/common/containers/TradeApprove/TradeApproveWidget.tsx
@@ -2,7 +2,7 @@ import { useAtom } from 'jotai'
 import { tradeApproveStateAtom } from './tradeApproveStateAtom'
 import TransactionConfirmationModal, { OperationType } from 'components/TransactionConfirmationModal'
 import React from 'react'
-import { formatSymbol } from '@cow/utils/format'
+import { TokenSymbol } from '@cow/common/pure/TokenSymbol'
 
 export function TradeApproveWidget() {
   const [{ approveInProgress, currency }, setState] = useAtom(tradeApproveStateAtom)
@@ -12,7 +12,7 @@ export function TradeApproveWidget() {
       isOpen={approveInProgress}
       operationType={OperationType.APPROVE_TOKEN}
       currencyToAdd={currency}
-      pendingText={`Approving ${formatSymbol(currency?.symbol)} for trading`}
+      pendingText={`Approving ${(<TokenSymbol token={currency} />)} for trading`}
       onDismiss={() => setState({ currency, approveInProgress: false })}
       attemptingTxn={true}
     />

--- a/src/cow-react/common/containers/TradeApprove/TradeApproveWidget.tsx
+++ b/src/cow-react/common/containers/TradeApprove/TradeApproveWidget.tsx
@@ -2,6 +2,7 @@ import { useAtom } from 'jotai'
 import { tradeApproveStateAtom } from './tradeApproveStateAtom'
 import TransactionConfirmationModal, { OperationType } from 'components/TransactionConfirmationModal'
 import React from 'react'
+import { TokenSymbol } from '@cow/common/pure/TokenSymbol'
 
 export function TradeApproveWidget() {
   const [{ approveInProgress, currency }, setState] = useAtom(tradeApproveStateAtom)
@@ -11,7 +12,7 @@ export function TradeApproveWidget() {
       isOpen={approveInProgress}
       operationType={OperationType.APPROVE_TOKEN}
       currencyToAdd={currency}
-      pendingText={`Approving ${currency?.symbol} for trading`}
+      pendingText={`Approving ${(<TokenSymbol token={currency} />)} for trading`}
       onDismiss={() => setState({ currency, approveInProgress: false })}
       attemptingTxn={true}
     />

--- a/src/cow-react/common/containers/TradeApprove/TradeApproveWidget.tsx
+++ b/src/cow-react/common/containers/TradeApprove/TradeApproveWidget.tsx
@@ -2,7 +2,7 @@ import { useAtom } from 'jotai'
 import { tradeApproveStateAtom } from './tradeApproveStateAtom'
 import TransactionConfirmationModal, { OperationType } from 'components/TransactionConfirmationModal'
 import React from 'react'
-import { TokenSymbol } from '@cow/common/pure/TokenSymbol'
+import { formatSymbol } from '@cow/utils/format'
 
 export function TradeApproveWidget() {
   const [{ approveInProgress, currency }, setState] = useAtom(tradeApproveStateAtom)
@@ -12,7 +12,7 @@ export function TradeApproveWidget() {
       isOpen={approveInProgress}
       operationType={OperationType.APPROVE_TOKEN}
       currencyToAdd={currency}
-      pendingText={`Approving ${(<TokenSymbol token={currency} />)} for trading`}
+      pendingText={`Approving ${formatSymbol(currency?.symbol)} for trading`}
       onDismiss={() => setState({ currency, approveInProgress: false })}
       attemptingTxn={true}
     />

--- a/src/cow-react/common/helpers/pendingOrderSummary.ts
+++ b/src/cow-react/common/helpers/pendingOrderSummary.ts
@@ -1,6 +1,7 @@
 import { Order, OrderKind } from 'state/orders/actions'
 import { formatSmartAmount } from '@cow/utils/format'
 import { CurrencyAmount } from '@uniswap/sdk-core'
+import { formatSymbol } from '@cow/utils/format'
 
 export function pendingOrderSummary(order: Order): string {
   const { kind, buyAmount, sellAmount, inputToken, outputToken, feeAmount } = order
@@ -13,7 +14,7 @@ export function pendingOrderSummary(order: Order): string {
   )
   const outputAmount = CurrencyAmount.fromRawAmount(outputToken, buyAmount.toString())
 
-  return `Swap ${inputPrefix}${formatSmartAmount(inputAmount)} ${
+  return `Swap ${inputPrefix}${formatSmartAmount(inputAmount)} ${formatSymbol(
     inputAmount.currency.symbol
-  } for ${outputPrefix}${formatSmartAmount(outputAmount)} ${outputAmount.currency.symbol}`
+  )} for ${outputPrefix}${formatSmartAmount(outputAmount)} ${formatSymbol(outputAmount.currency.symbol)}`
 }

--- a/src/cow-react/common/pure/ApproveButton/index.tsx
+++ b/src/cow-react/common/pure/ApproveButton/index.tsx
@@ -10,7 +10,7 @@ import { useContext, useMemo } from 'react'
 import { Currency } from '@uniswap/sdk-core'
 import { ThemeContext } from 'styled-components/macro'
 import { ApprovalState } from 'hooks/useApproveCallback'
-import { formatSymbol } from '@cow/utils/format'
+import { TokenSymbol } from '@cow/common/pure/TokenSymbol'
 
 export interface ApproveButtonProps {
   currency: Currency | undefined | null
@@ -22,7 +22,6 @@ export function ApproveButton(props: ApproveButtonProps) {
   const { currency, state, onClick } = props
 
   const theme = useContext(ThemeContext)
-  const symbol = formatSymbol(currency?.symbol)
   const isPending = state === ApprovalState.PENDING
   const isConfirmed = state === ApprovalState.APPROVED
   const disabled = state !== ApprovalState.NOT_APPROVED
@@ -31,7 +30,9 @@ export function ApproveButton(props: ApproveButtonProps) {
     if (isConfirmed) {
       return (
         <>
-          <Trans>You can now trade {symbol}</Trans>
+          <Trans>
+            You can now trade <TokenSymbol token={currency} />
+          </Trans>
           <CheckCircle size="24" color={theme.text1} />
         </>
       )
@@ -39,12 +40,14 @@ export function ApproveButton(props: ApproveButtonProps) {
       return (
         <>
           {/* we need to shorten this string on mobile */}
-          <Trans>Allow CoW Swap to use your {symbol}</Trans>
+          <Trans>
+            Allow CoW Swap to use your <TokenSymbol token={currency} />
+          </Trans>
           <MouseoverTooltip
             text={
               <Trans>
-                You must give the CoW Protocol smart contracts permission to use your {symbol}. You only have to do this
-                once per token.
+                You must give the CoW Protocol smart contracts permission to use your <TokenSymbol token={currency} />.
+                You only have to do this once per token.
               </Trans>
             }
           >
@@ -53,7 +56,7 @@ export function ApproveButton(props: ApproveButtonProps) {
         </>
       )
     }
-  }, [symbol, theme, isPending, isConfirmed])
+  }, [currency, theme, isPending, isConfirmed])
 
   return (
     <ButtonConfirmed

--- a/src/cow-react/common/pure/ApproveButton/index.tsx
+++ b/src/cow-react/common/pure/ApproveButton/index.tsx
@@ -10,6 +10,7 @@ import { useContext, useMemo } from 'react'
 import { Currency } from '@uniswap/sdk-core'
 import { ThemeContext } from 'styled-components/macro'
 import { ApprovalState } from 'hooks/useApproveCallback'
+import { formatSymbol } from '@cow/utils/format'
 
 export interface ApproveButtonProps {
   currency: Currency | undefined | null
@@ -21,7 +22,7 @@ export function ApproveButton(props: ApproveButtonProps) {
   const { currency, state, onClick } = props
 
   const theme = useContext(ThemeContext)
-  const symbol = currency?.symbol
+  const symbol = formatSymbol(currency?.symbol)
   const isPending = state === ApprovalState.PENDING
   const isConfirmed = state === ApprovalState.APPROVED
   const disabled = state !== ApprovalState.NOT_APPROVED

--- a/src/cow-react/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
+++ b/src/cow-react/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
@@ -139,8 +139,7 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
             {balance && !disabled && (
               <>
                 <styledEl.BalanceText title={balance.toExact() + ' ' + formatSymbol(currency?.symbol)}>
-                  <Trans>Balance</Trans>: {formatSmartAmount(balance) || '0'}{' '}
-                  <TokenSymbol token={currency} maxLength={40} />
+                  <Trans>Balance</Trans>: {formatSmartAmount(balance) || '0'} <TokenSymbol token={currency} />
                   {showSetMax && balance.greaterThan(0) && (
                     <styledEl.SetMaxBtn onClick={handleMaxInput}>Max</styledEl.SetMaxBtn>
                   )}

--- a/src/cow-react/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
+++ b/src/cow-react/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
@@ -17,6 +17,7 @@ import { isSupportedChainId } from 'lib/hooks/routing/clientSideSmartOrderRouter
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { MouseoverTooltip } from 'components/Tooltip'
 import { TokenSymbol } from '@cow/common/pure/TokenSymbol'
+import { formatSymbol } from '@cow/utils/format'
 
 interface BuiltItProps {
   className: string
@@ -137,8 +138,9 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
           <div>
             {balance && !disabled && (
               <>
-                <styledEl.BalanceText title={balance.toExact() + ' ' + currency?.symbol}>
-                  <Trans>Balance</Trans>: {formatSmartAmount(balance) || '0'} <TokenSymbol token={currency} />
+                <styledEl.BalanceText title={balance.toExact() + ' ' + formatSymbol(currency?.symbol)}>
+                  <Trans>Balance</Trans>: {formatSmartAmount(balance) || '0'}{' '}
+                  <TokenSymbol token={currency} maxLength={40} />
                   {showSetMax && balance.greaterThan(0) && (
                     <styledEl.SetMaxBtn onClick={handleMaxInput}>Max</styledEl.SetMaxBtn>
                   )}

--- a/src/cow-react/common/pure/CurrencyInputPanel/CurrencyPreview.tsx
+++ b/src/cow-react/common/pure/CurrencyInputPanel/CurrencyPreview.tsx
@@ -6,6 +6,7 @@ import { FiatValue } from 'components/CurrencyInputPanel/FiatValue'
 import { Trans } from '@lingui/macro'
 import { PriceImpact } from 'hooks/usePriceImpact'
 import { CurrencyInfo } from '@cow/common/pure/CurrencyInputPanel/types'
+import { formatSymbol } from '@cow/utils/format'
 
 interface BuiltItProps {
   className: string
@@ -34,7 +35,7 @@ export function CurrencyPreview(props: CurrencyPreviewProps) {
           </div>
           <div>
             <styledEl.NumericalInput
-              title={rawAmount?.toExact() + ' ' + currency?.symbol}
+              title={rawAmount?.toExact() + ' ' + formatSymbol(currency?.symbol)}
               className="token-amount-input"
               readOnly={true}
               value={viewAmount}
@@ -48,8 +49,8 @@ export function CurrencyPreview(props: CurrencyPreviewProps) {
           <div>
             {balance && (
               <>
-                <styledEl.BalanceText title={balance.toExact() + ' ' + currency?.symbol}>
-                  <Trans>Balance</Trans>: {formatSmartAmount(balance) || '0'} {currency?.symbol}
+                <styledEl.BalanceText title={balance.toExact() + ' ' + formatSymbol(currency?.symbol)}>
+                  <Trans>Balance</Trans>: {formatSmartAmount(balance) || '0'} {formatSymbol(currency?.symbol)}
                 </styledEl.BalanceText>
               </>
             )}

--- a/src/cow-react/common/pure/CurrencyInputPanel/CurrencyPreview.tsx
+++ b/src/cow-react/common/pure/CurrencyInputPanel/CurrencyPreview.tsx
@@ -7,6 +7,7 @@ import { Trans } from '@lingui/macro'
 import { PriceImpact } from 'hooks/usePriceImpact'
 import { CurrencyInfo } from '@cow/common/pure/CurrencyInputPanel/types'
 import { formatSymbol } from '@cow/utils/format'
+import { TokenSymbol } from '@cow/common/pure/TokenSymbol'
 
 interface BuiltItProps {
   className: string
@@ -50,7 +51,7 @@ export function CurrencyPreview(props: CurrencyPreviewProps) {
             {balance && (
               <>
                 <styledEl.BalanceText title={balance.toExact() + ' ' + formatSymbol(currency?.symbol)}>
-                  <Trans>Balance</Trans>: {formatSmartAmount(balance) || '0'} {formatSymbol(currency?.symbol)}
+                  <Trans>Balance</Trans>: {formatSmartAmount(balance) || '0'} {<TokenSymbol token={currency} />}
                 </styledEl.BalanceText>
               </>
             )}

--- a/src/cow-react/common/pure/CurrencyInputPanel/styled.tsx
+++ b/src/cow-react/common/pure/CurrencyInputPanel/styled.tsx
@@ -24,7 +24,8 @@ export const Wrapper = styled.div<{ withReceiveAmountInfo: boolean; disabled: bo
 export const CurrencyInputBox = styled.div`
   display: grid;
   width: 100%;
-  grid-template-columns: auto auto;
+  grid-template-columns: repeat(2, auto);
+  word-break: break-all;
   gap: 16px;
   margin: 0;
   font-weight: 400;

--- a/src/cow-react/common/pure/RateInfo/index.cosmos.tsx
+++ b/src/cow-react/common/pure/RateInfo/index.cosmos.tsx
@@ -4,6 +4,7 @@ import { CurrencyAmount, Token } from '@uniswap/sdk-core'
 import { COW, GNO } from 'constants/tokens'
 import { SupportedChainId } from 'constants/chains'
 import styled from 'styled-components/macro'
+import { formatSymbol } from '@cow/utils/format'
 
 const inputCurrency = WETH_GOERLI
 const outputCurrency = DAI_GOERLI
@@ -83,9 +84,9 @@ function SmartQuoteSelection() {
               return (
                 <Box key={i}>
                   <p>
-                    {inputCurrencyAmount?.toExact()} {inputCurrencyAmount?.currency.symbol}
+                    {inputCurrencyAmount?.toExact()} {formatSymbol(inputCurrencyAmount?.currency.symbol)}
                     {' -> '}
-                    {outputCurrencyAmount?.toExact()} {outputCurrencyAmount?.currency.symbol}{' '}
+                    {outputCurrencyAmount?.toExact()} {formatSymbol(outputCurrencyAmount?.currency.symbol)}{' '}
                   </p>
                   <RateInfo noLabel={true} rateInfoParams={rate} />
                 </Box>

--- a/src/cow-react/common/pure/RateInfo/index.cosmos.tsx
+++ b/src/cow-react/common/pure/RateInfo/index.cosmos.tsx
@@ -4,7 +4,7 @@ import { CurrencyAmount, Token } from '@uniswap/sdk-core'
 import { COW, GNO } from 'constants/tokens'
 import { SupportedChainId } from 'constants/chains'
 import styled from 'styled-components/macro'
-import { formatSymbol } from '@cow/utils/format'
+import { TokenSymbol } from '@cow/common/pure/TokenSymbol'
 
 const inputCurrency = WETH_GOERLI
 const outputCurrency = DAI_GOERLI
@@ -84,9 +84,9 @@ function SmartQuoteSelection() {
               return (
                 <Box key={i}>
                   <p>
-                    {inputCurrencyAmount?.toExact()} {formatSymbol(inputCurrencyAmount?.currency.symbol)}
+                    {inputCurrencyAmount?.toExact()} {<TokenSymbol token={inputCurrencyAmount?.currency} />}
                     {' -> '}
-                    {outputCurrencyAmount?.toExact()} {formatSymbol(outputCurrencyAmount?.currency.symbol)}{' '}
+                    {outputCurrencyAmount?.toExact()} {<TokenSymbol token={outputCurrencyAmount?.currency} />}{' '}
                   </p>
                   <RateInfo noLabel={true} rateInfoParams={rate} />
                 </Box>

--- a/src/cow-react/common/pure/RateInfo/index.tsx
+++ b/src/cow-react/common/pure/RateInfo/index.tsx
@@ -58,6 +58,8 @@ const InvertIcon = styled.div`
   color: ${({ theme }) => theme.text1};
   width: var(--size);
   height: var(--size);
+  min-width: var(--size);
+  min-height: var(--size);
   border-radius: var(--size);
   display: flex;
   align-items: center;
@@ -84,7 +86,7 @@ const RateWrapper = styled.button`
   color: inherit;
   font-size: 13px;
   letter-spacing: -0.1px;
-  text-align: left;
+  text-align: right;
   font-weight: 500;
 `
 

--- a/src/cow-react/common/pure/RateInfo/index.tsx
+++ b/src/cow-react/common/pure/RateInfo/index.tsx
@@ -75,7 +75,7 @@ const InvertIcon = styled.div`
   }
 `
 
-const RateWrapper = styled.button`
+export const RateWrapper = styled.button`
   display: inline;
   background: none;
   border: 0;

--- a/src/cow-react/common/pure/TokenSymbol/index.tsx
+++ b/src/cow-react/common/pure/TokenSymbol/index.tsx
@@ -9,9 +9,7 @@ export type Props = {
 export function TokenSymbol({ token, length }: Props) {
   const { symbol, name } = token || {}
 
-  if (!symbol || !name) {
-    return null
-  }
+  if (!symbol && !name) return null
 
   const fullSymbol = symbol || name
   const abbreviateSymbol = formatSymbol(fullSymbol, length)

--- a/src/cow-react/common/pure/TokenSymbol/index.tsx
+++ b/src/cow-react/common/pure/TokenSymbol/index.tsx
@@ -4,16 +4,15 @@ import { Currency } from '@uniswap/sdk-core'
 export type Props = {
   token: Pick<Currency, 'symbol' | 'name'> | undefined | null
   length?: number
-  maxLength?: number
 }
 
-export function TokenSymbol({ token, length, maxLength }: Props) {
+export function TokenSymbol({ token, length }: Props) {
   const { symbol, name } = token || {}
 
   if (!symbol && !name) return null
 
   const fullSymbol = symbol || name
-  const abbreviateSymbol = formatSymbol(fullSymbol, maxLength ? maxLength : length)
+  const abbreviateSymbol = formatSymbol(fullSymbol, length)
 
   return <span title={fullSymbol}>{abbreviateSymbol}</span>
 }

--- a/src/cow-react/common/pure/TokenSymbol/index.tsx
+++ b/src/cow-react/common/pure/TokenSymbol/index.tsx
@@ -13,7 +13,7 @@ export function TokenSymbol({ token, length, maxLength }: Props) {
   if (!symbol && !name) return null
 
   const fullSymbol = symbol || name
-  const abbreviateSymbol = formatSymbol(fullSymbol, length, maxLength)
+  const abbreviateSymbol = formatSymbol(fullSymbol, maxLength ? maxLength : length)
 
   return <span title={fullSymbol}>{abbreviateSymbol}</span>
 }

--- a/src/cow-react/common/pure/TokenSymbol/index.tsx
+++ b/src/cow-react/common/pure/TokenSymbol/index.tsx
@@ -4,15 +4,16 @@ import { Currency } from '@uniswap/sdk-core'
 export type Props = {
   token: Pick<Currency, 'symbol' | 'name'> | undefined | null
   length?: number
+  maxLength?: number
 }
 
-export function TokenSymbol({ token, length }: Props) {
+export function TokenSymbol({ token, length, maxLength }: Props) {
   const { symbol, name } = token || {}
 
   if (!symbol && !name) return null
 
   const fullSymbol = symbol || name
-  const abbreviateSymbol = formatSymbol(fullSymbol, length)
+  const abbreviateSymbol = formatSymbol(fullSymbol, length, maxLength)
 
   return <span title={fullSymbol}>{abbreviateSymbol}</span>
 }

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/styled.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/styled.tsx
@@ -79,14 +79,8 @@ export const StyledRemoveRecipient = styled(RemoveRecipient)`
 
 export const StyledRateInfo = styled(RateInfo)`
   padding: 8px 8px 0;
+  gap: 4px;
   font-size: 13px;
-
-  ${({ theme }) => theme.mediaWidth.upToSmall`
-    display: flex;
-    flex-flow: column wrap;
-    align-items: flex-start;
-    padding: 8px;
-    margin: 0;
-    gap: 4px;
-  `}
+  display: grid;
+  grid-template-columns: max-content auto;
 `

--- a/src/cow-react/modules/limitOrders/containers/RateInput/styled.ts
+++ b/src/cow-react/modules/limitOrders/containers/RateInput/styled.ts
@@ -46,12 +46,16 @@ export const MarketPriceButton = styled.button`
 `
 
 export const Body = styled.div`
-  padding: 0;
   display: flex;
+  align-items: center;
+  justify-content: space-between;
   width: 100%;
+  gap: 8px;
 `
 
 export const NumericalInput = styled(Input)<{ $loading: boolean }>`
+  display: flex;
+  align-items: center;
   background: none;
   border: none;
   width: 100%;
@@ -65,25 +69,33 @@ export const NumericalInput = styled(Input)<{ $loading: boolean }>`
 export const ActiveCurrency = styled.button`
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   border: none;
   background: none;
-  cursor: pointer;
   padding: 0;
   margin: 0 0 0 auto;
+  gap: 8px;
+  max-width: 130px;
+  width: auto;
+  cursor: pointer;
 `
 
 export const ActiveSymbol = styled.span`
   color: ${({ theme }) => theme.text1};
-  font-size: 0.85rem;
-  margin-right: 5px;
+  font-size: 13px;
   font-weight: 500;
+  text-align: right;
+  padding: 10px 0;
 `
 
 export const ActiveIcon = styled.div`
+  --size: 20px;
   background-color: ${({ theme }) => theme.bg1};
   color: ${({ theme }) => theme.text1};
-  width: 20px;
-  height: 20px;
+  width: var(--size);
+  min-width: var(--size);
+  height: var(--size);
+  min-height: var(--size);
   border-radius: 50%;
   display: flex;
   align-items: center;

--- a/src/cow-react/modules/limitOrders/containers/TradeButtons/limitOrdersTradeButtonsMap.tsx
+++ b/src/cow-react/modules/limitOrders/containers/TradeButtons/limitOrdersTradeButtonsMap.tsx
@@ -11,7 +11,7 @@ import { WrapUnwrapCallback } from 'hooks/useWrapCallback'
 import TransactionConfirmationModal from 'components/TransactionConfirmationModal'
 import { TransactionConfirmState } from '@cow/modules/swap/state/transactionConfirmAtom'
 import { TradeLoadingButton } from '@cow/modules/trade/pure/TradeLoadingButton'
-import { formatSymbol } from '@cow/utils/format'
+import { TokenSymbol } from '@cow/common/pure/TokenSymbol'
 
 export interface WrapUnwrapParams {
   isNativeIn: boolean
@@ -121,7 +121,7 @@ export const limitOrdersTradeButtonsMap: { [key in LimitOrdersFormState]: Button
   [LimitOrdersFormState.InsufficientBalance]: ({ tradeState }: TradeButtonsParams) => {
     return (
       <SwapButton disabled={true}>
-        <Trans>Insufficient {formatSymbol(tradeState.inputCurrency?.symbol)} balance</Trans>
+        <Trans>Insufficient {<TokenSymbol token={tradeState.inputCurrency} />} balance</Trans>
       </SwapButton>
     )
   },

--- a/src/cow-react/modules/limitOrders/containers/TradeButtons/limitOrdersTradeButtonsMap.tsx
+++ b/src/cow-react/modules/limitOrders/containers/TradeButtons/limitOrdersTradeButtonsMap.tsx
@@ -11,6 +11,7 @@ import { WrapUnwrapCallback } from 'hooks/useWrapCallback'
 import TransactionConfirmationModal from 'components/TransactionConfirmationModal'
 import { TransactionConfirmState } from '@cow/modules/swap/state/transactionConfirmAtom'
 import { TradeLoadingButton } from '@cow/modules/trade/pure/TradeLoadingButton'
+import { formatSymbol } from '@cow/utils/format'
 
 export interface WrapUnwrapParams {
   isNativeIn: boolean
@@ -120,7 +121,7 @@ export const limitOrdersTradeButtonsMap: { [key in LimitOrdersFormState]: Button
   [LimitOrdersFormState.InsufficientBalance]: ({ tradeState }: TradeButtonsParams) => {
     return (
       <SwapButton disabled={true}>
-        <Trans>Insufficient {tradeState.inputCurrency?.symbol} balance</Trans>
+        <Trans>Insufficient {formatSymbol(tradeState.inputCurrency?.symbol)} balance</Trans>
       </SwapButton>
     )
   },

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow.tsx
@@ -13,6 +13,7 @@ import { getSellAmountWithFee } from '@cow/modules/limitOrders/utils/getSellAmou
 import AlertTriangle from 'assets/cow-swap/alert.svg'
 import SVG from 'react-inlinesvg'
 import { TokenSymbol } from '@cow/common/pure/TokenSymbol'
+import { formatSymbol } from '@cow/utils/format'
 
 export const orderStatusTitleMap: { [key in OrderStatus]: string } = {
   [OrderStatus.PENDING]: 'Open',
@@ -158,7 +159,7 @@ const CancelOrderBtn = styled.button`
 
 function CurrencyAmountItem({ amount }: { amount: CurrencyAmount<Currency> }) {
   return (
-    <AmountItem title={amount.toExact() + ' ' + amount.currency.symbol}>
+    <AmountItem title={amount.toExact() + ' ' + formatSymbol(amount.currency.symbol)}>
       <div>
         <CurrencyLogo currency={amount.currency} size="24px" />
       </div>

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
@@ -12,6 +12,7 @@ import { transparentize } from 'polished'
 import { LIMIT_ORDERS_PAGE_SIZE } from '@cow/modules/limitOrders/const/limitOrdersTabs'
 import { getOrderParams } from './utils/getOrderParams'
 import { ordersSorter } from '@cow/modules/limitOrders/utils/ordersSorter'
+import { RateWrapper } from '@cow/common/pure/RateInfo'
 
 const TableBox = styled.div`
   display: block;
@@ -61,6 +62,10 @@ const RowElement = styled(Header)`
 
   &:last-child {
     border-bottom: 0;
+  }
+
+  ${RateWrapper} {
+    text-align: left;
   }
 `
 

--- a/src/cow-react/modules/limitOrders/pure/RateImpactIndicator/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/RateImpactIndicator/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/macro'
 import { MouseoverTooltipContent } from 'components/Tooltip'
 import { LOW_RATE_THRESHOLD_PERCENT } from '@cow/modules/limitOrders/const/trade'
 import { Currency } from '@uniswap/sdk-core'
-import { formatSymbol } from '@cow/utils/format'
+import { TokenSymbol } from '@cow/common/pure/TokenSymbol'
 
 interface RateImpactProps {
   rateImpact: number
@@ -40,8 +40,8 @@ export function RateImpactIndicator({ rateImpact, inputCurrency }: RateImpactPro
       {isPositive &&
         `Your order will execute when the market price is ${displayedPercent}% better than the current market price.`}
       {!isPositive &&
-        `This price is ${displayedPercent}% lower than current market price. You could be selling your ${formatSymbol(
-          inputCurrency?.symbol
+        `This price is ${displayedPercent}% lower than current market price. You could be selling your ${(
+          <TokenSymbol token={inputCurrency} />
         )} at a loss! Click on "Market price" to set your limit price to the current market price.`}
     </ImpactTooltip>
   )

--- a/src/cow-react/modules/limitOrders/pure/RateImpactIndicator/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/RateImpactIndicator/index.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components/macro'
 import { MouseoverTooltipContent } from 'components/Tooltip'
 import { LOW_RATE_THRESHOLD_PERCENT } from '@cow/modules/limitOrders/const/trade'
 import { Currency } from '@uniswap/sdk-core'
+import { formatSymbol } from '@cow/utils/format'
 
 interface RateImpactProps {
   rateImpact: number
@@ -39,7 +40,9 @@ export function RateImpactIndicator({ rateImpact, inputCurrency }: RateImpactPro
       {isPositive &&
         `Your order will execute when the market price is ${displayedPercent}% better than the current market price.`}
       {!isPositive &&
-        `This price is ${displayedPercent}% lower than current market price. You could be selling your ${inputCurrency?.symbol} at a loss! Click on "Market price" to set your limit price to the current market price.`}
+        `This price is ${displayedPercent}% lower than current market price. You could be selling your ${formatSymbol(
+          inputCurrency?.symbol
+        )} at a loss! Click on "Market price" to set your limit price to the current market price.`}
     </ImpactTooltip>
   )
 

--- a/src/cow-react/modules/limitOrders/pure/RateImpactWarning/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/RateImpactWarning/index.tsx
@@ -3,7 +3,7 @@ import { LOW_RATE_THRESHOLD_PERCENT } from '@cow/modules/limitOrders/const/trade
 import styled from 'styled-components/macro'
 import { AlertTriangle } from 'react-feather'
 import { transparentize, lighten, darken } from 'polished'
-import { formatSymbol } from '@cow/utils/format'
+import { TokenSymbol } from '@cow/common/pure/TokenSymbol'
 
 interface RateImpactAcknowledge {
   withAcknowledge: boolean
@@ -79,7 +79,7 @@ export function RateImpactWarning({
         </div>
         <div>
           Your limit price is {Math.abs(rateImpact)}% lower than current market price. You could be selling your{' '}
-          {formatSymbol(inputCurrency.symbol)} at a loss (although CoW Swap will always try to give you the best price
+          <TokenSymbol token={inputCurrency} /> at a loss (although CoW Swap will always try to give you the best price
           regardless).
           <ReadMoreLink target="_blank" href="https://www.investopedia.com/terms/l/limitorder.asp">
             Read more about limit orders

--- a/src/cow-react/modules/limitOrders/pure/RateImpactWarning/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/RateImpactWarning/index.tsx
@@ -3,6 +3,7 @@ import { LOW_RATE_THRESHOLD_PERCENT } from '@cow/modules/limitOrders/const/trade
 import styled from 'styled-components/macro'
 import { AlertTriangle } from 'react-feather'
 import { transparentize, lighten, darken } from 'polished'
+import { formatSymbol } from '@cow/utils/format'
 
 interface RateImpactAcknowledge {
   withAcknowledge: boolean
@@ -78,7 +79,8 @@ export function RateImpactWarning({
         </div>
         <div>
           Your limit price is {Math.abs(rateImpact)}% lower than current market price. You could be selling your{' '}
-          {inputCurrency.symbol} at a loss (although CoW Swap will always try to give you the best price regardless).
+          {formatSymbol(inputCurrency.symbol)} at a loss (although CoW Swap will always try to give you the best price
+          regardless).
           <ReadMoreLink target="_blank" href="https://www.investopedia.com/terms/l/limitorder.asp">
             Read more about limit orders
           </ReadMoreLink>

--- a/src/cow-react/modules/limitOrders/pure/ReceiptModal/PriceField.tsx
+++ b/src/cow-react/modules/limitOrders/pure/ReceiptModal/PriceField.tsx
@@ -15,7 +15,7 @@ export function PriceField({ order, price }: Props) {
     <styledEl.Value>
       {price ? (
         <styledEl.RateValue>
-          1 {formatSymbol(order.inputToken.symbol)} ={' '}
+          1 {<TokenSymbol token={order.inputToken} />} ={' '}
           <span title={price.toSignificant(18) + ' ' + formatSymbol(order.outputToken.symbol)}>
             {formatSmart(price)} <TokenSymbol token={order.outputToken} />
           </span>

--- a/src/cow-react/modules/limitOrders/pure/ReceiptModal/PriceField.tsx
+++ b/src/cow-react/modules/limitOrders/pure/ReceiptModal/PriceField.tsx
@@ -3,6 +3,7 @@ import { ParsedOrder } from '@cow/modules/limitOrders/containers/OrdersWidget/ho
 import { Fraction } from '@uniswap/sdk-core'
 import { formatSmart } from '@cow/utils/format'
 import { TokenSymbol } from '@cow/common/pure/TokenSymbol'
+import { formatSymbol } from '@cow/utils/format'
 
 interface Props {
   order: ParsedOrder
@@ -14,8 +15,8 @@ export function PriceField({ order, price }: Props) {
     <styledEl.Value>
       {price ? (
         <styledEl.RateValue>
-          1 {order.inputToken.symbol} ={' '}
-          <span title={price.toSignificant(18) + ' ' + order.outputToken.symbol}>
+          1 {formatSymbol(order.inputToken.symbol)} ={' '}
+          <span title={price.toSignificant(18) + ' ' + formatSymbol(order.outputToken.symbol)}>
             {formatSmart(price)} <TokenSymbol token={order.outputToken} />
           </span>
         </styledEl.RateValue>

--- a/src/cow-react/modules/limitOrders/pure/ReceiptModal/SurplusField.tsx
+++ b/src/cow-react/modules/limitOrders/pure/ReceiptModal/SurplusField.tsx
@@ -4,6 +4,7 @@ import * as styledEl from './styled'
 import { formatSmart } from '@cow/utils/format'
 import { CurrencyAmount } from '@uniswap/sdk-core'
 import { TokenSymbol } from '@cow/common/pure/TokenSymbol'
+import { formatSymbol } from '@cow/utils/format'
 
 interface Props {
   order: ParsedOrder
@@ -23,7 +24,7 @@ export function SurplusField({ order }: Props) {
   const formattedPercent = surplusPercentage?.multipliedBy(100)?.toFixed(2)
 
   return (
-    <styledEl.Value title={`${parsedSurplus.toExact()} ${surplusToken.symbol}`}>
+    <styledEl.Value title={`${parsedSurplus.toExact()} ${formatSymbol(surplusToken.symbol)}`}>
       <styledEl.InlineWrapper>
         <styledEl.Surplus>+{formattedPercent}%</styledEl.Surplus>
         <span>

--- a/src/cow-react/modules/swap/containers/Row/RowFee/index.tsx
+++ b/src/cow-react/modules/swap/containers/Row/RowFee/index.tsx
@@ -8,6 +8,7 @@ import { RowFeeContent } from '@cow/modules/swap/pure/Row/RowFeeContent'
 import { RowWithShowHelpersProps } from '@cow/modules/swap/pure/Row/types'
 import { useIsEthFlow } from '@cow/modules/swap/hooks/useIsEthFlow'
 import useNativeCurrency from 'lib/hooks/useNativeCurrency'
+import { formatSymbol } from '@cow/utils/format'
 
 export const GASLESS_FEE_TOOLTIP_MSG =
   'On CoW Swap you sign your order (hence no gas costs!). The fees are covering your gas costs already.'
@@ -63,7 +64,7 @@ export function RowFee({ trade, fee, feeFiatValue, allowsOffchainSigning, showHe
   // so we can take both
   const props = useMemo(() => {
     const displayFee = realizedFee || fee
-    const feeCurrencySymbol = displayFee?.currency.symbol || '-'
+    const feeCurrencySymbol = formatSymbol(displayFee?.currency.symbol) || '-'
     const smartFeeFiatValue = formatSmart(feeFiatValue, FIAT_PRECISION)
     const smartFeeTokenValue = formatSmart(displayFee, AMOUNT_PRECISION)
     const feeAmountWithCurrency = `${smartFeeTokenValue} ${feeCurrencySymbol} ${isEthFLow ? ' + gas' : ''}`

--- a/src/cow-react/modules/swap/pure/CurrencySelectButton/index.tsx
+++ b/src/cow-react/modules/swap/pure/CurrencySelectButton/index.tsx
@@ -25,7 +25,7 @@ export function CurrencySelectButton(props: CurrencySelectButtonProps) {
     >
       {currency ? <CurrencyLogo currency={currency} size={'24px'} /> : <div></div>}
       <styledEl.CurrencySymbol className="token-symbol-container" $stubbed={$stubbed}>
-        {currency ? <TokenSymbol token={currency} maxLength={40} /> : <Trans>Select a token</Trans>}
+        {currency ? <TokenSymbol token={currency} length={40} /> : <Trans>Select a token</Trans>}
       </styledEl.CurrencySymbol>
       {readonlyMode ? null : $stubbed ? <styledEl.ArrowDown $stubbed={$stubbed} /> : <styledEl.ArrowDown />}
     </styledEl.CurrencySelectWrapper>

--- a/src/cow-react/modules/swap/pure/CurrencySelectButton/index.tsx
+++ b/src/cow-react/modules/swap/pure/CurrencySelectButton/index.tsx
@@ -25,7 +25,7 @@ export function CurrencySelectButton(props: CurrencySelectButtonProps) {
     >
       {currency ? <CurrencyLogo currency={currency} size={'24px'} /> : <div></div>}
       <styledEl.CurrencySymbol className="token-symbol-container" $stubbed={$stubbed}>
-        {currency ? <TokenSymbol token={currency} /> : <Trans>Select a token</Trans>}
+        {currency ? <TokenSymbol token={currency} maxLength={40} /> : <Trans>Select a token</Trans>}
       </styledEl.CurrencySymbol>
       {readonlyMode ? null : $stubbed ? <styledEl.ArrowDown $stubbed={$stubbed} /> : <styledEl.ArrowDown />}
     </styledEl.CurrencySelectWrapper>

--- a/src/cow-react/modules/swap/pure/CurrencySelectButton/styled.tsx
+++ b/src/cow-react/modules/swap/pure/CurrencySelectButton/styled.tsx
@@ -19,6 +19,7 @@ export const CurrencySelectWrapper = styled.button<{ isLoading: boolean; $stubbe
   border-radius: 16px;
   padding: 6px;
   transition: background-color 0.15s ease-in-out;
+  max-width: 190px;
 
   &:hover {
     // TODO: Check what 'readonlyMode' does and proper style it.
@@ -29,6 +30,10 @@ export const CurrencySelectWrapper = styled.button<{ isLoading: boolean; $stubbe
 
 export const ArrowDown = styled(DropDown)<{ $stubbed?: boolean }>`
   margin: 0 3px;
+  width: 12px;
+  height: 7px;
+  min-width: 12px;
+  min-height: 7px;
 
   > path {
     stroke: ${({ $stubbed, theme }) => ($stubbed ? theme.white : theme.text1)};
@@ -43,7 +48,7 @@ export const ArrowDown = styled(DropDown)<{ $stubbed?: boolean }>`
 export const CurrencySymbol = styled.div<{ $stubbed: boolean }>`
   font-size: 19px;
   font-weight: 500;
-  white-space: nowrap;
+  text-align: left;
   color: ${({ $stubbed, theme }) => ($stubbed ? theme.white : theme.text1)};
 
   ${({ theme }) => theme.mediaWidth.upToSmall`

--- a/src/cow-react/modules/swap/pure/ReceiveAmountInfo/index.tsx
+++ b/src/cow-react/modules/swap/pure/ReceiveAmountInfo/index.tsx
@@ -4,6 +4,7 @@ import { ReceiveAmountInfo } from '@cow/modules/swap/helpers/tradeReceiveAmount'
 import { Currency } from '@uniswap/sdk-core'
 import { BalanceAndSubsidy } from 'hooks/useCowBalanceAndSubsidy'
 import { Trans } from '@lingui/macro'
+import { formatSymbol } from '@cow/utils/format'
 
 export interface ReceiveAmountInfoTooltipProps {
   receiveAmountInfo: ReceiveAmountInfo
@@ -35,7 +36,7 @@ export function ReceiveAmountInfoTooltip(props: ReceiveAmountInfoTooltipProps) {
           <Trans>Before fee</Trans>
         </span>
         <span>
-          {amountBeforeFees} {currency.symbol}
+          {amountBeforeFees} {formatSymbol(currency.symbol)}
         </span>
       </div>
       <div>
@@ -43,7 +44,7 @@ export function ReceiveAmountInfoTooltip(props: ReceiveAmountInfoTooltipProps) {
         {hasFee ? (
           <span>
             {typeString}
-            {feeAmount} {currency.symbol}
+            {feeAmount} {formatSymbol(currency.symbol)}
           </span>
         ) : (
           <styledEl.GreenText>
@@ -70,7 +71,7 @@ export function ReceiveAmountInfoTooltip(props: ReceiveAmountInfoTooltipProps) {
           <Trans>{type === 'from' ? 'From' : 'To'}</Trans>
         </span>
         <span>
-          {amountAfterFees} {currency.symbol}
+          {amountAfterFees} {formatSymbol(currency.symbol)}
         </span>
       </styledEl.TotalAmount>
     </styledEl.Box>

--- a/src/cow-react/modules/swap/pure/ReceiveAmountInfo/index.tsx
+++ b/src/cow-react/modules/swap/pure/ReceiveAmountInfo/index.tsx
@@ -4,7 +4,7 @@ import { ReceiveAmountInfo } from '@cow/modules/swap/helpers/tradeReceiveAmount'
 import { Currency } from '@uniswap/sdk-core'
 import { BalanceAndSubsidy } from 'hooks/useCowBalanceAndSubsidy'
 import { Trans } from '@lingui/macro'
-import { formatSymbol } from '@cow/utils/format'
+import { TokenSymbol } from '@cow/common/pure/TokenSymbol'
 
 export interface ReceiveAmountInfoTooltipProps {
   receiveAmountInfo: ReceiveAmountInfo
@@ -36,7 +36,7 @@ export function ReceiveAmountInfoTooltip(props: ReceiveAmountInfoTooltipProps) {
           <Trans>Before fee</Trans>
         </span>
         <span>
-          {amountBeforeFees} {formatSymbol(currency.symbol)}
+          {amountBeforeFees} {<TokenSymbol token={currency} />}
         </span>
       </div>
       <div>
@@ -44,7 +44,7 @@ export function ReceiveAmountInfoTooltip(props: ReceiveAmountInfoTooltipProps) {
         {hasFee ? (
           <span>
             {typeString}
-            {feeAmount} {formatSymbol(currency.symbol)}
+            {feeAmount} {<TokenSymbol token={currency} />}
           </span>
         ) : (
           <styledEl.GreenText>
@@ -71,7 +71,7 @@ export function ReceiveAmountInfoTooltip(props: ReceiveAmountInfoTooltipProps) {
           <Trans>{type === 'from' ? 'From' : 'To'}</Trans>
         </span>
         <span>
-          {amountAfterFees} {formatSymbol(currency.symbol)}
+          {amountAfterFees} {<TokenSymbol token={currency} />}
         </span>
       </styledEl.TotalAmount>
     </styledEl.Box>

--- a/src/cow-react/modules/swap/pure/ReceiveAmountInfo/styled.tsx
+++ b/src/cow-react/modules/swap/pure/ReceiveAmountInfo/styled.tsx
@@ -23,4 +23,8 @@ export const TotalAmount = styled.div`
   font-weight: bold;
   margin-top: 8px;
   padding-top: 8px;
+
+  > span:first-child {
+    white-space: nowrap;
+  }
 `

--- a/src/cow-react/modules/swap/pure/Row/RowFeeContent/index.tsx
+++ b/src/cow-react/modules/swap/pure/Row/RowFeeContent/index.tsx
@@ -4,7 +4,6 @@ import { StyledInfoIcon } from '@cow/modules/swap/pure/styled'
 import { FiatRate } from '@cow/common/pure/RateInfo/'
 import { StyledRowBetween, TextWrapper } from '@cow/modules/swap/pure/Row/styled'
 import { RowStyleProps, RowWithShowHelpersProps } from '@cow/modules/swap/pure/Row/types'
-import { TokenSymbol } from '@cow/common/pure/TokenSymbol'
 
 export interface RowFeeContentProps extends RowWithShowHelpersProps {
   includeGasMessage: string
@@ -39,7 +38,7 @@ export function RowFeeContent(props: RowFeeContentProps) {
       </RowFixed>
 
       <TextWrapper title={`${fullDisplayFee} ${feeCurrencySymbol}`}>
-        <TokenSymbol token={{ symbol: feeToken }} /> {feeUsd && <FiatRate>{feeUsd}</FiatRate>}
+        {feeToken} {feeUsd && <FiatRate>{feeUsd}</FiatRate>}
       </TextWrapper>
     </StyledRowBetween>
   )

--- a/src/cow-react/modules/swap/pure/Row/RowReceivedAfterSlippageContent/index.tsx
+++ b/src/cow-react/modules/swap/pure/Row/RowReceivedAfterSlippageContent/index.tsx
@@ -12,6 +12,7 @@ import { AMOUNT_PRECISION } from 'constants/index'
 import { StyledRowBetween, TextWrapper } from '../styled'
 import { RowStyleProps } from '@cow/modules/swap/pure/Row/types'
 import { TokenSymbol } from '@cow/common/pure/TokenSymbol'
+import { formatSymbol } from '@cow/utils/format'
 
 export interface RowReceivedAfterSlippageContentProps extends RowReceivedAfterSlippageProps {
   isExactIn: boolean
@@ -39,7 +40,7 @@ export function RowReceivedAfterSlippageContent(props: RowReceivedAfterSlippageC
         )}
       </RowFixed>
 
-      <TextWrapper textAlign="right" title={`${fullOutAmount} ${swapAmount?.currency?.symbol}`}>
+      <TextWrapper textAlign="right" title={`${fullOutAmount} ${formatSymbol(swapAmount?.currency?.symbol)}`}>
         {`${formatSmart(swapAmount, AMOUNT_PRECISION) || '-'} `}
         <TokenSymbol token={swapAmount?.currency} />
       </TextWrapper>

--- a/src/cow-react/modules/swap/pure/Row/styled.ts
+++ b/src/cow-react/modules/swap/pure/Row/styled.ts
@@ -15,6 +15,7 @@ export const StyledRowBetween = styled(RowBetween)<RowStyleProps>`
 
   ${RowFixed} {
     gap: 3px;
+    min-width: 200px;
   }
 
   ${TextWrapper} {

--- a/src/cow-react/utils/format.ts
+++ b/src/cow-react/utils/format.ts
@@ -194,7 +194,7 @@ export function truncateOnMaxDecimals(value: string, decimals: number): string {
 
 const DEFAULT_MAX_SYMBOL_LENGTH = 12
 
-export function formatSymbol(symbol: string | undefined, length?: number, maxLength?: number): string | undefined {
-  maxLength = maxLength ? maxLength : length || DEFAULT_MAX_SYMBOL_LENGTH
+export function formatSymbol(symbol: string | undefined, length?: number): string | undefined {
+  const maxLength = length || DEFAULT_MAX_SYMBOL_LENGTH
   return symbol && symbol.length > maxLength ? symbol.slice(0, maxLength) + '...' : symbol
 }

--- a/src/cow-react/utils/format.ts
+++ b/src/cow-react/utils/format.ts
@@ -192,7 +192,7 @@ export function truncateOnMaxDecimals(value: string, decimals: number): string {
   return value.replace(regex, '$1')
 }
 
-const DEFAULT_MAX_SYMBOL_LENGTH = 8
+const DEFAULT_MAX_SYMBOL_LENGTH = 40
 
 export function formatSymbol(symbol: string | undefined, length?: number): string | undefined {
   const maxLength = length || DEFAULT_MAX_SYMBOL_LENGTH

--- a/src/cow-react/utils/format.ts
+++ b/src/cow-react/utils/format.ts
@@ -195,6 +195,6 @@ export function truncateOnMaxDecimals(value: string, decimals: number): string {
 const DEFAULT_MAX_SYMBOL_LENGTH = 12
 
 export function formatSymbol(symbol: string | undefined, length?: number): string | undefined {
-  const maxLength = length || DEFAULT_MAX_SYMBOL_LENGTH
+  const maxLength = length ? length : DEFAULT_MAX_SYMBOL_LENGTH
   return symbol && symbol.length > maxLength ? symbol.slice(0, maxLength) + '...' : symbol
 }

--- a/src/cow-react/utils/format.ts
+++ b/src/cow-react/utils/format.ts
@@ -192,9 +192,9 @@ export function truncateOnMaxDecimals(value: string, decimals: number): string {
   return value.replace(regex, '$1')
 }
 
-const DEFAULT_MAX_SYMBOL_LENGTH = 40
+const DEFAULT_MAX_SYMBOL_LENGTH = 12
 
-export function formatSymbol(symbol: string | undefined, length?: number): string | undefined {
-  const maxLength = length || DEFAULT_MAX_SYMBOL_LENGTH
+export function formatSymbol(symbol: string | undefined, length?: number, maxLength?: number): string | undefined {
+  maxLength = maxLength ? maxLength : length || DEFAULT_MAX_SYMBOL_LENGTH
   return symbol && symbol.length > maxLength ? symbol.slice(0, maxLength) + '...' : symbol
 }

--- a/src/custom/components/AccountDetails/Transaction/ActivityDetails.tsx
+++ b/src/custom/components/AccountDetails/Transaction/ActivityDetails.tsx
@@ -28,6 +28,7 @@ import { RateInfoParams, RateInfo } from '@cow/common/pure/RateInfo'
 import { EthFlowStepper } from '@cow/modules/swap/containers/EthFlowStepper'
 import { StatusDetails } from './StatusDetails'
 import { useCancelOrder } from '@cow/common/hooks/useCancelOrder'
+import { formatSymbol } from '@cow/utils/format'
 
 const DEFAULT_ORDER_SUMMARY = {
   from: '',
@@ -217,8 +218,8 @@ export function ActivityDetails(props: {
 
     orderSummary = {
       ...DEFAULT_ORDER_SUMMARY,
-      from: `${formatSmart(inputAmount.add(feeAmount))} ${inputAmount.currency.symbol}`,
-      to: `${formatSmart(outputAmount)} ${outputAmount.currency.symbol}`,
+      from: `${formatSmart(inputAmount.add(feeAmount))} ${formatSymbol(inputAmount.currency.symbol)}`,
+      to: `${formatSmart(outputAmount)} ${formatSymbol(outputAmount.currency.symbol)}`,
       validTo: validTo ? new Date((validTo as number) * 1000).toLocaleString(undefined, DateFormatOptions) : undefined,
       fulfillmentTime: fulfillmentTime
         ? new Date(fulfillmentTime).toLocaleString(undefined, DateFormatOptions)

--- a/src/custom/components/AccountDetails/Transaction/styled.ts
+++ b/src/custom/components/AccountDetails/Transaction/styled.ts
@@ -5,6 +5,7 @@ import { TransactionState as OldTransactionState } from '../TransactionMod'
 import { RowFixed } from 'components/Row'
 import { transparentize } from 'polished'
 import { StyledLogo } from 'components/CurrencyLogo'
+import { RateWrapper } from '@cow/common/pure/RateInfo'
 
 export const TransactionWrapper = styled.div`
   width: 100%;
@@ -208,6 +209,10 @@ export const SummaryInnerRow = styled.div<{ isExpired?: boolean; isCancelled?: b
   + ${StyledLink} {
     align-self: center;
     margin: 16px 0 0;
+  }
+
+  ${RateWrapper} {
+    text-align: left;
   }
 `
 

--- a/src/custom/components/AddToMetamask/index.tsx
+++ b/src/custom/components/AddToMetamask/index.tsx
@@ -9,6 +9,7 @@ import { RowFixed } from 'components/Row'
 import MetaMaskLogo from 'assets/images/metamask.png'
 import { addTokenToMetamaskAnalytics } from 'components/analytics'
 import useCurrencyLogoURIs from 'lib/hooks/useCurrencyLogoURIs'
+import { formatSymbol } from '@cow/utils/format'
 
 export type AddToMetamaskProps = {
   currency: Currency | undefined
@@ -99,12 +100,13 @@ export default function AddToMetamask(props: AddToMetamaskProps) {
     <ButtonCustom onClick={addToken}>
       {!success ? (
         <RowFixed>
-          <StyledIcon src={MetaMaskLogo} /> {shortLabel ? 'Add token' : `Add ${currency.symbol} to Metamask`}
+          <StyledIcon src={MetaMaskLogo} />{' '}
+          {shortLabel ? 'Add token' : `Add ${formatSymbol(currency.symbol)} to Metamask`}
         </RowFixed>
       ) : (
         <RowFixed>
           <CheckCircleCustom size={'16px'} stroke={theme.green1} />
-          Added {currency.symbol}{' '}
+          Added {formatSymbol(currency.symbol)}{' '}
         </RowFixed>
       )}
     </ButtonCustom>

--- a/src/custom/components/AddToMetamask/index.tsx
+++ b/src/custom/components/AddToMetamask/index.tsx
@@ -101,12 +101,12 @@ export default function AddToMetamask(props: AddToMetamaskProps) {
       {!success ? (
         <RowFixed>
           <StyledIcon src={MetaMaskLogo} />{' '}
-          {shortLabel ? 'Add token' : `Add ${formatSymbol(currency.symbol)} to Metamask`}
+          {shortLabel ? 'Add token' : `Add ${formatSymbol(currency?.symbol)} to Metamask`}
         </RowFixed>
       ) : (
         <RowFixed>
           <CheckCircleCustom size={'16px'} stroke={theme.green1} />
-          Added {formatSymbol(currency.symbol)}{' '}
+          Added {formatSymbol(currency?.symbol)}{' '}
         </RowFixed>
       )}
     </ButtonCustom>

--- a/src/custom/components/CurrencyLogo/CurrencyLogoMod.tsx
+++ b/src/custom/components/CurrencyLogo/CurrencyLogoMod.tsx
@@ -8,6 +8,8 @@ import Logo from 'components/Logo'
 export const StyledLogo = styled(Logo)<{ size: string; $native: boolean }>`
   width: ${({ size }) => size};
   height: ${({ size }) => size};
+  min-width: ${({ size }) => size}; // MOD
+  min-height: ${({ size }) => size}; // MOD
   /* background: radial-gradient(white 50%, #ffffff00 calc(75% + 1px), #ffffff00 100%);
   border-radius: 50%;
   -mox-box-shadow: 0 0 1px ${({ $native }) => ($native ? 'white' : 'black')};

--- a/src/custom/components/SearchModal/CommonBases/CommonBasesMod.tsx
+++ b/src/custom/components/SearchModal/CommonBases/CommonBasesMod.tsx
@@ -123,7 +123,7 @@ export default function CommonBases({
                 >
                   <CurrencyLogoFromList currency={currency} />
                   <Text fontWeight={500} fontSize={16}>
-                    {formatSymbol(currency.symbol, 6)} {/* MOD */}
+                    {formatSymbol(currency?.symbol, 6)} {/* MOD */}
                   </Text>
                 </BaseWrapper>
               </TraceEvent>

--- a/src/custom/components/SearchModal/CommonBases/CommonBasesMod.tsx
+++ b/src/custom/components/SearchModal/CommonBases/CommonBasesMod.tsx
@@ -13,6 +13,7 @@ import { currencyId } from 'utils/currencyId'
 import QuestionHelper from 'components/QuestionHelper'
 import { BaseWrapper, CommonBasesRow, MobileWrapper } from '.' // mod
 import { useFavouriteOrCommonTokens } from 'hooks/useFavouriteOrCommonTokens'
+import { formatSymbol } from '@cow/utils/format'
 
 /* const MobileWrapper = styled(AutoColumn)`
   ${({ theme }) => theme.mediaWidth.upToSmall`
@@ -122,7 +123,7 @@ export default function CommonBases({
                 >
                   <CurrencyLogoFromList currency={currency} />
                   <Text fontWeight={500} fontSize={16}>
-                    {currency.symbol}
+                    {formatSymbol(currency.symbol, 6)} {/* MOD */}
                   </Text>
                 </BaseWrapper>
               </TraceEvent>

--- a/src/custom/components/SearchModal/CurrencyList/CurrencyListMod.tsx
+++ b/src/custom/components/SearchModal/CurrencyList/CurrencyListMod.tsx
@@ -29,6 +29,7 @@ import { MenuItem } from '.' // mod
 import { formatSmart } from '@cow/utils/format'
 import { AMOUNT_PRECISION } from 'constants/index'
 import { useIsUnsupportedTokenGp } from 'state/lists/hooks'
+import { formatSymbol } from '@cow/utils/format'
 
 function currencyKey(currency: Currency): string {
   return currency.isToken ? currency.address : 'ETHER'
@@ -162,7 +163,7 @@ function CurrencyRow({
         <CurrencyLogo currency={currency} size={'24px'} />
         <Column>
           <Text title={currency.name} fontWeight={500}>
-            {currency.symbol}
+            {formatSymbol(currency.symbol)} {/* MOD */}
           </Text>
           <ThemedText.DarkGray ml="0px" fontSize={'12px'} fontWeight={300}>
             {!currency.isNative && !isOnSelectedList && customAdded ? (

--- a/src/custom/components/SearchModal/ManageTokens/ManageTokensMod.tsx
+++ b/src/custom/components/SearchModal/ManageTokens/ManageTokensMod.tsx
@@ -22,6 +22,7 @@ import { PaddedColumn, SearchInput, Separator } from 'components/SearchModal/sty
 import { ImportTokensRowProps } from '.' // mod
 import useNetworkName from 'hooks/useNetworkName'
 import { getEtherscanLink as getExplorerLink } from 'utils'
+import { formatSymbol } from '@cow/utils/format'
 
 const Wrapper = styled.div`
   width: 100%;
@@ -89,7 +90,7 @@ export default function ManageTokens({ setModalView, setImportToken, ImportToken
             <CurrencyLogo currency={token} size={'20px'} />
             <ExternalLink href={getExplorerLink(chainId, token.address, 'address')}>
               <ThemedText.Main ml={'10px'} fontWeight={600}>
-                {token.symbol}
+                {formatSymbol(token.symbol)} {/* MOD */}
               </ThemedText.Main>
             </ExternalLink>
           </RowFixed>

--- a/src/custom/components/Tokens/TokensTable.tsx
+++ b/src/custom/components/Tokens/TokensTable.tsx
@@ -198,7 +198,7 @@ export default function TokenTable({
           <TableHeader>
             <IndexLabel>#</IndexLabel>
             <ClickableText onClick={() => handleSort(SORT_FIELD.NAME)}>
-              <Trans>Name {arrow(SORT_FIELD.NAME)}</Trans>
+              <Trans>Token {arrow(SORT_FIELD.NAME)}</Trans>
             </ClickableText>
             <ClickableText disabled={true} /* onClick={() => (account ? handleSort(SORT_FIELD.BALANCE) : false)} */>
               <Trans>Balance {arrow(SORT_FIELD.BALANCE)}</Trans>

--- a/src/custom/components/Tokens/TokensTableRow.tsx
+++ b/src/custom/components/Tokens/TokensTableRow.tsx
@@ -174,10 +174,10 @@ const DataRow = ({
           <ResponsiveLogo currency={tokenData} />
           <TokenText>
             <span>
-              <b>{tokenData.name}</b>
-              <i>
+              <b>
                 <TokenSymbol token={tokenData} />
-              </i>
+              </b>
+              <i>{tokenData.name}</i>
             </span>
           </TokenText>
         </Link>

--- a/src/custom/components/Tokens/TokensTableRow.tsx
+++ b/src/custom/components/Tokens/TokensTableRow.tsx
@@ -170,7 +170,7 @@ const DataRow = ({
       </Cell>
 
       <Cell>
-        <Link title={tokenData.name} to={tradeLink(tokenData, OrderKind.SELL)}>
+        <Link to={tradeLink(tokenData, OrderKind.SELL)}>
           <ResponsiveLogo currency={tokenData} />
           <TokenText>
             <span>

--- a/src/custom/components/Tokens/styled.ts
+++ b/src/custom/components/Tokens/styled.ts
@@ -379,11 +379,10 @@ export const TokenText = styled.div`
   > span > i {
     opacity: 0.6;
     font-style: normal;
-    font-size: 12px;
+    font-size: 14px;
     font-weight: 500;
     width: 100%;
     display: inline-block;
-    text-transform: uppercase;
   }
 
   ${({ theme }) => theme.mediaWidth.upToSmall`

--- a/src/custom/components/Tokens/styled.ts
+++ b/src/custom/components/Tokens/styled.ts
@@ -357,26 +357,31 @@ export const TokenText = styled.div`
 
   > span {
     display: flex;
+    flex-flow: column wrap;
     align-items: center;
+    justify-content: flex-start;
     max-width: inherit;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    gap: 2px;
   }
 
   > span > b {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    max-width: 100%;
-    font-weight: 500;
+    width: 100%;
+    font-weight: 600;
     display: inline-block;
   }
 
   > span > i {
     opacity: 0.6;
-    margin: 0 0 0 4px;
     font-style: normal;
+    font-size: 12px;
+    font-weight: 500;
+    width: 100%;
     display: inline-block;
     text-transform: uppercase;
   }

--- a/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
+++ b/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
@@ -32,6 +32,7 @@ import { LightCardType } from '.'
 import { transparentize } from 'polished'
 import { WarningProps } from 'components/SwapWarnings'
 import { RateInfo, RateInfoParams } from '@cow/common/pure/RateInfo'
+import { TokenSymbol } from '@cow/common/pure/TokenSymbol'
 
 export const ArrowWrapper = styled.div`
   --size: 26px;
@@ -150,7 +151,8 @@ SwapModalHeaderProps) {
             <RowFixed gap={'0px'}>
               <CurrencyLogo currency={trade.inputAmount.currency} size={'20px'} style={{ marginRight: '12px' }} />
               <Text fontSize={20} fontWeight={500}>
-                {trade.inputAmount.currency.symbol}
+                {/* {trade.inputAmount.currency.symbol} */}
+                <TokenSymbol token={trade.inputAmount.currency} /> {/* // MOD */}
               </Text>
             </RowFixed>
             <RowFixed gap={'0px'}>
@@ -219,7 +221,8 @@ SwapModalHeaderProps) {
             <RowFixed gap={'0px'}>
               <CurrencyLogo currency={trade.outputAmount.currency} size={'20px'} style={{ marginRight: '12px' }} />
               <Text fontSize={20} fontWeight={500}>
-                {trade.outputAmount.currency.symbol}
+                {/* {trade.outputAmount.currency.symbol} */}
+                <TokenSymbol token={trade.outputAmount.currency} /> {/* // MOD */}
               </Text>
             </RowFixed>
             <RowFixed gap={'0px'}>
@@ -299,7 +302,9 @@ SwapModalHeaderProps) {
               Output is estimated. You will receive at least{' '}
               <b>
                 {/* {trade.minimumAmountOut(allowedSlippage).toSignificant(6)} {trade.outputAmount.currency.symbol} */}
-                {formatSmart(slippageOut, AMOUNT_PRECISION) || '-'} {trade.outputAmount.currency.symbol}
+                {formatSmart(slippageOut, AMOUNT_PRECISION) || '-'} <TokenSymbol token={trade.outputAmount.currency} />{' '}
+                {/* // MOD */}
+                {/* {trade.outputAmount.currency.symbol} */}
               </b>{' '}
               or the swap will not execute. {INPUT_OUTPUT_EXPLANATION}
             </Trans>
@@ -310,7 +315,9 @@ SwapModalHeaderProps) {
               Input is estimated. You will sell at most{' '}
               <b>
                 {/* {trade.maximumAmountIn(allowedSlippage).toSignificant(6)} {trade.inputAmount.currency.symbol} */}
-                {formatSmart(slippageIn, AMOUNT_PRECISION) || '-'} {trade.inputAmount.currency.symbol}
+                {formatSmart(slippageIn, AMOUNT_PRECISION) || '-'}
+                {/* {trade.inputAmount.currency.symbol} */}
+                <TokenSymbol token={trade.inputAmount.currency} /> {/* // MOD */}
               </b>{' '}
               {/* or the transaction will revert. */}
               or the swap will not execute. {INPUT_OUTPUT_EXPLANATION}


### PR DESCRIPTION
# Summary

- This addresses https://github.com/cowprotocol/cowswap/issues/1852 by iterating on https://github.com/cowprotocol/cowswap/pull/1854 
- I think it's important to show the full symbol name at all times. I understand it becomes less useful beyond XX amount of characters. But in this PR I made sure our layout can fully support longer token names without kicking in the text ellipsis too soon.
- In this PR I've set `const DEFAULT_MAX_SYMBOL_LENGTH = 40` to have some kind of 'hard cap' for really long tokens. Technically in terms of layout it wouldn't be necessary (we can support it), although I think the argument of it being less useful might be more compelling. So I think we should review/fine tune this max symbol length.
- This applies to both the SWAP and LIMIT ORDER UI.


https://user-images.githubusercontent.com/31534717/212709802-38e8de24-352b-4296-b471-447accb5bb3d.mov

https://user-images.githubusercontent.com/31534717/212709837-0f60c518-9cf5-49ca-8fe6-523bdcaf6929.mov

