### PR TITLE
Inverting all prices on order row when any price is clicked

### DIFF
--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -131,7 +131,7 @@ export function OrderRow({
   const [isInverted, setIsInverted] = useState(() => {
     // On mount, apply smart quote selection
     const quoteCurrency = getQuoteCurrency(chainId, inputCurrencyAmount, outputCurrencyAmount)
-    return getAddress(quoteCurrency) !== getAddress(inputCurrencyAmount?.currency)
+    return getAddress(quoteCurrency) === getAddress(inputCurrencyAmount?.currency)
   })
   const onPriceClick = useCallback(() => setIsInverted((curr) => !curr), [])
 

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -133,12 +133,12 @@ export function OrderRow({
     const quoteCurrency = getQuoteCurrency(chainId, inputCurrencyAmount, outputCurrencyAmount)
     return getAddress(quoteCurrency) === getAddress(inputCurrencyAmount?.currency)
   })
-  const onPriceClick = useCallback(() => setIsInverted((curr) => !curr), [])
+  const toggleIsInverted = useCallback(() => setIsInverted((curr) => !curr), [])
 
   // Toggle isInverted whenever isGloballyInverted changes
   useEffect(() => {
-    setIsInverted((curr) => !curr)
-  }, [isGloballyInverted])
+    toggleIsInverted()
+  }, [isGloballyInverted, toggleIsInverted])
 
   const executionPriceInverted = isInverted ? estimatedExecutionPrice?.invert() : estimatedExecutionPrice
   const executedPriceInverted = isInverted ? executedPrice?.invert() : executedPrice
