### PR TITLE
Feature/limit UI - Small sell amount/high fee warning on limit orders widget

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
@@ -114,7 +114,7 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
             of your sell amount! Therefore, your order is unlikely to execute.
             <br />
             {/* TODO: add link to somewhere */}
-            <a href="/">Learn more</a>
+            {/*<a href="/">Learn more ↗</a>*/}
           </span>
         </styledEl.SmallVolumeWarningBanner>
       )}

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
@@ -16,9 +16,18 @@ import styled from 'styled-components/macro'
 import { LimitOrdersFormState, useLimitOrdersFormState } from '@cow/modules/limitOrders/hooks/useLimitOrdersFormState'
 import { isFractionFalsy } from '@cow/utils/isFractionFalsy'
 import { useWalletInfo } from '@cow/modules/wallet'
+import * as styledEl from '@cow/modules/limitOrders/containers/LimitOrdersWidget/styled'
+import AlertTriangle from 'assets/cow-swap/alert.svg'
+import SVG from 'react-inlinesvg'
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
+import { calculateFractionLikePercentDifference } from '@cow/modules/limitOrders/utils/calculateFractionLikePercentDifference'
+import { Nullish } from '@cow/types'
+import { HIGH_FEE_WARNING_PERCENTAGE } from '@cow/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice'
+import { TokenAmount } from '@cow/common/pure/TokenAmount'
 
 export interface LimitOrdersWarningsProps {
   priceImpact: PriceImpact
+  feeAmount?: Nullish<CurrencyAmount<Currency>>
   isConfirmScreen?: boolean
   className?: string
 }
@@ -31,7 +40,7 @@ const StyledRateImpactWarning = styled(RateImpactWarning)`
 `
 
 export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
-  const { priceImpact, isConfirmScreen = false, className } = props
+  const { priceImpact, feeAmount, isConfirmScreen = false, className } = props
 
   const { isPriceImpactAccepted, isRateImpactAccepted } = useAtomValue(limitOrdersWarningsAtom)
   const updateLimitOrdersWarnings = useSetAtom(updateLimitOrdersWarningsAtom)
@@ -45,14 +54,18 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
   const showPriceImpactWarning =
     !!chainId && !expertMode && !!account && !!priceImpact.error && formState === LimitOrdersFormState.CanTrade
 
-  const isVisible = showPriceImpactWarning || rateImpact < 0
+  const feePercentage = calculateFractionLikePercentDifference({ reference: feeAmount, delta: inputCurrencyAmount })
+
+  const showHighFeeWarning = feePercentage?.greaterThan(HIGH_FEE_WARNING_PERCENTAGE)
+
+  const isVisible = showPriceImpactWarning || rateImpact < 0 || showHighFeeWarning
 
   // Reset price impact flag when there is no price impact
   useEffect(() => {
     updateLimitOrdersWarnings({ isPriceImpactAccepted: !showPriceImpactWarning })
   }, [showPriceImpactWarning, updateLimitOrdersWarnings])
 
-  // Reset rate impact before openning confirmation screen
+  // Reset rate impact before opening confirmation screen
   useEffect(() => {
     if (isConfirmScreen) {
       updateLimitOrdersWarnings({ isRateImpactAccepted: false })
@@ -87,6 +100,23 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
           inputCurrency={inputCurrency}
           onAcknowledgeChange={onAcceptRateImpact}
         />
+      )}
+
+      {showHighFeeWarning && (
+        <styledEl.SmallVolumeWarningBanner>
+          <SVG src={AlertTriangle} description="Alert" />
+          <span>
+            Small orders are unlikely to be executed. For this order, network fees would be{' '}
+            <b>
+              {feePercentage?.toFixed(2)}% (
+              <TokenAmount amount={feeAmount} tokenSymbol={feeAmount?.currency} />)
+            </b>{' '}
+            of your sell amount! Therefore, your order is unlikely to execute.
+            <br />
+            {/* TODO: add link to somewhere */}
+            <a href="/">Learn more</a>
+          </span>
+        </styledEl.SmallVolumeWarningBanner>
       )}
     </div>
   ) : null

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
@@ -20,7 +20,7 @@ import * as styledEl from '@cow/modules/limitOrders/containers/LimitOrdersWidget
 import AlertTriangle from 'assets/cow-swap/alert.svg'
 import SVG from 'react-inlinesvg'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
