### PR TITLE
Feature/partial fills show surplus

### DIFF
--- a/src/cow-react/modules/limitOrders/pure/ReceiptModal/SurplusField.tsx
+++ b/src/cow-react/modules/limitOrders/pure/ReceiptModal/SurplusField.tsx
@@ -17,7 +17,7 @@ export function SurplusField({ order }: Props) {
     return <styledEl.Value>-</styledEl.Value>
   }
 
-  const parsedSurplus = CurrencyAmount.fromRawAmount(surplusToken, surplusAmount?.toNumber())
+  const parsedSurplus = CurrencyAmount.fromRawAmount(surplusToken, surplusAmount?.decimalPlaces(0).toFixed())
   const formattedPercent = surplusPercentage?.multipliedBy(100)?.toFixed(2)
 
   return (

--- a/src/cow-react/modules/limitOrders/utils/getOrderExecutedAmounts.ts
+++ b/src/cow-react/modules/limitOrders/utils/getOrderExecutedAmounts.ts
@@ -20,10 +20,10 @@ export function getOrderExecutedAmounts(order: Order): {
     }
   }
 
-  const { executedBuyAmount, executedSellAmount, executedFeeAmount } = apiAdditionalInfo
+  const { executedBuyAmount, executedSellAmountBeforeFees } = apiAdditionalInfo
 
   return {
     executedBuyAmount: JSBI.BigInt(executedBuyAmount),
-    executedSellAmount: JSBI.subtract(JSBI.BigInt(executedSellAmount), JSBI.BigInt(executedFeeAmount)),
+    executedSellAmount: JSBI.BigInt(executedSellAmountBeforeFees),
   }
 }

--- a/src/cow-react/modules/limitOrders/utils/getOrderSurplus.ts
+++ b/src/cow-react/modules/limitOrders/utils/getOrderSurplus.ts
@@ -1,7 +1,7 @@
 // Util functions that only pertain to/deal with operator API related stuff
 import BigNumber from 'bignumber.js'
 import { ZERO_BIG_NUMBER } from 'constants/index'
