### PR TITLE
Limit order creating e2e test

### DIFF
--- a/cypress-custom/integration/limit-orders.test.ts
+++ b/cypress-custom/integration/limit-orders.test.ts
@@ -8,8 +8,8 @@ function pickToken(symbol: string, role: 'input' | 'output') {
 
 describe('Limit orders', () => {
   it('Confirmation modal must contains values that were entered while creating', () => {
-    const inputAmount = '0.001'
-    const outputAmount = '90000000000000'
+    const inputAmount = '0.1'
+    const outputAmount = '2000000000000'
 
     cy.visit(`/#/${CHAIN_ID}/limit-orders`)
     cy.get('#unlock-limit-orders-btn').click()
@@ -21,7 +21,8 @@ describe('Limit orders', () => {
     cy.get('#rate-limit-amount-input').clear().type(outputAmount, { force: true })
     cy.get('#review-limit-order-btn').click()
 
+    cy.get('#limit-orders-currency-output .token-amount-input').should('have.value', '200B')
     cy.get('#limit-orders-confirm #input-currency-preview .token-amount-input').should('have.value', inputAmount)
-    cy.get('#limit-orders-confirm #output-currency-preview .token-amount-input').should('have.value', '90B')
+    cy.get('#limit-orders-confirm #output-currency-preview .token-amount-input').should('have.value', '200B')
   })
 })

--- a/cypress-custom/integration/limit-orders.test.ts
+++ b/cypress-custom/integration/limit-orders.test.ts
@@ -1,0 +1,27 @@
+const CHAIN_ID = 5
+
+function pickToken(symbol: string, role: 'input' | 'output') {
+  cy.get(`#limit-orders-currency-${role} .open-currency-select-button`).click()
+  cy.get('#token-search-input').type(symbol)
+  cy.get('#currency-list').get('div').contains(symbol).click({ force: true })
+}
+
+describe('Limit orders', () => {
+  it('Confirmation modal must contains values that were entered while creating', () => {
+    const inputAmount = '0.001'
+    const outputAmount = '90000000000000'
+
+    cy.visit(`/#/${CHAIN_ID}/limit-orders`)
+    cy.get('#unlock-limit-orders-btn').click()
+
+    pickToken('WETH', 'input')
+    pickToken('DAI', 'output')
+
+    cy.get('#limit-orders-currency-input .token-amount-input').type(inputAmount)
+    cy.get('#rate-limit-amount-input').clear().type(outputAmount, { force: true })
+    cy.get('#review-limit-order-btn').click()
+
+    cy.get('#limit-orders-confirm #input-currency-preview .token-amount-input').should('have.value', inputAmount)
+    cy.get('#limit-orders-confirm #output-currency-preview .token-amount-input').should('have.value', '90B')
+  })
+})

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -239,7 +239,7 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
           {isUnlocked ? (
             <>
               <CurrencyInputPanel
-                id="swap-currency-input"
+                id="limit-orders-currency-input"
                 disableNonToken={false}
                 chainId={chainId}
                 loading={currenciesLoadingInProgress}
@@ -269,7 +269,7 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
                 {showRecipient && recipient === null && <AddRecipient onChangeRecipient={onChangeRecipient} />}
               </styledEl.CurrencySeparatorBox>
               <CurrencyInputPanel
-                id="swap-currency-output"
+                id="limit-orders-currency-output"
                 disableNonToken={false}
                 chainId={chainId}
                 loading={currenciesLoadingInProgress}

--- a/src/cow-react/modules/limitOrders/containers/RateInput/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/RateInput/index.tsx
@@ -145,7 +145,7 @@ export function RateInput() {
         ) : (
           <styledEl.NumericalInput
             $loading={false}
-            className="rate-limit-amount-input"
+            id="rate-limit-amount-input"
             value={displayedRate}
             onUserInput={handleUserInput}
           />

--- a/src/cow-react/modules/limitOrders/containers/TradeButtons/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/TradeButtons/index.tsx
@@ -89,7 +89,7 @@ export function TradeButtons(props: TradeButtonsProps) {
     typeof buttonFactory === 'function' ? (
       buttonFactory({ tradeState, toggleWalletModal, quote, wrapUnwrapParams })
     ) : (
-      <SwapButton onClick={doTrade} disabled={isButtonDisabled}>
+      <SwapButton id={buttonFactory.id} onClick={doTrade} disabled={isButtonDisabled}>
         <Trans>{buttonFactory.text}</Trans>
       </SwapButton>
     )

--- a/src/cow-react/modules/limitOrders/containers/TradeButtons/limitOrdersTradeButtonsMap.tsx
+++ b/src/cow-react/modules/limitOrders/containers/TradeButtons/limitOrdersTradeButtonsMap.tsx
@@ -31,6 +31,7 @@ export interface TradeButtonsParams {
 interface ButtonConfig {
   disabled: boolean
   text: string
+  id?: string
 }
 
 interface ButtonCallback {
@@ -41,13 +42,21 @@ export function SwapButton({
   children,
   disabled,
   onClick,
+  id,
 }: {
   children: React.ReactNode
   disabled: boolean
   onClick?: () => void
+  id?: string
 }) {
   return (
-    <ButtonPrimary fontSize={'16px !important'} onClick={onClick} disabled={disabled} buttonSize={ButtonSize.BIG}>
+    <ButtonPrimary
+      id={id}
+      fontSize={'16px !important'}
+      onClick={onClick}
+      disabled={disabled}
+      buttonSize={ButtonSize.BIG}
+    >
       <Trans>{children}</Trans>
     </ButtonPrimary>
   )
@@ -72,6 +81,7 @@ export const limitOrdersTradeButtonsMap: { [key in LimitOrdersFormState]: Button
   [LimitOrdersFormState.CanTrade]: {
     disabled: false,
     text: 'Review limit order',
+    id: 'review-limit-order-btn',
   },
   [LimitOrdersFormState.SwapIsUnsupported]: {
     disabled: true,

--- a/src/cow-react/modules/limitOrders/pure/LimitOrdersConfirm/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/LimitOrdersConfirm/index.tsx
@@ -45,7 +45,7 @@ export function LimitOrdersConfirm(props: LimitOrdersConfirmProps) {
   const isTradeDisabled = isTooLowRate ? !warningsAccepted : false
 
   return (
-    <styledEl.ConfirmWrapper>
+    <styledEl.ConfirmWrapper id="limit-orders-confirm">
       <CurrencyPreview
         id="input-currency-preview"
         currencyInfo={inputCurrencyInfo}

--- a/src/cow-react/modules/limitOrders/pure/UnlockLimitOrders/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/UnlockLimitOrders/index.tsx
@@ -40,7 +40,9 @@ export function UnlockLimitOrders({ handleUnlock }: { handleUnlock: () => void }
         <ExternalLink href="https://cow-protocol.medium.com/the-cow-has-no-limits-342e7eae8794">
           Learn more about limit orders ↗
         </ExternalLink>
-        <ButtonPrimary onClick={handleUnlock}>Unlock limit orders (BETA)</ButtonPrimary>
+        <ButtonPrimary id="unlock-limit-orders-btn" onClick={handleUnlock}>
+          Unlock limit orders (BETA)
+        </ButtonPrimary>
       </styledEl.ControlSection>
     </styledEl.Container>
   )

--- a/src/cow-react/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
+++ b/src/cow-react/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
@@ -53,13 +53,16 @@ function areChainIdsTheSame(aChainId: Nullish<number>, bChainId: Nullish<number>
 }
 
 export function useSetupTradeState(): void {
-  const { chainId: currentChainId, connector, account } = useWeb3React()
+  const { chainId: providerChainId, connector, account } = useWeb3React()
   const [isChainIdSet, setIsChainIdSet] = useState(false)
   const tradeNavigate = useTradeNavigate()
   const tradeStateFromUrl = useTradeStateFromUrl()
   const tradeState = useTradeState()
 
   const chainIdFromUrl = tradeStateFromUrl.chainId
+  // When there is no account from provider, then we consider provider as not connected and use chainId from URL as current
+  const currentChainId = (account ? providerChainId : chainIdFromUrl) || providerChainId
+
   const prevChainIdFromUrl = usePrevious(chainIdFromUrl)
   const prevCurrentChainId = usePrevious(currentChainId)
 


### PR DESCRIPTION
# Summary

Test scenario:
1. Open limit orders page
2. Unlock the beta info screen
3. Pick sell token
4. Pick buy token
5. Input sell amount
6. Input buy amount
7. Click "Review limit order"
8. Compare entered values in the confirm screen

Also added fix to `useSetupTradeState.ts` for e2e tests. For some reason, the wallet provider for e2e tests sends irrelevant `chainId` at the beginning with empty `account`.
