### PR TITLE
Add back to top button to content pages

### DIFF
--- a/src/cow-react/modules/application/pure/Page/index.tsx
+++ b/src/cow-react/modules/application/pure/Page/index.tsx
@@ -123,8 +123,32 @@ export const Content = styled.div`
   }
 `
 
+export const BackToTopStyle = css`
+  #back-to-top {
+    background: #052b65;
+    font-size: 18px;
+    font-weight: 600;
+    border: none;
+    box-shadow: none;
+    border-radius: 16px;
+    color: #ffffff;
+    position: relative;
+    min-height: 58px;
+    padding: 16px;
+    transform: perspective(1px) translateZ(0);
+    transition: all 0.2s ease-in-out;
+    cursor: pointer;
+
+    :hover {
+      background: #073c8c;
+    }
+  }
+`
+
 export const GdocsListStyle = css`
   /* List styles */
+  ${BackToTopStyle}
+
   > ul,
   ol {
     margin: 24px 0;

--- a/src/cow-react/modules/application/pure/Page/index.tsx
+++ b/src/cow-react/modules/application/pure/Page/index.tsx
@@ -3,6 +3,7 @@ import { PropsWithChildren } from 'react'
 import styled, { css } from 'styled-components/macro'
 import { WithClassName } from 'types'
 import { Widget } from '@cow/modules/application/pure/Widget'
+import { lighten } from 'polished'
 
 export const PageWrapper = styled(Widget)`
   padding: 0 24px 24px;
@@ -125,22 +126,30 @@ export const Content = styled.div`
 
 export const BackToTopStyle = css`
   #back-to-top {
-    background: #052b65;
+    border: 1px solid transparent;
+    background: ${({ theme }) => theme.bg2};
+    color: ${({ theme }) => theme.white};
     font-size: 18px;
     font-weight: 600;
     border: none;
     box-shadow: none;
     border-radius: 16px;
-    color: #ffffff;
     position: relative;
     min-height: 58px;
     padding: 16px;
-    transform: perspective(1px) translateZ(0);
     transition: all 0.2s ease-in-out;
     cursor: pointer;
 
-    :hover {
-      background: #073c8c;
+    &:focus,
+    &:hover,
+    &:active {
+      box-shadow: none;
+      transform: none;
+      color: ${({ theme }) => theme.white};
+    }
+
+    &:hover {
+      background: ${({ theme }) => lighten(0.08, theme.bg2)};
     }
   }
 `

--- a/src/cow-react/pages/CookiePolicy/CookiePolicy.md
+++ b/src/cow-react/pages/CookiePolicy/CookiePolicy.md
@@ -181,3 +181,5 @@ _Table: Overview of cookies placed and the consequences if the cookies are not p
         </tbody>
     </table>
 </div>
+
+<button onClick="(() => {window.scrollTo({ top: 0, behavior: 'smooth' })})();return false;" id="back-to-top">Back to top ↑</button>

--- a/src/cow-react/pages/PrivacyPolicy/PrivacyPolicy.md
+++ b/src/cow-react/pages/PrivacyPolicy/PrivacyPolicy.md
@@ -309,3 +309,5 @@ We may make changes to this Policy from time to time. Where we do so, we will no
 This website is hosted by Nomev Labs, Lda on behalf of a client. We are registered in Portugal under registration number PT516811924, and our registered office is located at Rua António Maria Cardoso, No 25, piso 4, 1200-027 Lisboa.
 
 If you have any queries concerning your rights under this Privacy Policy, please contact us at <a href="mailto:legal@nomev.io">legal@nomev.io</a>
+
+<button onClick="(() => {window.scrollTo({ top: 0, behavior: 'smooth' })})();return false;" id="back-to-top">Back to top ↑</button>

--- a/src/cow-react/pages/TermsAndConditions/TermsAndConditions.md
+++ b/src/cow-react/pages/TermsAndConditions/TermsAndConditions.md
@@ -190,3 +190,5 @@ Transactions on Ethereum Mainnet, Gnosis Chain and Ethereum Virtual Machine comp
 </span>
 
 The Interface may in part be established on servers at data centre facilities of third party providers and on distributed systems for storing and accessing data including IPFS. Where centralised services may be used, we may be required to transfer the Interface to different facilities, and may incur service interruption in connection with such relocation. Data centre facilities are vulnerable to force majeure events or other failures. Third party providers may suffer breaches of security and others may obtain unauthorised access to our server data. Where content is stored via distributed systems, there may be interference in content addressing, content linking, indexing and discovery. As techniques used to obtain unauthorised access change frequently and generally are not recognised until used against a target, it may not be possible to anticipate these techniques or to implement adequate preventive measures.
+
+<button onClick="(() => {window.scrollTo({ top: 0, behavior: 'smooth' })})();return false;" id="back-to-top">Back to top ↑</button>

--- a/src/cow-react/pages/TermsAndConditions/index.tsx
+++ b/src/cow-react/pages/TermsAndConditions/index.tsx
@@ -1,12 +1,18 @@
 import contentFile from './TermsAndConditions.md'
 import { MarkdownPage } from 'components/Markdown'
 import { PageTitle } from '@cow/modules/application/containers/PageTitle'
+import styled from 'styled-components/macro'
+import { BackToTopStyle } from '@cow/modules/application/pure/Page'
+
+const Wrapper = styled(MarkdownPage)`
+  ${BackToTopStyle}
+`
 
 export default function TermsAndConditions() {
   return (
     <>
       <PageTitle title="ToC" />
-      <MarkdownPage contentFile={contentFile} />
+      <Wrapper contentFile={contentFile} />
     </>
   )
 }


### PR DESCRIPTION
# Summary

Fixes #1879

This PR adds "Back to top" button at the end of following pages
- Terms and conditions
- Privacy Policy
- Cookie Policy

# To test
- go to pages mentioned above
- scroll at the bottom
- test the button