### PR TITLE
#1893 Fixing issue with tokens with identical symbols

### DIFF
--- a/src/cow-react/common/hooks/useAreThereTokensWithSameSymbol.ts
+++ b/src/cow-react/common/hooks/useAreThereTokensWithSameSymbol.ts
@@ -10,7 +10,7 @@ export function useAreThereTokensWithSameSymbol(): (tokenAddressOrSymbol: string
     (tokenAddressOrSymbol: string | null | undefined) => {
       if (!tokenAddressOrSymbol || isAddress(tokenAddressOrSymbol)) return false
 
-      return tokensBySymbol[tokenAddressOrSymbol]?.length > 1
+      return tokensBySymbol[tokenAddressOrSymbol.toLowerCase()]?.length > 1
     },
     [tokensBySymbol]
   )


### PR DESCRIPTION
# Summary

Fixes #1893 

Lowercasing token symbol when searching for existing ones in the mapping

# To Test

1. On mainnet, search for `AURA` 
<img width="484" alt="Screenshot 2023-01-24 at 10 45 42" src="https://user-images.githubusercontent.com/43217/214272759-d0c0033b-9658-420c-ad6c-4e7ee8af593f.png">

2. There should be 2 results. Import both
3. Select the first one (with the purple symbol)
* It should be selectable
* The url should change to the token address `0xC0c293ce456fF0ED870ADd98a0828Dd4d2903DBF`
4. Select the other AURA token (with blue-ish symbol)
* It should be selectable
* The url should change to the token address `0xCdCFc0f66c522Fd086A1b725ea3c0Eeb9F9e8814`
