### PR TITLE
Refactor and add initial swap.cow.fi landing event

### DIFF
--- a/src/custom/components/analytics/events/listEvents.ts
+++ b/src/custom/components/analytics/events/listEvents.ts
@@ -1,4 +1,5 @@
-import { Category, sendEvent } from '../index'
+import { sendEvent } from '../index'
+import { Category } from '../types'
 
 type UpdateListLocation = 'Popup' | 'List Select'
 export function updateListAnalytics(location: UpdateListLocation, listUrl: string) {

--- a/src/custom/components/analytics/events/otherEvents.ts
+++ b/src/custom/components/analytics/events/otherEvents.ts
@@ -1,5 +1,6 @@
-import { Category, sendEvent } from '../index'
+import { sendEvent } from '../index'
 import { detectExplorer } from 'utils/explorer'
+import { Category } from '../types'
 
 type GameType = 'CoW Runner' | 'MEV Slicer'
 export function gameAnalytics(gameType: GameType) {
@@ -19,4 +20,23 @@ export function externalLinkAnalytics(href: string) {
       label: href,
     })
   }
+}
+
+export function serviceWorkerAnalytics() {
+  const installed = Boolean(window.navigator.serviceWorker?.controller)
+  const hit = Boolean((window as any).__isDocumentCached)
+  const action = installed ? (hit ? 'Cache hit' : 'Cache miss') : 'Not installed'
+
+  sendEvent({
+    category: Category.SERVICE_WORKER,
+    nonInteraction: true,
+    action,
+  })
+}
+
+export function initAnalytics() {
+  sendEvent({
+    category: Category.INIT,
+    action: 'Initial landing on swap.cow.fi',
+  })
 }

