### PR TITLE
Fix token search to be case insensitive

### DIFF
--- a/cypress-custom/integration/search.test.ts
+++ b/cypress-custom/integration/search.test.ts
@@ -1,0 +1,35 @@
+describe('Search', () => {
+  beforeEach(() => {
+    cy.visit('/#/swap')
+  })
+
+  it('should be able to find a token by its name', () => {
+    cy.get('.open-currency-select-button').first().click()
+    cy.get('#token-search-input').type('DAI')
+    cy.get('#currency-list').first().contains('Dai Stablecoin')
+  })
+
+  it('should be able to find a token by its address', () => {
+    cy.get('.open-currency-select-button').first().click()
+    cy.get('#token-search-input').type('0x6B175474E89094C44Da98b954EedeAC495271d0F')
+    cy.get('#currency-list').first().contains('Dai Stablecoin')
+  })
+
+  it('should be able to find a token by its address with case errors at the beginning', () => {
+    cy.get('.open-currency-select-button').first().click()
+    cy.get('#token-search-input').type('0X6B175474E89094C44Da98b954EedeAC495271d0F')
+    cy.get('#currency-list').first().contains('Dai Stablecoin')
+  })
+
+  it('should be able to find a token by its address with case errors in the address', () => {
+    cy.get('.open-currency-select-button').first().click()
+    cy.get('#token-search-input').type('0x6B175474E89094C44DA98B954eedeAC495271d0F')
+    cy.get('#currency-list').first().contains('Dai Stablecoin')
+  })
+
+  it('should be able to find a token by its address without 0x at the start', () => {
+    cy.get('.open-currency-select-button').first().click()
+    cy.get('#token-search-input').type('6B175474E89094C44Da98b954EedeAC495271d0F')
+    cy.get('#currency-list').first().contains('Dai Stablecoin')
+  })
+})

--- a/src/custom/components/SearchModal/CurrencyList/CurrencyListMod.tsx
+++ b/src/custom/components/SearchModal/CurrencyList/CurrencyListMod.tsx
@@ -86,6 +86,7 @@ export const StyledScrollarea = styled.div`
     overflow-y: auto; // fallback for 'overlay'
     overflow-y: overlay;
     ${({ theme }) => theme.colorScrollbar};
+  }
 `
 
 function TokenTags({ currency }: { currency: Currency }) {

--- a/src/custom/components/SearchModal/CurrencySearch/CurrencySearchMod.tsx
+++ b/src/custom/components/SearchModal/CurrencySearch/CurrencySearchMod.tsx
@@ -159,7 +159,9 @@ export function CurrencySearch({
   const inputRef = useRef<HTMLInputElement>()
   const handleInput = useCallback((event: ChangeEvent<HTMLInputElement>) => {
     const input = event.target.value
-    const checksummedInput = isAddress(input)
+    // We lowercase the input, so that address check can be case insensitive.
+    // https://github.com/cowprotocol/cowswap/issues/23
+    const checksummedInput = isAddress(input.toLowerCase())
     setSearchQuery(checksummedInput || input)
     fixedList.current?.scrollTo(0)
   }, [])


### PR DESCRIPTION
# Summary

Fixes #23 

As defined in the issue, we ensure that the input value is treated in a case insensitive fashion so that you can still find tokens even if you do a case typo.

Normally this would not be desirable (due to case sensitivity serving as a checksum), however in this case due to this being a search it should be ok.

  # To Test

1. Open Swap
2. Click on a currency to open the search modal
3. Enter a contract address that is incorrect in terms of case sensitivity. Following are examples for DAI (correct one would be 0x6B175474E89094C44Da98b954EedeAC495271d0F)
4. 0X6B175474E89094C44Da98b954EedeAC495271d0F
5. 0x6B175474E89094C44Da98b954EedeAC495271d0f
6. 0x6B175474e89094C44Da98b954EedeAC495271d0F
7. 0x6b175474E89094C44Da98b954EedeAC495271d0F
8. All of the above should find DAI

  # Background

Case sensitivity: https://ethereum.stackexchange.com/a/19048