### PR TITLE
Add surplus item to each order in recent savings

### DIFF
--- a/src/cow-react/modules/account/containers/Transaction/ActivityDetails.tsx
+++ b/src/cow-react/modules/account/containers/Transaction/ActivityDetails.tsx
@@ -28,6 +28,7 @@ import { EthFlowStepper } from '@cow/modules/swap/containers/EthFlowStepper'
 import { StatusDetails } from './StatusDetails'
 import { useCancelOrder } from '@cow/common/hooks/useCancelOrder'
 import { TokenAmount } from '@cow/common/pure/TokenAmount'
+import { getExecutedSummaryData } from '@src/custom/state/orders/helpers'
 
 const DEFAULT_ORDER_SUMMARY = {
   from: '',
@@ -175,6 +176,8 @@ export function ActivityDetails(props: {
     invertedActiveRateFiatAmount: null,
   }
   let isOrderFulfilled = false
+  let surplusAmount,
+    surplusToken = null
 
   if (order) {
     const {
@@ -225,6 +228,10 @@ export function ActivityDetails(props: {
         : undefined,
       kind: kind.toString(),
     }
+
+    const executedData = getExecutedSummaryData(order)
+    surplusAmount = executedData.surplusAmount
+    surplusToken = executedData.surplusToken
   } else {
     orderSummary = DEFAULT_ORDER_SUMMARY
   }
@@ -292,6 +299,14 @@ export function ActivityDetails(props: {
                   </>
                 )}
               </SummaryInnerRow>
+              {surplusAmount?.greaterThan(0) && (
+                <SummaryInnerRow>
+                  <b>Savings</b>
+                  <i>
+                    <TokenAmount amount={surplusAmount} tokenSymbol={surplusToken} />
+                  </i>
+                </SummaryInnerRow>
+              )}
             </>
           ) : (
             summary ?? id


### PR DESCRIPTION
# Summary

[Third task](https://www.notion.so/cownation/Show-Me-the-Money-hackathon-0a1b1b3e6a1b4d4eb9a46f96136a1865?pvs=4#508f2aed03594cfda071d93a68e373c0) in the Surplus saga

This PR adds savings (surplus) item to each order in recent activity modal

<img width="823" alt="Screenshot 2023-04-12 at 17 02 34" src="https://user-images.githubusercontent.com/34926005/231499489-13e1cd0f-aeb6-4f27-b83f-f7e639439096.png">

### To test
1. open activity modal
2. if the order had surplus there should be savings field
