### PR TITLE
Fix calculate difference

### DIFF
--- a/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.test.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.test.ts
@@ -1,98 +1,41 @@
-import { CurrencyAmount } from '@uniswap/sdk-core'
-import { DAI_GOERLI, USDC_GOERLI } from 'utils/goerli/constants'
-import { rawToTokenAmount } from '@cow/utils/rawToTokenAmount'
-import { buildPriceFromCurrencyAmounts } from '@cow/modules/limitOrders/utils/buildPriceFromCurrencyAmounts'
-import { calculateOrderExecutionStatus, CalculatePriceDifferenceParams } from './calculateOrderExecutionStatus'
-
-const USDC_1000 = CurrencyAmount.fromRawAmount(USDC_GOERLI, rawToTokenAmount(1000, USDC_GOERLI.decimals))
-const DAI_999 = _daiCurrencyAmount(999)
-const DAI_1000 = _daiCurrencyAmount(1000)
-
-/**
- * Dumb helper just to make it clearer to create DAI CurrencyAmount instances
- */
-function _daiCurrencyAmount(amount: number) {
-  return CurrencyAmount.fromRawAmount(DAI_GOERLI, rawToTokenAmount(amount, DAI_GOERLI.decimals))
-}
+import { Percent } from '@uniswap/sdk-core'
+import { calculateOrderExecutionStatus } from './calculateOrderExecutionStatus'
 
 describe('calculateOrderExecutionStatus', () => {
   it('returns `undefined` when any parameter is missing', () => {
-    expect(
-      calculateOrderExecutionStatus({
-        limitPrice: null,
-        spotPrice: null,
-        estimatedExecutionPrice: null,
-      })
-    ).toBe(undefined)
+    expect(calculateOrderExecutionStatus(undefined)).toBe(undefined)
   })
 
-  describe('limit price below market price', () => {
-    // Limit price will never be above estimated execution price
-    const baseParams = {
-      limitPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_999),
-    }
-
-    describe('market price <0.5% from execution price', () => {
-      test('positive difference', () => {
-        const params: CalculatePriceDifferenceParams = {
-          ...baseParams,
-          spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1001)),
-        }
-
-        expect(calculateOrderExecutionStatus(params)).toBe('veryClose')
-      })
-
-      test('negative difference', () => {
-        const params: CalculatePriceDifferenceParams = {
-          ...baseParams,
-          limitPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(990)),
-          spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_999),
-        }
-
-        expect(calculateOrderExecutionStatus(params)).toBe('veryClose')
-      })
+  describe('veryClose', () => {
+    test('-1%', () => {
+      expect(calculateOrderExecutionStatus(new Percent(-1, 100))).toBe('veryClose')
     })
-    describe('market price 0.5-5% from execution price', () => {
-      test('0.5% - lower bond', () => {
-        const params: CalculatePriceDifferenceParams = {
-          ...baseParams,
-          spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1005)),
-        }
-
-        expect(calculateOrderExecutionStatus(params)).toBe('close')
-      })
-
-      test('2.5% - middle range', () => {
-        const params: CalculatePriceDifferenceParams = {
-          ...baseParams,
-          spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1025)),
-        }
-
-        expect(calculateOrderExecutionStatus(params)).toBe('close')
-      })
-
-      test('5% - upper bond', () => {
-        const params: CalculatePriceDifferenceParams = {
-          ...baseParams,
-          spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-          estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1050)),
-        }
-
-        expect(calculateOrderExecutionStatus(params)).toBe('close')
-      })
+    test('0.1%', () => {
+      expect(calculateOrderExecutionStatus(new Percent(1, 1_000))).toBe('veryClose')
     })
-    test('market price >5% from execution price', () => {
-      const params: CalculatePriceDifferenceParams = {
-        ...baseParams,
-        spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
-        estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1051)),
-      }
+    test('0.49%', () => {
+      expect(calculateOrderExecutionStatus(new Percent(49, 100_000))).toBe('veryClose')
+    })
+  })
 
-      expect(calculateOrderExecutionStatus(params)).toBe('notClose')
+  describe('close', () => {
+    test('0.5%', () => {
+      expect(calculateOrderExecutionStatus(new Percent(5, 1_000))).toBe('close')
+    })
+    test('1%', () => {
+      expect(calculateOrderExecutionStatus(new Percent(1, 100))).toBe('close')
+    })
+    test('5%', () => {
+      expect(calculateOrderExecutionStatus(new Percent(5, 100))).toBe('close')
+    })
+  })
+
+  describe('notClose', () => {
+    test('5.01%', () => {
+      expect(calculateOrderExecutionStatus(new Percent(501, 10_000))).toBe('notClose')
+    })
+    test('10%', () => {
+      expect(calculateOrderExecutionStatus(new Percent(1, 10))).toBe('notClose')
     })
   })
 })

