### PR TITLE
Only show executes at tooltip if there's a value

### DIFF
--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
@@ -41,7 +41,8 @@ export const EstimatedExecutionPriceWrapper = styled.span<{ hasWarning: boolean;
   }
 
   // Popover container override
-  > div > div {
+  > div > div,
+  > span {
     display: flex;
     align-items: center;
   }
@@ -101,45 +102,45 @@ export function EstimatedExecutionPrice(props: EstimatedExecutionPriceProps) {
   const isNegativeDifference = percentageDifferenceInverted?.lessThan(ZERO_FRACTION)
   const marketPriceNeedsToGoDown = isInverted ? !isNegativeDifference : isNegativeDifference
 
+  const content = (
+    <>
+      <styledEl.ExecuteIndicator status={orderExecutionStatus} />
+      <TokenAmount amount={amount} {...rest} />
+    </>
+  )
+
   return (
     <EstimatedExecutionPriceWrapper hasWarning={!!feeWarning} showPointerCursor={!isUnfillable}>
       {isUnfillable ? (
         <UnfillableLabel>UNFILLABLE</UnfillableLabel>
+      ) : !absoluteDifferenceAmount ? (
+        <span>{content}</span>
       ) : (
-        absoluteDifferenceAmount && (
-          <MouseoverTooltipContent
-            wrap={true}
-            content={
-              <styledEl.ExecuteInformationTooltip>
-                {!isNegativeDifference ? (
-                  <>
-                    Market price needs to go {marketPriceNeedsToGoDown ? 'down 📉' : 'up 📈'} by&nbsp;
-                    <b>
-                      <TokenAmount {...rest} amount={absoluteDifferenceAmount} round={false} />
-                    </b>
-                    &nbsp;
-                    <span>
-                      (<i>{percentageDifferenceInverted?.toFixed(2)}%</i>)
-                    </span>
-                    &nbsp;to execute your order.
-                  </>
-                ) : (
-                  <>Will execute soon!</>
-                )}
-              </styledEl.ExecuteInformationTooltip>
-            }
-            placement="top"
-          >
-            {isUnfillable ? (
-              <UnfillableLabel>UNFILLABLE</UnfillableLabel>
-            ) : (
-              <>
-                <styledEl.ExecuteIndicator status={orderExecutionStatus} />
-                <TokenAmount amount={amount} {...rest} />
-              </>
-            )}
-          </MouseoverTooltipContent>
-        )
+        <MouseoverTooltipContent
+          wrap={true}
+          content={
+            <styledEl.ExecuteInformationTooltip>
+              {!isNegativeDifference ? (
+                <>
+                  Market price needs to go {marketPriceNeedsToGoDown ? 'down 📉' : 'up 📈'} by&nbsp;
+                  <b>
+                    <TokenAmount {...rest} amount={absoluteDifferenceAmount} round={false} />
+                  </b>
+                  &nbsp;
+                  <span>
+                    (<i>{percentageDifferenceInverted?.toFixed(2)}%</i>)
+                  </span>
+                  &nbsp;to execute your order.
+                </>
+              ) : (
+                <>Will execute soon!</>
+              )}
+            </styledEl.ExecuteInformationTooltip>
+          }
+          placement="top"
+        >
+          {content}
+        </MouseoverTooltipContent>
       )}
       {feeWarning && !isNegativeDifference && (
         <UnlikelyToExecuteWarning feePercentage={percentageFee} feeAmount={amountFee} />

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice.tsx
@@ -106,38 +106,40 @@ export function EstimatedExecutionPrice(props: EstimatedExecutionPriceProps) {
       {isUnfillable ? (
         <UnfillableLabel>UNFILLABLE</UnfillableLabel>
       ) : (
-        <MouseoverTooltipContent
-          wrap={true}
-          content={
-            <styledEl.ExecuteInformationTooltip>
-              {!isNegativeDifference ? (
-                <>
-                  Market price needs to go {marketPriceNeedsToGoDown ? 'down 📉' : 'up 📈'} by&nbsp;
-                  <b>
-                    <TokenAmount {...rest} amount={absoluteDifferenceAmount} round={false} />
-                  </b>
-                  &nbsp;
-                  <span>
-                    (<i>{percentageDifferenceInverted?.toFixed(2)}%</i>)
-                  </span>
-                  &nbsp;to execute your order.
-                </>
-              ) : (
-                <>Will execute soon!</>
-              )}
-            </styledEl.ExecuteInformationTooltip>
-          }
-          placement="top"
-        >
-          {isUnfillable ? (
-            <UnfillableLabel>UNFILLABLE</UnfillableLabel>
-          ) : (
-            <>
-              <styledEl.ExecuteIndicator status={orderExecutionStatus} />
-              <TokenAmount amount={amount} {...rest} />
-            </>
-          )}
-        </MouseoverTooltipContent>
+        absoluteDifferenceAmount && (
+          <MouseoverTooltipContent
+            wrap={true}
+            content={
+              <styledEl.ExecuteInformationTooltip>
+                {!isNegativeDifference ? (
+                  <>
+                    Market price needs to go {marketPriceNeedsToGoDown ? 'down 📉' : 'up 📈'} by&nbsp;
+                    <b>
+                      <TokenAmount {...rest} amount={absoluteDifferenceAmount} round={false} />
+                    </b>
+                    &nbsp;
+                    <span>
+                      (<i>{percentageDifferenceInverted?.toFixed(2)}%</i>)
+                    </span>
+                    &nbsp;to execute your order.
+                  </>
+                ) : (
+                  <>Will execute soon!</>
+                )}
+              </styledEl.ExecuteInformationTooltip>
+            }
+            placement="top"
+          >
+            {isUnfillable ? (
+              <UnfillableLabel>UNFILLABLE</UnfillableLabel>
+            ) : (
+              <>
+                <styledEl.ExecuteIndicator status={orderExecutionStatus} />
+                <TokenAmount amount={amount} {...rest} />
+              </>
+            )}
+          </MouseoverTooltipContent>
+        )
       )}
       {feeWarning && !isNegativeDifference && (
         <UnlikelyToExecuteWarning feePercentage={percentageFee} feeAmount={amountFee} />


### PR DESCRIPTION
# Summary

Closes #2291 


https://user-images.githubusercontent.com/43217/233088316-0725a627-ac12-4f55-8604-5e39f84d8725.mov



  # To Test

1. Block `native_price` requests in the network tab
* Should not show a tooltip in that case