-import { calculateFractionLikePercentDifference } from '@cow/modules/limitOrders/utils/calculateFractionLikePercentDifference'
+import { calculatePercentageInRelationToReference } from '@cow/modules/limitOrders/utils/calculatePercentageInRelationToReference'
 import { Nullish } from '@cow/types'
 import { HIGH_FEE_WARNING_PERCENTAGE } from '@cow/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice'
 import { TokenAmount } from '@cow/common/pure/TokenAmount'
@@ -54,7 +54,7 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
   const showPriceImpactWarning =
     !!chainId && !expertMode && !!account && !!priceImpact.error && formState === LimitOrdersFormState.CanTrade
 
-  const feePercentage = calculateFractionLikePercentDifference({ reference: feeAmount, delta: inputCurrencyAmount })
+  const feePercentage = calculatePercentageInRelationToReference({ value: feeAmount, reference: inputCurrencyAmount })
 
   const showHighFeeWarning = feePercentage?.greaterThan(HIGH_FEE_WARNING_PERCENTAGE)
 

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -43,8 +43,6 @@ import { FractionUtils } from '@cow/utils/fractionUtils'
 import { useSetupLimitOrderAmountsFromUrl } from '@cow/modules/limitOrders/hooks/useSetupLimitOrderAmountsFromUrl'
 import AffiliateStatusCheck from 'components/AffiliateStatusCheck'
 import { formatInputAmount } from '@cow/utils/amountFormat'
-import AlertTriangle from 'assets/cow-swap/alert.svg'
-import SVG from 'react-inlinesvg'
 import { InfoBanner } from '@cow/modules/limitOrders/pure/InfoBanner'
 
 export function LimitOrdersWidget() {
@@ -76,7 +74,7 @@ export function LimitOrdersWidget() {
   const tradeContext = useTradeFlowContext()
   const state = useAtomValue(limitOrdersAtom)
   const updateLimitOrdersState = useUpdateAtom(updateLimitOrdersAtom)
-  const { isLoading: isRateLoading, activeRate } = useAtomValue(limitRateAtom)
+  const { isLoading: isRateLoading, activeRate, feeAmount } = useAtomValue(limitRateAtom)
   const rateInfoParams = useRateInfoParams(inputCurrencyAmount, outputCurrencyAmount)
   const { isWrapOrUnwrap } = useDetectNativeToken()
 
@@ -175,6 +173,7 @@ export function LimitOrdersWidget() {
     rateInfoParams,
     priceImpact,
     tradeContext,
+    feeAmount,
   }
 
   return <LimitOrders {...props} />
@@ -199,6 +198,7 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
     rateInfoParams,
     priceImpact,
     tradeContext,
+    feeAmount,
   } = props
 
   const inputCurrency = inputCurrencyInfo.currency
@@ -294,15 +294,7 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
                 </styledEl.FooterBox>
               )}
 
