### PR TITLE
Feature/partial fills messages and warnings

### DIFF
--- a/src/cow-react/common/hooks/useCategorizeRecentActivity.ts
+++ b/src/cow-react/common/hooks/useCategorizeRecentActivity.ts
@@ -1,13 +1,9 @@
 import { useMemo } from 'react'
 import useRecentActivity, { TransactionAndOrder } from 'hooks/useRecentActivity'
-import { OrderStatus } from 'state/orders/actions'
+import { CONFIRMED_STATES, PENDING_STATES } from 'state/orders/actions'
 import { OrderClass } from '@cowprotocol/cow-sdk'
 
-const PENDING_STATES = [OrderStatus.PENDING, OrderStatus.PRESIGNATURE_PENDING, OrderStatus.CREATING]
-
 const isPending = (data: TransactionAndOrder) => PENDING_STATES.includes(data.status)
-
-const CONFIRMED_STATES = [OrderStatus.FULFILLED, OrderStatus.EXPIRED, OrderStatus.CANCELLED, OrderStatus.FAILED]
 
 const isConfirmed = (data: TransactionAndOrder) => CONFIRMED_STATES.includes(data.status)
 

--- a/src/cow-react/modules/limitOrders/containers/OrdersWidget/hooks/useLimitOrdersList.ts
+++ b/src/cow-react/modules/limitOrders/containers/OrdersWidget/hooks/useLimitOrdersList.ts
@@ -3,7 +3,7 @@ import JSBI from 'jsbi'
 
 import { useOrders } from 'state/orders/hooks'
 import { useCallback, useMemo } from 'react'
-import { Order, OrderStatus } from 'state/orders/actions'
+import { Order, OrderStatus, PENDING_STATES } from 'state/orders/actions'
 import { getOrderFilledAmount } from '@cow/modules/limitOrders/utils/getOrderFilledAmount'
 import { getOrderSurplus } from '@cow/modules/limitOrders/utils/getOrderSurplus'
 import { getOrderExecutedAmounts } from '@cow/modules/limitOrders/utils/getOrderExecutedAmounts'
@@ -38,11 +38,6 @@ export interface ParsedOrder extends Order {
 }
 
 const ORDERS_LIMIT = 100
