### PR TITLE
Mention work around to expired SSL certificate

### DIFF
--- a/config/announcements/announcements-1.md
+++ b/config/announcements/announcements-1.md
@@ -1,0 +1,1 @@
+If you are experiencing issues open [https://api.cow.fi/mainnet/api/](https://api.cow.fi/mainnet/api/) and manually trust it under the `Advanced` settings.


### PR DESCRIPTION
# Summary

Adds a banner explaining how to work around the expired SSL certificate on mainnet.