### PR TITLE
Limit UI prototype fix smart quote on table

### DIFF
--- a/src/cow-react/common/hooks/useRateInfoParams.ts
+++ b/src/cow-react/common/hooks/useRateInfoParams.ts
@@ -28,7 +28,7 @@ export function useRateInfoParams(
     tryParseCurrencyAmount(parseRate(false), outputCurrencyAmount?.currency || undefined)
   )
 
-  const inversedActiveRateFiatAmount = useHigherUSDValue(
+  const invertedActiveRateFiatAmount = useHigherUSDValue(
     tryParseCurrencyAmount(parseRate(true), inputCurrencyAmount?.currency || undefined)
   )
 
@@ -37,6 +37,6 @@ export function useRateInfoParams(
     inputCurrencyAmount,
     outputCurrencyAmount,
     activeRateFiatAmount,
-    inversedActiveRateFiatAmount,
+    invertedActiveRateFiatAmount,
   })
 }

--- a/src/cow-react/common/pure/RateInfo/index.cosmos.tsx
+++ b/src/cow-react/common/pure/RateInfo/index.cosmos.tsx
@@ -16,7 +16,7 @@ const rateInfoParams = {
   inputCurrencyAmount: CurrencyAmount.fromRawAmount(inputCurrency, 123 * 10 ** 18),
   outputCurrencyAmount: CurrencyAmount.fromRawAmount(outputCurrency, 456 * 10 ** 18),
   activeRateFiatAmount: CurrencyAmount.fromRawAmount(outputCurrency, 2 * 10 ** 18),
-  inversedActiveRateFiatAmount: CurrencyAmount.fromRawAmount(outputCurrency, 65 * 10 ** 18),
+  invertedActiveRateFiatAmount: CurrencyAmount.fromRawAmount(outputCurrency, 65 * 10 ** 18),
 }
 
 function buildRateInfoParams(
@@ -33,7 +33,7 @@ function buildRateInfoParams(
     inputCurrencyAmount,
     outputCurrencyAmount,
     activeRateFiatAmount: null,
-    inversedActiveRateFiatAmount: null,
+    invertedActiveRateFiatAmount: null,
   }
 }
 

