### PR TITLE
Fix network switching detection

### DIFF
--- a/src/cow-react/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
+++ b/src/cow-react/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
@@ -53,6 +53,21 @@ function areChainIdsTheSame(aChainId: Nullish<number>, bChainId: Nullish<number>
   return !!aChainId && !!bChainId && aChainId !== bChainId
 }
 
+// When there is no account from provider (wallet is not connected)
+// And there is no chainId in provider (edge case in E2E tests)
+// Then we use chainId from URL as current
+function getCurrentChainId(
+  account: string | undefined,
+  providerChainId: number | undefined,
+  chainIdFromUrl: number | null
+): number | null {
+  if (account) {
+    return providerChainId || null
+  }
+
+  return providerChainId || chainIdFromUrl
+}
+
 export function useSetupTradeState(): void {
   const { chainId: providerChainId, account } = useWalletInfo()
   const { connector } = useWeb3React()
@@ -62,8 +77,7 @@ export function useSetupTradeState(): void {
   const { state, updateState } = useTradeState()
 
   const chainIdFromUrl = tradeStateFromUrl.chainId
-  // When there is no account from provider, then we consider provider as not connected and use chainId from URL as current
-  const currentChainId = (account ? providerChainId : chainIdFromUrl) || providerChainId
+  const currentChainId = getCurrentChainId(account, providerChainId, chainIdFromUrl)
 
   const prevChainIdFromUrl = usePrevious(chainIdFromUrl)
   const prevCurrentChainId = usePrevious(currentChainId)
@@ -109,10 +123,10 @@ export function useSetupTradeState(): void {
     const newState: TradeState = chainIdFromProviderWasChanged
       ? getDefaultTradeState(newChainId)
       : {
-          chainId: newChainId,
-          recipient: tradeStateFromUrl.recipient || state.recipient,
-          ...getUpdatedCurrenciesIds(tradeStateFromUrl, state),
-        }
+        chainId: newChainId,
+        recipient: tradeStateFromUrl.recipient || state.recipient,
+        ...getUpdatedCurrenciesIds(tradeStateFromUrl, state)
+      }
 
     console.debug('UPDATE TRADE STATE:', newState)
 
@@ -120,7 +134,7 @@ export function useSetupTradeState(): void {
 
     tradeNavigate(newState.chainId, {
       inputCurrencyId: newState.inputCurrencyId || null,
-      outputCurrencyId: newState.outputCurrencyId || null,
+      outputCurrencyId: newState.outputCurrencyId || null
     })
   }, [tradeNavigate, newChainId, chainIdFromProviderWasChanged, state, updateState, tradeStateFromUrl])
 

--- a/src/cow-react/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
+++ b/src/cow-react/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
@@ -123,10 +123,10 @@ export function useSetupTradeState(): void {
     const newState: TradeState = chainIdFromProviderWasChanged
       ? getDefaultTradeState(newChainId)
       : {
-        chainId: newChainId,
-        recipient: tradeStateFromUrl.recipient || state.recipient,
-        ...getUpdatedCurrenciesIds(tradeStateFromUrl, state)
-      }
+          chainId: newChainId,
+          recipient: tradeStateFromUrl.recipient || state.recipient,
+          ...getUpdatedCurrenciesIds(tradeStateFromUrl, state),
+        }
 
     console.debug('UPDATE TRADE STATE:', newState)
 
@@ -134,7 +134,7 @@ export function useSetupTradeState(): void {
 
     tradeNavigate(newState.chainId, {
       inputCurrencyId: newState.inputCurrencyId || null,
-      outputCurrencyId: newState.outputCurrencyId || null
+      outputCurrencyId: newState.outputCurrencyId || null,
     })
   }, [tradeNavigate, newChainId, chainIdFromProviderWasChanged, state, updateState, tradeStateFromUrl])
 


### PR DESCRIPTION
# Summary

Fixes #2021

The bug was introduced here: https://github.com/cowprotocol/cowswap/pull/1942/files#diff-476acfe17c5b8c2a3ba90bcccd7dc4c43ca0b62c5971b172351d2223685ec8b3R64

`chainIdFromProviderWasChanged` was not changed because of it bug, consequently, `chainId` didn't change in URL and the Swap form didn't change. 

I'm very sorry for `useSetupTradeState` hook :( We should refactor it some a day.

Important! This change shouldn't break E2E tests.