### PR TITLE
Refactor useTradeState() return type

### DIFF
--- a/src/cow-react/modules/application/containers/TradeWidgetLinks/index.tsx
+++ b/src/cow-react/modules/application/containers/TradeWidgetLinks/index.tsx
@@ -13,7 +13,7 @@ export function TradeWidgetLinks() {
     () => ({
       inputCurrencyId: state?.inputCurrencyId || undefined,
       outputCurrencyId: state?.outputCurrencyId || undefined,
-      chainId: state?.chainId?.toString()
+      chainId: state?.chainId?.toString(),
     }),
     [state]
   )

--- a/src/cow-react/modules/application/containers/TradeWidgetLinks/index.tsx
+++ b/src/cow-react/modules/application/containers/TradeWidgetLinks/index.tsx
@@ -7,15 +7,15 @@ import { parameterizeTradeRoute } from '@cow/modules/trade/utils/parameterizeTra
 import * as styledEl from './styled'
 
 export function TradeWidgetLinks() {
-  const tradeState = useTradeState()
+  const { state } = useTradeState()
 
   const tradeContext = useMemo(
     () => ({
-      inputCurrencyId: tradeState?.state.inputCurrencyId || undefined,
-      outputCurrencyId: tradeState?.state.outputCurrencyId || undefined,
-      chainId: tradeState?.state.chainId?.toString(),
+      inputCurrencyId: state?.inputCurrencyId || undefined,
+      outputCurrencyId: state?.outputCurrencyId || undefined,
+      chainId: state?.chainId?.toString()
     }),
-    [tradeState?.state]
+    [state]
   )
 
   return (

--- a/src/cow-react/modules/swap/hooks/useDetectNativeToken.ts
+++ b/src/cow-react/modules/swap/hooks/useDetectNativeToken.ts
@@ -14,8 +14,8 @@ import { useWalletInfo } from '@cow/modules/wallet'
 // TODO: move it to `modules/trade`
 export function useDetectNativeToken() {
   const { chainId } = useWalletInfo()
-  const tradeState = useTradeState()
-  const { inputCurrencyId, outputCurrencyId } = tradeState?.state || {}
+  const { state } = useTradeState()
+  const { inputCurrencyId, outputCurrencyId } = state || {}
 
   const input = useTokenBySymbolOrAddress(inputCurrencyId)
   const output = useTokenBySymbolOrAddress(outputCurrencyId)

--- a/src/cow-react/modules/trade/containers/ImportTokenModal/index.tsx
+++ b/src/cow-react/modules/trade/containers/ImportTokenModal/index.tsx
@@ -17,14 +17,14 @@ export interface ImportTokenModalProps {
 export function ImportTokenModal(props: ImportTokenModalProps) {
   const { chainId, onDismiss } = props
 
-  const tradeState = useTradeState()
+  const { state } = useTradeState()
   const loadedInputCurrency = useSearchInactiveTokenLists(
-    tradeState?.state?.inputCurrencyId || undefined,
+    state?.inputCurrencyId || undefined,
     1,
     true //
   )?.[0]
   const loadedOutputCurrency = useSearchInactiveTokenLists(
-    tradeState?.state?.outputCurrencyId || undefined,
+    state?.outputCurrencyId || undefined,
     1,
     true
   )?.[0]

--- a/src/cow-react/modules/trade/containers/ImportTokenModal/index.tsx
+++ b/src/cow-react/modules/trade/containers/ImportTokenModal/index.tsx
@@ -23,11 +23,7 @@ export function ImportTokenModal(props: ImportTokenModalProps) {
     1,
     true //
   )?.[0]
-  const loadedOutputCurrency = useSearchInactiveTokenLists(
-    state?.outputCurrencyId || undefined,
-    1,
-    true
-  )?.[0]
+  const loadedOutputCurrency = useSearchInactiveTokenLists(state?.outputCurrencyId || undefined, 1, true)?.[0]
 
   const urlLoadedTokens: Token[] = useMemo(
     () => [loadedInputCurrency, loadedOutputCurrency]?.filter((c): c is Token => c?.isToken ?? false) ?? [],

--- a/src/cow-react/modules/trade/hooks/useOnCurrencySelection.ts
+++ b/src/cow-react/modules/trade/hooks/useOnCurrencySelection.ts
@@ -32,15 +32,15 @@ function useResolveCurrencyAddressOrSymbol(): (currency: Currency | null) => str
  */
 export function useOnCurrencySelection(): CurrencySelectionCallback {
   const { chainId } = useWalletInfo()
-  const tradeState = useTradeState()
+  const { state } = useTradeState()
   const navigate = useTradeNavigate()
   const resolveCurrencyAddressOrSymbol = useResolveCurrencyAddressOrSymbol()
 
   return useCallback(
     (field: Field, currency: Currency | null, stateUpdateCallback?: () => void) => {
-      if (!tradeState) return
+      if (!state) return
 
-      const { inputCurrencyId, outputCurrencyId } = tradeState.state
+      const { inputCurrencyId, outputCurrencyId } = state
       const tokenSymbolOrAddress = resolveCurrencyAddressOrSymbol(currency)
 
       const targetInputCurrencyId = field === Field.INPUT ? tokenSymbolOrAddress : inputCurrencyId
@@ -60,6 +60,6 @@ export function useOnCurrencySelection(): CurrencySelectionCallback {
 
       stateUpdateCallback?.()
     },
-    [navigate, chainId, tradeState, resolveCurrencyAddressOrSymbol]
+    [navigate, chainId, state, resolveCurrencyAddressOrSymbol]
   )
 }

--- a/src/cow-react/modules/trade/hooks/useTradeState.ts
+++ b/src/cow-react/modules/trade/hooks/useTradeState.ts
@@ -22,8 +22,7 @@ export function useLimitOrdersTradeState(): TradeState {
   return useAtomValue(limitOrdersAtom)
 }
 
-// TODO: maybe better to return empty object instead of null
-export function useTradeState(): { state: TradeState; updateState: (state: TradeState) => void } | null {
+export function useTradeState(): { state?: TradeState; updateState?: (state: TradeState) => void } {
   const dispatch = useAppDispatch()
   const tradeTypeInfo = useTradeTypeInfo()
 
@@ -49,7 +48,7 @@ export function useTradeState(): { state: TradeState; updateState: (state: Trade
   )
 
   return useMemo(() => {
-    if (!tradeTypeInfo) return null
+    if (!tradeTypeInfo) return {}
 
     if (tradeTypeInfo.tradeType === TradeType.SWAP) {
       return {

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -69,7 +69,7 @@ export default function Header() {
     toggleDarkModeAux()
   }, [toggleDarkModeAux, darkMode])
   const swapState = useSwapTradeState()
-  const tradeState = useTradeState()
+  const { state: tradeState } = useTradeState()
 
   const [isOrdersPanelOpen, setIsOrdersPanelOpen] = useState<boolean>(false)
   const handleOpenOrdersPanel = () => {
@@ -93,7 +93,7 @@ export default function Header() {
   }, [isUpToLarge, isMobileMenuOpen])
 
   const tradeMenuContext = useMemo(() => {
-    const state = tradeState?.state || swapState
+    const state = tradeState || swapState
     const defaultTradeState = getDefaultTradeState(chainId || state.chainId || SupportedChainId.MAINNET)
     const networkWasChanged = chainId && state.chainId && chainId !== state.chainId
 
@@ -112,7 +112,7 @@ export default function Header() {
       outputCurrencyId,
       chainId: defaultTradeState.chainId?.toString(),
     }
-  }, [chainId, tradeState?.state, swapState])
+  }, [chainId, tradeState, swapState])
 
   const menuContext: MainMenuContext = {
     darkMode,


### PR DESCRIPTION
# Summary

Refactored `useTradeState()` to make it return type simpler 
