### PR TITLE
Do not show high fee warning on limit orders table for market orders

### DIFF
--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
@@ -48,6 +48,7 @@ export const EstimatedExecutionPriceWrapper = styled.span<{ hasWarning: boolean 
 
 export type EstimatedExecutionPriceProps = TokenAmountProps & {
   isInverted: boolean
+  canShowWarning: boolean
   percentageDifference?: Percent
   amountDifference?: CurrencyAmount<Currency>
   percentageFee?: Percent
@@ -55,7 +56,16 @@ export type EstimatedExecutionPriceProps = TokenAmountProps & {
 }
 
 export function EstimatedExecutionPrice(props: EstimatedExecutionPriceProps) {
-  const { isInverted, percentageDifference, amountDifference, percentageFee, amountFee, amount, ...rest } = props
+  const {
+    isInverted,
+    canShowWarning,
+    percentageDifference,
+    amountDifference,
+    percentageFee,
+    amountFee,
+    amount,
+    ...rest
+  } = props
 
   const percentageDifferenceInverted = isInverted
     ? percentageDifference?.multiply(MINUS_ONE_FRACTION)
@@ -66,7 +76,7 @@ export function EstimatedExecutionPrice(props: EstimatedExecutionPriceProps) {
     ? amountDifference.multiply(MINUS_ONE_FRACTION)
     : amountDifference
   const orderExecutionStatus = calculateOrderExecutionStatus(percentageDifferenceInverted)
-  const feeWarning = percentageFee?.greaterThan(TEN_PERCENT)
+  const feeWarning = canShowWarning && percentageFee?.greaterThan(TEN_PERCENT)
   const isNegativeDifference = percentageDifferenceInverted?.lessThan(ZERO_FRACTION)
   const marketPriceNeedsToGoDown = isInverted ? !isNegativeDifference : isNegativeDifference
 

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useState } from 'react'
 import { DefaultTheme, StyledComponent, ThemeContext } from 'styled-components/macro'
-import { OrderStatus } from 'state/orders/actions'
+import { OrderClass, OrderStatus } from 'state/orders/actions'
 import { Currency, CurrencyAmount, Percent, Price } from '@uniswap/sdk-core'
 import { RateInfo } from '@cow/common/pure/RateInfo'
 import { MouseoverTooltipContent } from 'components/Tooltip'
@@ -223,6 +223,7 @@ export function OrderRow({
                 amountDifference={priceDiffs?.amount}
                 percentageFee={feeDifference}
                 amountFee={feeAmount}
+                canShowWarning={order.class !== OrderClass.MARKET}
               />
             </styledEl.ExecuteCellWrapper>
           ) : prices === null ? (
@@ -281,7 +282,7 @@ export function OrderRow({
         </styledEl.StatusBox>
       </styledEl.CellElement>
 
-      {/* Action contet menu */}
+      {/* Action content menu */}
       <styledEl.CellElement>
         <OrderContextMenu
           activityUrl={activityUrl}


### PR DESCRIPTION
# Summary

Do not show high fee warning on limit orders table for market orders

# To Test

1. Place the smallest swap order that you can
2. Go to limit orders table
* The order should NOT have the high fee percentage warning displayed for limit orders
3. Place the smallest limit order that you can
* (Assuming the fee is >10% of the sell amount) the order should have the high fee percentage warning