### PR TITLE
Showing a different button text when expert mode is enabled

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/TradeButtons/limitOrdersTradeButtonsMap.tsx
+++ b/src/cow-react/modules/limitOrders/containers/TradeButtons/limitOrdersTradeButtonsMap.tsx
@@ -83,6 +83,11 @@ export const limitOrdersTradeButtonsMap: { [key in LimitOrdersFormState]: Button
     text: 'Review limit order',
     id: 'review-limit-order-btn',
   },
+  [LimitOrdersFormState.ExpertCanTrade]: {
+    disabled: false,
+    text: 'Place limit order',
+    id: 'review-limit-order-btn',
+  },
   [LimitOrdersFormState.SwapIsUnsupported]: {
     disabled: true,
     text: 'Unsupported token',

--- a/src/cow-react/modules/limitOrders/hooks/useLimitOrdersFormState.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useLimitOrdersFormState.ts
@@ -13,10 +13,15 @@ import { limitOrdersQuoteAtom, LimitOrdersQuoteState } from '@cow/modules/limitO
 import { limitRateAtom } from '@cow/modules/limitOrders/state/limitRateAtom'
 import { useDetectNativeToken } from '@cow/modules/swap/hooks/useDetectNativeToken'
 import { isUnsupportedTokenInQuote } from '@cow/modules/limitOrders/utils/isUnsupportedTokenInQuote'
+import {
+  limitOrdersSettingsAtom,
+  LimitOrdersSettingsState,
+} from '@cow/modules/limitOrders/state/limitOrdersSettingsAtom'
 
 export enum LimitOrdersFormState {
   NotApproved = 'NotApproved',
   CanTrade = 'CanTrade',
+  ExpertCanTrade = 'ExpertCanTrade',
   Loading = 'Loading',
   SwapIsUnsupported = 'SwapIsUnsupported',
   WrapUnwrap = 'WrapUnwrap',
@@ -42,6 +47,7 @@ interface LimitOrdersFormParams {
   currentAllowance: CurrencyAmount<Token> | undefined
   approvalState: ApprovalState
   tradeState: LimitOrdersTradeState
+  settingsState: LimitOrdersSettingsState
   recipientEnsAddress: string | null
   quote: LimitOrdersQuoteState | null
   activeRate: Fraction | null
@@ -59,6 +65,7 @@ function getLimitOrdersFormState(params: LimitOrdersFormParams): LimitOrdersForm
     currentAllowance,
     approvalState,
     tradeState,
+    settingsState,
     recipientEnsAddress,
     quote,
     isWrapOrUnwrap,
@@ -152,12 +159,16 @@ function getLimitOrdersFormState(params: LimitOrdersFormParams): LimitOrdersForm
     return LimitOrdersFormState.FeeExceedsFrom
   }
 
+  if (settingsState.expertMode) {
+    return LimitOrdersFormState.ExpertCanTrade
+  }
   return LimitOrdersFormState.CanTrade
 }
 
 export function useLimitOrdersFormState(): LimitOrdersFormState {
   const { chainId, account } = useWalletInfo()
   const tradeState = useLimitOrdersTradeState()
+  const settingsState = useAtomValue(limitOrdersSettingsAtom)
   const { isSupportedWallet } = useWalletDetails()
   const gnosisSafeInfo = useGnosisSafeInfo()
   const isReadonlyGnosisSafeUser = gnosisSafeInfo?.isReadOnly || false
@@ -184,6 +195,7 @@ export function useLimitOrdersFormState(): LimitOrdersFormState {
     approvalState,
     currentAllowance,
     tradeState,
+    settingsState,
     recipientEnsAddress,
     quote,
     activeRate,


### PR DESCRIPTION
# Summary

Minor change, updating the button with text appropriated for expert mode, as there's no review modal when it's enabled

## Before
![image](https://user-images.githubusercontent.com/43217/228811798-ca17a09b-920a-43ad-a1c5-45e1c2a62fb5.png)

## Now
![image](https://user-images.githubusercontent.com/43217/228811626-38b50b53-73dd-4c80-b2f1-c02e8b96c66b.png)

  # To Test

1. Turn expert mode on
2. Fill in the form
* The button will show `Place limit order`
3. Click on `Place limit order` button
* It should trigger the wallet signature
4. Turn export mode off
* The button will show `Review limit order`
5. Click on `Review limit order` button
* It should show the review order modal