### PR TITLE
[Limit orders] Reset recipient value before each page opening and after each order placement

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersConfirmModal/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersConfirmModal/index.tsx
@@ -4,7 +4,7 @@ import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import { CloseIcon } from 'theme'
 import { CurrencyInfo } from '@cow/common/pure/CurrencyInputPanel/types'
 import { LimitOrdersConfirm } from '../../pure/LimitOrdersConfirm'
-import { PriceImpactDeclineError, tradeFlow, TradeFlowContext } from '../../services/tradeFlow'
+import { TradeFlowContext } from '../../services/tradeFlow'
 import TransactionConfirmationModal, { OperationType } from 'components/TransactionConfirmationModal'
 import { L2Content as TxSubmittedModal } from 'components/TransactionConfirmationModal'
 import { limitOrdersConfirmState } from '../LimitOrdersConfirmModal/state'
@@ -17,12 +17,12 @@ import { LimitOrdersWarnings } from '@cow/modules/limitOrders/containers/LimitOr
 import { PriceImpact } from 'hooks/usePriceImpact'
 import { useLimitOrdersWarningsAccepted } from '@cow/modules/limitOrders/hooks/useLimitOrdersWarningsAccepted'
 import { useErrorModal } from 'hooks/useErrorMessageAndModal'
-import OperatorError from '@cow/api/gnosisProtocol/errors/OperatorError'
 import { useAtomValue } from 'jotai/utils'
 import { limitOrdersSettingsAtom } from '@cow/modules/limitOrders/state/limitOrdersSettingsAtom'
 import { TokenAmount } from '@cow/common/pure/TokenAmount'
 import { executionPriceAtom } from '@cow/modules/limitOrders/state/executionPriceAtom'
 import { limitRateAtom } from '@cow/modules/limitOrders/state/limitRateAtom'
+import { useHandleOrderPlacement } from '@cow/modules/limitOrders/hooks/useHandleOrderPlacement'
 
 export interface LimitOrdersConfirmModalProps {
   isOpen: boolean
@@ -69,28 +69,16 @@ export function LimitOrdersConfirmModal(props: LimitOrdersConfirmModalProps) {
     setConfirmationState({ isPending: false, orderHash: null })
   }, [setConfirmationState])
 
-  const doTrade = useCallback(() => {
-    if (!tradeContext) return
-
-    const beforeTrade = () => {
+  const tradeCallbacks = {
+    beforeTrade: () => {
       onDismiss()
       setConfirmationState({ isPending: true, orderHash: null })
-    }
-
-    tradeFlow(tradeContext, priceImpact, settingsState, beforeTrade)
-      .then((orderHash) => {
-        setConfirmationState({ isPending: false, orderHash })
-      })
-      .catch((error: Error) => {
-        if (error instanceof PriceImpactDeclineError) return
-
-        onDismissConfirmation()
-
-        if (error instanceof OperatorError) {
-          handleSetError(error.message)
-        }
-      })
-  }, [onDismiss, handleSetError, settingsState, setConfirmationState, tradeContext, onDismissConfirmation, priceImpact])
+    },
+    onTradeSuccess: (orderHash: string | null) => setConfirmationState({ isPending: false, orderHash }),
+    onDismissConfirmation,
+    onError: handleSetError
+  }
+  const doTrade = useHandleOrderPlacement(tradeContext, priceImpact, settingsState, tradeCallbacks)
 
   const operationType = OperationType.ORDER_SIGN
   const pendingText = <PendingText inputRawAmount={inputRawAmount} outputRawAmount={outputRawAmount} />

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersConfirmModal/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersConfirmModal/index.tsx
@@ -76,7 +76,7 @@ export function LimitOrdersConfirmModal(props: LimitOrdersConfirmModalProps) {
     },
     onTradeSuccess: (orderHash: string | null) => setConfirmationState({ isPending: false, orderHash }),
     onDismissConfirmation,
-    onError: handleSetError
+    onError: handleSetError,
   }
   const doTrade = useHandleOrderPlacement(tradeContext, priceImpact, settingsState, tradeCallbacks)
 

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -3,7 +3,7 @@ import { Field } from 'state/swap/actions'
 import { CurrencyInputPanel } from '@cow/common/pure/CurrencyInputPanel'
 import { CurrencyArrowSeparator } from '@cow/common/pure/CurrencyArrowSeparator'
 import { AddRecipient } from '@cow/common/pure/AddRecipient'
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { BalanceAndSubsidy } from 'hooks/useCowBalanceAndSubsidy'
 import { CurrencyInfo } from '@cow/common/pure/CurrencyInputPanel/types'
 import { useLimitOrdersTradeState } from '../../hooks/useLimitOrdersTradeState'
@@ -175,6 +175,14 @@ export function LimitOrdersWidget() {
     tradeContext,
     feeAmount,
   }
