### PR TITLE
Fix formula

### DIFF
--- a/src/custom/state/orders/utils.ts
+++ b/src/custom/state/orders/utils.ts
@@ -292,9 +292,9 @@ export function getEstimatedExecutionPrice(
     return new Price(order.inputToken, order.outputToken, '0', '0')
   }
 
-  const numerator = amountMinusFees.multiply(limitPrice)
+  const numerator = inputAmount.multiply(limitPrice)
   // The divider in the formula is used as denominator, and the division is done inside the Price instance
-  const denominator = inputAmount
+  const denominator = amountMinusFees
 
   const feasibleExecutionPrice = new Price(
     order.inputToken,
@@ -308,16 +308,18 @@ export function getEstimatedExecutionPrice(
 
   // TODO: remove debug statement
   console.debug(`getEstimatedExecutionPrice`, {
-    A: inputAmount.toFixed(inputAmount.currency.decimals) + ' ' + inputAmount.currency.symbol,
-    F: feeAmount.toFixed(feeAmount.currency.decimals) + ' ' + feeAmount.currency.symbol,
-    LP: `${limitPrice.toFixed(8)} ${limitPrice.quoteCurrency.symbol} per ${limitPrice.baseCurrency.symbol}`,
-    FEP: `${feasibleExecutionPrice.toFixed(18)} ${feasibleExecutionPrice.quoteCurrency.symbol} per ${
-      feasibleExecutionPrice.baseCurrency.symbol
-    }`,
-    FP: `${fillPrice.toFixed(8)} ${fillPrice.quoteCurrency.symbol} per ${fillPrice.baseCurrency.symbol}`,
-    EEP: `${estimatedExecutionPrice.toFixed(8)} ${estimatedExecutionPrice.quoteCurrency.symbol} per ${
-      estimatedExecutionPrice.baseCurrency.symbol
-    }`,
+    'Amount (A)': inputAmount.toFixed(inputAmount.currency.decimals) + ' ' + inputAmount.currency.symbol,
+    'Fee (F)': feeAmount.toFixed(feeAmount.currency.decimals) + ' ' + feeAmount.currency.symbol,
+    'Limit Price (LP)': `${limitPrice.toFixed(8)} ${limitPrice.quoteCurrency.symbol} per ${
+      limitPrice.baseCurrency.symbol
+    } (${limitPrice.numerator.toString()}/${limitPrice.denominator.toString()})`,
+    'Feasable Execution Price (FEP)': `${feasibleExecutionPrice.toFixed(18)} ${
+      feasibleExecutionPrice.quoteCurrency.symbol
+    } per ${feasibleExecutionPrice.baseCurrency.symbol}`,
+    'Fill Price (FP)': `${fillPrice.toFixed(8)} ${fillPrice.quoteCurrency.symbol} per ${fillPrice.baseCurrency.symbol}`,
+    'Est.Execution Price (EEP)': `${estimatedExecutionPrice.toFixed(8)} ${
+      estimatedExecutionPrice.quoteCurrency.symbol
+    } per ${estimatedExecutionPrice.baseCurrency.symbol}`,
     id: order.id.slice(0, 8),
     class: order.class,
   })


### PR DESCRIPTION
# Summary

Attempt to fix the issue with the formula. 

The formula only works if we use it in the units that is expected. So it's very important to know if we have the prices in sell tokens or buy tokens.

`FEP = (A * LP) / (A - F)`   ---> If prices are in buy tokens
`FEP = (A - F) * LP / A`    ---> If prices are in sell tokens


Because how we construct the price here, it is expressed in BUY TOKENS
https://github.com/cowprotocol/cowswap/blob/use-buy-token-formula/src/custom/state/orders/utils.ts#L282


For this reason, 
* The formula are `FEP = (A * LP) / (A - F)` 
* ...and we use `MAX` (not `MIN`) for the Est. Execution Price 
* `EEP = MAX(FEP, FBOP)`


Tested a few cases with tokens with different decimals. I tested also to use for some USDC as the sell token, and DAI as the sell token for other ones.

<img width="1179" alt="Screenshot at Mar 27 18-22-39" src="https://user-images.githubusercontent.com/2352112/228022200-5ef477d4-689b-4133-ba64-98611b3a09af.png">


## Not included
I see some minor issue that should be reviewed independently

If you set a super-low price (as we are willing to receive virtually 0 like in the picture), we will select the Fill Price as the likely execution price.
<img width="1807" alt="Screenshot at Mar 27 18-31-14" src="https://user-images.githubusercontent.com/2352112/228023020-e12a9264-c27f-40b7-9d5a-84b88ec42d78.png">

For some reason, it shows the message that the price needs to go down 0.04% in order to execute. In reality, this is not TRUE! We should show either exactly the same price as the "Market Price" or a number below it. So it should show the message "It will execute soon". 



