### PR TITLE
Fix AUDIO token decimals

### DIFF
--- a/src/cow-react/modules/tokensList/updaters/TokensListUpdater.ts
+++ b/src/cow-react/modules/tokensList/updaters/TokensListUpdater.ts
@@ -2,6 +2,7 @@ import { useUpdateAtom } from 'jotai/utils'
 import { tokensByAddressAtom, tokensBySymbolAtom, TokenWithLogo } from '@cow/modules/tokensList/state/tokensListAtom'
 import { useEffect } from 'react'
 import { useTokensListWithDefaults } from 'state/lists/hooks/hooksMod'
+import { fixTokenInfo } from './utils'
 
 /**
  * This updater protects from redundant recalculations
@@ -17,19 +18,12 @@ export function TokensListUpdater() {
     const tokensBySymbolMap: { [address: string]: TokenWithLogo[] } = {}
 
     allTokens.forEach((token) => {
-      const wrappedToken: TokenWithLogo = new TokenWithLogo(
-        token.logoURI,
-        token.chainId,
-        token.address,
-        token.decimals,
-        token.symbol,
-        token.name
-      )
       const addressLowerCase = token.address.toLowerCase()
       const symbolLowerCase = token.symbol.toLowerCase()
+      const fixedToken = fixTokenInfo(token)
 
       if (!tokensByAddressMap[addressLowerCase]) {
-        tokensByAddressMap[addressLowerCase] = wrappedToken
+        tokensByAddressMap[addressLowerCase] = fixedToken
       }
 
       tokensBySymbolMap[symbolLowerCase] = tokensBySymbolMap[symbolLowerCase] || []
@@ -38,7 +32,7 @@ export function TokensListUpdater() {
         (token) => token.address.toLowerCase() === addressLowerCase
       )
       if (!isTokenInTheSymbolMap) {
-        tokensBySymbolMap[symbolLowerCase].push(wrappedToken)
+        tokensBySymbolMap[symbolLowerCase].push(fixedToken)
       }
     })
 

--- a/src/cow-react/modules/tokensList/updaters/utils.ts
+++ b/src/cow-react/modules/tokensList/updaters/utils.ts
@@ -1,0 +1,20 @@
+import { TokenWithLogo } from '@cow/modules/tokensList/state/tokensListAtom'
+import { TokenInfo } from '@uniswap/token-lists'
+
+const AUDIO_TOKEN_ADDRESS = '0x18aaa7115705e8be94bffebde57af9bfc265b998'
+const AUDIO_TOKEN_DECIMALS = 18
+
+export function fixTokenInfo(token: TokenInfo): TokenWithLogo {
+  const addressLowerCase = token.address.toLowerCase()
+
+  return new TokenWithLogo(
+    token.logoURI,
+    token.chainId,
+    token.address,
+    // Gemini list contains wrong decimals (0) for AUDIO token
+    // https://www.gemini.com/uniswap/manifest.json
+    addressLowerCase === AUDIO_TOKEN_ADDRESS ? AUDIO_TOKEN_DECIMALS : token.decimals,
+    token.symbol,
+    token.name
+  )
+}


### PR DESCRIPTION
# Summary

Fixes #1970

For some reason, gemini tokens list contains wrong decimals for AUDIO token (must be 18):
https://www.gemini.com/uniswap/manifest.json