### PR TITLE
Showing custom execution price label on receipt for partial fills

### DIFF
--- a/src/cow-react/modules/limitOrders/pure/ReceiptModal/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/ReceiptModal/index.tsx
@@ -102,7 +102,10 @@ export function ReceiptModal({
                 </>
               ) : (
                 <>
-                  <FieldLabel label="Execution price" tooltip={tooltips.EXECUTION_PRICE} />{' '}
+                  <FieldLabel
+                    label={order.partiallyFilled ? 'Avg. execution price' : 'Execution price'}
+                    tooltip={tooltips.EXECUTION_PRICE}
+                  />{' '}
                   <PriceField order={order} price={executionPrice} />
                 </>
               )}


### PR DESCRIPTION
# Summary

Show `Avg. execution price` on receipt for partial fills

|Before|After|
|-|-|
| ![image](https://user-images.githubusercontent.com/43217/229131608-f96405bd-5556-46e1-a5f1-f1501a3c7258.png) | ![image](https://user-images.githubusercontent.com/43217/229131479-e08d7ce3-484d-486e-9205-e540527ab27b.png) |

  # To Test

1. Open a partial fills order receipt
* You should see the field `Avg. execution price`