### PR TITLE
Exponential backoff

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "d3": "^7.8.1",
     "date-fns": "^2.29.3",
     "ethers": "^5.1.4",
+    "exponential-backoff": "^3.1.1",
     "fast-safe-stringify": "^2.0.8",
     "fortmatic": "^2.2.1",
     "fraction.js": "^4.2.0",

--- a/src/cow-react/api/coingecko/index.ts
+++ b/src/cow-react/api/coingecko/index.ts
@@ -1,3 +1,4 @@
+import { fetchWithBackoff } from '@cow/common/utils/fetch'
 import { PriceInformation } from '@cowprotocol/cow-sdk'
 import { SupportedChainId as ChainId } from 'constants/chains'
 import { SWR_OPTIONS } from 'constants/index'
@@ -47,7 +48,7 @@ function _getCoinGeckoAssetPlatform(chainId: ChainId) {
 
 function _fetch(chainId: ChainId, url: string, method: 'GET' | 'POST' | 'DELETE', data?: any): Promise<Response> {
   const baseUrl = _getApiBaseUrl(chainId)
-  return fetch(baseUrl + url, {
+  return fetchWithBackoff(baseUrl + url, {
     headers: DEFAULT_HEADERS,
     method,
     body: data !== undefined ? JSON.stringify(data) : data,

--- a/src/cow-react/api/gasPrices/index.ts
+++ b/src/cow-react/api/gasPrices/index.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
 import { SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
 import { GAS_FEE_ENDPOINTS, GAS_API_KEYS } from 'constants/index'
+import { fetchWithBackoff } from '@cow/common/utils/fetch'
 
 // Values are returned as floats in gwei
 const ONE_GWEI = 1_000_000_000
@@ -106,7 +107,7 @@ class GasFeeApi {
   async fetchData(chainId: ChainId) {
     const url = this.getUrl(chainId)
     const headers = this.getHeaders(chainId)
-    const response = await fetch(url, headers)
+    const response = await fetchWithBackoff(url, headers)
 
     return response.json()
   }

--- a/src/cow-react/api/gnosisProtocol/api.ts
+++ b/src/cow-react/api/gnosisProtocol/api.ts
@@ -33,6 +33,7 @@ import { Context } from '@sentry/types'
 import { PriceInformation, SimpleGetQuoteResponse } from '@cowprotocol/cow-sdk'
 import { GpPriceStrategy } from 'state/gas/atoms'
 import { OrderClass } from 'state/orders/actions'
+import { fetchWithBackoff } from '@cow/common/utils/fetch'
 
 function getGnosisProtocolUrl(): Partial<Record<ChainId, string>> {
   if (isLocal || isDev || isPr || isBarn) {
@@ -203,7 +204,7 @@ export function getOrderLink(chainId: ChainId, orderId: OrderID): string {
 
 function _fetch(chainId: ChainId, url: string, method: 'GET' | 'POST' | 'DELETE', data?: any): Promise<Response> {
   const baseUrl = _getApiBaseUrl(chainId)
-  return fetch(baseUrl + url, {
+  return fetchWithBackoff(baseUrl + url, {
     headers: DEFAULT_HEADERS,
     method,
     body: data !== undefined ? JSON.stringify(data) : data,
@@ -217,7 +218,7 @@ function _fetchProfile(
   data?: any
 ): Promise<Response> {
   const baseUrl = _getProfileApiBaseUrl(chainId)
-  return fetch(baseUrl + url, {
+  return fetchWithBackoff(baseUrl + url, {
     headers: DEFAULT_HEADERS,
     method,
     body: data !== undefined ? JSON.stringify(data) : data,
@@ -226,7 +227,7 @@ function _fetchProfile(
 
 function _fetchPriceStrategy(chainId: ChainId): Promise<Response> {
   const baseUrl = _getPriceStrategyApiBaseUrl(chainId)
-  return fetch(baseUrl)
+  return fetchWithBackoff(baseUrl)
 }
 
 function _post(chainId: ChainId, url: string, data: any): Promise<Response> {

--- a/src/cow-react/api/matcha-0x/index.ts
+++ b/src/cow-react/api/matcha-0x/index.ts
@@ -6,6 +6,7 @@ import { getTokensFromMarket } from 'utils/misc'
 import { getValidParams } from 'utils/price'
 import { LegacyPriceQuoteParams } from '@cow/api/gnosisProtocol/legacy/types'
 import { PriceInformation } from '@cowprotocol/cow-sdk'
+import { fetchWithBackoff } from '@cow/common/utils/fetch'
 
 // copy/pasting as the library types correspond to the internal types, not API response
 // e.g "price: BigNumber" when we want the API response type: "price: string"
@@ -94,7 +95,7 @@ function _getApiBaseUrl(chainId: ChainId): string {
 
 function _fetch(chainId: ChainId, url: string, method: 'GET' | 'POST' | 'DELETE', data?: any): Promise<Response> {
   const baseUrl = _getApiBaseUrl(chainId)
-  return fetch(baseUrl + url, {
+  return fetchWithBackoff(baseUrl + url, {
     headers: DEFAULT_HEADERS,
     method,
     body: data !== undefined ? JSON.stringify(data) : data,

--- a/src/cow-react/common/utils/fetch.test.ts
+++ b/src/cow-react/common/utils/fetch.test.ts
@@ -31,10 +31,7 @@ function mockAndFailUntilAttempt(attempt: number) {
 
 const fetchUrlWithBackoff = (attepts: number) => fetchWithBackoff(URL, undefined, { numOfAttempts: attepts })
 
-
 describe('Fetch with backoff', () => {
-
-
   it('No re-attempt if SUCCESS', async () => {
     // GIVEN: A working API
     mockAndFailUntilAttempt(0)
@@ -61,10 +58,9 @@ describe('Fetch with backoff', () => {
 
     // THEN: The result is OK
     expect(result).toBe(OK_RESPONSE)
-
   })
 
-  it("SUCCEED in the last attempt", async () => {
+  it('SUCCEED in the last attempt', async () => {
     // GIVEN: A API which fails 50 times
     mockAndFailUntilAttempt(3)
 

--- a/src/cow-react/common/utils/fetch.test.ts
+++ b/src/cow-react/common/utils/fetch.test.ts
@@ -1,0 +1,94 @@
+import { fetchWithBackoff } from './fetch'
+import fetchMock from 'jest-fetch-mock'
+
+fetchMock.enableMocks()
+// jest.useFakeTimers('modern')
+// jest.spyOn(global, 'setTimeout')
+// jest.useFakeTimers()
+
+const URL = 'https://cow.fi'
+const ERROR_MESSAGE = '💣💥 Booom!'
+
+const OK_RESPONSE = {
+  status: 200,
+  ok: true,
+  json: () => Promise.resolve({}),
+}
+
+beforeEach(() => {
+  fetchMock.mockClear()
+})
+
+function mockAndFailUntilAttempt(attempt: number) {
+  let count = 0
+  // @ts-ignore
+  fetchMock.mockImplementation(() => {
+    count++
+    // console.log('ATTEMPT', count)
+    return count >= attempt ? Promise.resolve(OK_RESPONSE) : Promise.reject(ERROR_MESSAGE)
+  })
+}
+
+const fetchUrlWithBackoff = (attepts: number) => fetchWithBackoff(URL, undefined, { numOfAttempts: attepts })
+
+
+describe('Fetch with backoff', () => {
+
+
+  it('No re-attempt if SUCCESS', async () => {
+    // GIVEN: A working API
+    mockAndFailUntilAttempt(0)
+
+    // WHEN: Fetch url (backoff up to 10 attempts)
+    const result = await fetchUrlWithBackoff(10)
+
+    // THEN: Only one request is needed (no need to re-attempt)
+    expect(fetchMock).toBeCalledTimes(1)
+
+    // THEN: The result is OK
+    expect(result).toBe(OK_RESPONSE)
+  })
+
+  it('3 re-attempts if FAILS 3 times and then SUCCEED', async () => {
+    // GIVEN: An API which fails 3 tiems, and then succeeds
+    mockAndFailUntilAttempt(3)
+
+    // WHEN: Fetch url (backoff up to 5 attempts)
+    const result = await fetchUrlWithBackoff(5)
+
+    // THEN: Only one request is needed
+    expect(fetchMock).toBeCalledTimes(3)
+
+    // THEN: The result is OK
+    expect(result).toBe(OK_RESPONSE)
+
+  })
+
+  it("SUCCEED in the last attempt", async () => {
+    // GIVEN: A API which fails 50 times
+    mockAndFailUntilAttempt(3)
+
+    // WHEN: Fetch url (backoff up to 3 attempts)
+    const result = await fetchUrlWithBackoff(3)
+
+    // THEN: We only call fetch 3 times
+    expect(fetchMock).toBeCalledTimes(3)
+
+    // THEN: The result is OK
+    expect(result).toBe(OK_RESPONSE)
+  })
+
+  it("Don't reattempt after FAILING the MAXIMUM number of times", async () => {
+    // GIVEN: A API which fails 50 times
+    mockAndFailUntilAttempt(50)
+
+    // WHEN: Fetch url (backoff up to 3 attempts)
+    const fetchPromise = fetchUrlWithBackoff(3)
+
+    // THEN: The result is ERROR
+    await expect(fetchPromise).rejects.toBe(ERROR_MESSAGE)
+
+    // THEN: We only call fetch 3 times
+    expect(fetchMock).toBeCalledTimes(3)
+  })
+})

--- a/src/cow-react/common/utils/fetch.ts
+++ b/src/cow-react/common/utils/fetch.ts
@@ -15,14 +15,6 @@ const DEFAULT_BACKOFF_OPTIONS: BackoffOptions = {
  * @returns A promise of the request
  */
 // By default, it will wait
-export function fetchWithBackoff(
-  input: RequestInfo | URL,
-  init?: RequestInit,
-  backoffOptions?: BackoffOptions
-): Promise<Response> {
-  if (backoffOptions) {
-    return backOff(() => fetch(input, init), { ...DEFAULT_BACKOFF_OPTIONS, ...backoffOptions })
-  }
-
-  return fetch(input, init)
+export function fetchWithBackoff(input: RequestInfo | URL, init?: RequestInit, backoffOptions?: BackoffOptions): Promise<Response> {
+  return backOff(() => fetch(input, init), {...DEFAULT_BACKOFF_OPTIONS, ...backoffOptions})
 }

--- a/src/cow-react/common/utils/fetch.ts
+++ b/src/cow-react/common/utils/fetch.ts
@@ -8,6 +8,14 @@ const DEFAULT_BACKOFF_OPTIONS: BackoffOptions = {
   jitter: 'none',
 }
 
+/**
+ * 
+ * @param input Request info (as in the fetch method)
+ * @param init Request options (as in fetch method)
+ * @param backoffOptions Backoff parameters. By default It will wait a maximum of ~102s maximun wait time. Wait time is 100ms * 2**(attenmpt)
+ * @returns A promise of the request
+ */
+// By default, it will wait
 export function fetchWithBackoff(input: RequestInfo | URL, init?: RequestInit, backoffOptions?: BackoffOptions): Promise<Response> {
 
   if (backoffOptions) {
@@ -16,3 +24,4 @@ export function fetchWithBackoff(input: RequestInfo | URL, init?: RequestInit, b
 
   return fetch(input, init)
 }
+

--- a/src/cow-react/common/utils/fetch.ts
+++ b/src/cow-react/common/utils/fetch.ts
@@ -15,6 +15,10 @@ const DEFAULT_BACKOFF_OPTIONS: BackoffOptions = {
  * @returns A promise of the request
  */
 // By default, it will wait
-export function fetchWithBackoff(input: RequestInfo | URL, init?: RequestInit, backoffOptions?: BackoffOptions): Promise<Response> {
-  return backOff(() => fetch(input, init), {...DEFAULT_BACKOFF_OPTIONS, ...backoffOptions})
+export function fetchWithBackoff(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  backoffOptions?: BackoffOptions
+): Promise<Response> {
+  return backOff(() => fetch(input, init), { ...DEFAULT_BACKOFF_OPTIONS, ...backoffOptions })
 }

--- a/src/cow-react/common/utils/fetch.ts
+++ b/src/cow-react/common/utils/fetch.ts
@@ -1,5 +1,4 @@
-import { backOff, BackoffOptions } from "exponential-backoff"
-
+import { backOff, BackoffOptions } from 'exponential-backoff'
 
 // See config in https://www.npmjs.com/package/@insertish/exponential-backoff
 const DEFAULT_BACKOFF_OPTIONS: BackoffOptions = {
@@ -9,19 +8,21 @@ const DEFAULT_BACKOFF_OPTIONS: BackoffOptions = {
 }
 
 /**
- * 
+ *
  * @param input Request info (as in the fetch method)
  * @param init Request options (as in fetch method)
  * @param backoffOptions Backoff parameters. By default It will wait a maximum of ~102s maximun wait time. Wait time is 100ms * 2**(attenmpt)
  * @returns A promise of the request
  */
 // By default, it will wait
-export function fetchWithBackoff(input: RequestInfo | URL, init?: RequestInit, backoffOptions?: BackoffOptions): Promise<Response> {
-
+export function fetchWithBackoff(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  backoffOptions?: BackoffOptions
+): Promise<Response> {
   if (backoffOptions) {
-    return backOff(() => fetch(input, init), {...DEFAULT_BACKOFF_OPTIONS, ...backoffOptions})
+    return backOff(() => fetch(input, init), { ...DEFAULT_BACKOFF_OPTIONS, ...backoffOptions })
   }
 
   return fetch(input, init)
 }
-

--- a/src/cow-react/common/utils/fetch.ts
+++ b/src/cow-react/common/utils/fetch.ts
@@ -11,7 +11,7 @@ const DEFAULT_BACKOFF_OPTIONS: BackoffOptions = {
  *
  * @param input Request info (as in the fetch method)
  * @param init Request options (as in fetch method)
- * @param backoffOptions Backoff parameters. By default It will wait a maximum of ~102s maximun wait time. Wait time is 100ms * 2**(attenmpt)
+ * @param backoffOptions Backoff parameters. By default It will wait a maximum of ~102s. Wait time is 100ms * 2**(attenmpt). Not more than 10 attempts
  * @returns A promise of the request
  */
 // By default, it will wait

--- a/src/cow-react/common/utils/fetch.ts
+++ b/src/cow-react/common/utils/fetch.ts
@@ -1,0 +1,18 @@
+import { backOff, BackoffOptions } from "exponential-backoff"
+
+
+// See config in https://www.npmjs.com/package/@insertish/exponential-backoff
+const DEFAULT_BACKOFF_OPTIONS: BackoffOptions = {
+  numOfAttempts: 10,
+  maxDelay: Infinity,
+  jitter: 'none',
+}
+
+export function fetchWithBackoff(input: RequestInfo | URL, init?: RequestInit, backoffOptions?: BackoffOptions): Promise<Response> {
+
+  if (backoffOptions) {
+    return backOff(() => fetch(input, init), {...DEFAULT_BACKOFF_OPTIONS, ...backoffOptions})
+  }
+
+  return fetch(input, init)
+}

--- a/src/hooks/useENSAvatar.ts
+++ b/src/hooks/useENSAvatar.ts
@@ -1,3 +1,4 @@
+import { fetchWithBackoff } from '@cow/common/utils/fetch'
 import { BigNumber } from '@ethersproject/bignumber'
 import { hexZeroPad } from '@ethersproject/bytes'
 import { namehash } from '@ethersproject/hash'
@@ -88,7 +89,7 @@ function useAvatarFromNFT(nftUri = '', enforceOwnership: boolean): { avatar?: st
     setAvatar(undefined)
     if (http) {
       setLoading(true)
-      fetch(http)
+      fetchWithBackoff(http)
         .then((res) => res.json())
         .then(({ image }) => {
           setAvatar(image)

--- a/yarn.lock
+++ b/yarn.lock
@@ -9519,6 +9519,11 @@ expect@^29.0.0:
     jest-message-util "^29.3.1"
     jest-util "^29.3.1"
 
+exponential-backoff@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.1.tgz#64ac7526fe341ab18a39016cd22c787d01e00bf6"
+  integrity sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==
+
 express@^4.14.0, express@^4.17.2, express@^4.17.3:
   version "4.18.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz#3fabe08296e930c796c19e3c516979386ba9fd59"


### PR DESCRIPTION
# Summary

Adds exponential backoff to all relevant requests.

The strategy by default It will wait a maximum of ~102s maximum wait time. Wait time is 100ms * 2**(attempt), and it will do 10 attempts

The new util allows us to define another backoff strategy.

## Test
- Everything should work as before
- We should re-test the cases where before was failing. Hopefully, now, the app will backoff and wait until the problem is solved (re-attempting later)
- This means, that if the backend is returning some errors, it might take a bit more to fetch the information. 
