### PR TITLE
Feature/partial fills estimating price again

### DIFF
--- a/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/custom/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -10,6 +10,7 @@ import {
   getEstimatedExecutionPrice,
   getOrderExecutionPrice,
   getOrderMarketPrice,
+  getRemainderAmount,
   isOrderUnfillable,
 } from 'state/orders/utils'
 import { getPromiseFulfilledValue } from 'utils/misc'
@@ -31,7 +32,9 @@ import { useGetGpPriceStrategy } from 'hooks/useGetGpPriceStrategy'
  * Thin wrapper around `getBestPrice` that builds the params and returns null on failure
  */
 async function _getOrderPrice(chainId: ChainId, order: Order, strategy: GpPriceStrategy) {
-  let amount, baseToken, quoteToken
+  let baseToken, quoteToken
+
+  const amount = getRemainderAmount(order.kind, order)
 
   if (order.kind === 'sell') {
     // this order sell amount is sellAmountAfterFees
@@ -39,11 +42,9 @@ async function _getOrderPrice(chainId: ChainId, order: Order, strategy: GpPriceS
     // e.g order submitted w/sellAmount adjusted for fee: 995, we re-query 995
     // e.g backend adjusts for fee again, 990 is used. We need to avoid double fee adjusting
     // e.g so here we need to pass the sellAmountBeforeFees
-    amount = order.sellAmountBeforeFee.toString()
     baseToken = order.sellToken
     quoteToken = order.buyToken
   } else {
-    amount = order.buyAmount.toString()
     baseToken = order.buyToken
     quoteToken = order.sellToken
   }

--- a/src/custom/state/orders/utils.test.ts
+++ b/src/custom/state/orders/utils.test.ts
@@ -20,6 +20,7 @@ const ORDER = generateOrder({ owner: '0x...', sellToken, buyToken })
 // Update to amounts reasonable for testing.
 // Price is 1 USDC per USDT == 1 USDT/USDC
 ORDER.sellAmount = '1000'
+ORDER.sellAmountBeforeFee = '1000'
 ORDER.buyAmount = '1000'
 
 describe('isOrderUnfillable', () => {

--- a/src/custom/state/orders/utils.ts
+++ b/src/custom/state/orders/utils.ts
@@ -268,3 +268,27 @@ export function getEstimatedExecutionPrice(
 
   return estimatedExecutionPrice
 }
+/**
+ * Get the remainder `kind` amount, based on executed amounts from the `apiAdditionalInfo`, if any
+ *
+ * For the sell amount, uses the variants that do not consider the fee:
+ * `sellAmountBeforeFee` and `executedSellAmountBeforeFees`
+ *
+ * @param kind The kind of remainder
+ * @param order The order object
+ */
+export function getRemainderAmount(kind: OrderKind, order: Order): string {
+  const { sellAmountBeforeFee, buyAmount, apiAdditionalInfo } = order
+
+  const fullAmount = kind === 'sell' ? sellAmountBeforeFee.toString() : buyAmount.toString()
+
+  if (!apiAdditionalInfo) {
+    return fullAmount
+  }
+
+  const { executedSellAmountBeforeFees, executedBuyAmount } = apiAdditionalInfo
+
+  const executedAmount = JSBI.BigInt((kind === 'sell' ? executedSellAmountBeforeFees : executedBuyAmount) || 0)
+
+  return JSBI.subtract(JSBI.BigInt(fullAmount), executedAmount).toString()
+}

--- a/src/custom/state/orders/utils.ts
+++ b/src/custom/state/orders/utils.ts
@@ -378,7 +378,7 @@ export function getRemainderAmountsWithoutSurplus(order: Order): { buyAmount: st
 export function getRemainderAmount(kind: OrderKind, order: Order): string {
   const { sellAmountBeforeFee, buyAmount, apiAdditionalInfo } = order
 
-  const fullAmount = kind === 'sell' ? sellAmountBeforeFee.toString() : buyAmount.toString()
+  const fullAmount = kind === OrderKind.SELL ? sellAmountBeforeFee.toString() : buyAmount.toString()
 
   if (!apiAdditionalInfo) {
     return fullAmount
@@ -386,7 +386,7 @@ export function getRemainderAmount(kind: OrderKind, order: Order): string {
 
   const { executedSellAmountBeforeFees, executedBuyAmount } = apiAdditionalInfo
 
-  const executedAmount = JSBI.BigInt((kind === 'sell' ? executedSellAmountBeforeFees : executedBuyAmount) || 0)
+  const executedAmount = JSBI.BigInt((kind === OrderKind.SELL ? executedSellAmountBeforeFees : executedBuyAmount) || 0)
 
   return JSBI.subtract(JSBI.BigInt(fullAmount), executedAmount).toString()
 }

--- a/src/custom/state/orders/utils.ts
+++ b/src/custom/state/orders/utils.ts
@@ -254,7 +254,7 @@ export function getEstimatedExecutionPrice(
 ): Price<Currency, Currency> {
   // Build CurrencyAmount and Price instances
   const feeAmount = CurrencyAmount.fromRawAmount(order.inputToken, fee)
-  //  Always use original amounts for building the limit price, as this will never change
+  // Always use original amounts for building the limit price, as this will never change
   const inputAmount = CurrencyAmount.fromRawAmount(order.inputToken, order.sellAmount.toString())
   const outputAmount = CurrencyAmount.fromRawAmount(order.outputToken, order.buyAmount.toString())
   const limitPrice = buildPriceFromCurrencyAmounts(inputAmount, outputAmount)
@@ -286,7 +286,7 @@ export function getEstimatedExecutionPrice(
     numerator.quotient
   )
 
-  // Picking the MAX between FEP and FP
+  // Pick the MAX between FEP and FP
   const estimatedExecutionPrice = fillPrice.greaterThan(feasibleExecutionPrice) ? fillPrice : feasibleExecutionPrice
 
   // Apply slippage to the estimated price to give us an extra wiggle room
@@ -309,7 +309,7 @@ export function getEstimatedExecutionPrice(
     'Limit Price (LP)': `${limitPrice.toFixed(8)} ${limitPrice.quoteCurrency.symbol} per ${
       limitPrice.baseCurrency.symbol
     } (${limitPrice.numerator.toString()}/${limitPrice.denominator.toString()})`,
-    'Feasable Execution Price (FEP)': `${feasibleExecutionPrice.toFixed(18)} ${
+    'Feasible Execution Price (FEP)': `${feasibleExecutionPrice.toFixed(18)} ${
       feasibleExecutionPrice.quoteCurrency.symbol
     } per ${feasibleExecutionPrice.baseCurrency.symbol}`,
     'Fill Price (FP)': `${fillPrice.toFixed(8)} ${fillPrice.quoteCurrency.symbol} per ${

--- a/src/custom/state/orders/utils.ts
+++ b/src/custom/state/orders/utils.ts
@@ -172,7 +172,7 @@ export function getOrderExecutionPrice(
 
   if (order.kind === OrderKind.SELL) {
     // For sell orders, the quoted amount is the buy amount
-    return new Price(order.inputToken, order.outputToken, remainderAmount, quoteAmount.toString())
+    return new Price(order.inputToken, order.outputToken, remainderAmount, quoteAmount)
   }
 
   // For buy orders, the quoted amount is the sell amount
@@ -180,7 +180,7 @@ export function getOrderExecutionPrice(
     order.inputToken,
     order.outputToken,
     // We need to add the quoted fee to have the price, as the quoted amount comes without it
-    JSBI.add(JSBI.BigInt(quoteAmount.toString()), JSBI.BigInt(feeAmount)),
+    JSBI.add(JSBI.BigInt(quoteAmount), JSBI.BigInt(feeAmount)),
     remainderAmount
   )
 }
@@ -201,12 +201,12 @@ export function getOrderMarketPrice(order: Order, quotedAmount: string, feeAmoun
       order.outputToken,
       // For sell orders, the market price has the fee subtracted from the sell amount
       JSBI.subtract(JSBI.BigInt(remainingAmount), JSBI.BigInt(feeAmount)),
-      quotedAmount.toString()
+      quotedAmount
     )
   }
 
   // For buy orders, the market price uses the quotedAmount which comes without the fee amount
-  return new Price(order.inputToken, order.outputToken, quotedAmount.toString(), remainingAmount)
+  return new Price(order.inputToken, order.outputToken, quotedAmount, remainingAmount)
 }
 
 /**


### PR DESCRIPTION
# Summary

Another iteration of estimated execution price, this time for partial fills

Now we'll take into account executed order amounts when quoting the price

Also applying a +0.5% slippage to estimated price to account for small variations leading to the order not executing when it says it should

# To Test

1. Place limit order
2. Hope if matches partially
* Estimated price should take into account only what's left to match in the order
* Estimated price should accurately estimate at what price the order should execute

Note: remember to test with both sell and buy orders