### PR TITLE
Added Paved and Microsoft pixel tracking

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -119,14 +119,21 @@
 
   <!-- Reddit Pixel -->
   <script>
-    !function(w,d){if(!w.rdt){var p=w.rdt=function(){p.sendEvent?p.sendEvent.apply(p,arguments):p.callQueue.push(arguments)};p.callQueue=[];
-    var t=d.createElement("script");t.src="https://www.redditstatic.com/ads/pixel.js",t.async=!0;var s=d.getElementsByTagName("script")[0];
-    s.parentNode.insertBefore(t,s)}}(window,document);
-    rdt('init','t2_v12pyheq', {"optOut":false,"useDecimalCurrencyValues":true,"aaid":"<AAID-HERE>"});
-    rdt('track', 'PageVisit');
+    !function(w,d){if(!w.rdt){var p=w.rdt=function(){p.sendEvent?p.sendEvent.apply(p,arguments):p.callQueue.push(arguments)};p.callQueue=[];var t=d.createElement("script");t.src="https://www.redditstatic.com/ads/pixel.js",t.async=!0;var s=d.getElementsByTagName("script")[0];s.parentNode.insertBefore(t,s)}}(window,document);rdt('init','t2_v12pyheq', {"optOut":false,"useDecimalCurrencyValues":true,"aaid":"<AAID-HERE>"});rdt('track', 'PageVisit');
   </script>
   <!-- DO NOT MODIFY UNLESS TO REPLACE A USER IDENTIFIER -->
   <!-- End Reddit Pixel -->
+
+  <!-- Start Paved Pixel Snippet -->
+  <script>
+    !function(e,t,n,o,p,i,a){e[o]||((p=e[o]=function(){p.process?p.process.apply(p,arguments):p.queue.push(arguments)}).queue=[],p.t=+new Date,(i=t.createElement(n)).async=1,i.src="https://pvdpix.com/pixel.js?t="+864e5*Math.ceil(new Date/864e5),(a=t.getElementsByTagName(n)[0]).parentNode.insertBefore(i,a))}(window,document,"script","pvd"),pvd("init","97dc323d-7e9e"),pvd("event","pageload");
+  </script>
+  <!-- End Paved Pixel Snippet -->
+
+  <!-- Start Microsoft Ads Pixel Snippet -->
+  <script>(function(w,d,t,r,u){var f,n,i;w[u]=w[u]||[],f=function(){var o={ti:"343027006"};o.q=w[u],w[u]=new UET(o),w[u].push("pageLoad")},n=d.createElement(t),n.src=r,n.async=1,n.onload=n.onreadystatechange=function(){var s=this.readyState;s&&s!=="loaded"&&s!=="complete"||(f(),n.onload=n.onreadystatechange=null)},i=d.getElementsByTagName(t)[0],i.parentNode.insertBefore(n,i)})(window,document,"script","//bat.bing.com/bat.js","uetq");</script>
+  <!-- End Microsoft Ads Pixel Snippet -->
+
 </body>
 
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -33,42 +33,6 @@
 
   <!-- Other tags -->
   <meta name="fortmatic-site-verification" content="%REACT_APP_FORTMATIC_SITE_VERIFICATION%" />
-</head>
-
-<body>
-  <noscript>
-    <style>
-      main {
-        max-width: 35em;
-        margin: 0 auto;
-      }
-
-      main img {
-        width: 100%;
-      }
-
-      .banner {
-        padding: 1em;
-        background-color: #fdfda8;
-        border-radius: 0.5em;
-      }
-    </style>
-    <main>
-      <img src="https://swap.cow.fi/images/og-meta-cowswap.png?v=2" alt="CoW Swap Logo" />
-      <p class="banner">CoW Swap uses JavasScript. Please <a
-          href="https://support.google.com/adsense/answer/12654?hl=en" target="_blank" rel="noopener noreferrer">enable
-          it in your browser</a> 🐮</p>
-
-      <ul>
-        <li><a href="https://swap.cow.fi/">Home | CoW Swap</a></li>
-        <li><a href="https://discord.com/invite/cowprotocol">Chat</a></li>
-        <li><a href="https://docs.cow.fi">Docs</a></li>
-        <li><a href="https://dune.com/cowprotocol/Gnosis-Protocol-V2">Stats</a></li>
-        <li><a href="https://twitter.com/CoWSwap">Twitter (@CoWSwap)</a></li>
-      </ul>
-    </main>
-  </noscript>
-  <div id="root"></div>
 
   <!-- Meta Pixel Code -->
   <script>
