### PR TITLE
Limit UI prototype orders table 6 indicator status 2

### DIFF
--- a/src/cow-react/common/hooks/usePrice.ts
+++ b/src/cow-react/common/hooks/usePrice.ts
@@ -1,21 +1,12 @@
 import { useSafeMemo } from '@cow/common/hooks/useSafeMemo'
 import { Currency, CurrencyAmount, Price } from '@uniswap/sdk-core'
-import { isFractionFalsy } from '@cow/utils/isFractionFalsy'
+import { buildPriceFromCurrencyAmounts } from '@cow/modules/limitOrders/utils/buildPriceFromCurrencyAmounts'
 
 export function usePrice(
   inputCurrencyAmount: CurrencyAmount<Currency> | null,
   outputCurrencyAmount: CurrencyAmount<Currency> | null
 ): Price<Currency, Currency> | null {
   return useSafeMemo(() => {
-    if (
-      !inputCurrencyAmount ||
-      !outputCurrencyAmount ||
-      isFractionFalsy(inputCurrencyAmount) ||
-      isFractionFalsy(outputCurrencyAmount)
-    ) {
-      return null
-    }
-
-    return new Price({ baseAmount: inputCurrencyAmount, quoteAmount: outputCurrencyAmount })
+    return buildPriceFromCurrencyAmounts(inputCurrencyAmount, outputCurrencyAmount)
   }, [inputCurrencyAmount, outputCurrencyAmount])
 }

--- a/src/cow-react/modules/application/containers/App/Updaters.tsx
+++ b/src/cow-react/modules/application/containers/App/Updaters.tsx
@@ -22,6 +22,7 @@ import { GasPriceStrategyUpdater } from 'state/gas/gas-price-strategy-updater'
 import { EthFlowSlippageUpdater, EthFlowDeadlineUpdater } from '@cow/modules/swap/state/EthFlow/updaters'
 import { TokensListUpdater } from '@cow/modules/tokensList/updaters/TokensListUpdater'
 import { AppDataUpdater } from 'state/appData/AppDataInfoUpdater'
