### PR TITLE
Add analytics hook that will set dimensions

### DIFF
--- a/src/cow-react/modules/application/containers/App/index.tsx
+++ b/src/cow-react/modules/application/containers/App/index.tsx
@@ -1,4 +1,5 @@
 import { initializeAnalytics } from 'components/AmplitudeAnalytics'
+import { useAnalyticsReporter } from '@src/custom/components/analytics'
 import TopLevelModals from 'components/TopLevelModals'
 import ApeModeQueryParamReader from 'hooks/useApeModeQueryParamReader'
 import ErrorBoundary from 'components/ErrorBoundary'
@@ -16,6 +17,7 @@ import * as styledEl from './styled'
 
 export function App() {
   initializeAnalytics()
+  useAnalyticsReporter()
 
   return (
     <ErrorBoundary>

--- a/src/custom/components/analytics/hooks/useAnalyticsReporter.ts
+++ b/src/custom/components/analytics/hooks/useAnalyticsReporter.ts
@@ -1,6 +1,6 @@
 import { useWeb3React } from '@web3-react/core'
 import { useEffect } from 'react'
-import { Path } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 import { getCLS, getFCP, getFID, getLCP, Metric } from 'web-vitals'
 
 // Mod imports
@@ -35,7 +35,9 @@ export function initGATracker() {
 }
 
 // tracks web vitals and pageviews
-export function useAnalyticsReporter({ pathname, search }: Path) {
+export function useAnalyticsReporter() {
+  const { pathname, search } = useLocation()
+
   // Handle chain id custom dimension
   const { chainId, connector, account } = useWeb3React()
   useEffect(() => {


### PR DESCRIPTION
# Summary

Not sure if this was my mistake or if this was excluded in some PR after this was implemented but this hook is missing and its not being called anywhere right now. 

The purpose of this hook is to set custom dimensions such as chainId and a walletName.

I've noticed today that custom dimensions are missing in google analytics dashboard so we should merge this ASAP.