### PR TITLE
Add ZenGo wallet banner

### DIFF
--- a/src/cow-react/modules/wallet/api/pure/WalletModal/index.tsx
+++ b/src/cow-react/modules/wallet/api/pure/WalletModal/index.tsx
@@ -16,6 +16,7 @@ import { HeaderRow, HoverText, CloseIcon, ContentWrapper } from '@cow/common/pur
 import { CloseColor, OptionGrid, TermsWrapper, UpperSection, Wrapper } from './styled'
 import { PendingView } from '@cow/modules/wallet/api/pure/PendingView'
 import { ConnectWalletOptions, TryActivation } from '@cow/modules/wallet/web3-react/connection'
+import { ZengoBanner } from '@cow/modules/wallet/api/pure/ZengoBanner'
 
 export type WalletModalView = 'options' | 'account' | 'pending'
 
@@ -30,12 +31,25 @@ interface WalletModalProps {
   // TODO: Remove dependency web3-react
   pendingConnector: Connector | undefined
   tryActivation: TryActivation
+  account: string | undefined
 }
 
 export function WalletModal(props: WalletModalProps) {
-  const { isOpen, toggleModal, view, openOptions, pendingError, tryActivation, tryConnection, pendingConnector } = props
+  const {
+    isOpen,
+    toggleModal,
+    view,
+    openOptions,
+    pendingError,
+    tryActivation,
+    tryConnection,
+    pendingConnector,
+    account,
+  } = props
 
   const isPending = view === 'pending'
+  const isOptions = view === 'options'
+  const showZengoBanner = !account && !window.ethereum && isOptions
 
   return (
     <GpModal maxWidth={600} isOpen={isOpen} onDismiss={toggleModal} minHeight={false} maxHeight={90}>
@@ -61,6 +75,7 @@ export function WalletModal(props: WalletModalProps) {
                   <ConnectWalletOptions tryActivation={tryActivation} />
                 </OptionGrid>
               )}
+              {showZengoBanner && <ZengoBanner />}
               {!pendingError && (
                 <LightCard>
                   <AutoRow style={{ flexWrap: 'nowrap' }}>

--- a/src/cow-react/modules/wallet/api/pure/ZengoBanner/index.tsx
+++ b/src/cow-react/modules/wallet/api/pure/ZengoBanner/index.tsx
@@ -1,0 +1,38 @@
+import { default as ZengoImage } from '@cow/modules/wallet/api/assets/zengo.svg'
+import { ExternalLink } from 'theme'
+import { Trans } from '@lingui/macro'
+import * as styled from './styled'
+
+const GET_ZENGO_LINK = 'https://zengo.com/'
+const HOW_TO_USE_ZENGO = 'https://help.zengo.com/en/collections/1646183-how-to-guides'
+
+export function ZengoBanner() {
+  return (
+    <styled.Wrapper>
+      <styled.Icon>
+        <img src={ZengoImage} alt="ZenGo Image" />
+      </styled.Icon>
+
+      <styled.Content>
+        <h4>
+          <Trans>Need a crypto wallet?</Trans>
+        </h4>
+        <p>
+          <Trans>Download ZenGo: The most secure crypto wallet.</Trans>
+        </p>
+      </styled.Content>
+
+      <styled.Actions>
+        <styled.GetZengoButton>
+          <ExternalLink target="_blank" href={GET_ZENGO_LINK}>
+            <Trans>Get ZenGo</Trans>
+          </ExternalLink>
+        </styled.GetZengoButton>
+
+        <styled.HowToUse target="_blank" href={HOW_TO_USE_ZENGO}>
+          <Trans>How to use ZenGo</Trans>
+        </styled.HowToUse>
+      </styled.Actions>
+    </styled.Wrapper>
+  )
+}

--- a/src/cow-react/modules/wallet/api/pure/ZengoBanner/styled.ts
+++ b/src/cow-react/modules/wallet/api/pure/ZengoBanner/styled.ts
@@ -1,0 +1,69 @@
+import styled from 'styled-components/macro'
+import { ButtonPrimary } from 'components/Button'
+import { ExternalLink } from 'theme'
+
+export const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  width: 100%;
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    flex-direction: column;
+    justify-content: center;
+  `};
+`
+
+export const Icon = styled.div`
+  max-width: 50px;
+  img {
+    max-width: 100%;
+  }
+`
+
+export const Content = styled.div`
+  flex: 1;
+  padding: 0 1rem;
+  color: ${({ theme }) => theme.text1};
+  h4 {
+    margin-bottom: 5px;
+    font-size: 1.1rem;
+  }
+  p {
+    margin: 0;
+    font-size: 0.8rem;
+  }
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    margin-top: 5px;
+    text-align: center;
+  `};
+`
+
+export const Actions = styled.div`
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    margin-top: 10px;
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+  `};
+`
+
+export const GetZengoButton = styled(ButtonPrimary)`
+  font-size: 12px;
+  border-radius: 8px;
+  padding: 8px;
+  min-height: auto;
+  a {
+    color: ${({ theme }) => theme.white};
+    &:hover {
+      text-decoration: none;
+    }
+  }
+`
+
+export const HowToUse = styled(ExternalLink)`
+  font-size: 0.8rem;
+  margin-top: 5px;
+  color: ${({ theme }) => theme.text1};
+  cursor: pointer;
+`

--- a/src/cow-react/modules/wallet/web3-react/containers/WalletModal/index.tsx
+++ b/src/cow-react/modules/wallet/web3-react/containers/WalletModal/index.tsx
@@ -120,6 +120,7 @@ export function WalletModal() {
       tryActivation={tryActivation}
       tryConnection={() => pendingConnector && tryActivation(pendingConnector)}
       view={walletView}
+      account={account}
     />
   )
 }


### PR DESCRIPTION
# Summary

Adds a ZenGo wallet banner to wallets modal if the user didn't connected his account.

Desktop - light
![Screenshot 2023-03-30 at 17 06 09](https://user-images.githubusercontent.com/34926005/228897542-d79b1e4f-9acc-4a08-b837-1ba8074e5b35.png)

Desktop - light
![Screenshot 2023-03-30 at 17 06 21](https://user-images.githubusercontent.com/34926005/228897587-31d64b70-94ff-4002-8f15-9c56586fbcb0.png)

Mobile
![Screenshot 2023-03-30 at 17 06 41](https://user-images.githubusercontent.com/34926005/228897612-78925729-79fa-44d3-9726-46645d83d0bb.png)

# To test
- open wallets modal
- makes sure it looks ok on all devices and screen sizes
- it should be hidden once the wallet is connected
