### PR TITLE
Update error handling

### DIFF
--- a/src/cow-react/modules/wallet/api/pure/PendingView/index.tsx
+++ b/src/cow-react/modules/wallet/api/pure/PendingView/index.tsx
@@ -49,10 +49,12 @@ export function PendingView({
   error = false,
   tryConnection,
   openOptions,
+  pendingError,
 }: {
   error?: boolean
   tryConnection: () => void
   openOptions: () => void
+  pendingError?: string
 }) {
   return (
     <PendingSection>
@@ -64,9 +66,12 @@ export function PendingView({
                 <Trans>Error connecting</Trans>
               </ThemedText.MediumHeader>
               <ThemedText.Body fontSize={14} marginBottom={36} textAlign="center">
-                <Trans>
-                  The connection attempt failed. Please click try again and follow the steps to connect in your wallet.
-                </Trans>
+                {pendingError || (
+                  <Trans>
+                    The connection attempt failed. Please click try again and follow the steps to connect in your
+                    wallet.
+                  </Trans>
+                )}
               </ThemedText.Body>
               <ButtonPrimary $borderRadius="12px" padding="12px" onClick={tryConnection}>
                 <Trans>Try Again</Trans>

--- a/src/cow-react/modules/wallet/api/pure/WalletModal/index.tsx
+++ b/src/cow-react/modules/wallet/api/pure/WalletModal/index.tsx
@@ -54,7 +54,12 @@ export function WalletModal(props: WalletModalProps) {
           <ContentWrapper>
             <AutoColumn gap="16px">
               {isPending && pendingConnector && (
-                <PendingView openOptions={openOptions} error={!!pendingError} tryConnection={tryConnection} />
+                <PendingView
+                  openOptions={openOptions}
+                  pendingError={pendingError}
+                  error={!!pendingError}
+                  tryConnection={tryConnection}
+                />
               )}
               {!isPending && (
                 <OptionGrid data-testid="option-grid">

--- a/src/cow-react/modules/wallet/web3-react/connectors/Ledger/connector.tsx
+++ b/src/cow-react/modules/wallet/web3-react/connectors/Ledger/connector.tsx
@@ -65,22 +65,30 @@ export class LedgerConnector extends Connector {
   async activate() {
     if (this.isActivated) return
 
-    const provider = new LedgerProvider(this.options)
+    try {
+      const provider = new LedgerProvider(this.options)
 
-    const engine = (await provider.activate()) as unknown as Provider
+      const engine = (await provider.activate()) as unknown as Provider
 
-    this.provider = engine
-    this.providerRequests.forEach((callback) => {
-      callback(engine)
-    })
-    this.providerRequests = []
+      this.provider = engine
+      this.providerRequests.forEach((callback) => {
+        callback(engine)
+      })
+      this.providerRequests = []
 
-    const accounts = await this.getAccounts()
-    const chainId = await this.getChainId()
+      const accounts = await this.getAccounts()
+      const chainId = await this.getChainId()
 
-    this.isActivated = true
+      this.isActivated = true
 
-    return this.actions.update({ chainId, accounts })
+      return this.actions.update({ chainId, accounts })
+    } catch (error) {
+      if (error.statusCode === 21781) {
+        throw Error('Please unlock your ledger device first and try again!')
+      }
+
+      throw error
+    }
   }
 
   async connectEagerly(): Promise<void> {

--- a/src/cow-react/modules/wallet/web3-react/connectors/Ledger/connector.tsx
+++ b/src/cow-react/modules/wallet/web3-react/connectors/Ledger/connector.tsx
@@ -14,6 +14,11 @@ export interface LedgerOptions {
   rpc?: { [chainId: number]: string }
 }
 
+enum Errors {
+  NOT_CONNECTED = 'Please make sure you are connected to Ethereun network on your Ledger device and try again!',
+  NOT_UNLOCKED = 'Please unlock your ledger device first and try again!',
+}
+
 export class LedgerConnector extends Connector {
   public provider?: Provider
   private readonly options: LedgerOptions
@@ -83,8 +88,12 @@ export class LedgerConnector extends Connector {
 
       return this.actions.update({ chainId, accounts })
     } catch (error) {
+      if (error.statusCode === 25873) {
+        throw Error(Errors.NOT_CONNECTED)
+      }
+
       if (error.statusCode === 21781) {
-        throw Error('Please unlock your ledger device first and try again!')
+        throw Error(Errors.NOT_UNLOCKED)
       }
 
       throw error

--- a/src/cow-react/modules/wallet/web3-react/containers/WalletModal/index.tsx
+++ b/src/cow-react/modules/wallet/web3-react/containers/WalletModal/index.tsx
@@ -117,7 +117,7 @@ export function WalletModal() {
       pendingConnector={pendingConnector}
       pendingError={pendingError}
       tryActivation={tryActivation}
-      tryConnection={() => tryActivation(connector)}
+      tryConnection={pendingConnector ? () => tryActivation(pendingConnector) : () => {}}
       view={walletView}
     />
   )


### PR DESCRIPTION
# Summary

- handle locked ledger error and display the error text to the user in the modal
- fix try again button to actually activate the pending connector

<img width="533" alt="Screenshot 2023-03-08 at 18 44 26" src="https://user-images.githubusercontent.com/34926005/223790955-8740b190-baf7-4598-8a36-6223d1309b75.png">

Error messages:
- if the ledger is not unlocked we will show this error `Please unlock your ledger device first and try again!`
- if the user didn't select the Ethereum app we will show `Please make sure you are connected to Ethereun network on your Ledger device and try again!`