### PR TITLE
Add info regarding if the quote os final

### DIFF
--- a/src/cow-react/modules/limitOrders/hooks/useTradeFlowContext.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useTradeFlowContext.ts
@@ -77,6 +77,7 @@ export function useTradeFlowContext(): TradeFlowContext | null {
       partiallyFillable: true, // Limit orders ALWAYS partially fillable - for now
       appDataHash: appData.hash,
       quoteId,
+      isQuoteFinal: quoteState.isQuoteFinal,
     },
   }
 }

--- a/src/cow-react/modules/limitOrders/pure/LimitOrdersConfirm/index.cosmos.tsx
+++ b/src/cow-react/modules/limitOrders/pure/LimitOrdersConfirm/index.cosmos.tsx
@@ -65,6 +65,7 @@ const tradeContext: TradeFlowContext = {
     allowsOffchainSigning: true,
     partiallyFillable: true,
     appDataHash: '0xabc',
+    isQuoteFinal: true,
   },
   rateImpact: 0,
   appData: {} as any,

--- a/src/cow-react/modules/limitOrders/pure/LimitOrdersDetails/index.cosmos.tsx
+++ b/src/cow-react/modules/limitOrders/pure/LimitOrdersDetails/index.cosmos.tsx
@@ -28,6 +28,7 @@ const tradeContext: TradeFlowContext = {
     allowsOffchainSigning: true,
     partiallyFillable: true,
     appDataHash: '0xabc',
+    isQuoteFinal: true,
   },
   rateImpact: 0,
   appData: {} as any,

--- a/src/cow-react/modules/limitOrders/state/limitOrdersQuoteAtom.ts
+++ b/src/cow-react/modules/limitOrders/state/limitOrdersQuoteAtom.ts
@@ -5,6 +5,7 @@ import { OrderQuoteResponse } from '@cowprotocol/cow-sdk'
 export interface LimitOrdersQuoteState {
   response?: OrderQuoteResponse
   error?: GpQuoteError
+  isQuoteFinal: boolean
 }
 
-export const limitOrdersQuoteAtom = atom<LimitOrdersQuoteState>({})
+export const limitOrdersQuoteAtom = atom<LimitOrdersQuoteState>({ isQuoteFinal: false })

--- a/src/cow-react/modules/limitOrders/updaters/MarketPriceUpdater/hooks/useFetchMarketPrice/index.ts
+++ b/src/cow-react/modules/limitOrders/updaters/MarketPriceUpdater/hooks/useFetchMarketPrice/index.ts
@@ -40,14 +40,13 @@ export function useFetchMarketPrice() {
       console.debug('[useFetchMarketPrice] No need to fetch quotes')
       return
     }
