### PR TITLE
Feature/partial fills update beta banner

### DIFF
--- a/src/cow-react/modules/limitOrders/pure/UnlockLimitOrders/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/UnlockLimitOrders/index.tsx
@@ -3,7 +3,6 @@ import * as styledEl from './styled'
 import { ButtonPrimary } from 'components/Button'
 import SVG from 'react-inlinesvg'
 import iconCompleted from 'assets/cow-swap/check.svg'
-import iconProgress from 'assets/cow-swap/loading.svg'
 import { ExternalLink } from 'theme'
 
 const BULLET_LIST_CONTENT = [
@@ -12,7 +11,15 @@ const BULLET_LIST_CONTENT = [
   { id: 3, content: 'Place multiple orders using the same balance' },
   { id: 4, content: 'Always receive 100% of your order surplus' },
   { id: 5, content: 'Protection from MEV by default' },
-  { id: 6, iconType: 'progress', content: 'Orders are fill or kill. Partial fills coming soon!' },
+  {
+    id: 6,
+    isNew: true,
+    content: (
+      <span>
+        NOW with&nbsp;<b>partial fills</b>&nbsp;support!
+      </span>
+    ),
+  },
 ]
 
 export function UnlockLimitOrders({ handleUnlock }: { handleUnlock: () => void }) {
@@ -25,10 +32,10 @@ export function UnlockLimitOrders({ handleUnlock }: { handleUnlock: () => void }
 
       {BULLET_LIST_CONTENT && (
         <styledEl.List>
-          {BULLET_LIST_CONTENT.map(({ id, iconType, content }) => (
-            <li key={id} data-icon={iconType || null}>
+          {BULLET_LIST_CONTENT.map(({ id, isNew, content }) => (
+            <li key={id} data-is-new={isNew || null}>
               <span>
-                <SVG src={iconType && iconType === 'progress' ? iconProgress : iconCompleted} />
+                <SVG src={iconCompleted} />
               </span>{' '}
               {content}
             </li>

--- a/src/cow-react/modules/limitOrders/pure/UnlockLimitOrders/styled.ts
+++ b/src/cow-react/modules/limitOrders/pure/UnlockLimitOrders/styled.ts
@@ -67,8 +67,7 @@ export const List = styled.ul`
   }
 
   > li[data-is-new='true'] > span {
-    display: flex;
-    width: max-content;
+    width: auto;
   }
 
   > li[data-is-new='true'] > span > b {

--- a/src/cow-react/modules/limitOrders/pure/UnlockLimitOrders/styled.ts
+++ b/src/cow-react/modules/limitOrders/pure/UnlockLimitOrders/styled.ts
@@ -66,8 +66,17 @@ export const List = styled.ul`
     fill: ${({ theme }) => theme.success};
   }
 
-  > li[data-icon='progress'] > span > svg > path {
-    fill: ${({ theme }) => theme.warning};
+  > li[data-is-new='true'] > span {
+    display: flex;
+    width: max-content;
+  }
+
+  > li[data-is-new='true'] > span > b {
+    color: ${({ theme }) => theme.yellow3};
+  }
+
+  > li[data-is-new='true'] > span > svg > path {
+    fill: ${({ theme }) => theme.yellow3};
   }
 `
 


### PR DESCRIPTION
# Summary

Update limit orders beta banner 
![image](https://user-images.githubusercontent.com/43217/228181893-b217b707-973b-4b22-984a-c904c49a9a84.png)


~*Note:* Some CSS help needed~ 
I think I got it \o/

  # To Test

1. Clear your limit orders local storage key `limit-orders-atom:v3`
2. Go to limit orders page
* The banner should be displayed