### PR TITLE
🎨 Limit UI iteration (styles & functionality)

### DIFF
--- a/src/cow-react/common/pure/TokenAmount/index.tsx
+++ b/src/cow-react/common/pure/TokenAmount/index.tsx
@@ -12,9 +12,10 @@ export const Wrapper = styled.span<{ highlight: boolean; lowVolumeWarning?: bool
   background: ${({ highlight }) => (highlight ? 'rgba(196,18,255,0.4)' : '')};
   color: ${({ lowVolumeWarning, theme }) =>
     lowVolumeWarning ? darken(theme.darkMode ? 0 : 0.15, theme.alert) : 'inherit'};
+  word-break: word-break;
 `
 
-const SymbolElement = styled.span<{ opacitySymbol?: boolean }>`
+export const SymbolElement = styled.span<{ opacitySymbol?: boolean }>`
   color: ${({ opacitySymbol, theme }) => transparentize(opacitySymbol ? 0.3 : 0, theme.text1)};
 `
 

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -331,8 +331,7 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
         />
       )}
       {chainId && <ImportTokenModal chainId={chainId} onDismiss={onImportDismiss} />}
-
-      <InfoBanner />
+      {isUnlocked && <InfoBanner />}
     </>
   )
 }, limitOrdersPropsChecker)

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -86,12 +86,24 @@ export const LowVolumeWarningTokenWrapper = styled.span<{ lowVolumeWarning: bool
   width: 100%;
   align-items: center;
   justify-content: space-between;
-  color: ${({ lowVolumeWarning, theme }) =>
-    lowVolumeWarning ? darken(theme.darkMode ? 0 : 0.15, theme.alert) : 'inherit'};
+  color: ${({ lowVolumeWarning, theme }) => lowVolumeWarning ? darken(theme.darkMode ? 0 : 0.15, theme.alert) : 'inherit'};
 
-    ${SymbolElement} {
-      color: inherit;
+  ${SymbolElement} {
+    color: inherit;
+  }
+
+  // Triangle warning icon override
+  ${styledEl.WarningIndicator} {
+    padding: 0 0 0 3px;
+
+    svg {
+      --size: 18px;
+      width: var(--size);
+      height: var(--size);
+      min-width: var(--size);
+      min-height: var(--size);
     }
+  }
 
   // Popover container override
   > div > div {

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -28,6 +28,7 @@ import { buildPriceFromCurrencyAmounts } from '@cow/modules/limitOrders/utils/bu
 import { darken } from 'polished'
 import { getQuoteCurrency } from '@cow/common/services/getQuoteCurrency'
 import { getAddress } from '@cow/utils/getAddress'
+import { SymbolElement } from '@cow/common/pure/TokenAmount'
 
 export const orderStatusTitleMap: { [key in OrderStatus]: string } = {
   [OrderStatus.PENDING]: 'Open',
@@ -82,9 +83,15 @@ export function LowVolumeWarningContent() {
 // TODO: temporary component, name and location. If keeping it, move it to its own module, rename, etc, etc
 export const LowVolumeWarningTokenWrapper = styled.span<{ lowVolumeWarning: boolean }>`
   display: flex;
+  width: 100%;
   align-items: center;
+  justify-content: space-between;
   color: ${({ lowVolumeWarning, theme }) =>
     lowVolumeWarning ? darken(theme.darkMode ? 0 : 0.15, theme.alert) : 'inherit'};
+
+    ${SymbolElement} {
+      color: inherit;
+    }
 
   // Popover container override
   > div > div {

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/styled.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/styled.tsx
@@ -179,7 +179,7 @@ export const ExecuteIndicator = styled.div<{ status?: OrderExecutionStatus }>`
   min-width: var(--size);
   min-height: var(--size);
   border-radius: var(--size);
-  display: contents;
+  display: block;
   margin: 0 3px 0 0;
   background: ${({ status, theme }) => {
     switch (status) {

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/styled.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/styled.tsx
@@ -176,8 +176,10 @@ export const ExecuteIndicator = styled.div<{ status?: OrderExecutionStatus }>`
   --size: 6px;
   width: var(--size);
   height: var(--size);
+  min-width: var(--size);
+  min-height: var(--size);
   border-radius: var(--size);
-  display: block;
+  display: contents;
   margin: 0 3px 0 0;
   background: ${({ status, theme }) => {
     switch (status) {

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/styled.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/styled.tsx
@@ -15,7 +15,7 @@ export const WarningIndicator = styled.button<{ hasBackground?: boolean }>`
   color: ${({ theme }) => theme.alert};
   line-height: 0;
   border: 0;
-  padding: 0 5px;
+  padding: 0 0 0 5px;
   width: auto;
   height: var(--height);
   border-radius: 0 9px 9px 0;
@@ -195,6 +195,7 @@ export const ExecuteIndicator = styled.div<{ status?: OrderExecutionStatus }>`
 `
 
 export const ExecuteCellWrapper = styled.div`
+  width: 100%;
   display: flex;
   align-items: center;
   gap: 4px;

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/styled.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/styled.tsx
@@ -15,7 +15,7 @@ export const WarningIndicator = styled.button<{ hasBackground?: boolean }>`
   color: ${({ theme }) => theme.alert};
   line-height: 0;
   border: 0;
-  padding: 0 0 0 5px;
+  padding: 0 5px;
   width: auto;
   height: var(--height);
   border-radius: 0 9px 9px 0;

--- a/src/cow-react/modules/limitOrders/pure/ReceiptModal/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/ReceiptModal/index.tsx
@@ -16,7 +16,6 @@ import { SurplusField } from './SurplusField'
 import { IdField } from './IdField'
 import { StatusField } from './StatusField'
 import { OrderTypeField } from './OrderTypeField'
-
 interface ReceiptProps {
   isOpen: boolean
   order: ParsedOrder
@@ -31,6 +30,8 @@ interface ReceiptProps {
 const tooltips: { [key: string]: string | JSX.Element } = {
   LIMIT_PRICE: 'You will receive this price or better for your tokens.',
   EXECUTION_PRICE: 'An order’s actual execution price will vary based on the market price and network fees.',
+  EXECUTES_AT:
+    'Fees (incl. gas) are covered by filling your order when the market price is better than your limit price.',
   FILLED:
     'CoW Swap doesn’t currently support partial fills. Your order will either be filled completely or not at all.',
   SURPLUS: 'The amount of extra tokens you get on top of your limit price.',
@@ -91,8 +92,16 @@ export function ReceiptModal({
             </styledEl.Field>
 
             <styledEl.Field>
-              <FieldLabel label="Execution price" tooltip={tooltips.EXECUTION_PRICE} />
-              <PriceField order={order} price={executionPrice} />
+              {order.fullyFilled ? (
+                <>
+                  <FieldLabel label="Execution price" tooltip={tooltips.EXECUTION_PRICE} />{' '}
+                  <PriceField order={order} price={executionPrice} />
+                </>
+              ) : (
+                <>
+                  <FieldLabel label="Executes at" tooltip={tooltips.EXECUTES_AT} />
+                </>
+              )}
             </styledEl.Field>
 
             <styledEl.Field>

--- a/src/cow-react/modules/limitOrders/pure/ReceiptModal/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/ReceiptModal/index.tsx
@@ -100,6 +100,8 @@ export function ReceiptModal({
               ) : (
                 <>
                   <FieldLabel label="Executes at" tooltip={tooltips.EXECUTES_AT} />
+                  {/* TODO: Replace below to add 'Executes at' price field */}
+                  <p>-</p>
                 </>
               )}
             </styledEl.Field>


### PR DESCRIPTION
# Summary

- Adds column 'Market price'
- Adds column 'Executes at'
- Adds column 'Filled'
- Small order warning banner + column indicator (+ tooltip)
- Tooltip hover on 'Executes at' price for open orders, indicating how close to executing the order is.
- Dot indicator for 'how close to executing' the order is.
- Explainer banner for Dot indicator functionality + column header tooltip
- Misc. style improvements on the order table layout.
- Adding back a close-able info banner below the limit order widget container.

<img width="1740" alt="Screenshot 2023-03-07 at 18 07 53" src="https://user-images.githubusercontent.com/31534717/223510715-9b812576-97e9-4aca-bacf-358dd23d3b99.png">

