### PR TITLE
Feature/partial fills chose type on submit

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersConfirmModal/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersConfirmModal/index.tsx
@@ -23,6 +23,7 @@ import { TokenAmount } from '@cow/common/pure/TokenAmount'
 import { executionPriceAtom } from '@cow/modules/limitOrders/state/executionPriceAtom'
 import { limitRateAtom } from '@cow/modules/limitOrders/state/limitRateAtom'
 import { useHandleOrderPlacement } from '@cow/modules/limitOrders/hooks/useHandleOrderPlacement'
+import { partiallyFillableOverrideAtom } from '@cow/modules/limitOrders/state/partiallyFillableOverride'
 
 export interface LimitOrdersConfirmModalProps {
   isOpen: boolean
@@ -57,6 +58,7 @@ export function LimitOrdersConfirmModal(props: LimitOrdersConfirmModalProps) {
   const settingsState = useAtomValue(limitOrdersSettingsAtom)
   const executionPrice = useAtomValue(executionPriceAtom)
   const limitRateState = useAtomValue(limitRateAtom)
+  const partiallyFillableOverride = useAtom(partiallyFillableOverrideAtom)
 
   const { rawAmount: inputRawAmount } = inputCurrencyInfo
   const { rawAmount: outputRawAmount, currency: outputCurrency } = outputCurrencyInfo
@@ -105,6 +107,7 @@ export function LimitOrdersConfirmModal(props: LimitOrdersConfirmModalProps) {
               rateImpact={rateImpact}
               priceImpact={priceImpact}
               warningsAccepted={warningsAccepted}
+              partiallyFillableOverride={partiallyFillableOverride}
               Warnings={Warnings}
             />
           </styledEl.ConfirmModalWrapper>

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -228,7 +228,7 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
   const currenciesLoadingInProgress = false
   const maxBalance = maxAmountSpend(inputCurrencyInfo.balance || undefined)
   const showSetMax = !!maxBalance && !inputCurrencyInfo.rawAmount?.equalTo(maxBalance)
-  const isPartiallyFillable = !!tradeContext?.postOrderParams.partiallyFillable
+  const isPartiallyFillable = tradeContext?.postOrderParams.partiallyFillable ?? true
 
   const subsidyAndBalance: BalanceAndSubsidy = {
     subsidy: {

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -43,6 +43,8 @@ import { useSetupLimitOrderAmountsFromUrl } from '@cow/modules/limitOrders/hooks
 import AffiliateStatusCheck from 'components/AffiliateStatusCheck'
 import { formatInputAmount } from '@cow/utils/amountFormat'
 import { InfoBanner } from '@cow/modules/limitOrders/pure/InfoBanner'
+import { partiallyFillableOverrideAtom } from '@cow/modules/limitOrders/state/partiallyFillableOverride'
+import { useAtom } from 'jotai'
 
 export function LimitOrdersWidget() {
   useSetupTradeState()
@@ -76,6 +78,7 @@ export function LimitOrdersWidget() {
   const { isLoading: isRateLoading, activeRate, feeAmount } = useAtomValue(limitRateAtom)
   const rateInfoParams = useRateInfoParams(inputCurrencyAmount, outputCurrencyAmount)
   const { isWrapOrUnwrap } = useDetectNativeToken()
+  const partiallyFillableOverride = useAtom(partiallyFillableOverrideAtom)
 
   const showRecipient = useMemo(
     () => !isWrapOrUnwrap && settingState.showRecipient,
@@ -176,6 +179,7 @@ export function LimitOrdersWidget() {
     onSwitchTokens,
     onCurrencySelection,
     onImportDismiss,
+    partiallyFillableOverride,
     rateInfoParams,
     priceImpact,
     tradeContext,
@@ -204,6 +208,7 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
     onSwitchTokens,
     onCurrencySelection,
     onImportDismiss,
+    partiallyFillableOverride,
     allowsOffchainSigning,
     isWrapOrUnwrap,
     showRecipient,
@@ -311,7 +316,10 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
 
               {isExpertMode && (
                 <styledEl.FooterBox>
-                  <styledEl.StyledOrderType isPartiallyFillable={isPartiallyFillable} />
+                  <styledEl.StyledOrderType
+                    isPartiallyFillable={isPartiallyFillable}
+                    partiallyFillableOverride={partiallyFillableOverride}
+                  />
                 </styledEl.FooterBox>
               )}
 

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/limitOrdersPropsChecker.ts
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/limitOrdersPropsChecker.ts
@@ -9,6 +9,7 @@ import { areFractionsEqual } from '@cow/utils/areFractionsEqual'
 import { genericPropsChecker } from '@cow/utils/genericPropsChecker'
 import { getAddress } from '@cow/utils/getAddress'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
+import { PartiallyFillableOverrideDispatcherType } from '@cow/modules/limitOrders/state/partiallyFillableOverride'
 
 export interface LimitOrdersProps {
   onChangeRecipient(value: string | null): void
@@ -27,6 +28,7 @@ export interface LimitOrdersProps {
 
   onUserInput(field: Field, typedValue: string): void
   onSwitchTokens(): void
+  partiallyFillableOverride: PartiallyFillableOverrideDispatcherType
   onCurrencySelection: CurrencySelectionCallback
   onImportDismiss: OnImportDismissCallback
 
@@ -51,6 +53,7 @@ export function limitOrdersPropsChecker(a: LimitOrdersProps, b: LimitOrdersProps
     a.onSwitchTokens === b.onSwitchTokens &&
     a.onCurrencySelection === b.onCurrencySelection &&
     a.onImportDismiss === b.onImportDismiss &&
+    a.partiallyFillableOverride[0] === b.partiallyFillableOverride[0] &&
     checkRateInfoParams(a.rateInfoParams, b.rateInfoParams) &&
     checkPriceImpact(a.priceImpact, b.priceImpact) &&
     checkTradeFlowContext(a.tradeContext, b.tradeContext) &&

--- a/src/cow-react/modules/limitOrders/hooks/useHandleOrderPlacement.test.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useHandleOrderPlacement.test.ts
@@ -10,7 +10,7 @@ jest.mock('@cow/modules/limitOrders/services/tradeFlow')
 
 const mockTradeFlow = tradeFlow as jest.MockedFunction<typeof tradeFlow>
 
-const tradeContextMock = 1 as any as TradeFlowContext
+const tradeContextMock = { postOrderParams: { partiallyFillable: true } } as any as TradeFlowContext
 const priceImpactMock: PriceImpact = {
   priceImpact: undefined,
   error: undefined,

--- a/src/cow-react/modules/limitOrders/pure/LimitOrdersConfirm/index.cosmos.tsx
+++ b/src/cow-react/modules/limitOrders/pure/LimitOrdersConfirm/index.cosmos.tsx
@@ -12,6 +12,7 @@ import React from 'react'
 import { PriceImpact } from 'hooks/usePriceImpact'
 import { defaultLimitOrdersSettings } from '@cow/modules/limitOrders/state/limitOrdersSettingsAtom'
 import { initLimitRateState } from '@cow/modules/limitOrders/state/limitRateAtom'
+import { SetStateAction } from 'jotai'
 
 const inputCurrency = COW[SupportedChainId.MAINNET]
 const outputCurrency = GNO[SupportedChainId.MAINNET]
@@ -108,6 +109,7 @@ const Fixtures = {
       warningsAccepted={true}
       executionPrice={null}
       onConfirm={() => void 0}
+      partiallyFillableOverride={[true, (_?: SetStateAction<boolean | undefined>) => void 0]}
     />
   ),
 }

--- a/src/cow-react/modules/limitOrders/pure/LimitOrdersConfirm/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/LimitOrdersConfirm/index.tsx
@@ -15,6 +15,7 @@ import { RateInfoParams } from '@cow/common/pure/RateInfo'
 import { LimitOrdersSettingsState } from '@cow/modules/limitOrders/state/limitOrdersSettingsAtom'
 import { Currency, Price } from '@uniswap/sdk-core'
 import { LimitRateState } from '@cow/modules/limitOrders/state/limitRateAtom'
+import { PartiallyFillableOverrideDispatcherType } from '@cow/modules/limitOrders/state/partiallyFillableOverride'
 
 export interface LimitOrdersConfirmProps {
   tradeContext: TradeFlowContext
@@ -29,6 +30,7 @@ export interface LimitOrdersConfirmProps {
   executionPrice: Price<Currency, Currency> | null
   limitRateState: LimitRateState
   onConfirm(): void
+  partiallyFillableOverride: PartiallyFillableOverrideDispatcherType
 }
 
 export function LimitOrdersConfirm(props: LimitOrdersConfirmProps) {
@@ -45,6 +47,7 @@ export function LimitOrdersConfirm(props: LimitOrdersConfirmProps) {
     settingsState,
     executionPrice,
     limitRateState,
+    partiallyFillableOverride,
   } = props
 
   const isTooLowRate = rateImpact < LOW_RATE_THRESHOLD_PERCENT
@@ -78,6 +81,7 @@ export function LimitOrdersConfirm(props: LimitOrdersConfirmProps) {
         rateInfoParams={rateInfoParams}
         settingsState={settingsState}
         executionPrice={executionPrice}
+        partiallyFillableOverride={partiallyFillableOverride}
       />
       {Warnings}
       <ButtonPrimary onClick={onConfirm} disabled={isTradeDisabled} buttonSize={ButtonSize.BIG}>

--- a/src/cow-react/modules/limitOrders/pure/LimitOrdersDetails/index.cosmos.tsx
+++ b/src/cow-react/modules/limitOrders/pure/LimitOrdersDetails/index.cosmos.tsx
@@ -7,6 +7,7 @@ import { TradeFlowContext } from '../../services/tradeFlow'
 import { LimitOrdersDetails } from './index'
 import { defaultLimitOrdersSettings } from '@cow/modules/limitOrders/state/limitOrdersSettingsAtom'
 import { initLimitRateState } from '@cow/modules/limitOrders/state/limitRateAtom'
+import { SetStateAction } from 'jotai'
 
 const inputCurrency = COW[SupportedChainId.MAINNET]
 const outputCurrency = GNO[SupportedChainId.MAINNET]
@@ -56,6 +57,7 @@ const Fixtures = {
       tradeContext={tradeContext}
       executionPrice={null}
       limitRateState={initLimitRateState()}
+      partiallyFillableOverride={[true, (_?: SetStateAction<boolean | undefined>) => void 0]}
     />
   ),
 }

--- a/src/cow-react/modules/limitOrders/pure/LimitOrdersDetails/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/LimitOrdersDetails/index.tsx
@@ -18,6 +18,7 @@ import { formatInputAmount } from '@cow/utils/amountFormat'
 import { limitOrdersFeatures } from '@cow/constants/featureFlags'
 import { DEFAULT_DATE_FORMAT } from '@cow/constants/intl'
 import { OrderType } from '@cow/modules/limitOrders/pure/OrderType'
+import { PartiallyFillableOverrideDispatcherType } from '@cow/modules/limitOrders/state/partiallyFillableOverride'
 
 const Wrapper = styled.div`
   font-size: 13px;
@@ -38,10 +39,12 @@ export interface LimitOrdersDetailsProps {
   settingsState: LimitOrdersSettingsState
   executionPrice: Price<Currency, Currency> | null
   limitRateState: LimitRateState
+  partiallyFillableOverride: PartiallyFillableOverrideDispatcherType
 }
 
 export function LimitOrdersDetails(props: LimitOrdersDetailsProps) {
-  const { executionPrice, tradeContext, settingsState, rateInfoParams, limitRateState } = props
+  const { executionPrice, tradeContext, settingsState, rateInfoParams, limitRateState, partiallyFillableOverride } =
+    props
   const { account, recipient, recipientAddressOrName, partiallyFillable } = tradeContext.postOrderParams
   const { feeAmount, activeRate, marketRate } = limitRateState
 
@@ -116,7 +119,7 @@ export function LimitOrdersDetails(props: LimitOrdersDetailsProps) {
           <span>Active</span>
         </div>
       </styledEl.DetailsRow> */}
-      <OrderType isPartiallyFillable={partiallyFillable} />
+      <OrderType isPartiallyFillable={partiallyFillable} partiallyFillableOverride={partiallyFillableOverride} />
       {recipientAddressOrName && recipient !== account && (
         <styledEl.DetailsRow>
           <div>

--- a/src/cow-react/modules/limitOrders/pure/OrderType/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/OrderType/index.tsx
@@ -1,9 +1,9 @@
-import SVG from 'react-inlinesvg'
 import { DetailsRow } from '@cow/modules/limitOrders/pure/LimitOrdersDetails/styled'
 import { InfoIcon } from 'components/InfoIcon'
-import { Menu, MenuButton, MenuItem, MenuList } from '@reach/menu-button'
 import IMAGE_CARET_DOWN from 'assets/cow-swap/carret-down.svg'
 import { PartiallyFillableOverrideDispatcherType } from '@cow/modules/limitOrders/state/partiallyFillableOverride'
+import * as styledEl from './styled'
+import { Menu } from '@reach/menu-button'
 
 export type OrderTypeProps = {
   isPartiallyFillable: boolean
@@ -37,21 +37,32 @@ function OrderTypePicker({ isPartiallyFillable, partiallyFillableOverride }: Ord
 
   const showPartiallyFillable = override ?? isPartiallyFillable
 
-  const [labelText, dropDownText] = showPartiallyFillable ? LABELS : [...LABELS].reverse()
+  const [labelText] = showPartiallyFillable ? LABELS : [...LABELS].reverse()
 
-  const onSelect = () => setOverride(!showPartiallyFillable)
+  const onSelect = (label: string) => setOverride(label === LABELS[0])
 
   return (
     <Menu>
-      {({ isExpanded }) => (
+      {({ isExpanded }: { isExpanded: boolean }) => (
         <>
-          <MenuButton>
-            <span>{labelText}</span>
-            <SVG src={IMAGE_CARET_DOWN} description="dropdown icon" className={isExpanded ? 'expanded' : ''} />
-          </MenuButton>
-          <MenuList portal={false}>
-            <MenuItem onSelect={onSelect}>{dropDownText}</MenuItem>
-          </MenuList>
+          <styledEl.Wrapper>
+            <styledEl.StyledMenuButton>
+              <styledEl.LabelText>{labelText}</styledEl.LabelText>
+              <styledEl.StyledSVG
+                src={IMAGE_CARET_DOWN}
+                description="dropdown icon"
+                className={isExpanded ? 'expanded' : ''}
+              />
+            </styledEl.StyledMenuButton>
+
+            <styledEl.StyledMenuList portal={false}>
+              {LABELS.map((label) => (
+                <styledEl.StyledMenuItem key={label} onSelect={() => onSelect(label)}>
+                  {label}
+                </styledEl.StyledMenuItem>
+              ))}
+            </styledEl.StyledMenuList>
+          </styledEl.Wrapper>
         </>
       )}
     </Menu>

--- a/src/cow-react/modules/limitOrders/pure/OrderType/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/OrderType/index.tsx
@@ -1,8 +1,10 @@
 import { DetailsRow } from '@cow/modules/limitOrders/pure/LimitOrdersDetails/styled'
 import { InfoIcon } from 'components/InfoIcon'
+import { PartiallyFillableOverrideDispatcherType } from '@cow/modules/limitOrders/state/partiallyFillableOverride'
 
 export type OrderTypeProps = {
   isPartiallyFillable: boolean
+  partiallyFillableOverride: PartiallyFillableOverrideDispatcherType
   className?: string
 }
 

--- a/src/cow-react/modules/limitOrders/pure/OrderType/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/OrderType/index.tsx
@@ -12,10 +12,15 @@ export type OrderTypeProps = {
 }
 
 export function OrderType(props: OrderTypeProps) {
-  const { isPartiallyFillable, className } = props
-  const textContent = isPartiallyFillable
-    ? 'This order can be partially filled'
-    : 'This order will either be filled completely or not filled.'
+  const {
+    isPartiallyFillable,
+    className,
+    partiallyFillableOverride: [override],
+  } = props
+  const textContent =
+    override ?? isPartiallyFillable
+      ? 'This order can be partially filled'
+      : 'This order will either be filled completely or not filled.'
 
   return (
     <DetailsRow className={className}>

--- a/src/cow-react/modules/limitOrders/pure/OrderType/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/OrderType/index.tsx
@@ -34,9 +34,12 @@ const LABELS = ['Partially fillable', 'Fill or kill']
 
 function OrderTypePicker({ isPartiallyFillable, partiallyFillableOverride }: OrderTypeProps) {
   const [override, setOverride] = partiallyFillableOverride
-  const [labelText, dropDownText] = override ?? isPartiallyFillable ? LABELS : [...LABELS].reverse()
 
-  const onSelect = () => setOverride(() => !(override ?? isPartiallyFillable))
+  const showPartiallyFillable = override ?? isPartiallyFillable
+
+  const [labelText, dropDownText] = showPartiallyFillable ? LABELS : [...LABELS].reverse()
+
+  const onSelect = () => setOverride(!showPartiallyFillable)
 
   return (
     <Menu>

--- a/src/cow-react/modules/limitOrders/pure/OrderType/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/OrderType/index.tsx
@@ -1,5 +1,8 @@
+import SVG from 'react-inlinesvg'
 import { DetailsRow } from '@cow/modules/limitOrders/pure/LimitOrdersDetails/styled'
 import { InfoIcon } from 'components/InfoIcon'
+import { Menu, MenuButton, MenuItem, MenuList } from '@reach/menu-button'
+import IMAGE_CARET_DOWN from 'assets/cow-swap/carret-down.svg'
 import { PartiallyFillableOverrideDispatcherType } from '@cow/modules/limitOrders/state/partiallyFillableOverride'
 
 export type OrderTypeProps = {
@@ -8,11 +11,11 @@ export type OrderTypeProps = {
   className?: string
 }
 
-export function OrderType({ isPartiallyFillable, className }: OrderTypeProps) {
+export function OrderType(props: OrderTypeProps) {
+  const { isPartiallyFillable, className } = props
   const textContent = isPartiallyFillable
     ? 'This order can be partially filled'
     : 'This order will either be filled completely or not filled.'
-  const labelText = isPartiallyFillable ? 'Partially fillable' : 'Fill or kill'
 
   return (
     <DetailsRow className={className}>
@@ -22,9 +25,32 @@ export function OrderType({ isPartiallyFillable, className }: OrderTypeProps) {
         </span>{' '}
         <InfoIcon content={textContent} />
       </div>
-      <div>
-        <span>{labelText}</span>
-      </div>
+      <OrderTypePicker {...props} />
     </DetailsRow>
+  )
+}
+
+const LABELS = ['Partially fillable', 'Fill or kill']
+
+export function OrderTypePicker({ isPartiallyFillable, partiallyFillableOverride }: OrderTypeProps) {
+  const [override, setOverride] = partiallyFillableOverride
+  const [labelText, dropDownText] = override ?? isPartiallyFillable ? LABELS : [...LABELS].reverse()
+
+  const onSelect = () => setOverride(() => !(override ?? isPartiallyFillable))
+
+  return (
+    <Menu>
+      {({ isExpanded }) => (
+        <>
+          <MenuButton>
+            <span>{labelText}</span>
+            <SVG src={IMAGE_CARET_DOWN} description="dropdown icon" className={isExpanded ? 'expanded' : ''} />
+          </MenuButton>
+          <MenuList portal={false}>
+            <MenuItem onSelect={onSelect}>{dropDownText}</MenuItem>
+          </MenuList>
+        </>
+      )}
+    </Menu>
   )
 }

--- a/src/cow-react/modules/limitOrders/pure/OrderType/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/OrderType/index.tsx
@@ -32,7 +32,7 @@ export function OrderType(props: OrderTypeProps) {
 
 const LABELS = ['Partially fillable', 'Fill or kill']
 
-export function OrderTypePicker({ isPartiallyFillable, partiallyFillableOverride }: OrderTypeProps) {
+function OrderTypePicker({ isPartiallyFillable, partiallyFillableOverride }: OrderTypeProps) {
   const [override, setOverride] = partiallyFillableOverride
   const [labelText, dropDownText] = override ?? isPartiallyFillable ? LABELS : [...LABELS].reverse()
 

--- a/src/cow-react/modules/limitOrders/pure/OrderType/styled.tsx
+++ b/src/cow-react/modules/limitOrders/pure/OrderType/styled.tsx
@@ -1,0 +1,60 @@
+import styled from 'styled-components/macro'
+import { MenuButton, MenuItem, MenuList } from '@reach/menu-button'
+import { transparentize } from 'polished'
+import SVG from 'react-inlinesvg'
+
+export const Wrapper = styled.div`
+  position: relative;
+`
+
+export const StyledMenuButton = styled(MenuButton)`
+  background: none;
+  border: none;
+  outline: none;
+  padding: 0;
+  margin: 0;
+  position: relative;
+
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  background: ${({ theme }) => theme.bg3};
+  padding: 4px 10px;
+  border-radius: 8px;
+`
+
+export const StyledSVG = styled(SVG)`
+  stroke: ${({ theme }) => theme.text1};
+  margin-left: 5px;
+  width: 8px;
+  transition: all 0.15s ease-in;
+
+  &.expanded {
+    transform: rotate(180deg);
+  }
+`
+
+export const LabelText = styled.span`
+  color: ${({ theme }) => theme.text1};
+`
+
+export const StyledMenuList = styled(MenuList)`
+  box-shadow: 0 4px 8px 0 ${({ theme }) => transparentize(0.95, theme.shadow1)};
+  background: ${({ theme }) => theme.bg1};
+  border-radius: 8px;
+  z-index: 2;
+  padding: 0.6rem 0.8rem;
+  min-width: 100%;
+  right: 0;
+  position: absolute;
+  white-space: nowrap;
+  text-align: left;
+`
+
+export const StyledMenuItem = styled(MenuItem)`
+  color: ${({ theme }) => theme.text1};
+  font-size: 0.8rem;
+  cursor: pointer;
+  padding: 4px 0;
+  font-weight: 400;
+`

--- a/src/cow-react/modules/limitOrders/state/limitOrdersSettingsAtom.ts
+++ b/src/cow-react/modules/limitOrders/state/limitOrdersSettingsAtom.ts
@@ -2,6 +2,7 @@ import { atomWithStorage } from 'jotai/utils'
 import { defaultLimitOrderDeadline } from '@cow/modules/limitOrders/pure/DeadlineSelector/deadlines'
 import { atom } from 'jotai'
 import { Milliseconds, Timestamp } from '@cow/types'
+import { partiallyFillableOverrideAtom } from '@cow/modules/limitOrders/state/partiallyFillableOverride'
 
 export interface LimitOrdersSettingsState {
   readonly expertMode: boolean
@@ -27,6 +28,11 @@ export const limitOrdersSettingsAtom = atomWithStorage<LimitOrdersSettingsState>
 export const updateLimitOrdersSettingsAtom = atom(null, (get, set, nextState: Partial<LimitOrdersSettingsState>) => {
   set(limitOrdersSettingsAtom, () => {
     const prevState = get(limitOrdersSettingsAtom)
+
+    if (nextState.partialFillsEnabled !== prevState.partialFillsEnabled) {
+      // Whenever `partialFillsEnabled` changes, reset `partiallyFillableOverrideAtom`
+      set(partiallyFillableOverrideAtom, undefined)
+    }
 
     return { ...prevState, ...nextState }
   })

--- a/src/cow-react/modules/limitOrders/state/partiallyFillableOverride.ts
+++ b/src/cow-react/modules/limitOrders/state/partiallyFillableOverride.ts
@@ -1,0 +1,9 @@
+import { atom, SetStateAction } from 'jotai'
+
+export type PartiallyFillableOverrideType = boolean | undefined
+export type PartiallyFillableOverrideDispatcherType = [
+  PartiallyFillableOverrideType,
+  (update?: SetStateAction<PartiallyFillableOverrideType>) => void
+]
+
+export const partiallyFillableOverrideAtom = atom<PartiallyFillableOverrideType>(undefined)


### PR DESCRIPTION
# Summary

Added logic (and terrible styles) for overriding limit order type on submit, both for regular and expert users

![image](https://user-images.githubusercontent.com/43217/230443799-08bc04f0-2dba-4a94-954c-96b7e0b4f942.png)

It'll override the settings behaviour until:
1. The order is placed OR
2. The Partial fills setting is changed

⚠️NOTE⚠️: Styles will be handled on https://github.com/cowprotocol/cowswap/pull/2275

# To Test

1. Fill in order fields, click on review order
* The `Order type` row should show what's the current option for partial fills
* If the default, it should be `partially fillable`
2. Click on `partially fillable` toggle and pick `fill or kill`
4. Place the order
* Order should be placed as `fill or kill`
5. Repeat step 1
* Order type should be back to `partially fillable`
6. Place order like it is
* Order should be placed as `partially fillable`
7. Review another order and change the toggle again to `fill or kill`
8. Close the order modal and open the settings modal
9. Change twice the `enable partial fill` toggle
10. Go back to review the order
* Order type should be back to `partially fillable`
11. Turn on expert mode
12. Repeat steps 1 - 10. Keep in mind there will be no review order modal, the Order type will be in the form itself
