### PR TITLE
Add retry limitations based on rawApiError

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@cowprotocol/app-data": "v0.1.0-alpha.0",
     "@cowprotocol/contracts": "^1.3.1",
     "@cowprotocol/cow-runner-game": "^0.2.9",
-    "@cowprotocol/cow-sdk": "^2.0.1",
+    "@cowprotocol/cow-sdk": "^2.0.2",
     "@cowprotocol/ethflowcontract": "cowprotocol/ethflowcontract.git#v1.0.0-artifacts",
     "@davatar/react": "1.8.1",
     "@fontsource/ibm-plex-mono": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@cowprotocol/app-data": "v0.1.0-alpha.0",
     "@cowprotocol/contracts": "^1.3.1",
     "@cowprotocol/cow-runner-game": "^0.2.9",
-    "@cowprotocol/cow-sdk": "^2.0.2",
+    "@cowprotocol/cow-sdk": "^2.0.3",
     "@cowprotocol/ethflowcontract": "cowprotocol/ethflowcontract.git#v1.0.0-artifacts",
     "@davatar/react": "1.8.1",
     "@fontsource/ibm-plex-mono": "^4.5.1",

--- a/src/cow-react/common/utils/fetch.ts
+++ b/src/cow-react/common/utils/fetch.ts
@@ -7,11 +7,36 @@ interface FetchWithRateLimit {
   backoff?: BackoffOptions // basic exponential back-off by default
 }
 
+const REQUEST_TIMEOUT = 408
+const TOO_EARLY = 425
+const TOO_MANY_REQUESTS = 429
+const INTERNAL_SERVER_ERROR = 500
+const BAD_GATEWAY = 502
+const SERVICE_UNAVAILABLE = 503
+const GATEWAY_TIMEOUT = 504
+
+const STATUS_CODES_TO_RETRY = [
+  REQUEST_TIMEOUT,
+  TOO_EARLY,
+  TOO_MANY_REQUESTS,
+  INTERNAL_SERVER_ERROR,
+  BAD_GATEWAY,
+  SERVICE_UNAVAILABLE,
+  GATEWAY_TIMEOUT,
+]
+
 // See config in https://www.npmjs.com/package/@insertish/exponential-backoff
 const DEFAULT_BACKOFF_OPTIONS: BackoffOptions = {
   numOfAttempts: 10,
   maxDelay: Infinity,
   jitter: 'none',
+  retry: (err) => {
+    if (err?.rawApiError?.status) {
+      return STATUS_CODES_TO_RETRY.includes(err.rawApiError.status)
+    }
+
+    return true
+  },
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1184,17 +1184,13 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/cow-runner-game/-/cow-runner-game-0.2.9.tgz#3f94b3f370bd114f77db8b1d238cba3ef4e9d644"
   integrity sha512-rX7HnoV+HYEEkBaqVUsAkGGo0oBrExi+d6Io+8nQZYwZk+IYLmS9jdcIObsLviM2h4YX8+iin6NuKl35AaiHmg==
 
-"@cowprotocol/cow-sdk@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-2.0.1.tgz#9467f8538048373d78dc355e97b878164e4be834"
-  integrity sha512-irfQTh0z6earB06lsX+rG6fa6pQqRSnyivnma/ZNPA+uT7AisZKlslbW2mgaKXkqWygZFnfL9UUz5dQMwTFMCQ==
+"@cowprotocol/cow-sdk@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-2.0.2.tgz#152c12bfcc97e796feb5210c562dba83df466cc0"
+  integrity sha512-L069bbppeBvrjMrjrSmI6xtXAP5Q/qUiFsYNYJ+JJqc1g+vJnPuP5ACRMrhnf55/RoOc2Jo9V3QO3plHFwqywQ==
   dependencies:
     "@cowprotocol/contracts" "^1.4.0"
-    axios "^1.3.4"
-    cross-fetch "^3.1.5"
-    ethers "^5.7.2"
-    graphql "^16.3.0"
-    graphql-request "^4.3.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
 
 "@cowprotocol/ethflowcontract@cowprotocol/ethflowcontract.git#v1.0.0-artifacts":
   version "1.0.0"
@@ -6034,15 +6030,6 @@ axios@^0.21.0, axios@^0.21.1:
   dependencies:
     follow-redirects "^1.14.0"
 
-axios@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.3.4.tgz#f5760cefd9cfb51fd2481acf88c05f67c4523024"
-  integrity sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==
-  dependencies:
-    follow-redirects "^1.15.0"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
-
 axobject-query@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-3.1.1.tgz#3b6e5c6d4e43ca7ba51c5babf99d22a9c68485e1"
@@ -10252,7 +10239,7 @@ follow-redirects@1.5.10:
   dependencies:
     debug "=3.1.0"
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.15.0:
+follow-redirects@^1.0.0, follow-redirects@^1.14.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -10759,24 +10746,10 @@ graphql-request@^3.4.0:
     extract-files "^9.0.0"
     form-data "^3.0.0"
 
-graphql-request@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-4.3.0.tgz#b934e08fcae764aa2cdc697d3c821f046cb5dbf2"
-  integrity sha512-2v6hQViJvSsifK606AliqiNiijb1uwWp6Re7o0RTyH+uRTv/u7Uqm2g4Fjq/LgZIzARB38RZEvVBFOQOVdlBow==
-  dependencies:
-    cross-fetch "^3.1.5"
-    extract-files "^9.0.0"
-    form-data "^3.0.0"
-
 graphql@^15.5.0:
   version "15.8.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
   integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==
-
-graphql@^16.3.0:
-  version "16.6.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
-  integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
 
 gzip-size@^6.0.0:
   version "6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1184,10 +1184,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/cow-runner-game/-/cow-runner-game-0.2.9.tgz#3f94b3f370bd114f77db8b1d238cba3ef4e9d644"
   integrity sha512-rX7HnoV+HYEEkBaqVUsAkGGo0oBrExi+d6Io+8nQZYwZk+IYLmS9jdcIObsLviM2h4YX8+iin6NuKl35AaiHmg==
 
-"@cowprotocol/cow-sdk@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-2.0.2.tgz#152c12bfcc97e796feb5210c562dba83df466cc0"
-  integrity sha512-L069bbppeBvrjMrjrSmI6xtXAP5Q/qUiFsYNYJ+JJqc1g+vJnPuP5ACRMrhnf55/RoOc2Jo9V3QO3plHFwqywQ==
+"@cowprotocol/cow-sdk@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-2.0.3.tgz#3f2a9be9d5b7acb928033ffcedaf03c07020d6ee"
+  integrity sha512-f6aXx7k/18OpXdQwblimdzmb/Z/GVFTA8T1i0EFzVXXz6TapKrz/ZVPD0r+ESHa8u8aBg8H8cEpDalqVMMui4A==
   dependencies:
     "@cowprotocol/contracts" "^1.4.0"
     "@ethersproject/abstract-signer" "^5.7.0"


### PR DESCRIPTION
# Summary

Fixes #2311

Relies on changes made in https://github.com/cowprotocol/cow-sdk/pull/120

As retry function has the error injected (i.e. not the whole response but just the body in this case) we need the enriched version, where we can extract this information.

# To Test

1. Open swap
2. Change to Goerli
3. Pick ETH/ZRX pair
4. Enter an amount
5. Low liquidity error should appear, without waiting a minute long
