### PR TITLE
Improve error on empty eth address

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/TradeButtons/limitOrdersTradeButtonsMap.tsx
+++ b/src/cow-react/modules/limitOrders/containers/TradeButtons/limitOrdersTradeButtonsMap.tsx
@@ -109,7 +109,7 @@ export const limitOrdersTradeButtonsMap: { [key in LimitOrdersFormState]: Button
   },
   [LimitOrdersFormState.InvalidRecipient]: {
     disabled: true,
-    text: 'Enter a recipient',
+    text: 'Enter a valid recipient',
   },
   [LimitOrdersFormState.CantLoadBalances]: {
     disabled: true,

--- a/src/cow-react/modules/limitOrders/hooks/useLimitOrdersFormState.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useLimitOrdersFormState.ts
@@ -79,6 +79,10 @@ function getLimitOrdersFormState(params: LimitOrdersFormParams): LimitOrdersForm
       ? CurrencyAmount.fromRawAmount(sellAmount.currency, quote?.response?.quote?.feeAmount)
       : null
 
+  if (recipient && !recipientEnsAddress && !isAddress(recipient)) {
+    return LimitOrdersFormState.InvalidRecipient
+  }
+
   if (quote?.error) {
     return LimitOrdersFormState.QuoteError
   }
@@ -107,10 +111,6 @@ function getLimitOrdersFormState(params: LimitOrdersFormParams): LimitOrdersForm
 
       return LimitOrdersFormState.AmountIsNotSet
     }
-  }
-
-  if (recipient !== null && !recipientEnsAddress && !isAddress(recipient)) {
-    return LimitOrdersFormState.InvalidRecipient
   }
 
   if (!isSupportedWallet) {

--- a/src/custom/state/swap/hooks.tsx
+++ b/src/custom/state/swap/hooks.tsx
@@ -223,7 +223,7 @@ export function useDerivedSwapInfo(): DerivedSwapInfo {
   const inputCurrency = useTokenBySymbolOrAddress(inputCurrencyId)
   const outputCurrency = useTokenBySymbolOrAddress(outputCurrencyId)
   const recipientLookup = useENS(recipient ?? undefined)
-  const to: string | null = (recipient === null ? account : recipientLookup.address) ?? null
+  const to: string | null = (recipient ? recipientLookup.address : account) ?? null
 
   const relevantTokenBalances = useCurrencyBalances(
     account ?? undefined,
@@ -317,7 +317,7 @@ export function useDerivedSwapInfo(): DerivedSwapInfo {
 
     const formattedTo = isAddress(to)
     if (!to || !formattedTo) {
-      inputError = inputError ?? t`Enter a recipient`
+      inputError = inputError ?? t`Enter a valid recipient`
     } else {
       if (BAD_RECIPIENT_ADDRESSES[formattedTo]) {
         inputError = inputError ?? t`Invalid recipient`


### PR DESCRIPTION
# Summary

Fixes  https://github.com/cowprotocol/cowswap/issues/2228

For SWAPS fix some edge case which was not enabling the button to post an order if you had not specified the Recipient (after you have specified one)

It also solves an issue for the LIMIT ORDERS which would show an error in the price estimation. The error was basically for having the Recipient empty. So I gave more prior to display the recipient error.


## Bonus
I change slightly the message from `Enter a recipient` to `Enter a valid recipient` when the recipient is wrong


# To Test

1. SWAP/LIMIT orders. Try the issues in #2228