### PR TITLE
Fix/update text for gas free transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 CoW Swap is the first trading interface built on top of CoW Protocol.
 
-It allows you to buy and sell tokens using gas-less orders that are settled peer-to-peer among its users or into any on-chain liquidity source while providing MEV protection.
+It allows you to buy and sell tokens using gasless orders that are settled peer-to-peer among its users or into any on-chain liquidity source while providing MEV protection.
 
 - 🐮**Official Website**🐮: <https://swap.cow.fi/>
 

--- a/src/cow-react/pages/About/index.tsx
+++ b/src/cow-react/pages/About/index.tsx
@@ -59,9 +59,9 @@ export default function About() {
             This economic phenomenon is known as <b>Coincidence Of Wants (CoW)</b>.
           </p>
 
-          <h3 id="gas-free">Gas Free Transactions</h3>
+          <h3 id="gasless">Gasless Transactions</h3>
           <p>
-            <img src={gaslessIMG} alt="CoW Swap - Gas Free Transactions" />
+            <img src={gaslessIMG} alt="CoW Swap - Gasless Transactions" />
           </p>
           <p>
             Gas costs are accounted for in your sell token already - no gas costs need to be paid! CoW Swap uses an

--- a/src/cow-react/pages/About/index.tsx
+++ b/src/cow-react/pages/About/index.tsx
@@ -40,7 +40,7 @@ export default function About() {
         <Content>
           <p>CoW Swap is the first trading interface built on top of CoW Protocol.</p>
           <p>
-            It allows you to buy and sell tokens using gas-less orders that are settled peer-to-peer among its users or
+            It allows you to buy and sell tokens using gasless orders that are settled peer-to-peer among its users or
             into any on-chain liquidity source while providing MEV protection.
           </p>
           <h2>

--- a/src/cow-react/pages/Faq/TradingFaq.tsx
+++ b/src/cow-react/pages/Faq/TradingFaq.tsx
@@ -50,10 +50,10 @@ export default function TokenFaq() {
               trader.
             </p>
 
-            <h3 id="why-is-cowswap-able-to-offer-gas-free-trades">Why is CoW Swap able to offer gas-free trades?</h3>
+            <h3 id="why-is-cowswap-able-to-offer-gasless-trades">Why is CoW Swap able to offer gasless trades?</h3>
 
             <p>
-              CoW Swap is able to offer gas-free trades because the orders are submitted off-chain via signed messages.
+              CoW Swap is able to offer gasless trades because the orders are submitted off-chain via signed messages.
               Once you approve your funds for spending on the dapp, you can submit orders via signed messages that
               contain the trade’s details, such as limit price, amount, timestamp, and so on.
             </p>
@@ -71,7 +71,7 @@ export default function TokenFaq() {
               <small>
                 * In the near future, if you are trying to sell an ERC20 that allows offline approvals, then the ETH
                 needed to pay for allowing your funds to be spent is not needed anymore, making the trading experience
-                fully gas-free. Keep in mind that this is only possible with ERC20 tokens that have such functionality;
+                fully gasless. Keep in mind that this is only possible with ERC20 tokens that have such functionality;
                 if not, you will need ETH to execute the approval transaction only.
               </small>
             </p>


### PR DESCRIPTION
# Summary

Updates gas free with gasless across the swap codebase.
<img width="652" alt="Screenshot 2023-03-20 at 15 56 34" src="https://user-images.githubusercontent.com/5172699/226380407-601eb3c7-7003-40e6-8e20-81a3ee3e36a3.png">
<img width="645" alt="Screenshot 2023-03-20 at 15 56 57" src="https://user-images.githubusercontent.com/5172699/226380414-ce859f0d-b0cf-4dae-8bfa-2c37b02c0c4d.png">
<img width="678" alt="Screenshot 2023-03-20 at 15 57 12" src="https://user-images.githubusercontent.com/5172699/226380418-789aaafe-012c-4ff4-9fad-93858fa61492.png">
<img width="673" alt="Screenshot 2023-03-20 at 16 03 02" src="https://user-images.githubusercontent.com/5172699/226381327-173cdd3a-5d9d-4cbe-90f6-2ddd5ca16bc2.png">


  # To Test

For the following pages, you should see gasless instead of gas free as the term being used;
* About
* FAQ > General
* FAQ > Trading

In addition, README file should read with gasless instead of gas free.

  # Background

Alex Vinyas has reported that we should be updating gas free to gasless as that would be a better description of what we are doing. More information can be found at: https://cowservices.slack.com/archives/C0361CDG8GP/p1678729116551859