### PR TITLE
Feature/partial fills no low fee warning when unfillable

### DIFF
--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -229,7 +229,7 @@ export function OrderRow({
                 amountDifference={priceDiffs?.amount}
                 percentageFee={feeDifference}
                 amountFee={feeAmount}
-                canShowWarning={order.class !== OrderClass.MARKET}
+                canShowWarning={order.class !== OrderClass.MARKET && !isUnfillable}
                 isUnfillable={isUnfillable}
               />
             </styledEl.ExecuteCellWrapper>


### PR DESCRIPTION
# Summary

Don't show high fee warning when order is unfillable

  # To Test

1. With an order that has a low amount and a high fee (> 10%)
2. Make sure to have either no balance or no approval for given sell token
* Order should show `unfillable` and there should not be a high fee warning for it