### PR TITLE
2246/unfillable only after load

### DIFF
--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -152,7 +152,8 @@ export function OrderRow({
   const priceDiffs = usePricesDifference(prices, spotPrice, isInverted)
   const feeDifference = useFeeAmountDifference(rateInfoParams, prices)
 
-  const isUnfillable = executedPriceInverted?.equalTo(ZERO_FRACTION) || withWarning
+  const isUnfillable =
+    (executedPriceInverted !== undefined && executedPriceInverted?.equalTo(ZERO_FRACTION)) || withWarning
   const isOrderCreating = CREATING_STATES.includes(order.status)
 
   return (

--- a/src/cow-react/modules/limitOrders/pure/Orders/utils/getOrderParams.ts
+++ b/src/cow-react/modules/limitOrders/pure/Orders/utils/getOrderParams.ts
@@ -37,8 +37,9 @@ export function getOrderParams(
   let hasEnoughBalance, hasEnoughAllowance
 
   if (order.partiallyFillable) {
-    hasEnoughBalance = !!balance?.greaterThan(ZERO_FRACTION)
-    hasEnoughAllowance = !!allowance?.greaterThan(ZERO_FRACTION)
+    // When balance or allowance are undefined (loading state), show as true
+    hasEnoughBalance = balance === undefined || balance.greaterThan(ZERO_FRACTION)
+    hasEnoughAllowance = allowance === undefined || allowance.greaterThan(ZERO_FRACTION)
   } else {
     hasEnoughBalance = isEnoughAmount(sellAmount, balance)
     hasEnoughAllowance = isEnoughAmount(sellAmount, allowance)


### PR DESCRIPTION
# Summary

Closes #2246

# To Test

1. Load the app
* Should show unfillable status only after balances, allowances and prices are loaded