### PR TITLE
Fix market price decimals

### DIFF
--- a/src/cow-react/utils/fractionUtils.ts
+++ b/src/cow-react/utils/fractionUtils.ts
@@ -63,14 +63,14 @@ export class FractionUtils {
   static lte(fraction: Fraction, value: BigintIsh): boolean {
     return fraction.equalTo(value) || fraction.lessThan(value)
   }
-}
 
-export function fractionToPrice(fraction: Fraction, inputCurrency: Token, outputCurrency: Token): Price<Token, Token> {
-  // Note that here the fraction shows the price in units (for both tokens). The Price class is decimals aware, so we need to adapt it
-  const adjustedFraction = adjustDecimalsAtoms(fraction, inputCurrency.decimals, outputCurrency.decimals)
+  static toPrice(fraction: Fraction, inputCurrency: Token, outputCurrency: Token): Price<Token, Token> {
+    // Note that here the fraction shows the price in units (for both tokens). The Price class is decimals aware, so we need to adapt it
+    const adjustedFraction = adjustDecimalsAtoms(fraction, inputCurrency.decimals, outputCurrency.decimals)
 
-  return new Price({
-    quoteAmount: CurrencyAmount.fromRawAmount(outputCurrency, adjustedFraction.numerator),
-    baseAmount: CurrencyAmount.fromRawAmount(inputCurrency, adjustedFraction.denominator),
-  })
+    return new Price({
+      quoteAmount: CurrencyAmount.fromRawAmount(outputCurrency, adjustedFraction.numerator),
+      baseAmount: CurrencyAmount.fromRawAmount(inputCurrency, adjustedFraction.denominator),
+    })
+  }
 }

--- a/src/custom/state/orders/priceUtils.ts
+++ b/src/custom/state/orders/priceUtils.ts
@@ -2,6 +2,8 @@
 
 import { DEFAULT_DECIMALS } from 'constants/index'
 import { BigNumber } from 'bignumber.js'
