### PR TITLE
Check at least 0.05% balance/allowance for warning

### DIFF
--- a/src/cow-react/modules/limitOrders/pure/Orders/utils/getOrderParams.test.ts
+++ b/src/cow-react/modules/limitOrders/pure/Orders/utils/getOrderParams.test.ts
@@ -1,0 +1,132 @@
+import { getOrderParams } from './getOrderParams'
+import { ordersMock } from '../orders.mock'
+import { CurrencyAmount } from '@uniswap/sdk-core'
+import { BalancesAndAllowances } from '../../../../tokens'
+
+describe('getOrderParams', () => {
+  const BASE_ORDER = ordersMock[0]
+  const BASE_BALANCES_AND_ALLOWANCES: BalancesAndAllowances = {
+    balances: {
+      [BASE_ORDER.inputToken.address]: {
+        value: CurrencyAmount.fromRawAmount(BASE_ORDER.inputToken, BASE_ORDER.sellAmount),
+        loading: false,
+        syncing: false,
+        valid: true,
+        error: false,
+      },
+    },
+    allowances: {
+      [BASE_ORDER.inputToken.address]: {
+        value: CurrencyAmount.fromRawAmount(BASE_ORDER.inputToken, BASE_ORDER.sellAmount),
+        loading: false,
+        syncing: false,
+        valid: true,
+        error: false,
+      },
+    },
+    isLoading: false,
+  }
+
+  describe('fill or kill', () => {
+    const FILL_OR_KILL_ORDER = {
+      ...BASE_ORDER,
+      partiallyFillable: false,
+    }
+    it('should have hasEnoughBalance true when order is fill or kill and balance is sufficient', () => {
+      const order = { ...FILL_OR_KILL_ORDER }
+      const balancesAndAllowances: BalancesAndAllowances = { ...BASE_BALANCES_AND_ALLOWANCES }
+      const result = getOrderParams(1, balancesAndAllowances, order)
+      expect(result.hasEnoughBalance).toEqual(true)
+    })
+
+    it('should have hasEnoughBalance false when order is fill or kill and balance is insufficient', () => {
+      const order = {
+        ...FILL_OR_KILL_ORDER,
+        sellAmount: String(+FILL_OR_KILL_ORDER.sellAmount + 1),
+      }
+      const balancesAndAllowances: BalancesAndAllowances = { ...BASE_BALANCES_AND_ALLOWANCES }
+      const result = getOrderParams(1, balancesAndAllowances, order)
+      expect(result.hasEnoughBalance).toEqual(false)
+    })
+
+    it('should have hasEnoughAllowance true when order is fill or kill and allowance is sufficient', () => {
+      const order = { ...FILL_OR_KILL_ORDER }
+      const balancesAndAllowances: BalancesAndAllowances = { ...BASE_BALANCES_AND_ALLOWANCES }
+      const result = getOrderParams(1, balancesAndAllowances, order)
+      expect(result.hasEnoughAllowance).toEqual(true)
+    })
+    it('should have hasEnoughAllowance false when order is fill or kill and allowance is insufficient', () => {
+      const order = {
+        ...FILL_OR_KILL_ORDER,
+        sellAmount: String(+FILL_OR_KILL_ORDER.sellAmount + 1),
+      }
+      const balancesAndAllowances: BalancesAndAllowances = { ...BASE_BALANCES_AND_ALLOWANCES }
+      const result = getOrderParams(1, balancesAndAllowances, order)
+      expect(result.hasEnoughAllowance).toEqual(false)
+    })
+  })
+
+  describe('partially fillable', () => {
+    const PARTIALLY_FILLABLE_ORDER = {
+      ...BASE_ORDER,
+      partiallyFillable: true,
+    }
+    it('should have hasEnoughBalance true when order is partially fillable and balance is > 0.05%', () => {
+      const order = { ...PARTIALLY_FILLABLE_ORDER }
+      const balancesAndAllowances: BalancesAndAllowances = {
+        ...BASE_BALANCES_AND_ALLOWANCES,
+        balances: {
+          [order.inputToken.address]: {
+            ...BASE_BALANCES_AND_ALLOWANCES.balances[order.inputToken.address],
+            value: CurrencyAmount.fromRawAmount(order.inputToken, String(+order.sellAmount * 0.00051)),
+          },
+        },
+      }
+      const result = getOrderParams(1, balancesAndAllowances, order)
+      expect(result.hasEnoughBalance).toEqual(true)
+    })
+    it('should have hasEnoughBalance false when order is partially fillable and balance is < 0.05%', () => {
+      const order = { ...PARTIALLY_FILLABLE_ORDER }
+      const balancesAndAllowances: BalancesAndAllowances = {
+        ...BASE_BALANCES_AND_ALLOWANCES,
+        balances: {
+          [order.inputToken.address]: {
+            ...BASE_BALANCES_AND_ALLOWANCES.balances[order.inputToken.address],
+            value: CurrencyAmount.fromRawAmount(order.inputToken, String(+order.sellAmount * 0.00049)),
+          },
+        },
+      }
+      const result = getOrderParams(1, balancesAndAllowances, order)
+      expect(result.hasEnoughBalance).toEqual(false)
+    })
+
+    it('should have hasEnoughAllowance true when order is partially fillable and allowance is > 0.05%', () => {
+      const order = { ...PARTIALLY_FILLABLE_ORDER }
+      const balancesAndAllowances: BalancesAndAllowances = {
+        ...BASE_BALANCES_AND_ALLOWANCES,
+        allowances: {
+          [order.inputToken.address]: {
+            ...BASE_BALANCES_AND_ALLOWANCES.allowances[order.inputToken.address],
+            value: CurrencyAmount.fromRawAmount(order.inputToken, String(+order.sellAmount * 0.00051)),
+          },
+        },
+      }
+      const result = getOrderParams(1, balancesAndAllowances, order)
+      expect(result.hasEnoughAllowance).toEqual(true)
+    })
+    it('should have hasEnoughAllowance false when order is partially fillable and allowance is < 0.05%', () => {
+      const order = { ...PARTIALLY_FILLABLE_ORDER }
+      const balancesAndAllowances: BalancesAndAllowances = {
+        ...BASE_BALANCES_AND_ALLOWANCES,
+        allowances: {
+          [order.inputToken.address]: {
+            ...BASE_BALANCES_AND_ALLOWANCES.allowances[order.inputToken.address],
+            value: CurrencyAmount.fromRawAmount(order.inputToken, String(+order.sellAmount * 0.00049)),
+          },
+        },
+      }
+      const result = getOrderParams(1, balancesAndAllowances, order)
+      expect(result.hasEnoughAllowance).toEqual(false)
+    })
+  })
+})