--- a/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculateOrderExecutionStatus.ts
@@ -10,6 +10,13 @@ export function calculateOrderExecutionStatus(difference: Percent | undefined): 
     return undefined
   }
 
+  console.log(
+    'diff',
+    difference.toFixed(2),
+    LOWER_PERCENTAGE_DIFFERENCE.toFixed(2),
+    UPPER_PERCENTAGE_DIFFERENCE.toFixed(2)
+  )
+
   if (difference.lessThan(LOWER_PERCENTAGE_DIFFERENCE)) {
     return 'veryClose'
   } else if (difference.greaterThan(UPPER_PERCENTAGE_DIFFERENCE)) {

--- a/src/cow-react/modules/limitOrders/utils/calculatePriceDifference.test.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculatePriceDifference.test.ts
@@ -1,0 +1,167 @@
+import { Currency, Percent, Price } from '@uniswap/sdk-core'
+// import { DAI_GOERLI, USDC_GOERLI } from 'utils/goerli/constants'
+import { buildPriceFromCurrencyAmounts } from '@cow/modules/limitOrders/utils/buildPriceFromCurrencyAmounts'
+import { calculatePriceDifference, CalculatePriceDifferenceParams } from './calculatePriceDifference'
+import tryParseCurrencyAmount from '../../../../custom/lib/utils/tryParseCurrencyAmount'
+import { DAI_GOERLI, USDC_GOERLI } from '../../../../custom/utils/goerli/constants'
+
+// const USDC_1000 = tryParseCurrencyAmount('1000', USDC_GOERLI)
+// const DAI_999 = _daiCurrencyAmount('999')
+// const DAI_1000 = _daiCurrencyAmount('1000')
+
+/**
+ * Dumb helper just to make it clearer to create DAI CurrencyAmount instances
+ */
+function _daiCurrencyAmount(amount: string) {
+  return tryParseCurrencyAmount(amount, DAI_GOERLI)
+}
+
+function buildPrice(usdcAmount: string, daiAmount: string): Price<Currency, Currency> {
+  const baseAmount = tryParseCurrencyAmount(usdcAmount, USDC_GOERLI)
+  const quoteAmount = tryParseCurrencyAmount(daiAmount, DAI_GOERLI)
+  return buildPriceFromCurrencyAmounts(baseAmount, quoteAmount)
+}
+
+describe('calculatePriceDifference', () => {
+  it('returns `null` when any parameter is missing', () => {
+    expect(
+      calculatePriceDifference({
+        reference: null,
+        delta: null,
+        isInverted: false,
+      })
+    ).toBe(null)
+  })
+
+  describe('regular', () => {
+    const baseParams = {
+      isInverted: false,
+    }
+
+    test('0 difference', () => {
+      const params: CalculatePriceDifferenceParams = {
+        ...baseParams,
+        reference: buildPrice('1', '1'),
+        delta: buildPrice('1', '1'),
+      }
+
+      const result = calculatePriceDifference(params)
+
+      expect(result?.percentage.toFixed(2)).toBe('0.00')
+      expect(result?.amount.toFixed(2)).toBe('0.00')
+    })
+
+    test('10% price diff, 0.1 amount diff', () => {
+      const params: CalculatePriceDifferenceParams = {
+        ...baseParams,
+        reference: buildPrice('10', '11'),
+        delta: buildPrice('1', '1'),
+      }
+
+      const result = calculatePriceDifference(params)
+
+      expect(result?.percentage.toFixed(2)).toBe('10.00')
+      expect(result?.amount.toFixed(10)).toBe('0.1000000000')
+    })
+
+    test('-10% price diff, -0.1111111111 amount diff', () => {
+      const params: CalculatePriceDifferenceParams = {
+        ...baseParams,
+        reference: buildPrice('1', '1'),
+        delta: buildPrice('9', '10'),
+      }
+
+      const result = calculatePriceDifference(params)
+
+      expect(result?.percentage.toFixed(2)).toBe('-10.00')
+      expect(result?.amount.toFixed(10)).toBe('-0.1111111111')
+    })
+
+    test('0.1% price diff, ?? amount diff', () => {
+      const params: CalculatePriceDifferenceParams = {
+        ...baseParams,
+        reference: buildPrice('1000', '1001'),
+        delta: buildPrice('9', '10'),
+      }
+
+      const result = calculatePriceDifference(params)
+
+      expect(result?.percentage.toFixed(2)).toBe('-10.00')
+      expect(result?.amount.toFixed(10)).toBe('-0.1111111111')
+    })
+  })
+})
+
+// describe('calculateOrderExecutionStatus', () => {
+//   it("returns 'veryClose' when negative")
+//
+//   describe('limit price below market price', () => {
+//     // Limit price will never be above estimated execution price
+//     const baseParams = {
+//       limitPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_999),
+//     }
+//
+//     describe('market price <0.5% from execution price', () => {
+//       test('positive difference', () => {
+//         const params: CalculatePriceDifferenceParams = {
+//           ...baseParams,
+//           spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
+//           estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1001)),
+//         }
+//
+//         expect(calculateOrderExecutionStatus(params)).toBe('veryClose')
+//       })
+//
+//       test('negative difference', () => {
+//         const params: CalculatePriceDifferenceParams = {
+//           ...baseParams,
+//           limitPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(990)),
+//           spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
+//           estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_999),
+//         }
+//
+//         expect(calculateOrderExecutionStatus(params)).toBe('veryClose')
+//       })
+//     })
+//     describe('market price 0.5-5% from execution price', () => {
+//       test('0.5% - lower bond', () => {
+//         const params: CalculatePriceDifferenceParams = {
+//           ...baseParams,
+//           spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
+//           estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1005)),
+//         }
+//
+//         expect(calculateOrderExecutionStatus(params)).toBe('close')
+//       })
+//
+//       test('2.5% - middle range', () => {
+//         const params: CalculatePriceDifferenceParams = {
+//           ...baseParams,
+//           spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
+//           estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1025)),
+//         }
+//
+//         expect(calculateOrderExecutionStatus(params)).toBe('close')
+//       })
+//
+//       test('5% - upper bond', () => {
+//         const params: CalculatePriceDifferenceParams = {
+//           ...baseParams,
+//           spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
+//           estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1050)),
+//         }
+//
+//         expect(calculateOrderExecutionStatus(params)).toBe('close')
+//       })
+//     })
+//     test('market price >5% from execution price', () => {
+//       const params: CalculatePriceDifferenceParams = {
+//         ...baseParams,
+//         spotPrice: buildPriceFromCurrencyAmounts(USDC_1000, DAI_1000),
+//         estimatedExecutionPrice: buildPriceFromCurrencyAmounts(USDC_1000, _daiCurrencyAmount(1051)),
+//       }
+//
+//       expect(calculateOrderExecutionStatus(params)).toBe('notClose')
+//     })
+//   })
+// })

--- a/src/cow-react/modules/limitOrders/utils/calculatePriceDifference.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculatePriceDifference.ts
@@ -1,6 +1,8 @@
 import { Currency, CurrencyAmount, Fraction, Percent, Price } from '@uniswap/sdk-core'
 import { Nullish } from '@cow/types'
-import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
+import { rawToTokenAmount } from '@cow/utils/rawToTokenAmount'
+import tryParseCurrencyAmount from '@src/custom/lib/utils/tryParseCurrencyAmount'
+import { FractionUtils } from '@cow/utils/fractionUtils'
 
 const ONE = new Fraction(1)
 
@@ -37,12 +39,30 @@ export function calculatePriceDifference({
   const percentageDifference = reference.divide(delta).subtract(ONE) // as Fraction
   const percentage = new Percent(percentageDifference.numerator, percentageDifference.denominator) // as Percent
 
-  // as Fraction
-  const amountDifference = isInverted
-    ? // If it's inverted in the UI, invert here as well to get the amounts in the new quote token
-      reference.invert().subtract(delta.invert())
-    : reference.subtract(delta)
-  const amount = tryParseCurrencyAmount(amountDifference.toFixed(18), delta.quoteCurrency) // as CurrencyAmount
+  let amount
+  // TODO: fix this mess
+  // Why is this a mess? Long story...
+  // Prices are just fancy fractions with reference to base and quote tokens
+  // doing subtraction or addition on them won't work as you expect when decimals are different
+  // Only way (that I could figure out so far) to get the raw price value without decimals
+  // is to get their string representation
+  // With that, I then convert them to numbers to get the actual price difference
+  // Then convert them to a fancy CurrencyAmount instance again
+  // But, if the amount is 0, tryParseCurrencyAmount returns undefined...
+  // So in that case I create a instance using 0
+  if (isInverted) {
+    const r = +FractionUtils.fractionLikeToExactString(reference.invert())
+    const d = +FractionUtils.fractionLikeToExactString(delta.invert())
+    const a = String(r - d)
+    amount =
+      tryParseCurrencyAmount(a, reference.baseCurrency) || CurrencyAmount.fromRawAmount(reference.baseCurrency, '0')
+  } else {
+    const r = +FractionUtils.fractionLikeToExactString(reference)
+    const d = +FractionUtils.fractionLikeToExactString(delta)
+    const a = String(r - d)
+    amount =
+      tryParseCurrencyAmount(a, reference.quoteCurrency) || CurrencyAmount.fromRawAmount(reference.quoteCurrency, '0')
+  }
 
   // TODO: remove debug logs
   console.debug(`calculatePriceDifference`, {
@@ -51,6 +71,10 @@ export function calculatePriceDifference({
     executionPrice: `${reference.toFixed(7)} ${reference.baseCurrency.symbol} per ${reference.quoteCurrency.symbol}`,
     difference: percentageDifference.toFixed(6),
     percentage: percentage.toFixed(6) + '%',
+    regularDiff: reference.scalar.subtract(delta.scalar).toSignificant(5),
+    invertedDiff: reference.invert().scalar.subtract(delta.invert().scalar).toSignificant(5),
+    referenceScalar: reference.scalar.toSignificant(5),
+    deltaScalar: delta.scalar.toSignificant(5),
     amount: amount?.toFixed(amount.currency.decimals),
   })
 

--- a/src/cow-react/modules/limitOrders/utils/calculatePriceDifference.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculatePriceDifference.ts
@@ -1,6 +1,5 @@
 import { Currency, CurrencyAmount, Fraction, Percent, Price } from '@uniswap/sdk-core'
 import { Nullish } from '@cow/types'
-import { rawToTokenAmount } from '@cow/utils/rawToTokenAmount'
 import tryParseCurrencyAmount from '@src/custom/lib/utils/tryParseCurrencyAmount'
 import { FractionUtils } from '@cow/utils/fractionUtils'
 

--- a/src/cow-react/utils/rawToTokenAmount.ts
+++ b/src/cow-react/utils/rawToTokenAmount.ts
@@ -1,5 +1,5 @@
 import JSBI from 'jsbi'
 
-export function rawToTokenAmount(value: number, tokenDecimals: number): JSBI {
+export function rawToTokenAmount(value: number | JSBI, tokenDecimals: number): JSBI {
   return JSBI.multiply(JSBI.BigInt(value), JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(tokenDecimals)))
 }

--- a/src/custom/lib/utils/tryParseCurrencyAmount.ts
+++ b/src/custom/lib/utils/tryParseCurrencyAmount.ts
@@ -11,7 +11,6 @@ export default function tryParseCurrencyAmount<T extends Currency>(
   value?: string,
   currency?: T
 ): CurrencyAmount<T> | undefined
-
 export default function tryParseCurrencyAmount<T extends Currency>(
   value?: string,
   currency?: T


### PR DESCRIPTION
# Summary

This PRs fixes a few issues in the calculation of the price differences

## It adds new tests, and make them green ✅
<img width="944" alt="Screenshot at Mar 11 13-04-05" src="https://user-images.githubusercontent.com/2352112/224486265-d0e728fb-e4e4-4201-b703-e039e93d58b6.png">

## Fixes the calculation
It takes into account if the price is inverted or not.

## Additional checks in the function
- Makes sure the prices are positive, otherwise return null
- Throws error if you compare apples with oranges (prices should be in the same market)
- Makes sure the reference price is not zero
- Takes into account that the target price can go to zero (is only the reference one that must be non-zero)

## Changes a bit the naming convention
Reference, is the price you want to compare with (as a base price) --> Spot Price in this case
Target, is the price you want to compare ---> Your est. execution price

I had to re-arrange also some places where the numerator/denominator was not correct

## Not included
Any test related to the status. I left you original comments. I think we should make a new test file for them (not in the same one)

## Widget details
I fixed some things in the widget, so it would work with the inverted prices, also I made the % green (I've seen is common), but I guess we will need to improve a bit the logic for all the cases. 

I would encourage to do this in Cosmos, so we make sure we have all the cases handled. 

# To Test
Run test, check the widget, invert the prices