### PR TITLE
[Hotfix] Update only displayed pending limit orders

### DIFF
--- a/src/cow-react/api/gnosisProtocol/errors/OperatorError.ts
+++ b/src/cow-react/api/gnosisProtocol/errors/OperatorError.ts
@@ -66,7 +66,7 @@ export enum ApiErrorCodeDetails {
   UnsupportedBuyTokenDestination = 'Buy token destination is unsupported. Please try again with a different destination.',
   UnsupportedSellTokenSource = 'Sell token source is unsupported. Please try again with a different source.',
   UnsupportedOrderType = 'Order type unsupported. Please try again with a different order type.',
-  TooManyLimitOrders = 'The limit of open limit orders has been reached. You can currently have up to 10 open limit orders.',
+  TooManyLimitOrders = 'The limit of open limit orders has been reached. You can currently have up to 50 open limit orders.',
   UNHANDLED_GET_ERROR = 'Order fetch failed. This may be due to a server or network connectivity issue. Please try again later.',
   UNHANDLED_CREATE_ERROR = 'The order was not accepted by the network.',
   UNHANDLED_DELETE_ERROR = 'The order cancellation was not accepted by the network.',

--- a/src/cow-react/modules/limitOrders/containers/OrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/OrdersWidget/index.tsx
@@ -11,6 +11,8 @@ import { buildLimitOrdersUrl, parseLimitOrdersPageParams } from '@cow/modules/li
 import { LIMIT_ORDERS_TABS, OPEN_TAB } from '@cow/modules/limitOrders/const/limitOrdersTabs'
 import { useValidatePageUrlParams } from './hooks/useValidatePageUrlParams'
 import { useCancelOrder } from '@cow/common/hooks/useCancelOrder'
+import { useUpdateAtom } from 'jotai/utils'
+import { limitOrdersPaginationAtom } from '@cow/modules/limitOrders/state/limitOrdersPaginationAtom'
 
 function getOrdersListByIndex(ordersList: LimitOrdersList, id: string): Order[] {
   return id === OPEN_TAB.id ? ordersList.pending : ordersList.history
@@ -22,6 +24,7 @@ export function OrdersWidget() {
   const ordersList = useLimitOrdersList()
   const { chainId, account } = useWeb3React()
   const getShowCancellationModal = useCancelOrder()
+  const updateLimitOrdersPagination = useUpdateAtom(limitOrdersPaginationAtom)
 
   const spender = useMemo(() => (chainId ? GP_VAULT_RELAYER[chainId] : undefined), [chainId])
 
@@ -51,6 +54,10 @@ export function OrdersWidget() {
     spender,
     ordersList.pending
   )
+
+  useEffect(() => {
+    updateLimitOrdersPagination({ pageNumber: currentPageNumber })
+  }, [currentPageNumber, updateLimitOrdersPagination])
 
   // Set page params initially once
   useEffect(() => {

--- a/src/cow-react/modules/limitOrders/containers/OrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/OrdersWidget/index.tsx
@@ -56,7 +56,7 @@ export function OrdersWidget() {
   )
 
   useEffect(() => {
-    updateLimitOrdersPagination({ pageNumber: currentPageNumber })
+    updateLimitOrdersPagination(currentPageNumber)
   }, [currentPageNumber, updateLimitOrdersPagination])
 
   // Set page params initially once

--- a/src/cow-react/modules/limitOrders/state/limitOrdersPaginationAtom.ts
+++ b/src/cow-react/modules/limitOrders/state/limitOrdersPaginationAtom.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai'
+
+export const limitOrdersPaginationAtom = atom<{ pageNumber: number }>({ pageNumber: 1 })

--- a/src/cow-react/modules/limitOrders/state/limitOrdersPaginationAtom.ts
+++ b/src/cow-react/modules/limitOrders/state/limitOrdersPaginationAtom.ts
@@ -1,3 +1,3 @@
 import { atom } from 'jotai'
 
-export const limitOrdersPaginationAtom = atom<{ pageNumber: number }>({ pageNumber: 1 })
+export const limitOrdersPaginationAtom = atom<number>(1)

--- a/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
@@ -265,7 +265,7 @@ export function PendingOrdersUpdater(): null {
   const presignOrders = usePresignOrders()
   const updatePresignGnosisSafeTx = useUpdatePresignGnosisSafeTx()
   const getSafeInfo = useGetSafeInfo()
-  const { pageNumber } = useAtomValue(limitOrdersPaginationAtom)
+  const pageNumber = useAtomValue(limitOrdersPaginationAtom)
 
   const updateOrders = useCallback(
     async (chainId: ChainId, account: string, orderClass: OrderClass) => {


### PR DESCRIPTION
# Summary

https://cowservices.slack.com/archives/C036G0J90BU/p1677172359678769

`PendingOrdersUpdater` periodically updates pending orders.
Since the limit of open pending limit orders was increased up to 50, we hit out the limit.
To fix it, I have added limit orders pagination into `PendingOrdersUpdater` and now we make maximum 10 requests.

# To Test
1. Create 50 pending limit orders
2. Open the Network tab in devtools
3. There should be not more than 10 `/order` request each 15 seconds