-
     console.debug('[useFetchMarketPrice] Periodically fetch quotes')
     const handleFetchQuote = () => {
       console.debug('[useFetchMarketPrice] Fetching price')
       getQuoteOnlyResolveLast(feeQuoteParams)
-        .then(handleResponse)
+        .then((result) => handleResponse(result, feeQuoteParams))
         .catch((error: GpQuoteError) => {
-          setLimitOrdersQuote({ error })
+          setLimitOrdersQuote({ error, isQuoteFinal: false })
           updateLimitRateState({ marketRate: null })
         })
         .finally(() => updateLimitRateState({ isLoadingMarketRate: false }))

--- a/src/cow-react/modules/limitOrders/updaters/MarketPriceUpdater/hooks/useFetchMarketPrice/useHandleResponse.ts
+++ b/src/cow-react/modules/limitOrders/updaters/MarketPriceUpdater/hooks/useFetchMarketPrice/useHandleResponse.ts
@@ -8,6 +8,7 @@ import { limitOrdersQuoteAtom } from '@cow/modules/limitOrders/state/limitOrders
 import { CancelableResult } from 'utils/async'
 import { FractionUtils } from '@cow/utils/fractionUtils'
 import { OrderQuoteResponse } from '@cowprotocol/cow-sdk'
+import { LimitOrdersQuoteParams } from '../useQuoteRequestParams'
 
 export const LIMIT_ORDERS_PRICE_SLIPPAGE = new Percent(1, 10) // 0.1%
 
@@ -48,7 +49,7 @@ export function useHandleResponse() {
   const setLimitOrdersQuote = useSetAtom(limitOrdersQuoteAtom)
 
   return useCallback(
-    (response: CancelableResult<OrderQuoteResponse>) => {
+    (response: CancelableResult<OrderQuoteResponse>, feeQuoteParams: LimitOrdersQuoteParams) => {
       try {
         const result = handleLimitOrderQuoteResponse(inputCurrency, outputCurrency, response)
 
@@ -57,7 +58,10 @@ export function useHandleResponse() {
         const { rateState, quote } = result
 
         updateLimitRateState(rateState)
-        setLimitOrdersQuote({ response: quote })
+        setLimitOrdersQuote({
+          response: quote,
+          isQuoteFinal: feeQuoteParams.priceQuality === undefined || feeQuoteParams.priceQuality === 'optimal',
+        })
       } catch (error: any) {
         console.debug('[useFetchMarketPrice] Failed to fetch exection price', error)
         updateLimitRateState({ marketRate: null })

--- a/src/cow-react/modules/swap/helpers/tradeReceiveAmount.test.ts
+++ b/src/cow-react/modules/swap/helpers/tradeReceiveAmount.test.ts
@@ -29,6 +29,7 @@ describe('Helpers to build ReceiveAmountInfo', () => {
             executionPrice: new Price(currency, currencyOut, 1, 4),
             tradeType: TradeType.EXACT_INPUT,
             quoteId: 10000,
+            isQuoteFinal: true,
           })
         )
 
@@ -54,6 +55,7 @@ describe('Helpers to build ReceiveAmountInfo', () => {
           executionPrice: new Price(currency, currencyOut, 1, 4),
           tradeType: TradeType.EXACT_INPUT,
           quoteId: 10000,
+          isQuoteFinal: true,
         })
       )
 

--- a/src/cow-react/modules/swap/hooks/useEthFlowContext.ts
+++ b/src/cow-react/modules/swap/hooks/useEthFlowContext.ts
@@ -14,6 +14,7 @@ import { useSetAtom, useAtomValue } from 'jotai'
 export function useEthFlowContext(): EthFlowContext | null {
   const contract = useEthFlowContract()
   const baseProps = useBaseFlowContextSetup()
+
   const addTransaction = useTransactionAdder()
 
   const ethFlowInFlightOrderIds = useAtomValue(ethFlowInFlightOrderIdsAtom)

--- a/src/cow-react/modules/swap/hooks/useFlowContext.ts
+++ b/src/cow-react/modules/swap/hooks/useFlowContext.ts
@@ -209,6 +209,7 @@ export function getFlowContext({ baseProps, sellToken, kind }: BaseGetFlowContex
     partiallyFillable: false, // SWAP orders are always fill or kill - for now
     appDataHash: appData.hash,
     quoteId: trade.quoteId,
+    isQuoteFinal: trade.isQuoteFinal,
   }
 
   return {

--- a/src/cow-react/modules/swap/hooks/useSwapButtonContext.ts
+++ b/src/cow-react/modules/swap/hooks/useSwapButtonContext.ts
@@ -126,5 +126,6 @@ export function useSwapButtonContext(input: SwapButtonInput): SwapButtonsContext
     toggleWalletModal,
     swapInputError,
     onCurrencySelection,
+    isQuoteFinal: trade?.isQuoteFinal || false,
   }
 }

--- a/src/cow-react/modules/swap/pure/Row/RowFeeContent/index.cosmos.tsx
+++ b/src/cow-react/modules/swap/pure/Row/RowFeeContent/index.cosmos.tsx
@@ -22,6 +22,7 @@ const trade = new TradeGp({
   executionPrice: new Price(currency, currencyOut, 1, 4),
   tradeType: TradeType.EXACT_INPUT,
   quoteId: 10000,
+  isQuoteFinal: true,
 })
 const defaultProps: RowFeeProps & RowFeeContentProps = {
   trade,

--- a/src/cow-react/modules/swap/pure/Row/RowReceivedAfterSlippageContent/index.cosmos.tsx
+++ b/src/cow-react/modules/swap/pure/Row/RowReceivedAfterSlippageContent/index.cosmos.tsx
@@ -24,6 +24,7 @@ const trade = new TradeGp({
   executionPrice: new Price(currency, currencyOut, 1, 4),
   tradeType: TradeType.EXACT_INPUT,
   quoteId: 10000,
+  isQuoteFinal: true,
 })
 const defaultProps: RowReceivedAfterSlippageProps & RowReceivedAfterSlippageContentProps = {
   trade,

--- a/src/cow-react/modules/swap/pure/SwapButtons/index.cosmos.tsx
+++ b/src/cow-react/modules/swap/pure/SwapButtons/index.cosmos.tsx
@@ -24,6 +24,7 @@ const swapButtonsContext: SwapButtonsContext = {
   openSwapConfirm: () => void 0,
   toggleWalletModal: () => void 0,
   hasEnoughWrappedBalanceForSwap: true,
+  isQuoteFinal: true,
 }
 
 function useCustomProps(): SwapButtonsContext {

--- a/src/cow-react/modules/swap/pure/SwapButtons/index.tsx
+++ b/src/cow-react/modules/swap/pure/SwapButtons/index.tsx
@@ -34,6 +34,7 @@ export interface SwapButtonsContext {
   hasEnoughWrappedBalanceForSwap: boolean
   swapInputError?: ReactNode
   onCurrencySelection: (field: Field, currency: Currency) => void
+  isQuoteFinal: boolean
 }
 
 const swapButtonStateMap: { [key in SwapButtonState]: (props: SwapButtonsContext) => JSX.Element } = {
@@ -187,5 +188,9 @@ function EthFlowSwapButton(props: SwapButtonsContext & { isExpertMode: boolean }
 export const SwapButtons = React.memo(function (props: SwapButtonsContext) {
   console.debug('RENDER SWAP BUTTON: ', props)
 
-  return <div id="swap-button">{swapButtonStateMap[props.swapButtonState](props)}</div>
+  return (
+    <div id="swap-button">
+      {swapButtonStateMap[props.swapButtonState](props)} (Is Quote Final? {Boolean(props.isQuoteFinal).toString()})
+    </div>
+  )
 }, genericPropsChecker)

--- a/src/cow-react/modules/swap/pure/TradeRates/index.cosmos.tsx
+++ b/src/cow-react/modules/swap/pure/TradeRates/index.cosmos.tsx
@@ -21,6 +21,7 @@ const trade = new TradeGp({
   executionPrice: new Price(currency, currencyOut, 1, 4),
   tradeType: TradeType.EXACT_INPUT,
   quoteId: 10000,
+  isQuoteFinal: true,
 })
 const rateInfoParams: RateInfoParams = {
   chainId: 5,

--- a/src/cow-react/modules/swap/pure/TradeSummary/index.cosmos.tsx
+++ b/src/cow-react/modules/swap/pure/TradeSummary/index.cosmos.tsx
@@ -21,6 +21,7 @@ const trade = new TradeGp({
   executionPrice: new Price(currency, currencyOut, 1, 4),
   tradeType: TradeType.EXACT_INPUT,
   quoteId: 10000,
+  isQuoteFinal: true,
 })
 const defaultProps: TradeSummaryProps & TradeSummaryContentProps = {
   trade,

--- a/src/custom/hooks/useRefetchPriceCallback.tsx
+++ b/src/custom/hooks/useRefetchPriceCallback.tsx
@@ -252,7 +252,7 @@ export function useRefetchQuoteCallback() {
 
       // Get the best quote
       getBestQuoteResolveOnlyLastCall(bestQuoteParams)
-        .then((res) => handleResponse(res, true))
+        //.then((res) => handleResponse(res, true)) // TODO: Uncomment later (this is to force always temporal prices)
         .catch(handleError)
     },
     [

--- a/src/custom/hooks/useRefetchPriceCallback.tsx
+++ b/src/custom/hooks/useRefetchPriceCallback.tsx
@@ -252,7 +252,12 @@ export function useRefetchQuoteCallback() {
 
       // Get the best quote
       getBestQuoteResolveOnlyLastCall(bestQuoteParams)
-        //.then((res) => handleResponse(res, true)) // TODO: Uncomment later (this is to force always temporal prices)
+        // .then((res) => handleResponse(res, true)) // TODO: Uncomment later and delete the other test below
+        .then((res) => setTimeout(() => handleResponse(res, true), 60000)) // Prentend to be slower!
+        // Prentend to throw
+        // .then(() => {
+        //   throw new Error('BOOM! Failed to get the quote!')
+        // })
         .catch(handleError)
     },
     [

--- a/src/custom/state/swap/TradeGp.ts
+++ b/src/custom/state/swap/TradeGp.ts
@@ -70,6 +70,7 @@ interface TradeGpConstructor {
   executionPrice: Price<Currency, Currency>
   tradeType: TradeType
   quoteId?: number
+  isQuoteFinal: boolean
 }
 
 /**
@@ -108,6 +109,17 @@ export default class TradeGp {
    */
   readonly quoteId?: number
 
+  /**
+   * Shows if the trade has a valid quote that can be used for posting the order to the protocol.
+   *
+   * Sometimes, it might be useful to query some services to get a rough estimation on the price of two assests.
+   * This helps to give a fast response to the user and show some illustrative prices while the official quote is being
+   * queried.
+   *
+   * This flag, if its not set, indicates that the trade shouldn't be posted to the protocol.
+   */
+  readonly isQuoteFinal: boolean
+
   public constructor({
     inputAmount,
     inputAmountWithFee,
@@ -118,6 +130,7 @@ export default class TradeGp {
     executionPrice,
     tradeType,
     quoteId,
+    isQuoteFinal,
   }: TradeGpConstructor) {
     this.tradeType = tradeType
     this.inputAmount = inputAmount
@@ -128,6 +141,7 @@ export default class TradeGp {
     this.fee = fee
     this.executionPrice = executionPrice
     this.quoteId = quoteId
+    this.isQuoteFinal = isQuoteFinal
   }
   /**
    * Get the minimum amount that must be received from this trade for the given slippage tolerance

--- a/src/custom/state/swap/extension.ts
+++ b/src/custom/state/swap/extension.ts
@@ -78,6 +78,7 @@ export function useTradeExactInWithFee({
     executionPrice,
     tradeType: TradeType.EXACT_INPUT,
     quoteId: quote.price.quoteId,
+    isQuoteFinal: quote.isBestQuote === true,
   })
 }
 
@@ -131,5 +132,6 @@ export function useTradeExactOutWithFee({
     executionPrice,
     tradeType: TradeType.EXACT_OUTPUT,
     quoteId: quote.price.quoteId,
+    isQuoteFinal: quote.isBestQuote === true,
   })
 }


### PR DESCRIPTION
# Summary

This PR helps to reproduce the case described in https://cowservices.slack.com/archives/C036G0J90BU/p1680169031535319

Basically, there's some cases where we allow users to submit orders with a "fast" price from the quote endpoint. 
We need to make the user wait in his last step. 


## Notes for the one fixing the issue
I left some pointers in this PR, please read my comments

I think we could do a PR on top this branch

# Changes in this PR
## Show if the quote is final
To easily see when we update the quote
<img width="817" alt="image" src="https://user-images.githubusercontent.com/2352112/229781380-d4810632-c76a-4a35-b681-30c98d28efb8.png">

## Delay artificially the final quote 
Delays 60s artificially the response from the endpoint of the final quote

## Adds a flag in the state to know if the quote is final
Will be handy to control the case

## Last resource: Throw if you try to sign an order with fast price
Ideally this error shouldn't be visible ever. In this PR on porpouse it is because we still haven't handled the issue. 

This is a convenient test for the PR build on top of this branch, so we can't arrive to the signing part with the "temporal quote"

<img width="786" alt="image" src="https://user-images.githubusercontent.com/2352112/229782556-08699d32-1d53-4a77-a3d9-bc6d3e451e43.png">

