### PR TITLE
Feature/partial fills fix executes at receipt

### DIFF
--- a/src/cow-react/modules/limitOrders/pure/ReceiptModal/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/ReceiptModal/index.tsx
@@ -104,7 +104,7 @@ export function ReceiptModal({
               ) : (
                 <>
                   <FieldLabel
-                    label={order.partiallyFilled ? 'Avg. execution price' : 'Execution price'}
+                    label={order.partiallyFillable ? 'Avg. execution price' : 'Execution price'}
                     tooltip={tooltips.EXECUTION_PRICE}
                   />{' '}
                   <PriceField order={order} price={executionPrice} />

--- a/src/cow-react/modules/limitOrders/pure/ReceiptModal/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/ReceiptModal/index.tsx
@@ -1,10 +1,9 @@
 import { GpModal } from '@cow/common/pure/Modal'
 import { CurrencyAmount, Fraction, Token } from '@uniswap/sdk-core'
 import * as styledEl from './styled'
-import { OrderKind } from '@cowprotocol/cow-sdk'
+import { OrderKind, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { CloseIcon } from 'theme'
 import { CurrencyField } from './CurrencyField'
-import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { ParsedOrder } from '@cow/modules/limitOrders/containers/OrdersWidget/hooks/useLimitOrdersList'
 import { getSellAmountWithFee } from '@cow/modules/limitOrders/utils/getSellAmountWithFee'
 import { FeeField } from './FeeField'
@@ -16,6 +15,8 @@ import { SurplusField } from './SurplusField'
 import { IdField } from './IdField'
 import { StatusField } from './StatusField'
 import { OrderTypeField } from './OrderTypeField'
+import { OrderStatus } from 'state/orders/actions'
+
 interface ReceiptProps {
   isOpen: boolean
   order: ParsedOrder
@@ -34,7 +35,7 @@ const tooltips: { [key: string]: string | JSX.Element } = {
   EXECUTES_AT:
     'Fees (incl. gas) are covered by filling your order when the market price is better than your limit price.',
   FILLED:
-    'CoW Swap doesn’t currently support partial fills. Your order will either be filled completely or not at all.',
+    "CoW Swap doesn't currently support partial fills. Your order will either be filled completely or not at all.",
   SURPLUS: 'The amount of extra tokens you get on top of your limit price.',
   FEE: 'CoW Protocol covers the fees by executing your order at a slightly better price than your limit price.',
   CREATED: 'Your order was created on this date & time. It will remain open until it expires or is filled.',
@@ -95,7 +96,7 @@ export function ReceiptModal({
             </styledEl.Field>
 
             <styledEl.Field>
-              {estimatedExecutionPrice ? (
+              {estimatedExecutionPrice && order.status === OrderStatus.PENDING ? (
                 <>
                   <FieldLabel label="Executes at" tooltip={tooltips.EXECUTES_AT} />
                   <PriceField order={order} price={estimatedExecutionPrice} />


### PR DESCRIPTION
# Summary

Only show `executes at` on receipt if order is pending

# To Test

1. Place limit order, wait for it to execute
2. Without refreshing, go to history and open the order receipt
* Should show `avg. execution price` instead of `executes at`

# Context

It was happening because the condition was only checking for the existence of the estimated execution price, regardless of the order status