### PR TITLE
[Limit orders] Removed excessive currencyId update

### DIFF
--- a/src/cow-react/modules/limitOrders/hooks/useOnCurrencySelection.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useOnCurrencySelection.ts
@@ -25,7 +25,7 @@ export function useOnCurrencySelection(): (field: Field, currency: Currency | nu
        */
       if (currency) {
         const amountField = field === Field.INPUT ? 'inputCurrencyAmount' : 'outputCurrencyAmount'
-        const currencyIdField = field === Field.INPUT ? 'inputCurrencyId' : 'outputCurrencyId'
+
         const amount = field === Field.INPUT ? inputCurrencyAmount : outputCurrencyAmount
 
         if (amount) {
@@ -33,8 +33,7 @@ export function useOnCurrencySelection(): (field: Field, currency: Currency | nu
 
           return onCurrencySelectionCommon(field, currency, () => {
             updateLimitOrdersState({
-              [amountField]: FractionUtils.serializeFractionToJSON(converted),
-              [currencyIdField]: currency.symbol,
+              [amountField]: FractionUtils.serializeFractionToJSON(converted)
             })
           })
         }

--- a/src/cow-react/modules/limitOrders/hooks/useOnCurrencySelection.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useOnCurrencySelection.ts
@@ -33,7 +33,7 @@ export function useOnCurrencySelection(): (field: Field, currency: Currency | nu
 
           return onCurrencySelectionCommon(field, currency, () => {
             updateLimitOrdersState({
-              [amountField]: FractionUtils.serializeFractionToJSON(converted)
+              [amountField]: FractionUtils.serializeFractionToJSON(converted),
             })
           })
         }


### PR DESCRIPTION
# Summary

Fixes #2224

`@cow/modules/trade/hooks/useOnCurrencySelection` contains the special hook `useResolveCurrencyAddressOrSymbol` that helps us to avoid token symbols collisions.  
But, it was overridden by a wrong value (always currency symbol) in `useOnCurrencySelection()`
