### PR TITLE
Add default test private key for local development purposes

### DIFF
--- a/cypress-custom/support/ethereum.ts
+++ b/cypress-custom/support/ethereum.ts
@@ -6,7 +6,8 @@ import { Eip1193Bridge } from '@ethersproject/experimental/lib/eip1193-bridge'
 import { JsonRpcProvider } from '@ethersproject/providers'
 import { Wallet } from '@ethersproject/wallet'
 
-const TEST_PRIVATE_KEY = Cypress.env('INTEGRATION_TEST_PRIVATE_KEY')
+const TEST_PRIVATE_KEY =
+  Cypress.env('INTEGRATION_TEST_PRIVATE_KEY') || '0x34cf49001445bf8faa64a0ff3780709c2af8378e75e29c077643a387be79f089'
 const INTEG_TESTS_INFURA_KEY = Cypress.env('INTEGRATION_TESTS_INFURA_KEY') || '1221fd11e90849509afafd330ec7acc6'
 // address of the above key
 export const TEST_ADDRESS_NEVER_USE = new Wallet(TEST_PRIVATE_KEY).address

--- a/cypress-custom/support/ethereum.ts
+++ b/cypress-custom/support/ethereum.ts
@@ -1,13 +1,11 @@
 /**
  * Updates cy.visit() to include an injected window.ethereum provider.
  */
-
 import { Eip1193Bridge } from '@ethersproject/experimental/lib/eip1193-bridge'
 import { JsonRpcProvider } from '@ethersproject/providers'
 import { Wallet } from '@ethersproject/wallet'
 
-const TEST_PRIVATE_KEY =
-  Cypress.env('INTEGRATION_TEST_PRIVATE_KEY') || '0x34cf49001445bf8faa64a0ff3780709c2af8378e75e29c077643a387be79f089'
+const TEST_PRIVATE_KEY = Cypress.env('INTEGRATION_TEST_PRIVATE_KEY')
 const INTEG_TESTS_INFURA_KEY = Cypress.env('INTEGRATION_TESTS_INFURA_KEY') || '1221fd11e90849509afafd330ec7acc6'
 // address of the above key
 export const TEST_ADDRESS_NEVER_USE = new Wallet(TEST_PRIVATE_KEY).address

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,4 +1,17 @@
+import * as dotenv from 'dotenv'
+import fs from 'fs'
 import { defineConfig } from 'cypress'
+
+let env = {}
+
+if (!process.env.GITHUB_ENV) {
+  try {
+    const localEnvFile = fs.readFileSync('./.env.local')
+    env = dotenv.parse(localEnvFile)
+  } catch (err) {
+    throw new Error('Could not read .env.local file: are you sure you have your local env vars set?')
+  }
+}
 
 export default defineConfig({
   projectId: 'yp82ef',
@@ -19,5 +32,6 @@ export default defineConfig({
     baseUrl: 'http://localhost:3000',
     specPattern: 'cypress-custom/integration/**/*.{js,jsx,ts,tsx}',
     supportFile: 'cypress-custom/support/index.js',
+    env,
   },
 })


### PR DESCRIPTION
# Summary

Fixes issues with not being able to run cypress locally by adding a default private key, if nothing is found in the environment.

This seems to be the approach uniswap uses as well (without environment secret keys even).

  # To Test

1. Run `yarn cypress`
2. Select an E2E test
3. You should be able to see it running instead of an error.

  # Background

Same file on uniswap: https://github.com/Uniswap/interface/blob/main/cypress/support/ethereum.ts