@@ -133,6 +97,42 @@
   <!-- Start Microsoft Ads Pixel Snippet -->
   <script>(function(w,d,t,r,u){var f,n,i;w[u]=w[u]||[],f=function(){var o={ti:"343027006"};o.q=w[u],w[u]=new UET(o),w[u].push("pageLoad")},n=d.createElement(t),n.src=r,n.async=1,n.onload=n.onreadystatechange=function(){var s=this.readyState;s&&s!=="loaded"&&s!=="complete"||(f(),n.onload=n.onreadystatechange=null)},i=d.getElementsByTagName(t)[0],i.parentNode.insertBefore(n,i)})(window,document,"script","//bat.bing.com/bat.js","uetq");</script>
   <!-- End Microsoft Ads Pixel Snippet -->
+</head>
+
+<body>
+  <noscript>
+    <style>
+      main {
+        max-width: 35em;
+        margin: 0 auto;
+      }
+
+      main img {
+        width: 100%;
+      }
+
+      .banner {
+        padding: 1em;
+        background-color: #fdfda8;
+        border-radius: 0.5em;
+      }
+    </style>
+    <main>
+      <img src="https://swap.cow.fi/images/og-meta-cowswap.png?v=2" alt="CoW Swap Logo" />
+      <p class="banner">CoW Swap uses JavasScript. Please <a
+          href="https://support.google.com/adsense/answer/12654?hl=en" target="_blank" rel="noopener noreferrer">enable
+          it in your browser</a> 🐮</p>
+
+      <ul>
+        <li><a href="https://swap.cow.fi/">Home | CoW Swap</a></li>
+        <li><a href="https://discord.com/invite/cowprotocol">Chat</a></li>
+        <li><a href="https://docs.cow.fi">Docs</a></li>
+        <li><a href="https://dune.com/cowprotocol/Gnosis-Protocol-V2">Stats</a></li>
+        <li><a href="https://twitter.com/CoWSwap">Twitter (@CoWSwap)</a></li>
+      </ul>
+    </main>
+  </noscript>
+  <div id="root"></div>
 
 </body>
 

--- a/src/cow-react/types.ts
+++ b/src/cow-react/types.ts
@@ -13,5 +13,7 @@ declare global {
     lintrk: any // Linkedin
     twq: any // Twitter
     rdt: any // Reddit
+    pvd: any // Paved
+    uetq: any // Microsoft Ads
   }
 }

