### PR TITLE
Change GA debug mode to rely on NODE_ENV

### DIFF
--- a/src/components/analytics/index.ts
+++ b/src/components/analytics/index.ts
@@ -1,3 +1,4 @@
+import { isDevelopmentEnv } from '@src/utils/env'
 import { useWeb3React } from '@web3-react/core'
 import { useEffect } from 'react'
 import { UaEventOptions } from 'react-ga4/types/ga4'
@@ -49,7 +50,8 @@ if (typeof GOOGLE_ANALYTICS_ID === 'string') {
       ? 'mobileWeb3'
       : 'mobileRegular',
   })
-} else {
+} else if (isDevelopmentEnv()) {
+  console.warn('No Google Analytics ID found. Initializing with debug mode.')
   googleAnalytics.initialize('test', { gtagOptions: { debug_mode: true } })
 }
 


### PR DESCRIPTION
# Summary

Fixes #1995 

Previously, GA test mode was being initialised when GA key could not have been found. Updated that to rely on NODE_ENV not being production.

  # Background

https://cowservices.slack.com/archives/C0361CDG8GP/p1676378568049579
