### PR TITLE
Adjusting positioning of expert mode icon for limit orders

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/SettingsWidget/styled.tsx
+++ b/src/cow-react/modules/limitOrders/containers/SettingsWidget/styled.tsx
@@ -21,11 +21,11 @@ export const MenuContent = styled(MenuList)`
 export const ExpertModeIndicator = styled.div`
   display: inline-block;
   position: relative;
-  width: 24px;
+  width: 12px;
   height: 24px;
   font-size: 20px;
   user-select: none;
-  margin-left: 6px;
+  margin-right: 17px;
   animation: expertModeOn 3s normal forwards ease-in-out;
 
   > span:first-child {


### PR DESCRIPTION
# Summary

Closes #2185 

Cow icon now aligned on both forms

https://user-images.githubusercontent.com/43217/228315098-215075f4-58c1-4e00-918d-ed52b02c7bdc.mov




# To Test

1. On limit orders form, turn on expert mode
* Expert cow emoji should not over extend