### PR TITLE
Modify styles unfillable label

### DIFF
--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
 import { Currency, CurrencyAmount, Fraction, Percent } from '@uniswap/sdk-core'
 import styled, { ThemeContext } from 'styled-components/macro'
-import { darken } from 'polished'
+import { transparentize, darken } from 'polished'
 import SVG from 'react-inlinesvg'
 
 import { MouseoverTooltipContent } from 'components/Tooltip'
@@ -48,18 +48,21 @@ export const EstimatedExecutionPriceWrapper = styled.span<{ hasWarning: boolean;
 `
 
 const UnfillableLabel = styled.span`
-  height: 28px;
-  width: 90px;
-  border: 1px solid;
-  color: ${({ theme }) => theme.attention};
+  width: 100%;
+  max-width: 90px;
+  background: ${({ theme }) => transparentize(0.86, theme.attention)};
+  color: ${({ theme }) => darken(0.15, theme.attention)};
   position: relative;
-  border-radius: 4px;
+  border-radius: 9px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 600;
-  overflow: hidden;
+  padding: 6px 2px;
+  margin: 0 4px 0 0;
+  letter-spacing: 0.2px;
+  text-transform: uppercase;
 `
 
 export type EstimatedExecutionPriceProps = TokenAmountProps & {


### PR DESCRIPTION
# Summary

- Minor style update for the 'unfillable' label

<img width="921" alt="Screenshot 2023-04-17 at 15 08 35" src="https://user-images.githubusercontent.com/31534717/232514800-b52e3b25-9fcc-4471-8940-5217c48aa0fa.png">
<img width="903" alt="Screenshot 2023-04-17 at 15 08 20" src="https://user-images.githubusercontent.com/31534717/232514828-63971a76-8f71-42fb-b2c5-8e61791edcce.png">
