### PR TITLE
Refactor polling + Poll only if window Visible

### DIFF
--- a/src/cow-react/common/hooks/usePolling.ts
+++ b/src/cow-react/common/hooks/usePolling.ts
@@ -1,0 +1,34 @@
+import useIsWindowVisible from '@src/hooks/useIsWindowVisible'
+import { useCallback, useEffect } from 'react'
+
+export interface UsePollingParams {
+  doPolling: () => void
+  pollingTimeMs: number
+  triggerEagerly?: boolean
+  name: string // Just for debugging porpouses
+}
+
+export function usePolling(params: UsePollingParams) {
+  const { doPolling: doPollingImpl, pollingTimeMs, triggerEagerly = true, name } = params
+  const isWindowVisible = useIsWindowVisible()
+
+  const doPolling = useCallback(() => {
+    console.debug(`[usePolling][${name}] Executing polling function`)
+    doPollingImpl()
+  }, [doPollingImpl, name])
+
+  useEffect(() => {
+    if (!isWindowVisible) {
+      console.debug(`[usePolling][${name}] No need to do polling`)
+      return
+    }
+
+    console.debug(`[usePolling][${name}] Schedule polling`)
+    const intervalId = setInterval(doPolling, pollingTimeMs)
+
+    if (triggerEagerly) {
+      doPolling()
+    }
+    return () => clearInterval(intervalId)
+  }, [doPolling, pollingTimeMs, triggerEagerly, name, isWindowVisible])
+}

--- a/src/cow-react/modules/limitOrders/hooks/useGetInitialPrice.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useGetInitialPrice.ts
@@ -1,14 +1,13 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useWeb3React } from '@web3-react/core'
 import { Currency, Fraction } from '@uniswap/sdk-core'
-import { useAsyncMemo } from 'use-async-memo'
 
 import { getNativePrice } from '@cow/api/gnosisProtocol/api'
 import { useLimitOrdersTradeState } from '@cow/modules/limitOrders/hooks/useLimitOrdersTradeState'
 import { getAddress } from '@cow/utils/getAddress'
 import ms from 'ms.macro'
 import { parsePrice } from '@cow/modules/limitOrders/utils/parsePrice'
-import useIsWindowVisible from 'hooks/useIsWindowVisible'
+import { usePolling } from '@cow/common/hooks/usePolling'
 
 type PriceResult = number | Error | undefined
 
