### PR TITLE
Estimated execution price for partial fills - minimal

### DIFF
--- a/src/custom/state/orders/utils.ts
+++ b/src/custom/state/orders/utils.ts
@@ -216,9 +216,6 @@ export function getEstimatedExecutionPrice(
   fee: string
 ): Price<Currency, Currency> {
   // TODO: implement estimation for partially fillable orders
-  if (order.partiallyFillable) {
-    throw Error('Not implemented!')
-  }
 
   // Build CurrencyAmount and Price instances
   const feeAmount = CurrencyAmount.fromRawAmount(order.inputToken, fee)


### PR DESCRIPTION
# Summary

Simply allowing partial fills to get the estimated execution price

It still uses `fill or kill` estimation method, so might not be accurate

# To Test

1. Place partial fill limit order
* Estimated execution price should be calculated

Same caveat applies as for fill or kill limit orders