### PR TITLE
Fix white token symbol on black color text

### DIFF
--- a/src/cow-react/common/pure/TokenAmount/index.tsx
+++ b/src/cow-react/common/pure/TokenAmount/index.tsx
@@ -16,7 +16,7 @@ export const Wrapper = styled.span<{ highlight: boolean; lowVolumeWarning?: bool
 `
 
 export const SymbolElement = styled.span<{ opacitySymbol?: boolean }>`
-  color: ${({ opacitySymbol, theme }) => transparentize(opacitySymbol ? 0.3 : 0, theme.text1)};
+  ${({ opacitySymbol, theme }) => (opacitySymbol ? `color: ${transparentize(0.3, theme.text1)}` : '')};
 `
 
 export interface TokenAmountProps {


### PR DESCRIPTION
# Summary

## Now
![image](https://user-images.githubusercontent.com/43217/226976577-2fbcb0aa-0709-44bb-baef-648fa02e071f.png)

## Before
![image](https://user-images.githubusercontent.com/43217/226976875-2b0152f1-e0bb-4b56-ba28-97a8fa68c766.png)

# To Test

1. Check the high fee warning on a pending limit order
* Token symbol color should match the surrounding text
* It should NOT break any symbols displayed in the app