@@ -179,7 +179,7 @@ export function OrderRow({
       {/* Market price */}
       {/* {isOpenOrdersTab && limitOrdersFeatures.DISPLAY_EST_EXECUTION_PRICE && ( */}
       {isOpenOrdersTab && (
-        <styledEl.CellElement onClick={onPriceClick}>
+        <styledEl.CellElement onClick={toggleIsInverted}>
           {/*// TODO: gray out the price when it was updated too long ago*/}
           {spotPrice ? (
             <TokenAmount amount={spotPriceInverted} tokenSymbol={spotPriceInverted?.quoteCurrency} opacitySymbol />
@@ -193,7 +193,7 @@ export function OrderRow({
 
       {/* Execution price */}
       {!isOpenOrdersTab && (
-        <styledEl.CellElement onClick={onPriceClick}>
+        <styledEl.CellElement onClick={toggleIsInverted}>
           {executedPriceInverted ? (
             <TokenAmount
               amount={executedPriceInverted}
@@ -208,7 +208,7 @@ export function OrderRow({
 
       {/* Executes at */}
       {isOpenOrdersTab && (
-        <styledEl.CellElement hasBackground onClick={onPriceClick}>
+        <styledEl.CellElement hasBackground onClick={toggleIsInverted}>
           {/*// TODO: gray out the price when it was updated too long ago*/}
           {prices ? (
             <styledEl.ExecuteCellWrapper>

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react'
+import { useCallback, useContext, useEffect, useState } from 'react'
 import { DefaultTheme, StyledComponent, ThemeContext } from 'styled-components/macro'
 import { OrderClass, OrderStatus } from 'state/orders/actions'
 import { Currency, CurrencyAmount, Percent, Price } from '@uniswap/sdk-core'
@@ -129,6 +129,7 @@ export function OrderRow({
   const activityUrl = chainId && activityId ? getEtherscanLink(chainId, activityId, 'transaction') : undefined
 
   const [isInverted, setIsInverted] = useState(isRateInverted)
+  const onPriceClick = useCallback(() => setIsInverted((curr) => !curr), [])
 
   // Update internal isInverted flag whenever prop change
   useEffect(() => {
@@ -169,6 +170,7 @@ export function OrderRow({
         <styledEl.RateValue>
           <RateInfo
             prependSymbol={false}
+            isInvertedState={[isInverted, setIsInverted]}
             noLabel={true}
             doNotUseSmartQuote
             isInverted={isInverted}
@@ -181,7 +183,7 @@ export function OrderRow({
       {/* Market price */}
       {/* {isOpenOrdersTab && limitOrdersFeatures.DISPLAY_EST_EXECUTION_PRICE && ( */}
       {isOpenOrdersTab && (
-        <styledEl.CellElement>
+        <styledEl.CellElement onClick={onPriceClick}>
           {/*// TODO: gray out the price when it was updated too long ago*/}
           {spotPrice ? (
             <TokenAmount amount={spotPriceInverted} tokenSymbol={spotPriceInverted?.quoteCurrency} opacitySymbol />
@@ -195,7 +197,7 @@ export function OrderRow({
 
       {/* Execution price */}
       {!isOpenOrdersTab && (
-        <styledEl.CellElement>
+        <styledEl.CellElement onClick={onPriceClick}>
           {executedPriceInverted ? (
             <TokenAmount
               amount={executedPriceInverted}
@@ -210,7 +212,7 @@ export function OrderRow({
 
       {/* Executes at */}
       {isOpenOrdersTab && (
-        <styledEl.CellElement hasBackground>
+        <styledEl.CellElement hasBackground onClick={onPriceClick}>
           {/*// TODO: gray out the price when it was updated too long ago*/}
           {prices ? (
             <styledEl.ExecuteCellWrapper>

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -179,7 +179,7 @@ export function OrderRow({
       {/* Market price */}
       {/* {isOpenOrdersTab && limitOrdersFeatures.DISPLAY_EST_EXECUTION_PRICE && ( */}
       {isOpenOrdersTab && (
-        <styledEl.CellElement onClick={toggleIsInverted}>
+        <styledEl.PriceElement onClick={toggleIsInverted}>
           {/*// TODO: gray out the price when it was updated too long ago*/}
           {spotPrice ? (
             <TokenAmount amount={spotPriceInverted} tokenSymbol={spotPriceInverted?.quoteCurrency} opacitySymbol />
@@ -188,12 +188,12 @@ export function OrderRow({
           ) : (
             <Loader size="14px" style={{ margin: '0 0 -2px 7px' }} />
           )}
-        </styledEl.CellElement>
+        </styledEl.PriceElement>
       )}
 
       {/* Execution price */}
       {!isOpenOrdersTab && (
-        <styledEl.CellElement onClick={toggleIsInverted}>
+        <styledEl.PriceElement onClick={toggleIsInverted}>
           {executedPriceInverted ? (
             <TokenAmount
               amount={executedPriceInverted}
@@ -203,12 +203,12 @@ export function OrderRow({
           ) : (
             '-'
           )}
-        </styledEl.CellElement>
+        </styledEl.PriceElement>
       )}
 
       {/* Executes at */}
       {isOpenOrdersTab && (
-        <styledEl.CellElement hasBackground onClick={toggleIsInverted}>
+        <styledEl.PriceElement hasBackground onClick={toggleIsInverted}>
           {/*// TODO: gray out the price when it was updated too long ago*/}
           {prices ? (
             <styledEl.ExecuteCellWrapper>
@@ -229,7 +229,7 @@ export function OrderRow({
           ) : (
             <Loader size="14px" style={{ margin: '0 0 -2px 7px' }} />
           )}
-        </styledEl.CellElement>
+        </styledEl.PriceElement>
       )}
 
       {/* Expires */}

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -104,7 +104,7 @@ export interface OrderRowProps {
 export function OrderRow({
   order,
   RowElement,
-  isRateInverted,
+  isRateInverted: isGloballyInverted,
   isOpenOrdersTab,
   getShowCancellationModal,
   orderParams,
@@ -128,21 +128,17 @@ export function OrderRow({
   // const executedTimeAgo = useTimeAgo(expirationTime, TIME_AGO_UPDATE_INTERVAL)
   const activityUrl = chainId && activityId ? getEtherscanLink(chainId, activityId, 'transaction') : undefined
 
-  const [isInverted, setIsInverted] = useState(isRateInverted)
+  const [isInverted, setIsInverted] = useState(() => {
+    // On mount, apply smart quote selection
+    const quoteCurrency = getQuoteCurrency(chainId, inputCurrencyAmount, outputCurrencyAmount)
+    return getAddress(quoteCurrency) !== getAddress(inputCurrencyAmount?.currency)
+  })
   const onPriceClick = useCallback(() => setIsInverted((curr) => !curr), [])
 
-  // Update internal isInverted flag whenever prop change
+  // Toggle isInverted whenever isGloballyInverted changes
   useEffect(() => {
-    setIsInverted(isRateInverted)
-  }, [isRateInverted])
-
-  // On mount, apply smart quote selection
-  useEffect(() => {
-    const quoteCurrency = getQuoteCurrency(chainId, inputCurrencyAmount, outputCurrencyAmount)
-    setIsInverted(getAddress(quoteCurrency) !== getAddress(inputCurrencyAmount?.currency))
-    // Intentionally empty, should run only once
-    // eslint-disable-next-line
-  }, [])
+    setIsInverted((curr) => !curr)
+  }, [isGloballyInverted])
 
   const executionPriceInverted = isInverted ? estimatedExecutionPrice?.invert() : estimatedExecutionPrice
   const executedPriceInverted = isInverted ? executedPrice?.invert() : executedPrice

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/styled.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/styled.tsx
@@ -120,6 +120,10 @@ export const CellElement = styled.div<{ doubleRow?: boolean; hasBackground?: boo
   }
 `
 
+export const PriceElement = styled(CellElement)`
+  cursor: pointer;
+`
+
 export const CurrencyLogoPair = styled.div`
   display: flex;
 
@@ -199,6 +203,7 @@ export const ExecuteCellWrapper = styled.div`
   display: flex;
   align-items: center;
   gap: 4px;
+  cursor: pointer;
 `
 
 export const ExecuteInformationTooltip = styled.div`


### PR DESCRIPTION
# Summary

Inverting all prices on order row when any price is clicked


https://user-images.githubusercontent.com/43217/226932693-3bf83069-1b44-4516-8920-41bd2d613ee9.mov

# To Test

1. On limit orders page, click on any price on a pending order
* Prices should invert when any is clicked
2. On limit orders history page, click on any price
* Prices should invert when any is clicked