### PR TITLE
Fix on-chain cancellation tx notifications

### DIFF
--- a/src/cow-react/common/hooks/useCancelOrder/__snapshots__/useSendOnChainCancellation.test.ts.snap
+++ b/src/cow-react/common/hooks/useCancelOrder/__snapshots__/useSendOnChainCancellation.test.ts.snap
@@ -4,6 +4,9 @@ exports[`useSendOnChainCancellation() + useGetOnChainCancellation() When a trans
 Array [
   Object {
     "hash": "0xcfwj23g4fwe111",
+    "onChainCancellation": Object {
+      "orderId": "xx1",
+    },
   },
 ]
 `;

--- a/src/cow-react/common/hooks/useCancelOrder/useSendOnChainCancellation.ts
+++ b/src/cow-react/common/hooks/useCancelOrder/useSendOnChainCancellation.ts
@@ -31,7 +31,10 @@ export function useSendOnChainCancellation() {
         if (isEthFlowOrder) {
           addTransaction({ hash: receipt.hash, ethFlow: { orderId: order.id, subType: 'cancellation' } })
         } else {
-          addTransaction({ hash: receipt.hash, onChainCancellation: { orderId: order.id } })
+          addTransaction({
+            hash: receipt.hash,
+            onChainCancellation: { orderId: order.id, sellTokenSymbol: order.inputToken.symbol || '' },
+          })
         }
       }
     },

--- a/src/cow-react/common/hooks/useCancelOrder/useSendOnChainCancellation.ts
+++ b/src/cow-react/common/hooks/useCancelOrder/useSendOnChainCancellation.ts
@@ -31,7 +31,7 @@ export function useSendOnChainCancellation() {
         if (isEthFlowOrder) {
           addTransaction({ hash: receipt.hash, ethFlow: { orderId: order.id, subType: 'cancellation' } })
         } else {
-          addTransaction({ hash: receipt.hash })
+          addTransaction({ hash: receipt.hash, onChainCancellation: { orderId: order.id } })
         }
       }
     },

