### PR TITLE
Fix focusing of search input in walletconnect modal

### DIFF
--- a/src/cow-react/common/pure/Modal/ModalMod.tsx
+++ b/src/cow-react/common/pure/Modal/ModalMod.tsx
@@ -123,7 +123,7 @@ export default function Modal({
               style={props}
               onDismiss={onDismiss}
               initialFocusRef={initialFocusRef}
-              unstable_lockFocusAcrossFrames={false}
+              dangerouslyBypassFocusLock={true}
             >
               <StyledDialogContent
                 {...(isMobile


### PR DESCRIPTION
# Summary

https://github.com/reach/reach-ui/issues/536

After `reach-ui/modal` update we got a bug from it.
The new version of the modal disables all `focus` events inside the modal.
`dangerouslyBypassFocusLock` property allows disabling of that behavior.

<img width="564" alt="image" src="https://user-images.githubusercontent.com/7122625/223674269-2018026c-2e5d-4e50-aec2-e897f078b4a4.png">

  # To Test

1. Open wallet-connect modal
2. Use the search input
