### PR TITLE
Fix eslint warnings

### DIFF
--- a/src/cow-react/modules/wallet/api/pure/ZengoBanner/index.tsx
+++ b/src/cow-react/modules/wallet/api/pure/ZengoBanner/index.tsx
@@ -10,7 +10,7 @@ export function ZengoBanner() {
   return (
     <styled.Wrapper>
       <styled.Icon>
-        <img src={ZengoImage} alt="ZenGo Image" />
+        <img src={ZengoImage} alt="" />
       </styled.Icon>
 
       <styled.Content>

--- a/src/state/application/updater.ts
+++ b/src/state/application/updater.ts
@@ -55,7 +55,7 @@ export default function Updater(): null {
     if (prevAccount && !account) {
       dispatch(updateSelectedWallet({ wallet: undefined }))
     }
-  }, [account, prevAccount])
+  }, [account, dispatch, prevAccount])
 
   return null
 }


### PR DESCRIPTION
# Summary

Small changes fixing eslint warnings:

```
WARNING in [eslint] 
src/cow-react/modules/wallet/api/pure/ZengoBanner/index.tsx
  Line 13:9:  img elements must have an alt prop, either with meaningful text, or an empty string for decorative images  jsx-a11y/alt-text

src/state/application/updater.ts
  Line 58:6:  React Hook useEffect has a missing dependency: 'dispatch'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
```