--- a/src/custom/hooks/useRecentActivity.ts
+++ b/src/custom/hooks/useRecentActivity.ts
@@ -84,10 +84,14 @@ export default function useRecentActivity() {
     return (
       Object.values(allTransactions)
         // Only show orders for connected account
-        .filter((tx) => tx.from.toLowerCase() === accountLowerCase)
-        // Only recent transactions
-        .filter(isTransactionRecent)
-        .filter(isNotEthFlowTx)
+        .filter((tx) => {
+          return (
+            tx.from.toLowerCase() === accountLowerCase &&
+            isTransactionRecent(tx) &&
+            isNotEthFlowTx(tx) &&
+            isNotOnChainCancellationTx(tx)
+          )
+        })
         .map((tx) => ({
           ...tx,
           // we need to adjust Transaction object and add "id" + "status" to match Orders type
@@ -297,6 +301,10 @@ export function useRecentActivityLastPendingOrder() {
   }, [JSON.stringify(pending)])
 }
 
-export function isNotEthFlowTx(tx: EnhancedTransactionDetails): boolean {
+function isNotEthFlowTx(tx: EnhancedTransactionDetails): boolean {
   return !tx.ethFlow
+}
+
+function isNotOnChainCancellationTx(tx: EnhancedTransactionDetails): boolean {
+  return !tx.onChainCancellation
 }

--- a/src/custom/state/enhancedTransactions/actions.ts
+++ b/src/custom/state/enhancedTransactions/actions.ts
@@ -31,6 +31,7 @@ export type AddTransactionParams = WithChainId &
     | 'swapVCow'
     | 'swapLockedGNOvCow'
     | 'ethFlow'
+    | 'onChainCancellation'
   >
 
 export const addTransaction = createAction<AddTransactionParams>('enhancedTransactions/addTransaction')

--- a/src/custom/state/enhancedTransactions/reducer.ts
+++ b/src/custom/state/enhancedTransactions/reducer.ts
@@ -40,7 +40,7 @@ export interface EnhancedTransactionDetails {
   swapVCow?: boolean
   swapLockedGNOvCow?: boolean
   ethFlow?: { orderId: string; subType: 'creation' | 'cancellation' | 'refund' }
-  onChainCancellation?: { orderId: string }
+  onChainCancellation?: { orderId: string; sellTokenSymbol: string }
   // Wallet specific
   safeTransaction?: SafeMultisigTransactionResponse // Gnosis Safe transaction info
 

--- a/src/custom/state/enhancedTransactions/reducer.ts
+++ b/src/custom/state/enhancedTransactions/reducer.ts
@@ -40,7 +40,7 @@ export interface EnhancedTransactionDetails {
   swapVCow?: boolean
   swapLockedGNOvCow?: boolean
   ethFlow?: { orderId: string; subType: 'creation' | 'cancellation' | 'refund' }
-
+  onChainCancellation?: { orderId: string }
   // Wallet specific
   safeTransaction?: SafeMultisigTransactionResponse // Gnosis Safe transaction info
 
@@ -90,6 +90,7 @@ export default createReducer(initialState, (builder) =>
             swapVCow,
             swapLockedGNOvCow,
             ethFlow,
+            onChainCancellation,
           },
         }
       ) => {
@@ -116,6 +117,7 @@ export default createReducer(initialState, (builder) =>
           swapVCow,
           swapLockedGNOvCow,
           ethFlow,
+          onChainCancellation,
         }
         transactions[chainId] = txs
       }

--- a/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
+++ b/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
@@ -89,20 +89,26 @@ function finalizeEthereumTransaction(
     })
   )
 
-  if (!transaction.ethFlow) {
-    addPopup(
-      {
-        txn: {
-          hash: receipt.transactionHash,
-          success: receipt.status === 1 && transaction.replacementType !== 'cancel',
-          summary: transaction.summary,
-        },
-      },
-      hash
-    )
-  } else {
+  if (transaction.ethFlow) {
     finalizeEthFlowTx(transaction.ethFlow, receipt, params, hash)
+    return
   }
+
+  if (transaction.onChainCancellation) {
+    finalizeOnChainCancellation(receipt, params, hash, transaction.onChainCancellation.orderId)
+    return
+  }
+
+  addPopup(
+    {
+      txn: {
+        hash: receipt.transactionHash,
+        success: receipt.status === 1 && transaction.replacementType !== 'cancel',
+        summary: transaction.summary,
+      },
+    },
+    hash
+  )
 }
 
 function finalizeEthFlowTx(
@@ -137,25 +143,36 @@ function finalizeEthFlowTx(
   }
 
   if (subType === 'cancellation') {
-    if (receipt.status === 1) {
-      // If cancellation succeeded, mark order as cancelled
-      dispatch(cancelOrdersBatch({ chainId, ids: [orderId] }))
-    } else {
-      // If cancellation failed:
-      // 1. Update order state and remove the isCancelling flag and cancellationHash
-      dispatch(updateOrder({ chainId, order: { id: orderId, isCancelling: false, cancellationHash: undefined } }))
-      // 2. Show failure tx pop-up
-      addPopup(
-        {
-          txn: {
-            hash,
-            success: false,
-            summary: `Failed to cancel order selling ${nativeCurrencySymbol}`,
-          },
+    finalizeOnChainCancellation(receipt, params, hash, orderId)
+  }
+}
+
+function finalizeOnChainCancellation(
+  receipt: TransactionReceipt,
+  params: CheckEthereumTransactions,
+  hash: string,
+  orderId: string
+) {
+  const { chainId, dispatch, addPopup, nativeCurrencySymbol } = params
+
+  if (receipt.status === 1) {
+    // If cancellation succeeded, mark order as cancelled
+    dispatch(cancelOrdersBatch({ chainId, ids: [orderId] }))
+  } else {
+    // If cancellation failed:
+    // 1. Update order state and remove the isCancelling flag and cancellationHash
+    dispatch(updateOrder({ chainId, order: { id: orderId, isCancelling: false, cancellationHash: undefined } }))
+    // 2. Show failure tx pop-up
+    addPopup(
+      {
+        txn: {
+          hash,
+          success: false,
+          summary: `Failed to cancel order selling ${nativeCurrencySymbol}`,
         },
-        hash
-      )
-    }
+      },
+      hash
+    )
   }
 }
 

--- a/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
+++ b/src/custom/state/enhancedTransactions/updater/FinalizeTxUpdater.tsx
@@ -95,7 +95,9 @@ function finalizeEthereumTransaction(
   }
 
   if (transaction.onChainCancellation) {
-    finalizeOnChainCancellation(receipt, params, hash, transaction.onChainCancellation.orderId)
+    const { orderId, sellTokenSymbol } = transaction.onChainCancellation
+
+    finalizeOnChainCancellation(receipt, params, hash, orderId, sellTokenSymbol)
     return
   }
 
@@ -143,7 +145,7 @@ function finalizeEthFlowTx(
   }
 
   if (subType === 'cancellation') {
-    finalizeOnChainCancellation(receipt, params, hash, orderId)
+    finalizeOnChainCancellation(receipt, params, hash, orderId, nativeCurrencySymbol)
   }
 }
 
@@ -151,9 +153,10 @@ function finalizeOnChainCancellation(
   receipt: TransactionReceipt,
   params: CheckEthereumTransactions,
   hash: string,
-  orderId: string
+  orderId: string,
+  sellTokenSymbol: string
 ) {
-  const { chainId, dispatch, addPopup, nativeCurrencySymbol } = params
+  const { chainId, dispatch, addPopup } = params
 
   if (receipt.status === 1) {
     // If cancellation succeeded, mark order as cancelled
@@ -168,7 +171,7 @@ function finalizeOnChainCancellation(
         txn: {
           hash,
           success: false,
-          summary: `Failed to cancel order selling ${nativeCurrencySymbol}`,
+          summary: `Failed to cancel order selling ${sellTokenSymbol}`,
         },
       },
       hash


### PR DESCRIPTION
# Summary

Fixes #2325

Following the example of `eth-flow` cancellation added conditions for on-chain cancellation transactions.
