### PR TITLE
Fix/tokens page case sensitive search

### DIFF
--- a/cypress-custom/integration/token.test.ts
+++ b/cypress-custom/integration/token.test.ts
@@ -1,0 +1,20 @@
+describe('Tokens', () => {
+  beforeEach(() => {
+    cy.visit('/#/account/tokens?chain=goerli')
+  })
+
+  it('should be able to find a token by its name', () => {
+    cy.get('#token-search-input').type('cow')
+    cy.get('#tokens-table').contains('CoW Protocol Token')
+  })
+
+  it('should be able to find a token by its address', () => {
+    cy.get('#token-search-input').type('0xdc31Ee1784292379Fbb2964b3B9C4124D8F89C60')
+    cy.get('#tokens-table').contains('DAI')
+  })
+
+  it('should be able to find a token by its address with case errors', () => {
+    cy.get('#token-search-input').type('0XdC31eE1784292379fBB2964b3B9C4124D8F89C60')
+    cy.get('#tokens-table').contains('DAI')
+  })
+})

--- a/src/cow-react/pages/Account/Tokens/TokensOverview.tsx
+++ b/src/cow-react/pages/Account/Tokens/TokensOverview.tsx
@@ -143,7 +143,7 @@ export default function TokensOverview() {
 
   const handleSearch: ChangeEventHandler<HTMLInputElement> = useCallback(
     (event) => {
-      const input = event.target.value.trim()
+      const input = event.target.value.trim().toLowerCase()
       const checksummedInput = isAddress(input)
       setQuery(checksummedInput || input)
       if (page !== 1) setPage(1)

--- a/src/custom/components/Tokens/TokensTable.tsx
+++ b/src/custom/components/Tokens/TokensTable.tsx
@@ -189,7 +189,7 @@ export default function TokenTable({
   }, [page, prevPageIndex])
 
   return (
-    <Wrapper>
+    <Wrapper id="tokens-table">
       <ErrorModal />
       <TransactionConfirmationModal />
 


### PR DESCRIPTION
# Summary

Fixes #2168

Allows for case insensitive searches in tokens page.
Adds e2e tests for this.

  # To Test

1. Open the application
2. Go to tokens page (/#/account/tokens)
3. On Goerli: search for 0XdC31eE1784292379fBB2964b3B9C4124D8F89C60
4. This should show you DAI even though there are case issues
