### PR TITLE
Fix launch darkly env var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
     # Deploys to Vercel dev environment
     name: Vercel dev
     needs: [test, lint]
-    if: github.ref == 'refs/heads/develop'
+#    if: github.ref == 'refs/heads/develop'
     uses: ./.github/workflows/vercel.yml
     secrets: inherit
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
     # Deploys to Vercel dev environment
     name: Vercel dev
     needs: [test, lint]
-#    if: github.ref == 'refs/heads/develop'
+    if: github.ref == 'refs/heads/develop'
     uses: ./.github/workflows/vercel.yml
     secrets: inherit
     with:

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -40,6 +40,7 @@ jobs:
           REACT_APP_BLOCKNATIVE_API_KEY=${{ secrets.REACT_APP_BLOCKNATIVE_API_KEY }}
           REACT_APP_GOOGLE_ANALYTICS_ID=${{ secrets.REACT_APP_GOOGLE_ANALYTICS_ID }}
           REACT_APP_AMPLITUDE_KEY=${{ secrets.REACT_APP_AMPLITUDE_KEY }}
+          REACT_APP_LAUNCH_DARKLY_KEY=${{ secrets.REACT_APP_LAUNCH_DARKLY_KEY }}
           vercel build -t ${{ secrets.VERCEL_TOKEN }} --prod
 
       - name: Get the version


### PR DESCRIPTION
# Summary

Simply adding launch darkly env var to vercel build

Simple version of https://github.com/cowprotocol/cowswap/pull/2310 to fix the immediate issue

# To Test

Forcefully deploying dev env for testing

1. Dev should work and use dev launch darkly's key