### PR TITLE
Surplus/executed popup

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/OrdersWidget/hooks/useLimitOrdersList.ts
+++ b/src/cow-react/modules/limitOrders/containers/OrdersWidget/hooks/useLimitOrdersList.ts
@@ -18,6 +18,7 @@ export interface LimitOrdersList {
   history: ParsedOrder[]
 }
 
+// TODO: we should move this to a separate module independent of limit orders, because it could be used for other oder types
 export interface ParsedOrder extends Order {
   executedBuyAmount: JSBI
   executedSellAmount: JSBI

--- a/src/cow-react/modules/limitOrders/pure/ReceiptModal/FilledField.tsx
+++ b/src/cow-react/modules/limitOrders/pure/ReceiptModal/FilledField.tsx
@@ -1,82 +1,18 @@
 // Code based on https://github.com/cowprotocol/explorer/blob/develop/src/components/orders/FilledProgress/index.tsx
 import * as styledEl from './styled'
 import { ParsedOrder } from '@cow/modules/limitOrders/containers/OrdersWidget/hooks/useLimitOrdersList'
-import { CurrencyAmount, Token } from '@uniswap/sdk-core'
-import { OrderKind } from '@cowprotocol/cow-sdk'
-import { BigNumber } from 'bignumber.js'
-import JSBI from 'jsbi'
 import { TokenAmount } from '@cow/common/pure/TokenAmount'
+import { getFilledAmounts } from '@cow/modules/limitOrders/utils/getFilledAmounts'
 
 interface Props {
   order: ParsedOrder
-  sellAmount: CurrencyAmount<Token>
-  buyAmount: CurrencyAmount<Token>
 }
 
-// TODO: using .toNumber() we potentially lose accuracy
-// TODO: must be refactored with replacing bignumber.js by @ethersproject/bignumber
-function legacyBigNumberToCurrencyAmount(currency: Token, value: BigNumber | undefined): CurrencyAmount<Token> {
-  return CurrencyAmount.fromRawAmount(currency, Math.ceil((value?.toNumber() || 0) * 10 ** currency.decimals))
-}
-
-export function FilledField({ order, sellAmount, buyAmount }: Props) {
-  const {
-    inputToken,
-    outputToken,
-    filledPercentage,
-    formattedPercentage,
-    fullyFilled,
-    kind,
-    feeAmount,
-    executedBuyAmount,
-    executedSellAmount,
-    executedFeeAmount,
-    filledAmount,
-  } = order
+export function FilledField({ order }: Props) {
+  const { filledPercentage, formattedPercentage, fullyFilled } = order
+  const { action, mainAmount, formattedFilledAmount, formattedSwappedAmount } = getFilledAmounts(order)
 
   const touched = !!filledPercentage?.gt(0)
-
-  let mainToken: Token
-  let mainAmount: CurrencyAmount<Token>
-  let swappedToken: Token
-  let swappedAmount: JSBI | undefined
-  let action: string
-
-  // TODO: set types, move calculations logic to a function
-  let filledAmountWithFee, swappedAmountWithFee
-  if (kind === OrderKind.SELL) {
-    action = 'sold'
-
-    mainToken = inputToken
-    mainAmount = sellAmount.add(CurrencyAmount.fromRawAmount(mainToken, feeAmount.toString()))
-
-    swappedToken = outputToken
-    swappedAmount = executedBuyAmount
-
-    // Sell orders, add the fee in to the sellAmount (mainAmount, in this case)
-    filledAmountWithFee = filledAmount?.plus(executedFeeAmount || '0')
-    swappedAmountWithFee = new BigNumber(swappedAmount?.toString() || '0')
-  } else {
-    action = 'bought'
-
-    mainToken = outputToken
-    mainAmount = buyAmount
-
-    swappedToken = inputToken
-    swappedAmount = executedSellAmount
-
-    // Buy orders need to add the fee, to the sellToken too (swappedAmount in this case)
-    filledAmountWithFee = filledAmount
-    swappedAmountWithFee = new BigNumber(swappedAmount?.toString() || '0').plus(executedFeeAmount || '0')
-  }
-
-  // In case the token object is empty, display the raw amount (`decimals || 0` part)
-
-  const filledAmountDecimal = filledAmountWithFee?.div(new BigNumber(10 ** mainToken.decimals))
-  const formattedFilledAmount = legacyBigNumberToCurrencyAmount(mainToken, filledAmountDecimal)
-
-  const swappedAmountDecimal = swappedAmountWithFee.div(new BigNumber(10 ** swappedToken.decimals))
-  const formattedSwappedAmount = legacyBigNumberToCurrencyAmount(swappedToken, swappedAmountDecimal)
 
   return (
     <styledEl.Value>

--- a/src/cow-react/modules/limitOrders/pure/ReceiptModal/FilledField.tsx
+++ b/src/cow-react/modules/limitOrders/pure/ReceiptModal/FilledField.tsx
@@ -12,7 +12,7 @@ export function FilledField({ order }: Props) {
   const { filledPercentage, formattedPercentage, fullyFilled } = order
   const { action, mainAmount, formattedFilledAmount, formattedSwappedAmount } = getFilledAmounts(order)
 
-  const touched = !!filledPercentage?.gt(0)
+  const touched = filledPercentage?.gt(0)
 
   return (
     <styledEl.Value>

--- a/src/cow-react/modules/limitOrders/pure/ReceiptModal/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/ReceiptModal/index.tsx
@@ -59,7 +59,6 @@ export function ReceiptModal({
   onDismiss,
   order,
   chainId,
-  sellAmount,
   buyAmount,
   limitPrice,
   executionPrice,
@@ -114,7 +113,7 @@ export function ReceiptModal({
 
             <styledEl.Field>
               <FieldLabel label="Filled" tooltip={tooltips.FILLED} />
-              <FilledField order={order} sellAmount={sellAmount} buyAmount={buyAmount} />
+              <FilledField order={order} />
             </styledEl.Field>
 
             <styledEl.Field>

--- a/src/cow-react/modules/limitOrders/utils/getFilledAmounts.ts
+++ b/src/cow-react/modules/limitOrders/utils/getFilledAmounts.ts
@@ -1,0 +1,78 @@
+import { ParsedOrder } from '@cow/modules/limitOrders/containers/OrdersWidget/hooks/useLimitOrdersList'
+import { CurrencyAmount, Token } from '@uniswap/sdk-core'
+import { OrderKind } from '@cowprotocol/cow-sdk'
+import { BigNumber } from 'bignumber.js'
+import JSBI from 'jsbi'
+
+// TODO: using .toNumber() we potentially lose accuracy
+// TODO: must be refactored with replacing bignumber.js by @ethersproject/bignumber
+function legacyBigNumberToCurrencyAmount(currency: Token, value: BigNumber | undefined): CurrencyAmount<Token> {
+  return CurrencyAmount.fromRawAmount(currency, Math.ceil((value?.toNumber() || 0) * 10 ** currency.decimals))
+}
+
+export function getFilledAmounts(order: ParsedOrder) {
+  const {
+    inputToken,
+    outputToken,
+    kind,
+    feeAmount,
+    executedBuyAmount,
+    executedSellAmount,
+    executedFeeAmount,
+    filledAmount,
+    sellAmount,
+    buyAmount,
+  } = order
+
+  let mainToken: Token
+  let mainAmount: CurrencyAmount<Token>
+  let swappedToken: Token
+  let swappedAmount: JSBI | undefined
+  let action: string
+
+  const sellAmountCurrency = CurrencyAmount.fromRawAmount(inputToken, sellAmount.toString())
+  const buyAmountCurrency = CurrencyAmount.fromRawAmount(outputToken, buyAmount.toString())
+
+  // TODO: set types, move calculations logic to a function
+  let filledAmountWithFee, swappedAmountWithFee
+  if (kind === OrderKind.SELL) {
+    action = 'sold'
+
+    mainToken = inputToken
+    mainAmount = sellAmountCurrency.add(CurrencyAmount.fromRawAmount(mainToken, feeAmount.toString()))
+
+    swappedToken = outputToken
+    swappedAmount = executedBuyAmount
+
+    // Sell orders, add the fee in to the sellAmount (mainAmount, in this case)
+    filledAmountWithFee = filledAmount?.plus(executedFeeAmount || '0')
+    swappedAmountWithFee = new BigNumber(swappedAmount?.toString() || '0')
+  } else {
+    action = 'bought'
+
+    mainToken = outputToken
+    mainAmount = buyAmountCurrency
+
+    swappedToken = inputToken
+    swappedAmount = executedSellAmount
+
+    // Buy orders need to add the fee, to the sellToken too (swappedAmount in this case)
+    filledAmountWithFee = filledAmount
+    swappedAmountWithFee = new BigNumber(swappedAmount?.toString() || '0').plus(executedFeeAmount || '0')
+  }
+
+  // In case the token object is empty, display the raw amount (`decimals || 0` part)
+
+  const filledAmountDecimal = filledAmountWithFee?.div(new BigNumber(10 ** mainToken.decimals))
+  const formattedFilledAmount = legacyBigNumberToCurrencyAmount(mainToken, filledAmountDecimal)
+
+  const swappedAmountDecimal = swappedAmountWithFee.div(new BigNumber(10 ** swappedToken.decimals))
+  const formattedSwappedAmount = legacyBigNumberToCurrencyAmount(swappedToken, swappedAmountDecimal)
+
+  return {
+    formattedFilledAmount,
+    formattedSwappedAmount,
+    mainAmount,
+    action,
+  }
+}

--- a/src/cow-react/modules/limitOrders/utils/getFilledAmounts.ts
+++ b/src/cow-react/modules/limitOrders/utils/getFilledAmounts.ts
@@ -5,7 +5,7 @@ import { BigNumber } from 'bignumber.js'
 import JSBI from 'jsbi'
 
 // TODO: using .toNumber() we potentially lose accuracy
-// TODO: must be refactored with replacing bignumber.js by @ethersproject/bignumber
+// TODO: if we do migrations to etherjs v6, we should use native ES6 bignumber
 function legacyBigNumberToCurrencyAmount(currency: Token, value: BigNumber | undefined): CurrencyAmount<Token> {
   return CurrencyAmount.fromRawAmount(currency, Math.ceil((value?.toNumber() || 0) * 10 ** currency.decimals))
 }
@@ -62,7 +62,6 @@ export function getFilledAmounts(order: ParsedOrder) {
   }
 
   // In case the token object is empty, display the raw amount (`decimals || 0` part)
-
   const filledAmountDecimal = filledAmountWithFee?.div(new BigNumber(10 ** mainToken.decimals))
   const formattedFilledAmount = legacyBigNumberToCurrencyAmount(mainToken, filledAmountDecimal)
 

--- a/src/cow-react/modules/wallet/web3-react/connection/trust.tsx
+++ b/src/cow-react/modules/wallet/web3-react/connection/trust.tsx
@@ -22,11 +22,11 @@ const BASE_PROPS = {
 
 const [trustWallet, trustWalletHooks] = initializeConnector<Connector>(
   (actions) =>
-  new InjectedWallet({
-    actions,
-    walletUrl: WALLET_LINK,
-    searchKeywords: ['isTrust', 'isTrustWallet'],
-  })
+    new InjectedWallet({
+      actions,
+      walletUrl: WALLET_LINK,
+      searchKeywords: ['isTrust', 'isTrustWallet'],
+    })
 )
 export const trustWalletConnection: Web3ReactConnection = {
   connector: trustWallet,

--- a/src/custom/state/orders/helpers.tsx
+++ b/src/custom/state/orders/helpers.tsx
@@ -12,7 +12,7 @@ interface SetOrderSummaryParams {
   id: string
   status?: OrderStatusExtended
   summary?: string | JSX.Element
-  descriptor?: string
+  descriptor?: string | null
 }
 
 // what is passed to addPopup action
@@ -49,11 +49,22 @@ type MetaPopupContent = GPPopupContent<OrderTxTypes.METATXN>
 type TxnPopupContent = GPPopupContent<OrderTxTypes.TXN>
 
 function setOrderSummary({ id, summary, status, descriptor }: SetOrderSummaryParams) {
-  return !summary
-    ? `Order ${formatOrderId(id)} ${descriptor || status || ''}`
-    : typeof summary === 'string'
-    ? `${summary} ${descriptor || status || ''}`
-    : summary
+  // If there isn't summary, return generalized summary
+  if (!summary) {
+    return `Order ${formatOrderId(id)} ${descriptor || status || ''}`
+  }
+
+  if (typeof summary === 'string') {
+    // If descriptor is specifically null, just return summary
+    if (descriptor === null) {
+      return summary
+    }
+
+    // Otherwise return summary with descriptor or status
+    return `${summary} ${descriptor || status || ''}`
+  }
+
+  return summary
 }
 
 const Wrapper = styled.div`

--- a/src/custom/state/orders/helpers.tsx
+++ b/src/custom/state/orders/helpers.tsx
@@ -157,11 +157,6 @@ const Strong = styled.strong`
   white-space: nowrap;
 `
 
-const Percentage = styled.span`
-  color: ${({ theme }) => theme.green1};
-  margin-right: 5px;
-`
-
 export function getExecutedSummary(order: ParsedOrder): JSX.Element | string {
   if (!order) {
     return ''
@@ -186,9 +181,8 @@ export function getExecutedSummary(order: ParsedOrder): JSX.Element | string {
 
   const surplusToken = order.kind === OrderKind.SELL ? parsedOutputToken : parsedInputToken
 
-  const { amount, percentage } = getOrderSurplus(order)
+  const { amount } = getOrderSurplus(order)
   const parsedSurplus = CurrencyAmount.fromRawAmount(surplusToken, amount.toString())
-  const formattedPercent = percentage?.multipliedBy(100)?.toFixed(2)
 
   const { formattedFilledAmount, formattedSwappedAmount } = getFilledAmounts({
     ...order,
@@ -213,7 +207,6 @@ export function getExecutedSummary(order: ParsedOrder): JSX.Element | string {
         <div>
           <span>Order surplus: </span>
           <Strong>
-            <Percentage>+{formattedPercent}%</Percentage>
             <TokenAmount amount={parsedSurplus} tokenSymbol={surplusToken} />
           </Strong>
         </div>

--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -17,6 +17,8 @@ import { isOrderInPendingTooLong, openNpsAppziSometimes } from 'utils/appzi'
 import { OrderObject, OrdersStateNetwork } from 'state/orders/reducer'
 import { timeSinceInSeconds } from '@cow/utils/time'
 import { getExplorerOrderLink } from 'utils/explorer'
+import { Order } from 'state/orders/actions'
+import { getExecutedSummary } from '@src/custom/utils/trade'
 
 // action syntactic sugar
 const isSingleOrderChangeAction = isAnyOf(OrderActions.addPendingOrder)
@@ -117,10 +119,10 @@ export const popupMiddleware: Middleware<Record<string, unknown>, AppState> = (s
           // it's an OrderTxTypes.TXN, yes, but we still want to point to the explorer
           // because it's nicer there
           const popup = setPopupData(OrderTxTypes.METATXN, {
-            summary,
             id,
+            summary: getExecutedSummary(orderObject?.order as Order) || summary,
             status: OrderActions.OrderStatus.FULFILLED,
-            descriptor: 'was traded',
+            descriptor: null,
           })
           orderAnalytics('Executed', orderClass)
 

--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -18,7 +18,7 @@ import { OrderObject, OrdersStateNetwork } from 'state/orders/reducer'
 import { timeSinceInSeconds } from '@cow/utils/time'
 import { getExplorerOrderLink } from 'utils/explorer'
 import { Order } from 'state/orders/actions'
-import { getExecutedSummary } from '@src/custom/utils/trade'
+import { getExecutedSummary } from './helpers'
 
 // action syntactic sugar
 const isSingleOrderChangeAction = isAnyOf(OrderActions.addPendingOrder)

--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -17,8 +17,9 @@ import { isOrderInPendingTooLong, openNpsAppziSometimes } from 'utils/appzi'
 import { OrderObject, OrdersStateNetwork } from 'state/orders/reducer'
 import { timeSinceInSeconds } from '@cow/utils/time'
 import { getExplorerOrderLink } from 'utils/explorer'
-import { Order } from 'state/orders/actions'
 import { getExecutedSummary } from './helpers'
+import { parseOrder } from '@cow/modules/limitOrders/containers/OrdersWidget/hooks/useLimitOrdersList'
+import { Order } from 'state/orders/actions'
 
 // action syntactic sugar
 const isSingleOrderChangeAction = isAnyOf(OrderActions.addPendingOrder)
@@ -118,9 +119,11 @@ export const popupMiddleware: Middleware<Record<string, unknown>, AppState> = (s
           const { class: orderClass } = orderObject.order
           // it's an OrderTxTypes.TXN, yes, but we still want to point to the explorer
           // because it's nicer there
+          const parsedOrder = parseOrder(orderObject.order as Order)
+
           const popup = setPopupData(OrderTxTypes.METATXN, {
             id,
-            summary: getExecutedSummary(orderObject?.order as Order) || summary,
+            summary: getExecutedSummary(parsedOrder) || summary,
             status: OrderActions.OrderStatus.FULFILLED,
             descriptor: null,
           })

--- a/src/custom/utils/trade.ts
+++ b/src/custom/utils/trade.ts
@@ -19,7 +19,6 @@ import {
 import { getProfileData } from '@cow/api/gnosisProtocol/api'
 import { formatTokenAmount } from '@cow/utils/amountFormat'
 import { orderBookApi } from '@cow/cowSdk'
-import { getSellAmountWithFee } from '@cow/modules/limitOrders/utils/getSellAmountWithFee'
 
 export type PostOrderParams = {
   account: string
@@ -84,29 +83,6 @@ function _getSummary(params: PostOrderParams): string {
 
     return `${base} to ${toAddress}`
   }
-}
-
-export function getExecutedSummary(order: Order): string | null {
-  if (!order) {
-    return null
-  }
-
-  const inputT = order.inputToken
-  const outputT = order.outputToken
-
-  const inputToken = new Token(inputT.chainId, inputT.address, inputT.decimals, inputT.symbol, inputT.name)
-  const outputToken = new Token(outputT.chainId, outputT.address, outputT.decimals, outputT.symbol, outputT.name)
-
-  const inputSymbol = inputToken.symbol
-  const outputSymbol = outputToken.symbol
-
-  const inputAmountCurrency = getSellAmountWithFee({ ...order, inputToken })
-  const outputAmountCyrrency = CurrencyAmount.fromRawAmount(outputToken, order.buyAmount)
-
-  const inputAmount = formatTokenAmount(inputAmountCurrency)
-  const outputAmount = formatTokenAmount(outputAmountCyrrency)
-
-  return `Traded ${inputAmount} ${inputSymbol} for a total of ${outputAmount} ${outputSymbol}`
 }
 
 export function getOrderParams(params: PostOrderParams): {

--- a/src/custom/utils/trade.ts
+++ b/src/custom/utils/trade.ts
@@ -19,6 +19,7 @@ import {
 import { getProfileData } from '@cow/api/gnosisProtocol/api'
 import { formatTokenAmount } from '@cow/utils/amountFormat'
 import { orderBookApi } from '@cow/cowSdk'
+import { getSellAmountWithFee } from '@cow/modules/limitOrders/utils/getSellAmountWithFee'
 
 export type PostOrderParams = {
   account: string
@@ -83,6 +84,29 @@ function _getSummary(params: PostOrderParams): string {
 
     return `${base} to ${toAddress}`
   }
+}
+
+export function getExecutedSummary(order: Order): string | null {
+  if (!order) {
+    return null
+  }
+
+  const inputT = order.inputToken
+  const outputT = order.outputToken
+
+  const inputToken = new Token(inputT.chainId, inputT.address, inputT.decimals, inputT.symbol, inputT.name)
+  const outputToken = new Token(outputT.chainId, outputT.address, outputT.decimals, outputT.symbol, outputT.name)
+
+  const inputSymbol = inputToken.symbol
+  const outputSymbol = outputToken.symbol
+
+  const inputAmountCurrency = getSellAmountWithFee({ ...order, inputToken })
+  const outputAmountCyrrency = CurrencyAmount.fromRawAmount(outputToken, order.buyAmount)
+
+  const inputAmount = formatTokenAmount(inputAmountCurrency)
+  const outputAmount = formatTokenAmount(outputAmountCyrrency)
+
+  return `Traded ${inputAmount} ${inputSymbol} for a total of ${outputAmount} ${outputSymbol}`
 }
 
 export function getOrderParams(params: PostOrderParams): {


### PR DESCRIPTION
# Summary

Part of the [Surplus tasks](https://www.notion.so/cownation/Show-Me-the-Money-hackathon-0a1b1b3e6a1b4d4eb9a46f96136a1865)

This PR
- updates the message in executed order popup, as requested `Traded <amount TOKEN> for a total of <traded amount TOKEN>` and some styling
- adds surplus amount to the popup

![Screenshot 2023-04-11 at 16 12 09](https://user-images.githubusercontent.com/34926005/231196329-981558ec-1cc9-4910-969e-50329b021d71.png)

![Screenshot 2023-04-11 at 16 34 47](https://user-images.githubusercontent.com/34926005/231196889-eeb9d3ff-b32e-4dc3-b831-4b1b82134af3.png)

