### PR TITLE
1970/replace gemini with coingecko list

### DIFF
--- a/src/custom/constants/lists.ts
+++ b/src/custom/constants/lists.ts
@@ -46,6 +46,8 @@ export const DEFAULT_LIST_OF_LISTS_BY_NETWORK: NetworkLists = {
   [ChainId.MAINNET]: buildNetworkDefaultLists({
     chainId: ChainId.MAINNET,
     networkLists: [
+      COW_DAO_LIST,
+      COW_COINGECKO_LIST,
       COMPOUND_LIST,
       AAVE_LIST,
       SYNTHETIX_LIST,
@@ -58,8 +60,6 @@ export const DEFAULT_LIST_OF_LISTS_BY_NETWORK: NetworkLists = {
       CMC_ALL_LIST,
       CMC_STABLECOIN,
       KLEROS_LIST,
-      COW_DAO_LIST,
-      COW_COINGECKO_LIST,
     ],
   }),
   [ChainId.GOERLI]: buildNetworkDefaultLists({

--- a/src/custom/constants/lists.ts
+++ b/src/custom/constants/lists.ts
@@ -1,4 +1,3 @@
-// used to mark unsupported tokens, these are hosted lists of unsupported tokens
 import { SupportedChainId as ChainId } from 'constants/chains'
 import { RAW_CODE_LINK } from '.'
 
@@ -33,9 +32,6 @@ const HONEY_SWAP_XDAI = 'https://tokens.honeyswap.org'
 
 export const UNSUPPORTED_LIST_URLS: NetworkLists = {
   [ChainId.MAINNET]: [BA_LIST],
-  // [ChainId.KOVAN]: [BA_LIST],
-  // [ChainId.RINKEBY]: [BA_LIST],
-  // [ChainId.ROPSTEN]: [BA_LIST],
   [ChainId.GOERLI]: [BA_LIST],
   [ChainId.GNOSIS_CHAIN]: [BA_LIST],
 }
@@ -66,18 +62,6 @@ export const DEFAULT_LIST_OF_LISTS_BY_NETWORK: NetworkLists = {
       COW_COINGECKO_LIST,
     ],
   }),
-  // [ChainId.KOVAN]: buildNetworkDefaultLists({
-  //   chainId: ChainId.KOVAN,
-  //   networkLists: [COMPOUND_LIST],
-  // }),
-  // [ChainId.RINKEBY]: buildNetworkDefaultLists({
-  //   chainId: ChainId.RINKEBY,
-  //   networkLists: [RINKEBY_LIST, COMPOUND_LIST],
-  // }),
-  // [ChainId.ROPSTEN]: buildNetworkDefaultLists({
-  //   chainId: ChainId.ROPSTEN,
-  //   networkLists: [COMPOUND_LIST],
-  // }),
   [ChainId.GOERLI]: buildNetworkDefaultLists({
     chainId: ChainId.GOERLI,
     networkLists: [GOERLI_LIST, COMPOUND_LIST],
@@ -91,9 +75,6 @@ export const DEFAULT_LIST_OF_LISTS_BY_NETWORK: NetworkLists = {
 // default lists to be 'active' aka searched across
 export const DEFAULT_ACTIVE_LIST_URLS_BY_NETWORK: NetworkLists = {
   [ChainId.MAINNET]: [COW_DAO_LIST, COW_COINGECKO_LIST],
-  // [ChainId.KOVAN]: [GEMINI_LIST],
-  // [ChainId.RINKEBY]: [COW_DAO_LIST, RINKEBY_LIST],
-  // [ChainId.ROPSTEN]: [GEMINI_LIST],
   [ChainId.GNOSIS_CHAIN]: [COW_DAO_LIST, HONEY_SWAP_XDAI],
   [ChainId.GOERLI]: [COW_DAO_LIST, GOERLI_LIST],
 }

--- a/src/custom/constants/lists.ts
+++ b/src/custom/constants/lists.ts
@@ -100,5 +100,3 @@ export const DEFAULT_ACTIVE_LIST_URLS_BY_NETWORK: NetworkLists = {
 
 // Set what we want as the default list when no chain id available: default = MAINNET
 export const DEFAULT_NETWORK_FOR_LISTS = ChainId.MAINNET
-// for testing in reducer.test.ts
-export const DEFAULT_LIST_OF_LISTS = DEFAULT_LIST_OF_LISTS_BY_NETWORK[ChainId.MAINNET]

--- a/src/custom/constants/lists.ts
+++ b/src/custom/constants/lists.ts
@@ -23,7 +23,6 @@ const ROLL_LIST = 'https://app.tryroll.com/tokens.json'
 const CMC_ALL_LIST = 'defi.cmc.eth'
 const CMC_STABLECOIN = 'stablecoin.cmc.eth'
 const KLEROS_LIST = 't2crtokens.eth'
-const GEMINI_LIST = 'https://www.gemini.com/uniswap/manifest.json'
 const BA_LIST = 'https://raw.githubusercontent.com/The-Blockchain-Association/sec-notice-list/master/ba-sec-list.json'
 
 // Goerli Default
@@ -63,7 +62,6 @@ export const DEFAULT_LIST_OF_LISTS_BY_NETWORK: NetworkLists = {
       CMC_ALL_LIST,
       CMC_STABLECOIN,
       KLEROS_LIST,
-      GEMINI_LIST,
       COW_DAO_LIST,
       COW_COINGECKO_LIST,
     ],
@@ -92,7 +90,7 @@ export const DEFAULT_LIST_OF_LISTS_BY_NETWORK: NetworkLists = {
 
 // default lists to be 'active' aka searched across
 export const DEFAULT_ACTIVE_LIST_URLS_BY_NETWORK: NetworkLists = {
-  [ChainId.MAINNET]: [COW_DAO_LIST, GEMINI_LIST],
+  [ChainId.MAINNET]: [COW_DAO_LIST, COW_COINGECKO_LIST],
   // [ChainId.KOVAN]: [GEMINI_LIST],
   // [ChainId.RINKEBY]: [COW_DAO_LIST, RINKEBY_LIST],
   // [ChainId.ROPSTEN]: [GEMINI_LIST],

--- a/src/custom/state/lists/reducer/reducerMod.test.ts
+++ b/src/custom/state/lists/reducer/reducerMod.test.ts
@@ -1,12 +1,11 @@
 import { createStore, Store } from 'redux'
-import {
-  /* DEFAULT_ACTIVE_LIST_URLS,  */ DEFAULT_LIST_OF_LISTS,
-  DEFAULT_ACTIVE_LIST_URLS_BY_NETWORK,
-} from 'constants/lists'
+import { DEFAULT_ACTIVE_LIST_URLS_BY_NETWORK, DEFAULT_LIST_OF_LISTS_BY_NETWORK } from 'constants/lists'
 import { updateVersion } from 'state/global/actions'
 import { fetchTokenList, acceptListUpdate, addList, removeList, enableList } from 'state/lists/actions'
 import reducer, { ListsStateByNetwork } from '.'
 import { SupportedChainId as ChainId } from 'constants/chains'
+
+const DEFAULT_LIST_OF_LISTS = DEFAULT_LIST_OF_LISTS_BY_NETWORK[ChainId.MAINNET]
 
 const STUB_TOKEN_LIST = {
   name: '',


### PR DESCRIPTION
# Summary

Closes #1970 
Supersedes https://github.com/cowprotocol/cowswap/pull/1994

Removed Gemini token list, which has wrong data for AUDIO token, and enabled by default our subset of Coingecko's list, where the AUDIO token has the right data. 

![Screenshot 2023-02-15 at 11 11 56](https://user-images.githubusercontent.com/43217/219013119-0318e84c-e225-4812-a4d2-d5da3dccaddc.png)

# To Test

1. Open the app on mainnet
2. Go to manage tokens
* Gemini list should not be preset
* Coingecko list should be present and enabled
3. Search for AUDIO token
* It should be present and contain the right number of decimals