--- a/src/custom/components/analytics/events/otherEvents.ts
+++ b/src/custom/components/analytics/events/otherEvents.ts
@@ -37,6 +37,6 @@ export function serviceWorkerAnalytics() {
 export function initAnalytics() {
   sendEvent({
     category: Category.INIT,
-    action: 'Initial landing on swap.cow.fi',
+    action: 'initial_landing_on_swap_cow_fi',
   })
 }

--- a/src/custom/components/analytics/events/settingsEvents.ts
+++ b/src/custom/components/analytics/events/settingsEvents.ts
@@ -1,4 +1,5 @@
-import { Category, sendEvent } from '../index'
+import { sendEvent } from '../index'
+import { Category } from '../types'
 import { debounce } from 'utils/misc'
 
 export function toggleExpertModeAnalytics(enable: boolean) {

--- a/src/custom/components/analytics/events/swapEvents.ts
+++ b/src/custom/components/analytics/events/swapEvents.ts
@@ -1,4 +1,6 @@
-import { Category, sendEvent } from '../index'
+import { sendEvent } from '../index'
+import { Category } from '../types'
+
 import { Field } from 'state/swap/actions'
 import { debounce } from 'utils/misc'
 

--- a/src/custom/components/analytics/events/themeEvents.ts
+++ b/src/custom/components/analytics/events/themeEvents.ts
@@ -1,4 +1,5 @@
-import { Category, sendEvent } from '../index'
+import { sendEvent } from '../index'
+import { Category } from '../types'
 
 export function toggleDarkModeAnalytics(darkMode: boolean) {
   sendEvent({

--- a/src/custom/components/analytics/events/transactionEvents.ts
+++ b/src/custom/components/analytics/events/transactionEvents.ts
@@ -1,5 +1,6 @@
 import { OrderClass } from 'state/orders/actions'
-import { Category, sendEvent } from '../index'
+import { sendEvent } from '../index'
+import { Category } from '../types'
 
 import { PIXEL_EVENTS } from '../pixel/constants'
 import { sendFacebookEvent } from '../pixel/facebook'

--- a/src/custom/components/analytics/events/walletEvents.ts
+++ b/src/custom/components/analytics/events/walletEvents.ts
@@ -1,4 +1,5 @@
-import { Category, sendEvent } from '../index'
+import { sendEvent } from '../index'
+import { Category } from '../types'
 
 export function changeWalletAnalytics(walletName: string) {
   sendEvent({

--- a/src/custom/components/analytics/hooks/useAnalyticsReporter.ts
+++ b/src/custom/components/analytics/hooks/useAnalyticsReporter.ts
@@ -8,7 +8,7 @@ import { useWalletDetails, useWalletInfo } from '@cow/modules/wallet'
 import { getConnectionName, getIsMetaMask } from '@cow/modules/wallet/api/utils/connection'
 import { getWeb3ReactConnection } from '@cow/modules/wallet/web3-react/connection'
 import { googleAnalytics, GOOGLE_ANALYTICS_CLIENT_ID_STORAGE_KEY } from '..'
-import { Dimensions } from '../GoogleAnalyticsProvider'
+import { Dimensions } from '../types'
 import usePrevious from 'hooks/usePrevious'
 
 import { PIXEL_EVENTS } from '../pixel/constants'

--- a/src/custom/components/analytics/index.ts
+++ b/src/custom/components/analytics/index.ts
@@ -1,16 +1,9 @@
-// import { useWeb3React } from '@web3-react/core'
-// import { useEffect } from 'react'
 import { UaEventOptions } from 'react-ga4/types/ga4'
-// import { RouteComponentProps } from 'react-router-dom'
 import { isMobile } from 'utils/userAgent'
-// import { getCLS, getFCP, getFID, getLCP, Metric } from 'web-vitals'
-
-import GoogleAnalyticsProvider from './GoogleAnalyticsProvider'
-
-// Mod imports
 import { ErrorInfo } from 'react'
-import { Dimensions } from './GoogleAnalyticsProvider'
-
+import { GAProvider } from './provider'
+import { Dimensions } from './types'
+import { serviceWorkerAnalytics, initAnalytics } from './events/otherEvents'
 export { useAnalyticsReporter } from './hooks/useAnalyticsReporter'
 
 const GOOGLE_ANALYTICS_ID: string | undefined = process.env.REACT_APP_GOOGLE_ANALYTICS_ID
@@ -18,7 +11,7 @@ export const GOOGLE_ANALYTICS_CLIENT_ID_STORAGE_KEY = 'ga_client_id'
 
 const storedClientId = window.localStorage.getItem(GOOGLE_ANALYTICS_CLIENT_ID_STORAGE_KEY)
 
-export const googleAnalytics = new GoogleAnalyticsProvider()
+export const googleAnalytics = new GAProvider()
 
 export function sendEvent(event: string | UaEventOptions, params?: any) {
   return googleAnalytics.sendEvent(event, params)
@@ -55,10 +48,8 @@ if (typeof GOOGLE_ANALYTICS_ID === 'string') {
   googleAnalytics.initialize('test', { gtagOptions: { debug_mode: true } })
 }
 
-const installed = Boolean(window.navigator.serviceWorker?.controller)
-const hit = Boolean((window as any).__isDocumentCached)
-const action = installed ? (hit ? 'Cache hit' : 'Cache miss') : 'Not installed'
-sendEvent({ category: 'Service Worker', action, nonInteraction: true })
+serviceWorkerAnalytics()
+initAnalytics()
 
 // MOD
 export * from './events/listEvents'
@@ -68,26 +59,3 @@ export * from './events/transactionEvents'
 export * from './events/walletEvents'
 export * from './events/swapEvents'
 export * from './events/otherEvents'
-
-export enum Category {
-  SWAP = 'Swap',
-  LIST = 'Lists',
-  CURRENCY_SELECT = 'Currency Select',
-  EXPERT_MODE = 'Expert mode',
-  RECIPIENT_ADDRESS = 'Recipient address',
-  ORDER_SLIPAGE_TOLERANCE = 'Order Slippage Tolerance',
-  ORDER_EXPIRATION_TIME = 'Order Expiration Time',
-  WALLET = 'Wallet',
-  WRAP_NATIVE_TOKEN = 'Wrapped Native Token',
-  CLAIM_COW_FOR_LOCKED_GNO = 'Claim COW for Locked GNO',
-  THEME = 'Theme',
-  GAMES = 'Games',
-  EXTERNAL_LINK = 'External Link',
-}
-
-export interface EventParams {
-  category: Category
-  action: string
-  label?: string
-  value?: number
-}

--- a/src/custom/components/analytics/provider/index.ts
+++ b/src/custom/components/analytics/provider/index.ts
@@ -2,12 +2,7 @@ import ReactGA from 'react-ga4'
 import { ErrorInfo } from 'react'
 import { GaOptions, InitOptions, UaEventOptions } from 'react-ga4/types/ga4'
 import { debounce } from 'utils/misc'
-
-export enum Dimensions {
-  chainId = 'chainId',
-  walletName = 'walletName',
-  customBrowserType = 'customBrowserType',
-}
+import { Dimensions } from '../types'
 
 const DIMENSION_MAP = {
   [Dimensions.chainId]: 'dimension1',
@@ -20,7 +15,7 @@ type DimensionKey = keyof typeof DIMENSION_MAP
 /**
  * Google Analytics Provider containing all methods used throughout app to log events to Google Analytics.
  */
-export default class GoogleAnalyticsProvider {
+export class GAProvider {
   dimensions: { [key in DimensionKey]: any }
 
   constructor() {

--- a/src/custom/components/analytics/types.ts
+++ b/src/custom/components/analytics/types.ts
@@ -1,0 +1,30 @@
+export enum Category {
+  SWAP = 'Swap',
+  LIST = 'Lists',
+  CURRENCY_SELECT = 'Currency Select',
+  EXPERT_MODE = 'Expert mode',
+  RECIPIENT_ADDRESS = 'Recipient address',
+  ORDER_SLIPAGE_TOLERANCE = 'Order Slippage Tolerance',
+  ORDER_EXPIRATION_TIME = 'Order Expiration Time',
+  WALLET = 'Wallet',
+  WRAP_NATIVE_TOKEN = 'Wrapped Native Token',
+  CLAIM_COW_FOR_LOCKED_GNO = 'Claim COW for Locked GNO',
+  THEME = 'Theme',
+  GAMES = 'Games',
+  EXTERNAL_LINK = 'External Link',
+  INIT = 'Init',
+  SERVICE_WORKER = 'Service workder',
+}
+
+export interface EventParams {
+  category: Category
+  action: string
+  label?: string
+  value?: number
+}
+
+export enum Dimensions {
+  chainId = 'chainId',
+  walletName = 'walletName',
+  customBrowserType = 'customBrowserType',
+}


### PR DESCRIPTION
# Summary

- adds a new GA event when user lands on swap.cow.fi any page, called `Initial landing on swap.cow.fi` and it is fired only once the app is loaded
- also adds some refactoring to make code better

## To test
- download [GA debug extension on Chrome](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en)
- turn it on
- open the demo app
- open dev tools and go to Console tab
- you should be able to see `Initial landing on swap.cow.fi` event dispatched in the console
