### PR TITLE
Fix trailing spaces breaking search

### DIFF
--- a/cypress-custom/integration/search.test.ts
+++ b/cypress-custom/integration/search.test.ts
@@ -6,30 +6,49 @@ describe('Search', () => {
   it('should be able to find a token by its name', () => {
     cy.get('.open-currency-select-button').first().click()
     cy.get('#token-search-input').type('DAI')
-    cy.get('#currency-list').first().contains('DAI')
+    cy.get('#currency-list').contains('DAI')
+    cy.get('#currency-list').should('not.contain.text', 'GNO')
   })
 
   it('should be able to find a token by its address', () => {
     cy.get('.open-currency-select-button').first().click()
     cy.get('#token-search-input').type('0xdc31ee1784292379fbb2964b3b9c4124d8f89c60')
-    cy.get('#currency-list').first().contains('DAI')
+    cy.get('#currency-list').contains('DAI')
+    cy.get('#currency-list').should('not.contain.text', 'GNO')
   })
 
   it('should be able to find a token by its address with case errors at the beginning', () => {
     cy.get('.open-currency-select-button').first().click()
     cy.get('#token-search-input').type('0Xdc31ee1784292379fbb2964b3b9c4124d8f89c60')
-    cy.get('#currency-list').first().contains('DAI')
+    cy.get('#currency-list').contains('DAI')
+    cy.get('#currency-list').should('not.contain.text', 'GNO')
   })
 
   it('should be able to find a token by its address with case errors in the address', () => {
     cy.get('.open-currency-select-button').first().click()
     cy.get('#token-search-input').type('0xDC31EE1784292379fbb2964b3b9c4124d8f89c60')
-    cy.get('#currency-list').first().contains('DAI')
+    cy.get('#currency-list').contains('DAI')
+    cy.get('#currency-list').should('not.contain.text', 'GNO')
   })
 
   it('should be able to find a token by its address without 0x at the start', () => {
     cy.get('.open-currency-select-button').first().click()
     cy.get('#token-search-input').type('dc31ee1784292379fbb2964b3b9c4124d8f89c60')
-    cy.get('#currency-list').first().contains('DAI')
+    cy.get('#currency-list').contains('DAI')
+    cy.get('#currency-list').should('not.contain.text', 'GNO')
+  })
+
+  it('should be able to find a token by its address when there is a trailing or leading space', () => {
+    cy.get('.open-currency-select-button').first().click()
+    cy.get('#token-search-input').type(' 0xdc31ee1784292379fbb2964b3b9c4124d8f89c60 ')
+    cy.get('#currency-list').contains('DAI')
+    cy.get('#currency-list').should('not.contain.text', 'GNO')
+  })
+
+  it('should be able to find a token by its name when there is a trailing or leading space', () => {
+    cy.get('.open-currency-select-button').first().click()
+    cy.get('#token-search-input').type(' DAI ')
+    cy.get('#currency-list').contains('DAI')
+    cy.get('#currency-list').should('not.contain.text', 'GNO')
   })
 })

--- a/src/custom/components/SearchModal/CurrencySearch/CurrencySearchMod.tsx
+++ b/src/custom/components/SearchModal/CurrencySearch/CurrencySearchMod.tsx
@@ -160,7 +160,7 @@ export function CurrencySearch({
   const handleInput = useCallback((event: ChangeEvent<HTMLInputElement>) => {
     const input = event.target.value
     // Do a case-insensitive search
-    const checksummedInput = isAddress(input.toLowerCase())
+    const checksummedInput = isAddress(input.toLowerCase().trim())
     setSearchQuery(checksummedInput || input)
     fixedList.current?.scrollTo(0)
   }, [])


### PR DESCRIPTION
# Summary

Fixes #163 

Token search is now working when there are trailing spaces. The issue was due to address check failing with the space, so we are now trimming it.

  # To Test

1. Open swap page
2. Click on a currency name to search
3. Enter an address with a trailing or leading space. (e.g. on Goerli, this should give you DAI  0xdc31ee1784292379fbb2964b3b9c4124d8f89c60 )
4. It should show still results.
