### PR TITLE
change text color

### DIFF
--- a/src/cow-react/modules/swap/pure/Row/RowDeadline/index.tsx
+++ b/src/cow-react/modules/swap/pure/Row/RowDeadline/index.tsx
@@ -6,8 +6,7 @@ import { INPUT_OUTPUT_EXPLANATION, MINIMUM_ETH_FLOW_DEADLINE_SECONDS } from 'con
 import { RowSlippageProps } from '@cow/modules/swap/containers/Row/RowSlippage'
 import { StyledRowBetween, TextWrapper } from '@cow/modules/swap/pure/Row/styled'
 import { RowStyleProps } from '@cow/modules/swap/pure/Row/typings'
-import { ThemedText } from 'theme/index'
-import { StyledInfoIcon } from '@cow/modules/swap/pure/styled'
+import { StyledInfoIcon, TransactionText } from '@cow/modules/swap/pure/styled'
 import { ClickableText } from '@cow/modules/swap/pure/Row/RowSlippageContent'
 
 export function getNativeOrderDeadlineTooltip(symbols: (string | undefined)[] | undefined) {
@@ -78,14 +77,9 @@ type DeadlineTextContentsProps = { isEthFlow: boolean }
 
 function DeadlineTextContents({ isEthFlow }: DeadlineTextContentsProps) {
   return (
-    <>
+    <TransactionText>
       <Trans>Transaction expiration</Trans>
-      {isEthFlow && (
-        <>
-          {' '}
-          <ThemedText.Warn override>(modified)</ThemedText.Warn>
-        </>
-      )}
-    </>
+      {isEthFlow && (<i>(modified)</i>)}
+    </TransactionText>
   )
 }

--- a/src/cow-react/modules/swap/pure/Row/RowDeadline/index.tsx
+++ b/src/cow-react/modules/swap/pure/Row/RowDeadline/index.tsx
@@ -79,7 +79,7 @@ function DeadlineTextContents({ isEthFlow }: DeadlineTextContentsProps) {
   return (
     <TransactionText>
       <Trans>Transaction expiration</Trans>
-      {isEthFlow && (<i>(modified)</i>)}
+      {isEthFlow && <i>(modified)</i>}
     </TransactionText>
   )
 }

--- a/src/cow-react/modules/swap/pure/Row/RowSlippageContent/index.tsx
+++ b/src/cow-react/modules/swap/pure/Row/RowSlippageContent/index.tsx
@@ -7,8 +7,7 @@ import { RowStyleProps } from '@cow/modules/swap/pure/Row/types'
 import { INPUT_OUTPUT_EXPLANATION, MINIMUM_ETH_FLOW_SLIPPAGE, PERCENTAGE_PRECISION } from 'constants/index'
 import { RowSlippageProps } from '@cow/modules/swap/containers/Row/RowSlippage'
 import { StyledRowBetween, TextWrapper } from '@cow/modules/swap/pure/Row/styled'
-import { ThemedText } from 'theme/index'
-import { StyledInfoIcon } from '@cow/modules/swap/pure/styled'
+import { StyledInfoIcon, TransactionText } from '@cow/modules/swap/pure/styled'
 
 export const ClickableText = styled.button`
   background: none;
@@ -92,14 +91,9 @@ type SlippageTextContentsProps = { isEthFlow: boolean }
 
 function SlippageTextContents({ isEthFlow }: SlippageTextContentsProps) {
   return (
-    <>
+    <TransactionText>
       <Trans>Slippage tolerance</Trans>
-      {isEthFlow && (
-        <>
-          {' '}
-          <ThemedText.Warn override>(modified)</ThemedText.Warn>
-        </>
-      )}
-    </>
+      {isEthFlow && (<i>(modified)</i>)}
+    </TransactionText>
   )
 }

--- a/src/cow-react/modules/swap/pure/Row/RowSlippageContent/index.tsx
+++ b/src/cow-react/modules/swap/pure/Row/RowSlippageContent/index.tsx
@@ -93,7 +93,7 @@ function SlippageTextContents({ isEthFlow }: SlippageTextContentsProps) {
   return (
     <TransactionText>
       <Trans>Slippage tolerance</Trans>
-      {isEthFlow && (<i>(modified)</i>)}
+      {isEthFlow && <i>(modified)</i>}
     </TransactionText>
   )
 }

--- a/src/cow-react/modules/swap/pure/styled.tsx
+++ b/src/cow-react/modules/swap/pure/styled.tsx
@@ -44,3 +44,13 @@ export const StyledInfoIcon = styled(Info)`
     opacity: 1;
   }
 `
+
+export const TransactionText = styled.span`
+  display: flex;
+  gap: 3px;
+  cursor: pointer;
+
+  > i {
+    font-style: normal;
+  }
+`


### PR DESCRIPTION
# Summary

Addresses feedback to change the `modified` text from being orange to a neutral (matching) color.

**NOW**
<img width="487" alt="Screenshot 2023-02-03 at 16 30 28" src="https://user-images.githubusercontent.com/31534717/216656661-e0dee29e-b180-4e87-837d-f2644bc7a557.png">

**AFTER**
<img width="481" alt="Screenshot 2023-02-03 at 16 31 22" src="https://user-images.githubusercontent.com/31534717/216656651-5115e549-8972-4b22-abe6-bc9514db1e7b.png">

