### PR TITLE
Feature/limit UI update - wire up tooltips

### DIFF
--- a/src/cow-react/common/utils/markets.ts
+++ b/src/cow-react/common/utils/markets.ts
@@ -1,4 +1,6 @@
+import invariant from 'tiny-invariant'
 import { SupportedChainId } from 'constants/chains'
+import { Currency, Price } from '@uniswap/sdk-core'
 
 /**
  * Convenient method to identify a market so it doesn't matter what is the sell token or buy token.
@@ -47,4 +49,12 @@ export function getCanonicalMarketChainKey(
     marketKey: `${chainId}@${marketKey}`,
     marketInverted,
   }
+}
+
+export function assertSameMarket(price1: Price<Currency, Currency>, price2: Price<Currency, Currency>) {
+  // Assert I'm comparing apples with apples (prices should refer to market)
+  invariant(
+    price1.baseCurrency.equals(price2.baseCurrency) && price1.quoteCurrency.equals(price2.quoteCurrency),
+    'Prices are not from the same market'
+  )
 }

--- a/src/cow-react/common/utils/markets.ts
+++ b/src/cow-react/common/utils/markets.ts
@@ -1,0 +1,50 @@
+import { SupportedChainId } from 'constants/chains'
+
+/**
+ * Convenient method to identify a market so it doesn't matter what is the sell token or buy token.
+ *
+ * This methods is used internally for example to identify the keys in hash maps caches.
+ * This method has the communitative property, so getCanonicalMarketKey(A, B) = getCanonicalMarketKey(B, A)
+ *
+ * @param tokenAddressA
+ * @param tokenAddressB
+ * @returns A string with the key
+ */
+export function getCanonicalMarketKey(
+  tokenAddressA: string,
+  tokenAddressB: string
+): { marketKey: string; marketInverted: boolean } {
+  const tokenAddressALower = tokenAddressA.toLocaleLowerCase()
+  const tokenAddressBLower = tokenAddressB.toLocaleLowerCase()
+  const marketInverted = tokenAddressALower > tokenAddressBLower
+
+  return {
+    marketKey: marketInverted
+      ? `${tokenAddressBLower}/${tokenAddressALower}`
+      : `${tokenAddressALower}/${tokenAddressBLower}`,
+    marketInverted,
+  }
+}
+
+/**
+ * Convenient method to identify a market so it doesn't matter what is the sell token or buy token.
+ *
+ * This methods is used internally for example to identify the keys in hash maps caches.
+ * This method has the communitative property, so getCanonicalMarketChainKey(chainId, A, B) = getCanonicalMarketChainKey(chainId, B, A)
+ *
+ * @param tokenAddressA
+ * @param tokenAddressB
+ * @returns A string with the key
+ */
+export function getCanonicalMarketChainKey(
+  chainId: SupportedChainId,
+  tokenAddressA: string,
+  tokenAddressB: string
+): { marketKey: string; marketInverted: boolean } {
+  const { marketKey, marketInverted } = getCanonicalMarketKey(tokenAddressA, tokenAddressB)
+
+  return {
+    marketKey: `${chainId}@${marketKey}`,
+    marketInverted,
+  }
+}

--- a/src/cow-react/modules/limitOrders/containers/OrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/OrdersWidget/index.tsx
@@ -12,7 +12,7 @@ import { useCancelOrder } from '@cow/common/hooks/useCancelOrder'
 import { useAtomValue } from 'jotai/utils'
 import { pendingOrdersPricesAtom } from '@cow/modules/orders/state/pendingOrdersPricesAtom'
 import { useWalletInfo } from '@cow/modules/wallet'
