### PR TITLE
Feature/partial fills explicit order type

### DIFF
--- a/src/cow-react/modules/limitOrders/pure/ReceiptModal/OrderTypeField.tsx
+++ b/src/cow-react/modules/limitOrders/pure/ReceiptModal/OrderTypeField.tsx
@@ -9,7 +9,7 @@ export function OrderTypeField({ order }: Props) {
   return (
     <styledEl.Value>
       <styledEl.OrderTypeValue>
-        {order.class} {order.kind} order {!order.partiallyFillable && '(Fill or Kill)'}
+        {order.class} {order.kind} order {order.partiallyFillable ? '(Partially fillable)' : '(Fill or Kill)'}
       </styledEl.OrderTypeValue>
     </styledEl.Value>
   )


### PR DESCRIPTION
# Summary

Explicitly showing `Partially fillable` order type on receipt

![image](https://user-images.githubusercontent.com/43217/230121795-68e5189b-578e-470b-b7c6-c104611fc072.png)

  # To Test

1. Open a partially fillable order
* Receipt should show `partially fillable`
2. Open a fill or kill order
* Receipt should show `fill or kill`

# Notes

Additional styling out of the scope. This is a minimal change only to show the implicit info