### PR TITLE
Cancelled status takes precedence on limit orders table

### DIFF
--- a/src/cow-react/modules/limitOrders/pure/OrderStatusBox/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/OrderStatusBox/index.tsx
@@ -14,14 +14,14 @@ const Wrapper = styled.div<{
   --statusColor: ${({ theme, status, cancelling, partiallyFilled }) =>
     cancelling
       ? theme.text1
+      : status === OrderStatus.CANCELLED
+      ? theme.danger
       : status === OrderStatus.FULFILLED || partiallyFilled
       ? theme.success
       : status === OrderStatus.PENDING // OPEN order
       ? theme.text3
       : status === OrderStatus.EXPIRED
       ? theme.warning
-      : status === OrderStatus.CANCELLED
-      ? theme.danger
       : status === OrderStatus.FAILED
       ? theme.danger
       : // Remaining statuses should use the same
@@ -71,6 +71,9 @@ export function OrderStatusBox({ order, widthAuto, withWarning }: OrderStatusBox
         // Cancelling is not a real order status
         order.isCancelling
           ? 'Cancelling...'
+          : // Cancelled status takes precedence
+          order.status === OrderStatus.CANCELLED
+          ? orderStatusTitleMap[order.status]
           : // We consider the order fully filled for display purposes even if not 100% filled
           // For this reason we use the flag to override the order status
           order.fullyFilled


### PR DESCRIPTION
# Summary

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/43217/229127607-8d30c862-e326-40ea-836c-a85ffb7b39bd.png) | ![image](https://user-images.githubusercontent.com/43217/229127225-7d93ad99-5ee2-41e4-9653-aa15498eae30.png) |

# To Test

1. Place an order
2. Have it fill less than 100%
3. Cancel it
* Status on the history tab should be `cancelled` instead of `partially filled`