### PR TITLE
Updated Safe urls to new endpoints

### DIFF
--- a/src/cow-react/api/gnosisSafe/index.ts
+++ b/src/cow-react/api/gnosisSafe/index.ts
@@ -7,12 +7,12 @@ import EthersAdapter from '@safe-global/safe-ethers-lib'
 import { ethers } from 'ethers'
 
 const SAFE_TRANSACTION_SERVICE_URL: Partial<Record<number, string>> = {
-  [ChainId.MAINNET]: 'https://safe-transaction.gnosis.io',
-  [ChainId.GNOSIS_CHAIN]: 'https://safe-transaction.xdai.gnosis.io',
-  [ChainId.GOERLI]: 'https://safe-transaction.goerli.gnosis.io',
+  [ChainId.MAINNET]: 'https://safe-transaction-mainnet.safe.global',
+  [ChainId.GNOSIS_CHAIN]: 'https://safe-transaction-gnosis-chain.safe.global',
+  [ChainId.GOERLI]: 'https://safe-transaction-goerli.safe.global',
 }
 
-const SAFE_BASE_URL = 'https://gnosis-safe.io'
+const SAFE_BASE_URL = 'https://app.safe.global'
 const CHAIN_SHORT_NAME: Partial<Record<number, string>> = {
   [ChainId.MAINNET]: 'eth', // https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-1.json
   [ChainId.GNOSIS_CHAIN]: 'xdai', // https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-100.json
@@ -63,7 +63,7 @@ export function getSafeWebUrl(chaindId: number, safeAddress: string): string | n
     return null
   }
 
-  return `${SAFE_BASE_URL}/app/${chainShortName}:${safeAddress}/transactions/queue` // TODO: This will change soon in https://github.com/gnosis/safe-react/issues/970
+  return `${SAFE_BASE_URL}/${chainShortName}:${safeAddress}/transactions`
 }
 
 export function getSafeTransaction(

--- a/src/cow-react/api/gnosisSafe/index.ts
+++ b/src/cow-react/api/gnosisSafe/index.ts
@@ -15,7 +15,7 @@ const SAFE_TRANSACTION_SERVICE_URL: Partial<Record<number, string>> = {
 const SAFE_BASE_URL = 'https://app.safe.global'
 const CHAIN_SHORT_NAME: Partial<Record<number, string>> = {
   [ChainId.MAINNET]: 'eth', // https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-1.json
-  [ChainId.GNOSIS_CHAIN]: 'xdai', // https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-100.json
+  [ChainId.GNOSIS_CHAIN]: 'gno', // https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-100.json
   [ChainId.GOERLI]: 'gor', // https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-5.json
 }
 

--- a/src/cow-react/api/gnosisSafe/index.ts
+++ b/src/cow-react/api/gnosisSafe/index.ts
@@ -56,14 +56,14 @@ function _getClientOrThrow(chainId: number, library: Web3Provider): SafeServiceC
   return client
 }
 
-export function getSafeWebUrl(chaindId: number, safeAddress: string): string | null {
+export function getSafeWebUrl(chaindId: number, safeAddress: string, safeTxHash: string): string | null {
   const chainShortName = CHAIN_SHORT_NAME[chaindId]
 
   if (!chainShortName) {
     return null
   }
 
-  return `${SAFE_BASE_URL}/${chainShortName}:${safeAddress}/transactions`
+  return `${SAFE_BASE_URL}/${chainShortName}:${safeAddress}/transactions/tx?id=multisig_${safeAddress}_${safeTxHash}`
 }
 
 export function getSafeTransaction(

--- a/src/custom/components/AccountDetails/Transaction/StatusDetails.tsx
+++ b/src/custom/components/AccountDetails/Transaction/StatusDetails.tsx
@@ -26,8 +26,8 @@ export function GnosisSafeLink(props: {
     return null
   }
 
-  const { safe } = safeTransaction
-  const safeUrl = getSafeWebUrl(chainId, safe)
+  const { safe, safeTxHash } = safeTransaction
+  const safeUrl = getSafeWebUrl(chainId, safe, safeTxHash)
 
   // Only show the link to the safe, if we have the "safeUrl"
   if (safeUrl === null) {

--- a/src/custom/hooks/useActivityDerivedState.ts
+++ b/src/custom/hooks/useActivityDerivedState.ts
@@ -91,8 +91,8 @@ export function getActivityLinkUrl(params: {
       return getEtherscanLink(chainId, transactionHash, 'transaction')
     } else if (safeTransaction && safeTransaction) {
       // It's a safe transaction: Gnosis Safe Web link
-      const { safe } = safeTransaction
-      return getSafeWebUrl(chainId, safe) ?? undefined
+      const { safe, safeTxHash } = safeTransaction
+      return getSafeWebUrl(chainId, safe, safeTxHash) ?? undefined
     }
   } else if (order) {
     if (order.orderCreationHash && (order.status === OrderStatus.CREATING || order.status === OrderStatus.FAILED)) {

--- a/src/custom/hooks/useWalletInfo.ts
+++ b/src/custom/hooks/useWalletInfo.ts
@@ -11,7 +11,7 @@ import { gnosisSafeAtom } from 'state/gnosisSafe/atoms'
 import { useMemo } from 'react'
 
 const GNOSIS_SAFE_APP_NAME = 'Gnosis Safe App'
-const SAFE_ICON_URL = 'https://apps.gnosis-safe.io/wallet-connect/favicon.ico'
+const SAFE_ICON_URL = 'https://app.safe.global/favicon.ico'
 
 export interface ConnectedWalletInfo {
   chainId?: number


### PR DESCRIPTION
# Summary

Updating Safe endpoints

# To Test

1. Connect to the app using the Safe
2. Open the network console and filter by `safe`
3. Perform any operation (approval, order placement)
4. Open the activity modal
* It should link to the new Safe endpoints (app.safe.global)
![Screenshot 2023-01-25 at 16 27 15](https://user-images.githubusercontent.com/43217/214619818-6bdee7d1-67a3-4bfb-91f1-0ed588ea5766.png)
* Open the link and make sure it loads the safe and txs properly
* The network requests should go to safe-transaction-`network name`
![Screenshot 2023-01-25 at 16 30 40](https://user-images.githubusercontent.com/43217/214620555-fceddc9b-6727-414d-bab0-e88e2c7eb5cd.png)
5. Repeat steps 1-4 for all networks

# Bonus

Also updated the safe link to point to the exact tx with deeplinking which was introduced recently

Example: https://app.safe.global/gor:0x5895fCf0A96a4d19E17d2dD759926d1A02781ef8/transactions/tx?id=multisig_0x5895fCf0A96a4d19E17d2dD759926d1A02781ef8_0x2f9eea9047c4d6547d7b0c883d1a4426b66f1907458d193dae5cab2fbe8d3290

