### PR TITLE
Don't show import if we have a token for you

### DIFF
--- a/cypress-custom/integration/search.test.ts
+++ b/cypress-custom/integration/search.test.ts
@@ -51,4 +51,18 @@ describe('Search', () => {
     cy.get('#currency-list').contains('DAI')
     cy.get('#currency-list').should('not.contain.text', 'GNO')
   })
+
+  it('should not show import when token is in our lists', () => {
+    cy.get('.open-currency-select-button').first().click()
+    cy.get('#token-search-input').type('0xdc31ee1784292379fbb2964b3b9c4124d8f89c60')
+    cy.get('#currency-list').contains('DAI')
+    cy.get('#currency-list').should('not.contain.text', 'Import')
+  })
+
+  it('should show import when token is unknown to us', () => {
+    cy.get('.open-currency-select-button').first().click()
+    cy.get('#token-search-input').type('0x82f418D75F836385092eB8EaBf1608cd4b91961c')
+    cy.get('#currency-import').contains('stETH')
+    cy.get('#currency-import').contains('Import')
+  })
 })

--- a/src/custom/components/SearchModal/CurrencySearch/CurrencySearchMod.tsx
+++ b/src/custom/components/SearchModal/CurrencySearch/CurrencySearchMod.tsx
@@ -246,8 +246,8 @@ export function CurrencySearch({
           )}
         </PaddedColumn>
         <Separator />
-        {searchToken && !searchTokenIsAdded ? (
-          <Column style={{ padding: '20px 0', height: '100%' }}>
+        {searchToken && !searchTokenIsAdded && filteredSortedTokens?.length === 0 ? (
+          <Column id="currency-import" style={{ padding: '20px 0', height: '100%' }}>
             <ImportRow token={searchToken} showImportView={showImportView} setImportToken={setImportToken} />
           </Column>
         ) : filteredSortedTokens?.length > 0 || filteredInactiveTokens?.length > 0 || additionalTokens.length > 0 ? (


### PR DESCRIPTION
# Summary

Fixes #2181 

Before this change, we have been showing import rows as opposed to our own currency search results, especially in the case of an address search.

With this change, we will check whether or not we have our own results first - and if we do, we will show that. This fixes showing unnecessary import rows.

<img width="496" alt="Screenshot 2023-04-05 at 11 29 23" src="https://user-images.githubusercontent.com/5172699/230040750-d23bc379-f3f9-47a8-80cd-b20226b1067a.png">

  # To Test

1. Go to swap
2. Switch to Goerli
3. Click on a currency to open currency search modal
4. Search for 0xdc31ee1784292379fbb2964b3b9c4124d8f89c60
5. This is a known currency on Goerli (DAI). It should not have an import button.
6. Search instead for 0x82f418D75F836385092eB8EaBf1608cd4b91961c
7. This is an unknown currency on Goerli (stETH). It should have an import button.
