### PR TITLE
Feature/partial fills order type

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -82,6 +82,12 @@ export function LimitOrdersWidget() {
     () => !isWrapOrUnwrap && settingState.showRecipient,
     [settingState.showRecipient, isWrapOrUnwrap]
   )
+
+  const isExpertMode = useMemo(
+    () => !isWrapOrUnwrap && settingState.expertMode,
+    [isWrapOrUnwrap, settingState.expertMode]
+  )
+
   const priceImpact = usePriceImpact(useLimitOrdersPriceImpactParams())
   const inputViewAmount = formatInputAmount(inputCurrencyAmount, inputCurrencyBalance, orderKind === OrderKind.SELL)
 
@@ -163,6 +169,7 @@ export function LimitOrdersWidget() {
     allowsOffchainSigning,
     isWrapOrUnwrap,
     showRecipient,
+    isExpertMode,
     recipient,
     chainId,
     onChangeRecipient,
@@ -193,6 +200,7 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
     allowsOffchainSigning,
     isWrapOrUnwrap,
     showRecipient,
+    isExpertMode,
     recipient,
     onChangeRecipient,
     rateInfoParams,
@@ -291,6 +299,12 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
               {!isWrapOrUnwrap && (
                 <styledEl.FooterBox>
                   <styledEl.StyledRateInfo rateInfoParams={rateInfoParams} />
+                </styledEl.FooterBox>
+              )}
+
+              {isExpertMode && (
+                <styledEl.FooterBox>
+                  <styledEl.StyledOrderType isPartiallyFillable />
                 </styledEl.FooterBox>
               )}
 

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/limitOrdersPropsChecker.ts
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/limitOrdersPropsChecker.ts
@@ -20,6 +20,7 @@ export interface LimitOrdersProps extends AddRecipientProps {
   allowsOffchainSigning: boolean
   isWrapOrUnwrap: boolean
   showRecipient: boolean
+  isExpertMode: boolean
 
   recipient: string | null
   chainId: number | undefined

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/styled.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/styled.tsx
@@ -3,6 +3,7 @@ import { RemoveRecipient } from '@cow/modules/swap/containers/RemoveRecipient'
 import { RateInfo } from '@cow/common/pure/RateInfo'
 import { NumericalInput } from '@cow/modules/limitOrders/containers/RateInput/styled'
 import { transparentize, darken } from 'polished'
+import { OrderType } from '@cow/modules/limitOrders/pure/OrderType'
 
 export const Container = styled.div`
   width: 100%;
@@ -87,6 +88,10 @@ export const StyledRateInfo = styled(RateInfo)`
   min-height: 24px;
   display: grid;
   grid-template-columns: max-content auto;
+`
+
+export const StyledOrderType = styled(OrderType)`
+  font-size: 13px;
 `
 
 export const SmallVolumeWarningBanner = styled.div`

--- a/src/cow-react/modules/limitOrders/pure/LimitOrdersDetails/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/LimitOrdersDetails/index.tsx
@@ -17,6 +17,7 @@ import { LimitRateState } from '@cow/modules/limitOrders/state/limitRateAtom'
 import { formatInputAmount } from '@cow/utils/amountFormat'
 import { limitOrdersFeatures } from '@cow/constants/featureFlags'
 import { DEFAULT_DATE_FORMAT } from '@cow/constants/intl'
+import { OrderType } from '@cow/modules/limitOrders/pure/OrderType'
 
 const Wrapper = styled.div`
   font-size: 13px;
@@ -115,19 +116,8 @@ export function LimitOrdersDetails(props: LimitOrdersDetailsProps) {
           <span>Active</span>
         </div>
       </styledEl.DetailsRow> */}
-      {/* <styledEl.DetailsRow>
-        <div>
-          <span>Order type</span>{' '}
-          <InfoIcon
-            content={
-              'This order will either be filled completely or not filled. (Support for partially fillable orders is coming soon!)'
-            }
-          />
-        </div>
-        <div>
-          <span>Fill or kill</span>
-        </div>
-      </styledEl.DetailsRow> */}
+      {/* TODO: adjust flag when settings are available */}
+      <OrderType isPartiallyFillable />
       {recipientAddressOrName && recipient !== account && (
         <styledEl.DetailsRow>
           <div>

--- a/src/cow-react/modules/limitOrders/pure/OrderType/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/OrderType/index.tsx
@@ -1,0 +1,28 @@
+import { DetailsRow } from '@cow/modules/limitOrders/pure/LimitOrdersDetails/styled'
+import { InfoIcon } from 'components/InfoIcon'
+
+export type OrderTypeProps = {
+  isPartiallyFillable: boolean
+  className?: string
+}
+
+export function OrderType({ isPartiallyFillable, className }: OrderTypeProps) {
+  const textContent = isPartiallyFillable
+    ? 'This order can be partially filled'
+    : 'This order will either be filled completely or not filled.'
+  const labelText = isPartiallyFillable ? 'Partially fillable' : 'Fill or kill'
+
+  return (
+    <DetailsRow className={className}>
+      <div>
+        <span>
+          <p>Order type</p>
+        </span>{' '}
+        <InfoIcon content={textContent} />
+      </div>
+      <div>
+        <span>{labelText}</span>
+      </div>
+    </DetailsRow>
+  )
+}

--- a/src/cow-react/modules/limitOrders/pure/ReceiptModal/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/ReceiptModal/index.tsx
@@ -46,7 +46,8 @@ const tooltips: { [key: string]: string | JSX.Element } = {
       set) or limit orders (which fill at a price you specify).
       <br />
       <br />
-      All orders are currently fill or kill, but support for partially fillable limit orders is coming soon!
+      Market orders are always fill or kill, while limit orders are currently partially fillable. Soon it'll be possible
+      to chose the type
     </span>
   ),
 }


### PR DESCRIPTION
# Summary

Added order type to the form (when expert mode)

![image](https://user-images.githubusercontent.com/43217/228819016-76b0d1a6-1aaf-4d26-841e-ab3a31097b7b.png)

And to the review modal (when regular mode)
![image](https://user-images.githubusercontent.com/43217/228819160-e6219586-1fb5-46dc-89b5-0009fa20ef06.png)

Also updated the tooltip on order receipt
![image](https://user-images.githubusercontent.com/43217/228818897-176270d3-e4d4-42c3-80b9-9820acd27af3.png)


  # To Test

1. Fill in the form
2. Click on `Review order`
* You should see the filed `Order type` at the bottom of the modal
3. Turn expert mode on
* You should see the filed `Order type` at the bottom of the form
4. On the orders table, click on any order to show the receipt modal
* The `Order type` tooltip should be updated