### PR TITLE
Wireup date picker

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/DeadlineInput/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/DeadlineInput/index.tsx
@@ -25,7 +25,7 @@ export function DeadlineInput() {
   )
 
   const selectCustomDeadline = useCallback(
-    (customDeadline: number) => {
+    (customDeadline: number | null) => {
       updateSettingsState({ customDeadlineTimestamp: customDeadline })
     },
     [updateSettingsState]

--- a/src/cow-react/modules/limitOrders/pure/DeadlineSelector/deadlines.ts
+++ b/src/cow-react/modules/limitOrders/pure/DeadlineSelector/deadlines.ts
@@ -5,8 +5,8 @@ export interface LimitOrderDeadline {
   value: number
 }
 
-export const MIN_CUSTOM_DEADLINE = ms`10min`
-export const MAX_CUSTOM_DEADLINE = Math.round(ms`1y` / 2) // A half of year
+export const MIN_CUSTOM_DEADLINE = ms`30min`
+export const MAX_CUSTOM_DEADLINE = Math.round(ms`1y` / 2) // 6 months
 
 export const defaultLimitOrderDeadline: LimitOrderDeadline = { title: '7 Days', value: ms`7d` }
 

--- a/src/cow-react/modules/limitOrders/pure/DeadlineSelector/deadlines.ts
+++ b/src/cow-react/modules/limitOrders/pure/DeadlineSelector/deadlines.ts
@@ -5,7 +5,8 @@ export interface LimitOrderDeadline {
   value: number
 }
 
-export const maxCustomDeadline = Math.round(ms`1y` / 2) // A half of year
+export const MIN_CUSTOM_DEADLINE = ms`30min`
+export const MAX_CUSTOM_DEADLINE = Math.round(ms`1y` / 2) // A half of year
 
 export const defaultLimitOrderDeadline: LimitOrderDeadline = { title: '7 Days', value: ms`7d` }
 

--- a/src/cow-react/modules/limitOrders/pure/DeadlineSelector/deadlines.ts
+++ b/src/cow-react/modules/limitOrders/pure/DeadlineSelector/deadlines.ts
@@ -5,7 +5,7 @@ export interface LimitOrderDeadline {
   value: number
 }
 
-export const MIN_CUSTOM_DEADLINE = ms`30min`
+export const MIN_CUSTOM_DEADLINE = ms`10min`
 export const MAX_CUSTOM_DEADLINE = Math.round(ms`1y` / 2) // A half of year
 
 export const defaultLimitOrderDeadline: LimitOrderDeadline = { title: '7 Days', value: ms`7d` }

--- a/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
@@ -180,6 +180,33 @@ function _limitDateString(date: Date | number): string {
   return [first, second].join(':')
 }
 
+const LOCAL_DATE_FORMATTER = new Intl.DateTimeFormat(
+  'en-CA', // using CA because the format is yyyy-mm-dd, which is what we need
+  {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }
+)
+
+/**
+ * Formats a date object into a Timezone aware string in the format: `yyyy-mm-ddTHH:MM`
+ *
+ * The important part is the timezone awareness.
+ * The `datetime-local` input can't deal with timezones while all Date objs are tz aware.
+ * When passing the initial value to the input, using the ISO string representation of the date
+ * causes it to be in a different time from user's
+ */
+function _formatDateToLocalTime(date: Date | number): string {
+  const _date = typeof date === 'number' ? new Date(date * 1000) : date
+
+  return LOCAL_DATE_FORMATTER.format(_date) // this returns `2017-06-01, 08:30`
+    .replace(/, /, 'T') // we want `2017-06-01T08:30`
+}
+
 function _calculateMinMax(): [Date, Date] {
   const now = Date.now()
   return [_trimSeconds(new Date(now + MIN_CUSTOM_DEADLINE)), _trimSeconds(new Date(now + MAX_CUSTOM_DEADLINE))]
@@ -187,4 +214,25 @@ function _calculateMinMax(): [Date, Date] {
 
 function _trimSeconds(date: Date): Date {
   return new Date(new Date(date.setMilliseconds(0)).setSeconds(0))
+}
+
+/**
+ * Get client side timezone offset
+ *
+ * @returns {(+|-)HH:mm} - Where `HH` is 2 digits hours and `mm` 2 digits minutes.
+ *
+ * From https://stackoverflow.com/a/30377368/1272513 on 2023/01/31
+ */
+function _getTimeZoneOffset() {
+  const timezoneOffset = new Date().getTimezoneOffset()
+  const offset = Math.abs(timezoneOffset)
+  const offsetOperator = timezoneOffset < 0 ? '+' : '-'
+  const offsetHours = Math.floor(offset / 60)
+    .toString()
+    .padStart(2, '0')
+  const offsetMinutes = Math.floor(offset % 60)
+    .toString()
+    .padStart(2, '0')
+
+  return `${offsetOperator}${offsetHours}:${offsetMinutes}`
 }

--- a/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
@@ -159,6 +159,8 @@ export function DeadlineSelector(props: DeadlineSelectorProps) {
                 type="datetime-local"
                 id="custom-deadline"
                 onChange={onChange}
+                // For some reason, `min/max` values require the same format as `value`,
+                // but they don't need to be in the user's timezone
                 min={min}
                 max={max}
                 value={value}

--- a/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
@@ -60,11 +60,12 @@ export function DeadlineSelector(props: DeadlineSelectorProps) {
   useEffect(() => {
     try {
       const newDeadline = new Date(value).getTime()
+      const { timeZone } = Intl.DateTimeFormat().resolvedOptions()
 
       if (newDeadline < minDate.getTime()) {
-        setError(`Must be after ${minDate.toLocaleString()} ${Intl.DateTimeFormat().resolvedOptions().timeZone}`)
+        setError(`Must be after ${minDate.toLocaleString()} ${timeZone}`)
       } else if (newDeadline > maxDate.getTime()) {
-        setError(`Must be before ${maxDate.toLocaleString()} ${Intl.DateTimeFormat().resolvedOptions().timeZone}`)
+        setError(`Must be before ${maxDate.toLocaleString()} ${timeZone}`)
       } else {
         setError(null)
       }

--- a/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
@@ -171,6 +171,8 @@ export function DeadlineSelector(props: DeadlineSelectorProps) {
                 min={min}
                 max={max}
                 value={value}
+                // The `pattern` is not used at all in `datetime-local` input, but is in place
+                // to enforce it when it isn't support. In that case it's rendered as a regular `text` input
                 pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}"
               />
             </CustomLabel>

--- a/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
@@ -108,7 +108,9 @@ export function DeadlineSelector(props: DeadlineSelectorProps) {
   const onDismiss = useCallback(() => setIsOpen(false), [])
 
   const setCustomDeadline = useCallback(() => {
-    const newDeadline = Math.round(new Date(value).getTime() / 1000)
+    // `value` is a timezone aware string
+    // thus, we append the timezone offset (if any) when building the date object
+    const newDeadline = Math.round(new Date(value + _getTimeZoneOffset()).getTime() / 1000)
 
     selectCustomDeadline(newDeadline)
     onDismiss()

--- a/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
@@ -24,6 +24,7 @@ import { ButtonPrimary, ButtonSecondary } from '@src/components/Button'
 import {
   calculateMinMax,
   formatDateToLocalTime,
+  getInputStartDate,
   getTimeZoneOffset,
   limitDateString,
 } from '@cow/modules/limitOrders/pure/DeadlineSelector/utils'
@@ -105,13 +106,17 @@ export function DeadlineSelector(props: DeadlineSelectorProps) {
   )
 
   const [isOpen, setIsOpen] = useState(false)
-  const openModal = () => {
+
+  const openModal = useCallback(() => {
     currentDeadlineNode.current?.click() // Close dropdown
     setIsOpen(true)
     setError(null)
-    setMinMax(calculateMinMax()) // Update min/max every time modal is open
-    setValue(formatDateToLocalTime(customDeadline || minDate)) // reset input to clear unsaved values
-  }
+
+    const minMax = calculateMinMax()
+    setMinMax(minMax) // Update min/max every time modal is open
+    setValue(formatDateToLocalTime(getInputStartDate(customDeadline, minMax[0]))) // reset input to clear unsaved values
+  }, [customDeadline])
+
   const onDismiss = useCallback(() => setIsOpen(false), [])
 
   const setCustomDeadline = useCallback(() => {

--- a/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
@@ -105,7 +105,7 @@ export function DeadlineSelector(props: DeadlineSelectorProps) {
     setMinMax(_calculateMinMax()) // Update min/max every time modal is open
     setValue(customDeadline ? _limitDateString(customDeadline) : min) // reset input to clear unsaved values
   }
-  const onDismiss = () => setIsOpen(false)
+  const onDismiss = useCallback(() => setIsOpen(false), [])
 
   const setCustomDeadline = useCallback(() => {
     const newDeadline = Math.round(new Date(value).getTime() / 1000)

--- a/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
@@ -87,9 +87,15 @@ export function DeadlineSelector(props: DeadlineSelectorProps) {
   )
 
   // Sets value from input, if it exists
-  const onChange = useCallback(({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => {
-    value && setValue(value)
-  }, [])
+  const onChange = useCallback(
+    ({ target: { value, valueAsNumber } }: React.ChangeEvent<HTMLInputElement>) => {
+      // Some browsers offer a `clear` button in their date picker
+      // That action sets the value to `''`
+      // In that case, use the default min value
+      setValue(value || _formatDateToLocalTime(minDate))
+    },
+    [minDate]
+  )
 
   const [isOpen, setIsOpen] = useState(false)
   const openModal = () => {

--- a/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
@@ -48,7 +48,7 @@ export function DeadlineSelector(props: DeadlineSelectorProps) {
   const max = _limitDateString(maxDate)
 
   const [error, setError] = useState<string | null>(null)
-  const [value, setValue] = useState<string>(customDeadline ? _limitDateString(customDeadline) : min)
+  const [value, setValue] = useState<string>('')
 
   // Validate `value` from datetime-local input
   useEffect(() => {

--- a/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
@@ -103,7 +103,7 @@ export function DeadlineSelector(props: DeadlineSelectorProps) {
     setIsOpen(true)
     setError(null)
     setMinMax(_calculateMinMax()) // Update min/max every time modal is open
-    setValue(customDeadline ? _limitDateString(customDeadline) : min) // reset input to clear unsaved values
+    setValue(_formatDateToLocalTime(customDeadline || minDate)) // reset input to clear unsaved values
   }
   const onDismiss = useCallback(() => setIsOpen(false), [])
 

--- a/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
@@ -175,7 +175,11 @@ export function DeadlineSelector(props: DeadlineSelectorProps) {
               />
             </CustomLabel>
             {/* TODO: style me!!! */}
-            {error && <div>{error}</div>}
+            {error && (
+              <div>
+                <Trans>{error}</Trans>
+              </div>
+            )}
           </ModalContent>
           <ModalFooter>
             <ButtonSecondary onClick={onDismiss}>Cancel</ButtonSecondary>

--- a/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
@@ -174,6 +174,11 @@ export function DeadlineSelector(props: DeadlineSelectorProps) {
                 // The `pattern` is not used at all in `datetime-local` input, but is in place
                 // to enforce it when it isn't support. In that case it's rendered as a regular `text` input
                 pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}"
+                onFocus={(event: React.FocusEvent<HTMLInputElement>) => {
+                  // Bug fix for resetting input with `reset` button iOS
+                  // See https://github.com/facebook/react/issues/8938
+                  event.target.defaultValue = ''
+                }}
               />
             </CustomLabel>
             {/* TODO: style me!!! */}

--- a/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/DeadlineSelector/index.tsx
@@ -56,9 +56,9 @@ export function DeadlineSelector(props: DeadlineSelectorProps) {
       const newDeadline = new Date(value).getTime()
 
       if (newDeadline < minDate.getTime()) {
-        setError(`Must be after ${minDate.toLocaleDateString()} ${minDate.toLocaleTimeString()}`)
+        setError(`Must be after ${minDate.toLocaleString()} ${Intl.DateTimeFormat().resolvedOptions().timeZone}`)
       } else if (newDeadline > maxDate.getTime()) {
-        setError(`Must be before ${maxDate.toLocaleDateString()} ${maxDate.toLocaleTimeString()}`)
+        setError(`Must be before ${maxDate.toLocaleString()} ${Intl.DateTimeFormat().resolvedOptions().timeZone}`)
       } else {
         setError(null)
       }

--- a/src/cow-react/modules/limitOrders/pure/DeadlineSelector/utils.ts
+++ b/src/cow-react/modules/limitOrders/pure/DeadlineSelector/utils.ts
@@ -1,0 +1,66 @@
+import { MAX_CUSTOM_DEADLINE, MIN_CUSTOM_DEADLINE } from '@cow/modules/limitOrders/pure/DeadlineSelector/deadlines'
+
+export function limitDateString(date: Date | number): string {
+  const _date = typeof date === 'number' ? new Date(date * 1000) : date
+
+  const [first, second] = _date.toISOString().split(':')
+
+  return [first, second].join(':')
+}
+
+const LOCAL_DATE_FORMATTER = new Intl.DateTimeFormat(
+  'en-CA', // using CA because the format is yyyy-mm-dd, which is what we need
+  {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }
+)
+
+/**
+ * Formats a date object into a Timezone aware string in the format: `yyyy-mm-ddTHH:MM`
+ *
+ * The important part is the timezone awareness.
+ * The `datetime-local` input can't deal with timezones while all Date objs are tz aware.
+ * When passing the initial value to the input, using the ISO string representation of the date
+ * causes it to be in a different time from user's
+ */
+export function formatDateToLocalTime(date: Date | number): string {
+  const _date = typeof date === 'number' ? new Date(date * 1000) : date
+
+  return LOCAL_DATE_FORMATTER.format(_date) // this returns `2017-06-01, 08:30`
+    .replace(/, /, 'T') // we want `2017-06-01T08:30`
+}
+
+export function calculateMinMax(): [Date, Date] {
+  const now = Date.now()
+  return [_trimSeconds(new Date(now + MIN_CUSTOM_DEADLINE)), _trimSeconds(new Date(now + MAX_CUSTOM_DEADLINE))]
+}
+
+function _trimSeconds(date: Date): Date {
+  return new Date(new Date(date.setMilliseconds(0)).setSeconds(0))
+}
+
+/**
+ * Get client side timezone offset
+ *
+ * @returns {(+|-)HH:mm} - Where `HH` is 2 digits hours and `mm` 2 digits minutes.
+ *
+ * From https://stackoverflow.com/a/30377368/1272513 on 2023/01/31
+ */
+export function getTimeZoneOffset() {
+  const timezoneOffset = new Date().getTimezoneOffset()
+  const offset = Math.abs(timezoneOffset)
+  const offsetOperator = timezoneOffset < 0 ? '+' : '-'
+  const offsetHours = Math.floor(offset / 60)
+    .toString()
+    .padStart(2, '0')
+  const offsetMinutes = Math.floor(offset % 60)
+    .toString()
+    .padStart(2, '0')
+
+  return `${offsetOperator}${offsetHours}:${offsetMinutes}`
+}

--- a/src/cow-react/modules/limitOrders/pure/DeadlineSelector/utils.ts
+++ b/src/cow-react/modules/limitOrders/pure/DeadlineSelector/utils.ts
@@ -45,6 +45,22 @@ function _trimSeconds(date: Date): Date {
 }
 
 /**
+ * Gets the datetime-local input initial value based on current stored value and min allowed
+ *
+ * If a value was previously saved, but it's older than min, use min instead
+ */
+export function getInputStartDate(customDeadline: number | null, minDate: Date): Date {
+  if (customDeadline) {
+    const customDate = new Date(customDeadline * 1000)
+
+    if (customDate > minDate) {
+      return customDate
+    }
+  }
+  return minDate
+}
+
+/**
  * Get client side timezone offset
  *
  * @returns {(+|-)HH:mm} - Where `HH` is 2 digits hours and `mm` 2 digits minutes.


### PR DESCRIPTION
# Summary

PR on top of https://github.com/cowprotocol/cowswap/pull/1922

- Wiring up the picker with state
- Added error msgs for when:
  - `< min date
  - `> max date
  - Unable to parse inserted date
- Deadline will only be updated if valid, even if input validation/picker is bypassed

⚠️ Error msg is in desperate need of styling. Will delegate that to Michel ;)

<img width="481" alt="Screenshot 2023-01-27 at 15 55 52" src="https://user-images.githubusercontent.com/43217/215130390-7d869d7d-cb10-4a64-a094-0fed1900b608.png">

# To Test

1. On limit orders, open the date picker and select `custom`
2. Play around with the custom date
3. Chose a date < 30min from now
4. Chose a date > 6 months from now