-import { spotPricesAtom } from '@cow/modules/orders/state/spotPricesAtom'
+import { useGetSpotPrice } from '@cow/modules/orders/state/spotPricesAtom'
 
 function getOrdersListByIndex(ordersList: LimitOrdersList, id: string): ParsedOrder[] {
   return id === OPEN_TAB.id ? ordersList.pending : ordersList.history
@@ -25,7 +25,7 @@ export function OrdersWidget() {
   const { chainId, account } = useWalletInfo()
   const getShowCancellationModal = useCancelOrder()
   const pendingOrdersPrices = useAtomValue(pendingOrdersPricesAtom)
-  const spotPrices = useAtomValue(spotPricesAtom)
+  const getSpotPrice = useGetSpotPrice()
 
   const spender = useMemo(() => (chainId ? GP_VAULT_RELAYER[chainId] : undefined), [chainId])
 
@@ -75,7 +75,7 @@ export function OrdersWidget() {
         balancesAndAllowances={pendingBalancesAndAllowances}
         isWalletConnected={!!account}
         getShowCancellationModal={getShowCancellationModal}
-        spotPrices={spotPrices}
+        getSpotPrice={getSpotPrice}
       ></Orders>
       <OrdersReceiptModal />
     </>

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
@@ -1,0 +1,120 @@
+import { useContext } from 'react'
+import { Currency, CurrencyAmount, Fraction, Percent } from '@uniswap/sdk-core'
+import styled, { ThemeContext } from 'styled-components/macro'
+import { darken } from 'polished'
+import SVG from 'react-inlinesvg'
+
+import { MouseoverTooltipContent } from 'components/Tooltip'
+import { TokenAmount, TokenAmountProps } from '@cow/common/pure/TokenAmount'
+import AlertTriangle from 'assets/cow-swap/alert.svg'
+import { calculateOrderExecutionStatus } from '@cow/modules/limitOrders/utils/calculateOrderExecutionStatus'
+import * as styledEl from './styled'
+
+const ZERO_FRACTION = new Fraction(0)
+const MINUS_ONE_FRACTION = new Fraction(-1)
+const TEN_PERCENT = new Percent(1, 10)
+
+export const EstimatedExecutionPriceWrapper = styled.span<{ hasWarning: boolean }>`
+  display: flex;
+  align-items: center;
+  color: ${({ hasWarning, theme }) => (hasWarning ? darken(theme.darkMode ? 0 : 0.15, theme.alert) : 'inherit')};
+
+  // Popover container override
+  > div > div {
+    display: flex;
+    align-items: center;
+  }
+`
+
+export type EstimatedExecutionPriceProps = TokenAmountProps & {
+  isInverted: boolean
+  percentageDifference?: Percent
+  amountDifference?: CurrencyAmount<Currency>
+  percentageFee?: Percent
+  amountFee?: CurrencyAmount<Currency>
+}
+
+export function EstimatedExecutionPrice(props: EstimatedExecutionPriceProps) {
+  const { isInverted, percentageDifference, amountDifference, percentageFee, amountFee, ...rest } = props
+
+  // This amount can be negative (when price is inverted) and we don't want to show it negative
+  const absoluteDifferenceAmount = amountDifference?.lessThan(ZERO_FRACTION)
+    ? amountDifference.multiply(MINUS_ONE_FRACTION)
+    : amountDifference
+  const orderExecutionStatus = calculateOrderExecutionStatus(percentageDifference)
+  const feeWarning = percentageFee?.greaterThan(TEN_PERCENT)
+  const isNegativeDifference = percentageDifference?.lessThan(ZERO_FRACTION)
+
+  return (
+    <EstimatedExecutionPriceWrapper hasWarning={!!feeWarning}>
+      <MouseoverTooltipContent
+        wrap={true}
+        content={
+          <styledEl.ExecuteInformationTooltip>
+            {!isNegativeDifference ? (
+              <>
+                Market price needs to go {isInverted ? 'down 📉' : 'up 📈'} by&nbsp;
+                <b>
+                  <TokenAmount {...rest} amount={absoluteDifferenceAmount} round={false} />
+                </b>
+                &nbsp;
+                <b>
+                  <i>(~{percentageDifference?.toFixed(2)}%)</i>
+                </b>
+                &nbsp;to execute your order.
+              </>
+            ) : feeWarning ? (
+              <>Unlikely to execute due to high fee</>
+            ) : (
+              <>Will execute soon!</>
+            )}
+          </styledEl.ExecuteInformationTooltip>
+        }
+        placement="top"
+      >
+        <styledEl.ExecuteIndicator status={orderExecutionStatus} />
+        <TokenAmount {...rest} />
+      </MouseoverTooltipContent>
+
+      {feeWarning && <UnlikelyToExecuteWarning feePercentage={percentageFee} feeAmount={amountFee} />}
+    </EstimatedExecutionPriceWrapper>
+  )
+}
+
+export type UnlikelyToExecuteWarningProps = {
+  feePercentage?: Percent
+  feeAmount?: CurrencyAmount<Currency>
+}
+
+export function UnlikelyToExecuteWarning(props: UnlikelyToExecuteWarningProps) {
+  const theme = useContext(ThemeContext)
+  const { feePercentage, feeAmount } = props
+
+  if (!feePercentage || !feeAmount) {
+    return null
+  }
+
+  return (
+    <styledEl.WarningIndicator hasBackground={false}>
+      <MouseoverTooltipContent
+        wrap={true}
+        bgColor={theme.alert}
+        content={
+          <styledEl.WarningContent>
+            <h3>Order unlikely to execute</h3>
+            For this order, network fees would be <b>{feePercentage?.toFixed(2)}%</b>{' '}
+            <b>
+              <i>
+                (<TokenAmount amount={feeAmount} round={false} tokenSymbol={feeAmount.currency} />)
+              </i>
+            </b>{' '}
+            of your sell amount! Therefore, your order is unlikely to execute.
+          </styledEl.WarningContent>
+        }
+        placement="bottom"
+      >
+        <SVG src={AlertTriangle} description="Alert" width="14" height="13" />
+      </MouseoverTooltipContent>
+    </styledEl.WarningIndicator>
+  )
+}

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -304,7 +304,7 @@ function usePricesDifference(
   const { estimatedExecutionPrice } = prices || {}
 
   return useSafeMemo(() => {
-    return calculatePriceDifference({ reference: estimatedExecutionPrice, delta: spotPrice, isInverted })
+    return calculatePriceDifference({ referencePrice: spotPrice, targetPrice: estimatedExecutionPrice, isInverted })
   }, [estimatedExecutionPrice, spotPrice, isInverted])
 }
 

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useState } from 'react'
-import styled, { DefaultTheme, StyledComponent, ThemeContext } from 'styled-components/macro'
+import { DefaultTheme, StyledComponent, ThemeContext } from 'styled-components/macro'
 import { OrderStatus } from 'state/orders/actions'
-import { Currency, CurrencyAmount, Price } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount, Percent, Price } from '@uniswap/sdk-core'
 import { RateInfo } from '@cow/common/pure/RateInfo'
 import { MouseoverTooltipContent } from 'components/Tooltip'
 import { OrderParams } from '../utils/getOrderParams'
@@ -9,7 +9,7 @@ import { getSellAmountWithFee } from '@cow/modules/limitOrders/utils/getSellAmou
 import AlertTriangle from 'assets/cow-swap/alert.svg'
 import SVG from 'react-inlinesvg'
 import { TokenSymbol } from '@cow/common/pure/TokenSymbol'
-import { TokenAmount, TokenAmountProps } from '@cow/common/pure/TokenAmount'
+import { TokenAmount } from '@cow/common/pure/TokenAmount'
 import CurrencyLogo from 'components/CurrencyLogo'
 import useTimeAgo from 'hooks/useTimeAgo'
 import { ParsedOrder } from '@cow/modules/limitOrders/containers/OrdersWidget/hooks/useLimitOrdersList'
@@ -19,15 +19,12 @@ import { getEtherscanLink } from 'utils'
 import { PendingOrderPrices } from '@cow/modules/orders/state/pendingOrdersPricesAtom'
 import Loader from '@src/components/Loader'
 import { OrderContextMenu } from '@cow/modules/limitOrders/pure/Orders/OrderRow/OrderContextMenu'
-import {
-  calculateOrderExecutionStatus,
-  OrderExecutionStatus,
-} from '@cow/modules/limitOrders/utils/calculateOrderExecutionStatus'
 import { useSafeMemo } from '@cow/common/hooks/useSafeMemo'
-import { buildPriceFromCurrencyAmounts } from '@cow/modules/limitOrders/utils/buildPriceFromCurrencyAmounts'
-import { darken } from 'polished'
 import { getQuoteCurrency } from '@cow/common/services/getQuoteCurrency'
 import { getAddress } from '@cow/utils/getAddress'
+import { calculatePriceDifference, PriceDifference } from '@cow/modules/limitOrders/utils/calculatePriceDifference'
+import { calculateFractionLikePercentDifference } from '@cow/modules/limitOrders/utils/calculateFractionLikePercentDifference'
+import { EstimatedExecutionPrice } from '@cow/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice'
 
 export const orderStatusTitleMap: { [key in OrderStatus]: string } = {
   [OrderStatus.PENDING]: 'Open',
@@ -51,77 +48,6 @@ function CurrencyAmountItem({ amount }: { amount: CurrencyAmount<Currency> }) {
 
 function CurrencySymbolItem({ amount }: { amount: CurrencyAmount<Currency> }) {
   return <CurrencyLogo currency={amount.currency} size="28px" />
-}
-
-export function LowVolumeWarningContent() {
-  const theme = useContext(ThemeContext)
-
-  return (
-    <styledEl.WarningIndicator hasBackground={false}>
-      <MouseoverTooltipContent
-        wrap={true}
-        bgColor={theme.alert}
-        content={
-          <styledEl.WarningContent>
-            <h3>Order unlikely to execute</h3>
-            For this order, network fees would be <b>52.11%</b>{' '}
-            <b>
-              <i>(12.34 USDC)</i>
-            </b>{' '}
-            of your sell amount! Therefore, your order is unlikely to execute.
-          </styledEl.WarningContent>
-        }
-        placement="bottom"
-      >
-        <SVG src={AlertTriangle} description="Alert" width="14" height="13" />
-      </MouseoverTooltipContent>
-    </styledEl.WarningIndicator>
-  )
-}
-
-// TODO: temporary component, name and location. If keeping it, move it to its own module, rename, etc, etc
-export const LowVolumeWarningTokenWrapper = styled.span<{ lowVolumeWarning: boolean }>`
-  display: flex;
-  align-items: center;
-  color: ${({ lowVolumeWarning, theme }) =>
-    lowVolumeWarning ? darken(theme.darkMode ? 0 : 0.15, theme.alert) : 'inherit'};
-
-  // Popover container override
-  > div > div {
-    display: flex;
-    align-items: center;
-  }
-`
-
-export function LowVolumeWarningToken(
-  props: TokenAmountProps & { executeIndicator: React.ReactNode; lowVolumeWarning: boolean }
-) {
-  const { lowVolumeWarning, ...rest } = props
-
-  return (
-    <LowVolumeWarningTokenWrapper lowVolumeWarning={lowVolumeWarning}>
-      <MouseoverTooltipContent
-        wrap={true}
-        content={
-          <styledEl.ExecuteInformationTooltip>
-            {/* TODO: Add logic to get the down/up + icon and the values below */}
-            Market price needs to go down/up 📉📈 by
-            <b>17.70 USDC</b>&nbsp;
-            <b>
-              <i>(~1.15%)</i>
-            </b>
-            &nbsp;to execute your order.
-          </styledEl.ExecuteInformationTooltip>
-        }
-        placement="top"
-      >
-        {props.executeIndicator}
-        <TokenAmount {...rest} />
-      </MouseoverTooltipContent>
-
-      {lowVolumeWarning && <LowVolumeWarningContent />}
-    </LowVolumeWarningTokenWrapper>
-  )
 }
 
 const BalanceWarning = (symbol: string) => (
@@ -189,7 +115,7 @@ export function OrderRow({
   const { buyAmount, rateInfoParams, hasEnoughAllowance, hasEnoughBalance, chainId } = orderParams
   const { parsedCreationTime, expirationTime, activityId, formattedPercentage, executedPrice } = order
   const { inputCurrencyAmount, outputCurrencyAmount } = rateInfoParams
-  const { estimatedExecutionPrice } = prices || {}
+  const { estimatedExecutionPrice, feeAmount } = prices || {}
 
   const showCancellationModal = getShowCancellationModal(order)
 
@@ -202,17 +128,17 @@ export function OrderRow({
   // const executedTimeAgo = useTimeAgo(expirationTime, TIME_AGO_UPDATE_INTERVAL)
   const activityUrl = chainId && activityId ? getEtherscanLink(chainId, activityId, 'transaction') : undefined
 
-  const [isInverted, setIsinverted] = useState(isRateInverted)
+  const [isInverted, setIsInverted] = useState(isRateInverted)
 
   // Update internal isInverted flag whenever prop change
   useEffect(() => {
-    setIsinverted(isRateInverted)
+    setIsInverted(isRateInverted)
   }, [isRateInverted])
 
   // On mount, apply smart quote selection
   useEffect(() => {
     const quoteCurrency = getQuoteCurrency(chainId, inputCurrencyAmount, outputCurrencyAmount)
-    setIsinverted(getAddress(quoteCurrency) !== getAddress(inputCurrencyAmount?.currency))
+    setIsInverted(getAddress(quoteCurrency) !== getAddress(inputCurrencyAmount?.currency))
     // Intentionally empty, should run only once
     // eslint-disable-next-line
   }, [])
@@ -221,7 +147,8 @@ export function OrderRow({
   const executedPriceInverted = isInverted ? executedPrice?.invert() : executedPrice
   const spotPriceInverted = isInverted ? spotPrice?.invert() : spotPrice
 
-  const executionOrderStatus = useOrderExecutionStatus(rateInfoParams, prices, spotPrice)
+  const priceDiffs = usePricesDifference(prices, spotPrice, isInverted)
+  const feeDifference = useFeeAmountDifference(rateInfoParams, prices)
 
   return (
     <RowElement isOpenOrdersTab={isOpenOrdersTab}>
@@ -287,13 +214,15 @@ export function OrderRow({
           {/*// TODO: gray out the price when it was updated too long ago*/}
           {prices ? (
             <styledEl.ExecuteCellWrapper>
-              <LowVolumeWarningToken
-                // TODO: Add condition to show the lowVolumeWarning.
-                executeIndicator={<styledEl.ExecuteIndicator status={executionOrderStatus} />}
-                lowVolumeWarning={true}
+              <EstimatedExecutionPrice
                 amount={executionPriceInverted}
                 tokenSymbol={executionPriceInverted?.quoteCurrency}
                 opacitySymbol
+                isInverted={isInverted}
+                percentageDifference={priceDiffs?.percentage}
+                amountDifference={priceDiffs?.amount}
+                percentageFee={feeDifference}
+                amountFee={feeAmount}
               />
             </styledEl.ExecuteCellWrapper>
           ) : prices === null ? (
@@ -364,15 +293,32 @@ export function OrderRow({
   )
 }
 
-function useOrderExecutionStatus(
-  rateInfo: OrderRowProps['orderParams']['rateInfoParams'],
+/**
+ * Helper hook to prepare the parameters to calculate price difference
+ */
+function usePricesDifference(
   prices: OrderRowProps['prices'],
-  spotPrice: OrderRowProps['spotPrice']
-): OrderExecutionStatus | undefined {
-  return useSafeMemo(() => {
-    const limitPrice = buildPriceFromCurrencyAmounts(rateInfo.inputCurrencyAmount, rateInfo.outputCurrencyAmount)
-    const { estimatedExecutionPrice } = prices || {}
+  spotPrice: OrderRowProps['spotPrice'],
+  isInverted: boolean
+): PriceDifference {
+  const { estimatedExecutionPrice } = prices || {}
 
-    return calculateOrderExecutionStatus({ limitPrice, spotPrice, estimatedExecutionPrice })
-  }, [rateInfo.inputCurrencyAmount, rateInfo.outputCurrencyAmount, prices?.estimatedExecutionPrice, spotPrice])
+  return useSafeMemo(() => {
+    return calculatePriceDifference({ reference: estimatedExecutionPrice, delta: spotPrice, isInverted })
+  }, [estimatedExecutionPrice, spotPrice, isInverted])
+}
+
+/**
+ * Helper hook to calculate fee amount percentage
+ */
+function useFeeAmountDifference(
+  { inputCurrencyAmount }: OrderRowProps['orderParams']['rateInfoParams'],
+  prices: OrderRowProps['prices']
+): Percent | undefined {
+  const { feeAmount } = prices || {}
+
+  return useSafeMemo(
+    () => calculateFractionLikePercentDifference({ reference: feeAmount, delta: inputCurrencyAmount }),
+    [feeAmount, inputCurrencyAmount]
+  )
 }

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
@@ -23,7 +23,8 @@ import SVG from 'react-inlinesvg'
 import iconOrderExecution from 'assets/cow-swap/orderExecution.svg'
 import { X } from 'react-feather'
 import { OrderExecutionStatusList } from '@cow/modules/limitOrders/pure/ExecutionPriceTooltip'
-import { getSpotPrice, SpotPrices } from '@cow/modules/orders/state/spotPricesAtom'
+import { SpotPricesKeyParams } from '@cow/modules/orders/state/spotPricesAtom'
+import { Currency, Price } from '@uniswap/sdk-core'
 
 const TableBox = styled.div`
   display: block;
@@ -216,7 +217,7 @@ export interface OrdersTableProps {
   pendingOrdersPrices: PendingOrdersPrices
   orders: ParsedOrder[]
   balancesAndAllowances: BalancesAndAllowances
-  spotPrices: SpotPrices
+  getSpotPrice: (params: SpotPricesKeyParams) => Price<Currency, Currency> | null
   getShowCancellationModal(order: Order): (() => void) | null
 }
 
@@ -226,7 +227,7 @@ export function OrdersTable({
   orders,
   pendingOrdersPrices,
   balancesAndAllowances,
-  spotPrices,
+  getSpotPrice,
   getShowCancellationModal,
   currentPageNumber,
 }: OrdersTableProps) {
@@ -357,14 +358,11 @@ export function OrdersTable({
                 key={order.id}
                 isOpenOrdersTab={isOpenOrdersTab}
                 order={order}
-                spotPrice={getSpotPrice(
-                  {
-                    chainId: chainId as SupportedChainId,
-                    sellTokenAddress: order.sellToken,
-                    buyTokenAddress: order.buyToken,
-                  },
-                  spotPrices
-                )}
+                spotPrice={getSpotPrice({
+                  chainId: chainId as SupportedChainId,
+                  sellTokenAddress: order.sellToken,
+                  buyTokenAddress: order.buyToken,
+                })}
                 prices={pendingOrdersPrices[order.id]}
                 orderParams={getOrderParams(chainId, balancesAndAllowances, order)}
                 RowElement={RowElement}

--- a/src/cow-react/modules/limitOrders/pure/Orders/index.cosmos.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/index.cosmos.tsx
@@ -33,7 +33,7 @@ export default (
     isOpenOrdersTab={true}
     isWalletConnected={true}
     balancesAndAllowances={balancesAndAllowances}
-    spotPrices={{}}
+    getSpotPrice={() => null}
     getShowCancellationModal={(order) => {
       if (order.status === 'pending') {
         return () => alert('cancelling!')

--- a/src/cow-react/modules/limitOrders/pure/Orders/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/index.tsx
@@ -130,7 +130,7 @@ export function Orders({
   getShowCancellationModal,
   currentPageNumber,
   pendingOrdersPrices,
-  spotPrices,
+  getSpotPrice,
   children,
 }: OrdersProps) {
   const content = () => {
@@ -186,7 +186,7 @@ export function Orders({
         chainId={chainId}
         orders={orders}
         balancesAndAllowances={balancesAndAllowances}
-        spotPrices={spotPrices}
+        getSpotPrice={getSpotPrice}
         getShowCancellationModal={getShowCancellationModal}
       />
     )

--- a/src/cow-react/modules/limitOrders/utils/calculateFractionLikePercentDifference.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculateFractionLikePercentDifference.ts
@@ -1,0 +1,26 @@
+import { FractionLike, Nullish } from '@cow/types'
+import { Percent } from '@uniswap/sdk-core'
+
+export type CalculateAmountPercentDifferenceProps = {
+  reference: Nullish<FractionLike>
+  delta: Nullish<FractionLike>
+}
+
+/**
+ * Helper function to calculate and return a Percent instance between 2 FractionLike instances
+ *
+ * @param reference
+ * @param delta
+ */
+export function calculateFractionLikePercentDifference({
+  reference,
+  delta,
+}: CalculateAmountPercentDifferenceProps): Percent | undefined {
+  if (!reference || !delta) {
+    return undefined
+  }
+
+  const percentage = reference.divide(delta)
+
+  return new Percent(percentage.numerator, percentage.denominator)
+}

--- a/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.test.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.test.ts
@@ -2,7 +2,7 @@ import { CurrencyAmount } from '@uniswap/sdk-core'
 import { DAI_GOERLI, USDC_GOERLI } from 'utils/goerli/constants'
 import { rawToTokenAmount } from '@cow/utils/rawToTokenAmount'
 import { buildPriceFromCurrencyAmounts } from '@cow/modules/limitOrders/utils/buildPriceFromCurrencyAmounts'
-import { calculateOrderExecutionStatus, CalculateOrderExecutionStatusParams } from './calculateOrderExecutionStatus'
+import { calculateOrderExecutionStatus, CalculatePriceDifferenceParams } from './calculateOrderExecutionStatus'
 
 const USDC_1000 = CurrencyAmount.fromRawAmount(USDC_GOERLI, rawToTokenAmount(1000, USDC_GOERLI.decimals))
 const DAI_999 = _daiCurrencyAmount(999)
@@ -34,7 +34,7 @@ describe('calculateOrderExecutionStatus', () => {
 
     describe('market price <0.5% from execution price', () => {
       test('positive difference', () => {
-        const params: CalculateOrderExecutionStatusParams = {
+        const params: CalculatePriceDifferenceParams = {
           ...baseParams,
           spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
           estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1001)),
@@ -44,7 +44,7 @@ describe('calculateOrderExecutionStatus', () => {
       })
 
       test('negative difference', () => {
-        const params: CalculateOrderExecutionStatusParams = {
+        const params: CalculatePriceDifferenceParams = {
           ...baseParams,
           limitPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(990)),
           spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
@@ -56,7 +56,7 @@ describe('calculateOrderExecutionStatus', () => {
     })
     describe('market price 0.5-5% from execution price', () => {
       test('0.5% - lower bond', () => {
-        const params: CalculateOrderExecutionStatusParams = {
+        const params: CalculatePriceDifferenceParams = {
           ...baseParams,
           spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
           estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1005)),
@@ -66,7 +66,7 @@ describe('calculateOrderExecutionStatus', () => {
       })
 
       test('2.5% - middle range', () => {
-        const params: CalculateOrderExecutionStatusParams = {
+        const params: CalculatePriceDifferenceParams = {
           ...baseParams,
           spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
           estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1025)),
@@ -76,7 +76,7 @@ describe('calculateOrderExecutionStatus', () => {
       })
 
       test('5% - upper bond', () => {
-        const params: CalculateOrderExecutionStatusParams = {
+        const params: CalculatePriceDifferenceParams = {
           ...baseParams,
           spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
           estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1050)),
@@ -86,7 +86,7 @@ describe('calculateOrderExecutionStatus', () => {
       })
     })
     test('market price >5% from execution price', () => {
-      const params: CalculateOrderExecutionStatusParams = {
+      const params: CalculatePriceDifferenceParams = {
         ...baseParams,
         spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
         estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1051)),

--- a/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.test.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.test.ts
@@ -1,98 +1,41 @@
-import { CurrencyAmount } from '@uniswap/sdk-core'
-import { DAI_GOERLI, USDC_GOERLI } from 'utils/goerli/constants'
-import { rawToTokenAmount } from '@cow/utils/rawToTokenAmount'
-import { buildPriceFromCurrencyAmounts } from '@cow/modules/limitOrders/utils/buildPriceFromCurrencyAmounts'
-import { calculateOrderExecutionStatus, CalculatePriceDifferenceParams } from './calculateOrderExecutionStatus'
-
-const USDC_1000 = CurrencyAmount.fromRawAmount(USDC_GOERLI, rawToTokenAmount(1000, USDC_GOERLI.decimals))
-const DAI_999 = _daiCurrencyAmount(999)
-const DAI_1000 = _daiCurrencyAmount(1000)
-
-/**
- * Dumb helper just to make it clearer to create DAI CurrencyAmount instances
- */
-function _daiCurrencyAmount(amount: number) {
-  return CurrencyAmount.fromRawAmount(DAI_GOERLI, rawToTokenAmount(amount, DAI_GOERLI.decimals))
-}
+import { Percent } from '@uniswap/sdk-core'
+import { calculateOrderExecutionStatus } from './calculateOrderExecutionStatus'
 
 describe('calculateOrderExecutionStatus', () => {
   it('returns `undefined` when any parameter is missing', () => {
-    expect(
-      calculateOrderExecutionStatus({
-        limitPrice: null,
-        spotPrice: null,
-        estimatedExecutionPrice: null,
-      })
-    ).toBe(undefined)
+    expect(calculateOrderExecutionStatus(undefined)).toBe(undefined)
   })
 
-  describe('limit price below market price', () => {
-    // Limit price will never be above estimated execution price
-    const baseParams = {
-      limitPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_999),
-    }
-
-    describe('market price <0.5% from execution price', () => {
-      test('positive difference', () => {
-        const params: CalculatePriceDifferenceParams = {
-          ...baseParams,
-          spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1001)),
-        }
-
-        expect(calculateOrderExecutionStatus(params)).toBe('veryClose')
-      })
-
-      test('negative difference', () => {
-        const params: CalculatePriceDifferenceParams = {
-          ...baseParams,
-          limitPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(990)),
-          spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_999),
-        }
-
-        expect(calculateOrderExecutionStatus(params)).toBe('veryClose')
-      })
+  describe('veryClose', () => {
+    test('-1%', () => {
+      expect(calculateOrderExecutionStatus(new Percent(-1, 100))).toBe('veryClose')
     })
-    describe('market price 0.5-5% from execution price', () => {
-      test('0.5% - lower bond', () => {
-        const params: CalculatePriceDifferenceParams = {
-          ...baseParams,
-          spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1005)),
-        }
-
-        expect(calculateOrderExecutionStatus(params)).toBe('close')
-      })
-
-      test('2.5% - middle range', () => {
-        const params: CalculatePriceDifferenceParams = {
-          ...baseParams,
-          spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1025)),
-        }
-
-        expect(calculateOrderExecutionStatus(params)).toBe('close')
-      })
-
-      test('5% - upper bond', () => {
-        const params: CalculatePriceDifferenceParams = {
-          ...baseParams,
-          spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1050)),
-        }
-
-        expect(calculateOrderExecutionStatus(params)).toBe('close')
-      })
+    test('0.1%', () => {
+      expect(calculateOrderExecutionStatus(new Percent(1, 1_000))).toBe('veryClose')
     })
-    test('market price >5% from execution price', () => {
-      const params: CalculatePriceDifferenceParams = {
-        ...baseParams,
-        spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-        estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1051)),
-      }
+    test('0.49%', () => {
+      expect(calculateOrderExecutionStatus(new Percent(49, 100_000))).toBe('veryClose')
+    })
+  })
 
-      expect(calculateOrderExecutionStatus(params)).toBe('notClose')
+  describe('close', () => {
+    test('0.5%', () => {
+      expect(calculateOrderExecutionStatus(new Percent(5, 1_000))).toBe('close')
+    })
+    test('1%', () => {
+      expect(calculateOrderExecutionStatus(new Percent(1, 100))).toBe('close')
+    })
+    test('5%', () => {
+      expect(calculateOrderExecutionStatus(new Percent(5, 100))).toBe('close')
+    })
+  })
+
+  describe('notClose', () => {
+    test('5.01%', () => {
+      expect(calculateOrderExecutionStatus(new Percent(501, 10_000))).toBe('notClose')
+    })
+    test('10%', () => {
+      expect(calculateOrderExecutionStatus(new Percent(1, 10))).toBe('notClose')
     })
   })
 })

--- a/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.ts
@@ -10,6 +10,13 @@ export function calculateOrderExecutionStatus(difference: Percent | undefined): 
     return undefined
   }
 
+  console.log(
+    'diff',
+    difference.toFixed(2),
+    LOWER_PERCENTAGE_DIFFERENCE.toFixed(2),
+    UPPER_PERCENTAGE_DIFFERENCE.toFixed(2)
+  )
+
   if (difference.lessThan(LOWER_PERCENTAGE_DIFFERENCE)) {
     return 'veryClose'
   } else if (difference.greaterThan(UPPER_PERCENTAGE_DIFFERENCE)) {

--- a/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.ts
@@ -1,43 +1,18 @@
-import { Currency, Fraction, Percent, Price } from '@uniswap/sdk-core'
-import { Nullish } from '@cow/types'
+import { Percent } from '@uniswap/sdk-core'
 
-const HALF_PERCENT = new Percent(5, 1000)
-const FIVE_PERCENT = new Percent(5, 100)
-const ONE = new Fraction(1)
+const LOWER_PERCENTAGE_DIFFERENCE = new Percent(5, 1000) // 0.5%
+const UPPER_PERCENTAGE_DIFFERENCE = new Percent(5, 100) // 5%
 
 export type OrderExecutionStatus = 'notClose' | 'close' | 'veryClose'
 
-export type CalculateOrderExecutionStatusParams = {
-  limitPrice: Nullish<Price<Currency, Currency>>
-  spotPrice: Nullish<Price<Currency, Currency>>
-  estimatedExecutionPrice: Nullish<Price<Currency, Currency>>
-}
-
-export function calculateOrderExecutionStatus({
-  limitPrice,
-  spotPrice,
-  estimatedExecutionPrice,
-}: CalculateOrderExecutionStatusParams): OrderExecutionStatus | undefined {
-  if (!limitPrice || !spotPrice || !estimatedExecutionPrice) {
+export function calculateOrderExecutionStatus(difference: Percent | undefined): OrderExecutionStatus | undefined {
+  if (!difference) {
     return undefined
   }
 
-  const percentageDifference = estimatedExecutionPrice.divide(spotPrice).subtract(ONE)
-
-  // TODO: remove debug logs
-  console.debug(`calculateOrderExecutionStatus`, {
-    pair: `${spotPrice.quoteCurrency.symbol}/${spotPrice.baseCurrency.symbol}`,
-    limitPrice: `${limitPrice.toFixed(7)} ${limitPrice.baseCurrency.symbol} per ${limitPrice.quoteCurrency.symbol}`,
-    marketPrice: `${spotPrice.toFixed(7)} ${spotPrice.baseCurrency.symbol} per ${spotPrice.quoteCurrency.symbol}`,
-    executionPrice: `${estimatedExecutionPrice.toFixed(7)} ${estimatedExecutionPrice.baseCurrency.symbol} per ${
-      estimatedExecutionPrice.quoteCurrency.symbol
-    }`,
-    percentageDifference: percentageDifference.multiply(new Fraction(100)).toFixed(2) + '%',
-  })
-
-  if (percentageDifference.lessThan(HALF_PERCENT)) {
+  if (difference.lessThan(LOWER_PERCENTAGE_DIFFERENCE)) {
     return 'veryClose'
-  } else if (percentageDifference.greaterThan(FIVE_PERCENT)) {
+  } else if (difference.greaterThan(UPPER_PERCENTAGE_DIFFERENCE)) {
     return 'notClose'
   } else {
     return 'close'

--- a/src/cow-react/modules/limitOrders/utils/calculatePriceDifference.test.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculatePriceDifference.test.ts
@@ -1,0 +1,208 @@
+import { Currency, Price } from '@uniswap/sdk-core'
+import { DAI_GOERLI, USDC_GOERLI } from 'utils/goerli/constants'
+import { calculatePriceDifference, CalculatePriceDifferenceParams } from './calculatePriceDifference'
+import tryParseCurrencyAmount from '../../../../custom/lib/utils/tryParseCurrencyAmount'
+import { buildPriceFromCurrencyAmounts } from './buildPriceFromCurrencyAmounts'
+import { FractionUtils } from '../../../utils/fractionUtils'
+import { ZERO_FRACTION } from '../../../../custom/constants'
+
+function buildPrice(daiAmount: string, usdcAmount: string): Price<Currency, Currency> {
+  const quoteAmount = tryParseCurrencyAmount(daiAmount, DAI_GOERLI)
+  const baseAmount = tryParseCurrencyAmount(usdcAmount, USDC_GOERLI)
+
+  return buildPriceFromCurrencyAmounts(baseAmount, quoteAmount)
+}
+
+describe('Not enough parameters (returns null)', () => {
+  it('returns `null` when referencePrice is missing', () => {
+    expect(
+      calculatePriceDifference({
+        referencePrice: undefined,
+        targetPrice: buildPrice('1', '1'),
+        isInverted: false,
+      })
+    ).toBe(null)
+  })
+  it('returns `null` when referencePrice is null', () => {
+    expect(
+      calculatePriceDifference({
+        referencePrice: null,
+        targetPrice: buildPrice('1', '1'),
+        isInverted: false,
+      })
+    ).toBe(null)
+  })
+
+  it('returns `null` when targetPrice is null', () => {
+    expect(
+      calculatePriceDifference({
+        referencePrice: buildPrice('1', '1'),
+        targetPrice: null,
+        isInverted: false,
+      })
+    ).toBe(null)
+  })
+})
+
+describe('Prices are Negative or Zero', () => {
+  test('Both prices are Zero, return null', () => {
+    const params: CalculatePriceDifferenceParams = {
+      referencePrice: buildPrice('0', '1'),
+      targetPrice: buildPrice('0', '1'),
+      isInverted: false,
+    }
+
+    expect(calculatePriceDifference(params)).toBe(null)
+  })
+
+  test('ReferencePrice is Zero, return null', () => {
+    const params: CalculatePriceDifferenceParams = {
+      referencePrice: buildPrice('0', '1'),
+      targetPrice: buildPrice('1', '1'),
+      isInverted: false,
+    }
+
+    expect(calculatePriceDifference(params)).toBe(null)
+  })
+})
+
+describe('Not Inverted Price', () => {
+  const baseParams = {
+    isInverted: false,
+  }
+
+  describe('Prices are equal', () => {
+    test('0% price difference, when both prices are equal', () => {
+      const params: CalculatePriceDifferenceParams = {
+        ...baseParams,
+        referencePrice: buildPrice('1', '1'),
+        targetPrice: buildPrice('1', '1'),
+      }
+
+      const result = calculatePriceDifference(params)
+
+      expect(result?.percentage.toFixed(2)).toBe('0.00')
+      expect(result?.amount.toFixed(2)).toBe('0.00')
+    })
+  })
+
+  describe('Target Price is ABOVE Reference Prices', () => {
+    test('10% price difference', () => {
+      const params: CalculatePriceDifferenceParams = {
+        ...baseParams,
+        targetPrice: buildPrice('11', '10'), // 1.1
+        referencePrice: buildPrice('1', '1'), // 1
+      }
+
+      const result = calculatePriceDifference(params)
+
+      expect(result?.amount.toFixed(10)).toBe('0.1000000000') // 1.1 - 1 = 0.1
+      expect(result?.percentage.toFixed(2)).toBe('10.00') //  0.1 / 1 * 100 = 10
+    })
+
+    test('0.1% price difference', () => {
+      const params: CalculatePriceDifferenceParams = {
+        ...baseParams,
+        targetPrice: buildPrice('1001', '1000'), // 1001/1000 = 1.001
+        referencePrice: buildPrice('1', '1'), // 1
+      }
+
+      const result = calculatePriceDifference(params)
+
+      expect(result?.amount.toFixed(10)).toBe('0.0010000000') // 1.001 - 1
+      expect(result?.percentage.toFixed(2)).toBe('0.10') // (1.001 - 1) / 1 * 100 = 0.1
+    })
+  })
+
+  describe('Target Price is BELOW Reference Prices', () => {
+    test('-10% price difference', () => {
+      const params: CalculatePriceDifferenceParams = {
+        ...baseParams,
+        targetPrice: buildPrice('1', '1'), // 1
+        referencePrice: buildPrice('10', '9'), // 10/9
+      }
+
+      const result = calculatePriceDifference(params)
+
+      expect(result?.amount.toFixed(10)).toBe('-0.1111111111') // 1 - 10/9 = -0.1111111111
+      expect(result?.percentage.toFixed(2)).toBe('-10.00') // (1 - 10/9) / (10/9) * 100 = -10
+    })
+
+    test('-100% price difference (target price is Zero)', () => {
+      const params: CalculatePriceDifferenceParams = {
+        referencePrice: buildPrice('1', '1'),
+        targetPrice: FractionUtils.toPrice(ZERO_FRACTION, USDC_GOERLI, DAI_GOERLI), // zero
+        isInverted: false,
+      }
+
+      const result = calculatePriceDifference(params)
+
+      expect(result?.amount.toFixed(2)).toBe('-1.00')
+      expect(result?.percentage.toFixed(2)).toBe('-100.00')
+    })
+  })
+})
+
+describe('Inverted Price', () => {
+  const baseParams = {
+    isInverted: true,
+  }
+
+  describe('Prices are equal', () => {
+    test('0% price difference, when both prices are equal', () => {
+      const params: CalculatePriceDifferenceParams = {
+        ...baseParams,
+        referencePrice: buildPrice('1', '1'),
+        targetPrice: buildPrice('1', '1'),
+      }
+
+      const result = calculatePriceDifference(params)
+
+      expect(result?.percentage.toFixed(2)).toBe('0.00')
+      expect(result?.amount.toFixed(2)).toBe('0.00')
+    })
+  })
+
+  describe('Target Price is ABOVE Reference Prices (therefore is below)', () => {
+    test('10% price difference', () => {
+      const params: CalculatePriceDifferenceParams = {
+        ...baseParams,
+        targetPrice: buildPrice('10', '11'), // 10/11 ---> 10/11 = 1.1
+        referencePrice: buildPrice('1', '1'), // 1
+      }
+
+      const result = calculatePriceDifference(params)
+
+      expect(result?.amount.toFixed(6)).toBe('0.100000') // 1.1 - 1 = 0.1
+      expect(result?.percentage.toFixed(2)).toBe('10.00') //  0.1 / 1 * 100 = 10
+    })
+
+    test('0.1% price difference', () => {
+      const params: CalculatePriceDifferenceParams = {
+        ...baseParams,
+        targetPrice: buildPrice('1000', '1001'), // 1000/1001  ---> 1001/1000  = 1.001
+        referencePrice: buildPrice('1', '1'), // 1
+      }
+
+      const result = calculatePriceDifference(params)
+
+      expect(result?.amount.toFixed(6)).toBe('0.001000') // 1.001 - 1
+      expect(result?.percentage.toFixed(2)).toBe('0.10') // (1.001 - 1) / 1 * 100 = 0.1
+    })
+  })
+
+  describe('Target Price is BELOW Reference Prices', () => {
+    test('-10% price difference', () => {
+      const params: CalculatePriceDifferenceParams = {
+        ...baseParams,
+        targetPrice: buildPrice('1', '1'), // 1
+        referencePrice: buildPrice('9', '10'), // 9/10 ---> 10/9
+      }
+
+      const result = calculatePriceDifference(params)
+
+      expect(result?.amount.toFixed(6)).toBe('-0.111111') // 1 - 10/9 = -0.111111
+      expect(result?.percentage.toFixed(2)).toBe('-10.00') // (1 - 10/9) / (10/9) * 100 = -10
+    })
+  })
+})

--- a/src/cow-react/modules/limitOrders/utils/calculatePriceDifference.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculatePriceDifference.ts
@@ -51,7 +51,7 @@ export function calculatePriceDifference({
     executionPrice: `${reference.toFixed(7)} ${reference.baseCurrency.symbol} per ${reference.quoteCurrency.symbol}`,
     difference: percentageDifference.toFixed(6),
     percentage: percentage.toFixed(6) + '%',
-    amount: amount?.toFixed(18),
+    amount: amount?.toFixed(amount.currency.decimals),
   })
 
   return { percentage, amount }

--- a/src/cow-react/modules/limitOrders/utils/calculatePriceDifference.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculatePriceDifference.ts
@@ -1,0 +1,58 @@
+import { Currency, CurrencyAmount, Fraction, Percent, Price } from '@uniswap/sdk-core'
+import { Nullish } from '@cow/types'
+import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
+
+const ONE = new Fraction(1)
+
+export type CalculatePriceDifferenceParams = {
+  reference: Nullish<Price<Currency, Currency>>
+  delta: Nullish<Price<Currency, Currency>>
+  isInverted: boolean
+}
+
+export type PriceDifference = {
+  percentage: Percent
+  amount: CurrencyAmount<Currency>
+} | null
+
+/**
+ * Helper function to calculate Percent and amount difference between 2 Price instances
+ *
+ * Amount is the difference between prices in a CurrencyAmount instance.
+ * The quote currency is used in regular cases and base currency when `isInverted` is set
+ *
+ * @param reference
+ * @param delta
+ * @param isInverted
+ */
+export function calculatePriceDifference({
+  reference,
+  delta,
+  isInverted,
+}: CalculatePriceDifferenceParams): PriceDifference {
+  if (!delta || !reference) {
+    return null
+  }
+
+  const percentageDifference = reference.divide(delta).subtract(ONE) // as Fraction
+  const percentage = new Percent(percentageDifference.numerator, percentageDifference.denominator) // as Percent
+
+  // as Fraction
+  const amountDifference = isInverted
+    ? // If it's inverted in the UI, invert here as well to get the amounts in the new quote token
+      reference.invert().subtract(delta.invert())
+    : reference.subtract(delta)
+  const amount = tryParseCurrencyAmount(amountDifference.toFixed(18), delta.quoteCurrency) // as CurrencyAmount
+
+  // TODO: remove debug logs
+  console.debug(`calculatePriceDifference`, {
+    pair: `${delta.quoteCurrency.symbol}/${delta.baseCurrency.symbol}`,
+    marketPrice: `${delta.toFixed(7)} ${delta.baseCurrency.symbol} per ${delta.quoteCurrency.symbol}`,
+    executionPrice: `${reference.toFixed(7)} ${reference.baseCurrency.symbol} per ${reference.quoteCurrency.symbol}`,
+    difference: percentageDifference.toFixed(6),
+    percentage: percentage.toFixed(6) + '%',
+    amount: amount?.toFixed(18),
+  })
+
+  return { percentage, amount }
+}

--- a/src/cow-react/modules/orders/state/pendingOrdersPricesAtom.ts
+++ b/src/cow-react/modules/orders/state/pendingOrdersPricesAtom.ts
@@ -1,10 +1,11 @@
 import { atom } from 'jotai'
-import { Currency, Price } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount, Price } from '@uniswap/sdk-core'
 
 export interface PendingOrderPrices {
   marketPrice: Price<Currency, Currency>
   estimatedExecutionPrice: Price<Currency, Currency>
   lastUpdateTimestamp: number
+  feeAmount: CurrencyAmount<Currency>
 }
 
 // When the price is null, it means that we got error from the quote API

--- a/src/cow-react/modules/orders/state/spotPricesAtom.ts
+++ b/src/cow-react/modules/orders/state/spotPricesAtom.ts
@@ -1,8 +1,9 @@
-import { atom } from 'jotai'
+import { atom, useAtomValue } from 'jotai'
 import { Currency, Price } from '@uniswap/sdk-core'
 
 import { SupportedChainId } from 'constants/chains'
 import { getCanonicalMarketChainKey } from '@cow/common/utils/markets'
+import { useCallback } from 'react'
 
 export type SpotPrices = Record<string, Price<Currency, Currency>>
 
@@ -44,7 +45,7 @@ export const updateSpotPricesAtom = atom(null, (get, set, params: UpdateSpotPric
  * @param params {chainId, sellTokenAddress, buyTokenAddress}
  * @param spotPrices Spot prices map
  */
-export function getSpotPrice(params: SpotPricesKeyParams, spotPrices: SpotPrices): Price<Currency, Currency> | null {
+function getSpotPrice(params: SpotPricesKeyParams, spotPrices: SpotPrices): Price<Currency, Currency> | null {
   const { chainId, sellTokenAddress, buyTokenAddress } = params
   const { marketKey, marketInverted } = getCanonicalMarketChainKey(chainId, sellTokenAddress, buyTokenAddress)
   const spotPrice = spotPrices[marketKey]
@@ -54,4 +55,9 @@ export function getSpotPrice(params: SpotPricesKeyParams, spotPrices: SpotPrices
   }
 
   return marketInverted ? spotPrice.invert() : spotPrice
+}
+
+export function useGetSpotPrice() {
+  const spotPrices = useAtomValue(spotPricesAtom)
+  return useCallback((params: SpotPricesKeyParams) => getSpotPrice(params, spotPrices), [spotPrices])
 }

--- a/src/cow-react/modules/orders/state/spotPricesAtom.ts
+++ b/src/cow-react/modules/orders/state/spotPricesAtom.ts
@@ -2,6 +2,7 @@ import { atom } from 'jotai'
 import { Currency, Price } from '@uniswap/sdk-core'
 
 import { SupportedChainId } from 'constants/chains'
+import { getCanonicalMarketChainKey } from '@cow/common/utils/markets'
 
 export type SpotPrices = Record<string, Price<Currency, Currency>>
 
@@ -20,31 +21,19 @@ export const updateSpotPricesAtom = atom(null, (get, set, params: UpdateSpotPric
   set(spotPricesAtom, () => {
     const { price, ...rest } = params
 
-    const key = buildSpotPricesKey(rest)
     const prevState = get(spotPricesAtom)
+    const previousPrice = getSpotPrice(rest, prevState)
 
-    if (prevState[key]?.equalTo(price)) {
+    if (previousPrice?.equalTo(price)) {
       // Avoid unnecessary updates if price hasn't changed
       return prevState
     }
 
-    return { ...prevState, [key]: price }
+    const { chainId, sellTokenAddress, buyTokenAddress } = rest
+    const { marketKey, marketInverted } = getCanonicalMarketChainKey(chainId, sellTokenAddress, buyTokenAddress)
+    return { ...prevState, [marketKey]: marketInverted ? price.invert() : price }
   })
 })
-
-/**
- * Build Spot Prices Key
- *
- * Helper function to build the key used to store spot prices
- * With this we can make the search faster and keep the structure flat
- *
- * @param params {chainId, sellTokenAddress, buyTokenAddress}
- */
-export function buildSpotPricesKey(params: SpotPricesKeyParams): string {
-  return Object.values(params)
-    .map((v) => String(v).toLowerCase())
-    .join('|')
-}
 
 /**
  * Get Spot Price
@@ -56,7 +45,13 @@ export function buildSpotPricesKey(params: SpotPricesKeyParams): string {
  * @param spotPrices Spot prices map
  */
 export function getSpotPrice(params: SpotPricesKeyParams, spotPrices: SpotPrices): Price<Currency, Currency> | null {
-  const key = buildSpotPricesKey(params)
+  const { chainId, sellTokenAddress, buyTokenAddress } = params
+  const { marketKey, marketInverted } = getCanonicalMarketChainKey(chainId, sellTokenAddress, buyTokenAddress)
+  const spotPrice = spotPrices[marketKey]
 
-  return spotPrices[key] || null
+  if (!spotPrice) {
+    return null
+  }
+
+  return marketInverted ? spotPrice.invert() : spotPrice
 }

--- a/src/cow-react/utils/fractionUtils.ts
+++ b/src/cow-react/utils/fractionUtils.ts
@@ -1,8 +1,9 @@
-import { CurrencyAmount, Fraction, Price, BigintIsh, Rounding } from '@uniswap/sdk-core'
+import { CurrencyAmount, Fraction, Price, BigintIsh, Rounding, Token } from '@uniswap/sdk-core'
 import { FractionLike, Nullish } from '@cow/types'
 import { FULL_PRICE_PRECISION } from 'constants/index'
 import { trimTrailingZeros } from '@cow/utils/trimTrailingZeros'
 import JSBI from 'jsbi'
+import { adjustDecimalsAtoms } from '@cow/modules/limitOrders/utils/calculateAmountForRate'
 
 export class FractionUtils {
   static serializeFractionToJSON(fraction: Nullish<Fraction>): string {
@@ -61,5 +62,15 @@ export class FractionUtils {
 
   static lte(fraction: Fraction, value: BigintIsh): boolean {
     return fraction.equalTo(value) || fraction.lessThan(value)
+  }
+
+  static toPrice(fraction: Fraction, inputCurrency: Token, outputCurrency: Token): Price<Token, Token> {
+    // Note that here the fraction shows the price in units (for both tokens). The Price class is decimals aware, so we need to adapt it
+    const adjustedFraction = adjustDecimalsAtoms(fraction, inputCurrency.decimals, outputCurrency.decimals)
+
+    return new Price({
+      quoteAmount: CurrencyAmount.fromRawAmount(outputCurrency, adjustedFraction.numerator),
+      baseAmount: CurrencyAmount.fromRawAmount(inputCurrency, adjustedFraction.denominator),
+    })
   }
 }

--- a/src/cow-react/utils/rawToTokenAmount.ts
+++ b/src/cow-react/utils/rawToTokenAmount.ts
@@ -1,5 +1,5 @@
 import JSBI from 'jsbi'
 
-export function rawToTokenAmount(value: number, tokenDecimals: number): JSBI {
+export function rawToTokenAmount(value: number | JSBI, tokenDecimals: number): JSBI {
   return JSBI.multiply(JSBI.BigInt(value), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(tokenDecimals)))
 }

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -16,6 +16,7 @@ const EthFlowBarn = ethFlowBarnJson.CoWSwapEthFlow
 const EthFlowProd = ethFlowProdJson.CoWSwapEthFlow
 
 export const ZERO_BIG_NUMBER = new BigNumber(0)
+export const ZERO_FRACTION = new Fraction(0)
 
 export const DEFAULT_SLIPPAGE_BPS = 50 // 0.5%
 export const MAX_SLIPPAGE_BPS = 5000 // 50%

--- a/src/custom/lib/utils/tryParseCurrencyAmount.ts
+++ b/src/custom/lib/utils/tryParseCurrencyAmount.ts
@@ -6,6 +6,12 @@ import JSBI from 'jsbi'
  * Parses a CurrencyAmount from the passed string.
  * Returns the CurrencyAmount, or undefined if parsing fails.
  */
+export default function tryParseCurrencyAmount<T extends Currency>(value: string, currency: T): CurrencyAmount<T>
+export default function tryParseCurrencyAmount<T extends Currency>(
+  value?: string,
+  currency?: T
+): CurrencyAmount<T> | undefined
+
 export default function tryParseCurrencyAmount<T extends Currency>(
   value?: string,
   currency?: T

--- a/src/custom/lib/utils/tryParseCurrencyAmount.ts
+++ b/src/custom/lib/utils/tryParseCurrencyAmount.ts
@@ -11,7 +11,6 @@ export default function tryParseCurrencyAmount<T extends Currency>(
   value?: string,
   currency?: T
 ): CurrencyAmount<T> | undefined
-
 export default function tryParseCurrencyAmount<T extends Currency>(
   value?: string,
   currency?: T

--- a/src/custom/state/orders/updaters/SpotPricesUpdater.ts
+++ b/src/custom/state/orders/updaters/SpotPricesUpdater.ts
@@ -5,7 +5,6 @@ import { Token } from '@uniswap/sdk-core'
 import useIsWindowVisible from 'hooks/useIsWindowVisible'
 import { supportedChainId } from 'utils/supportedChainId'
 import { usePendingOrders } from 'state/orders/hooks'
-import { OrderClass } from 'state/orders/actions'
 import { UpdateSpotPriceAtom, updateSpotPricesAtom } from '@cow/modules/orders/state/spotPricesAtom'
 import { useUpdateAtom } from 'state/application/atoms'
 import { SPOT_PRICE_CHECK_POLL_INTERVAL } from 'state/orders/consts'
@@ -30,7 +29,7 @@ function useMarkets(chainId?: SupportedChainId): MarketRecord {
   return useSafeMemo(() => {
     return pending.reduce<Record<string, { chainId: number; inputCurrency: Token; outputCurrency: Token }>>(
       (acc, order) => {
-        if (chainId && order.class === OrderClass.LIMIT) {
+        if (chainId) {
           // Aggregating pending orders per market. No need to query multiple times same market
           const { marketInverted, marketKey } = getCanonicalMarketChainKey(chainId, order.sellToken, order.buyToken)
 

--- a/src/custom/state/orders/updaters/SpotPricesUpdater.ts
+++ b/src/custom/state/orders/updaters/SpotPricesUpdater.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react'
 import { useWeb3React } from '@web3-react/core'
-import { CurrencyAmount, Price, Token } from '@uniswap/sdk-core'
+import { Token } from '@uniswap/sdk-core'
 
 import useIsWindowVisible from 'hooks/useIsWindowVisible'
 import { supportedChainId } from 'utils/supportedChainId'
@@ -13,6 +13,7 @@ import { requestPrice } from '@cow/modules/limitOrders/hooks/useGetInitialPrice'
 import { useSafeMemo } from '@cow/common/hooks/useSafeMemo'
 import { getCanonicalMarketChainKey } from '@cow/common/utils/markets'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { FractionUtils } from '@cow/utils/fractionUtils'
 
 type MarketRecord = Record<
   string,
@@ -77,10 +78,7 @@ function useUpdatePending(props: UseUpdatePendingProps) {
             return
           }
 
-          const price = new Price({
-            quoteAmount: CurrencyAmount.fromRawAmount(outputCurrency, fraction.numerator),
-            baseAmount: CurrencyAmount.fromRawAmount(inputCurrency, fraction.denominator),
-          })
+          const price = FractionUtils.toPrice(fraction, inputCurrency, outputCurrency)
 
           console.debug(`[SpotPricesUpdater] Got new price for ${key}`, price.toFixed(6))
 

--- a/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -204,9 +204,9 @@ export function UnfillableOrdersUpdater(): null {
             })
 
             console.debug(
-              `[UnfillableOrdersUpdater::updateUnfillable] Failed to get quote on chain ${chainId} for order ${order?.id}`
+              `[UnfillableOrdersUpdater::updateUnfillable] Failed to get quote on chain ${chainId} for order ${order?.id}`,
+              e
             )
-            console.debug(e)
           })
       })
     } finally {

--- a/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -24,7 +24,7 @@ import { WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
 import { PRICE_QUOTE_VALID_TO_TIME } from '@cow/constants/quote'
 import { useUpdateAtom } from 'jotai/utils'
 import { updatePendingOrderPricesAtom } from '@cow/modules/orders/state/pendingOrdersPricesAtom'
-import { Currency, Price } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount, Price } from '@uniswap/sdk-core'
 import { PENDING_ORDERS_PRICE_CHECK_POLL_INTERVAL } from 'state/orders/consts'
 import useIsWindowVisible from 'hooks/useIsWindowVisible'
 
@@ -114,6 +114,7 @@ export function UnfillableOrdersUpdater(): null {
           lastUpdateTimestamp: Date.now(),
           marketPrice,
           estimatedExecutionPrice,
+          feeAmount: CurrencyAmount.fromRawAmount(marketPrice.baseCurrency, fee.amount),
         },
       })
     },


### PR DESCRIPTION
# Summary

Tooltips wired up for `Executes at` column

![image](https://user-images.githubusercontent.com/43217/224326125-cf248658-fec4-4b22-8df6-0cbd7f16a202.png)

Cases:

## Go up
![Screenshot 2023-03-10 at 13 12 40](https://user-images.githubusercontent.com/43217/224324877-7e14803e-3f47-402f-8f50-00e58e404e89.png)
Shown when current display is the regular for the market

## Go down
![image](https://user-images.githubusercontent.com/43217/224324973-64ed8e8e-4cbd-4d56-8412-92f161773abc.png)
Shown when currently display is inverted

## Fee >10% sell amount
![image](https://user-images.githubusercontent.com/43217/224325097-654553d6-6124-4cdb-bfec-75d2c6a012a8.png)

### Special case when this happens but also it's within the execution range
Tooptip will display `Unlikely to execute due to high fee`

## When Estimated execution price < market price 
Tooltip will display `Will execute soon!`

# To Test

1. Play around with different pairs and amounts to trigger the messages above