+import { SpotPricesUpdater } from 'state/orders/updaters/SpotPricesUpdater'
 
 export function Updaters() {
   return (
@@ -48,6 +49,7 @@ export function Updaters() {
       <GasPriceStrategyUpdater />
       <EthFlowSlippageUpdater />
       <EthFlowDeadlineUpdater />
+      <SpotPricesUpdater />
     </>
   )
 }

--- a/src/cow-react/modules/limitOrders/containers/OrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/OrdersWidget/index.tsx
@@ -12,6 +12,7 @@ import { useValidatePageUrlParams } from './hooks/useValidatePageUrlParams'
 import { useCancelOrder } from '@cow/common/hooks/useCancelOrder'
 import { useAtomValue } from 'jotai/utils'
 import { pendingOrdersPricesAtom } from '@cow/modules/orders/state/pendingOrdersPricesAtom'
+import { spotPricesAtom } from '@cow/modules/orders/state/spotPricesAtom'
 
 function getOrdersListByIndex(ordersList: LimitOrdersList, id: string): ParsedOrder[] {
   return id === OPEN_TAB.id ? ordersList.pending : ordersList.history
@@ -24,6 +25,7 @@ export function OrdersWidget() {
   const { chainId, account } = useWeb3React()
   const getShowCancellationModal = useCancelOrder()
   const pendingOrdersPrices = useAtomValue(pendingOrdersPricesAtom)
+  const spotPrices = useAtomValue(spotPricesAtom)
 
   const spender = useMemo(() => (chainId ? GP_VAULT_RELAYER[chainId] : undefined), [chainId])
 
@@ -73,6 +75,7 @@ export function OrdersWidget() {
         balancesAndAllowances={pendingBalancesAndAllowances}
         isWalletConnected={!!account}
         getShowCancellationModal={getShowCancellationModal}
+        spotPrices={spotPrices}
       ></Orders>
       <OrdersReceiptModal />
     </>

--- a/src/cow-react/modules/limitOrders/hooks/useGetInitialPrice.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useGetInitialPrice.ts
@@ -44,7 +44,7 @@ async function requestPriceForCurrency(chainId: number | undefined, currency: Cu
   }
 }
 
-async function requestPrice(
+export async function requestPrice(
   chainId: number | undefined,
   inputCurrency: Currency | null,
   outputCurrency: Currency | null

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
@@ -23,6 +23,7 @@ import SVG from 'react-inlinesvg'
 import iconOrderExecution from 'assets/cow-swap/orderExecution.svg'
 import { X } from 'react-feather'
 import { OrderExecutionStatusList } from '@cow/modules/limitOrders/pure/ExecutionPriceTooltip'
+import { getSpotPrice, SpotPrices } from '@cow/modules/orders/state/spotPricesAtom'
 
 const TableBox = styled.div`
   display: block;
@@ -215,6 +216,7 @@ export interface OrdersTableProps {
   pendingOrdersPrices: PendingOrdersPrices
   orders: ParsedOrder[]
   balancesAndAllowances: BalancesAndAllowances
+  spotPrices: SpotPrices
   getShowCancellationModal(order: Order): (() => void) | null
 }
 
@@ -224,6 +226,7 @@ export function OrdersTable({
   orders,
   pendingOrdersPrices,
   balancesAndAllowances,
+  spotPrices,
   getShowCancellationModal,
   currentPageNumber,
 }: OrdersTableProps) {
@@ -354,6 +357,14 @@ export function OrdersTable({
                 key={order.id}
                 isOpenOrdersTab={isOpenOrdersTab}
                 order={order}
+                spotPrice={getSpotPrice(
+                  {
+                    chainId: chainId as SupportedChainId,
+                    sellTokenAddress: order.sellToken,
+                    buyTokenAddress: order.buyToken,
+                  },
+                  spotPrices
+                )}
                 prices={pendingOrdersPrices[order.id]}
                 orderParams={getOrderParams(chainId, balancesAndAllowances, order)}
                 RowElement={RowElement}

--- a/src/cow-react/modules/limitOrders/pure/Orders/index.cosmos.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/index.cosmos.tsx
@@ -33,6 +33,7 @@ export default (
     isOpenOrdersTab={true}
     isWalletConnected={true}
     balancesAndAllowances={balancesAndAllowances}
+    spotPrices={{}}
     getShowCancellationModal={(order) => {
       if (order.status === 'pending') {
         return () => alert('cancelling!')

--- a/src/cow-react/modules/limitOrders/pure/Orders/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/index.tsx
@@ -130,6 +130,7 @@ export function Orders({
   getShowCancellationModal,
   currentPageNumber,
   pendingOrdersPrices,
+  spotPrices,
   children,
 }: OrdersProps) {
   const content = () => {
@@ -185,6 +186,7 @@ export function Orders({
         chainId={chainId}
         orders={orders}
         balancesAndAllowances={balancesAndAllowances}
+        spotPrices={spotPrices}
         getShowCancellationModal={getShowCancellationModal}
       />
     )

--- a/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.test.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.test.ts
@@ -1,5 +1,5 @@
 import { CurrencyAmount } from '@uniswap/sdk-core'
-import { DAI_GOERLI, USDC_GOERLI } from '../../../../custom/utils/goerli/constants'
+import { DAI_GOERLI, USDC_GOERLI } from 'utils/goerli/constants'
 import { rawToTokenAmount } from '@cow/utils/rawToTokenAmount'
 import { buildPriceFromCurrencyAmounts } from '@cow/modules/limitOrders/utils/buildPriceFromCurrencyAmounts'
 import { calculateOrderExecutionStatus, CalculateOrderExecutionStatusParams } from './calculateOrderExecutionStatus'

--- a/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.test.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.test.ts
@@ -27,6 +27,7 @@ describe('calculateOrderExecutionStatus', () => {
   })
 
   describe('limit price below market price', () => {
+    // Limit price will never be above estimated execution price
     const baseParams = {
       limitPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_999),
     }
@@ -89,67 +90,6 @@ describe('calculateOrderExecutionStatus', () => {
         ...baseParams,
         spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
         estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1051)),
-      }
-
-      expect(calculateOrderExecutionStatus(params)).toBe('notClose')
-    })
-  })
-  describe('limit price above market price', () => {
-    const baseParams = {
-      limitPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-      marketPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(900)),
-    }
-
-    describe('market price <0.5% from execution price', () => {
-      test('positive difference', () => {
-        const params: CalculateOrderExecutionStatusParams = {
-          ...baseParams,
-          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_999),
-        }
-
-        expect(calculateOrderExecutionStatus(params)).toBe('veryClose')
-      })
-      test('negative difference', () => {
-        const params: CalculateOrderExecutionStatusParams = {
-          ...baseParams,
-          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1001)),
-        }
-
-        expect(calculateOrderExecutionStatus(params)).toBe('veryClose')
-      })
-    })
-    describe('market price 0.5-5% from execution price', () => {
-      test('0.5% - lower bond', () => {
-        const params: CalculateOrderExecutionStatusParams = {
-          ...baseParams,
-          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(995)),
-        }
-
-        expect(calculateOrderExecutionStatus(params)).toBe('close')
-      })
-
-      test('1% - middle range', () => {
-        const params: CalculateOrderExecutionStatusParams = {
-          ...baseParams,
-          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(990)),
-        }
-
-        expect(calculateOrderExecutionStatus(params)).toBe('close')
-      })
-
-      test('5% - upper bond', () => {
-        const params: CalculateOrderExecutionStatusParams = {
-          ...baseParams,
-          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(950)),
-        }
-
-        expect(calculateOrderExecutionStatus(params)).toBe('close')
-      })
-    })
-    test('market price >5% from execution price', () => {
-      const params: CalculateOrderExecutionStatusParams = {
-        ...baseParams,
-        estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(949)),
       }
 
       expect(calculateOrderExecutionStatus(params)).toBe('notClose')

--- a/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.test.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.test.ts
@@ -20,8 +20,8 @@ describe('calculateOrderExecutionStatus', () => {
     expect(
       calculateOrderExecutionStatus({
         limitPrice: null,
-        marketPrice: null,
-        executionPrice: null,
+        spotPrice: null,
+        estimatedExecutionPrice: null,
       })
     ).toBe(undefined)
   })
@@ -35,8 +35,8 @@ describe('calculateOrderExecutionStatus', () => {
       test('positive difference', () => {
         const params: CalculateOrderExecutionStatusParams = {
           ...baseParams,
-          marketPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-          executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1001)),
+          spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
+          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1001)),
         }
 
         expect(calculateOrderExecutionStatus(params)).toBe('veryClose')
@@ -46,8 +46,8 @@ describe('calculateOrderExecutionStatus', () => {
         const params: CalculateOrderExecutionStatusParams = {
           ...baseParams,
           limitPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(990)),
-          marketPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-          executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_999),
+          spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
+          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_999),
         }
 
         expect(calculateOrderExecutionStatus(params)).toBe('veryClose')
@@ -57,8 +57,8 @@ describe('calculateOrderExecutionStatus', () => {
       test('0.5% - lower bond', () => {
         const params: CalculateOrderExecutionStatusParams = {
           ...baseParams,
-          marketPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-          executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1005)),
+          spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
+          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1005)),
         }
 
         expect(calculateOrderExecutionStatus(params)).toBe('close')
@@ -67,8 +67,8 @@ describe('calculateOrderExecutionStatus', () => {
       test('2.5% - middle range', () => {
         const params: CalculateOrderExecutionStatusParams = {
           ...baseParams,
-          marketPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-          executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1025)),
+          spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
+          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1025)),
         }
 
         expect(calculateOrderExecutionStatus(params)).toBe('close')
@@ -77,8 +77,8 @@ describe('calculateOrderExecutionStatus', () => {
       test('5% - upper bond', () => {
         const params: CalculateOrderExecutionStatusParams = {
           ...baseParams,
-          marketPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-          executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1050)),
+          spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
+          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1050)),
         }
 
         expect(calculateOrderExecutionStatus(params)).toBe('close')
@@ -87,8 +87,8 @@ describe('calculateOrderExecutionStatus', () => {
     test('market price >5% from execution price', () => {
       const params: CalculateOrderExecutionStatusParams = {
         ...baseParams,
-        marketPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-        executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1051)),
+        spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
+        estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1051)),
       }
 
       expect(calculateOrderExecutionStatus(params)).toBe('notClose')
@@ -104,7 +104,7 @@ describe('calculateOrderExecutionStatus', () => {
       test('positive difference', () => {
         const params: CalculateOrderExecutionStatusParams = {
           ...baseParams,
-          executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_999),
+          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_999),
         }
 
         expect(calculateOrderExecutionStatus(params)).toBe('veryClose')
@@ -112,7 +112,7 @@ describe('calculateOrderExecutionStatus', () => {
       test('negative difference', () => {
         const params: CalculateOrderExecutionStatusParams = {
           ...baseParams,
-          executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1001)),
+          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1001)),
         }
 
         expect(calculateOrderExecutionStatus(params)).toBe('veryClose')
@@ -122,7 +122,7 @@ describe('calculateOrderExecutionStatus', () => {
       test('0.5% - lower bond', () => {
         const params: CalculateOrderExecutionStatusParams = {
           ...baseParams,
-          executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(995)),
+          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(995)),
         }
 
         expect(calculateOrderExecutionStatus(params)).toBe('close')
@@ -131,7 +131,7 @@ describe('calculateOrderExecutionStatus', () => {
       test('1% - middle range', () => {
         const params: CalculateOrderExecutionStatusParams = {
           ...baseParams,
-          executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(990)),
+          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(990)),
         }
 
         expect(calculateOrderExecutionStatus(params)).toBe('close')
@@ -140,7 +140,7 @@ describe('calculateOrderExecutionStatus', () => {
       test('5% - upper bond', () => {
         const params: CalculateOrderExecutionStatusParams = {
           ...baseParams,
-          executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(950)),
+          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(950)),
         }
 
         expect(calculateOrderExecutionStatus(params)).toBe('close')
@@ -149,7 +149,7 @@ describe('calculateOrderExecutionStatus', () => {
     test('market price >5% from execution price', () => {
       const params: CalculateOrderExecutionStatusParams = {
         ...baseParams,
-        executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(949)),
+        estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(949)),
       }
 
       expect(calculateOrderExecutionStatus(params)).toBe('notClose')

--- a/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.test.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.test.ts
@@ -1,5 +1,5 @@
 import { CurrencyAmount } from '@uniswap/sdk-core'
-import { DAI_GOERLI, USDC_GOERLI } from 'utils/goerli/constants'
+import { DAI_GOERLI, USDC_GOERLI } from '../../../../custom/utils/goerli/constants'
 import { rawToTokenAmount } from '@cow/utils/rawToTokenAmount'
 import { buildPriceFromCurrencyAmounts } from '@cow/modules/limitOrders/utils/buildPriceFromCurrencyAmounts'
 import { calculateOrderExecutionStatus, CalculateOrderExecutionStatusParams } from './calculateOrderExecutionStatus'
@@ -31,39 +31,58 @@ describe('calculateOrderExecutionStatus', () => {
       limitPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_999),
     }
 
-    test('market price <0.5% from execution price', () => {
-      const params: CalculateOrderExecutionStatusParams = {
-        ...baseParams,
-        marketPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-        executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1001)),
-      }
+    describe('market price <0.5% from execution price', () => {
+      test('positive difference', () => {
+        const params: CalculateOrderExecutionStatusParams = {
+          ...baseParams,
+          marketPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
+          executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1001)),
+        }
 
-      expect(calculateOrderExecutionStatus(params)).toBe('veryClose')
+        expect(calculateOrderExecutionStatus(params)).toBe('veryClose')
+      })
+
+      test('negative difference', () => {
+        const params: CalculateOrderExecutionStatusParams = {
+          ...baseParams,
+          limitPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(990)),
+          marketPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
+          executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_999),
+        }
+
+        expect(calculateOrderExecutionStatus(params)).toBe('veryClose')
+      })
     })
-    test('market price 0.5-5% from execution price', () => {
-      const lowerBound: CalculateOrderExecutionStatusParams = {
-        ...baseParams,
-        marketPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-        executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1005)),
-      }
+    describe('market price 0.5-5% from execution price', () => {
+      test('0.5% - lower bond', () => {
+        const params: CalculateOrderExecutionStatusParams = {
+          ...baseParams,
+          marketPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
+          executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1005)),
+        }
 
-      expect(calculateOrderExecutionStatus(lowerBound)).toBe('close')
+        expect(calculateOrderExecutionStatus(params)).toBe('close')
+      })
 
-      const middleRange: CalculateOrderExecutionStatusParams = {
-        ...baseParams,
-        marketPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-        executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1025)),
-      }
+      test('2.5% - middle range', () => {
+        const params: CalculateOrderExecutionStatusParams = {
+          ...baseParams,
+          marketPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
+          executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1025)),
+        }
 
-      expect(calculateOrderExecutionStatus(middleRange)).toBe('close')
+        expect(calculateOrderExecutionStatus(params)).toBe('close')
+      })
 
-      const upperBound: CalculateOrderExecutionStatusParams = {
-        ...baseParams,
-        marketPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-        executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1050)),
-      }
+      test('5% - upper bond', () => {
+        const params: CalculateOrderExecutionStatusParams = {
+          ...baseParams,
+          marketPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
+          executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1050)),
+        }
 
-      expect(calculateOrderExecutionStatus(upperBound)).toBe('close')
+        expect(calculateOrderExecutionStatus(params)).toBe('close')
+      })
     })
     test('market price >5% from execution price', () => {
       const params: CalculateOrderExecutionStatusParams = {
@@ -81,35 +100,51 @@ describe('calculateOrderExecutionStatus', () => {
       marketPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(900)),
     }
 
-    test('market price <0.5% from execution price', () => {
-      const params: CalculateOrderExecutionStatusParams = {
-        ...baseParams,
-        executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_999),
-      }
+    describe('market price <0.5% from execution price', () => {
+      test('positive difference', () => {
+        const params: CalculateOrderExecutionStatusParams = {
+          ...baseParams,
+          executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_999),
+        }
 
-      expect(calculateOrderExecutionStatus(params)).toBe('veryClose')
+        expect(calculateOrderExecutionStatus(params)).toBe('veryClose')
+      })
+      test('negative difference', () => {
+        const params: CalculateOrderExecutionStatusParams = {
+          ...baseParams,
+          executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1001)),
+        }
+
+        expect(calculateOrderExecutionStatus(params)).toBe('veryClose')
+      })
     })
-    test('market price 0.5-5% from execution price', () => {
-      const lowerBound: CalculateOrderExecutionStatusParams = {
-        ...baseParams,
-        executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(995)),
-      }
+    describe('market price 0.5-5% from execution price', () => {
+      test('0.5% - lower bond', () => {
+        const params: CalculateOrderExecutionStatusParams = {
+          ...baseParams,
+          executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(995)),
+        }
 
-      expect(calculateOrderExecutionStatus(lowerBound)).toBe('close')
+        expect(calculateOrderExecutionStatus(params)).toBe('close')
+      })
 
-      const middleRange: CalculateOrderExecutionStatusParams = {
-        ...baseParams,
-        executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(990)),
-      }
+      test('1% - middle range', () => {
+        const params: CalculateOrderExecutionStatusParams = {
+          ...baseParams,
+          executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(990)),
+        }
 
-      expect(calculateOrderExecutionStatus(middleRange)).toBe('close')
+        expect(calculateOrderExecutionStatus(params)).toBe('close')
+      })
 
-      const upperBound: CalculateOrderExecutionStatusParams = {
-        ...baseParams,
-        executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(950)),
-      }
+      test('5% - upper bond', () => {
+        const params: CalculateOrderExecutionStatusParams = {
+          ...baseParams,
+          executionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(950)),
+        }
 
-      expect(calculateOrderExecutionStatus(upperBound)).toBe('close')
+        expect(calculateOrderExecutionStatus(params)).toBe('close')
+      })
     })
     test('market price >5% from execution price', () => {
       const params: CalculateOrderExecutionStatusParams = {

--- a/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.ts
@@ -4,48 +4,34 @@ import { Nullish } from '@cow/types'
 const HALF_PERCENT = new Percent(5, 1000)
 const FIVE_PERCENT = new Percent(5, 100)
 const ONE = new Fraction(1)
-const MINUS_ONE = new Fraction(-1)
 
 export type OrderExecutionStatus = 'notClose' | 'close' | 'veryClose'
 
 export type CalculateOrderExecutionStatusParams = {
   limitPrice: Nullish<Price<Currency, Currency>>
-  marketPrice: Nullish<Price<Currency, Currency>>
-  executionPrice: Nullish<Price<Currency, Currency>>
+  spotPrice: Nullish<Price<Currency, Currency>>
+  estimatedExecutionPrice: Nullish<Price<Currency, Currency>>
 }
 
 export function calculateOrderExecutionStatus({
   limitPrice,
-  marketPrice,
-  executionPrice,
+  spotPrice,
+  estimatedExecutionPrice,
 }: CalculateOrderExecutionStatusParams): OrderExecutionStatus | undefined {
-  if (!limitPrice || !marketPrice || !executionPrice) {
+  if (!limitPrice || !spotPrice || !estimatedExecutionPrice) {
     return undefined
   }
 
-  const [referencePrice, multiplier] = limitPrice.greaterThan(marketPrice)
-    ? // When limit price is > market price:
-      // Use it for comparing with execution price
-      // It'll be likely bigger than execution price, so we invert it
-      // by multiplying by -1
-      // Thus, everything < 0 is very close
-      [limitPrice, MINUS_ONE]
-    : // When market price is >= limit price
-      // Use it for comparing with execution price
-      // It'll likely be smaller than execution price, so we keep it as is
-      // by multiplying by 1
-      // Thus, everything < 0 is very close
-      [marketPrice, ONE]
-
-  const percentageDifference = executionPrice.divide(referencePrice).subtract(ONE).multiply(multiplier)
+  const percentageDifference = estimatedExecutionPrice.divide(spotPrice).subtract(ONE)
 
   // TODO: remove debug logs
   console.debug(`calculateOrderExecutionStatus`, {
-    pair: `${marketPrice.baseCurrency.symbol}/${marketPrice.quoteCurrency.symbol}`,
-    limitPrice: limitPrice.toFixed(7),
-    marketPrice: marketPrice.toFixed(7),
-    referencePrice: referencePrice.toFixed(7),
-    executionPrice: executionPrice.toFixed(7),
+    pair: `${spotPrice.quoteCurrency.symbol}/${spotPrice.baseCurrency.symbol}`,
+    limitPrice: `${limitPrice.toFixed(7)} ${limitPrice.baseCurrency.symbol} per ${limitPrice.quoteCurrency.symbol}`,
+    marketPrice: `${spotPrice.toFixed(7)} ${spotPrice.baseCurrency.symbol} per ${spotPrice.quoteCurrency.symbol}`,
+    executionPrice: `${estimatedExecutionPrice.toFixed(7)} ${estimatedExecutionPrice.baseCurrency.symbol} per ${
+      estimatedExecutionPrice.quoteCurrency.symbol
+    }`,
     percentageDifference: percentageDifference.multiply(new Fraction(100)).toFixed(2) + '%',
   })
 

--- a/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.ts
@@ -39,7 +39,16 @@ export function calculateOrderExecutionStatus({
 
   const percentageDifference = executionPrice.divide(referencePrice).subtract(ONE).multiply(multiplier)
 
-  if (absolutePercentageDifference.lessThan(HALF_PERCENT)) {
+  // TODO: remove debug logs
+  console.debug(`calculateOrderExecutionStatus`, {
+    pair: `${marketPrice.baseCurrency.symbol}/${marketPrice.quoteCurrency.symbol}`,
+    limitPrice: limitPrice.toFixed(7),
+    marketPrice: marketPrice.toFixed(7),
+    referencePrice: referencePrice.toFixed(7),
+    executionPrice: executionPrice.toFixed(7),
+    percentageDifference: percentageDifference.multiply(new Fraction(100)).toFixed(2) + '%',
+  })
+
   if (percentageDifference.lessThan(HALF_PERCENT)) {
     return 'veryClose'
   } else if (percentageDifference.greaterThan(FIVE_PERCENT)) {

--- a/src/cow-react/modules/orders/state/pendingOrdersPricesAtom.ts
+++ b/src/cow-react/modules/orders/state/pendingOrdersPricesAtom.ts
@@ -3,7 +3,7 @@ import { Currency, Price } from '@uniswap/sdk-core'
 
 export interface PendingOrderPrices {
   marketPrice: Price<Currency, Currency>
-  executionPrice: Price<Currency, Currency>
+  estimatedExecutionPrice: Price<Currency, Currency>
   lastUpdateTimestamp: number
 }
 

--- a/src/cow-react/modules/orders/state/spotPricesAtom.ts
+++ b/src/cow-react/modules/orders/state/spotPricesAtom.ts
@@ -1,0 +1,62 @@
+import { atom } from 'jotai'
+import { Currency, Price } from '@uniswap/sdk-core'
+
+import { SupportedChainId } from 'constants/chains'
+
+export type SpotPrices = Record<string, Price<Currency, Currency>>
+
+export type SpotPricesKeyParams = {
+  chainId: SupportedChainId
+  sellTokenAddress: string
+  buyTokenAddress: string
+}
+
+export type UpdateSpotPriceAtom = SpotPricesKeyParams & {
+  price: Price<Currency, Currency>
+}
+export const spotPricesAtom = atom<SpotPrices>({})
+
+export const updateSpotPricesAtom = atom(null, (get, set, params: UpdateSpotPriceAtom) => {
+  set(spotPricesAtom, () => {
+    const { price, ...rest } = params
+
+    const key = buildSpotPricesKey(rest)
+    const prevState = get(spotPricesAtom)
+
+    if (prevState[key]?.equalTo(price)) {
+      // Avoid unnecessary updates if price hasn't changed
+      return prevState
+    }
+
+    return { ...prevState, [key]: price }
+  })
+})
+
+/**
+ * Build Spot Prices Key
+ *
+ * Helper function to build the key used to store spot prices
+ * With this we can make the search faster and keep the structure flat
+ *
+ * @param params {chainId, sellTokenAddress, buyTokenAddress}
+ */
+export function buildSpotPricesKey(params: SpotPricesKeyParams): string {
+  return Object.values(params)
+    .map((v) => String(v).toLowerCase())
+    .join('|')
+}
+
+/**
+ * Get Spot Price
+ *
+ * Helper function to get the spot price from the spot prices map
+ * Syntactic sugar to build the key and search the map
+ *
+ * @param params {chainId, sellTokenAddress, buyTokenAddress}
+ * @param spotPrices Spot prices map
+ */
+export function getSpotPrice(params: SpotPricesKeyParams, spotPrices: SpotPrices): Price<Currency, Currency> | null {
+  const key = buildSpotPricesKey(params)
+
+  return spotPrices[key] || null
+}

--- a/src/custom/state/orders/consts.ts
+++ b/src/custom/state/orders/consts.ts
@@ -11,6 +11,7 @@ export const MARKET_OPERATOR_API_POLL_INTERVAL = ms`2s`
 // We can have lots of limit orders and it creates a high load, so we poll them no so ofter as market orders
 export const LIMIT_OPERATOR_API_POLL_INTERVAL = ms`15s`
 export const PENDING_ORDERS_PRICE_CHECK_POLL_INTERVAL = ms`15s`
+export const SPOT_PRICE_CHECK_POLL_INTERVAL = ms`15s`
 export const EXPIRED_ORDERS_CHECK_POLL_INTERVAL = ms`15s`
 
 export const OUT_OF_MARKET_PRICE_DELTA_PERCENTAGE = new Percent(1, 100) // 1/100 => 0.01 => 1%

--- a/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
@@ -306,7 +306,7 @@ export function PendingOrdersUpdater(): null {
       return
     }
 
-    const marketIinterval = setInterval(
+    const marketInterval = setInterval(
       () => updateOrders(chainId, account, OrderClass.MARKET),
       MARKET_OPERATOR_API_POLL_INTERVAL
     )
@@ -316,7 +316,7 @@ export function PendingOrdersUpdater(): null {
     )
 
     return () => {
-      clearInterval(marketIinterval)
+      clearInterval(marketInterval)
       clearInterval(limitInterval)
     }
   }, [account, chainId, updateOrders])

--- a/src/custom/state/orders/updaters/SpotPricesUpdater.ts
+++ b/src/custom/state/orders/updaters/SpotPricesUpdater.ts
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { useWeb3React } from '@web3-react/core'
+import { CurrencyAmount, Price, Token } from '@uniswap/sdk-core'
+
+import useIsWindowVisible from 'hooks/useIsWindowVisible'
+import { supportedChainId } from 'utils/supportedChainId'
+import { usePendingOrders } from 'state/orders/hooks'
+import { OrderClass } from 'state/orders/actions'
+import { buildSpotPricesKey, updateSpotPricesAtom } from '@cow/modules/orders/state/spotPricesAtom'
+import { useUpdateAtom } from 'state/application/atoms'
+import { SPOT_PRICE_CHECK_POLL_INTERVAL } from 'state/orders/consts'
+import { requestPrice } from '@cow/modules/limitOrders/hooks/useGetInitialPrice'
+import { useSafeMemo } from '@cow/common/hooks/useSafeMemo'
+
+/**
+ * Spot Prices Updater
+ *
+ * Goes over all pending LIMIT orders and aggregates all markets
+ * Queries the spot price for given markets at every SPOT_PRICE_CHECK_POLL_INTERVAL
+ */
+export function SpotPricesUpdater(): null {
+  const { chainId: _chainId } = useWeb3React()
+  const chainId = supportedChainId(_chainId)
+
+  const isWindowVisible = useIsWindowVisible()
+  const updateSpotPrices = useUpdateAtom(updateSpotPricesAtom)
+
+  const pending = usePendingOrders({ chainId })
+
+  const markets = useSafeMemo(() => {
+    return pending.reduce<Record<string, { chainId: number; inputCurrency: Token; outputCurrency: Token }>>(
+      (acc, order) => {
+        if (chainId && order.class === OrderClass.LIMIT) {
+          // Aggregating pending orders per market. No need to query multiple times same market
+          const key = buildSpotPricesKey({
+            chainId,
+            sellTokenAddress: order.sellToken,
+            buyTokenAddress: order.buyToken,
+          })
+          acc[key] = { chainId, inputCurrency: order.inputToken, outputCurrency: order.outputToken }
+        }
+        return acc
+      },
+      {}
+    )
+  }, [pending])
+
+  const isUpdating = useRef(false) // TODO: Implement using SWR or retry/cancellable promises
+
+  const updatePending = useCallback(async () => {
+    if (isUpdating.current) {
+      console.debug('[SpotPricesUpdater] Update in progress, skipping')
+      return
+    }
+    console.debug('[SpotPricesUpdater] Starting update')
+
+    // Lock updates
+    isUpdating.current = true
+
+    const promises = Object.keys(markets).map((key) => {
+      const { chainId, inputCurrency, outputCurrency } = markets[key]
+
+      return requestPrice(chainId, inputCurrency, outputCurrency)
+        .then((fraction) => {
+          if (!fraction) {
+            return
+          }
+
+          const price = new Price({
+            quoteAmount: CurrencyAmount.fromRawAmount(outputCurrency, fraction.numerator),
+            baseAmount: CurrencyAmount.fromRawAmount(inputCurrency, fraction.denominator),
+          })
+
+          console.debug(`[SpotPricesUpdater] Got new price for ${key}`, price.toFixed(6))
+
+          updateSpotPrices({
+            chainId,
+            sellTokenAddress: inputCurrency.address,
+            buyTokenAddress: outputCurrency.address,
+            price,
+          })
+        })
+        .catch((e) => {
+          console.debug(`[SpotPricesUpdater] Failed to get price for ${key}`, e)
+        })
+    })
+
+    // Wait everything to finish, regardless if failed or not
+    await Promise.allSettled(promises)
+
+    // Release update lock
+    isUpdating.current = false
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [Object.keys(markets).sort().join(','), updateSpotPrices])
+
+  useEffect(() => {
+    if (!chainId || !isWindowVisible) {
+      console.debug('[SpotPricesUpdater] No need to update spot prices')
+      return
+    }
+
+    console.debug('[SpotPricesUpdater] Periodically check spot prices')
+
+    updatePending()
+    const interval = setInterval(updatePending, SPOT_PRICE_CHECK_POLL_INTERVAL)
+
+    return () => clearInterval(interval)
+  }, [chainId, isWindowVisible, updatePending])
+
+  return null
+}

--- a/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -8,7 +8,12 @@ import { Order, OrderClass } from 'state/orders/actions'
 import { SupportedChainId as ChainId } from 'constants/chains'
 
 import { getBestQuote } from 'utils/price'
-import { getOrderExecutionPrice, getOrderMarketPrice, isOrderUnfillable } from 'state/orders/utils'
+import {
+  getEstimatedExecutionPrice,
+  getOrderExecutionPrice,
+  getOrderMarketPrice,
+  isOrderUnfillable,
+} from 'state/orders/utils'
 import useGetGpPriceStrategy from 'hooks/useGetGpPriceStrategy'
 import { getPromiseFulfilledValue } from 'utils/misc'
 import { FeeInformation, PriceInformation } from '@cowprotocol/cow-sdk'
@@ -100,7 +105,7 @@ export function UnfillableOrdersUpdater(): null {
       order: Order,
       fee: FeeInformation | null,
       marketPrice: Price<Currency, Currency>,
-      executionPrice: Price<Currency, Currency>
+      estimatedExecutionPrice: Price<Currency, Currency>
     ) => {
       if (!fee?.amount) return
 
@@ -109,7 +114,7 @@ export function UnfillableOrdersUpdater(): null {
         data: {
           lastUpdateTimestamp: Date.now(),
           marketPrice,
-          executionPrice,
+          estimatedExecutionPrice,
         },
       })
     },
@@ -134,6 +139,7 @@ export function UnfillableOrdersUpdater(): null {
 
       const executionPrice = getOrderExecutionPrice(order, price.amount, fee.amount)
       const marketPrice = getOrderMarketPrice(order, price.amount, fee.amount)
+      const estimatedExecutionPrice = getEstimatedExecutionPrice(order, marketPrice, fee.amount)
       const isUnfillable = isOrderUnfillable(order, orderPrice, executionPrice)
 
       // Only trigger state update if flag changed
@@ -147,7 +153,7 @@ export function UnfillableOrdersUpdater(): null {
         }
       }
 
-      updateOrderMarketPriceCallback(order, fee, marketPrice, executionPrice)
+      updateOrderMarketPriceCallback(order, fee, marketPrice, estimatedExecutionPrice)
     },
     [setIsOrderUnfillable, updateOrderMarketPriceCallback]
   )


### PR DESCRIPTION
# Summary

## Update 2023-03-09

Whole lot of changes

- Using spot price (non volume dependent) on table and for % difference calculations
- Added updater for fetching the spot prices, querying every 15s
- Doing a fancy calculation to get to the estimated execution price. See [here](https://www.notion.so/cownation/Execution-Price-Market-Price-90524299d1874a59bb34c658293a0316?pvs=4)
- Simplified how the % difference is calculated. Now it's based only on the estimated execution price and the spot price

Testing steps should be the same.

⚠️ Partial fills not supported!
⚠️ Still have not implemented tooltips/highlighting logic. Will be part of follow up PRs

## Original 

Continuing addressing indicator status

![Screenshot 2023-03-06 at 11 40 30](https://user-images.githubusercontent.com/43217/223101316-183c12f1-2638-4c40-8b5b-a31938c037d6.png)

![Screenshot 2023-03-06 at 11 43 24](https://user-images.githubusercontent.com/43217/223101328-fa3d3614-1051-474c-a4a1-73ad48b3b122.png)

Changes from previous:
- No longer using absolute percentage values
- When limit <= market price - use percentage as is
- When limit > market price - multiply percentage by `-1`

The formula is:

```
  if limit price > market price
    difference = ((execution price / limit price) - 1) * -1
  if limit price <= market price
    difference = (execution price / market price) - 1
```

Then we compare with the given thresholds:
- < 0.5% difference (negative percentages included): green
- 0.5 - 5% difference (boundaries included): blue
- '> 5% difference: grey

  # To Test

1. Unit tests

1. Place orders above/below market
2. Observe indicator dot color and console logs