### PR TITLE
Disable Swap form while loading best price

### DIFF
--- a/src/cow-react/modules/swap/helpers/getSwapButtonState.ts
+++ b/src/cow-react/modules/swap/helpers/getSwapButtonState.ts
@@ -49,6 +49,7 @@ export interface SwapButtonStateParams {
   trade: TradeGp | undefined | null
   isNativeIn: boolean
   isSmartContractWallet: boolean
+  isBestQuoteLoading: boolean
   wrappedToken: Token
 }
 
@@ -103,7 +104,7 @@ export function getSwapButtonState(input: SwapButtonStateParams): SwapButtonStat
     return SwapButtonState.ShouldUnwrapNativeToken
   }
 
-  if (swapBlankState || input.isGettingNewQuote) {
+  if (swapBlankState || input.isGettingNewQuote || input.isBestQuoteLoading) {
     return SwapButtonState.Loading
   }
 

--- a/src/cow-react/modules/swap/hooks/useSwapButtonContext.ts
+++ b/src/cow-react/modules/swap/hooks/useSwapButtonContext.ts
@@ -14,7 +14,7 @@ import {
 } from 'hooks/useWrapCallback'
 import { getSwapButtonState } from '@cow/modules/swap/helpers/getSwapButtonState'
 import { SwapButtonsContext } from '@cow/modules/swap/pure/SwapButtons'
-import { useGetQuoteAndStatus } from 'state/price/hooks'
+import { useGetQuoteAndStatus, useIsBestQuoteLoading } from 'state/price/hooks'
 import { useSwapFlowContext } from '@cow/modules/swap/hooks/useSwapFlowContext'
 import { PriceImpact } from 'hooks/usePriceImpact'
 import { useTradeApproveState } from '@cow/common/containers/TradeApprove/useTradeApproveState'
@@ -52,6 +52,7 @@ export function useSwapButtonContext(input: SwapButtonInput): SwapButtonsContext
   const swapFlowContext = useSwapFlowContext()
   const ethFlowContext = useEthFlowContext()
   const { onCurrencySelection } = useSwapActionHandlers()
+  const isBestQuoteLoading = useIsBestQuoteLoading()
 
   const currencyIn = currencies[Field.INPUT]
   const currencyOut = currencies[Field.OUTPUT]
@@ -105,6 +106,7 @@ export function useSwapButtonContext(input: SwapButtonInput): SwapButtonsContext
     isGettingNewQuote,
     swapCallbackError,
     trade,
+    isBestQuoteLoading,
   })
 
   return {

--- a/src/custom/hooks/useRefetchPriceCallback.tsx
+++ b/src/custom/hooks/useRefetchPriceCallback.tsx
@@ -252,7 +252,20 @@ export function useRefetchQuoteCallback() {
 
       // Get the best quote
       getBestQuoteResolveOnlyLastCall(bestQuoteParams)
-        .then((res) => handleResponse(res, true))
+        .then((res) => {
+          const bestQuoteDelay = localStorage.getItem('delayBestQuote')
+
+          // TODO: remove after testing
+          // The flag serves to make an artificial delay before getting "best" quote
+          if (bestQuoteDelay) {
+            setTimeout(() => {
+              handleResponse(res, true)
+            }, +bestQuoteDelay)
+            return
+          }
+
+          handleResponse(res, true)
+        })
         .catch(handleError)
     },
     [

--- a/src/custom/hooks/useRefetchPriceCallback.tsx
+++ b/src/custom/hooks/useRefetchPriceCallback.tsx
@@ -253,17 +253,6 @@ export function useRefetchQuoteCallback() {
       // Get the best quote
       getBestQuoteResolveOnlyLastCall(bestQuoteParams)
         .then((res) => {
-          const bestQuoteDelay = localStorage.getItem('delayBestQuote')
-
-          // TODO: remove after testing
-          // The flag serves to make an artificial delay before getting "best" quote
-          if (bestQuoteDelay) {
-            setTimeout(() => {
-              handleResponse(res, true)
-            }, +bestQuoteDelay)
-            return
-          }
-
           handleResponse(res, true)
         })
         .catch(handleError)


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C036G0J90BU/p1680169031535319

Basically, there's some cases where we allow users to submit orders with a "fast" price from the quote endpoint. 
In this PR we are displaying "Hang in there. Calculating best price..." state until we get the best price.

<img width="556" alt="image" src="https://user-images.githubusercontent.com/7122625/229796186-963afef2-8476-48a2-8b5e-8ddac70cd1fa.png">

  # To Test

1. Open vercel from https://github.com/cowprotocol/cowswap/pull/2255
2. Open swap page, setup a trade, run `localStorage.setItem('delayBestQuote', '200000')` in console and reload the page
3. Keep developed tools open in network tab
4. Just after page load do a swap
- [ ] check POST /orders request, it should NOT contain`quoteId` field
5. Open vercel from the current PR
6. Open swap page, setup a trade, run `localStorage.setItem('delayBestQuote', '10000')` in console and reload the page
- [ ] first ~10 seconds "Hang in there. Calculating best price..." must be displayed
- [ ] first ~10 seconds it's impossible to swap
7. Do a swap when it's possible
- [ ] check POST /orders request, it MUST contain`quoteId` field with a number value
8. After all tests run `localStorage.removeItem('delayBestQuote')` in console

![image](https://user-images.githubusercontent.com/7122625/229807525-cb71ec73-73da-401b-9e5d-75e7af6d1937.png)
