### PR TITLE
Fixes unconfigured backoff limit parameter

### DIFF
--- a/src/cow-react/common/utils/fetch.test.ts
+++ b/src/cow-react/common/utils/fetch.test.ts
@@ -1,4 +1,4 @@
-import { fetchWithBackoff } from './fetch'
+import { fetchWithRateLimit } from './fetch'
 import fetchMock from 'jest-fetch-mock'
 
 fetchMock.enableMocks()
@@ -29,7 +29,9 @@ function mockAndFailUntilAttempt(attempt: number) {
   })
 }
 
-const fetchUrlWithBackoff = (attepts: number) => fetchWithBackoff(URL, undefined, { numOfAttempts: attepts })
+// We use fetchWithRateLimit instead of fetchWithBackoff, since that is just a default config version of fetchWithBackoff
+const fetchUrlWithBackoff = (attempts: number) =>
+  fetchWithRateLimit({ backoff: { numOfAttempts: attempts } })(URL, undefined)
 
 describe('Fetch with backoff', () => {
   it('No re-attempt if SUCCESS', async () => {


### PR DESCRIPTION
# Summary

It'd seem that we have used fetchWithBackoff incorrectly here, which made it so that our assumption of giving a numberOfAttempts was not being honored. This led to longer than expected execution (default being 10) and gave an obscure error.

I've fixed this via utilising fetchWithRateLimit. fetchWithBackoff is a no param singleton of fetchWithRateLimit, as such this should not make any difference.