+
+  /**
+   * Reset recipient value only once at App start
+   */
+  useEffect(() => {
+    onChangeRecipient(null)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return <LimitOrders {...props} />
 }

--- a/src/cow-react/modules/limitOrders/containers/TradeButtons/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/TradeButtons/index.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react'
 import { Trans } from '@lingui/macro'
 import { useAtomValue } from 'jotai/utils'
 import { useSetAtom } from 'jotai'
-import { PriceImpactDeclineError, tradeFlow, TradeFlowContext } from '@cow/modules/limitOrders/services/tradeFlow'
+import { TradeFlowContext } from '@cow/modules/limitOrders/services/tradeFlow'
 import { limitOrdersSettingsAtom } from '@cow/modules/limitOrders/state/limitOrdersSettingsAtom'
 import { useLimitOrdersTradeState } from '@cow/modules/limitOrders/hooks/useLimitOrdersTradeState'
 import { useLimitOrdersFormState } from '../../hooks/useLimitOrdersFormState'
@@ -17,11 +17,11 @@ import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import { transactionConfirmAtom } from '@cow/modules/swap/state/transactionConfirmAtom'
 import { ApplicationModal } from 'state/application/reducer'
 import { useErrorModal } from 'hooks/useErrorMessageAndModal'
-import OperatorError from '@cow/api/gnosisProtocol/errors/OperatorError'
 import { CompatibilityIssuesWarning } from '@cow/modules/trade/pure/CompatibilityIssuesWarning'
 import { useWalletDetails } from '@cow/modules/wallet'
 import styled from 'styled-components/macro'
 import { isUnsupportedTokenInQuote } from '@cow/modules/limitOrders/utils/isUnsupportedTokenInQuote'
+import { useHandleOrderPlacement } from '@cow/modules/limitOrders/hooks/useHandleOrderPlacement'
 
 const CompatibilityIssuesWarningWrapper = styled.div`
   margin-top: -10px;
@@ -60,25 +60,19 @@ export function TradeButtons(props: TradeButtonsProps) {
     showTransactionConfirmationModal,
   }
 
+  const tradeCallbacks = {
+    beforeTrade: () => setConfirmationState({ isPending: true, orderHash: null }),
+    onError: handleSetError,
+    finally: () => setConfirmationState({ isPending: false, orderHash: null })
+  }
+  const handleTrade = useHandleOrderPlacement(tradeContext, priceImpact, settingsState, tradeCallbacks)
   const doTrade = useCallback(() => {
-    if (settingsState.expertMode && tradeContext) {
-      const beforeTrade = () => setConfirmationState({ isPending: true, orderHash: null })
-
-      tradeFlow(tradeContext, priceImpact, settingsState, beforeTrade)
-        .catch((error) => {
-          if (error instanceof PriceImpactDeclineError) return
-
-          if (error instanceof OperatorError) {
-            handleSetError(error.message)
-          }
-        })
-        .finally(() => {
-          setConfirmationState({ isPending: false, orderHash: null })
-        })
+    if (settingsState.expertMode) {
+      handleTrade()
     } else {
       openConfirmScreen()
     }
-  }, [handleSetError, settingsState, tradeContext, openConfirmScreen, setConfirmationState, priceImpact])
+  }, [settingsState.expertMode, handleTrade, openConfirmScreen])
 
   const buttonFactory = limitOrdersTradeButtonsMap[formState]
 

--- a/src/cow-react/modules/limitOrders/containers/TradeButtons/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/TradeButtons/index.tsx
@@ -63,7 +63,7 @@ export function TradeButtons(props: TradeButtonsProps) {
   const tradeCallbacks = {
     beforeTrade: () => setConfirmationState({ isPending: true, orderHash: null }),
     onError: handleSetError,
-    finally: () => setConfirmationState({ isPending: false, orderHash: null })
+    finally: () => setConfirmationState({ isPending: false, orderHash: null }),
   }
   const handleTrade = useHandleOrderPlacement(tradeContext, priceImpact, settingsState, tradeCallbacks)
   const doTrade = useCallback(() => {

--- a/src/cow-react/modules/limitOrders/hooks/useHandleOrderPlacement.test.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useHandleOrderPlacement.test.ts
@@ -1,0 +1,46 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { PriceImpact } from 'hooks/usePriceImpact'
+import { useHandleOrderPlacement } from './useHandleOrderPlacement'
+import { tradeFlow, TradeFlowContext } from '@cow/modules/limitOrders/services/tradeFlow'
+import { defaultLimitOrdersSettings } from '../state/limitOrdersSettingsAtom'
+import { limitOrdersAtom, updateLimitOrdersAtom } from '../state/limitOrdersAtom'
+import { useAtomValue, useUpdateAtom } from 'jotai/utils'
+
+jest.mock('@cow/modules/limitOrders/services/tradeFlow')
+
+const mockTradeFlow = tradeFlow as jest.MockedFunction<typeof tradeFlow>
+
+const tradeContextMock = 1 as any as TradeFlowContext
+const priceImpactMock: PriceImpact = {
+  priceImpact: undefined,
+  error: undefined,
+  loading: false
+}
+const recipient = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045'
+
+describe('useHandleOrderPlacement', () => {
+  beforeEach(() => {
+    mockTradeFlow.mockImplementation(() => Promise.resolve(null))
+  })
+
+  it('When a limit order placed, then the recipient value should be deleted', async () => {
+    // Arrange
+    renderHook(() => {
+      const updateLimitOrdersState = useUpdateAtom(updateLimitOrdersAtom)
+
+      updateLimitOrdersState({ recipient })
+    })
+
+    // Assert
+    const { result: limitOrdersStateResultBefore } = renderHook(() => useAtomValue(limitOrdersAtom))
+    expect(limitOrdersStateResultBefore.current.recipient).toBe(recipient)
+
+    // Act
+    const { result } = renderHook(() => useHandleOrderPlacement(tradeContextMock, priceImpactMock, defaultLimitOrdersSettings, {}))
+    await result.current()
+
+    // Assert
+    const { result: limitOrdersStateResultAfter } = renderHook(() => useAtomValue(limitOrdersAtom))
+    expect(limitOrdersStateResultAfter.current.recipient).toBe(null)
+  })
+})

--- a/src/cow-react/modules/limitOrders/hooks/useHandleOrderPlacement.test.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useHandleOrderPlacement.test.ts
@@ -14,7 +14,7 @@ const tradeContextMock = 1 as any as TradeFlowContext
 const priceImpactMock: PriceImpact = {
   priceImpact: undefined,
   error: undefined,
-  loading: false
+  loading: false,
 }
 const recipient = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045'
 
@@ -36,7 +36,9 @@ describe('useHandleOrderPlacement', () => {
     expect(limitOrdersStateResultBefore.current.recipient).toBe(recipient)
 
     // Act
-    const { result } = renderHook(() => useHandleOrderPlacement(tradeContextMock, priceImpactMock, defaultLimitOrdersSettings, {}))
+    const { result } = renderHook(() =>
+      useHandleOrderPlacement(tradeContextMock, priceImpactMock, defaultLimitOrdersSettings, {})
+    )
     await result.current()
 
     // Assert

--- a/src/cow-react/modules/limitOrders/hooks/useHandleOrderPlacement.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useHandleOrderPlacement.ts
@@ -1,0 +1,51 @@
+import { useCallback } from 'react'
+import { PriceImpactDeclineError, tradeFlow, TradeFlowContext } from '@cow/modules/limitOrders/services/tradeFlow'
+import OperatorError from '@cow/api/gnosisProtocol/errors/OperatorError'
+import { PriceImpact } from 'hooks/usePriceImpact'
+import { LimitOrdersSettingsState } from '@cow/modules/limitOrders/state/limitOrdersSettingsAtom'
+import { useUpdateAtom } from 'jotai/utils'
+import { updateLimitOrdersAtom } from '@cow/modules/limitOrders/state/limitOrdersAtom'
+
+interface HandleTradeCallback {
+  beforeTrade(): void
+
+  onDismissConfirmation(): void
+
+  onTradeSuccess(hash: string | null): void
+
+  onError(error: string): void
+  finally(): void
+}
+
+
+export function useHandleOrderPlacement(
+  tradeContext: TradeFlowContext | null,
+  priceImpact: PriceImpact,
+  settingsState: LimitOrdersSettingsState,
+  callbacks: Partial<HandleTradeCallback>
+): () => Promise<void> {
+  const updateLimitOrdersState = useUpdateAtom(updateLimitOrdersAtom)
+
+  return useCallback(() => {
+    if (!tradeContext) return Promise.resolve()
+
+    return tradeFlow(tradeContext, priceImpact, settingsState, callbacks.beforeTrade)
+      .then((orderHash) => {
+        callbacks.onTradeSuccess?.(orderHash)
+
+        updateLimitOrdersState({ recipient: null })
+      })
+      .catch((error: Error) => {
+        if (error instanceof PriceImpactDeclineError) return
+
+        callbacks.onDismissConfirmation?.()
+
+        if (error instanceof OperatorError) {
+          callbacks.onError?.(error.message)
+        }
+      })
+      .finally(() => {
+        callbacks.finally?.()
+      })
+  }, [tradeContext, priceImpact, settingsState, callbacks, updateLimitOrdersState])
+}

--- a/src/cow-react/modules/limitOrders/hooks/useHandleOrderPlacement.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useHandleOrderPlacement.ts
@@ -17,7 +17,6 @@ interface HandleTradeCallback {
   finally(): void
 }
 
-
 export function useHandleOrderPlacement(
   tradeContext: TradeFlowContext | null,
   priceImpact: PriceImpact,


### PR DESCRIPTION
# Summary

Fixes #2215

Behavior before the fix:
The entered recipient address value persisted always.

Behavior after the fix: 
1. Recipient value resets before each limit orders page opening
2. Recipient value resets after each trade

  # To Test

1. Open limit orders page
2. Enter any address to the recipient field
3. Go to limit orders page
4. Go to limit orders back
- [ ] the recipient field must be empty

1. Open limit orders
2. Enter any address to the recipient field
3. Sign and send order
- [ ] the recipient field must be empty
