### PR TITLE
Feature/partial fills settings

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -228,6 +228,7 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
   const currenciesLoadingInProgress = false
   const maxBalance = maxAmountSpend(inputCurrencyInfo.balance || undefined)
   const showSetMax = !!maxBalance && !inputCurrencyInfo.rawAmount?.equalTo(maxBalance)
+  const isPartiallyFillable = !!tradeContext?.postOrderParams.partiallyFillable
 
   const subsidyAndBalance: BalanceAndSubsidy = {
     subsidy: {
@@ -310,7 +311,7 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
 
               {isExpertMode && (
                 <styledEl.FooterBox>
-                  <styledEl.StyledOrderType isPartiallyFillable />
+                  <styledEl.StyledOrderType isPartiallyFillable={isPartiallyFillable} />
                 </styledEl.FooterBox>
               )}
 

--- a/src/cow-react/modules/limitOrders/hooks/useTradeFlowContext.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useTradeFlowContext.ts
@@ -13,6 +13,7 @@ import { limitOrdersQuoteAtom } from '@cow/modules/limitOrders/state/limitOrders
 import { useUpdateAtom } from 'jotai/utils'
 import { addAppDataToUploadQueueAtom, appDataInfoAtom } from 'state/appData/atoms'
 import { useRateImpact } from '@cow/modules/limitOrders/hooks/useRateImpact'
+import { limitOrdersSettingsAtom } from '@cow/modules/limitOrders/state/limitOrdersSettingsAtom'
 
 export function useTradeFlowContext(): TradeFlowContext | null {
   const { provider } = useWeb3React()
@@ -27,6 +28,7 @@ export function useTradeFlowContext(): TradeFlowContext | null {
   const { address: ensRecipientAddress } = useENSAddress(state.recipient)
   const quoteState = useAtomValue(limitOrdersQuoteAtom)
   const rateImpact = useRateImpact()
+  const settingsState = useAtomValue(limitOrdersSettingsAtom)
 
   if (
     !chainId ||
@@ -74,7 +76,7 @@ export function useTradeFlowContext(): TradeFlowContext | null {
       inputAmount: state.inputCurrencyAmount,
       outputAmount: state.outputCurrencyAmount,
       sellAmountBeforeFee: state.inputCurrencyAmount,
-      partiallyFillable: true, // Limit orders ALWAYS partially fillable - for now
+      partiallyFillable: settingsState.partialFillsEnabled,
       appDataHash: appData.hash,
       quoteId,
     },

--- a/src/cow-react/modules/limitOrders/pure/LimitOrdersDetails/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/LimitOrdersDetails/index.tsx
@@ -42,7 +42,7 @@ export interface LimitOrdersDetailsProps {
 
 export function LimitOrdersDetails(props: LimitOrdersDetailsProps) {
   const { executionPrice, tradeContext, settingsState, rateInfoParams, limitRateState } = props
-  const { account, recipient, recipientAddressOrName } = tradeContext.postOrderParams
+  const { account, recipient, recipientAddressOrName, partiallyFillable } = tradeContext.postOrderParams
   const { feeAmount, activeRate, marketRate } = limitRateState
 
   const validTo = calculateLimitOrdersDeadline(settingsState)
@@ -116,8 +116,7 @@ export function LimitOrdersDetails(props: LimitOrdersDetailsProps) {
           <span>Active</span>
         </div>
       </styledEl.DetailsRow> */}
-      {/* TODO: adjust flag when settings are available */}
-      <OrderType isPartiallyFillable />
+      <OrderType isPartiallyFillable={partiallyFillable} />
       {recipientAddressOrName && recipient !== account && (
         <styledEl.DetailsRow>
           <div>

--- a/src/cow-react/modules/limitOrders/pure/Settings/index.cosmos.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Settings/index.cosmos.tsx
@@ -1,7 +1,13 @@
 import { Settings, SettingsProps } from './index'
 
 const defaultProps: SettingsProps = {
-  state: { expertMode: true, showRecipient: false, deadlineMilliseconds: 200_000, customDeadlineTimestamp: null },
+  state: {
+    expertMode: true,
+    showRecipient: false,
+    partialFillsEnabled: true,
+    deadlineMilliseconds: 200_000,
+    customDeadlineTimestamp: null,
+  },
   onStateChanged(state) {
     console.log('Settings state changed: ', state)
   },

--- a/src/cow-react/modules/limitOrders/pure/Settings/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Settings/index.tsx
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro'
 import QuestionHelper from 'components/QuestionHelper'
-import { useContext } from 'react'
+import { ReactNode, useContext } from 'react'
 import { ThemeContext } from 'styled-components/macro'
 import Toggle from 'components/Toggle'
 import * as styledEl from './styled'
@@ -8,7 +8,7 @@ import { LimitOrdersSettingsState } from '../../state/limitOrdersSettingsAtom'
 
 interface SettingsBoxProps {
   title: string
-  tooltip: string
+  tooltip: ReactNode
   value: boolean
   disabled?: boolean
   toggle: () => void
@@ -34,7 +34,7 @@ export interface SettingsProps {
 }
 
 export function Settings({ state, onStateChanged }: SettingsProps) {
-  const { expertMode, showRecipient } = state
+  const { expertMode, showRecipient, partialFillsEnabled } = state
 
   return (
     <styledEl.SettingsContainer>
@@ -51,6 +51,23 @@ export function Settings({ state, onStateChanged }: SettingsProps) {
         tooltip="Allows you to choose a destination address for the swap other than the connected one."
         value={showRecipient}
         toggle={() => onStateChanged({ showRecipient: !showRecipient })}
+      />
+
+      <SettingsBox
+        title="Enable Partial Executions"
+        tooltip={
+          <>
+            Allow you to chose whether your limit orders will be <i>Partially fillable</i> or <i>Fill or kill</i>.
+            <br />
+            <br />
+            <i>Fill-or-kill</i> orders will either be filled fully or not at all.
+            <br />
+            <i>Partially fillable</i> orders may be filled partially if there isn't enough liquidity to fill the full
+            amount.
+          </>
+        }
+        value={partialFillsEnabled}
+        toggle={() => onStateChanged({ partialFillsEnabled: !partialFillsEnabled })}
       />
     </styledEl.SettingsContainer>
   )

--- a/src/cow-react/modules/limitOrders/state/limitOrdersSettingsAtom.ts
+++ b/src/cow-react/modules/limitOrders/state/limitOrdersSettingsAtom.ts
@@ -6,6 +6,7 @@ import { Milliseconds, Timestamp } from '@cow/types'
 export interface LimitOrdersSettingsState {
   readonly expertMode: boolean
   readonly showRecipient: boolean
+  readonly partialFillsEnabled: boolean
   readonly deadlineMilliseconds: Milliseconds
   readonly customDeadlineTimestamp: Timestamp | null
 }
@@ -13,12 +14,13 @@ export interface LimitOrdersSettingsState {
 export const defaultLimitOrdersSettings: LimitOrdersSettingsState = {
   expertMode: false,
   showRecipient: false,
+  partialFillsEnabled: true,
   deadlineMilliseconds: defaultLimitOrderDeadline.value,
   customDeadlineTimestamp: null,
 }
 
 export const limitOrdersSettingsAtom = atomWithStorage<LimitOrdersSettingsState>(
-  'limit-orders-settings-atom:v1',
+  'limit-orders-settings-atom:v2',
   defaultLimitOrdersSettings
 )
 


### PR DESCRIPTION
# Summary

Added limit order settings to toggle between partial fill and fill or kill

![image](https://user-images.githubusercontent.com/43217/230143001-2156d36a-bb21-4d83-8ff7-e64feb82106f.png)

  # To Test

1. On limit orders page, open the settings
* Partial fills should be enabled by default
2. Review order
* Review modal should show type as partial fill
3. Place order
* It should be a partial fill order
4. Turn on expert mode
* Form should show partial fill
5. Place order
* It should be a partial fill order
6. Turn off partial fill and repeat steps 2 - 5
* It should show fill or kill and place fill or kill orders instead of partial fill