--- a/src/cow-react/common/pure/RateInfo/index.tsx
+++ b/src/cow-react/common/pure/RateInfo/index.tsx
@@ -30,6 +30,7 @@ export interface RateInfoProps {
   prependSymbol?: boolean
   isInverted?: boolean
   setSmartQuoteSelectionOnce?: boolean
+  doNotUseSmartQuote?: boolean
   isInvertedState?: [boolean, Dispatch<SetStateAction<boolean>>]
   rateInfoParams: RateInfoParams
   opacitySymbol?: boolean
@@ -120,6 +121,7 @@ export function RateInfo({
   className,
   label = 'Limit price',
   setSmartQuoteSelectionOnce = false,
+  doNotUseSmartQuote = false,
   stylized = false,
   isInverted = false,
   noLabel = false,
@@ -165,7 +167,7 @@ export function RateInfo({
 
   // Set isInverted based on quoteCurrency
   useEffect(() => {
-    if (isSmartQuoteSelectionSet) return
+    if (isSmartQuoteSelectionSet || doNotUseSmartQuote) return
 
     const [quoteCurrencyAddress, inputCurrencyAddress] = [getAddress(quoteCurrency), getAddress(inputCurrency)]
 
@@ -182,6 +184,7 @@ export function RateInfo({
     isSmartQuoteSelectionSet,
     setIsSmartQuoteSelectionSet,
     setSmartQuoteSelectionOnce,
+    doNotUseSmartQuote,
   ])
 
   if (!rateInputCurrency || !rateOutputCurrency || !currentActiveRate) return null

--- a/src/cow-react/common/pure/RateInfo/index.tsx
+++ b/src/cow-react/common/pure/RateInfo/index.tsx
@@ -19,7 +19,7 @@ export interface RateInfoParams {
   inputCurrencyAmount: CurrencyAmount<Currency> | null
   outputCurrencyAmount: CurrencyAmount<Currency> | null
   activeRateFiatAmount: CurrencyAmount<Currency> | null
-  inversedActiveRateFiatAmount: CurrencyAmount<Currency> | null
+  invertedActiveRateFiatAmount: CurrencyAmount<Currency> | null
 }
 
 export interface RateInfoProps {
@@ -28,9 +28,9 @@ export interface RateInfoProps {
   stylized?: boolean
   noLabel?: boolean
   prependSymbol?: boolean
-  isInversed?: boolean
+  isInverted?: boolean
   setSmartQuoteSelectionOnce?: boolean
-  isInversedState?: [boolean, Dispatch<SetStateAction<boolean>>]
+  isInvertedState?: [boolean, Dispatch<SetStateAction<boolean>>]
   rateInfoParams: RateInfoParams
   opacitySymbol?: boolean
 }
@@ -121,13 +121,13 @@ export function RateInfo({
   label = 'Limit price',
   setSmartQuoteSelectionOnce = false,
   stylized = false,
-  isInversed = false,
+  isInverted = false,
   noLabel = false,
   prependSymbol = true,
-  isInversedState,
+  isInvertedState,
   opacitySymbol = false,
 }: RateInfoProps) {
-  const { chainId, inputCurrencyAmount, outputCurrencyAmount, activeRateFiatAmount, inversedActiveRateFiatAmount } =
+  const { chainId, inputCurrencyAmount, outputCurrencyAmount, activeRateFiatAmount, invertedActiveRateFiatAmount } =
     rateInfoParams
 
   const activeRate = usePrice(inputCurrencyAmount, outputCurrencyAmount)
@@ -135,41 +135,41 @@ export function RateInfo({
   const outputCurrency = outputCurrencyAmount?.currency
 
   const [isSmartQuoteSelectionSet, setIsSmartQuoteSelectionSet] = useState(false)
-  const customDispatcher = useState(isInversed)
-  const [currentIsInversed, setCurrentIsInversed] = isInversedState || customDispatcher
+  const customDispatcher = useState(isInverted)
+  const [currentIsInverted, setCurrentIsInverted] = isInvertedState || customDispatcher
 
   const currentActiveRate = useMemo(() => {
     if (!activeRate) return null
-    return currentIsInversed ? activeRate.invert() : activeRate
-  }, [currentIsInversed, activeRate])
+    return currentIsInverted ? activeRate.invert() : activeRate
+  }, [currentIsInverted, activeRate])
 
   const fiatAmount = useMemo(() => {
-    return currentIsInversed ? inversedActiveRateFiatAmount : activeRateFiatAmount
-  }, [currentIsInversed, activeRateFiatAmount, inversedActiveRateFiatAmount])
+    return currentIsInverted ? invertedActiveRateFiatAmount : activeRateFiatAmount
+  }, [currentIsInverted, activeRateFiatAmount, invertedActiveRateFiatAmount])
 
   const rateInputCurrency = useMemo(() => {
-    return currentIsInversed ? outputCurrency : inputCurrency
-  }, [currentIsInversed, inputCurrency, outputCurrency])
+    return currentIsInverted ? outputCurrency : inputCurrency
+  }, [currentIsInverted, inputCurrency, outputCurrency])
 
   const rateOutputCurrency = useMemo(() => {
-    return currentIsInversed ? inputCurrency : outputCurrency
-  }, [currentIsInversed, inputCurrency, outputCurrency])
+    return currentIsInverted ? inputCurrency : outputCurrency
+  }, [currentIsInverted, inputCurrency, outputCurrency])
 
   const quoteCurrency = useMemo(() => {
     return getQuoteCurrency(chainId, inputCurrencyAmount, outputCurrencyAmount)
   }, [chainId, inputCurrencyAmount, outputCurrencyAmount])
 
   useEffect(() => {
-    setCurrentIsInversed(isInversed)
-  }, [isInversed, setCurrentIsInversed])
+    setCurrentIsInverted(isInverted)
+  }, [isInverted, setCurrentIsInverted])
 
-  // Set isInversed based on quoteCurrency
+  // Set isInverted based on quoteCurrency
   useEffect(() => {
     if (isSmartQuoteSelectionSet) return
 
     const [quoteCurrencyAddress, inputCurrencyAddress] = [getAddress(quoteCurrency), getAddress(inputCurrency)]
 
-    setCurrentIsInversed(quoteCurrencyAddress !== inputCurrencyAddress)
+    setCurrentIsInverted(quoteCurrencyAddress !== inputCurrencyAddress)
 
     if (setSmartQuoteSelectionOnce) {
       setIsSmartQuoteSelectionSet(true)
@@ -178,7 +178,7 @@ export function RateInfo({
     quoteCurrency,
     inputCurrency,
     outputCurrency,
-    setCurrentIsInversed,
+    setCurrentIsInverted,
     isSmartQuoteSelectionSet,
     setIsSmartQuoteSelectionSet,
     setSmartQuoteSelectionOnce,
@@ -191,11 +191,11 @@ export function RateInfo({
       {!noLabel && (
         <RateLabel>
           <Trans>{label}</Trans>
-          <InvertRateControl onClick={() => setCurrentIsInversed((state) => !state)} />
+          <InvertRateControl onClick={() => setCurrentIsInverted((state) => !state)} />
         </RateLabel>
       )}
       <div>
-        <RateWrapper onClick={() => setCurrentIsInversed((state) => !state)}>
+        <RateWrapper onClick={() => setCurrentIsInverted((state) => !state)}>
           <span
             title={
               currentActiveRate.toFixed(rateOutputCurrency.decimals || DEFAULT_DECIMALS) +

--- a/src/cow-react/modules/account/containers/Transaction/ActivityDetails.tsx
+++ b/src/cow-react/modules/account/containers/Transaction/ActivityDetails.tsx
@@ -172,7 +172,7 @@ export function ActivityDetails(props: {
     inputCurrencyAmount: null,
     outputCurrencyAmount: null,
     activeRateFiatAmount: null,
-    inversedActiveRateFiatAmount: null,
+    invertedActiveRateFiatAmount: null,
   }
   let isOrderFulfilled = false
 
@@ -207,7 +207,7 @@ export function ActivityDetails(props: {
       inputCurrencyAmount: rateInputCurrencyAmount,
       outputCurrencyAmount: rateOutputCurrencyAmount,
       activeRateFiatAmount: null,
-      inversedActiveRateFiatAmount: null,
+      invertedActiveRateFiatAmount: null,
     }
 
     const DateFormatOptions: Intl.DateTimeFormatOptions = {

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/limitOrdersPropsChecker.ts
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/limitOrdersPropsChecker.ts
@@ -73,7 +73,7 @@ function checkRateInfoParams(a: RateInfoParams, b: RateInfoParams): boolean {
     areFractionsEqual(a.inputCurrencyAmount, b.inputCurrencyAmount) &&
     areFractionsEqual(a.outputCurrencyAmount, b.outputCurrencyAmount) &&
     areFractionsEqual(a.activeRateFiatAmount, b.activeRateFiatAmount) &&
-    areFractionsEqual(a.inversedActiveRateFiatAmount, b.inversedActiveRateFiatAmount)
+    areFractionsEqual(a.invertedActiveRateFiatAmount, b.invertedActiveRateFiatAmount)
   )
 }
 

--- a/src/cow-react/modules/limitOrders/containers/RateInput/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/RateInput/index.tsx
@@ -26,7 +26,7 @@ export function RateInput() {
   const { chainId } = useWeb3React()
   // Rate state
   const {
-    isInversed,
+    isInverted,
     activeRate,
     isLoading,
     marketRate,
@@ -48,8 +48,8 @@ export function RateInput() {
   const inputCurrencyId = inputCurrency?.symbol
   const outputCurrencyId = outputCurrency?.symbol
 
-  const primaryCurrency = isInversed ? outputCurrency : inputCurrency
-  const secondaryCurrency = isInversed ? inputCurrency : outputCurrency
+  const primaryCurrency = isInverted ? outputCurrency : inputCurrency
+  const secondaryCurrency = isInverted ? inputCurrency : outputCurrency
 
   // Handle rate display
   const displayedRate = useMemo(() => {
@@ -57,10 +57,10 @@ export function RateInput() {
 
     if (!activeRate || !areBothCurrencies || activeRate.equalTo(0)) return ''
 
-    const rate = isInversed ? activeRate.invert() : activeRate
+    const rate = isInverted ? activeRate.invert() : activeRate
 
     return formatInputAmount(rate)
-  }, [activeRate, areBothCurrencies, isInversed, isTypedValue, typedValue])
+  }, [activeRate, areBothCurrencies, isInverted, isTypedValue, typedValue])
 
   // Handle set market price
   const handleSetMarketPrice = useCallback(() => {
@@ -76,18 +76,18 @@ export function RateInput() {
     (typedValue: string) => {
       updateLimitRateState({ typedValue })
       updateRate({
-        activeRate: toFraction(typedValue, isInversed),
+        activeRate: toFraction(typedValue, isInverted),
         isTypedValue: true,
         isRateFromUrl: false,
       })
     },
-    [isInversed, updateRate, updateLimitRateState]
+    [isInverted, updateRate, updateLimitRateState]
   )
 
   // Handle toggle primary field
   const handleToggle = useCallback(() => {
-    updateLimitRateState({ isInversed: !isInversed, isTypedValue: false })
-  }, [isInversed, updateLimitRateState])
+    updateLimitRateState({ isInverted: !isInverted, isTypedValue: false })
+  }, [isInverted, updateLimitRateState])
 
   const isDisabledMPrice = useMemo(() => {
     if (isLoadingMarketRate) return true
@@ -120,7 +120,7 @@ export function RateInput() {
       getQuoteCurrency(chainId, inputCurrencyAmount, outputCurrencyAmount)
     const [quoteCurrencyAddress, inputCurrencyAddress] = [getAddress(quoteCurrency), getAddress(inputCurrency)]
 
-    updateLimitRateState({ isInversed: quoteCurrencyAddress !== inputCurrencyAddress })
+    updateLimitRateState({ isInverted: quoteCurrencyAddress !== inputCurrencyAddress })
     setIsQuoteCurrencySet(true)
   }, [
     isQuoteCurrencySet,
@@ -181,7 +181,7 @@ export function RateInput() {
               <QuestionHelper
                 text={
                   <ExecutionPriceTooltip
-                    isInversed={isInversed}
+                    isInverted={isInverted}
                     feeAmount={feeAmount}
                     marketRate={marketRate}
                     displayedRate={displayedRate}
@@ -192,7 +192,7 @@ export function RateInput() {
             ) : null}
           </b>
           {!isLoadingMarketRate && executionPrice && (
-            <ExecutionPrice executionPrice={executionPrice} isInversed={isInversed} />
+            <ExecutionPrice executionPrice={executionPrice} isInverted={isInverted} />
           )}
         </styledEl.EstimatedRate>
       )}

--- a/src/cow-react/modules/limitOrders/hooks/useExecutionPriceFiat.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useExecutionPriceFiat.ts
@@ -2,8 +2,8 @@ import { useHigherUSDValue } from 'hooks/useStablecoinPrice'
 import { Currency, CurrencyAmount, Price } from '@uniswap/sdk-core'
 import { rawToTokenAmount } from '@cow/utils/rawToTokenAmount'
 
-function getPriceQuoteAmount(price: Price<Currency, Currency>, isInversed: boolean): CurrencyAmount<Currency> {
-  const executionPrice = isInversed ? price.invert() : price
+function getPriceQuoteAmount(price: Price<Currency, Currency>, isInverted: boolean): CurrencyAmount<Currency> {
+  const executionPrice = isInverted ? price.invert() : price
 
   return CurrencyAmount.fromRawAmount(
     executionPrice.baseCurrency,
@@ -13,9 +13,9 @@ function getPriceQuoteAmount(price: Price<Currency, Currency>, isInversed: boole
 
 export function useExecutionPriceFiat(
   executionPrice: Price<Currency, Currency> | null,
-  isInversed: boolean
+  isInverted: boolean
 ): CurrencyAmount<Currency> | null {
-  const amount = executionPrice ? getPriceQuoteAmount(executionPrice, isInversed) : undefined
+  const amount = executionPrice ? getPriceQuoteAmount(executionPrice, isInverted) : undefined
 
   return useHigherUSDValue(amount)
 }

--- a/src/cow-react/modules/limitOrders/pure/ExecutionPrice/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/ExecutionPrice/index.tsx
@@ -5,16 +5,16 @@ import { Currency, Price } from '@uniswap/sdk-core'
 
 export interface ExecutionPriceProps {
   executionPrice: Price<Currency, Currency>
-  isInversed: boolean
+  isInverted: boolean
 }
 
-export function ExecutionPrice({ executionPrice, isInversed }: ExecutionPriceProps) {
-  const executionPriceFiat = useExecutionPriceFiat(executionPrice, isInversed)
-  const quoteCurrency = isInversed ? executionPrice?.baseCurrency : executionPrice?.quoteCurrency
+export function ExecutionPrice({ executionPrice, isInverted }: ExecutionPriceProps) {
+  const executionPriceFiat = useExecutionPriceFiat(executionPrice, isInverted)
+  const quoteCurrency = isInverted ? executionPrice?.baseCurrency : executionPrice?.quoteCurrency
 
   return (
     <span>
-      ≈ <TokenAmount amount={isInversed ? executionPrice.invert() : executionPrice} tokenSymbol={quoteCurrency} />
+      ≈ <TokenAmount amount={isInverted ? executionPrice.invert() : executionPrice} tokenSymbol={quoteCurrency} />
       {executionPriceFiat && (
         <i>
           &nbsp;(

--- a/src/cow-react/modules/limitOrders/pure/ExecutionPriceTooltip/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/ExecutionPriceTooltip/index.tsx
@@ -8,7 +8,7 @@ import { convertAmountToCurrency } from '@cow/modules/limitOrders/utils/calculat
 import { ExecuteIndicator } from '@cow/modules/limitOrders/pure/Orders/OrderRow/styled'
 
 export interface ExecutionPriceTooltipProps {
-  isInversed: boolean
+  isInverted: boolean
   feeAmount: CurrencyAmount<Currency> | null
   displayedRate: string | null
   executionPrice: Price<Currency, Currency> | null
@@ -53,13 +53,13 @@ export function RateTooltipHeader({ isOpenOrdersTab }: RateTooltipHeaderProps) {
 function formatFeeAmount({
   marketRate,
   feeAmount,
-  isInversed,
+  isInverted,
   executionPrice,
 }: ExecutionPriceTooltipProps): CurrencyAmount<Currency> | null {
-  const currency = isInversed ? executionPrice?.baseCurrency : executionPrice?.quoteCurrency
+  const currency = isInverted ? executionPrice?.baseCurrency : executionPrice?.quoteCurrency
   const invertedFee = marketRate && feeAmount ? marketRate.multiply(feeAmount) : null
 
-  return !isInversed && invertedFee && currency && feeAmount
+  return !isInverted && invertedFee && currency && feeAmount
     ? convertAmountToCurrency(
         CurrencyAmount.fromFractionalAmount(feeAmount.currency, invertedFee.numerator, invertedFee.denominator),
         currency
@@ -68,9 +68,9 @@ function formatFeeAmount({
 }
 
 export function ExecutionPriceTooltip(props: ExecutionPriceTooltipProps) {
-  const { isInversed, displayedRate, executionPrice, isOpenOrdersTab } = props
+  const { isInverted, displayedRate, executionPrice, isOpenOrdersTab } = props
 
-  const currentCurrency = isInversed ? executionPrice?.baseCurrency : executionPrice?.quoteCurrency
+  const currentCurrency = isInverted ? executionPrice?.baseCurrency : executionPrice?.quoteCurrency
   const formattedFeeAmount = formatFeeAmount(props)
 
   const feeUsdValue = useHigherUSDValue(formattedFeeAmount || undefined)
@@ -111,7 +111,7 @@ export function ExecutionPriceTooltip(props: ExecutionPriceTooltipProps) {
       <styledEl.FeeItem highlighted>
         <b>Order executes at</b>
         <span>
-          <b>{executionPrice && <ExecutionPrice executionPrice={executionPrice} isInversed={isInversed} />}</b>
+          <b>{executionPrice && <ExecutionPrice executionPrice={executionPrice} isInverted={isInverted} />}</b>
         </span>
       </styledEl.FeeItem>
     </styledEl.FeeTooltipWrapper>

--- a/src/cow-react/modules/limitOrders/pure/LimitOrdersConfirm/index.cosmos.tsx
+++ b/src/cow-react/modules/limitOrders/pure/LimitOrdersConfirm/index.cosmos.tsx
@@ -80,7 +80,7 @@ const rateInfoParams = {
   inputCurrencyAmount: CurrencyAmount.fromRawAmount(outputCurrency, 123 * 10 ** 18),
   outputCurrencyAmount: CurrencyAmount.fromRawAmount(outputCurrency, 456 * 10 ** 18),
   activeRateFiatAmount: CurrencyAmount.fromRawAmount(outputCurrency, 2 * 10 ** 18),
-  inversedActiveRateFiatAmount: CurrencyAmount.fromRawAmount(outputCurrency, 65 * 10 ** 18),
+  invertedActiveRateFiatAmount: CurrencyAmount.fromRawAmount(outputCurrency, 65 * 10 ** 18),
 }
 
 const priceImpact: PriceImpact = {

--- a/src/cow-react/modules/limitOrders/pure/LimitOrdersDetails/index.cosmos.tsx
+++ b/src/cow-react/modules/limitOrders/pure/LimitOrdersDetails/index.cosmos.tsx
@@ -43,7 +43,7 @@ const rateInfoParams = {
   inputCurrencyAmount: CurrencyAmount.fromRawAmount(outputCurrency, 123 * 10 ** 18),
   outputCurrencyAmount: CurrencyAmount.fromRawAmount(outputCurrency, 456 * 10 ** 18),
   activeRateFiatAmount: CurrencyAmount.fromRawAmount(outputCurrency, 2 * 10 ** 18),
-  inversedActiveRateFiatAmount: CurrencyAmount.fromRawAmount(outputCurrency, 65 * 10 ** 18),
+  invertedActiveRateFiatAmount: CurrencyAmount.fromRawAmount(outputCurrency, 65 * 10 ** 18),
 }
 
 const Fixtures = {

--- a/src/cow-react/modules/limitOrders/pure/LimitOrdersDetails/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/LimitOrdersDetails/index.tsx
@@ -46,20 +46,20 @@ export function LimitOrdersDetails(props: LimitOrdersDetailsProps) {
 
   const validTo = calculateLimitOrdersDeadline(settingsState)
   const expiryDate = new Date(validTo * 1000)
-  const isInversedState = useState(false)
-  const [isInversed] = isInversedState
+  const isInvertedState = useState(false)
+  const [isInverted] = isInvertedState
 
   const displayedRate = useMemo(() => {
     if (!activeRate) return ''
-    const rate = isInversed ? activeRate.invert() : activeRate
+    const rate = isInverted ? activeRate.invert() : activeRate
 
     return formatInputAmount(rate)
-  }, [isInversed, activeRate])
+  }, [isInverted, activeRate])
 
   return (
     <Wrapper>
       <styledEl.DetailsRow>
-        <styledEl.StyledRateInfo isInversedState={isInversedState} rateInfoParams={rateInfoParams} />
+        <styledEl.StyledRateInfo isInvertedState={isInvertedState} rateInfoParams={rateInfoParams} />
       </styledEl.DetailsRow>
 
       {limitOrdersFeatures.DISPLAY_EXECUTION_TIME && (
@@ -73,7 +73,7 @@ export function LimitOrdersDetails(props: LimitOrdersDetailsProps) {
               <QuestionHelper
                 text={
                   <ExecutionPriceTooltip
-                    isInversed={isInversed}
+                    isInverted={isInverted}
                     feeAmount={feeAmount}
                     marketRate={marketRate}
                     displayedRate={displayedRate}
@@ -83,7 +83,7 @@ export function LimitOrdersDetails(props: LimitOrdersDetailsProps) {
               />
             </span>
           </div>
-          <div>{executionPrice && <ExecutionPrice executionPrice={executionPrice} isInversed={isInversed} />}</div>
+          <div>{executionPrice && <ExecutionPrice executionPrice={executionPrice} isInverted={isInverted} />}</div>
         </styledEl.DetailsRow>
       )}
 

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -214,6 +214,7 @@ export function OrderRow({
     const quoteCurrency = getQuoteCurrency(chainId, inputCurrencyAmount, outputCurrencyAmount)
     setIsinverted(getAddress(quoteCurrency) !== getAddress(inputCurrencyAmount?.currency))
     // Intentionally empty, should run only once
+    // eslint-disable-next-line
   }, [])
 
   const executionPriceInverted = isInverted ? estimatedExecutionPrice?.invert() : estimatedExecutionPrice

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -243,7 +243,7 @@ export function OrderRow({
           <RateInfo
             prependSymbol={false}
             noLabel={true}
-            setSmartQuoteSelectionOnce={false}
+            doNotUseSmartQuote
             isInverted={isInverted}
             rateInfoParams={rateInfoParams}
             opacitySymbol={true}

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -168,7 +168,7 @@ export interface OrderRowProps {
   prices: PendingOrderPrices | undefined | null
   spotPrice: Price<Currency, Currency> | undefined | null
   RowElement: StyledComponent<'div', DefaultTheme, { isOpenOrdersTab?: boolean; hasBackground?: boolean }>
-  isRateInversed: boolean
+  isRateInverted: boolean
   isOpenOrdersTab: boolean
   orderParams: OrderParams
   onClick: () => void
@@ -178,7 +178,7 @@ export interface OrderRowProps {
 export function OrderRow({
   order,
   RowElement,
-  isRateInversed,
+  isRateInverted,
   isOpenOrdersTab,
   getShowCancellationModal,
   orderParams,
@@ -202,12 +202,12 @@ export function OrderRow({
   // const executedTimeAgo = useTimeAgo(expirationTime, TIME_AGO_UPDATE_INTERVAL)
   const activityUrl = chainId && activityId ? getEtherscanLink(chainId, activityId, 'transaction') : undefined
 
-  const [isInverted, setIsinverted] = useState(isRateInversed)
+  const [isInverted, setIsinverted] = useState(isRateInverted)
 
   // Update internal isInverted flag whenever prop change
   useEffect(() => {
-    setIsinverted(isRateInversed)
-  }, [isRateInversed])
+    setIsinverted(isRateInverted)
+  }, [isRateInverted])
 
   // On mount, apply smart quote selection
   useEffect(() => {
@@ -216,8 +216,8 @@ export function OrderRow({
     // Intentionally empty, should run only once
   }, [])
 
-  const executionPriceInversed = isInverted ? estimatedExecutionPrice?.invert() : estimatedExecutionPrice
-  const executedPriceInversed = isInverted ? executedPrice?.invert() : executedPrice
+  const executionPriceInverted = isInverted ? estimatedExecutionPrice?.invert() : estimatedExecutionPrice
+  const executedPriceInverted = isInverted ? executedPrice?.invert() : executedPrice
   const spotPriceInverted = isInverted ? spotPrice?.invert() : spotPrice
 
   const executionOrderStatus = useOrderExecutionStatus(rateInfoParams, prices, spotPrice)
@@ -243,7 +243,7 @@ export function OrderRow({
             prependSymbol={false}
             noLabel={true}
             setSmartQuoteSelectionOnce={false}
-            isInversed={isInverted}
+            isInverted={isInverted}
             rateInfoParams={rateInfoParams}
             opacitySymbol={true}
           />
@@ -268,10 +268,10 @@ export function OrderRow({
       {/* Execution price */}
       {!isOpenOrdersTab && (
         <styledEl.CellElement>
-          {executedPriceInversed ? (
+          {executedPriceInverted ? (
             <TokenAmount
-              amount={executedPriceInversed}
-              tokenSymbol={executedPriceInversed?.quoteCurrency}
+              amount={executedPriceInverted}
+              tokenSymbol={executedPriceInverted?.quoteCurrency}
               opacitySymbol
             />
           ) : (
@@ -290,8 +290,8 @@ export function OrderRow({
                 // TODO: Add condition to show the lowVolumeWarning.
                 executeIndicator={<styledEl.ExecuteIndicator status={executionOrderStatus} />}
                 lowVolumeWarning={true}
-                amount={executionPriceInversed}
-                tokenSymbol={executionPriceInversed?.quoteCurrency}
+                amount={executionPriceInverted}
+                tokenSymbol={executionPriceInverted?.quoteCurrency}
                 opacitySymbol
               />
             </styledEl.ExecuteCellWrapper>

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
@@ -230,7 +230,7 @@ export function OrdersTable({
   getShowCancellationModal,
   currentPageNumber,
 }: OrdersTableProps) {
-  const [isRateInversed, setIsRateInversed] = useState(false)
+  const [isRateInverted, setIsRateInverted] = useState(false)
 
   const selectReceiptOrder = useSelectReceiptOrder()
   const step = currentPageNumber * LIMIT_ORDERS_PAGE_SIZE
@@ -268,7 +268,7 @@ export function OrdersTable({
               <span>
                 <Trans>Limit price</Trans>
               </span>
-              <StyledInvertRateControl onClick={() => setIsRateInversed(!isRateInversed)} />
+              <StyledInvertRateControl onClick={() => setIsRateInverted(!isRateInverted)} />
             </HeaderElement>
 
             {isOpenOrdersTab && limitOrdersFeatures.DISPLAY_EST_EXECUTION_PRICE && (
@@ -368,7 +368,7 @@ export function OrdersTable({
                 prices={pendingOrdersPrices[order.id]}
                 orderParams={getOrderParams(chainId, balancesAndAllowances, order)}
                 RowElement={RowElement}
-                isRateInversed={isRateInversed}
+                isRateInverted={isRateInverted}
                 getShowCancellationModal={getShowCancellationModal}
                 onClick={() => selectReceiptOrder(order.id)}
               />

--- a/src/cow-react/modules/limitOrders/pure/Orders/utils/getOrderParams.ts
+++ b/src/cow-react/modules/limitOrders/pure/Orders/utils/getOrderParams.ts
@@ -26,7 +26,7 @@ export function getOrderParams(
     inputCurrencyAmount: sellAmount,
     outputCurrencyAmount: buyAmount,
     activeRateFiatAmount: null,
-    inversedActiveRateFiatAmount: null,
+    invertedActiveRateFiatAmount: null,
   }
 
   const { balances, allowances } = balancesAndAllowances

--- a/src/cow-react/modules/limitOrders/state/limitRateAtom.ts
+++ b/src/cow-react/modules/limitOrders/state/limitRateAtom.ts
@@ -4,7 +4,7 @@ import { atom } from 'jotai'
 export interface LimitRateState {
   readonly isLoading: boolean
   readonly isLoadingMarketRate: boolean
-  readonly isInversed: boolean
+  readonly isInverted: boolean
   readonly initialRate: Fraction | null
   readonly activeRate: Fraction | null
   readonly marketRate: Fraction | null
@@ -16,7 +16,7 @@ export interface LimitRateState {
 }
 
 export const initLimitRateState = () => ({
-  isInversed: false,
+  isInverted: false,
   isLoading: false,
   isLoadingMarketRate: false,
   initialRate: null,

--- a/src/cow-react/modules/limitOrders/utils/calculateExecutionPrice.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculateExecutionPrice.ts
@@ -48,8 +48,8 @@ export function calculateExecutionPrice(params: ExecutionPriceParams): Price<Cur
 
   if (inputCurrencyAmount.currency !== feeAmount.currency) return null
 
-  const isInversed = marketRate.lessThan(1)
-  const marketRateFixed = isInversed ? marketRate.invert() : marketRate
+  const isInverted = marketRate.lessThan(1)
+  const marketRateFixed = isInverted ? marketRate.invert() : marketRate
   /**
    * Since a user can specify an arbitrary price
    * And the specified price can be less than the market price
@@ -63,7 +63,7 @@ export function calculateExecutionPrice(params: ExecutionPriceParams): Price<Cur
       outputCurrencyAmount.currency
     ),
   })
-  const marketPrice = isInversed ? marketPriceRaw.invert() : marketPriceRaw
+  const marketPrice = isInverted ? marketPriceRaw.invert() : marketPriceRaw
 
   const currentPrice = new Price({
     baseAmount: inputCurrencyAmount.subtract(feeAmount),

--- a/src/cow-react/modules/limitOrders/utils/toFraction.ts
+++ b/src/cow-react/modules/limitOrders/utils/toFraction.ts
@@ -1,12 +1,12 @@
 import { Fraction } from '@uniswap/sdk-core'
 import F from 'fraction.js'
 
-export function toFraction(value: string, isInversed = false): Fraction {
+export function toFraction(value: string, isInverted = false): Fraction {
   if (!value || !Number(value)) return new Fraction(0)
 
   const { n: numerator, d: denominator } = new F(value)
 
-  const params: [number, number] = !isInversed ? [numerator, denominator] : [denominator, numerator]
+  const params: [number, number] = !isInverted ? [numerator, denominator] : [denominator, numerator]
 
   return new Fraction(...params)
 }

--- a/src/cow-react/modules/swap/pure/TradeRates/index.cosmos.tsx
+++ b/src/cow-react/modules/swap/pure/TradeRates/index.cosmos.tsx
@@ -27,7 +27,7 @@ const rateInfoParams: RateInfoParams = {
   inputCurrencyAmount: null,
   outputCurrencyAmount: null,
   activeRateFiatAmount: null,
-  inversedActiveRateFiatAmount: null,
+  invertedActiveRateFiatAmount: null,
 }
 const defaultProps: TradeRatesProps = {
   trade,


### PR DESCRIPTION
# Summary

Fixes issues with smart quote selection on orders table

![image](https://user-images.githubusercontent.com/43217/224103448-dcf761ff-4fac-4af1-9262-362bd651f6d2.png)

Also fixed a typo across several files which was bothering me. Sorry about the noise 😬 

  # To Test

1. Place an limit order with COW/WETH, then another with WETH/COW
* Both should display in the list using COW prices in all price fields