### PR TITLE
Added settingsState to limit orders memo component props

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -69,7 +69,7 @@ export function LimitOrdersWidget() {
   const onCurrencySelection = useOnCurrencySelection()
   const onImportDismiss = useOnImportDismiss()
   const limitOrdersNavigate = useTradeNavigate()
-  const settingState = useAtomValue(limitOrdersSettingsAtom)
+  const settingsState = useAtomValue(limitOrdersSettingsAtom)
   const updateCurrencyAmount = useUpdateCurrencyAmount()
   const isSellOrder = useIsSellOrder()
   const tradeContext = useTradeFlowContext()
@@ -81,13 +81,13 @@ export function LimitOrdersWidget() {
   const partiallyFillableOverride = useAtom(partiallyFillableOverrideAtom)
 
   const showRecipient = useMemo(
-    () => !isWrapOrUnwrap && settingState.showRecipient,
-    [settingState.showRecipient, isWrapOrUnwrap]
+    () => !isWrapOrUnwrap && settingsState.showRecipient,
+    [settingsState.showRecipient, isWrapOrUnwrap]
   )
 
   const isExpertMode = useMemo(
-    () => !isWrapOrUnwrap && settingState.expertMode,
-    [isWrapOrUnwrap, settingState.expertMode]
+    () => !isWrapOrUnwrap && settingsState.expertMode,
+    [isWrapOrUnwrap, settingsState.expertMode]
   )
 
   const priceImpact = usePriceImpact(useLimitOrdersPriceImpactParams())
@@ -183,6 +183,7 @@ export function LimitOrdersWidget() {
     rateInfoParams,
     priceImpact,
     tradeContext,
+    settingsState,
     feeAmount,
   }
 
@@ -218,6 +219,7 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
     rateInfoParams,
     priceImpact,
     tradeContext,
+    settingsState,
     feeAmount,
   } = props
 
@@ -233,7 +235,7 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
   const currenciesLoadingInProgress = false
   const maxBalance = maxAmountSpend(inputCurrencyInfo.balance || undefined)
   const showSetMax = !!maxBalance && !inputCurrencyInfo.rawAmount?.equalTo(maxBalance)
-  const isPartiallyFillable = tradeContext?.postOrderParams.partiallyFillable ?? true
+  const isPartiallyFillable = settingsState.partialFillsEnabled
 
   const subsidyAndBalance: BalanceAndSubsidy = {
     subsidy: {

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/limitOrdersPropsChecker.ts
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/limitOrdersPropsChecker.ts
@@ -10,6 +10,7 @@ import { genericPropsChecker } from '@cow/utils/genericPropsChecker'
 import { getAddress } from '@cow/utils/getAddress'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import { PartiallyFillableOverrideDispatcherType } from '@cow/modules/limitOrders/state/partiallyFillableOverride'
+import { LimitOrdersSettingsState } from '@cow/modules/limitOrders/state/limitOrdersSettingsAtom'
 
 export interface LimitOrdersProps {
   onChangeRecipient(value: string | null): void
@@ -35,6 +36,7 @@ export interface LimitOrdersProps {
   rateInfoParams: RateInfoParams
   priceImpact: PriceImpact
   tradeContext: TradeFlowContext | null
+  settingsState: LimitOrdersSettingsState
   feeAmount: CurrencyAmount<Currency> | null
 }
 
@@ -57,6 +59,7 @@ export function limitOrdersPropsChecker(a: LimitOrdersProps, b: LimitOrdersProps
     checkRateInfoParams(a.rateInfoParams, b.rateInfoParams) &&
     checkPriceImpact(a.priceImpact, b.priceImpact) &&
     checkTradeFlowContext(a.tradeContext, b.tradeContext) &&
+    genericPropsChecker(a.settingsState, b.settingsState) &&
     checkCurrencyAmount(a.feeAmount, b.feeAmount)
   )
 }


### PR DESCRIPTION
# Summary

Fixes #2296 

# To Test

1. On limit orders page, turn on expert mode
2. While not connected, change the partial fills setting
* Order type should be updated immediately
* Same thing while connected