### PR TITLE
Reduce usage of RPC providers via relying on them sparingly

### DIFF
--- a/src/cow-react/modules/wallet/web3-react/connection/coinbase.tsx
+++ b/src/cow-react/modules/wallet/web3-react/connection/coinbase.tsx
@@ -9,7 +9,7 @@ import { useIsActiveWallet } from 'hooks/useIsActiveWallet'
 import { ConnectWalletOption } from '@cow/modules/wallet/api/pure/ConnectWalletOption'
 
 import CowImage from 'assets/cow-swap/cow_v2.svg'
-import { RPC_URLS } from 'constants/networks'
+import { getRpcUrls } from 'constants/networks'
 
 import { TryActivation, onError } from '.'
 import { Web3ReactConnection } from '../types'
@@ -38,7 +38,7 @@ const [web3CoinbaseWallet, web3CoinbaseWalletHooks] = initializeConnector<AsyncC
             new m.CoinbaseWallet({
               actions,
               options: {
-                url: RPC_URLS[SupportedChainId.MAINNET],
+                url: getRpcUrls(SupportedChainId.MAINNET)[0],
                 appName: 'CoW Swap',
                 appLogoUrl: CowImage,
                 reloadOnDisconnect: false,

--- a/src/cow-react/modules/wallet/web3-react/connection/ledger.tsx
+++ b/src/cow-react/modules/wallet/web3-react/connection/ledger.tsx
@@ -7,7 +7,7 @@ import { ConnectWalletOption } from '@cow/modules/wallet/api/pure/ConnectWalletO
 import { default as LedgerImage } from '@cow/modules/wallet/api/assets/ledger.svg'
 import { initializeConnector } from '@web3-react/core'
 import { Web3ReactConnection } from '../types'
-import { RPC_URLS } from 'constants/networks'
+import { PROVIDERS_RPC_URLS_FIRST_ONLY } from 'constants/networks'
 import { AsyncConnector } from './asyncConnector'
 
 const BASE_PROPS = {
@@ -26,7 +26,7 @@ const [ledger, ledgerHooks] = initializeConnector<AsyncConnector>(
               return new m.Ledger({
                 actions,
                 options: {
-                  rpc: RPC_URLS,
+                  rpc: PROVIDERS_RPC_URLS_FIRST_ONLY,
                 },
                 kit,
               })

--- a/src/cow-react/modules/wallet/web3-react/connection/network.tsx
+++ b/src/cow-react/modules/wallet/web3-react/connection/network.tsx
@@ -1,7 +1,6 @@
 import { initializeConnector } from '@web3-react/core'
 import { Network } from '@web3-react/network'
 
-// import { RPC_URLS } from 'constants/networks'
 import { ConnectionType } from '@cow/modules/wallet'
 import { Web3ReactConnection } from '../types'
 import { PROVIDERS } from '@src/custom/constants/networks'

--- a/src/cow-react/modules/wallet/web3-react/connection/network.tsx
+++ b/src/cow-react/modules/wallet/web3-react/connection/network.tsx
@@ -1,12 +1,13 @@
 import { initializeConnector } from '@web3-react/core'
 import { Network } from '@web3-react/network'
 
-import { RPC_URLS } from 'constants/networks'
+// import { RPC_URLS } from 'constants/networks'
 import { ConnectionType } from '@cow/modules/wallet'
 import { Web3ReactConnection } from '../types'
+import { PROVIDERS } from '@src/custom/constants/networks'
 
 const [web3Network, web3NetworkHooks] = initializeConnector<Network>(
-  (actions) => new Network({ actions, urlMap: RPC_URLS, defaultChainId: 1 })
+  (actions) => new Network({ actions, urlMap: PROVIDERS, defaultChainId: 1 })
 )
 export const networkConnection: Web3ReactConnection = {
   connector: web3Network,

--- a/src/cow-react/modules/wallet/web3-react/connection/network.tsx
+++ b/src/cow-react/modules/wallet/web3-react/connection/network.tsx
@@ -7,7 +7,7 @@ import { Web3ReactConnection } from '../types'
 import { PROVIDERS } from '@src/custom/constants/networks'
 
 const [web3Network, web3NetworkHooks] = initializeConnector<Network>(
-  (actions) => new Network({ actions, urlMap: PROVIDERS, defaultChainId: 1 })
+  (actions) => new Network({ actions, urlMap: PROVIDERS })
 )
 export const networkConnection: Web3ReactConnection = {
   connector: web3Network,

--- a/src/cow-react/modules/wallet/web3-react/connection/walletConnect.tsx
+++ b/src/cow-react/modules/wallet/web3-react/connection/walletConnect.tsx
@@ -13,7 +13,7 @@ import { useWalletMetaData } from '@cow/modules/wallet'
 import { initializeConnector } from '@web3-react/core'
 import { WalletConnect } from '@web3-react/walletconnect'
 
-import { RPC_URLS } from 'constants/networks'
+import { PROVIDERS_RPC_URLS } from 'constants/networks'
 import { Web3ReactConnection } from '../types'
 import { default as WalletConnectImage } from '@cow/modules/wallet/api/assets/walletConnectIcon.svg'
 import { WC_DISABLED_TEXT } from '@cow/modules/wallet/constants'
@@ -29,7 +29,7 @@ const [web3WalletConnect, web3WalletConnectHooks] = initializeConnector<WalletCo
     new WalletConnect({
       actions,
       options: {
-        rpc: RPC_URLS,
+        rpc: PROVIDERS_RPC_URLS,
         qrcode: true,
       },
       onError,

--- a/src/cow-react/modules/wallet/web3-react/hooks/switchChain.ts
+++ b/src/cow-react/modules/wallet/web3-react/hooks/switchChain.ts
@@ -3,21 +3,8 @@ import { walletConnectConnection } from '@cow/modules/wallet/web3-react/connecti
 import { Connector } from '@web3-react/types'
 import { getChainInfo } from 'constants/chainInfo'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { RPC_URLS } from 'constants/networks'
+import { getRpcUrls } from 'constants/networks'
 import { isChainAllowed } from '../connection'
-
-function getRpcUrls(chainId: SupportedChainId): [string] {
-  switch (chainId) {
-    case SupportedChainId.MAINNET:
-    case SupportedChainId.GOERLI:
-      return [RPC_URLS[chainId]]
-    case SupportedChainId.GNOSIS_CHAIN:
-      return ['https://rpc.gnosischain.com/']
-    default:
-  }
-  // Our API-keyed URLs will fail security checks when used with external wallets.
-  throw new Error('RPC URLs must use public endpoints')
-}
 
 export const switchChain = async (connector: Connector, chainId: SupportedChainId) => {
   if (!isChainAllowed(connector, chainId)) {

--- a/src/cow-react/types.ts
+++ b/src/cow-react/types.ts
@@ -8,6 +8,16 @@ export type Writeable<T> = { -readonly [P in keyof T]: T[P] }
 
 export type Nullish<T> = T | null | undefined
 
+/*
+  A generic class type.
+
+  You can use this to refer to a class and not an instance of it.
+  More info at: https://www.typescriptlang.org/docs/handbook/2/generics.html#using-class-types-in-generics
+*/
+export type Newable<T extends new (...args: any) => any> = {
+  new (...args: ConstructorParameters<T>): InstanceType<T>
+}
+
 // This is for Pixel tracking injected code
 declare global {
   interface Window {

--- a/src/custom/constants/networks.ts
+++ b/src/custom/constants/networks.ts
@@ -90,8 +90,6 @@ function getProvider(chainId: SupportedChainId): JsonRpcProvider[] {
     result.push(new Web3Provider(window.ethereum, RPC_CONFIG[chainId]))
   }
 
-  result.pop()
-
   if (typeof RPC_CONFIG[chainId].rpcUrl === 'string') {
     result.push(new StaticJsonRpcProvider(RPC_CONFIG[chainId].rpcUrl))
   } else {

--- a/src/custom/constants/networks.ts
+++ b/src/custom/constants/networks.ts
@@ -4,11 +4,11 @@ import {
   JsonRpcProvider,
   UrlJsonRpcProvider,
   StaticJsonRpcProvider,
-  InfuraProvider as EthersInfuraProvider,
-  CloudflareProvider as EthersCloudflareProvider,
-  AlchemyProvider as EthersAlchemyProvider,
-  PocketProvider as EthersPocketProvider,
-  AnkrProvider as EthersAnkrProvider,
+  InfuraProvider,
+  CloudflareProvider,
+  AlchemyProvider,
+  PocketProvider,
+  AnkrProvider,
 } from '@ethersproject/providers'
 import * as Sentry from '@sentry/react'
 
@@ -53,28 +53,6 @@ export const RPC_CONFIG: Record<SupportedChainId, RpcConfig> = {
  */
 class BaseUrlJsonRpcProvider extends UrlJsonRpcProvider {}
 type ProviderClass = Newable<typeof BaseUrlJsonRpcProvider>
-
-/**
- * UrlJsonRpcProvider instances do not have a getSigner implementation, however we need it.
- *
- * As they are all based on JsonRpcProvider, we can use JsonRpcProvider's getSigner implementation.
- *
- * Why not use JsonRpcProvider directly? Because it does not have specific API provider optimisations,
- * and it does not automatically support community resources.
- *
- * Why not instantiate and return a JsonRpcSigner? Because it has a constructor guard that prevents it from being instantiated directly.
- * Intention with this guard is to prevent users from accidentally using a JsonRpcSigner with another provider. Which is not possible here.
- */
-class InfuraProvider extends EthersInfuraProvider {}
-InfuraProvider.prototype.getSigner = JsonRpcProvider.prototype.getSigner
-class CloudflareProvider extends EthersCloudflareProvider {}
-CloudflareProvider.prototype.getSigner = JsonRpcProvider.prototype.getSigner
-class AlchemyProvider extends EthersAlchemyProvider {}
-AlchemyProvider.prototype.getSigner = JsonRpcProvider.prototype.getSigner
-class PocketProvider extends EthersPocketProvider {}
-PocketProvider.prototype.getSigner = JsonRpcProvider.prototype.getSigner
-class AnkrProvider extends EthersAnkrProvider {}
-AnkrProvider.prototype.getSigner = JsonRpcProvider.prototype.getSigner
 
 // List of public providers that don't require an API key, per chain support.
 const PUBLIC_PROVIDER_LIST: Record<SupportedChainId, ProviderClass[]> = {

--- a/src/custom/constants/networks.ts
+++ b/src/custom/constants/networks.ts
@@ -1,4 +1,4 @@
-import { JsonRpcProvider } from '@ethersproject/providers'
+import { Web3Provider, JsonRpcProvider, StaticJsonRpcProvider, InfuraProvider } from '@ethersproject/providers'
 
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
@@ -6,8 +6,6 @@ const INFURA_KEY = process.env.REACT_APP_INFURA_KEY
 if (typeof INFURA_KEY === 'undefined') {
   throw new Error(`REACT_APP_INFURA_KEY must be a defined environment variable`)
 }
-
-export const MAINNET_PROVIDER = new JsonRpcProvider(`https://mainnet.infura.io/v3/${INFURA_KEY}`)
 
 /**
  * These are the network URLs used by the interface when there is not another available source of chain data
@@ -28,3 +26,49 @@ export const RPC_URLS: { [key in SupportedChainId]: string } = {
   // [SupportedChainId.CELO_ALFAJORES]: `https://alfajores-forno.celo-testnet.org`,
   [SupportedChainId.GNOSIS_CHAIN]: `https://rpc.gnosis.gateway.fm`,
 }
+
+export const RPC_CONFIG: { [key in SupportedChainId]: { chainId: SupportedChainId; name: string } } = {
+  [SupportedChainId.MAINNET]: {
+    chainId: SupportedChainId.MAINNET,
+    name: 'homestead',
+  },
+  [SupportedChainId.GOERLI]: {
+    chainId: SupportedChainId.GOERLI,
+    name: 'goerli',
+  },
+  [SupportedChainId.GNOSIS_CHAIN]: {
+    chainId: SupportedChainId.GNOSIS_CHAIN,
+    name: 'gnosis',
+  },
+}
+
+const RPC_TYPE: { [key in SupportedChainId]: 'infura' | 'custom' } = {
+  [SupportedChainId.MAINNET]: 'infura',
+  [SupportedChainId.GOERLI]: 'infura',
+  [SupportedChainId.GNOSIS_CHAIN]: 'custom',
+}
+
+function getProvider(chainId: SupportedChainId): JsonRpcProvider {
+  try {
+    if (!window.ethereum) {
+      throw new Error('No ethereum provider found in window object.')
+    }
+    return new Web3Provider(window.ethereum, RPC_CONFIG[chainId])
+  } catch (err: unknown) {
+    if (RPC_TYPE[chainId] === 'infura') {
+      return new InfuraProvider(RPC_CONFIG[chainId].name, INFURA_KEY)
+    } else {
+      return new StaticJsonRpcProvider(RPC_URLS[chainId])
+    }
+  }
+}
+
+export const PROVIDERS: {
+  [key in SupportedChainId]: JsonRpcProvider
+} = {
+  [SupportedChainId.MAINNET]: getProvider(SupportedChainId.MAINNET),
+  [SupportedChainId.GOERLI]: getProvider(SupportedChainId.GOERLI),
+  [SupportedChainId.GNOSIS_CHAIN]: getProvider(SupportedChainId.GNOSIS_CHAIN),
+}
+
+export const MAINNET_PROVIDER = getProvider(SupportedChainId.MAINNET)

--- a/src/custom/constants/networks.ts
+++ b/src/custom/constants/networks.ts
@@ -1,6 +1,18 @@
-import { Web3Provider, JsonRpcProvider, StaticJsonRpcProvider, InfuraProvider } from '@ethersproject/providers'
+import {
+  Web3Provider,
+  JsonRpcProvider,
+  UrlJsonRpcProvider,
+  StaticJsonRpcProvider,
+  InfuraProvider as EthersInfuraProvider,
+  CloudflareProvider as EthersCloudflareProvider,
+  AlchemyProvider as EthersAlchemyProvider,
+  PocketProvider as EthersPocketProvider,
+  AnkrProvider as EthersAnkrProvider,
+} from '@ethersproject/providers'
+import * as Sentry from '@sentry/react'
 
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { Newable } from '@cow/types'
 
 const INFURA_KEY = process.env.REACT_APP_INFURA_KEY
 if (typeof INFURA_KEY === 'undefined') {
@@ -42,33 +54,126 @@ export const RPC_CONFIG: { [key in SupportedChainId]: { chainId: SupportedChainI
   },
 }
 
+/**
+ * We use this class for type inference.
+ *
+ * UrlJsonRpcProvider is an abstract class, therefore we have trouble inferring the type of its constructor.
+ * However, as all of the RPC providers we use extend UrlJsonRpcProvider, we can use this class to infer the type of the constructor, by turning it into a concrete one.
+ */
+class BaseUrlJsonRpcProvider extends UrlJsonRpcProvider {}
+type ProviderClass = Newable<typeof BaseUrlJsonRpcProvider>
+
+/**
+ * UrlJsonRpcProvider instances do not have a getSigner implementation, however we need it.
+ *
+ * As they are all based on JsonRpcProvider, we can use JsonRpcProvider's getSigner implementation.
+ *
+ * Why not use JsonRpcProvider directly? Because it does not have specific API provider optimisations,
+ * and it does not automatically support community resources.
+ *
+ * Why not instantiate and return a JsonRpcSigner? Because it has a constructor guard that prevents it from being instantiated directly.
+ * Intention with this guard is to prevent users from accidentally using a JsonRpcSigner with another provider. Which is not possible here.
+ */
+class InfuraProvider extends EthersInfuraProvider {}
+InfuraProvider.prototype.getSigner = JsonRpcProvider.prototype.getSigner
+class CloudflareProvider extends EthersCloudflareProvider {}
+CloudflareProvider.prototype.getSigner = JsonRpcProvider.prototype.getSigner
+class AlchemyProvider extends EthersAlchemyProvider {}
+AlchemyProvider.prototype.getSigner = JsonRpcProvider.prototype.getSigner
+class PocketProvider extends EthersPocketProvider {}
+PocketProvider.prototype.getSigner = JsonRpcProvider.prototype.getSigner
+class AnkrProvider extends EthersAnkrProvider {}
+AnkrProvider.prototype.getSigner = JsonRpcProvider.prototype.getSigner
+
+// List of public providers that don't require an API key, per chain support.
+const PUBLIC_PROVIDER_LIST: Record<SupportedChainId, ProviderClass[]> = {
+  [SupportedChainId.MAINNET]: [InfuraProvider, CloudflareProvider, AlchemyProvider, PocketProvider, AnkrProvider],
+  [SupportedChainId.GOERLI]: [InfuraProvider, AlchemyProvider, PocketProvider, AnkrProvider],
+  [SupportedChainId.GNOSIS_CHAIN]: [],
+}
+
 const RPC_TYPE: { [key in SupportedChainId]: 'infura' | 'custom' } = {
   [SupportedChainId.MAINNET]: 'infura',
   [SupportedChainId.GOERLI]: 'infura',
   [SupportedChainId.GNOSIS_CHAIN]: 'custom',
 }
 
-function getProvider(chainId: SupportedChainId): JsonRpcProvider {
-  try {
-    if (!window.ethereum) {
-      throw new Error('No ethereum provider found in window object.')
-    }
-    return new Web3Provider(window.ethereum, RPC_CONFIG[chainId])
-  } catch (err: unknown) {
-    if (RPC_TYPE[chainId] === 'infura') {
-      return new InfuraProvider(RPC_CONFIG[chainId].name, INFURA_KEY)
-    } else {
-      return new StaticJsonRpcProvider(RPC_URLS[chainId])
+function getProvider(chainId: SupportedChainId): JsonRpcProvider[] {
+  const result: JsonRpcProvider[] = []
+
+  if (window.ethereum) {
+    result.push(new Web3Provider(window.ethereum, RPC_CONFIG[chainId]))
+  }
+
+  result.pop()
+
+  if (RPC_TYPE[chainId] === 'infura') {
+    result.push(new InfuraProvider(RPC_CONFIG[chainId], INFURA_KEY))
+  } else {
+    result.push(new StaticJsonRpcProvider(RPC_URLS[chainId]))
+  }
+
+  if (result.length > 0) {
+    return result
+  }
+
+  for (const Provider of PUBLIC_PROVIDER_LIST[chainId]) {
+    try {
+      const provider = new Provider(RPC_CONFIG[chainId])
+
+      result.push(provider)
+    } catch (error) {
+      const { sentryError, tags } = constructSentryError(error, { message: "Couldn't create public provider" })
+
+      Sentry.captureException(sentryError, { tags })
     }
   }
+
+  return result
 }
 
-export const PROVIDERS: {
-  [key in SupportedChainId]: JsonRpcProvider
-} = {
+export const PROVIDERS: Record<SupportedChainId, JsonRpcProvider[]> = {
   [SupportedChainId.MAINNET]: getProvider(SupportedChainId.MAINNET),
   [SupportedChainId.GOERLI]: getProvider(SupportedChainId.GOERLI),
   [SupportedChainId.GNOSIS_CHAIN]: getProvider(SupportedChainId.GNOSIS_CHAIN),
 }
 
-export const MAINNET_PROVIDER = getProvider(SupportedChainId.MAINNET)
+export const getRpcUrls = (chainId: SupportedChainId) => PROVIDERS[chainId].map((provider) => provider.connection.url)
+
+export const PROVIDERS_RPC_URLS: Record<SupportedChainId, string[]> = {
+  [SupportedChainId.MAINNET]: getRpcUrls(SupportedChainId.MAINNET),
+  [SupportedChainId.GOERLI]: getRpcUrls(SupportedChainId.GOERLI),
+  [SupportedChainId.GNOSIS_CHAIN]: getRpcUrls(SupportedChainId.GNOSIS_CHAIN),
+}
+
+export const providers = {
+  get mainnet() {
+    const _providers = getProvider(SupportedChainId.MAINNET)
+
+    if (_providers.length > 0) {
+      return _providers[0]
+    } else {
+      const message = 'No provider found for MAINNET_PROVIDER'
+      const { sentryError, tags } = constructSentryError(new Error(), {
+        message,
+      })
+
+      Sentry.captureException(sentryError, { tags })
+
+      throw new Error(message)
+    }
+  },
+}
+
+function constructSentryError(baseError: unknown, { message }: { message: string }) {
+  const constructedError = Object.assign(new Error(), baseError, {
+    message,
+    name: 'ProviderError',
+  })
+
+  const tags = {
+    errorType: 'provider',
+  }
+
+  return { baseError, sentryError: constructedError, tags }
+}

--- a/src/custom/hooks/useFetchListCallback/useFetchListCallbackMod.ts
+++ b/src/custom/hooks/useFetchListCallback/useFetchListCallbackMod.ts
@@ -1,7 +1,7 @@
 import { useWalletInfo } from '@cow/modules/wallet'
 import { nanoid } from '@reduxjs/toolkit'
 import { TokenList } from '@uniswap/token-lists'
-import { MAINNET_PROVIDER } from 'constants/networks'
+import { providers } from 'constants/networks'
 import getTokenList from 'lib/hooks/useTokenList/fetchTokenList'
 import resolveENSContentHash from 'lib/utils/resolveENSContentHash'
 import { useCallback } from 'react'
@@ -21,7 +21,7 @@ export function useFetchListCallback(): (listUrl: string, sendDispatch?: boolean
       const requestId = nanoid()
       // Mod: add chainId
       sendDispatch && dispatch(fetchTokenList.pending({ requestId, url: listUrl, chainId }))
-      return getTokenList(listUrl, (ensName: string) => resolveENSContentHash(ensName, MAINNET_PROVIDER))
+      return getTokenList(listUrl, (ensName: string) => resolveENSContentHash(ensName, providers.mainnet))
         .then((tokenList) => {
           // Mod: add chainId
           sendDispatch && dispatch(fetchTokenList.fulfilled({ url: listUrl, tokenList, requestId, chainId }))

--- a/src/hooks/useFetchListCallback.ts
+++ b/src/hooks/useFetchListCallback.ts
@@ -1,6 +1,6 @@
 import { nanoid } from '@reduxjs/toolkit'
 import { TokenList } from '@uniswap/token-lists'
-import { MAINNET_PROVIDER } from 'constants/networks'
+import { providers } from 'constants/networks'
 import getTokenList from 'lib/hooks/useTokenList/fetchTokenList'
 import resolveENSContentHash from 'lib/utils/resolveENSContentHash'
 import { useCallback } from 'react'
@@ -16,7 +16,7 @@ export function useFetchListCallback(): (listUrl: string, sendDispatch?: boolean
     async (listUrl: string, sendDispatch = true) => {
       const requestId = nanoid()
       sendDispatch && dispatch(fetchTokenList.pending({ requestId, url: listUrl }))
-      return getTokenList(listUrl, (ensName: string) => resolveENSContentHash(ensName, MAINNET_PROVIDER))
+      return getTokenList(listUrl, (ensName: string) => resolveENSContentHash(ensName, providers.mainnet))
         .then((tokenList) => {
           sendDispatch && dispatch(fetchTokenList.fulfilled({ url: listUrl, tokenList, requestId }))
           return tokenList

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -1,8 +1,8 @@
-import { BaseProvider, JsonRpcProvider } from '@ethersproject/providers'
+import { BaseProvider, Web3Provider } from '@ethersproject/providers'
 import { createApi, fetchBaseQuery, FetchBaseQueryError } from '@reduxjs/toolkit/query/react'
 import { Protocol } from '@uniswap/router-sdk'
 import { ChainId } from '@uniswap/smart-order-router'
-import { RPC_URLS } from 'constants/networks'
+import { PROVIDERS } from 'constants/networks'
 import { getClientSideQuote, toSupportedChainId } from 'lib/hooks/routing/clientSideSmartOrderRouter'
 import ms from 'ms.macro'
 import qs from 'qs'
@@ -16,7 +16,7 @@ function getRouterProvider(chainId: ChainId): BaseProvider {
 
   const supportedChainId = toSupportedChainId(chainId)
   if (supportedChainId) {
-    const provider = new JsonRpcProvider(RPC_URLS[supportedChainId])
+    const provider = PROVIDERS[supportedChainId]
     routerProviders.set(chainId, provider)
     return provider
   }


### PR DESCRIPTION
# Current Situation
We are currently relying on a `JsonRpcProvider`, in every instance, via Infura.

# What
This PR includes a couple of proposals. Code quality can definitely be improved, this iteration is mainly for discussion of the ideas.

* Use RPC providers only when we cannot setup a provider based off of `window.ethereum`.
  * This would allow us to not hit infura, for said users. Might be beneficial.
  * Due to reduced calls, our usage of infura would go down significantly.
  * Certain calls are "free" when done in this fashion - such as `eth_chainId` (Based on `ethers.js` discussion here https://github.com/ethers-io/ethers.js/issues/901)
* Use `InfuraProvider` instead of `JsonRpcProvider` for infura endpoints.
  * `ethers.js` claims this would include optimisations on their end, specifically for infura.
* Use `StaticJsonRpcProvider` instead of `JsonRpcProvider` for non-infura cases.
  * The difference is essentially making the `eth_chainId` call.
  * This is useful for when the `chainId` could change on the fly. However, the way we use these endpoints, it does seem like that is not a possibility (i.e. we create a provider for Gnosis Chain, specifically).

# Why
Main point for this was trying to figure out amount of calls we are making to infura, as it has been a recent source of pain. During this process, I've noticed that `eth_chainId` and `eth_blockNumber` are the highest hit calls, main reason being this information needing to be polled. Specifically,
* Every 10-15 secs, we poll for `eth_blockNumber`.
  * This is in line with what Infura suggests.
* Every call we make, we verify `eth_chainId`.
  * `StaticJsonRpcProvider` would stop making this call, albeit definitely should be discussed.
  * Relying on wallets instead of RPC would make this a cost-free call.
  * Main reason this is being called all the time is due to EIP-155.

Which made me also think about if we could reduce our reliance in general. A recent Slack discussion (https://cowservices.slack.com/archives/C036G0J90BU/p1679062770503109) was related to this topic, as such I've started exploring this PR.

# Important Points
I've mainly tested this out as;
* One browser with Metamask
* One browser without any wallet

After which I have mainly tested;
* Can I load the application?
* Can I connect using Wallet Connect?
* Can I send a transaction?

Which seems to be working, however this is nowhere near enough. I presume, if we desire such a change, we should;
* Test all wallets
* Think about a list of functionality that must pass instead of what I could think about randomly

Thank you, and looking forward to hearing what everybody thinks 🐮