### PR TITLE
Make deterministic and simplify updater

### DIFF
--- a/src/cow-react/common/utils/markets.ts
+++ b/src/cow-react/common/utils/markets.ts
@@ -1,0 +1,50 @@
+import { SupportedChainId } from 'constants/chains'
+
+/**
+ * Convenient method to identify a market so it doesn't matter what is the sell token or buy token.
+ *
+ * This methods is used internally for example to identify the keys in hash maps caches.
+ * This method has the communitative property, so getCanonicalMarketKey(A, B) = getCanonicalMarketKey(B, A)
+ *
+ * @param tokenAddressA
+ * @param tokenAddressB
+ * @returns A string with the key
+ */
+export function getCanonicalMarketKey(
+  tokenAddressA: string,
+  tokenAddressB: string
+): { marketKey: string; marketInverted: boolean } {
+  const tokenAddressALower = tokenAddressA.toLocaleLowerCase()
+  const tokenAddressBLower = tokenAddressB.toLocaleLowerCase()
+  const marketInverted = tokenAddressALower > tokenAddressBLower
+
+  return {
+    marketKey: marketInverted
+      ? `${tokenAddressBLower}/${tokenAddressALower}`
+      : `${tokenAddressALower}/${tokenAddressBLower}`,
+    marketInverted,
+  }
+}
+
+/**
+ * Convenient method to identify a market so it doesn't matter what is the sell token or buy token.
+ *
+ * This methods is used internally for example to identify the keys in hash maps caches.
+ * This method has the communitative property, so getCanonicalMarketChainKey(chainId, A, B) = getCanonicalMarketChainKey(chainId, B, A)
+ *
+ * @param tokenAddressA
+ * @param tokenAddressB
+ * @returns A string with the key
+ */
+export function getCanonicalMarketChainKey(
+  chainId: SupportedChainId,
+  tokenAddressA: string,
+  tokenAddressB: string
+): { marketKey: string; marketInverted: boolean } {
+  const { marketKey, marketInverted } = getCanonicalMarketKey(tokenAddressA, tokenAddressB)
+
+  return {
+    marketKey: `${chainId}@${marketKey}`,
+    marketInverted,
+  }
+}

--- a/src/cow-react/modules/orders/state/spotPricesAtom.ts
+++ b/src/cow-react/modules/orders/state/spotPricesAtom.ts
@@ -2,6 +2,7 @@ import { atom } from 'jotai'
 import { Currency, Price } from '@uniswap/sdk-core'
 
 import { SupportedChainId } from 'constants/chains'
+import { getCanonicalMarketChainKey } from '@cow/common/utils/markets'
 
 export type SpotPrices = Record<string, Price<Currency, Currency>>
 
@@ -20,31 +21,19 @@ export const updateSpotPricesAtom = atom(null, (get, set, params: UpdateSpotPric
   set(spotPricesAtom, () => {
     const { price, ...rest } = params
 
-    const key = buildSpotPricesKey(rest)
     const prevState = get(spotPricesAtom)
+    const previousPrice = getSpotPrice(rest, prevState)
 
-    if (prevState[key]?.equalTo(price)) {
+    if (previousPrice?.equalTo(price)) {
       // Avoid unnecessary updates if price hasn't changed
       return prevState
     }
 
-    return { ...prevState, [key]: price }
+    const { chainId, sellTokenAddress, buyTokenAddress } = rest
+    const { marketKey, marketInverted } = getCanonicalMarketChainKey(chainId, sellTokenAddress, buyTokenAddress)
+    return { ...prevState, [marketKey]: marketInverted ? price.invert() : price }
   })
 })
-
-/**
- * Build Spot Prices Key
- *
- * Helper function to build the key used to store spot prices
- * With this we can make the search faster and keep the structure flat
- *
- * @param params {chainId, sellTokenAddress, buyTokenAddress}
- */
-export function buildSpotPricesKey(params: SpotPricesKeyParams): string {
-  return Object.values(params)
-    .map((v) => String(v).toLowerCase())
-    .join('|')
-}
 
 /**
  * Get Spot Price
@@ -56,7 +45,13 @@ export function buildSpotPricesKey(params: SpotPricesKeyParams): string {
  * @param spotPrices Spot prices map
  */
 export function getSpotPrice(params: SpotPricesKeyParams, spotPrices: SpotPrices): Price<Currency, Currency> | null {
-  const key = buildSpotPricesKey(params)
+  const { chainId, sellTokenAddress, buyTokenAddress } = params
+  const { marketKey, marketInverted } = getCanonicalMarketChainKey(chainId, sellTokenAddress, buyTokenAddress)
+  const spotPrice = spotPrices[marketKey]
 
-  return spotPrices[key] || null
+  if (!spotPrice) {
+    return null
+  }
+
+  return marketInverted ? spotPrice.invert() : spotPrice
 }


### PR DESCRIPTION
# Summary

This PR tries to make the creation of the keys for the CACHE deterministic. 

For that, I just created some convenient methods (`getCanonicalMarketKey` and `getCanonicalMarketChainKey`) in the `common` module, to create a key for a market with the commutative property. 

It will use lexicografic order to determine the first token. 

It applies this to the Market Price atom logics. So this PR in principle should reuse the price of the inverse markets. 
So if you try to store tokenA/tokenB, and you try to get the price tokenB/tokenA, it will understand that you can use the other price and invert it. 

## Aditionally
It adapts the updater, and simplify it by extracting two custom hooks


# To Test
Make sure i didn't break anything. Probably nice test is to see that if you have in the order list two orders of the same market but the tokens are invested, we can see if we reuse the same market.