### PR TITLE
Simplify getSpotPrice

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/OrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/OrdersWidget/index.tsx
@@ -12,7 +12,7 @@ import { useCancelOrder } from '@cow/common/hooks/useCancelOrder'
 import { useAtomValue } from 'jotai/utils'
 import { pendingOrdersPricesAtom } from '@cow/modules/orders/state/pendingOrdersPricesAtom'
 import { useWalletInfo } from '@cow/modules/wallet'
-import { spotPricesAtom } from '@cow/modules/orders/state/spotPricesAtom'
+import { useGetSpotPrice } from '@cow/modules/orders/state/spotPricesAtom'
 
 function getOrdersListByIndex(ordersList: LimitOrdersList, id: string): ParsedOrder[] {
   return id === OPEN_TAB.id ? ordersList.pending : ordersList.history
@@ -25,7 +25,7 @@ export function OrdersWidget() {
   const { chainId, account } = useWalletInfo()
   const getShowCancellationModal = useCancelOrder()
   const pendingOrdersPrices = useAtomValue(pendingOrdersPricesAtom)
-  const spotPrices = useAtomValue(spotPricesAtom)
+  const getSpotPrice = useGetSpotPrice()
 
   const spender = useMemo(() => (chainId ? GP_VAULT_RELAYER[chainId] : undefined), [chainId])
 
@@ -75,7 +75,7 @@ export function OrdersWidget() {
         balancesAndAllowances={pendingBalancesAndAllowances}
         isWalletConnected={!!account}
         getShowCancellationModal={getShowCancellationModal}
-        spotPrices={spotPrices}
+        getSpotPrice={getSpotPrice}
       ></Orders>
       <OrdersReceiptModal />
     </>

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
@@ -23,7 +23,8 @@ import SVG from 'react-inlinesvg'
 import iconOrderExecution from 'assets/cow-swap/orderExecution.svg'
 import { X } from 'react-feather'
 import { OrderExecutionStatusList } from '@cow/modules/limitOrders/pure/ExecutionPriceTooltip'
-import { getSpotPrice, SpotPrices } from '@cow/modules/orders/state/spotPricesAtom'
+import { SpotPricesKeyParams } from '@cow/modules/orders/state/spotPricesAtom'
+import { Currency, Price } from '@uniswap/sdk-core'
 
 const TableBox = styled.div`
   display: block;
@@ -216,7 +217,7 @@ export interface OrdersTableProps {
   pendingOrdersPrices: PendingOrdersPrices
   orders: ParsedOrder[]
   balancesAndAllowances: BalancesAndAllowances
-  spotPrices: SpotPrices
+  getSpotPrice: (params: SpotPricesKeyParams) => Price<Currency, Currency> | null
   getShowCancellationModal(order: Order): (() => void) | null
 }
 
@@ -226,7 +227,7 @@ export function OrdersTable({
   orders,
   pendingOrdersPrices,
   balancesAndAllowances,
-  spotPrices,
+  getSpotPrice,
   getShowCancellationModal,
   currentPageNumber,
 }: OrdersTableProps) {
@@ -357,14 +358,11 @@ export function OrdersTable({
                 key={order.id}
                 isOpenOrdersTab={isOpenOrdersTab}
                 order={order}
-                spotPrice={getSpotPrice(
-                  {
-                    chainId: chainId as SupportedChainId,
-                    sellTokenAddress: order.sellToken,
-                    buyTokenAddress: order.buyToken,
-                  },
-                  spotPrices
-                )}
+                spotPrice={getSpotPrice({
+                  chainId: chainId as SupportedChainId,
+                  sellTokenAddress: order.sellToken,
+                  buyTokenAddress: order.buyToken,
+                })}
                 prices={pendingOrdersPrices[order.id]}
                 orderParams={getOrderParams(chainId, balancesAndAllowances, order)}
                 RowElement={RowElement}

--- a/src/cow-react/modules/limitOrders/pure/Orders/index.cosmos.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/index.cosmos.tsx
@@ -33,7 +33,7 @@ export default (
     isOpenOrdersTab={true}
     isWalletConnected={true}
     balancesAndAllowances={balancesAndAllowances}
-    spotPrices={{}}
+    getSpotPrice={() => null}
     getShowCancellationModal={(order) => {
       if (order.status === 'pending') {
         return () => alert('cancelling!')

--- a/src/cow-react/modules/limitOrders/pure/Orders/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/index.tsx
@@ -130,7 +130,7 @@ export function Orders({
   getShowCancellationModal,
   currentPageNumber,
   pendingOrdersPrices,
-  spotPrices,
+  getSpotPrice,
   children,
 }: OrdersProps) {
   const content = () => {
@@ -186,7 +186,7 @@ export function Orders({
         chainId={chainId}
         orders={orders}
         balancesAndAllowances={balancesAndAllowances}
-        spotPrices={spotPrices}
+        getSpotPrice={getSpotPrice}
         getShowCancellationModal={getShowCancellationModal}
       />
     )

--- a/src/cow-react/modules/orders/state/spotPricesAtom.ts
+++ b/src/cow-react/modules/orders/state/spotPricesAtom.ts
@@ -1,8 +1,9 @@
-import { atom } from 'jotai'
+import { atom, useAtomValue } from 'jotai'
 import { Currency, Price } from '@uniswap/sdk-core'
 
 import { SupportedChainId } from 'constants/chains'
 import { getCanonicalMarketChainKey } from '@cow/common/utils/markets'
+import { useCallback } from 'react'
 
 export type SpotPrices = Record<string, Price<Currency, Currency>>
 
@@ -44,7 +45,7 @@ export const updateSpotPricesAtom = atom(null, (get, set, params: UpdateSpotPric
  * @param params {chainId, sellTokenAddress, buyTokenAddress}
  * @param spotPrices Spot prices map
  */
-export function getSpotPrice(params: SpotPricesKeyParams, spotPrices: SpotPrices): Price<Currency, Currency> | null {
+function getSpotPrice(params: SpotPricesKeyParams, spotPrices: SpotPrices): Price<Currency, Currency> | null {
   const { chainId, sellTokenAddress, buyTokenAddress } = params
   const { marketKey, marketInverted } = getCanonicalMarketChainKey(chainId, sellTokenAddress, buyTokenAddress)
   const spotPrice = spotPrices[marketKey]
@@ -54,4 +55,9 @@ export function getSpotPrice(params: SpotPricesKeyParams, spotPrices: SpotPrices
   }
 
   return marketInverted ? spotPrice.invert() : spotPrice
+}
+
+export function useGetSpotPrice() {
+  const spotPrices = useAtomValue(spotPricesAtom)
+  return useCallback((params: SpotPricesKeyParams) => getSpotPrice(params, spotPrices), [spotPrices])
 }


### PR DESCRIPTION
# Summary

This PR simplifies the dumb component so it doesn't need to have all the market prices. 
The components receive a "dumb function" that let the component get the market price. 

Creates a new hook next to the atoms which would expose the function to get the market price given a market. This time, it won't need to be provided with all the list of markets.

# To Test
Nothing should have changed