### PR TITLE
Add helpers to use remote images when available

### DIFF
--- a/src/custom/components/SearchModal/CurrencySearch/useTokenSearch.ts
+++ b/src/custom/components/SearchModal/CurrencySearch/useTokenSearch.ts
@@ -50,11 +50,11 @@ const tokensData = loadable(
 )
 
 export function useTokenLogo(currency?: Currency | null): string | void {
-  const tokens = useAtomValue(tokensData)
+  const tokens = useAtomValue(useMemo(() => tokensData, [currency]))
 
   if (!!currency && currency.isToken && tokens.state === 'hasData' && tokens.data) {
     const token = tokens.data.data.find(
-      (token) => token.chainId === currency.chainId && token.address === currency.address
+      (token) => token.chainId === currency.chainId && token.address.toLowerCase() === currency.address.toLowerCase()
     )
 
     return token?.logoURI

--- a/src/custom/components/SearchModal/CurrencySearch/useTokenSearch.ts
+++ b/src/custom/components/SearchModal/CurrencySearch/useTokenSearch.ts
@@ -53,8 +53,9 @@ export function useTokenLogo(currency?: Currency | null): string | void {
   const tokens = useAtomValue(useMemo(() => tokensData, [currency]))
 
   if (!!currency && currency.isToken && tokens.state === 'hasData' && tokens.data) {
+    const currencyAddressLowerCase = currency.address.toLowerCase()
     const token = tokens.data.data.find(
-      (token) => token.chainId === currency.chainId && token.address.toLowerCase() === currency.address.toLowerCase()
+      (token) => token.chainId === currency.chainId && token.address.toLowerCase() === currencyAddressLowerCase
     )
 
     return token?.logoURI

--- a/src/custom/components/SearchModal/CurrencySearch/useTokenSearch.ts
+++ b/src/custom/components/SearchModal/CurrencySearch/useTokenSearch.ts
@@ -1,5 +1,5 @@
 import { useWalletInfo } from '@cow/modules/wallet'
-import { Token } from '@uniswap/sdk-core'
+import { Currency, Token } from '@uniswap/sdk-core'
 import { atom, useAtom, useAtomValue } from 'jotai'
 import { loadable } from 'jotai/utils'
 import { useEffect, useMemo } from 'react'
@@ -48,6 +48,18 @@ const tokensData = loadable(
     return undefined
   })
 )
+
+export function useTokenLogo(currency?: Currency | null): string | void {
+  const tokens = useAtomValue(tokensData)
+
+  if (!!currency && currency.isToken && tokens.state === 'hasData' && tokens.data) {
+    const token = tokens.data.data.find(
+      (token) => token.chainId === currency.chainId && token.address === currency.address
+    )
+
+    return token?.logoURI
+  }
+}
 
 export function useTokenSearch(_query: string, existingTokens: Map<string, boolean>): Token[] {
   const [query, setQuery] = useAtom(searchQuery)

--- a/src/custom/lib/hooks/useCurrencyLogoURIs/useCurrencyLogoURIsMod.ts
+++ b/src/custom/lib/hooks/useCurrencyLogoURIs/useCurrencyLogoURIsMod.ts
@@ -9,6 +9,7 @@ import XDaiLogo from 'assets/cow-swap/xdai.png'
 import { ADDRESS_IMAGE_OVERRIDE } from 'constants/tokens'
 import { NATIVE_CURRENCY_BUY_ADDRESS } from 'constants/index'
 import uriToHttp from 'lib/utils/uriToHttp'
+import { useTokenLogo } from '@src/custom/components/SearchModal/CurrencySearch/useTokenSearch'
 
 type Network = 'ethereum' | /*'arbitrum' | 'optimism'*/ 'xdai' | 'rinkeby'
 
@@ -53,6 +54,7 @@ function getTokenLogoURI(address: string, chainId: SupportedChainId = SupportedC
 const currencyLogoCache = new Map<string, Array<string>>()
 // TODO: must be refactored
 export default function useCurrencyLogoURIs(currency?: Currency | null): string[] {
+  const externalLogoURI = useTokenLogo(currency)
   // There is a modification of Token in useDetectNativeToken()
   const currencyAddress = currency ? (currency.isNative ? NATIVE_CURRENCY_BUY_ADDRESS : currency.address) : null
   const cacheKey = `${currencyAddress}|${currency?.chainId}`
@@ -84,6 +86,12 @@ export default function useCurrencyLogoURIs(currency?: Currency | null): string[
     if (logoURI) {
       logoURIs.push(logoURI)
     }
+
+    if (externalLogoURI) {
+      logoURIs.push(externalLogoURI)
+    }
+
+    console.log(logoURIs)
   }
 
   currencyLogoCache.set(`${currencyAddress}|${currency?.chainId}`, logoURIs)

--- a/src/custom/lib/hooks/useCurrencyLogoURIs/useCurrencyLogoURIsMod.ts
+++ b/src/custom/lib/hooks/useCurrencyLogoURIs/useCurrencyLogoURIsMod.ts
@@ -90,8 +90,6 @@ export default function useCurrencyLogoURIs(currency?: Currency | null): string[
     if (externalLogoURI) {
       logoURIs.push(externalLogoURI)
     }
-
-    console.log(logoURIs)
   }
 
   currencyLogoCache.set(`${currencyAddress}|${currency?.chainId}`, logoURIs)


### PR DESCRIPTION
# Summary

Adds helpers to use images from external sources when available.

![Screenshot 2023-03-24 at 15 04 30](https://user-images.githubusercontent.com/5172699/227542685-620735d3-6721-49d5-9da6-2b588ecbf324.png)

# To Test

1. Open Swap
2. Click on a currency to open search
3. Search for FORTUNE
4. External results list should show the logo, as opposed to no logo symbol