-import { Order, OrderStatus } from 'state/orders/actions'
+import { Order } from 'state/orders/actions'
 import { getOrderExecutedAmounts } from './getOrderExecutedAmounts'
 
 type Surplus = {
@@ -135,17 +135,15 @@ function _getPartialFillBuySurplus(order: Order): Surplus | null {
   return { amount, percentage }
 }
 
-const SURPLUS_AVAILABLE_STATUSES = [OrderStatus.EXPIRED, OrderStatus.CANCELLED, OrderStatus.FULFILLED]
-
 const ZERO_SURPLUS: Surplus = { amount: ZERO_BIG_NUMBER, percentage: ZERO_BIG_NUMBER }
 
 export function getOrderSurplus(order: Order): Surplus {
-  const { kind, status } = order
+  const { kind } = order
 
   // `executedSellAmount` already has `executedFeeAmount` discounted
   const { executedBuyAmount, executedSellAmount } = getOrderExecutedAmounts(order)
 
-  if (!executedBuyAmount || !executedSellAmount || !SURPLUS_AVAILABLE_STATUSES.includes(status)) {
+  if (!executedBuyAmount || !executedSellAmount) {
     return ZERO_SURPLUS
   }
 

--- a/src/cow-react/modules/limitOrders/utils/getOrderSurplus.ts
+++ b/src/cow-react/modules/limitOrders/utils/getOrderSurplus.ts
@@ -1,7 +1,7 @@
 // Util functions that only pertain to/deal with operator API related stuff
 import BigNumber from 'bignumber.js'
 import { ZERO_BIG_NUMBER } from 'constants/index'
-import { Order } from 'state/orders/actions'
+import { Order, OrderStatus } from 'state/orders/actions'
 import { BigNumberish } from '@ethersproject/bignumber'
 import { getOrderExecutedAmounts } from './getOrderExecutedAmounts'
 
@@ -53,14 +53,15 @@ export function getBuySurplus(sellAmount: BigNumberish, executedSellAmountMinusF
   return { amount, percentage }
 }
 
+const SURPLUS_AVAILABLE_STATUSES = [OrderStatus.EXPIRED, OrderStatus.CANCELLED, OrderStatus.FULFILLED]
+
 export function getOrderSurplus(order: Order): Surplus {
-  const { kind, buyAmount, sellAmount, partiallyFillable } = order
+  const { kind, buyAmount, sellAmount, status } = order
 
   // `executedSellAmount` already has `executedFeeAmount` discounted
   const { executedBuyAmount, executedSellAmount } = getOrderExecutedAmounts(order)
 
-  if (partiallyFillable || !executedBuyAmount || !executedSellAmount) {
-    // TODO: calculate how much was matched based on the type and check whether there was any surplus
+  if (!executedBuyAmount || !executedSellAmount || !SURPLUS_AVAILABLE_STATUSES.includes(status)) {
     return { amount: ZERO_BIG_NUMBER, percentage: ZERO_BIG_NUMBER }
   }
 

--- a/src/cow-react/modules/limitOrders/utils/getOrderSurplus.ts
+++ b/src/cow-react/modules/limitOrders/utils/getOrderSurplus.ts
@@ -2,7 +2,6 @@
 import BigNumber from 'bignumber.js'
 import { ZERO_BIG_NUMBER } from 'constants/index'
 import { Order, OrderStatus } from 'state/orders/actions'
-import { BigNumberish } from '@ethersproject/bignumber'
 import { getOrderExecutedAmounts } from './getOrderExecutedAmounts'
 
 type Surplus = {
@@ -11,63 +10,148 @@ type Surplus = {
 }
 
 /**
- * Calculates SELL surplus based on buy amounts
+ * Calculates SELL surplus
  *
- * @param buyAmount buyAmount
- * @param executedBuyAmount executedBuyAmount
  * @returns Sell surplus
  */
-export function getSellSurplus(buyAmount: BigNumberish, executedBuyAmount: BigNumberish): Surplus {
+export function getSellSurplus(order: Order): Surplus {
+  const { partiallyFillable } = order
+
+  const surplus = partiallyFillable ? _getPartialFillSellSurplus(order) : _getFillOrKillSellSurplus(order)
+
+  return surplus || ZERO_SURPLUS
+}
+
+function _getFillOrKillSellSurplus(order: Order): Surplus | null {
+  const { buyAmount, apiAdditionalInfo } = order
+
+  if (!apiAdditionalInfo) {
+    return null
+  }
+
+  const { executedBuyAmount } = apiAdditionalInfo
+
   const buyAmountBigNumber = new BigNumber(buyAmount.toString())
-  const executedAmountBigNumber = new BigNumber(executedBuyAmount.toString())
-  // SELL order has the sell amount fixed, so it'll buy AT LEAST `buyAmount`
-  // Surplus is in the form of additional buy amount
-  // The difference between `executedBuyAmount - buyAmount` is the surplus.
-  const amount = executedAmountBigNumber.gt(buyAmountBigNumber)
-    ? executedAmountBigNumber.minus(buyAmountBigNumber)
-    : ZERO_BIG_NUMBER
+  const executedBuyAmountBigNumber = new BigNumber(executedBuyAmount)
+
+  // Difference between what you got minus what you wanted to get is the surplus
+  const difference = executedBuyAmountBigNumber.minus(buyAmountBigNumber)
+
+  const amount = difference.gt(ZERO_BIG_NUMBER) ? difference : ZERO_BIG_NUMBER
+
   const percentage = amount.dividedBy(buyAmountBigNumber)
 
   return { amount, percentage }
 }
 
+function _getPartialFillSellSurplus(order: Order): Surplus | null {
+  const { buyAmount, sellAmount, apiAdditionalInfo } = order
+
+  if (!apiAdditionalInfo) {
+    return null
+  }
+
+  const { executedSellAmountBeforeFees, executedBuyAmount } = apiAdditionalInfo
+
+  const sellAmountBigNumber = new BigNumber(sellAmount)
+  const executedSellAmountBigNumber = new BigNumber(executedSellAmountBeforeFees)
+  const buyAmountBigNumber = new BigNumber(buyAmount)
+  const executedBuyAmountBigNumber = new BigNumber(executedBuyAmount)
+
+  // BUY is QUOTE
+  const price = buyAmountBigNumber.dividedBy(sellAmountBigNumber)
+
+  // What you would get at limit price, in sell token atoms
+  const minimumBuyAmount = executedSellAmountBigNumber.multipliedBy(price)
+
+  // Surplus is the difference between what you got minus what you would get if executed at limit price
+  // Surplus amount, in sell token atoms
+  const amount = executedBuyAmountBigNumber.minus(minimumBuyAmount)
+
+  // The percentage is based on the amount you would receive, if executed at limit price
+  const percentage = amount.dividedBy(minimumBuyAmount)
+
+  return { amount, percentage }
+}
+
 /**
- * Calculates BUY surplus based on sell amounts
+ * Calculates BUY surplus
  *
- * @param sellAmount sellAmount
- * @param executedSellAmountMinusFees executedSellAmount minus executedFeeAmount
  * @returns Buy surplus
  */
-export function getBuySurplus(sellAmount: BigNumberish, executedSellAmountMinusFees: BigNumberish): Surplus {
-  const sellAmountBigNumber = new BigNumber(sellAmount.toString())
-  const executedAmountBigNumber = new BigNumber(executedSellAmountMinusFees.toString())
+export function getBuySurplus(order: Order): Surplus {
+  const { partiallyFillable } = order
+
+  const surplus = partiallyFillable ? _getPartialFillBuySurplus(order) : _getFillOrKillBuySurplus(order)
+
+  return surplus || ZERO_SURPLUS
+}
+
+function _getFillOrKillBuySurplus(order: Order): Surplus | null {
+  const { sellAmount, apiAdditionalInfo } = order
+
+  if (!apiAdditionalInfo) {
+    return null
+  }
+
+  const { executedSellAmountBeforeFees } = apiAdditionalInfo
+
+  const sellAmountBigNumber = new BigNumber(sellAmount)
+  const executedSellAmountBigNumber = new BigNumber(executedSellAmountBeforeFees)
+
   // BUY order has the buy amount fixed, so it'll sell AT MOST `sellAmount`
   // Surplus will come in the form of a "discount", selling less than `sellAmount`
   // The difference between `sellAmount - executedSellAmount` is the surplus.
-  const amount =
-    executedAmountBigNumber.gt(ZERO_BIG_NUMBER) && sellAmountBigNumber.gt(executedAmountBigNumber)
-      ? sellAmountBigNumber.minus(executedAmountBigNumber)
-      : ZERO_BIG_NUMBER
+  const amount = sellAmountBigNumber.minus(executedSellAmountBigNumber)
+
   const percentage = amount.dividedBy(sellAmountBigNumber)
+
+  return { amount, percentage }
+}
+
+function _getPartialFillBuySurplus(order: Order): Surplus | null {
+  const { buyAmount, sellAmount, apiAdditionalInfo } = order
+
+  if (!apiAdditionalInfo) {
+    return null
+  }
+
+  const { executedSellAmountBeforeFees, executedBuyAmount } = apiAdditionalInfo
+
+  const sellAmountBigNumber = new BigNumber(sellAmount)
+  const executedSellAmountBigNumber = new BigNumber(executedSellAmountBeforeFees)
+  const buyAmountBigNumber = new BigNumber(buyAmount)
+  const executedBuyAmountBigNumber = new BigNumber(executedBuyAmount)
+
+  // SELL is QUOTE
+  const price = sellAmountBigNumber.dividedBy(buyAmountBigNumber)
+
+  const maximumSellAmount = executedBuyAmountBigNumber.multipliedBy(price)
+
+  const amount = maximumSellAmount.minus(executedSellAmountBigNumber)
+
+  const percentage = amount.dividedBy(maximumSellAmount)
 
   return { amount, percentage }
 }
 
 const SURPLUS_AVAILABLE_STATUSES = [OrderStatus.EXPIRED, OrderStatus.CANCELLED, OrderStatus.FULFILLED]
 
+const ZERO_SURPLUS: Surplus = { amount: ZERO_BIG_NUMBER, percentage: ZERO_BIG_NUMBER }
+
 export function getOrderSurplus(order: Order): Surplus {
-  const { kind, buyAmount, sellAmount, status } = order
+  const { kind, status } = order
 
   // `executedSellAmount` already has `executedFeeAmount` discounted
   const { executedBuyAmount, executedSellAmount } = getOrderExecutedAmounts(order)
 
   if (!executedBuyAmount || !executedSellAmount || !SURPLUS_AVAILABLE_STATUSES.includes(status)) {
-    return { amount: ZERO_BIG_NUMBER, percentage: ZERO_BIG_NUMBER }
+    return ZERO_SURPLUS
   }
 
   if (kind === 'buy') {
-    return getBuySurplus(sellAmount, executedSellAmount?.toString())
+    return getBuySurplus(order)
   } else {
-    return getSellSurplus(buyAmount, executedBuyAmount?.toString())
+    return getSellSurplus(order)
   }
 }


### PR DESCRIPTION
# Summary

Showing surplus for partial fills

|Type | Before | After |
|-|-|-|
|Limit sell filled| ![image](https://user-images.githubusercontent.com/43217/228858807-bda29d6c-ce11-441a-84c4-80c9b918dbe9.png) |  ![image](https://user-images.githubusercontent.com/43217/228858722-24be7f6b-9c62-406f-b136-1e261ab59b81.png) |
|Limit sell expired| ![image](https://user-images.githubusercontent.com/43217/229064003-54f0b0f7-744d-4403-8596-fb7bac78e78f.png) | ![image](https://user-images.githubusercontent.com/43217/229064099-b4b8a348-e2ed-41c3-bf87-69dba0089b1f.png) |
|Liquidity buy open| ![image](https://user-images.githubusercontent.com/43217/229070738-c21442ae-b565-4297-978e-6a78f88919da.png) | ![image](https://user-images.githubusercontent.com/43217/229070411-b7aee47c-c084-4498-a366-3bc004f1db63.png) |


# To Test

1. Open the receipt modal for a partial fill order that is closed and had any trades (filled, partially filled, cancelled) 
* Surplus should be displayed

Note: Make sure you test with sell and buy limit orders, also with USDC or any other token that uses less than 18 decimals