### PR TITLE
Unify posted order analytics event

### DIFF
--- a/src/custom/components/analytics/events/transactionEvents.ts
+++ b/src/custom/components/analytics/events/transactionEvents.ts
@@ -69,7 +69,7 @@ export function signSwapAnalytics(action: SignSwapAction, orderClass: OrderClass
 export type OrderType = 'Posted' | 'Executed' | 'Canceled' | 'Expired'
 export function orderAnalytics(action: OrderType, orderClass: OrderClass, label?: string) {
   const classLabel = LABEL_FROM_CLASS[orderClass]
-  const eventAction = action === 'Posted' ? 'Posted order' : `${action} ${classLabel}`
+  const eventAction = action === 'Posted' ? 'Posted Order' : `${action} ${classLabel}`
 
   sendEvent({
     category: Category.SWAP,

--- a/src/custom/components/analytics/events/transactionEvents.ts
+++ b/src/custom/components/analytics/events/transactionEvents.ts
@@ -69,9 +69,11 @@ export function signSwapAnalytics(action: SignSwapAction, orderClass: OrderClass
 export type OrderType = 'Posted' | 'Executed' | 'Canceled' | 'Expired'
 export function orderAnalytics(action: OrderType, orderClass: OrderClass, label?: string) {
   const classLabel = LABEL_FROM_CLASS[orderClass]
+  const eventAction = action === 'Posted' ? 'Posted order' : `${action} ${classLabel}`
+
   sendEvent({
     category: Category.SWAP,
-    action: `${action} ${classLabel}`,
+    action: eventAction,
     label,
   })
 }


### PR DESCRIPTION
# Summary

This PR unifies the `Posted Limit Order` and `Posted Market Order` into one event called 'Posted Order'

Before 
<img width="507" alt="Screenshot 2023-01-17 at 12 49 44" src="https://user-images.githubusercontent.com/34926005/212892468-8af6f96b-bc7f-4391-a1d1-d8687c44b8ff.png">
<img width="712" alt="Screenshot 2023-01-17 at 12 50 16" src="https://user-images.githubusercontent.com/34926005/212892493-0ef0173d-84b6-4639-8d8a-6d972b9f20b1.png">

After
<img width="525" alt="Screenshot 2023-01-17 at 12 48 33" src="https://user-images.githubusercontent.com/34926005/212892525-c9eb995d-d038-4af9-9677-32a2073ec1a9.png">

# To test
1. Turn on GA debugger add-on 
2. Post Market or Limit order
3. Make sure that in console the correct  `Posted Order` event is logged