### PR TITLE
Fixed bought token symbol on limit orders table receipt

### DIFF
--- a/src/cow-react/modules/limitOrders/pure/ReceiptModal/FilledField.tsx
+++ b/src/cow-react/modules/limitOrders/pure/ReceiptModal/FilledField.tsx
@@ -76,7 +76,7 @@ export function FilledField({ order, sellAmount, buyAmount }: Props) {
   const formattedFilledAmount = legacyBigNumberToCurrencyAmount(mainToken, filledAmountDecimal)
 
   const swappedAmountDecimal = swappedAmountWithFee.div(new BigNumber(10 ** swappedToken.decimals))
-  const formattedSwappedAmount = legacyBigNumberToCurrencyAmount(outputToken, swappedAmountDecimal)
+  const formattedSwappedAmount = legacyBigNumberToCurrencyAmount(swappedToken, swappedAmountDecimal)
 
   return (
     <styledEl.Value>


### PR DESCRIPTION
# Summary

Fixed bought token symbol for limit orders receipt

## Before
![image](https://user-images.githubusercontent.com/43217/228590385-6a4997d2-bf6e-46ea-9272-d9d7b477239b.png)
## After
![image](https://user-images.githubusercontent.com/43217/228590488-36af0d55-e4ad-48bd-9791-f0662fa34cde.png)

# To Test

1. On a filled BUY limit order (probably should work for SWAP, but I haven't tested), open the receipt modal
* The `filled` row should show the correct token symbols