### PR TITLE
Feature/partial fills default for limit orders

### DIFF
--- a/src/cow-react/api/gnosisProtocol/api.ts
+++ b/src/cow-react/api/gnosisProtocol/api.ts
@@ -121,7 +121,7 @@ export interface OrderMetaData {
   appData: number
   feeAmount: string
   kind: OrderKind
-  partiallyFillable: false
+  partiallyFillable: boolean
   signature: string
   signingScheme: SigningSchemeValue
   status: ApiOrderStatus

--- a/src/cow-react/modules/limitOrders/hooks/useTradeFlowContext.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useTradeFlowContext.ts
@@ -74,6 +74,7 @@ export function useTradeFlowContext(): TradeFlowContext | null {
       inputAmount: state.inputCurrencyAmount,
       outputAmount: state.outputCurrencyAmount,
       sellAmountBeforeFee: state.inputCurrencyAmount,
+      partiallyFillable: true, // Limit orders ALWAYS partially fillable - for now
       appDataHash: appData.hash,
       quoteId,
     },

--- a/src/cow-react/modules/limitOrders/pure/LimitOrdersConfirm/index.cosmos.tsx
+++ b/src/cow-react/modules/limitOrders/pure/LimitOrdersConfirm/index.cosmos.tsx
@@ -62,6 +62,7 @@ const tradeContext: TradeFlowContext = {
     recipient: '0xaaa',
     recipientAddressOrName: null,
     allowsOffchainSigning: true,
+    partiallyFillable: true,
     appDataHash: '0xabc',
   },
   rateImpact: 0,

--- a/src/cow-react/modules/limitOrders/pure/LimitOrdersDetails/index.cosmos.tsx
+++ b/src/cow-react/modules/limitOrders/pure/LimitOrdersDetails/index.cosmos.tsx
@@ -25,6 +25,7 @@ const tradeContext: TradeFlowContext = {
     recipient: '0xaaa',
     recipientAddressOrName: null,
     allowsOffchainSigning: true,
+    partiallyFillable: true,
     appDataHash: '0xabc',
   },
   rateImpact: 0,

--- a/src/cow-react/modules/swap/hooks/useFlowContext.ts
+++ b/src/cow-react/modules/swap/hooks/useFlowContext.ts
@@ -206,6 +206,7 @@ export function getFlowContext({ baseProps, sellToken, kind }: BaseGetFlowContex
     recipientAddressOrName,
     signer: provider.getSigner(),
     allowsOffchainSigning,
+    partiallyFillable: false, // SWAP orders are always fill or kill - for now
     appDataHash: appData.hash,
     quoteId: trade.quoteId,
   }

--- a/src/custom/utils/trade.ts
+++ b/src/custom/utils/trade.ts
@@ -30,6 +30,7 @@ export type PostOrderParams = {
   allowsOffchainSigning: boolean
   appDataHash: string
   class: OrderClass
+  partiallyFillable: boolean
   quoteId?: number
 }
 
@@ -82,8 +83,19 @@ export function getOrderParams(params: PostOrderParams): {
   quoteId: number | undefined
   order: UnsignedOrder
 } {
-  const { kind, inputAmount, outputAmount, sellToken, buyToken, feeAmount, validTo, recipient, appDataHash, quoteId } =
-    params
+  const {
+    kind,
+    inputAmount,
+    outputAmount,
+    sellToken,
+    buyToken,
+    feeAmount,
+    validTo,
+    recipient,
+    partiallyFillable,
+    appDataHash,
+    quoteId,
+  } = params
   const sellTokenAddress = sellToken.address
 
   if (!sellTokenAddress) {
@@ -112,7 +124,7 @@ export function getOrderParams(params: PostOrderParams): {
       feeAmount: feeAmount?.quotient.toString() || '0',
       kind,
       receiver,
-      partiallyFillable: false, // Always fill or kill
+      partiallyFillable,
     },
   }
 }


### PR DESCRIPTION
# Summary

First step for partial fills

Limit orders are now always partial fills

# To Test

1. Place limit order
2. Check the backed response. Example https://barn.api.cow.fi/goerli/api/v1/orders/0x5e687cbea7ec387454a0bc2f42e6b3e7bfb43857dc5b7e3b8387d793e49914305b0abe214ab7875562adee331deff0fe1912fe426448fefe
* The `partiallyFillable` flag should be set to `true`
![image](https://user-images.githubusercontent.com/43217/227919894-3c1342de-3516-41f8-b157-845d87937e79.png)
* Should work the same for buy and sell orders
3. Place a regular swap order
* The `partiallyFillable` flag should be set to `false`

# Notes

- Orders might not fill yet - pending solvers support
- AFAICT only Goerli support is enabled - have not tested other chains