-const pendingOrderStatuses: OrderStatus[] = [
-  OrderStatus.PRESIGNATURE_PENDING,
-  OrderStatus.PENDING,
-  OrderStatus.CREATING,
-]
 
 export const parseOrder = (order: Order): ParsedOrder => {
   const { amount: filledAmount, percentage: filledPercentage } = getOrderFilledAmount(order)
@@ -103,7 +98,7 @@ export function useLimitOrdersList(): LimitOrdersList {
   return useMemo(() => {
     const { pending, history } = allSortedOrders.reduce(
       (acc, order) => {
-        if (pendingOrderStatuses.includes(order.status)) {
+        if (PENDING_STATES.includes(order.status)) {
           acc.pending.push(order)
         } else {
           acc.history.push(order)

--- a/src/cow-react/modules/limitOrders/pure/OrderStatusBox/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/OrderStatusBox/index.tsx
@@ -18,17 +18,15 @@ const Wrapper = styled.div<{
       ? theme.success
       : status === OrderStatus.PENDING // OPEN order
       ? theme.text3
-      : status === OrderStatus.PRESIGNATURE_PENDING
-      ? theme.text1
       : status === OrderStatus.EXPIRED
       ? theme.warning
       : status === OrderStatus.CANCELLED
       ? theme.danger
       : status === OrderStatus.FAILED
       ? theme.danger
-      : status === (OrderStatus.CREATING || OrderStatus.PRESIGNATURE_PENDING || OrderStatus)
-      ? theme.text1
-      : theme.text1};
+      : // Remaining statuses should use the same
+        // OrderStatus.CREATING || OrderStatus.PRESIGNATURE_PENDING
+        theme.text1};
 
   display: flex;
   align-items: center;

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
@@ -64,6 +64,7 @@ const UnfillableLabel = styled.span`
 
 export type EstimatedExecutionPriceProps = TokenAmountProps & {
   isInverted: boolean
+  isUnfillable: boolean
   canShowWarning: boolean
   percentageDifference?: Percent
   amountDifference?: CurrencyAmount<Currency>
@@ -74,6 +75,7 @@ export type EstimatedExecutionPriceProps = TokenAmountProps & {
 export function EstimatedExecutionPrice(props: EstimatedExecutionPriceProps) {
   const {
     isInverted,
+    isUnfillable,
     canShowWarning,
     percentageDifference,
     amountDifference,
@@ -95,11 +97,10 @@ export function EstimatedExecutionPrice(props: EstimatedExecutionPriceProps) {
   const feeWarning = canShowWarning && percentageFee?.greaterThan(HIGH_FEE_WARNING_PERCENTAGE)
   const isNegativeDifference = percentageDifferenceInverted?.lessThan(ZERO_FRACTION)
   const marketPriceNeedsToGoDown = isInverted ? !isNegativeDifference : isNegativeDifference
-  const isZeroPrice = amount?.equalTo(ZERO_FRACTION)
 
   return (
-    <EstimatedExecutionPriceWrapper hasWarning={!!feeWarning} showPointerCursor={!isZeroPrice}>
-      {isZeroPrice ? (
+    <EstimatedExecutionPriceWrapper hasWarning={!!feeWarning} showPointerCursor={!isUnfillable}>
+      {isUnfillable ? (
         <UnfillableLabel>UNFILLABLE</UnfillableLabel>
       ) : (
         <MouseoverTooltipContent
@@ -125,7 +126,7 @@ export function EstimatedExecutionPrice(props: EstimatedExecutionPriceProps) {
           }
           placement="top"
         >
-          {isZeroPrice ? (
+          {isUnfillable ? (
             <UnfillableLabel>UNFILLABLE</UnfillableLabel>
           ) : (
             <>

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -153,6 +153,7 @@ export function OrderRow({
   const feeDifference = useFeeAmountDifference(rateInfoParams, prices)
 
   const isUnfillable = executedPriceInverted?.equalTo(ZERO_FRACTION) || withWarning
+  const isOrderCreating = CREATING_STATES.includes(order.status)
 
   return (
     <RowElement isOpenOrdersTab={isOpenOrdersTab}>
@@ -232,7 +233,7 @@ export function OrderRow({
                 isUnfillable={isUnfillable}
               />
             </styledEl.ExecuteCellWrapper>
-          ) : prices === null ? (
+          ) : prices === null || isOrderCreating ? (
             '-'
           ) : (
             <Loader size="14px" style={{ margin: '0 0 -2px 7px' }} />

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useContext, useEffect, useState } from 'react'
 import { DefaultTheme, StyledComponent, ThemeContext } from 'styled-components/macro'
-import { OrderStatus } from 'state/orders/actions'
+import { CREATING_STATES, OrderStatus, PENDING_STATES } from 'state/orders/actions'
 import { Currency, CurrencyAmount, Percent, Price } from '@uniswap/sdk-core'
 import { RateInfo } from '@cow/common/pure/RateInfo'
 import { MouseoverTooltipContent } from 'components/Tooltip'
@@ -115,13 +115,16 @@ export function OrderRow({
   spotPrice,
 }: OrderRowProps) {
   const { buyAmount, rateInfoParams, hasEnoughAllowance, hasEnoughBalance, chainId } = orderParams
-  const { parsedCreationTime, expirationTime, activityId, formattedPercentage, executedPrice } = order
+  const { parsedCreationTime, expirationTime, activityId, formattedPercentage, executedPrice, status } = order
   const { inputCurrencyAmount, outputCurrencyAmount } = rateInfoParams
   const { estimatedExecutionPrice, feeAmount } = prices || {}
 
   const showCancellationModal = getShowCancellationModal(order)
 
-  const withWarning = !hasEnoughBalance || !hasEnoughAllowance
+  const withWarning =
+    (!hasEnoughBalance || !hasEnoughAllowance) &&
+    // don't show the warning for closed orders
+    PENDING_STATES.includes(status)
   const theme = useContext(ThemeContext)
 
   const expirationTimeAgo = useTimeAgo(expirationTime, TIME_AGO_UPDATE_INTERVAL)

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -26,6 +26,7 @@ import { calculatePriceDifference, PriceDifference } from '@cow/modules/limitOrd
 import { calculatePercentageInRelationToReference } from '@cow/modules/limitOrders/utils/calculatePercentageInRelationToReference'
 import { EstimatedExecutionPrice } from '@cow/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice'
 import { OrderClass } from '@cowprotocol/cow-sdk'
+import { ZERO_FRACTION } from 'constants/index'
 
 export const orderStatusTitleMap: { [key in OrderStatus]: string } = {
   [OrderStatus.PENDING]: 'Open',
@@ -148,6 +149,8 @@ export function OrderRow({
   const priceDiffs = usePricesDifference(prices, spotPrice, isInverted)
   const feeDifference = useFeeAmountDifference(rateInfoParams, prices)
 
+  const isUnfillable = executedPriceInverted?.equalTo(ZERO_FRACTION) || withWarning
+
   return (
     <RowElement isOpenOrdersTab={isOpenOrdersTab}>
       {/* Order sell/buy tokens */}
@@ -223,6 +226,7 @@ export function OrderRow({
                 percentageFee={feeDifference}
                 amountFee={feeAmount}
                 canShowWarning={order.class !== OrderClass.MARKET}
+                isUnfillable={isUnfillable}
               />
             </styledEl.ExecuteCellWrapper>
           ) : prices === null ? (

--- a/src/cow-react/modules/limitOrders/pure/Orders/utils/getOrderParams.ts
+++ b/src/cow-react/modules/limitOrders/pure/Orders/utils/getOrderParams.ts
@@ -33,7 +33,8 @@ export function getOrderParams(
   const balance = balances[order.inputToken.address]
   const allowance = allowances[order.inputToken.address]
 
-  const hasEnoughBalance = isEnoughAmount(sellAmount, balance)
+  // Warning irrelevant for partially fillable orders
+  const hasEnoughBalance = isEnoughAmount(sellAmount, balance) || order.partiallyFillable
   const hasEnoughAllowance = isEnoughAmount(sellAmount, allowance)
 
   return {

--- a/src/cow-react/modules/limitOrders/pure/Orders/utils/getOrderParams.ts
+++ b/src/cow-react/modules/limitOrders/pure/Orders/utils/getOrderParams.ts
@@ -3,6 +3,7 @@ import { BalancesAndAllowances } from '@cow/modules/limitOrders/containers/Order
 import { Order } from 'state/orders/actions'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import { RateInfoParams } from '@cow/common/pure/RateInfo'
+import { ZERO_FRACTION } from 'constants/index'
 
 export interface OrderParams {
   chainId: SupportedChainId | undefined
@@ -33,9 +34,15 @@ export function getOrderParams(
   const balance = balances[order.inputToken.address]
   const allowance = allowances[order.inputToken.address]
 
-  // Warning irrelevant for partially fillable orders
-  const hasEnoughBalance = isEnoughAmount(sellAmount, balance) || order.partiallyFillable
-  const hasEnoughAllowance = isEnoughAmount(sellAmount, allowance)
+  let hasEnoughBalance, hasEnoughAllowance
+
+  if (order.partiallyFillable) {
+    hasEnoughBalance = !!balance?.greaterThan(ZERO_FRACTION)
+    hasEnoughAllowance = !!allowance?.greaterThan(ZERO_FRACTION)
+  } else {
+    hasEnoughBalance = isEnoughAmount(sellAmount, balance)
+    hasEnoughAllowance = isEnoughAmount(sellAmount, allowance)
+  }
 
   return {
     chainId,

--- a/src/cow-react/modules/limitOrders/utils/calculatePercentageInRelationToReference.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculatePercentageInRelationToReference.ts
@@ -1,5 +1,6 @@
 import { FractionLike, Nullish } from '@cow/types'
 import { Percent } from '@uniswap/sdk-core'
+import { ZERO_FRACTION } from 'constants/index'
 
 export type CalculateAmountPercentDifferenceProps = {
   reference: Nullish<FractionLike>
@@ -25,7 +26,7 @@ export function calculatePercentageInRelationToReference({
   reference,
   value,
 }: CalculateAmountPercentDifferenceProps): Percent | undefined {
-  if (!value || !reference) {
+  if (!value || !reference || reference.equalTo(ZERO_FRACTION)) {
     return undefined
   }
 

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { isTransactionRecent, useAllTransactions, useTransactionsByHash } from 'state/enhancedTransactions/hooks'
-import { useOrder, useOrders, useOrdersById, usePendingOrders } from 'state/orders/hooks'
+import { useOrder, useOrders, useOrdersById, useCombinedPendingOrders } from 'state/orders/hooks'
 import { Order, OrderStatus } from 'state/orders/actions'
 import { EnhancedTransactionDetails } from 'state/enhancedTransactions/reducer'
 import { SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
@@ -284,7 +284,7 @@ export function groupActivitiesByDay(activities: ActivityDescriptors[]): Activit
 
 export function useRecentActivityLastPendingOrder() {
   const { chainId } = useWalletInfo()
-  const pending = usePendingOrders({ chainId })
+  const pending = useCombinedPendingOrders({ chainId })
 
   return useMemo(() => {
     if (!pending.length) {

--- a/src/custom/state/orders/actions.ts
+++ b/src/custom/state/orders/actions.ts
@@ -17,6 +17,11 @@ export enum OrderStatus {
   FAILED = 'failed',
 }
 
+// Common states groups
+export const PENDING_STATES = [OrderStatus.PENDING, OrderStatus.PRESIGNATURE_PENDING, OrderStatus.CREATING]
+export const CONFIRMED_STATES = [OrderStatus.FULFILLED, OrderStatus.EXPIRED, OrderStatus.CANCELLED, OrderStatus.FAILED]
+export const CREATING_STATES = [OrderStatus.PRESIGNATURE_PENDING, OrderStatus.CREATING]
+
 // Abstract type for the order used in the Dapp. It's composed out of 3 types of props:
 //  - Information present in the order creation type used in the API to post new orders
 //  - Additional information available in the API

--- a/src/custom/state/orders/hooks.ts
+++ b/src/custom/state/orders/hooks.ts
@@ -206,7 +206,7 @@ export const useOrdersById = ({ chainId, ids }: GetOrdersByIdParams): OrdersMap 
   }, [allOrders, ids])
 }
 
-export const usePendingOrders = ({ chainId }: GetOrdersParams): Order[] => {
+export const useCombinedPendingOrders = ({ chainId }: GetOrdersParams): Order[] => {
   const state = useSelector<
     AppState,
     | {
@@ -235,6 +235,27 @@ export const usePendingOrders = ({ chainId }: GetOrdersParams): Order[] => {
     const allPending = Object.values(pending).concat(Object.values(presignaturePending)).concat(Object.values(creating))
 
     return allPending.map(_deserializeOrder).filter(isTruthy)
+  }, [state])
+}
+
+/**
+ * Use ONLY OrderStatus.PENDING orders
+ *
+ * Similar to usePendingOrders
+ *
+ * The difference is that this hook returns only orders that have the status PENDING
+ * while usePendingOrders aggregates all pending states
+ * @param chainId
+ */
+export const useOnlyPendingOrders = ({ chainId }: GetOrdersParams): Order[] => {
+  const state = useSelector<AppState, PartialOrdersMap | undefined>(
+    (state) => chainId && state.orders?.[chainId]?.pending
+  )
+
+  return useMemo(() => {
+    if (!state) return []
+
+    return Object.values(state).map(_deserializeOrder).filter(isTruthy)
   }, [state])
 }
 

--- a/src/custom/state/orders/reducer.ts
+++ b/src/custom/state/orders/reducer.ts
@@ -6,6 +6,7 @@ import {
   addPendingOrder,
   cancelOrdersBatch,
   clearOrders,
+  CREATING_STATES,
   expireOrdersBatch,
   fulfillOrdersBatch,
   invalidateOrdersBatch,
@@ -169,8 +170,6 @@ function popOrder(state: OrdersState, chainId: ChainId, status: OrderStatus, id:
   return orderObj
 }
 
-const STATES_FOR_ORDERS_NOT_YET_OPEN = [OrderStatus.PRESIGNATURE_PENDING, OrderStatus.CREATING]
-
 function getValidTo(apiAdditionalInfo: OrderInfoApi | undefined, order: SerializedOrder): number {
   return (apiAdditionalInfo?.ethflowData?.userValidTo || order.validTo) as number
 }
@@ -183,7 +182,7 @@ export default createReducer(initialState, (builder) =>
       prefillState(state, action)
       const { order, id, chainId } = action.payload
 
-      order.openSince = STATES_FOR_ORDERS_NOT_YET_OPEN.includes(order.status) ? undefined : Date.now()
+      order.openSince = CREATING_STATES.includes(order.status) ? undefined : Date.now()
 
       switch (order.status) {
         // EthFlow or PreSign orders have their respective buckets

--- a/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/PendingOrdersUpdater.ts
@@ -11,7 +11,7 @@ import {
   useCancelOrdersBatch,
   useExpireOrdersBatch,
   useFulfillOrdersBatch,
-  usePendingOrders,
+  useCombinedPendingOrders,
   usePresignOrders,
   useUpdatePresignGnosisSafeTx,
 } from 'state/orders/hooks'
@@ -249,7 +249,7 @@ export function PendingOrdersUpdater(): null {
   const { chainId: _chainId, account } = useWalletInfo()
   const chainId = supportedChainId(_chainId)
 
-  const pending = usePendingOrders({ chainId })
+  const pending = useCombinedPendingOrders({ chainId })
   const isUpdating = useRef(false) // TODO: Implement using SWR or retry/cancellable promises
 
   // Ref, so we don't rerun useEffect

--- a/src/custom/state/orders/updaters/SpotPricesUpdater.ts
+++ b/src/custom/state/orders/updaters/SpotPricesUpdater.ts
@@ -4,7 +4,7 @@ import { Token } from '@uniswap/sdk-core'
 
 import useIsWindowVisible from 'hooks/useIsWindowVisible'
 import { supportedChainId } from 'utils/supportedChainId'
-import { usePendingOrders } from 'state/orders/hooks'
+import { useCombinedPendingOrders } from 'state/orders/hooks'
 import { UpdateSpotPriceAtom, updateSpotPricesAtom } from '@cow/modules/orders/state/spotPricesAtom'
 import { useUpdateAtom } from 'state/application/atoms'
 import { SPOT_PRICE_CHECK_POLL_INTERVAL } from 'state/orders/consts'
@@ -24,7 +24,7 @@ type MarketRecord = Record<
 >
 
 function useMarkets(chainId?: SupportedChainId): MarketRecord {
-  const pending = usePendingOrders({ chainId })
+  const pending = useCombinedPendingOrders({ chainId })
 
   return useSafeMemo(() => {
     return pending.reduce<Record<string, { chainId: number; inputCurrency: Token; outputCurrency: Token }>>(

--- a/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react'
 import { timestamp } from '@cowprotocol/contracts'
 import { useWalletInfo } from '@cow/modules/wallet'
-import { usePendingOrders, useSetIsOrderUnfillable } from 'state/orders/hooks'
+import { useOnlyPendingOrders, useSetIsOrderUnfillable } from 'state/orders/hooks'
 import { Order } from 'state/orders/actions'
 import { OrderClass } from '@cowprotocol/cow-sdk'
 import { SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
@@ -88,7 +88,7 @@ export function UnfillableOrdersUpdater(): null {
   const updatePendingOrderPrices = useUpdateAtom(updatePendingOrderPricesAtom)
   const isWindowVisible = useIsWindowVisible()
 
-  const pending = usePendingOrders({ chainId })
+  const pending = useOnlyPendingOrders({ chainId })
   const setIsOrderUnfillable = useSetIsOrderUnfillable()
   const strategy = useGetGpPriceStrategy()
 


### PR DESCRIPTION
# Summary

1. When `fill or kill` order has low balance or low approval, show unfillable on `executes at`
2. When `partial fill` order has 0 balance, show the warning and show unfillable on `executes at`
3. When `partial fill` order has 0 approval, show the warning and show unfillable on `executes at`

  # To Test

1. Place limit order
2. Remove balance from sell token
* Low balance warning should appear only if it's 0
3. Reduce/remove approval for sell token
* Low approval warning should appear only if it's 0
4. Place a fill or kill limit order (using dev.swap.cow.fi for example)
5. Remove balance and/or approval
* `Executes at` should show `unfillable`