### PR TITLE
Feature/partial fills notifications only for 100%

### DIFF
--- a/src/cow-react/api/gnosisProtocol/api.ts
+++ b/src/cow-react/api/gnosisProtocol/api.ts
@@ -112,7 +112,7 @@ export interface OrderMetaData {
   executedSellAmountBeforeFees: string
   executedFeeAmount: string
   executedSurplusFee: string | null
-  invalidated: false
+  invalidated: boolean
   sellToken: string
   buyToken: string
   sellAmount: string

--- a/src/custom/state/orders/utils.test.ts
+++ b/src/custom/state/orders/utils.test.ts
@@ -2,14 +2,13 @@
  * @jest-environment ./custom-test-env.js
  */
 
-import { OrderKind } from 'state/orders/actions'
-
 import { USDC_MAINNET as USDC, USDT } from 'constants/tokens'
 
-import { generateOrder } from 'state/orders/mocks'
-
-import { getOrderExecutionPrice, isOrderUnfillable } from './utils'
+import { classifyOrder, getOrderExecutionPrice, isOrderUnfillable } from './utils'
 import { Price } from '@uniswap/sdk-core'
+import { generateOrder } from './mocks'
+import { OrderKind } from '@cowprotocol/cow-sdk'
+import ms from 'ms.macro'
 
 // Picked stable coins with same amount of decimals (6) for making easier to visually reason the amounts
 const sellToken = USDT
@@ -121,6 +120,109 @@ describe('isOrderUnfillable', () => {
       const executionPrice = getOrderExecutionPrice(order, price, fee)
 
       expect(isOrderUnfillable(order, orderPrice, executionPrice)).toBeTruthy()
+    })
+  })
+})
+
+describe('classifyOrder', () => {
+  const BASE_ORDER: Parameters<typeof classifyOrder>[0] = {
+    uid: '0x0000000000...',
+    validTo: +ORDER.validTo,
+    creationDate: new Date(Date.now() - ms`1h`).toISOString(),
+    invalidated: false,
+    buyAmount: '1000',
+    sellAmount: '1000',
+    executedBuyAmount: '0',
+    executedSellAmountBeforeFees: '0',
+    kind: OrderKind.SELL,
+    signingScheme: 'eip712',
+    status: 'open',
+  }
+
+  describe('unknown', () => {
+    it('returns unknown when null', () => {
+      expect(classifyOrder(null)).toBe('unknown')
+    })
+  })
+  describe('fulfilled', () => {
+    it('is sell', () => {
+      const order: typeof BASE_ORDER = { ...BASE_ORDER, executedSellAmountBeforeFees: BASE_ORDER.sellAmount }
+      expect(classifyOrder(order)).toBe('fulfilled')
+    })
+
+    it('is buy', () => {
+      const order: typeof BASE_ORDER = { ...BASE_ORDER, executedBuyAmount: BASE_ORDER.buyAmount, kind: OrderKind.BUY }
+      expect(classifyOrder(order)).toBe('fulfilled')
+    })
+  })
+  describe('expired', () => {
+    it('is expired when validTo in the past', () => {
+      const order: typeof BASE_ORDER = { ...BASE_ORDER, validTo: (Date.now() - ms`50 min`) / 1000 }
+      expect(classifyOrder(order)).toBe('expired')
+    })
+  })
+  describe('cancelled', () => {
+    it('is cancelled when invalidated for more than X time', () => {
+      const order: typeof BASE_ORDER = { ...BASE_ORDER, invalidated: true }
+      expect(classifyOrder(order)).toBe('cancelled')
+    })
+  })
+  describe('presignaturePending', () => {
+    it('is pending pre-signature', () => {
+      const order: typeof BASE_ORDER = { ...BASE_ORDER, status: 'presignaturePending' }
+      expect(classifyOrder(order)).toBe('presignaturePending')
+    })
+  })
+  describe('presigned', () => {
+    it('is presigned when open and signScheme is presign', () => {
+      const order: typeof BASE_ORDER = { ...BASE_ORDER, signingScheme: 'presign' }
+      expect(classifyOrder(order)).toBe('presigned')
+    })
+  })
+  describe('pending', () => {
+    // Fulfilled rejects
+    it('has not sold 100%', () => {
+      const order: typeof BASE_ORDER = { ...BASE_ORDER, executedSellAmountBeforeFees: '100' }
+      expect(classifyOrder(order)).toBe('pending')
+    })
+
+    it('has not bought 100%', () => {
+      const order: typeof BASE_ORDER = { ...BASE_ORDER, executedBuyAmount: '100', kind: OrderKind.BUY }
+      expect(classifyOrder(order)).toBe('pending')
+    })
+
+    // Expired rejects
+    it('expired but within buffer', () => {
+      const order: typeof BASE_ORDER = { ...BASE_ORDER, validTo: (Date.now() - ms`1min`) / 1000 }
+      expect(classifyOrder(order)).toBe('pending')
+    })
+
+    // Cancelled rejects
+    it('invalidated but within buffer', () => {
+      const order: typeof BASE_ORDER = {
+        ...BASE_ORDER,
+        invalidated: true,
+        creationDate: new Date(Date.now() - ms`1min`).toISOString(),
+      }
+      expect(classifyOrder(order)).toBe('pending')
+    })
+    it('outside buffer but not invalidated', () => {
+      const order: typeof BASE_ORDER = {
+        ...BASE_ORDER,
+        invalidated: false,
+        creationDate: new Date(Date.now() - ms`10min`).toISOString(),
+      }
+      expect(classifyOrder(order)).toBe('pending')
+    })
+
+    // Presigned rejects
+    it('open but signing method not presign', () => {
+      const order: typeof BASE_ORDER = { ...BASE_ORDER, signingScheme: 'eip712' }
+      expect(classifyOrder(order)).toBe('pending')
+    })
+    it('presign but not open', () => {
+      const order: typeof BASE_ORDER = { ...BASE_ORDER, signingScheme: 'presign', status: 'fulfilled' }
+      expect(classifyOrder(order)).toBe('pending')
     })
   })
 })


### PR DESCRIPTION
# Summary

Trigger notifications only when order matches 100%

Change should not affect fill or kill (SWAP) orders

  # To Test

1. Place a swap order
* When it executes, a notification should be displayed
2. Place a limit order
* When it matches, it shouldn't show a notification unless 100% of it has been filled

## Caveats

1. Partial fills might not happen at all
2. You might not be able to "make" your order match 100%