### PR TITLE
Feature/limit UI update - #2164 negative price

### DIFF
--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
@@ -15,12 +15,13 @@ import { ZERO_FRACTION } from '@src/custom/constants'
 const MINUS_ONE_FRACTION = new Fraction(-1)
 export const HIGH_FEE_WARNING_PERCENTAGE = new Percent(1, 10)
 
-export const EstimatedExecutionPriceWrapper = styled.span<{ hasWarning: boolean }>`
+export const EstimatedExecutionPriceWrapper = styled.span<{ hasWarning: boolean; showPointerCursor: boolean }>`
   display: flex;
   width: 100%;
   align-items: center;
   justify-content: space-between;
   color: ${({ hasWarning, theme }) => (hasWarning ? darken(theme.darkMode ? 0 : 0.15, theme.alert) : 'inherit')};
+  cursor: ${({ showPointerCursor }) => (showPointerCursor ? 'pointer' : 'default')};
 
   ${SymbolElement} {
     color: inherit;
@@ -97,7 +98,7 @@ export function EstimatedExecutionPrice(props: EstimatedExecutionPriceProps) {
   const isZeroPrice = amount?.equalTo(ZERO_FRACTION)
 
   return (
-    <EstimatedExecutionPriceWrapper hasWarning={!!feeWarning}>
+    <EstimatedExecutionPriceWrapper hasWarning={!!feeWarning} showPointerCursor={!isZeroPrice}>
       {isZeroPrice ? (
         <UnfillableLabel>UNFILLABLE</UnfillableLabel>
       ) : (

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
@@ -98,46 +98,44 @@ export function EstimatedExecutionPrice(props: EstimatedExecutionPriceProps) {
 
   return (
     <EstimatedExecutionPriceWrapper hasWarning={!!feeWarning}>
-      <MouseoverTooltipContent
-        wrap={true}
-        content={
-          <styledEl.ExecuteInformationTooltip>
-            {isZeroPrice ? (
-              <>
-                For this order, network fees are higher than the sell amount. Therefore, your order will not execute
-                given the current market conditions.
-              </>
-            ) : !isNegativeDifference ? (
-              <>
-                Market price needs to go {marketPriceNeedsToGoDown ? 'down 📉' : 'up 📈'} by&nbsp;
-                <b>
-                  <TokenAmount {...rest} amount={absoluteDifferenceAmount} round={false} />
-                </b>
-                &nbsp;
-                <span>
-                  (<i>{percentageDifferenceInverted?.toFixed(2)}%</i>)
-                </span>
-                &nbsp;to execute your order.
-              </>
-            ) : feeWarning ? (
-              <>Unlikely to execute due to high fee</>
-            ) : (
-              <>Will execute soon!</>
-            )}
-          </styledEl.ExecuteInformationTooltip>
-        }
-        placement="top"
-      >
-        {isZeroPrice ? (
-          <UnfillableLabel>UNFILLABLE</UnfillableLabel>
-        ) : (
-          <>
-            <styledEl.ExecuteIndicator status={orderExecutionStatus} />
-            <TokenAmount amount={amount} {...rest} />
-          </>
-        )}
-      </MouseoverTooltipContent>
-
+      {isZeroPrice ? (
+        <UnfillableLabel>UNFILLABLE</UnfillableLabel>
+      ) : (
+        <MouseoverTooltipContent
+          wrap={true}
+          content={
+            <styledEl.ExecuteInformationTooltip>
+              {!isNegativeDifference ? (
+                <>
+                  Market price needs to go {marketPriceNeedsToGoDown ? 'down 📉' : 'up 📈'} by&nbsp;
+                  <b>
+                    <TokenAmount {...rest} amount={absoluteDifferenceAmount} round={false} />
+                  </b>
+                  &nbsp;
+                  <span>
+                    (<i>{percentageDifferenceInverted?.toFixed(2)}%</i>)
+                  </span>
+                  &nbsp;to execute your order.
+                </>
+              ) : feeWarning ? (
+                <>Unlikely to execute due to high fee</>
+              ) : (
+                <>Will execute soon!</>
+              )}
+            </styledEl.ExecuteInformationTooltip>
+          }
+          placement="top"
+        >
+          {isZeroPrice ? (
+            <UnfillableLabel>UNFILLABLE</UnfillableLabel>
+          ) : (
+            <>
+              <styledEl.ExecuteIndicator status={orderExecutionStatus} />
+              <TokenAmount amount={amount} {...rest} />
+            </>
+          )}
+        </MouseoverTooltipContent>
+      )}
       {feeWarning && <UnlikelyToExecuteWarning feePercentage={percentageFee} feeAmount={amountFee} />}
     </EstimatedExecutionPriceWrapper>
   )

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
@@ -79,6 +79,7 @@ export function EstimatedExecutionPrice(props: EstimatedExecutionPriceProps) {
   const feeWarning = canShowWarning && percentageFee?.greaterThan(HIGH_FEE_WARNING_PERCENTAGE)
   const isNegativeDifference = percentageDifferenceInverted?.lessThan(ZERO_FRACTION)
   const marketPriceNeedsToGoDown = isInverted ? !isNegativeDifference : isNegativeDifference
+  const isZeroPrice = amount?.equalTo(ZERO_FRACTION)
 
   return (
     <EstimatedExecutionPriceWrapper hasWarning={!!feeWarning}>
@@ -86,7 +87,9 @@ export function EstimatedExecutionPrice(props: EstimatedExecutionPriceProps) {
         wrap={true}
         content={
           <styledEl.ExecuteInformationTooltip>
-            {!isNegativeDifference ? (
+            {isZeroPrice ? (
+              <>Fee is over 100% of sell amount</>
+            ) : !isNegativeDifference ? (
               <>
                 Market price needs to go {marketPriceNeedsToGoDown ? 'down 📉' : 'up 📈'} by&nbsp;
                 <b>
@@ -108,7 +111,7 @@ export function EstimatedExecutionPrice(props: EstimatedExecutionPriceProps) {
         placement="top"
       >
         <styledEl.ExecuteIndicator status={orderExecutionStatus} />
-        <TokenAmount amount={amount} {...rest} />
+        {isZeroPrice ? <>&infin;</> : <TokenAmount amount={amount} {...rest} />}
       </MouseoverTooltipContent>
 
       {feeWarning && <UnlikelyToExecuteWarning feePercentage={percentageFee} feeAmount={amountFee} />}

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
@@ -103,7 +103,10 @@ export function EstimatedExecutionPrice(props: EstimatedExecutionPriceProps) {
         content={
           <styledEl.ExecuteInformationTooltip>
             {isZeroPrice ? (
-              <>Fee is over 100% of sell amount</>
+              <>
+                For this order, network fees are higher than the sell amount. Therefore, your order will not execute
+                given the current market conditions.
+              </>
             ) : !isNegativeDifference ? (
               <>
                 Market price needs to go {marketPriceNeedsToGoDown ? 'down 📉' : 'up 📈'} by&nbsp;

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
@@ -46,6 +46,21 @@ export const EstimatedExecutionPriceWrapper = styled.span<{ hasWarning: boolean 
   }
 `
 
+const UnfillableLabel = styled.span`
+  height: 28px;
+  width: 90px;
+  border: 1px solid;
+  color: ${({ theme }) => theme.attention};
+  position: relative;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 600;
+  overflow: hidden;
+`
+
 export type EstimatedExecutionPriceProps = TokenAmountProps & {
   isInverted: boolean
   canShowWarning: boolean
@@ -110,8 +125,14 @@ export function EstimatedExecutionPrice(props: EstimatedExecutionPriceProps) {
         }
         placement="top"
       >
-        <styledEl.ExecuteIndicator status={orderExecutionStatus} />
-        {isZeroPrice ? <>&infin;</> : <TokenAmount amount={amount} {...rest} />}
+        {isZeroPrice ? (
+          <UnfillableLabel>UNFILLABLE</UnfillableLabel>
+        ) : (
+          <>
+            <styledEl.ExecuteIndicator status={orderExecutionStatus} />
+            <TokenAmount amount={amount} {...rest} />
+          </>
+        )}
       </MouseoverTooltipContent>
 
       {feeWarning && <UnlikelyToExecuteWarning feePercentage={percentageFee} feeAmount={amountFee} />}

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/styled.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/styled.tsx
@@ -203,7 +203,6 @@ export const ExecuteCellWrapper = styled.div`
   display: flex;
   align-items: center;
   gap: 4px;
-  cursor: pointer;
 `
 
 export const ExecuteInformationTooltip = styled.div`

--- a/src/cow-react/modules/limitOrders/utils/calculatePriceDifference.test.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculatePriceDifference.test.ts
@@ -137,8 +137,7 @@ describe('Not Inverted Price', () => {
 
       const result = calculatePriceDifference(params)
 
-      expect(result?.amount.toFixed(2)).toBe('-1.00')
-      expect(result?.percentage.toFixed(2)).toBe('-100.00')
+      expect(result).toBe(null)
     })
   })
 })

--- a/src/cow-react/modules/limitOrders/utils/calculatePriceDifference.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculatePriceDifference.ts
@@ -43,7 +43,8 @@ export function calculatePriceDifference({
   if (
     referencePrice.equalTo(ZERO_FRACTION) || // The reference cannot be zero (infinite relative difference)
     referencePrice.lessThan(ZERO_FRACTION) || // The prices can't be negative
-    targetPrice.lessThan(ZERO_FRACTION) // The prices can't be negative
+    targetPrice.lessThan(ZERO_FRACTION) || // The prices can't be negative
+    targetPrice.equalTo(ZERO_FRACTION) // We can't calculate a difference if target is zero
   ) {
     return null
   }

--- a/src/cow-react/utils/amountFormat/index.ts
+++ b/src/cow-react/utils/amountFormat/index.ts
@@ -1,7 +1,7 @@
 import { FractionLike, Nullish } from '@cow/types'
 import { Currency, CurrencyAmount, Percent, Rounding } from '@uniswap/sdk-core'
 import { maxAmountSpend } from 'utils/maxAmountSpend'
-import { AMOUNT_PRECISION, FIAT_PRECISION, PERCENTAGE_PRECISION } from 'constants/index'
+import { AMOUNT_PRECISION, FIAT_PRECISION, PERCENTAGE_PRECISION, ZERO_FRACTION } from 'constants/index'
 import { trimTrailingZeros } from '@cow/utils/trimTrailingZeros'
 import { FractionUtils } from '@cow/utils/fractionUtils'
 import { getPrecisionForAmount, getSuffixForAmount, lessThanPrecisionSymbol, trimHugeAmounts } from './utils'
@@ -25,6 +25,10 @@ export function formatAmountWithPrecision(
   numberFormat = INTL_NUMBER_FORMAT
 ): string {
   if (!amount) return ''
+
+  if (amount.equalTo(ZERO_FRACTION)) {
+    return '0'
+  }
 
   // Align fraction-like types to Fraction
   const amountAsFraction = FractionUtils.fractionLikeToFraction(amount)

--- a/src/custom/state/orders/utils.ts
+++ b/src/custom/state/orders/utils.ts
@@ -302,7 +302,15 @@ export function getEstimatedExecutionPrice(
   )
 
   // Picking the MAX between FEP and FP
-  const estimatedExecutionPrice = fillPrice.greaterThan(feasibleExecutionPrice) ? fillPrice : feasibleExecutionPrice
+  // NOTE: For some obscure reason, the sign is not considered in the comparison
+  // For example when feasibleExecutionPrice is negative but the absolute value is greater than fillPrice,
+  // it will be picked...🤦
+  // To circumvent that issue, the additional conditional is added, which is the root cause of negative
+  // feasibleExecutionPrice: feeAmount being greater than inputAmount
+  const estimatedExecutionPrice =
+    fillPrice.greaterThan(feasibleExecutionPrice) || feeAmount.greaterThan(inputAmount)
+      ? fillPrice
+      : feasibleExecutionPrice
 
   // TODO: remove debug statement
   console.debug(`getEstimatedExecutionPrice`, {

--- a/src/custom/state/orders/utils.ts
+++ b/src/custom/state/orders/utils.ts
@@ -302,15 +302,7 @@ export function getEstimatedExecutionPrice(
   )
 
   // Picking the MAX between FEP and FP
-  // NOTE: For some obscure reason, the sign is not considered in the comparison
-  // For example when feasibleExecutionPrice is negative but the absolute value is greater than fillPrice,
-  // it will be picked...🤦
-  // To circumvent that issue, the additional conditional is added, which is the root cause of negative
-  // feasibleExecutionPrice: feeAmount being greater than inputAmount
-  const estimatedExecutionPrice =
-    fillPrice.greaterThan(feasibleExecutionPrice) || feeAmount.greaterThan(inputAmount)
-      ? fillPrice
-      : feasibleExecutionPrice
+  const estimatedExecutionPrice = fillPrice.greaterThan(feasibleExecutionPrice) ? fillPrice : feasibleExecutionPrice
 
   // TODO: remove debug statement
   console.debug(`getEstimatedExecutionPrice`, {


### PR DESCRIPTION
# Summary

Fixes #2164 

Should no longer show prices with negative values

## Before
![Screenshot 2023-03-23 at 11 00 19](https://user-images.githubusercontent.com/43217/227193694-d1822c83-e997-4700-89bb-253a2184d341.png)
## After
![image](https://user-images.githubusercontent.com/43217/227193739-a780a7f1-4a9b-4fb5-8447-d5aa4510148f.png)


# To Test

1. Place one order with a tiny sell amount
2. Wait for the fees to higher than the sell amount
* You should NOT see a negative price