@@ -72,36 +71,23 @@ export function useGetInitialPrice(): { price: Fraction | null; isLoading: boole
   const { chainId } = useWeb3React()
   const { inputCurrency, outputCurrency } = useLimitOrdersTradeState()
   const [isLoading, setIsLoading] = useState(false)
-  const [updateTimestamp, setUpdateTimestamp] = useState(Date.now())
-  const isWindowVisible = useIsWindowVisible()
 
-  const price = useAsyncMemo(
-    () => {
-      setIsLoading(true)
+  const [price, setPrice] = useState<Fraction | null>(null)
 
-      console.debug('[useGetInitialPrice] Fetching price')
-      return requestPrice(chainId, inputCurrency, outputCurrency).finally(() => {
+  const fetchPrice = useCallback(() => {
+    setIsLoading(true)
+    requestPrice(chainId, inputCurrency, outputCurrency)
+      .then(setPrice)
+      .finally(() => {
         setIsLoading(false)
       })
-    },
-    [chainId, inputCurrency, outputCurrency, updateTimestamp],
-    null
-  )
+  }, [chainId, inputCurrency, outputCurrency])
 
-  // Update initial price every 10 seconds
-  useEffect(() => {
-    if (!isWindowVisible) {
-      console.debug('[useGetInitialPrice] No need to fetch quotes')
-      return
-    }
-
-    console.debug('[useGetInitialPrice] Periodically fetch price')
-    const interval = setInterval(() => {
-      setUpdateTimestamp(Date.now())
-    }, PRICE_UPDATE_INTERVAL)
-
-    return () => clearInterval(interval)
-  }, [isWindowVisible])
+  usePolling({
+    doPolling: fetchPrice,
+    name: 'useGetInitialPrice',
+    pollingTimeMs: PRICE_UPDATE_INTERVAL,
+  })
 
   return { price, isLoading }
 }

--- a/src/cow-react/modules/limitOrders/updaters/QuoteUpdater/hooks/useFetchMarketPrice/index.ts
+++ b/src/cow-react/modules/limitOrders/updaters/QuoteUpdater/hooks/useFetchMarketPrice/index.ts
@@ -13,9 +13,10 @@ import GpQuoteError from '@cow/api/gnosisProtocol/errors/QuoteError'
 import { onlyResolvesLast } from 'utils/async'
 import { SimpleGetQuoteResponse } from '@cowprotocol/cow-sdk'
 import { useDetectNativeToken } from '@cow/modules/swap/hooks/useDetectNativeToken'
+import useIsWindowVisible from '@src/hooks/useIsWindowVisible'
 
 // Every 10s
-const REFETCH_CHECK_INTERVAL = 10000
+const REFETCH_CHECK_INTERVAL = 1000
 
 const getQuoteOnlyResolveLast = onlyResolvesLast<SimpleGetQuoteResponse>(getQuote)
 
@@ -31,14 +32,18 @@ export function useFetchMarketPrice() {
   const { inputCurrency, outputCurrency, orderKind } = useLimitOrdersTradeState()
   const handleResponse = useHandleResponse()
 
+  const isWindowVisible = useIsWindowVisible()
+
   // Main hook updater
   useLayoutEffect(() => {
-    const handleFetchQuote = () => {
-      if (!feeQuoteParams || isWrapOrUnwrap) {
-        setLimitOrdersQuote({})
-        return
-      }
+    if (!feeQuoteParams || isWrapOrUnwrap || !isWindowVisible) {
+      console.debug('[useFetchMarketPrice] No need to fetch quotes')
+      return
+    }
 
+    console.debug('[useFetchMarketPrice] Periodically fetch quotes')
+    const handleFetchQuote = () => {
+      console.debug('[useFetchMarketPrice] Fetching price')
       getQuoteOnlyResolveLast(feeQuoteParams)
         .then(handleResponse)
         .catch((error: GpQuoteError) => {
@@ -54,7 +59,7 @@ export function useFetchMarketPrice() {
     const intervalId = setInterval(handleFetchQuote, REFETCH_CHECK_INTERVAL)
 
     return () => clearInterval(intervalId)
-  }, [feeQuoteParams, handleResponse, updateLimitRateState, setLimitOrdersQuote, isWrapOrUnwrap])
+  }, [feeQuoteParams, handleResponse, updateLimitRateState, setLimitOrdersQuote, isWrapOrUnwrap, isWindowVisible])
 
   // Turn on the loading if some of these dependencies have changed and remove execution rate
   useLayoutEffect(() => {

--- a/src/cow-react/modules/limitOrders/updaters/QuoteUpdater/hooks/useFetchMarketPrice/index.ts
+++ b/src/cow-react/modules/limitOrders/updaters/QuoteUpdater/hooks/useFetchMarketPrice/index.ts
@@ -16,7 +16,7 @@ import { useDetectNativeToken } from '@cow/modules/swap/hooks/useDetectNativeTok
 import useIsWindowVisible from '@src/hooks/useIsWindowVisible'
 
 // Every 10s
-const REFETCH_CHECK_INTERVAL = 1000
+const REFETCH_CHECK_INTERVAL = 10000
 
 const getQuoteOnlyResolveLast = onlyResolvesLast<SimpleGetQuoteResponse>(getQuote)
 

--- a/src/cow-react/modules/limitOrders/updaters/QuoteUpdater/hooks/useFetchMarketPrice/index.ts
+++ b/src/cow-react/modules/limitOrders/updaters/QuoteUpdater/hooks/useFetchMarketPrice/index.ts
@@ -13,7 +13,7 @@ import GpQuoteError from '@cow/api/gnosisProtocol/errors/QuoteError'
 import { onlyResolvesLast } from 'utils/async'
 import { SimpleGetQuoteResponse } from '@cowprotocol/cow-sdk'
 import { useDetectNativeToken } from '@cow/modules/swap/hooks/useDetectNativeToken'
-import useIsWindowVisible from '@src/hooks/useIsWindowVisible'
+import useIsWindowVisible from 'hooks/useIsWindowVisible'
 
 // Every 10s
 const REFETCH_CHECK_INTERVAL = 10000

--- a/src/custom/hooks/useFetchProfile.ts
+++ b/src/custom/hooks/useFetchProfile.ts
@@ -2,6 +2,7 @@ import { useWeb3React } from '@web3-react/core'
 import { useEffect, useState } from 'react'
 import { getProfileData } from '@cow/api/gnosisProtocol'
 import { ProfileData } from '@cow/api/gnosisProtocol/api'
+import useIsWindowVisible from 'hooks/useIsWindowVisible'
 
 type FetchProfileState = {
   profileData: ProfileData | null
@@ -20,9 +21,16 @@ const FETCH_INTERVAL_IN_MINUTES = 5
 export default function useFetchProfile(): FetchProfileState {
   const { account, chainId } = useWeb3React()
   const [profile, setProfile] = useState<FetchProfileState>(emptyState)
+  const isWindowVisible = useIsWindowVisible()
 
   useEffect(() => {
+    if (!isWindowVisible) {
+      console.debug('[useFetchProfile] No need to fetch profile info')
+      return
+    }
+
     async function fetchAndSetProfileData() {
+      console.debug('[useFetchProfile] Fetching profile info')
       try {
         if (chainId && account) {
           setProfile((profile) => ({ ...profile, isLoading: true, error: '' }))
@@ -41,11 +49,12 @@ export default function useFetchProfile(): FetchProfileState {
       }
     }
 
+    console.debug('[useFetchProfile] No need to fetch profile info')
     const intervalId = setInterval(fetchAndSetProfileData, FETCH_INTERVAL_IN_MINUTES * 60_000)
 
     fetchAndSetProfileData()
     return () => clearInterval(intervalId)
-  }, [account, chainId])
+  }, [account, chainId, isWindowVisible])
 
   return profile
 }

--- a/src/custom/hooks/useFetchProfile.ts
+++ b/src/custom/hooks/useFetchProfile.ts
@@ -1,8 +1,8 @@
 import { useWeb3React } from '@web3-react/core'
-import { useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { getProfileData } from '@cow/api/gnosisProtocol'
 import { ProfileData } from '@cow/api/gnosisProtocol/api'
-import useIsWindowVisible from 'hooks/useIsWindowVisible'
+import { usePolling } from '@cow/common/hooks/usePolling'
 
 type FetchProfileState = {
   profileData: ProfileData | null
@@ -21,40 +21,32 @@ const FETCH_INTERVAL_IN_MINUTES = 5
 export default function useFetchProfile(): FetchProfileState {
   const { account, chainId } = useWeb3React()
   const [profile, setProfile] = useState<FetchProfileState>(emptyState)
-  const isWindowVisible = useIsWindowVisible()
 
-  useEffect(() => {
-    if (!isWindowVisible) {
-      console.debug('[useFetchProfile] No need to fetch profile info')
-      return
-    }
-
-    async function fetchAndSetProfileData() {
-      console.debug('[useFetchProfile] Fetching profile info')
-      try {
-        if (chainId && account) {
-          setProfile((profile) => ({ ...profile, isLoading: true, error: '' }))
-          const profileData = await getProfileData(chainId, account)
-          setProfile((profile) => ({ ...profile, isLoading: false, profileData }))
-        } else {
-          setProfile(emptyState)
-        }
-      } catch (error) {
-        console.error(error)
-        setProfile((profile) => ({
-          ...profile,
-          isLoading: false,
-          error: 'There was an error while fetching the profile data',
-        }))
+  const fetchAndSetProfileData = useCallback(async () => {
+    console.debug('[useFetchProfile] Fetching profile info')
+    try {
+      if (chainId && account) {
+        setProfile((profile) => ({ ...profile, isLoading: true, error: '' }))
+        const profileData = await getProfileData(chainId, account)
+        setProfile((profile) => ({ ...profile, isLoading: false, profileData }))
+      } else {
+        setProfile(emptyState)
       }
+    } catch (error) {
+      console.error(error)
+      setProfile((profile) => ({
+        ...profile,
+        isLoading: false,
+        error: 'There was an error while fetching the profile data',
+      }))
     }
+  }, [account, chainId])
 
-    console.debug('[useFetchProfile] No need to fetch profile info')
-    const intervalId = setInterval(fetchAndSetProfileData, FETCH_INTERVAL_IN_MINUTES * 60_000)
-
-    fetchAndSetProfileData()
-    return () => clearInterval(intervalId)
-  }, [account, chainId, isWindowVisible])
+  usePolling({
+    doPolling: fetchAndSetProfileData,
+    name: 'useFetchMarketPrice',
+    pollingTimeMs: FETCH_INTERVAL_IN_MINUTES * 60_000,
+  })
 
   return profile
 }

--- a/src/custom/hooks/usePriceImpact/useFallbackPriceImpact.ts
+++ b/src/custom/hooks/usePriceImpact/useFallbackPriceImpact.ts
@@ -8,7 +8,7 @@ import { QuoteInformationObject } from 'state/price/reducer'
 import { QuoteError } from 'state/price/actions'
 import { LegacyFeeQuoteParams } from '@cow/api/gnosisProtocol/legacy/types'
 import { PRICE_QUOTE_VALID_TO_TIME } from '@cow/constants/quote'
-import useIsWindowVisible from '@src/hooks/useIsWindowVisible'
+import useIsWindowVisible from 'hooks/useIsWindowVisible'
 
 type SwapParams = { abTrade?: PriceImpactTrade; sellToken?: string | null; buyToken?: string | null }
 

--- a/src/custom/hooks/usePriceImpact/useFallbackPriceImpact.ts
+++ b/src/custom/hooks/usePriceImpact/useFallbackPriceImpact.ts
@@ -8,6 +8,7 @@ import { QuoteInformationObject } from 'state/price/reducer'
 import { QuoteError } from 'state/price/actions'
 import { LegacyFeeQuoteParams } from '@cow/api/gnosisProtocol/legacy/types'
 import { PRICE_QUOTE_VALID_TO_TIME } from '@cow/constants/quote'
+import useIsWindowVisible from '@src/hooks/useIsWindowVisible'
 
 type SwapParams = { abTrade?: PriceImpactTrade; sellToken?: string | null; buyToken?: string | null }
 
@@ -48,8 +49,10 @@ export default function useFallbackPriceImpact({
 }: FallbackPriceImpactParams) {
   const [loading, setLoading] = useState(false)
 
+  const isWindowVisible = useIsWindowVisible()
+
   // Should we even calc this? Check if fiatPriceImpact exists OR user is wrapping token
-  const shouldCalculate = !!abTrade && !isWrapping
+  const shouldCalculate = !!abTrade && !isWrapping && isWindowVisible
 
   // to bail out early
   useEffect(() => {

--- a/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useRef } from 'react'
 import { timestamp } from '@cowprotocol/contracts'
 
 import { useWeb3React } from '@web3-react/core'
@@ -20,7 +20,7 @@ import { NATIVE_CURRENCY_BUY_ADDRESS } from 'constants/index'
 import { WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
 import { PRICE_QUOTE_VALID_TO_TIME } from '@cow/constants/quote'
 
-import useIsWindowVisible from 'hooks/useIsWindowVisible'
+import { usePolling } from '@cow/common/hooks/usePolling'
 
 /**
  * Thin wrapper around `getBestPrice` that builds the params and returns null on failure
@@ -162,19 +162,11 @@ export function UnfillableOrdersUpdater(): null {
     }
   }, [account, chainId, strategy, updateIsUnfillableFlag])
 
-  const isWindowVisible = useIsWindowVisible()
-
-  useEffect(() => {
-    if (!chainId || !account || !isWindowVisible) {
-      console.debug('[UnfillableOrdersUpdater] No need to fetch unfillable orders')
-      return
-    }
-
-    console.debug('[UnfillableOrdersUpdater] Periodically check for unfillable orders')
-    updatePending()
-    const interval = setInterval(updatePending, PENDING_ORDERS_PRICE_CHECK_POLL_INTERVAL)
-    return () => clearInterval(interval)
-  }, [updatePending, chainId, account, isWindowVisible])
+  usePolling({
+    doPolling: updatePending,
+    name: 'UnfillableOrdersUpdater',
+    pollingTimeMs: PENDING_ORDERS_PRICE_CHECK_POLL_INTERVAL,
+  })
 
   return null
 }

--- a/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -20,6 +20,8 @@ import { NATIVE_CURRENCY_BUY_ADDRESS } from 'constants/index'
 import { WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
 import { PRICE_QUOTE_VALID_TO_TIME } from '@cow/constants/quote'
 
+import useIsWindowVisible from '@src/hooks/useIsWindowVisible'
+
 /**
  * Thin wrapper around `getBestPrice` that builds the params and returns null on failure
  */
@@ -131,7 +133,8 @@ export function UnfillableOrdersUpdater(): null {
         )
       }
 
-      pending.forEach((order, index) =>
+      pending.forEach((order, index) => {
+        console.debug(`[UnfillableOrdersUpdater] Check order`, order)
         _getOrderPrice(chainId, order, strategy)
           .then((quote) => {
             if (quote) {
@@ -152,20 +155,26 @@ export function UnfillableOrdersUpdater(): null {
               e
             )
           })
-      )
+      })
     } finally {
       isUpdating.current = false
       console.debug(`[UnfillableOrdersUpdater] Checked pending orders in ${Date.now() - startTime}ms`)
     }
   }, [account, chainId, strategy, updateIsUnfillableFlag])
 
+  const isWindowVisible = useIsWindowVisible()
+
   useEffect(() => {
+    if (!chainId || !account || !isWindowVisible) {
+      console.debug('[UnfillableOrdersUpdater] No need to fetch unfillable orders')
+      return
+    }
+
+    console.debug('[UnfillableOrdersUpdater] Periodically check for unfillable orders')
     updatePending()
-
     const interval = setInterval(updatePending, PENDING_ORDERS_PRICE_CHECK_POLL_INTERVAL)
-
     return () => clearInterval(interval)
-  }, [updatePending])
+  }, [updatePending, chainId, account, isWindowVisible])
 
   return null
 }

--- a/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -20,7 +20,7 @@ import { NATIVE_CURRENCY_BUY_ADDRESS } from 'constants/index'
 import { WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
 import { PRICE_QUOTE_VALID_TO_TIME } from '@cow/constants/quote'
 
-import useIsWindowVisible from '@src/hooks/useIsWindowVisible'
+import useIsWindowVisible from 'hooks/useIsWindowVisible'
 
 /**
  * Thin wrapper around `getBestPrice` that builds the params and returns null on failure

--- a/src/custom/state/price/updater.ts
+++ b/src/custom/state/price/updater.ts
@@ -160,7 +160,7 @@ export default function FeesUpdater(): null {
   const refetchQuote = useRefetchQuoteCallback()
   const setQuoteError = useSetQuoteError()
 
-  const windowVisible = useIsWindowVisible()
+  const isWindowVisible = useIsWindowVisible()
   const isOnline = useIsOnline()
   const { validTo } = useOrderValidTo()
 
@@ -179,7 +179,7 @@ export default function FeesUpdater(): null {
       !sellCurrencyId ||
       !buyCurrencyId ||
       !typedValue ||
-      !windowVisible ||
+      !isWindowVisible ||
       sellTokenAddressInvalid ||
       buyTokenAddressInvalid
     )
@@ -275,7 +275,7 @@ export default function FeesUpdater(): null {
     return () => clearInterval(intervalId)
   }, [
     isEthFlow,
-    windowVisible,
+    isWindowVisible,
     isOnline,
     chainId,
     sellCurrencyId,

--- a/src/custom/state/price/updater.ts
+++ b/src/custom/state/price/updater.ts
@@ -11,7 +11,6 @@ import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
 import { Field } from 'state/swap/actions'
 import { useIsUnsupportedTokenGp } from 'state/lists/hooks/hooksMod'
 
-import useIsWindowVisible from 'hooks/useIsWindowVisible'
 import { useAllQuotes, useIsQuoteLoading, useSetQuoteError } from './hooks'
 import { useRefetchQuoteCallback } from 'hooks/useRefetchPriceCallback'
 import { useWeb3React } from '@web3-react/core'
@@ -161,7 +160,6 @@ export default function FeesUpdater(): null {
   const refetchQuote = useRefetchQuoteCallback()
   const setQuoteError = useSetQuoteError()
 
-  const isWindowVisible = useIsWindowVisible()
   const isOnline = useIsOnline()
   const { validTo } = useOrderValidTo()
 
@@ -180,7 +178,6 @@ export default function FeesUpdater(): null {
       !sellCurrencyId ||
       !buyCurrencyId ||
       !typedValue ||
-      !isWindowVisible ||
       sellTokenAddressInvalid ||
       buyTokenAddressInvalid
     )
@@ -261,7 +258,6 @@ export default function FeesUpdater(): null {
     }
   }, [
     isEthFlow,
-    isWindowVisible,
     isOnline,
     chainId,
     sellCurrencyId,


### PR DESCRIPTION
# Summary

Iterates over PR https://github.com/cowprotocol/cowswap/pull/1913 to refactor a bunch of places where we use polling. 

This PR creates a new hook: `usePolling`

This hook will periodically invoke a polling function and ensure the polling is not done while the browser tab/window is not visible.

## Motivation
While addressing this comment from Leandro https://github.com/cowprotocol/cowswap/pull/1913#pullrequestreview-1267805562 I saw how many repetitions we have in the polling logic. So, I gave it a try to use refactor into a new hook. 


## Testing
Testing instructions are coming soon