-              {/* TODO: Move this component inside LimitOrdersWarnings */}
-              <styledEl.SmallVolumeWarningBanner>
-                <SVG src={AlertTriangle} description="Alert" />
-                <span>
-                  Small orders are unlikely to be executed. Try to increase your sell amount for better results.
-                </span>
-              </styledEl.SmallVolumeWarningBanner>
-
-              <LimitOrdersWarnings priceImpact={priceImpact} />
+              <LimitOrdersWarnings priceImpact={priceImpact} feeAmount={feeAmount} />
 
               <styledEl.TradeButtonBox>
                 <TradeButtons

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/limitOrdersPropsChecker.ts
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/limitOrdersPropsChecker.ts
@@ -9,6 +9,7 @@ import { TradeFlowContext } from '@cow/modules/limitOrders/services/tradeFlow'
 import { areFractionsEqual } from '@cow/utils/areFractionsEqual'
 import { genericPropsChecker } from '@cow/utils/genericPropsChecker'
 import { getAddress } from '@cow/utils/getAddress'
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
 export interface LimitOrdersProps extends AddRecipientProps {
   inputCurrencyInfo: CurrencyInfo
@@ -31,6 +32,7 @@ export interface LimitOrdersProps extends AddRecipientProps {
   rateInfoParams: RateInfoParams
   priceImpact: PriceImpact
   tradeContext: TradeFlowContext | null
+  feeAmount: CurrencyAmount<Currency> | null
 }
 
 export function limitOrdersPropsChecker(a: LimitOrdersProps, b: LimitOrdersProps): boolean {
@@ -50,8 +52,15 @@ export function limitOrdersPropsChecker(a: LimitOrdersProps, b: LimitOrdersProps
     a.onImportDismiss === b.onImportDismiss &&
     checkRateInfoParams(a.rateInfoParams, b.rateInfoParams) &&
     checkPriceImpact(a.priceImpact, b.priceImpact) &&
-    checkTradeFlowContext(a.tradeContext, b.tradeContext)
+    checkTradeFlowContext(a.tradeContext, b.tradeContext) &&
+    checkCurrencyAmount(a.feeAmount, b.feeAmount)
   )
+}
+
+function checkCurrencyAmount(a: CurrencyAmount<Currency> | null, b: CurrencyAmount<Currency> | null): boolean {
+  if (!a || !b) return a === b
+
+  return a.currency.equals(b.currency) && a.equalTo(b)
 }
 
 function checkCurrencyInfo(a: CurrencyInfo, b: CurrencyInfo): boolean {

--- a/src/cow-react/modules/limitOrders/containers/TradeButtons/limitOrdersTradeButtonsMap.tsx
+++ b/src/cow-react/modules/limitOrders/containers/TradeButtons/limitOrdersTradeButtonsMap.tsx
@@ -119,6 +119,10 @@ export const limitOrdersTradeButtonsMap: { [key in LimitOrdersFormState]: Button
     disabled: true,
     text: 'Invalid price. Try increasing input/output amount.',
   },
+  [LimitOrdersFormState.FeeExceedsFrom]: {
+    disabled: true,
+    text: 'Sell amount is too small',
+  },
   [LimitOrdersFormState.QuoteError]: ({ quote }: TradeButtonsParams) => {
     return (
       <SwapButton disabled={true}>

--- a/src/cow-react/modules/limitOrders/hooks/useLimitOrdersFormState.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useLimitOrdersFormState.ts
@@ -31,6 +31,7 @@ export enum LimitOrdersFormState {
   CantLoadBalances = 'CantLoadBalances',
   QuoteError = 'QuoteError',
   ZeroPrice = 'ZeroPrice',
+  FeeExceedsFrom = 'FeeExceedsFrom',
 }
 
 interface LimitOrdersFormParams {
@@ -73,6 +74,10 @@ function getLimitOrdersFormState(params: LimitOrdersFormParams): LimitOrdersForm
 
   const inputAmountIsNotSet = !inputCurrencyAmount || inputCurrencyAmount.equalTo(0)
   const outputAmountIsNotSet = !outputCurrencyAmount || outputCurrencyAmount.equalTo(0)
+  const feeAmount =
+    quote?.response?.quote?.feeAmount && sellAmount
+      ? CurrencyAmount.fromRawAmount(sellAmount.currency, quote?.response?.quote?.feeAmount)
+      : null
 
   if (quote?.error) {
     return LimitOrdersFormState.QuoteError
@@ -141,6 +146,10 @@ function getLimitOrdersFormState(params: LimitOrdersFormParams): LimitOrdersForm
     (!buyAmount?.equalTo(0) && buyAmount?.toExact() === '0')
   ) {
     return LimitOrdersFormState.ZeroPrice
+  }
+
+  if (sellAmount && feeAmount?.greaterThan(sellAmount)) {
+    return LimitOrdersFormState.FeeExceedsFrom
   }
 
   return LimitOrdersFormState.CanTrade

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
@@ -13,7 +13,7 @@ import * as styledEl from './styled'
 import { ZERO_FRACTION } from '@src/custom/constants'
 
 const MINUS_ONE_FRACTION = new Fraction(-1)
-const TEN_PERCENT = new Percent(1, 10)
+export const HIGH_FEE_WARNING_PERCENTAGE = new Percent(1, 10)
 
 export const EstimatedExecutionPriceWrapper = styled.span<{ hasWarning: boolean }>`
   display: flex;
@@ -76,7 +76,7 @@ export function EstimatedExecutionPrice(props: EstimatedExecutionPriceProps) {
     ? amountDifference.multiply(MINUS_ONE_FRACTION)
     : amountDifference
   const orderExecutionStatus = calculateOrderExecutionStatus(percentageDifferenceInverted)
-  const feeWarning = canShowWarning && percentageFee?.greaterThan(TEN_PERCENT)
+  const feeWarning = canShowWarning && percentageFee?.greaterThan(HIGH_FEE_WARNING_PERCENTAGE)
   const isNegativeDifference = percentageDifferenceInverted?.lessThan(ZERO_FRACTION)
   const marketPriceNeedsToGoDown = isInverted ? !isNegativeDifference : isNegativeDifference
 

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -23,7 +23,7 @@ import { useSafeMemo } from '@cow/common/hooks/useSafeMemo'
 import { getQuoteCurrency } from '@cow/common/services/getQuoteCurrency'
 import { getAddress } from '@cow/utils/getAddress'
 import { calculatePriceDifference, PriceDifference } from '@cow/modules/limitOrders/utils/calculatePriceDifference'
-import { calculateFractionLikePercentDifference } from '@cow/modules/limitOrders/utils/calculateFractionLikePercentDifference'
+import { calculatePercentageInRelationToReference } from '@cow/modules/limitOrders/utils/calculatePercentageInRelationToReference'
 import { EstimatedExecutionPrice } from '@cow/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice'
 
 export const orderStatusTitleMap: { [key in OrderStatus]: string } = {
@@ -317,7 +317,7 @@ function useFeeAmountDifference(
   const { feeAmount } = prices || {}
 
   return useSafeMemo(
-    () => calculateFractionLikePercentDifference({ reference: feeAmount, delta: inputCurrencyAmount }),
+    () => calculatePercentageInRelationToReference({ value: feeAmount, reference: inputCurrencyAmount }),
     [feeAmount, inputCurrencyAmount]
   )
 }

--- a/src/cow-react/modules/limitOrders/utils/calculatePercentageInRelationToReference.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculatePercentageInRelationToReference.ts
@@ -3,24 +3,33 @@ import { Percent } from '@uniswap/sdk-core'
 
 export type CalculateAmountPercentDifferenceProps = {
   reference: Nullish<FractionLike>
-  delta: Nullish<FractionLike>
+  value: Nullish<FractionLike>
 }
 
 /**
  * Helper function to calculate and return a Percent instance between 2 FractionLike instances
  *
+ * It follows the formula: percentage = value*100/reference
+ *
+ * Example:
+ * Sell amount is 100 - this is the `reference`
+ * Fee amount is 5 - this is the `value`
+ * The `percentage` is how much the `value` is compared to `reference`
+ * percentage = 5*100/100 => 5%
+ *
+ *
  * @param reference
- * @param delta
+ * @param value
  */
-export function calculateFractionLikePercentDifference({
+export function calculatePercentageInRelationToReference({
   reference,
-  delta,
+  value,
 }: CalculateAmountPercentDifferenceProps): Percent | undefined {
-  if (!reference || !delta) {
+  if (!value || !reference) {
     return undefined
   }
 
-  const percentage = reference.divide(delta)
+  const percentage = value.divide(reference)
 
   return new Percent(percentage.numerator, percentage.denominator)
 }


### PR DESCRIPTION
# Summary

Implements the fee warning banner on limit orders widget

![image](https://user-images.githubusercontent.com/43217/226702343-db4b1d2b-8f25-4f04-9782-8dc5eb60eab9.png)

Currently displayed when current estimated fee > 10% of selected sell amount

# To Test

1. On limit orders page, select a pair
2. Pick a small sell amount (you might need to adjust for the network conditions)
* The warning will be shown when current fee is > 10% of selected sell amount