+import { CurrencyAmount, Fraction, Price, Token } from '@uniswap/sdk-core'
+import { adjustDecimalsAtoms } from '@cow/modules/limitOrders/utils/calculateAmountForRate'
 
 interface PriceTokenInfo {
   amount: BigNumber | string
@@ -52,4 +54,14 @@ export function calculatePrice(params: CalculatePriceParams): BigNumber {
  */
 export function invertPrice(price: BigNumber): BigNumber {
   return ONE_BIG_NUMBER.div(price)
+}
+
+export function fractionToPrice(fraction: Fraction, inputCurrency: Token, outputCurrency: Token): Price<Token, Token> {
+  // Note that here the fraction shows the price in units (for both tokens). The Price class is decimals aware, so we need to adapt it
+  const adjustedFraction = adjustDecimalsAtoms(fraction, inputCurrency.decimals, outputCurrency.decimals)
+
+  return new Price({
+    quoteAmount: CurrencyAmount.fromRawAmount(outputCurrency, adjustedFraction.numerator),
+    baseAmount: CurrencyAmount.fromRawAmount(inputCurrency, adjustedFraction.denominator),
+  })
 }

--- a/src/custom/state/orders/priceUtils.ts
+++ b/src/custom/state/orders/priceUtils.ts
@@ -2,8 +2,6 @@
 
 import { DEFAULT_DECIMALS } from 'constants/index'
 import { BigNumber } from 'bignumber.js'
-import { CurrencyAmount, Fraction, Price, Token } from '@uniswap/sdk-core'
-import { adjustDecimalsAtoms } from '@cow/modules/limitOrders/utils/calculateAmountForRate'
 
 interface PriceTokenInfo {
   amount: BigNumber | string
@@ -54,14 +52,4 @@ export function calculatePrice(params: CalculatePriceParams): BigNumber {
  */
 export function invertPrice(price: BigNumber): BigNumber {
   return ONE_BIG_NUMBER.div(price)
-}
-
-export function fractionToPrice(fraction: Fraction, inputCurrency: Token, outputCurrency: Token): Price<Token, Token> {
-  // Note that here the fraction shows the price in units (for both tokens). The Price class is decimals aware, so we need to adapt it
-  const adjustedFraction = adjustDecimalsAtoms(fraction, inputCurrency.decimals, outputCurrency.decimals)
-
-  return new Price({
-    quoteAmount: CurrencyAmount.fromRawAmount(outputCurrency, adjustedFraction.numerator),
-    baseAmount: CurrencyAmount.fromRawAmount(inputCurrency, adjustedFraction.denominator),
-  })
 }

--- a/src/custom/state/orders/updaters/SpotPricesUpdater.ts
+++ b/src/custom/state/orders/updaters/SpotPricesUpdater.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react'
 import { useWeb3React } from '@web3-react/core'
-import { CurrencyAmount, Price, Token } from '@uniswap/sdk-core'
+import { Token } from '@uniswap/sdk-core'
 
 import useIsWindowVisible from 'hooks/useIsWindowVisible'
 import { supportedChainId } from 'utils/supportedChainId'
@@ -13,6 +13,7 @@ import { requestPrice } from '@cow/modules/limitOrders/hooks/useGetInitialPrice'
 import { useSafeMemo } from '@cow/common/hooks/useSafeMemo'
 import { getCanonicalMarketChainKey } from '@cow/common/utils/markets'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { fractionToPrice } from '../priceUtils'
 
 type MarketRecord = Record<
   string,
@@ -77,12 +78,10 @@ function useUpdatePending(props: UseUpdatePendingProps) {
             return
           }
 
-          const price = new Price({
-            quoteAmount: CurrencyAmount.fromRawAmount(outputCurrency, fraction.numerator),
-            baseAmount: CurrencyAmount.fromRawAmount(inputCurrency, fraction.denominator),
-          })
+          const price = fractionToPrice(fraction, inputCurrency, outputCurrency)
 
           console.debug(`[SpotPricesUpdater] Got new price for ${key}`, price.toFixed(6))
+          console.debug(`[SpotPricesUpdater] currencies`, { inputCurrency, outputCurrency })
 
           updateSpotPrices({
             chainId,

--- a/src/custom/state/orders/updaters/SpotPricesUpdater.ts
+++ b/src/custom/state/orders/updaters/SpotPricesUpdater.ts
@@ -13,7 +13,7 @@ import { requestPrice } from '@cow/modules/limitOrders/hooks/useGetInitialPrice'
 import { useSafeMemo } from '@cow/common/hooks/useSafeMemo'
 import { getCanonicalMarketChainKey } from '@cow/common/utils/markets'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { fractionToPrice } from '../priceUtils'
+import { fractionToPrice } from '@cow/utils/fractionUtils'
 
 type MarketRecord = Record<
   string,
@@ -81,7 +81,6 @@ function useUpdatePending(props: UseUpdatePendingProps) {
           const price = fractionToPrice(fraction, inputCurrency, outputCurrency)
 
           console.debug(`[SpotPricesUpdater] Got new price for ${key}`, price.toFixed(6))
-          console.debug(`[SpotPricesUpdater] currencies`, { inputCurrency, outputCurrency })
 
           updateSpotPrices({
             chainId,

--- a/src/custom/state/orders/updaters/SpotPricesUpdater.ts
+++ b/src/custom/state/orders/updaters/SpotPricesUpdater.ts
@@ -13,7 +13,7 @@ import { requestPrice } from '@cow/modules/limitOrders/hooks/useGetInitialPrice'
 import { useSafeMemo } from '@cow/common/hooks/useSafeMemo'
 import { getCanonicalMarketChainKey } from '@cow/common/utils/markets'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { fractionToPrice } from '@cow/utils/fractionUtils'
+import { FractionUtils } from '@cow/utils/fractionUtils'
 
 type MarketRecord = Record<
   string,
@@ -78,7 +78,7 @@ function useUpdatePending(props: UseUpdatePendingProps) {
             return
           }
 
-          const price = fractionToPrice(fraction, inputCurrency, outputCurrency)
+          const price = FractionUtils.toPrice(fraction, inputCurrency, outputCurrency)
 
           console.debug(`[SpotPricesUpdater] Got new price for ${key}`, price.toFixed(6))
 


### PR DESCRIPTION
# Summary

This PR fixes the issue with the decimals in the market price

The issue was because, the API returns the price in units (natural to the user). For example, 1.1/1 for USDC-DAI price
However, Uniswap SDK needs in the `Price` class we are using to be aware of the decimals. And they understand the ratio is in atoms, not in units.

For solving it, i created a convenient util, and reused some similar logic we were using for adapting Fractions.


Before:

![image](https://user-images.githubusercontent.com/2352112/224371149-783354a2-3471-4ca2-9c64-3667c65cc586.png)

After (pls ignore the light theme change 😂, just the numbers):

<img width="616" alt="image" src="https://user-images.githubusercontent.com/2352112/224371322-05177f1d-00dc-43e5-b7e7-aedc8f4434d4.png">


# To Test
Trade DAI to USDC and check the issue is solved