### PR TITLE
Fix Cosmos build

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -10,7 +10,7 @@ const { version } = require('./package.json')
 
 const plugins = [
   new webpack.ProvidePlugin({
-    Buffer: [ 'buffer', 'Buffer' ],
+    Buffer: ['buffer', 'Buffer'],
   }),
 ]
 const SENTRY_AUTH_TOKEN = process.env.REACT_APP_SENTRY_AUTH_TOKEN

--- a/craco.config.js
+++ b/craco.config.js
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path')
+const webpack = require('webpack')
 const SentryWebpackPlugin = require('@sentry/webpack-plugin')
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
 const CracoWorkboxPlugin = require('craco-workbox')
@@ -7,7 +8,11 @@ const { version } = require('./package.json')
 
 // see https://github.com/gsoft-inc/craco/blob/master/packages/craco/README.md#configuration-overview
 
-const plugins = []
+const plugins = [
+  new webpack.ProvidePlugin({
+    Buffer: [ 'buffer', 'Buffer' ],
+  }),
+]
 const SENTRY_AUTH_TOKEN = process.env.REACT_APP_SENTRY_AUTH_TOKEN
 const SENTRY_RELEASE_VERSION = 'CowSwap@v' + version
 const ANALYZE_BUNDLE = process.env.REACT_APP_ANALYZE_BUNDLE

--- a/src/cow-react/index.tsx
+++ b/src/cow-react/index.tsx
@@ -1,6 +1,5 @@
 import '@reach/dialog/styles.css'
 import 'inter-ui'
-import './polyfills'
 
 import 'components/analytics'
 import '@cow/utils/sentry'

--- a/src/cow-react/polyfills.ts
+++ b/src/cow-react/polyfills.ts
@@ -1,3 +1,0 @@
-import { Buffer } from 'buffer'
-
-window.Buffer = window.Buffer || Buffer


### PR DESCRIPTION
# Summary

Polyfills were not included in the Cosmos build.
Actually, we use only one polyfill, for `window.Buffer`.
So I moved it to Webpack side and now it's included in Cosmos.