--- a/src/cow-react/modules/limitOrders/pure/Orders/utils/getOrderParams.ts
+++ b/src/cow-react/modules/limitOrders/pure/Orders/utils/getOrderParams.ts
@@ -13,7 +13,7 @@ export interface OrderParams {
   hasEnoughAllowance: boolean
 }
 
-const PERCENTAGE_FOR_PARTIAL_FILLS = new Percent(5, 1000) // 0.05%
+const PERCENTAGE_FOR_PARTIAL_FILLS = new Percent(5, 10000) // 0.05%
 
 export function getOrderParams(
   chainId: SupportedChainId | undefined,

--- a/src/cow-react/modules/limitOrders/pure/Orders/utils/getOrderParams.ts
+++ b/src/cow-react/modules/limitOrders/pure/Orders/utils/getOrderParams.ts
@@ -1,9 +1,8 @@
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { BalancesAndAllowances } from '@cow/modules/tokens'
 import { Order } from 'state/orders/actions'
-import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
 import { RateInfoParams } from '@cow/common/pure/RateInfo'
-import { ZERO_FRACTION } from 'constants/index'
 
 export interface OrderParams {
   chainId: SupportedChainId | undefined
@@ -13,6 +12,8 @@ export interface OrderParams {
   hasEnoughBalance: boolean
   hasEnoughAllowance: boolean
 }
+
+const PERCENTAGE_FOR_PARTIAL_FILLS = new Percent(5, 1000) // 0.05%
 
 export function getOrderParams(
   chainId: SupportedChainId | undefined,
@@ -38,8 +39,10 @@ export function getOrderParams(
 
   if (order.partiallyFillable) {
     // When balance or allowance are undefined (loading state), show as true
-    hasEnoughBalance = balance === undefined || balance.greaterThan(ZERO_FRACTION)
-    hasEnoughAllowance = allowance === undefined || allowance.greaterThan(ZERO_FRACTION)
+    // When loaded, check there's at least PERCENTAGE_FOR_PARTIAL_FILLS of balance/allowance to consider it as enough
+    const amount = sellAmount.multiply(PERCENTAGE_FOR_PARTIAL_FILLS)
+    hasEnoughBalance = balance === undefined || isEnoughAmount(amount, balance)
+    hasEnoughAllowance = allowance === undefined || isEnoughAmount(amount, allowance)
   } else {
     hasEnoughBalance = isEnoughAmount(sellAmount, balance)
     hasEnoughAllowance = isEnoughAmount(sellAmount, allowance)


### PR DESCRIPTION
# Summary

## Update 2023/04/19

I use 5% in the original example.
Also, in the implementation I was using 0.5% instead of 0.05%

Now with the correct values:
![image](https://user-images.githubusercontent.com/43217/233096525-2c5fe575-83a2-4cb1-afdf-ebfade3bf013.png)


## Original

Closes #2268 

Check there's at least 0.05% of balance/allowance to consider partial fill order with enough balance/allowance

BAT balance is 1, order unfillable
![Screenshot 2023-04-18 at 17 18 22](https://user-images.githubusercontent.com/43217/232842212-2e0b6074-1920-407d-88f6-20e9053cc5d1.png)

BAT balance is 731 (> 0.05% of sell amount), warning not displayed
![Screenshot 2023-04-18 at 17 22 45](https://user-images.githubusercontent.com/43217/232842236-f963e151-6dc2-4480-aa9a-a4acee00ab4a.png)

# To Test

1. Place order
2. Remove sell balance
* Warning displayed
3. Add at least 0.05% of sell amount
* Warning not displayed
4. Repeat steps with allowance