### PR TITLE
Apply back-off strategy for order-book API calls

### DIFF
--- a/src/cow-react/api/gnosisProtocol/api.ts
+++ b/src/cow-react/api/gnosisProtocol/api.ts
@@ -10,15 +10,20 @@ import { ZERO_ADDRESS } from 'constants/misc'
 import { getAppDataHash } from 'constants/appDataHash'
 import { orderBookApi } from '@cow/cowSdk'
 import { OrderQuoteRequest, SigningScheme, OrderQuoteResponse, EnrichedOrder } from '@cowprotocol/cow-sdk'
-import { fetchWithRateLimit } from '@cow/common/utils/fetch'
+import { FetchWithRateLimit, fetchWithRateLimit, requestWithRateLimit } from '@cow/common/utils/fetch'
 import GpQuoteError, { mapOperatorErrorToQuoteError } from '@cow/api/gnosisProtocol/errors/QuoteError'
+import { NativePriceResponse, Trade } from '@cowprotocol/cow-sdk'
 
-const fetchRateLimitted = fetchWithRateLimit({
+const backOffStrategy: FetchWithRateLimit = {
   rateLimit: {
     tokensPerInterval: 5,
     interval: 'second',
   },
-})
+}
+
+const fetchRateLimitted = fetchWithRateLimit(backOffStrategy)
+
+const orderBookFetchRateLimitted = requestWithRateLimit(backOffStrategy)
 
 function getProfileUrl(): Partial<Record<ChainId, string>> {
   if (isLocal || isDev || isPr || isBarn) {
@@ -132,7 +137,9 @@ export async function getQuote(params: FeeQuoteParams): Promise<OrderQuoteRespon
   const { chainId } = params
   const quoteParams = _mapNewToLegacyParams(params)
 
-  return orderBookApi.getQuote(quoteParams, { chainId }).catch((error) => {
+  return orderBookFetchRateLimitted(() => {
+    return orderBookApi.getQuote(quoteParams, { chainId })
+  }).catch((error) => {
     const errorObject = mapOperatorErrorToQuoteError(error)
 
     return Promise.reject(errorObject ? new GpQuoteError(errorObject) : error)
@@ -140,11 +147,19 @@ export async function getQuote(params: FeeQuoteParams): Promise<OrderQuoteRespon
 }
 
 export async function getOrder(chainId: ChainId, orderId: string): Promise<EnrichedOrder | null> {
-  return orderBookApi.getOrder(orderId, { chainId })
+  return orderBookFetchRateLimitted(() => orderBookApi.getOrder(orderId, { chainId }))
 }
 
 export async function getOrders(chainId: ChainId, owner: string, limit = 1000, offset = 0): Promise<EnrichedOrder[]> {
-  return orderBookApi.getOrders({ owner, limit, offset }, { chainId })
+  return orderBookFetchRateLimitted(() => orderBookApi.getOrders({ owner, limit, offset }, { chainId }))
+}
+
+export async function getTrades(chainId: ChainId, owner: string): Promise<Trade[]> {
+  return orderBookFetchRateLimitted(() => orderBookApi.getTrades({ owner }, { chainId }))
+}
+
+export async function getNativePrice(chainId: ChainId, currencyAddress: string): Promise<NativePriceResponse> {
+  return orderBookFetchRateLimitted(() => orderBookApi.getNativePrice(currencyAddress, { chainId }))
 }
 
 export type ProfileData = {

--- a/src/cow-react/api/gnosisProtocol/hooks.ts
+++ b/src/cow-react/api/gnosisProtocol/hooks.ts
@@ -1,6 +1,6 @@
 import useSWR from 'swr'
 
-import { getOrders } from '@cow/api/gnosisProtocol/api'
+import { getOrders } from '@cow/api/gnosisProtocol'
 import { AMOUNT_OF_ORDERS_TO_FETCH } from 'constants/index'
 import { supportedChainId } from 'utils/supportedChainId'
 import { useWalletInfo } from '@cow/modules/wallet'

--- a/src/cow-react/api/gnosisProtocol/index.ts
+++ b/src/cow-react/api/gnosisProtocol/index.ts
@@ -14,5 +14,8 @@ export const {
   getProfileData,
   getQuote = realApi.getQuote,
   getOrder = realApi.getOrder,
+  getOrders = realApi.getOrders,
+  getNativePrice = realApi.getNativePrice,
+  getTrades = realApi.getTrades,
   // functions that only have a mock
 } = useMock ? { ...mockApi } : { ...realApi }

--- a/src/cow-react/modules/limitOrders/hooks/useGetInitialPrice.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useGetInitialPrice.ts
@@ -7,8 +7,8 @@ import { getAddress } from '@cow/utils/getAddress'
 import ms from 'ms.macro'
 import { parsePrice } from '@cow/modules/limitOrders/utils/parsePrice'
 import useIsWindowVisible from 'hooks/useIsWindowVisible'
-import { orderBookApi } from '@cow/cowSdk'
 import { useWalletInfo } from '@cow/modules/wallet'
+import { getNativePrice } from '@cow/api/gnosisProtocol'
 
 type PriceResult = number | Error | undefined
 
@@ -26,7 +26,7 @@ async function requestPriceForCurrency(chainId: number | undefined, currency: Cu
       return parsePrice(1, currency)
     }
 
-    const result = await orderBookApi.getNativePrice(currencyAddress, { chainId })
+    const result = await getNativePrice(chainId, currencyAddress)
 
     if (!result) {
       throw new Error('Cannot parse initial price')

--- a/src/cow-react/modules/wallet/web3-react/connection/trust.tsx
+++ b/src/cow-react/modules/wallet/web3-react/connection/trust.tsx
@@ -22,11 +22,11 @@ const BASE_PROPS = {
 
 const [trustWallet, trustWalletHooks] = initializeConnector<Connector>(
   (actions) =>
-  new InjectedWallet({
-    actions,
-    walletUrl: WALLET_LINK,
-    searchKeywords: ['isTrust', 'isTrustWallet'],
-  })
+    new InjectedWallet({
+      actions,
+      walletUrl: WALLET_LINK,
+      searchKeywords: ['isTrust', 'isTrustWallet'],
+    })
 )
 export const trustWalletConnection: Web3ReactConnection = {
   connector: trustWallet,

--- a/src/custom/utils/trade.ts
+++ b/src/custom/utils/trade.ts
@@ -3,7 +3,7 @@ import { isAddress, shortenAddress } from 'utils'
 import { ChangeOrderStatusParams, Order, OrderStatus } from 'state/orders/actions'
 import { AddUnserialisedPendingOrderParams } from 'state/orders/hooks'
 
-import { OrderID } from '@cow/api/gnosisProtocol'
+import { getTrades, OrderID } from '@cow/api/gnosisProtocol'
 import { Signer } from '@ethersproject/abstract-signer'
 import { RADIX_DECIMAL, NATIVE_CURRENCY_BUY_ADDRESS } from 'constants/index'
 import { SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
@@ -273,10 +273,7 @@ export async function sendOrderCancellation(params: OrderCancellationParams): Pr
 }
 
 export async function hasTrades(chainId: ChainId, address: string): Promise<boolean> {
-  const [trades, profileData] = await Promise.all([
-    orderBookApi.getTrades({ owner: address }, { chainId }),
-    getProfileData(chainId, address),
-  ])
+  const [trades, profileData] = await Promise.all([getTrades(chainId, address), getProfileData(chainId, address)])
 
   return trades.length > 0 || (profileData?.totalTrades ?? 0) > 0
 }


### PR DESCRIPTION
The strategy was accidentally lost after a major SDK update.

# Summary

Fixes #2280

  # To Test

For api.cow.fi requests should work as before: https://github.com/cowprotocol/cowswap/pull/2069