--- a/src/custom/components/analytics/events/transactionEvents.ts
+++ b/src/custom/components/analytics/events/transactionEvents.ts
@@ -73,6 +73,9 @@ export function orderAnalytics(action: OrderType, orderClass: OrderClass, label?
     window.lintrk?.('track', { conversion_id: 10759522 })
     window.twq?.('event', 'tw-oddz2-oddzb', {})
     window.rdt?.('track', 'Purchase')
+    window.pvd?.('event', 'purchase')
+    window.uetq = window.uetq || []
+    window.uetq.push('event', 'purchase', {})
   }
 
   sendEvent({

--- a/src/custom/components/analytics/events/transactionEvents.ts
+++ b/src/custom/components/analytics/events/transactionEvents.ts
@@ -1,6 +1,14 @@
 import { OrderClass } from 'state/orders/actions'
 import { Category, sendEvent } from '../index'
 
+import { PIXEL_EVENTS } from '../pixel/constants'
+import { sendFacebookEvent } from '../pixel/facebook'
+import { sendLinkedinEvent } from '../pixel/linkedin'
+import { sendTwitterEvent } from '../pixel/twitter'
+import { sendRedditEvent } from '../pixel/reddit'
+import { sendPavedEvent } from '../pixel/paved'
+import { sendMicrosoftEvent } from '../pixel/microsoft'
+
 const LABEL_FROM_CLASS: Record<OrderClass, string> = {
   limit: 'Limit Order',
   market: 'Market Order',
@@ -69,13 +77,12 @@ export function signSwapAnalytics(orderClass: OrderClass, label?: string) {
 export type OrderType = 'Posted' | 'Executed' | 'Canceled' | 'Expired'
 export function orderAnalytics(action: OrderType, orderClass: OrderClass, label?: string) {
   if (action === 'Posted') {
-    window.fbq?.('track', 'Lead')
-    window.lintrk?.('track', { conversion_id: 10759522 })
-    window.twq?.('event', 'tw-oddz2-oddzb', {})
-    window.rdt?.('track', 'Purchase')
-    window.pvd?.('event', 'purchase')
-    window.uetq = window.uetq || []
-    window.uetq.push('event', 'purchase', {})
+    sendFacebookEvent(PIXEL_EVENTS.POST_TRADE)
+    sendLinkedinEvent(PIXEL_EVENTS.POST_TRADE)
+    sendTwitterEvent(PIXEL_EVENTS.POST_TRADE)
+    sendRedditEvent(PIXEL_EVENTS.POST_TRADE)
+    sendPavedEvent(PIXEL_EVENTS.POST_TRADE)
+    sendMicrosoftEvent(PIXEL_EVENTS.POST_TRADE)
   }
 
   sendEvent({

--- a/src/custom/components/analytics/hooks/useAnalyticsReporter.ts
+++ b/src/custom/components/analytics/hooks/useAnalyticsReporter.ts
@@ -67,6 +67,9 @@ export function useAnalyticsReporter() {
       window.lintrk?.('track', { conversion_id: 10759514 })
       window.twq?.('event', 'tw-oddz2-oddza', {})
       window.rdt?.('track', 'SignUp')
+      window.pvd?.('event', 'sign_up')
+      window.uetq = window.uetq || []
+      window.uetq.push('event', 'begin_checkout', {})
     }
   }, [account, walletName, prevAccount])
 
@@ -86,6 +89,9 @@ export function useAnalyticsReporter() {
       window.lintrk?.('track', { conversion_id: 10759506 })
       window.twq?.('event', 'tw-oddz2-oddz8', {})
       window.rdt?.('track', 'Lead')
+      window.pvd?.('event', 'search')
+      window.uetq = window.uetq || []
+      window.uetq.push('event', 'page_view', {})
 
       initiatedPixel = true
     }

--- a/src/custom/components/analytics/hooks/useAnalyticsReporter.ts
+++ b/src/custom/components/analytics/hooks/useAnalyticsReporter.ts
@@ -10,6 +10,14 @@ import { googleAnalytics, GOOGLE_ANALYTICS_CLIENT_ID_STORAGE_KEY } from '..'
 import { Dimensions } from '../GoogleAnalyticsProvider'
 import usePrevious from 'hooks/usePrevious'
 
+import { PIXEL_EVENTS } from '../pixel/constants'
+import { sendFacebookEvent } from '../pixel/facebook'
+import { sendLinkedinEvent } from '../pixel/linkedin'
+import { sendTwitterEvent } from '../pixel/twitter'
+import { sendRedditEvent } from '../pixel/reddit'
+import { sendPavedEvent } from '../pixel/paved'
+import { sendMicrosoftEvent } from '../pixel/microsoft'
+
 export function sendTiming(timingCategory: any, timingVar: any, timingValue: any, timingLabel: any) {
   return googleAnalytics.gaCommandSendTiming(timingCategory, timingVar, timingValue, timingLabel)
 }
@@ -63,13 +71,12 @@ export function useAnalyticsReporter() {
 
     // Handle pixel tracking on wallet connection
     if (!prevAccount && account) {
-      window.fbq?.('track', 'Contact')
-      window.lintrk?.('track', { conversion_id: 10759514 })
-      window.twq?.('event', 'tw-oddz2-oddza', {})
-      window.rdt?.('track', 'SignUp')
-      window.pvd?.('event', 'sign_up')
-      window.uetq = window.uetq || []
-      window.uetq.push('event', 'begin_checkout', {})
+      sendFacebookEvent(PIXEL_EVENTS.CONNECT_WALLET)
+      sendLinkedinEvent(PIXEL_EVENTS.CONNECT_WALLET)
+      sendTwitterEvent(PIXEL_EVENTS.CONNECT_WALLET)
+      sendRedditEvent(PIXEL_EVENTS.CONNECT_WALLET)
+      sendPavedEvent(PIXEL_EVENTS.CONNECT_WALLET)
+      sendMicrosoftEvent(PIXEL_EVENTS.CONNECT_WALLET)
     }
   }, [account, walletName, prevAccount])
 
@@ -85,13 +92,12 @@ export function useAnalyticsReporter() {
   // Handle initiate pixel tracking
   useEffect(() => {
     if (!initiatedPixel) {
-      window.fbq?.('track', 'InitiateCheckout')
-      window.lintrk?.('track', { conversion_id: 10759506 })
-      window.twq?.('event', 'tw-oddz2-oddz8', {})
-      window.rdt?.('track', 'Lead')
-      window.pvd?.('event', 'search')
-      window.uetq = window.uetq || []
-      window.uetq.push('event', 'page_view', {})
+      sendFacebookEvent(PIXEL_EVENTS.INIT)
+      sendLinkedinEvent(PIXEL_EVENTS.INIT)
+      sendTwitterEvent(PIXEL_EVENTS.INIT)
+      sendRedditEvent(PIXEL_EVENTS.INIT)
+      sendPavedEvent(PIXEL_EVENTS.INIT)
+      sendMicrosoftEvent(PIXEL_EVENTS.INIT)
 
       initiatedPixel = true
     }

--- a/src/custom/components/analytics/pixel/constants.ts
+++ b/src/custom/components/analytics/pixel/constants.ts
@@ -1,0 +1,5 @@
+export enum PIXEL_EVENTS {
+  INIT = 'init',
+  CONNECT_WALLET = 'connect_wallet',
+  POST_TRADE = 'post_trade',
+}

--- a/src/custom/components/analytics/pixel/facebook.ts
+++ b/src/custom/components/analytics/pixel/facebook.ts
@@ -1,0 +1,11 @@
+import { PIXEL_EVENTS } from './constants'
+
+const events = {
+  [PIXEL_EVENTS.INIT]: 'InitiateCheckout',
+  [PIXEL_EVENTS.CONNECT_WALLET]: 'Contact',
+  [PIXEL_EVENTS.POST_TRADE]: 'Lead',
+}
+
+export const sendFacebookEvent = (event: PIXEL_EVENTS) => {
+  window.fbq?.('track', events[event])
+}

--- a/src/custom/components/analytics/pixel/linkedin.ts
+++ b/src/custom/components/analytics/pixel/linkedin.ts
@@ -1,0 +1,11 @@
+import { PIXEL_EVENTS } from './constants'
+
+const events = {
+  [PIXEL_EVENTS.INIT]: 10759506,
+  [PIXEL_EVENTS.CONNECT_WALLET]: 10759514,
+  [PIXEL_EVENTS.POST_TRADE]: 10759522,
+}
+
+export const sendLinkedinEvent = (event: PIXEL_EVENTS) => {
+  window.lintrk?.('track', { conversion_id: events[event] })
+}

--- a/src/custom/components/analytics/pixel/microsoft.ts
+++ b/src/custom/components/analytics/pixel/microsoft.ts
@@ -1,0 +1,12 @@
+import { PIXEL_EVENTS } from './constants'
+
+const events = {
+  [PIXEL_EVENTS.INIT]: 'page_view',
+  [PIXEL_EVENTS.CONNECT_WALLET]: 'begin_checkout',
+  [PIXEL_EVENTS.POST_TRADE]: 'purchase',
+}
+
+export const sendMicrosoftEvent = (event: PIXEL_EVENTS) => {
+  window.uetq = window.uetq || []
+  window.uetq.push('event', events[event], {})
+}

--- a/src/custom/components/analytics/pixel/paved.ts
+++ b/src/custom/components/analytics/pixel/paved.ts
@@ -1,0 +1,11 @@
+import { PIXEL_EVENTS } from './constants'
+
+const events = {
+  [PIXEL_EVENTS.INIT]: 'search',
+  [PIXEL_EVENTS.CONNECT_WALLET]: 'sign_up',
+  [PIXEL_EVENTS.POST_TRADE]: 'purchase',
+}
+
+export const sendPavedEvent = (event: PIXEL_EVENTS) => {
+  window.pvd?.('event', events[event])
+}

--- a/src/custom/components/analytics/pixel/reddit.ts
+++ b/src/custom/components/analytics/pixel/reddit.ts
@@ -1,0 +1,11 @@
+import { PIXEL_EVENTS } from './constants'
+
+const events = {
+  [PIXEL_EVENTS.INIT]: 'Lead',
+  [PIXEL_EVENTS.CONNECT_WALLET]: 'SignUp',
+  [PIXEL_EVENTS.POST_TRADE]: 'Purchase',
+}
+
+export const sendRedditEvent = (event: PIXEL_EVENTS) => {
+  window.rdt?.('track', events[event])
+}

--- a/src/custom/components/analytics/pixel/twitter.ts
+++ b/src/custom/components/analytics/pixel/twitter.ts
@@ -1,0 +1,11 @@
+import { PIXEL_EVENTS } from './constants'
+
+const events = {
+  [PIXEL_EVENTS.INIT]: 'tw-oddz2-oddz8',
+  [PIXEL_EVENTS.CONNECT_WALLET]: 'tw-oddz2-oddza',
+  [PIXEL_EVENTS.POST_TRADE]: 'tw-oddz2-oddzb',
+}
+
+export const sendTwitterEvent = (event: PIXEL_EVENTS) => {
+  window.twq?.('event', events[event], {})
+}


### PR DESCRIPTION
# Summary

Continues on top of https://github.com/cowprotocol/cowswap/pull/1977
Adds pixel tracking for Paved and Microsoft.
- when the page (url) is changed
- when the app is loaded
- when an account is connected
- when trade is posted

For more context [this is the document](https://docs.google.com/spreadsheets/d/1GFg-gXmBboLGLeLsTGA_7FxmuCB3P0xNbdwHhEEe7d4/edit?pli=1#gid=1015340718) where the events are defined

# To test
To test this check the requests in dev-tools Network tab

Paved
- when the app is loaded, filter by `search`
- when the account is connect, filter by `sign_up`
- when the order is placed, filter by `purchase`

Microsoft Ads
- when the app is loaded, I'm not really sure how to test this one but there should be one request with the `bat.bing.com ` filter
- when the account is connect, filter by `begin_checkout`
- when the order is placed, filter by `purchase bat.bing.com `