### PR TITLE
Fix detection of Gnosis transactions

### DIFF
--- a/src/cow-react/modules/wallet/web3-react/hooks/useWalletMetadata.ts
+++ b/src/cow-react/modules/wallet/web3-react/hooks/useWalletMetadata.ts
@@ -6,7 +6,7 @@ import { useMemo } from 'react'
 const WC_DESKTOP_GNOSIS_SAFE_APP_NAME = 'WalletConnect Safe App'
 const WC_MOBILE_GNOSIS_SAFE_APP_NAME = 'Safe'
 const GNOSIS_SAFE_APP_NAME = 'Gnosis Safe App'
-const GNOSIS_NAMES = [GNOSIS_SAFE_APP_NAME, WC_DESKTOP_GNOSIS_SAFE_APP_NAME, WC_MOBILE_GNOSIS_SAFE_APP_NAME]
+const GNOSIS_APP_NAMES = [GNOSIS_SAFE_APP_NAME, WC_DESKTOP_GNOSIS_SAFE_APP_NAME, WC_MOBILE_GNOSIS_SAFE_APP_NAME]
 
 const SAFE_ICON_URL = 'https://app.safe.global/favicon.ico'
 
@@ -74,9 +74,16 @@ export function useWalletMetaData(): WalletMetaData {
 export function useIsGnosisSafeApp(): boolean {
   const { walletName } = useWalletMetaData()
 
+  return walletName === GNOSIS_SAFE_APP_NAME
+}
+
+// Safe App, WC desktop, WC mobile
+export function useIsGnosisApp(): boolean {
+  const { walletName } = useWalletMetaData()
+
   if (!walletName) return false
 
-  return GNOSIS_NAMES.includes(walletName)
+  return GNOSIS_APP_NAMES.includes(walletName)
 }
 
 export function useIsGnosisSafeWallet(): boolean {

--- a/src/cow-react/modules/wallet/web3-react/hooks/useWalletMetadata.ts
+++ b/src/cow-react/modules/wallet/web3-react/hooks/useWalletMetadata.ts
@@ -3,8 +3,11 @@ import { getWeb3ReactConnection } from '@cow/modules/wallet/web3-react/connectio
 import { ConnectionType } from '@cow/modules/wallet'
 import { useMemo } from 'react'
 
-const WC_GNOSIS_SAFE_APP_NAME = 'WalletConnect Safe App'
+const WC_DESKTOP_GNOSIS_SAFE_APP_NAME = 'WalletConnect Safe App'
+const WC_MOBILE_GNOSIS_SAFE_APP_NAME = 'Safe'
 const GNOSIS_SAFE_APP_NAME = 'Gnosis Safe App'
+const GNOSIS_NAMES = [GNOSIS_SAFE_APP_NAME, WC_DESKTOP_GNOSIS_SAFE_APP_NAME, WC_MOBILE_GNOSIS_SAFE_APP_NAME]
+
 const SAFE_ICON_URL = 'https://app.safe.global/favicon.ico'
 
 const METADATA_DISCONNECTED: WalletMetaData = {
@@ -73,7 +76,7 @@ export function useIsGnosisSafeApp(): boolean {
 
   if (!walletName) return false
 
-  return [GNOSIS_SAFE_APP_NAME, WC_GNOSIS_SAFE_APP_NAME].includes(walletName)
+  return GNOSIS_NAMES.includes(walletName)
 }
 
 export function useIsGnosisSafeWallet(): boolean {

--- a/src/cow-react/modules/wallet/web3-react/hooks/useWalletMetadata.ts
+++ b/src/cow-react/modules/wallet/web3-react/hooks/useWalletMetadata.ts
@@ -3,6 +3,7 @@ import { getWeb3ReactConnection } from '@cow/modules/wallet/web3-react/connectio
 import { ConnectionType } from '@cow/modules/wallet'
 import { useMemo } from 'react'
 
+const WC_GNOSIS_SAFE_APP_NAME = 'WalletConnect Safe App'
 const GNOSIS_SAFE_APP_NAME = 'Gnosis Safe App'
 const SAFE_ICON_URL = 'https://app.safe.global/favicon.ico'
 
@@ -70,7 +71,9 @@ export function useWalletMetaData(): WalletMetaData {
 export function useIsGnosisSafeApp(): boolean {
   const { walletName } = useWalletMetaData()
 
-  return walletName === GNOSIS_SAFE_APP_NAME
+  if (!walletName) return false
+
+  return [GNOSIS_SAFE_APP_NAME, WC_GNOSIS_SAFE_APP_NAME].includes(walletName)
 }
 
 export function useIsGnosisSafeWallet(): boolean {

--- a/src/custom/state/enhancedTransactions/hooks/index.ts
+++ b/src/custom/state/enhancedTransactions/hooks/index.ts
@@ -4,7 +4,7 @@ import { useAppDispatch } from 'state/hooks'
 import { addTransaction, AddTransactionParams } from '../actions'
 import { EnhancedTransactionDetails, HashType } from '../reducer'
 import { useAllTransactions } from 'state/enhancedTransactions/hooks'
-import { useWalletDetails, useWalletInfo } from '@cow/modules/wallet'
+import { useIsGnosisSafeApp, useWalletInfo } from '@cow/modules/wallet'
 
 export * from './TransactionHooksMod'
 
@@ -16,16 +16,14 @@ export type TransactionAdder = (params: AddTransactionHookParams) => void
  */
 export function useTransactionAdder(): TransactionAdder {
   const { chainId, account } = useWalletInfo()
-  const { gnosisSafeInfo } = useWalletDetails()
   const dispatch = useAppDispatch()
-
-  const isGnosisSafeWallet = !!gnosisSafeInfo
+  const isGnosisSafeApp = useIsGnosisSafeApp()
 
   return useCallback(
     (addTransactionParams: AddTransactionHookParams) => {
       if (!account || !chainId) return
 
-      const hashType = isGnosisSafeWallet ? HashType.GNOSIS_SAFE_TX : HashType.ETHEREUM_TX
+      const hashType = isGnosisSafeApp ? HashType.GNOSIS_SAFE_TX : HashType.ETHEREUM_TX
       if (!addTransactionParams.hash) {
         throw Error('No transaction hash found')
       }
@@ -38,7 +36,7 @@ export function useTransactionAdder(): TransactionAdder {
         })
       )
     },
-    [dispatch, chainId, account, isGnosisSafeWallet]
+    [dispatch, chainId, account, isGnosisSafeApp]
   )
 }
 

--- a/src/custom/state/enhancedTransactions/hooks/index.ts
+++ b/src/custom/state/enhancedTransactions/hooks/index.ts
@@ -4,7 +4,7 @@ import { useAppDispatch } from 'state/hooks'
 import { addTransaction, AddTransactionParams } from '../actions'
 import { EnhancedTransactionDetails, HashType } from '../reducer'
 import { useAllTransactions } from 'state/enhancedTransactions/hooks'
-import { useIsGnosisSafeApp, useWalletInfo } from '@cow/modules/wallet'
+import { useIsGnosisApp, useWalletInfo } from '@cow/modules/wallet'
 
 export * from './TransactionHooksMod'
 
@@ -17,13 +17,13 @@ export type TransactionAdder = (params: AddTransactionHookParams) => void
 export function useTransactionAdder(): TransactionAdder {
   const { chainId, account } = useWalletInfo()
   const dispatch = useAppDispatch()
-  const isGnosisSafeApp = useIsGnosisSafeApp()
+  const isGnosisApp = useIsGnosisApp()
 
   return useCallback(
     (addTransactionParams: AddTransactionHookParams) => {
       if (!account || !chainId) return
 
-      const hashType = isGnosisSafeApp ? HashType.GNOSIS_SAFE_TX : HashType.ETHEREUM_TX
+      const hashType = isGnosisApp ? HashType.GNOSIS_SAFE_TX : HashType.ETHEREUM_TX
       if (!addTransactionParams.hash) {
         throw Error('No transaction hash found')
       }
@@ -36,7 +36,7 @@ export function useTransactionAdder(): TransactionAdder {
         })
       )
     },
-    [dispatch, chainId, account, isGnosisSafeApp]
+    [dispatch, chainId, account, isGnosisApp]
   )
 }
 


### PR DESCRIPTION
# Summary

Fixes #1638 #1847

`useTransactionAdder` didn't detect Gnosis when it's connected via WalletConnect and set the wrong type to transactions.
Because of it we got the wrong behaviour of pending txs monitoring
