### PR TITLE
Don't update limit order amounts when price was entered by user

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/RateInput/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/RateInput/index.tsx
@@ -66,7 +66,7 @@ export function RateInput() {
   const handleSetMarketPrice = useCallback(() => {
     updateRate({
       activeRate: isFractionFalsy(marketRate) ? initialRate : marketRate,
-      isTypedValue: false,
+      isTypedValue: true,
       isRateFromUrl: false,
     })
   }, [marketRate, initialRate, updateRate])

--- a/src/cow-react/modules/limitOrders/hooks/useUpdateActiveRate.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useUpdateActiveRate.ts
@@ -19,7 +19,7 @@ export function useUpdateActiveRate(): UpdateRateCallback {
   const updateCurrencyAmount = useUpdateCurrencyAmount()
   const updateRateState = useUpdateAtom(updateLimitRateAtom)
 
-  const { isRateFromUrl: currentIsRateFromUrl } = rateState
+  const { isRateFromUrl: currentIsRateFromUrl, isTypedValue } = rateState
 
   return useCallback(
     (update: RateUpdateParams) => {
@@ -30,6 +30,10 @@ export function useUpdateActiveRate(): UpdateRateCallback {
       if (activeRate) {
         // Don't update amounts when rate is set from URL. See useSetupLimitOrderAmountsFromUrl()
         if (currentIsRateFromUrl || isRateFromUrl) {
+          return
+        }
+        // Don't update amounts when the limit price was entered by user
+        if (isTypedValue && !update.isTypedValue) {
           return
         }
 
@@ -57,6 +61,7 @@ export function useUpdateActiveRate(): UpdateRateCallback {
       updateRateState,
       updateLimitOrdersState,
       currentIsRateFromUrl,
+      isTypedValue,
     ]
   )
 }

--- a/src/cow-react/modules/limitOrders/updaters/InitialPriceUpdater/index.tsx
+++ b/src/cow-react/modules/limitOrders/updaters/InitialPriceUpdater/index.tsx
@@ -1,6 +1,6 @@
 import { useLayoutEffect, useState } from 'react'
-import { useUpdateAtom } from 'jotai/utils'
-import { LimitRateState, updateLimitRateAtom } from '@cow/modules/limitOrders/state/limitRateAtom'
+import { useAtomValue, useUpdateAtom } from 'jotai/utils'
+import { limitRateAtom, LimitRateState, updateLimitRateAtom } from '@cow/modules/limitOrders/state/limitRateAtom'
 import { useGetInitialPrice } from '@cow/modules/limitOrders/hooks/useGetInitialPrice'
 import { useLimitOrdersTradeState } from '../../hooks/useLimitOrdersTradeState'
 import usePrevious from 'hooks/usePrevious'
@@ -11,6 +11,7 @@ import { Writeable } from '@cow/types'
 export function InitialPriceUpdater() {
   const { inputCurrency, outputCurrency } = useLimitOrdersTradeState()
   const updateLimitRateState = useUpdateAtom(updateLimitRateAtom)
+  const { isTypedValue } = useAtomValue(limitRateAtom)
   const updateRate = useUpdateActiveRate()
 
   const [isInitialPriceSet, setIsInitialPriceSet] = useState(false)
@@ -24,12 +25,12 @@ export function InitialPriceUpdater() {
       isLoading: isInitialPriceSet ? false : isLoading,
     }
 
-    if (!isInitialPriceSet) {
+    if (!isTypedValue && !isInitialPriceSet) {
       update.isTypedValue = false
     }
 
     updateLimitRateState(update)
-  }, [isInitialPriceSet, price, isLoading, updateLimitRateState])
+  }, [isTypedValue, isInitialPriceSet, price, isLoading, updateLimitRateState])
 
   // Set initial price once
   useLayoutEffect(() => {


### PR DESCRIPTION
# Summary

Fixes #2040

The cause of the bug:
1. `InitialPriceUpdater` wrongly updated `activeRate` ([src](https://github.com/cowprotocol/cowswap/pull/2116/files#diff-5e4e0924caedfe8c669950e7c993b0e251527de25c387e98809e5aac8daccce2R40))
2. `useUpdateActiveRate` wrongly allowed updating of amounts event when the price was entered by user ([src](https://github.com/cowprotocol/cowswap/pull/2116/files#diff-2afd91a3dc661a99b1d19b819437d8a4dbf31b9d0ab25a1cf97b3d6c1829f602R36))

# Testing
1. Please, pay attention on hte `set max` functionality
