### PR TITLE
Simplify analytics

### DIFF
--- a/src/cow-react/modules/trade/utils/analytics.ts
+++ b/src/cow-react/modules/trade/utils/analytics.ts
@@ -15,15 +15,8 @@ export const tradeFlowAnalytics = {
     swapAnalytics('Send', context.orderClass, context.marketLabel)
   },
   sign(context: SwapFlowAnalyticsContext) {
-    const { account, recipient, recipientAddress, marketLabel, orderClass } = context
-
-    if (recipient === null) {
-      signSwapAnalytics('Sign', orderClass, marketLabel)
-    } else {
-      ;(recipientAddress ?? recipient) === account
-        ? signSwapAnalytics('SignToSelf', orderClass, marketLabel)
-        : signSwapAnalytics('SignAndSend', orderClass, marketLabel)
-    }
+    const { marketLabel, orderClass } = context
+    signSwapAnalytics(orderClass, marketLabel)
   },
   error(error: any, errorMessage: string, context: SwapFlowAnalyticsContext) {
     const { marketLabel, orderClass } = context

--- a/src/custom/components/analytics/events/transactionEvents.ts
+++ b/src/custom/components/analytics/events/transactionEvents.ts
@@ -6,6 +6,11 @@ const LABEL_FROM_CLASS: Record<OrderClass, string> = {
   market: 'Market Order',
 }
 
+function getClassLabel(orderClass: OrderClass, label?: string) {
+  const classLabel = LABEL_FROM_CLASS[orderClass]
+  return label ? `${label}::${classLabel}` : classLabel
+}
+
 type ExpirationType = 'Default' | 'Custom'
 export function orderExpirationTimeAnalytics(type: ExpirationType, value: number) {
   sendEvent({
@@ -45,34 +50,28 @@ export function approvalAnalytics(action: ApprovalAction, label?: string, value?
 
 export type SwapAction = 'Send' | 'Error' | 'Reject'
 export function swapAnalytics(action: SwapAction, orderClass: OrderClass, label?: string, value?: number) {
-  const classLabel = LABEL_FROM_CLASS[orderClass]
-
   sendEvent({
     category: Category.SWAP,
-    action: `${action} ${classLabel}`,
-    label,
+    action,
+    label: getClassLabel(orderClass, label),
     value,
   })
 }
 
-export type SignSwapAction = 'Sign' | 'SignAndSend' | 'SignToSelf' // TODO: Does it make sense to differenciate these options?
-export function signSwapAnalytics(action: SignSwapAction, orderClass: OrderClass, label?: string) {
-  const classLabel = LABEL_FROM_CLASS[orderClass]
-
+export function signSwapAnalytics(orderClass: OrderClass, label?: string) {
   sendEvent({
     category: Category.SWAP,
-    action: `${action} ${classLabel}`,
-    label,
+    action: 'Sign',
+    label: getClassLabel(orderClass, label),
   })
 }
 
 export type OrderType = 'Posted' | 'Executed' | 'Canceled' | 'Expired'
 export function orderAnalytics(action: OrderType, orderClass: OrderClass, label?: string) {
-  const classLabel = LABEL_FROM_CLASS[orderClass]
   sendEvent({
     category: Category.SWAP,
-    action: `${action} ${classLabel}`,
-    label,
+    action,
+    label: getClassLabel(orderClass, label),
   })
 }
 


### PR DESCRIPTION
# Summary

The analytic events are too complex. 
Because the type of order is included in the event name, the dashboards/funnels are harder to implement. 

This PR unifies a lot of the events

![image](https://user-images.githubusercontent.com/2352112/212947153-74ed287a-6453-458c-a72b-90220de0dee9.png)


# To Test
Enable analytics plugin and check the new events match the expectations on https://cowservices.slack.com/archives/C04J0438VTJ/p1673968708883919