### PR TITLE
Don't update prices if not visible

### DIFF
--- a/src/cow-react/modules/limitOrders/updaters/QuoteUpdater/hooks/useFetchMarketPrice/index.ts
+++ b/src/cow-react/modules/limitOrders/updaters/QuoteUpdater/hooks/useFetchMarketPrice/index.ts
@@ -13,9 +13,10 @@ import GpQuoteError from '@cow/api/gnosisProtocol/errors/QuoteError'
 import { onlyResolvesLast } from 'utils/async'
 import { SimpleGetQuoteResponse } from '@cowprotocol/cow-sdk'
 import { useDetectNativeToken } from '@cow/modules/swap/hooks/useDetectNativeToken'
+import useIsWindowVisible from '@src/hooks/useIsWindowVisible'
 
 // Every 10s
-const REFETCH_CHECK_INTERVAL = 10000
+const REFETCH_CHECK_INTERVAL = 1000
 
 const getQuoteOnlyResolveLast = onlyResolvesLast<SimpleGetQuoteResponse>(getQuote)
 
@@ -31,14 +32,18 @@ export function useFetchMarketPrice() {
   const { inputCurrency, outputCurrency, orderKind } = useLimitOrdersTradeState()
   const handleResponse = useHandleResponse()
 
+  const isWindowVisible = useIsWindowVisible()
+
   // Main hook updater
   useLayoutEffect(() => {
-    const handleFetchQuote = () => {
-      if (!feeQuoteParams || isWrapOrUnwrap) {
-        setLimitOrdersQuote({})
-        return
-      }
+    if (!feeQuoteParams || isWrapOrUnwrap || !isWindowVisible) {
+      console.debug('[useFetchMarketPrice] No need to fetch quotes')
+      return
+    }
 
+    console.debug('[useFetchMarketPrice] Periodically fetch quotes')
+    const handleFetchQuote = () => {
+      console.debug('[useFetchMarketPrice] Fetching price')
       getQuoteOnlyResolveLast(feeQuoteParams)
         .then(handleResponse)
         .catch((error: GpQuoteError) => {
@@ -54,7 +59,7 @@ export function useFetchMarketPrice() {
     const intervalId = setInterval(handleFetchQuote, REFETCH_CHECK_INTERVAL)
 
     return () => clearInterval(intervalId)
-  }, [feeQuoteParams, handleResponse, updateLimitRateState, setLimitOrdersQuote, isWrapOrUnwrap])
+  }, [feeQuoteParams, handleResponse, updateLimitRateState, setLimitOrdersQuote, isWrapOrUnwrap, isWindowVisible])
 
   // Turn on the loading if some of these dependencies have changed and remove execution rate
   useLayoutEffect(() => {

--- a/src/cow-react/modules/limitOrders/updaters/QuoteUpdater/hooks/useFetchMarketPrice/index.ts
+++ b/src/cow-react/modules/limitOrders/updaters/QuoteUpdater/hooks/useFetchMarketPrice/index.ts
@@ -16,7 +16,7 @@ import { useDetectNativeToken } from '@cow/modules/swap/hooks/useDetectNativeTok
 import useIsWindowVisible from '@src/hooks/useIsWindowVisible'
 
 // Every 10s
-const REFETCH_CHECK_INTERVAL = 1000
+const REFETCH_CHECK_INTERVAL = 10000
 
 const getQuoteOnlyResolveLast = onlyResolvesLast<SimpleGetQuoteResponse>(getQuote)
 

--- a/src/cow-react/modules/limitOrders/updaters/QuoteUpdater/hooks/useFetchMarketPrice/index.ts
+++ b/src/cow-react/modules/limitOrders/updaters/QuoteUpdater/hooks/useFetchMarketPrice/index.ts
@@ -13,7 +13,7 @@ import GpQuoteError from '@cow/api/gnosisProtocol/errors/QuoteError'
 import { onlyResolvesLast } from 'utils/async'
 import { SimpleGetQuoteResponse } from '@cowprotocol/cow-sdk'
 import { useDetectNativeToken } from '@cow/modules/swap/hooks/useDetectNativeToken'
-import useIsWindowVisible from '@src/hooks/useIsWindowVisible'
+import useIsWindowVisible from 'hooks/useIsWindowVisible'
 
 // Every 10s
 const REFETCH_CHECK_INTERVAL = 10000

--- a/src/custom/hooks/useFetchProfile.ts
+++ b/src/custom/hooks/useFetchProfile.ts
@@ -2,6 +2,7 @@ import { useWeb3React } from '@web3-react/core'
 import { useEffect, useState } from 'react'
 import { getProfileData } from '@cow/api/gnosisProtocol'
 import { ProfileData } from '@cow/api/gnosisProtocol/api'
+import useIsWindowVisible from 'hooks/useIsWindowVisible'
 
 type FetchProfileState = {
   profileData: ProfileData | null
@@ -20,9 +21,16 @@ const FETCH_INTERVAL_IN_MINUTES = 5
 export default function useFetchProfile(): FetchProfileState {
   const { account, chainId } = useWeb3React()
   const [profile, setProfile] = useState<FetchProfileState>(emptyState)
+  const isWindowVisible = useIsWindowVisible()
 
   useEffect(() => {
+    if (!isWindowVisible) {
+      console.debug('[useFetchProfile] No need to fetch profile info')
+      return
+    }
+
     async function fetchAndSetProfileData() {
+      console.debug('[useFetchProfile] Fetching profile info')
       try {
         if (chainId && account) {
           setProfile((profile) => ({ ...profile, isLoading: true, error: '' }))
@@ -41,11 +49,12 @@ export default function useFetchProfile(): FetchProfileState {
       }
     }
 
+    console.debug('[useFetchProfile] No need to fetch profile info')
     const intervalId = setInterval(fetchAndSetProfileData, FETCH_INTERVAL_IN_MINUTES * 60_000)
 
     fetchAndSetProfileData()
     return () => clearInterval(intervalId)
-  }, [account, chainId])
+  }, [account, chainId, isWindowVisible])
 
   return profile
 }

--- a/src/custom/hooks/usePriceImpact/useFallbackPriceImpact.ts
+++ b/src/custom/hooks/usePriceImpact/useFallbackPriceImpact.ts
@@ -8,7 +8,7 @@ import { QuoteInformationObject } from 'state/price/reducer'
 import { QuoteError } from 'state/price/actions'
 import { LegacyFeeQuoteParams } from '@cow/api/gnosisProtocol/legacy/types'
 import { PRICE_QUOTE_VALID_TO_TIME } from '@cow/constants/quote'
-import useIsWindowVisible from '@src/hooks/useIsWindowVisible'
+import useIsWindowVisible from 'hooks/useIsWindowVisible'
 
 type SwapParams = { abTrade?: PriceImpactTrade; sellToken?: string | null; buyToken?: string | null }
 

--- a/src/custom/hooks/usePriceImpact/useFallbackPriceImpact.ts
+++ b/src/custom/hooks/usePriceImpact/useFallbackPriceImpact.ts
@@ -8,6 +8,7 @@ import { QuoteInformationObject } from 'state/price/reducer'
 import { QuoteError } from 'state/price/actions'
 import { LegacyFeeQuoteParams } from '@cow/api/gnosisProtocol/legacy/types'
 import { PRICE_QUOTE_VALID_TO_TIME } from '@cow/constants/quote'
+import useIsWindowVisible from '@src/hooks/useIsWindowVisible'
 
 type SwapParams = { abTrade?: PriceImpactTrade; sellToken?: string | null; buyToken?: string | null }
 
@@ -48,8 +49,10 @@ export default function useFallbackPriceImpact({
 }: FallbackPriceImpactParams) {
   const [loading, setLoading] = useState(false)
 
+  const isWindowVisible = useIsWindowVisible()
+
   // Should we even calc this? Check if fiatPriceImpact exists OR user is wrapping token
-  const shouldCalculate = !!abTrade && !isWrapping
+  const shouldCalculate = !!abTrade && !isWrapping && isWindowVisible
 
   // to bail out early
   useEffect(() => {

--- a/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -20,6 +20,8 @@ import { NATIVE_CURRENCY_BUY_ADDRESS } from 'constants/index'
 import { WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
 import { PRICE_QUOTE_VALID_TO_TIME } from '@cow/constants/quote'
 
+import useIsWindowVisible from '@src/hooks/useIsWindowVisible'
+
 /**
  * Thin wrapper around `getBestPrice` that builds the params and returns null on failure
  */
@@ -131,7 +133,8 @@ export function UnfillableOrdersUpdater(): null {
         )
       }
 
-      pending.forEach((order, index) =>
+      pending.forEach((order, index) => {
+        console.debug(`[UnfillableOrdersUpdater] Check order`, order)
         _getOrderPrice(chainId, order, strategy)
           .then((quote) => {
             if (quote) {
@@ -152,20 +155,26 @@ export function UnfillableOrdersUpdater(): null {
               e
             )
           })
-      )
+      })
     } finally {
       isUpdating.current = false
       console.debug(`[UnfillableOrdersUpdater] Checked pending orders in ${Date.now() - startTime}ms`)
     }
   }, [account, chainId, strategy, updateIsUnfillableFlag])
 
+  const isWindowVisible = useIsWindowVisible()
+
   useEffect(() => {
+    if (!chainId || !account || !isWindowVisible) {
+      console.debug('[UnfillableOrdersUpdater] No need to fetch unfillable orders')
+      return
+    }
+
+    console.debug('[UnfillableOrdersUpdater] Periodically check for unfillable orders')
     updatePending()
-
     const interval = setInterval(updatePending, PENDING_ORDERS_PRICE_CHECK_POLL_INTERVAL)
-
     return () => clearInterval(interval)
-  }, [updatePending])
+  }, [updatePending, chainId, account, isWindowVisible])
 
   return null
 }

--- a/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -20,7 +20,7 @@ import { NATIVE_CURRENCY_BUY_ADDRESS } from 'constants/index'
 import { WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
 import { PRICE_QUOTE_VALID_TO_TIME } from '@cow/constants/quote'
 
-import useIsWindowVisible from '@src/hooks/useIsWindowVisible'
+import useIsWindowVisible from 'hooks/useIsWindowVisible'
 
 /**
  * Thin wrapper around `getBestPrice` that builds the params and returns null on failure

--- a/src/custom/state/price/updater.ts
+++ b/src/custom/state/price/updater.ts
@@ -160,7 +160,7 @@ export default function FeesUpdater(): null {
   const refetchQuote = useRefetchQuoteCallback()
   const setQuoteError = useSetQuoteError()
 
-  const windowVisible = useIsWindowVisible()
+  const isWindowVisible = useIsWindowVisible()
   const isOnline = useIsOnline()
   const { validTo } = useOrderValidTo()
 
@@ -179,7 +179,7 @@ export default function FeesUpdater(): null {
       !sellCurrencyId ||
       !buyCurrencyId ||
       !typedValue ||
-      !windowVisible ||
+      !isWindowVisible ||
       sellTokenAddressInvalid ||
       buyTokenAddressInvalid
     )
@@ -275,7 +275,7 @@ export default function FeesUpdater(): null {
     return () => clearInterval(intervalId)
   }, [
     isEthFlow,
-    windowVisible,
+    isWindowVisible,
     isOnline,
     chainId,
     sellCurrencyId,


### PR DESCRIPTION
# Summary

Tries to prevent to get the quotes when the tab/window is not active

It does it for:
- ABA updater
- Unfillable orders updater
- Limit Orders useFetchMarketPrice
- Limit Orders initial Price

## Test
Everything should work as before, but if you use another tab, it should stop doing quote requests