### PR TITLE
useAppData hook is designed for using only from an updater

### DIFF
--- a/src/cow-react/modules/application/containers/App/Updaters.tsx
+++ b/src/cow-react/modules/application/containers/App/Updaters.tsx
@@ -21,6 +21,7 @@ import { UploadToIpfsUpdater } from 'state/appData/updater'
 import { GasPriceStrategyUpdater } from 'state/gas/gas-price-strategy-updater'
 import { EthFlowSlippageUpdater, EthFlowDeadlineUpdater } from '@cow/modules/swap/state/EthFlow/updaters'
 import { TokensListUpdater } from '@cow/modules/tokensList/updaters/TokensListUpdater'
+import { AppDataUpdater } from 'state/appData/AppDataInfoUpdater'
 
 export function Updaters() {
   return (
@@ -42,6 +43,7 @@ export function Updaters() {
       <LogsUpdater />
       <SentryUpdater />
       <UploadToIpfsUpdater />
+      <AppDataUpdater />
       <GnosisSafeUpdater />
       <GasPriceStrategyUpdater />
       <EthFlowSlippageUpdater />

--- a/src/cow-react/modules/limitOrders/hooks/useTradeFlowContext.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useTradeFlowContext.ts
@@ -5,15 +5,13 @@ import { useWalletInfo } from 'hooks/useWalletInfo'
 import { useGP2SettlementContract } from 'hooks/useContract'
 import { useDispatch } from 'react-redux'
 import { AppDispatch } from 'state'
-import { useAppData } from 'hooks/useAppData'
-import { LIMIT_ORDER_SLIPPAGE } from '@cow/modules/limitOrders/const/trade'
 import useENSAddress from 'hooks/useENSAddress'
 import { useLimitOrdersTradeState } from './useLimitOrdersTradeState'
 import { OrderClass } from '@src/custom/state/orders/actions'
 import { useAtomValue } from 'jotai/utils'
 import { limitOrdersQuoteAtom } from '@cow/modules/limitOrders/state/limitOrdersQuoteAtom'
 import { useUpdateAtom } from 'jotai/utils'
-import { addAppDataToUploadQueueAtom } from 'state/appData/atoms'
+import { addAppDataToUploadQueueAtom, appDataInfoAtom } from 'state/appData/atoms'
 import { useRateImpact } from '@cow/modules/limitOrders/hooks/useRateImpact'
 
 export function useTradeFlowContext(): TradeFlowContext | null {
@@ -22,7 +20,7 @@ export function useTradeFlowContext(): TradeFlowContext | null {
   const { allowsOffchainSigning, gnosisSafeInfo } = useWalletInfo()
   const settlementContract = useGP2SettlementContract()
   const dispatch = useDispatch<AppDispatch>()
-  const appData = useAppData({ chainId, allowedSlippage: LIMIT_ORDER_SLIPPAGE, orderClass: OrderClass.LIMIT })
+  const appData = useAtomValue(appDataInfoAtom)
   const addAppDataToUploadQueue = useUpdateAtom(addAppDataToUploadQueueAtom)
   const { address: ensRecipientAddress } = useENSAddress(state.recipient)
   const quoteState = useAtomValue(limitOrdersQuoteAtom)

--- a/src/cow-react/modules/swap/hooks/useFlowContext.ts
+++ b/src/cow-react/modules/swap/hooks/useFlowContext.ts
@@ -5,7 +5,6 @@ import { GpEther as ETHER } from 'constants/tokens'
 import { useWalletInfo } from 'hooks/useWalletInfo'
 import { useCloseModals } from 'state/application/hooks'
 import { AddOrderCallback, useAddPendingOrder } from 'state/orders/hooks'
-import { useAppData } from 'hooks/useAppData'
 import { useDispatch } from 'react-redux'
 import { AppDispatch } from 'state'
 import { SwapFlowAnalyticsContext } from '@cow/modules/trade/utils/analytics'
@@ -17,8 +16,8 @@ import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
 import { OrderKind } from '@cowprotocol/contracts'
 import { NATIVE_CURRENCY_BUY_TOKEN } from 'constants/index'
 import { useUserTransactionTTL } from 'state/user/hooks'
-import { useUpdateAtom } from 'jotai/utils'
-import { addAppDataToUploadQueueAtom } from 'state/appData/atoms'
+import { useAtomValue, useUpdateAtom } from 'jotai/utils'
+import { addAppDataToUploadQueueAtom, appDataInfoAtom } from 'state/appData/atoms'
 import { useIsEthFlow } from '@cow/modules/swap/hooks/useIsEthFlow'
 import { Weth } from '@cow/abis/types'
 import TradeGp from 'state/swap/TradeGp'
@@ -79,7 +78,7 @@ export function useBaseFlowContextSetup(): BaseFlowContextSetup {
   const { v2Trade: trade, allowedSlippage } = useDerivedSwapInfo()
   const { allowsOffchainSigning, gnosisSafeInfo } = useWalletInfo()
 
-  const appData = useAppData({ chainId, allowedSlippage, orderClass: OrderClass.MARKET })
+  const appData = useAtomValue(appDataInfoAtom)
   const closeModals = useCloseModals()
   const addAppDataToUploadQueue = useUpdateAtom(addAppDataToUploadQueueAtom)
   const addOrderCallback = useAddPendingOrder()

--- a/src/custom/hooks/useAppData.ts
+++ b/src/custom/hooks/useAppData.ts
@@ -1,38 +1,33 @@
 import { useEffect } from 'react'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { useAtom } from 'jotai'
-import { Percent } from '@uniswap/sdk-core'
 
 import { APP_DATA_HASH } from 'constants/index'
 import { buildAppData, BuildAppDataParams } from 'utils/appData'
 import { appDataInfoAtom } from 'state/appData/atoms'
-import { AppDataInfo } from 'state/appData/types'
 import { useReferralAddress } from 'state/affiliate/hooks'
 import { useAppCode } from 'hooks/useAppCode'
-import { percentToBips } from 'utils/misc'
 import { OrderClass } from 'state/orders/actions'
+import { useUpdateAtom } from 'jotai/utils'
 
-type UseAppDataParams = {
+export type UseAppDataParams = {
   chainId?: SupportedChainId
-  allowedSlippage: Percent
+  slippageBips: string
   orderClass: OrderClass
 }
 
 /**
  * Fetches and updates appDataInfo whenever a dependency changes
+ * The hook can be called only from an updater
  */
-export function useAppData({ chainId, allowedSlippage, orderClass }: UseAppDataParams): AppDataInfo | null {
+export function useAppData({ chainId, slippageBips, orderClass }: UseAppDataParams): void {
   // AppDataInfo, from Jotai
-  const [appDataInfo, setAppDataInfo] = useAtom(appDataInfoAtom)
+  const setAppDataInfo = useUpdateAtom(appDataInfoAtom)
   // Referrer address, from Redux
   const referrer = useReferralAddress()
   // De-normalizing as we only care about the address if it's set, valid and active
   const referrerAccount = referrer?.value && referrer?.isActive && referrer?.isValid ? referrer.value : undefined
   // AppCode is dynamic and based on how it's loaded (if used as a Gnosis Safe app)
   const appCode = useAppCode()
-
-  // Transform slippage Percent to bips
-  const slippageBips = percentToBips(allowedSlippage)
 
   useEffect(() => {
     if (!chainId) {
@@ -56,13 +51,12 @@ export function useAppData({ chainId, allowedSlippage, orderClass }: UseAppDataP
           throw new Error("Couldn't calculate appDataHash")
         }
       } catch (e: any) {
-        console.error(`[useAppData] failed to generate appData, falling back to default`, params, e.message)
+        console.error(`[useAppData] failed to generate appData, falling back to default`, params)
+        console.error(e)
         setAppDataInfo({ hash: APP_DATA_HASH })
       }
     }
 
     updateAppData()
   }, [appCode, chainId, referrerAccount, setAppDataInfo, slippageBips, orderClass])
-
-  return appDataInfo
 }

--- a/src/custom/state/appData/AppDataInfoUpdater.tsx
+++ b/src/custom/state/appData/AppDataInfoUpdater.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { useWeb3React } from '@web3-react/core'
+import { useDerivedSwapInfo } from 'state/swap/hooks'
+import { useAppData, UseAppDataParams } from 'hooks/useAppData'
+import { OrderClass } from 'state/orders/actions'
+import { LIMIT_ORDER_SLIPPAGE } from '@cow/modules/limitOrders/const/trade'
+import { TradeType, useTradeTypeInfo } from '@cow/modules/trade'
+import { percentToBips } from 'utils/misc'
+
+export function AppDataUpdater() {
+  const { chainId } = useWeb3React()
+  const { allowedSlippage: allowedSlippageSwap } = useDerivedSwapInfo()
+  const tradeTypeInfo = useTradeTypeInfo()
+
+  if (!chainId || !tradeTypeInfo) return null
+
+  const isLimitOrders = tradeTypeInfo.tradeType === TradeType.LIMIT_ORDER
+  const allowedSlippage = isLimitOrders ? LIMIT_ORDER_SLIPPAGE : allowedSlippageSwap
+  const slippageBips = percentToBips(allowedSlippage)
+  const orderClass = isLimitOrders ? OrderClass.LIMIT : OrderClass.MARKET
+
+  return <AppDataUpdaterMemo chainId={chainId} slippageBips={slippageBips} orderClass={orderClass}/>
+}
+
+const AppDataUpdaterMemo = React.memo(({chainId, slippageBips, orderClass}: UseAppDataParams) => {
+  useAppData({chainId, slippageBips, orderClass})
+
+  return null
+})

--- a/src/custom/state/appData/AppDataInfoUpdater.tsx
+++ b/src/custom/state/appData/AppDataInfoUpdater.tsx
@@ -19,11 +19,11 @@ export function AppDataUpdater() {
   const slippageBips = percentToBips(allowedSlippage)
   const orderClass = isLimitOrders ? OrderClass.LIMIT : OrderClass.MARKET
 
-  return <AppDataUpdaterMemo chainId={chainId} slippageBips={slippageBips} orderClass={orderClass}/>
+  return <AppDataUpdaterMemo chainId={chainId} slippageBips={slippageBips} orderClass={orderClass} />
 }
 
-const AppDataUpdaterMemo = React.memo(({chainId, slippageBips, orderClass}: UseAppDataParams) => {
-  useAppData({chainId, slippageBips, orderClass})
+const AppDataUpdaterMemo = React.memo(({ chainId, slippageBips, orderClass }: UseAppDataParams) => {
+  useAppData({ chainId, slippageBips, orderClass })
 
   return null
 })


### PR DESCRIPTION
# Summary

Fixes #2019

The root of the problem is here:
https://github.com/cowprotocol/app-data/blob/main/src/utils.ts#L92

In general, the sequence of problems is long enough.
But, the `validateAppDataDoc` from `app-data` is designed to be called once.
Before the fix, we had a race condition and called it at least twice.
