### PR TITLE
Feature/partial fills order type tooltip

### DIFF
--- a/src/cow-react/modules/limitOrders/pure/ReceiptModal/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/ReceiptModal/index.tsx
@@ -48,7 +48,7 @@ const tooltips: { [key: string]: string | JSX.Element } = {
       <br />
       <br />
       Market orders are always <i>Fill or kill</i>, while limit orders are by default <i>Partially fillable</i>, but can
-      also be <i>Fill or kill</i>.
+      also be changed to <i>Fill or kill</i> through your order settings.
     </span>
   ),
 }

--- a/src/cow-react/modules/limitOrders/pure/ReceiptModal/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/ReceiptModal/index.tsx
@@ -47,8 +47,8 @@ const tooltips: { [key: string]: string | JSX.Element } = {
       set) or limit orders (which fill at a price you specify).
       <br />
       <br />
-      Market orders are always fill or kill, while limit orders are currently partially fillable. Soon it'll be possible
-      to chose the type
+      Market orders are always <i>Fill or kill</i>, while limit orders are by default <i>Partially fillable</i>, but can
+      also be <i>Fill or kill</i>.
     </span>
   ),
 }

--- a/src/cow-react/modules/limitOrders/pure/Settings/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Settings/index.tsx
@@ -60,7 +60,7 @@ export function Settings({ state, onStateChanged }: SettingsProps) {
             Allow you to chose whether your limit orders will be <i>Partially fillable</i> or <i>Fill or kill</i>.
             <br />
             <br />
-            <i>Fill-or-kill</i> orders will either be filled fully or not at all.
+            <i>Fill or kill</i> orders will either be filled fully or not at all.
             <br />
             <i>Partially fillable</i> orders may be filled partially if there isn't enough liquidity to fill the full
             amount.

--- a/src/cow-react/pages/Faq/LimitOrdersFaq.tsx
+++ b/src/cow-react/pages/Faq/LimitOrdersFaq.tsx
@@ -49,26 +49,13 @@ export default function LimitOrderFAQ() {
             <h3 id="what-type-of-limit-orders-does-cow-protocol-support">
               What types of limit orders does CoW Protocol support?
             </h3>
+            <p>CoW Protocol supports Fill or kill as well as Partially fillable limit orders.</p>
+            <p>With Fill or kill, the limit order is executed in its entirety, or not at all.</p>
             <p>
-              Currently, CoW Protocol only supports fill-or-kill limit orders. With fill-or-kill, the limit order is
-              executed in its entirety, or not at all.
-            </p>
-            <p>
-              In the future, CoW Protocol will support partial-fill limit orders as well. With partial-fill limit
-              orders, the limit order does not need to be executed in full. It may be executed in part, so long as the
-              limit price is respected. This would be relevant, for example, if a{' '}
+              With Partially fillable limit orders, the order does not need to be executed in full. It may be executed
+              in part, so long as the limit price is respected. This would be relevant, for example, if a{' '}
               <ExternalLinkFaq href="https://docs.cow.fi/off-chain-services/solvers">solver</ExternalLinkFaq> is able to
               find liquidity to fill half of an order but not all of it.
-            </p>
-
-            <h3 id="when-will-i-be-able-to-place-partially-fillable-limit-orders">
-              When will I be able to place partially-fillable limit orders?
-            </h3>
-            <p>
-              Solvers are currently not capable of handling partially-fillable limit orders, but they’re actively
-              working on it. If you are interested in seeing partially-fillable orders asap, please{' '}
-              <ExternalLinkFaq href="https://t.me/+60olZD2C2HswMzRh">reach out</ExternalLinkFaq> – you could help build
-              a solver that specializes in these types of orders!
             </p>
 
             <h3 id="how-do-fees-work">How do fees work?</h3>
@@ -179,10 +166,10 @@ export default function LimitOrderFAQ() {
               There are a few possible reasons for this:
               <ul>
                 <li>
-                  Though the market price reached your limit price, there wasn’t enough liquidity to fill your order.
-                  CoW Swap currently only supports fill-or-kill orders, so if there isn’t enough liquidity to fill an
-                  order completely, the order doesn’t get filled at all. We are planning to enable partially fillable
-                  orders soon, which will mitigate this risk substantially.
+                  Though the market price reached your limit price, there wasn't enough liquidity to fill your order.
+                  For Fill or kill orders, if there isn't enough liquidity to fill an order completely, the order
+                  doesn't get filled at all. Limit orders do now support also Partially fillable orders, which mitigates
+                  this risk substantially.
                 </li>
                 <li>
                   CoW Swap covers fees on limit orders by executing the order at a slightly better price than the limit

--- a/src/cow-react/pages/Faq/LimitOrdersFaq.tsx
+++ b/src/cow-react/pages/Faq/LimitOrdersFaq.tsx
@@ -68,7 +68,7 @@ export default function LimitOrderFAQ() {
             <p>
               Fees are taken from the surplus CoW Protocol generates for your order – that is, by executing your order
               at a better price than your limit price. CoW Protocol is capable of finding much better prices than are
-              otherwise available due to its unique batch auction mechanism; in situations where it can’t find a better
+              otherwise available due to its unique batch auction mechanism; in situations where it can't find a better
               price, it will wait until the market price is sufficient to cover both your limit price and the network
               fees. This means that your order may not execute exactly when the market price hits your limit price.
             </p>
@@ -80,7 +80,7 @@ export default function LimitOrderFAQ() {
               more than you initially expected to get).
             </p>
             <p>
-              CoW Swap’s unique fee model for limit orders ensures that you will always get the token amount you ordered
+              CoW Swap's unique fee model for limit orders ensures that you will always get the token amount you ordered
               at the limit price you set – or better.
             </p>
 
@@ -96,8 +96,8 @@ export default function LimitOrderFAQ() {
 
             <h3 id="what-if-my-limit-order-reverts-or-expires">What if my limit order reverts or expires?</h3>
             <p>
-              Limit orders placed through CoW Protocol cannot revert. You therefore don’t need to pay fees for reverted
-              orders. If an order expires, you won’t pay for that either.
+              Limit orders placed through CoW Protocol cannot revert. You therefore don't need to pay fees for reverted
+              orders. If an order expires, you won't pay for that either.
             </p>
 
             <h3 id="so-i-can-shamelessly-place-a-bunch-of-orders">
@@ -118,9 +118,9 @@ export default function LimitOrderFAQ() {
               balance, your order will be executed immediately.
             </p>
 
-            <h3 id="who-is-the-counterparty">Who is the counterparty in CoW Protocol’s limit orders?</h3>
+            <h3 id="who-is-the-counterparty">Who is the counterparty in CoW Protocol's limit orders?</h3>
             <p>
-              Limit orders on CoW Protocol don’t need a counterparty to function properly. CoW Protocol – through its
+              Limit orders on CoW Protocol don't need a counterparty to function properly. CoW Protocol – through its
               decentralized network of solvers – sources liquidity from AMMs, DEX aggregators, private market makers,
               and other CoW Protocol users. As soon as a solver is able to find an execution path that meets the
               conditions of a limit order, CoW Protocol will execute the order.
@@ -128,7 +128,7 @@ export default function LimitOrderFAQ() {
 
             <h3 id="what-does-surplus-capturing-limit-orders-mean">What does “surplus-capturing limit orders” mean?</h3>
             <p>
-              CoW Protocol’s limit orders are different from all other DeFi limit orders because they are
+              CoW Protocol's limit orders are different from all other DeFi limit orders because they are
               surplus-capturing.
             </p>
             <p>
@@ -160,7 +160,7 @@ export default function LimitOrderFAQ() {
             </p>
 
             <h3 id="why-isnt-my-order-getting-filled">
-              Why isn’t my order getting filled when the market price hits my limit price?
+              Why isn't my order getting filled when the market price hits my limit price?
             </h3>
             <p>
               There are a few possible reasons for this:
@@ -180,7 +180,7 @@ export default function LimitOrderFAQ() {
             </p>
 
             <h3 id="why-do-i-see-orders-i-didnt-place">
-              Why do I see orders I didn’t place in my limit order history?
+              Why do I see orders I didn't place in my limit order history?
             </h3>
             <p>
               The order history panel visible in the limit orders tab of CoW Swap shows both limit orders and market
@@ -188,9 +188,9 @@ export default function LimitOrderFAQ() {
               orders.
             </p>
 
-            <h3 id="why-cant-i-trade-eth">Why can’t I trade ETH?</h3>
+            <h3 id="why-cant-i-trade-eth">Why can't I trade ETH?</h3>
             <p>
-              You can’t trade ETH directly because ETH is not an ERC-20 token. Limit orders on CoW Protocol currently
+              You can't trade ETH directly because ETH is not an ERC-20 token. Limit orders on CoW Protocol currently
               only work for ERC-20 tokens. If you wish to sell ETH using limit orders on CoW Protocol, you can wrap your
               ETH and place the limit order with WETH.
             </p>

--- a/src/cow-react/pages/Faq/TradingFaq.tsx
+++ b/src/cow-react/pages/Faq/TradingFaq.tsx
@@ -27,7 +27,11 @@ export default function TokenFaq() {
 
             <h3 id="what-types-of-orders-does-cowswap-support">What types of orders does CoW Swap support?</h3>
 
-            <p>At the moment, only limit sell and buy orders (fill-or-kill) are enabled. </p>
+            <p>Swap buy and sell orders, which are always Fill or kill</p>
+            <p>
+              Limit buy and sell orders, which can either be Partially fillable or Fill or kill. By default, limit
+              orders are Partially fillable
+            </p>
 
             <h3 id="what-token-pairs-does-cowswap-allow-to-trade">
               What token pairs does CoW Swap allow you to trade?

--- a/src/cow-react/pages/Faq/TradingFaq.tsx
+++ b/src/cow-react/pages/Faq/TradingFaq.tsx
@@ -27,10 +27,10 @@ export default function TokenFaq() {
 
             <h3 id="what-types-of-orders-does-cowswap-support">What types of orders does CoW Swap support?</h3>
 
-            <p>Swap buy and sell orders, which are always Fill or kill</p>
+            <p>Swap buy and sell orders, which are always Fill or kill.</p>
             <p>
               Limit buy and sell orders, which can either be Partially fillable or Fill or kill. By default, limit
-              orders are Partially fillable
+              orders are Partially fillable.
             </p>
 
             <h3 id="what-token-pairs-does-cowswap-allow-to-trade">

--- a/src/cow-react/pages/Faq/TradingFaq.tsx
+++ b/src/cow-react/pages/Faq/TradingFaq.tsx
@@ -131,7 +131,7 @@ export default function TokenFaq() {
 
             <p>
               In order for solvers (order settlement solution providers) to be economically viable, they need to take
-              into account how much gas they spend executing the settlement transaction. The protocol’s fee ensures that
+              into account how much gas they spend executing the settlement transaction. The protocol's fee ensures that
               solvers are incentivized to include the order in a settlement (similar to how gas is paid on traditional
               DEXes). The fee is directly taken from the sell amount, which therefore has to have a certain minimum
               size.
@@ -142,7 +142,7 @@ export default function TokenFaq() {
             </h3>
 
             <p>
-              When an order is executed, the settlement contract withdraws the sell amount from the trader’s token
+              When an order is executed, the settlement contract withdraws the sell amount from the trader's token
               balance via the CoW Protocol Vault Relayer (for more information read{' '}
               <ExternalLinkFaq
                 href="https://github.com/cowprotocol/contracts/blob/main/src/contracts/GPv2VaultRelayer.sol"
@@ -177,7 +177,7 @@ export default function TokenFaq() {
 
             <p>
               Yes, you can directly place buy and sell orders for ETH. Before the actual order is placed, the UI will
-              allow you to wrap and unwrap ETH into WETH without needing to leave the dapp’s UI.
+              allow you to wrap and unwrap ETH into WETH without needing to leave the dapp's UI.
             </p>
 
             <h3 id="why-is-selling-eth-more-troublesome">Why is selling ETH more troublesome?</h3>


### PR DESCRIPTION
# Summary

Closes https://github.com/cowprotocol/cowswap/issues/2279

Updating couple of texts:

- Order type tooltip
- For consistency, updated all references to `Fill-or-kill` with `Fill or kill`
- Updated FAQ entries mentioning Partial fills were not available

![image](https://user-images.githubusercontent.com/43217/231225834-1b9660f7-1ef8-4169-b801-59f5d33de9fa.png)


  # To Test

1. Check order type tooltip
2. Check FAQs