### PR TITLE
Surplus/usd value

### DIFF
--- a/src/cow-react/common/pure/ExecutedSummary/index.tsx
+++ b/src/cow-react/common/pure/ExecutedSummary/index.tsx
@@ -1,16 +1,15 @@
 import { getExecutedSummaryData } from '@cow/utils/getExecutedSummaryData'
 import { Order } from '@src/custom/state/orders/actions'
-import { useHigherUSDValue } from '@src/custom/hooks/useStablecoinPrice'
+import { useCoingeckoUsdValue } from '@src/custom/hooks/useStablecoinPrice'
 import * as styledEl from './styled'
-
-const MIN_FIAT_VALUE = 0.01
+import { MIN_FIAT_SURPLUS_VALUE } from '@src/custom/constants'
 
 export function ExecutedSummary({ order }: { order: Order }) {
   const { formattedFilledAmount, formattedSwappedAmount, surplusAmount, surplusToken } = getExecutedSummaryData(order)
 
-  const fiatValue = useHigherUSDValue(surplusAmount)
+  const fiatValue = useCoingeckoUsdValue(surplusAmount)
   // I think its fine here to use Number because its always USD value
-  const showFiatValue = Number(fiatValue?.toExact()) > MIN_FIAT_VALUE
+  const showFiatValue = Number(fiatValue?.toExact()) > MIN_FIAT_SURPLUS_VALUE
 
   return (
     <styledEl.SummaryWrapper>

--- a/src/cow-react/common/pure/ExecutedSummary/index.tsx
+++ b/src/cow-react/common/pure/ExecutedSummary/index.tsx
@@ -1,52 +1,36 @@
-import styled from 'styled-components/macro'
-
-import { TokenAmount } from '@cow/common/pure/TokenAmount'
 import { getExecutedSummaryData } from '@cow/utils/getExecutedSummaryData'
 import { Order } from '@src/custom/state/orders/actions'
+import { useHigherUSDValue } from '@src/custom/hooks/useStablecoinPrice'
+import * as styledEl from './styled'
 
-const SummaryWrapper = styled.div`
-  font-size: 1rem;
+const MIN_FIAT_VALUE = 0.01
 
-  > div {
-    margin-bottom: 1rem;
-
-    &:last-child {
-      margin-bottom: 0.6rem;
-    }
-  }
-`
-
-const Strong = styled.strong`
-  font-size: 0.9rem;
-  white-space: nowrap;
-`
-
-export function getExecutedSummary(order: Order): JSX.Element | string | null {
-  if (!order) return null
-
+export function ExecutedSummary({ order }: { order: Order }) {
   const { formattedFilledAmount, formattedSwappedAmount, surplusAmount, surplusToken } = getExecutedSummaryData(order)
 
+  const fiatValue = useHigherUSDValue(surplusAmount)
+  // I think its fine here to use Number because its always USD value
+  const showFiatValue = Number(fiatValue?.toExact()) > MIN_FIAT_VALUE
+
   return (
-    <SummaryWrapper>
+    <styledEl.SummaryWrapper>
       <div>
         Traded{' '}
-        <Strong>
-          <TokenAmount amount={formattedFilledAmount} tokenSymbol={formattedFilledAmount.currency} />
-        </Strong>{' '}
-        for a total of{' '}
-        <Strong>
-          <TokenAmount amount={formattedSwappedAmount} tokenSymbol={formattedSwappedAmount.currency} />
-        </Strong>
+        <styledEl.StyledTokenAmount amount={formattedFilledAmount} tokenSymbol={formattedFilledAmount.currency} /> for a
+        total of{' '}
+        <styledEl.StyledTokenAmount amount={formattedSwappedAmount} tokenSymbol={formattedSwappedAmount.currency} />
       </div>
 
       {!!surplusAmount && (
         <div>
           <span>Order surplus: </span>
-          <Strong>
-            <TokenAmount amount={surplusAmount} tokenSymbol={surplusToken} />
-          </Strong>
+
+          <styledEl.SurplusAmount>
+            <styledEl.StyledTokenAmount amount={surplusAmount} tokenSymbol={surplusToken} />
+            {showFiatValue && <styledEl.StyledFiatAmount amount={fiatValue} />}
+          </styledEl.SurplusAmount>
         </div>
       )}
-    </SummaryWrapper>
+    </styledEl.SummaryWrapper>
   )
 }

--- a/src/cow-react/common/pure/ExecutedSummary/index.tsx
+++ b/src/cow-react/common/pure/ExecutedSummary/index.tsx
@@ -21,14 +21,18 @@ export function ExecutedSummary({ order }: { order: Order }) {
       </div>
 
       {!!surplusAmount && (
-        <div>
+        <styledEl.SurplusWrapper>
           <span>Order surplus: </span>
 
           <styledEl.SurplusAmount>
             <styledEl.StyledTokenAmount amount={surplusAmount} tokenSymbol={surplusToken} />
-            {showFiatValue && <styledEl.StyledFiatAmount amount={fiatValue} />}
+            {showFiatValue && (
+              <styledEl.FiatWrapper>
+                (<styledEl.StyledFiatAmount amount={fiatValue} />)
+              </styledEl.FiatWrapper>
+            )}
           </styledEl.SurplusAmount>
-        </div>
+        </styledEl.SurplusWrapper>
       )}
     </styledEl.SummaryWrapper>
   )

--- a/src/cow-react/common/pure/ExecutedSummary/styled.ts
+++ b/src/cow-react/common/pure/ExecutedSummary/styled.ts
@@ -23,6 +23,7 @@ export const StyledTokenAmount = styled(TokenAmount)`
 
 export const StyledFiatAmount = styled(FiatAmount)`
   font-weight: 600;
+  font-size: 0.9rem;
   margin: 0;
 `
 

--- a/src/cow-react/common/pure/ExecutedSummary/styled.ts
+++ b/src/cow-react/common/pure/ExecutedSummary/styled.ts
@@ -1,0 +1,31 @@
+import styled from 'styled-components/macro'
+
+import { TokenAmount } from '@cow/common/pure/TokenAmount'
+import { FiatAmount } from '../FiatAmount'
+
+export const SummaryWrapper = styled.div`
+  font-size: 1rem;
+
+  > div {
+    margin-bottom: 1rem;
+
+    &:last-child {
+      margin-bottom: 0.6rem;
+    }
+  }
+`
+
+export const StyledTokenAmount = styled(TokenAmount)`
+  font-size: 0.9rem;
+  white-space: nowrap;
+  font-weight: 600;
+`
+
+export const StyledFiatAmount = styled(FiatAmount)`
+  font-size: 12px;
+  margin-left: 5px;
+`
+
+export const SurplusAmount = styled.div`
+  white-space: nowrap;
+`

--- a/src/cow-react/common/pure/ExecutedSummary/styled.ts
+++ b/src/cow-react/common/pure/ExecutedSummary/styled.ts
@@ -22,10 +22,25 @@ export const StyledTokenAmount = styled(TokenAmount)`
 `
 
 export const StyledFiatAmount = styled(FiatAmount)`
+  font-weight: 600;
   font-size: 12px;
-  margin-left: 5px;
+  margin: 0;
 `
 
 export const SurplusAmount = styled.div`
   white-space: nowrap;
+`
+
+export const FiatWrapper = styled.span`
+  margin-left: 5px;
+`
+
+export const SurplusWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+
+  > span:first-child {
+    margin-right: 5px;
+  }
 `

--- a/src/cow-react/common/pure/ExecutedSummary/styled.ts
+++ b/src/cow-react/common/pure/ExecutedSummary/styled.ts
@@ -23,7 +23,6 @@ export const StyledTokenAmount = styled(TokenAmount)`
 
 export const StyledFiatAmount = styled(FiatAmount)`
   font-weight: 600;
-  font-size: 12px;
   margin: 0;
 `
 

--- a/src/custom/components/OrderProgressBar/index.tsx
+++ b/src/custom/components/OrderProgressBar/index.tsx
@@ -32,15 +32,8 @@ import { getExplorerOrderLink } from 'utils/explorer'
 import { useIsSmartContractWallet } from '@cow/common/hooks/useIsSmartContractWallet'
 import { useCancelOrder } from '@cow/common/hooks/useCancelOrder'
 import { CancelButton } from '@cow/common/pure/CancelButton'
-import { getExecutedSummaryData } from '@cow/utils/getExecutedSummaryData'
-import { Order } from 'state/orders/actions'
-import styled from 'styled-components/macro'
-import { DisplayLink } from '../TransactionConfirmationModal'
-import { TokenAmount } from '@cow/common/pure/TokenAmount'
 import ms from 'ms.macro'
-import { useCoingeckoUsdValue } from '@src/custom/hooks/useStablecoinPrice'
-import { MIN_FIAT_SURPLUS_VALUE } from '@src/custom/constants'
-import { FiatAmount } from '@cow/common/pure/FiatAmount'
+import { TransactionExecutedContent } from '../TransactionExecutedContent'
 
 const REFRESH_INTERVAL_MS = ms`0.2s`
 const COW_STATE_SECONDS = ms`0.03s`
@@ -365,85 +358,4 @@ function useGetProgressBarInfo({
     expirationInSeconds: (validTo.getTime() - creationTime.getTime()) / 1000,
     isPending: orderIsPending,
   }
-}
-
-// TODO: Make a dumb component and Cosmos preview for different
-const ExecutedWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  padding-bottom: 1rem;
-
-  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
-    font-size: 0.8rem;
-  `};
-
-  img {
-    padding: 1rem;
-    margin-right: 10px;
-
-    ${({ theme }) => theme.mediaWidth.upToExtraSmall`
-      padding: 0;
-      max-width: 60px;
-    `};
-  }
-
-  a {
-    margin: 0;
-    margin-top: 15px;
-    display: block;
-  }
-
-  > div > div {
-    margin-bottom: 5px;
-  }
-`
-
-const StyledTokenAmount = styled(TokenAmount)`
-  font-size: 0.9rem;
-  white-space: nowrap;
-  font-weight: 600;
-`
-
-const StyledFiatAmount = styled(FiatAmount)`
-  margin-left: 5px;
-  font-size: 12px;
-  font-weight: 600;
-`
-
-function TransactionExecutedContent({
-  order,
-  chainId,
-  hash,
-}: {
-  order: Order
-  chainId: SupportedChainId
-  hash?: string
-}) {
-  const { formattedFilledAmount, formattedSwappedAmount, surplusAmount, surplusToken } = getExecutedSummaryData(order)
-
-  const fiatValue = useCoingeckoUsdValue(surplusAmount)
-  // I think its fine here to use Number because its always USD value
-  const showFiatValue = Number(fiatValue?.toExact()) > MIN_FIAT_SURPLUS_VALUE
-
-  return (
-    <ExecutedWrapper>
-      <img src={cowMeditatingSmooth} alt="Cow Smoooth ..." />
-
-      <div>
-        <div>
-          Traded <StyledTokenAmount amount={formattedFilledAmount} tokenSymbol={formattedFilledAmount.currency} /> for a
-          total of <StyledTokenAmount amount={formattedSwappedAmount} tokenSymbol={formattedSwappedAmount.currency} />
-        </div>
-
-        {!!surplusAmount && (
-          <div>
-            You received a surplus of <StyledTokenAmount amount={surplusAmount} tokenSymbol={surplusToken} />{' '}
-            {showFiatValue && <StyledFiatAmount amount={fiatValue} />} on this trade!
-          </div>
-        )}
-
-        <DisplayLink id={hash} chainId={chainId} />
-      </div>
-    </ExecutedWrapper>
-  )
 }

--- a/src/custom/components/TransactionExecutedContent/index.tsx
+++ b/src/custom/components/TransactionExecutedContent/index.tsx
@@ -1,0 +1,48 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import cowMeditatingSmooth from 'assets/images/cow-meditating-smoooth.svg'
+import { getExecutedSummaryData } from '@cow/utils/getExecutedSummaryData'
+import { Order } from 'state/orders/actions'
+import { DisplayLink } from '../TransactionConfirmationModal'
+import { useCoingeckoUsdValue } from '@src/custom/hooks/useStablecoinPrice'
+import { MIN_FIAT_SURPLUS_VALUE } from '@src/custom/constants'
+import * as styledEl from './styled'
+
+export function TransactionExecutedContent({
+  order,
+  chainId,
+  hash,
+}: {
+  order: Order
+  chainId: SupportedChainId
+  hash?: string
+}) {
+  const { formattedFilledAmount, formattedSwappedAmount, surplusAmount, surplusToken } = getExecutedSummaryData(order)
+
+  const fiatValue = useCoingeckoUsdValue(surplusAmount)
+  // I think its fine here to use Number because its always USD value
+  const showFiatValue = Number(fiatValue?.toExact()) > MIN_FIAT_SURPLUS_VALUE
+
+  return (
+    <styledEl.ExecutedWrapper>
+      <img src={cowMeditatingSmooth} alt="Cow Smoooth ..." />
+
+      <div>
+        <div>
+          Traded{' '}
+          <styledEl.StyledTokenAmount amount={formattedFilledAmount} tokenSymbol={formattedFilledAmount.currency} /> for
+          a total of{' '}
+          <styledEl.StyledTokenAmount amount={formattedSwappedAmount} tokenSymbol={formattedSwappedAmount.currency} />
+        </div>
+
+        {!!surplusAmount && (
+          <div>
+            You received a surplus of <styledEl.StyledTokenAmount amount={surplusAmount} tokenSymbol={surplusToken} />{' '}
+            {showFiatValue && <styledEl.StyledFiatAmount amount={fiatValue} />} on this trade!
+          </div>
+        )}
+
+        <DisplayLink id={hash} chainId={chainId} />
+      </div>
+    </styledEl.ExecutedWrapper>
+  )
+}

--- a/src/custom/components/TransactionExecutedContent/index.tsx
+++ b/src/custom/components/TransactionExecutedContent/index.tsx
@@ -37,7 +37,12 @@ export function TransactionExecutedContent({
         {!!surplusAmount && (
           <div>
             You received a surplus of <styledEl.StyledTokenAmount amount={surplusAmount} tokenSymbol={surplusToken} />{' '}
-            {showFiatValue && <styledEl.StyledFiatAmount amount={fiatValue} />} on this trade!
+            {showFiatValue && (
+              <span>
+                (<styledEl.StyledFiatAmount amount={fiatValue} />)
+              </span>
+            )}{' '}
+            on this trade!
           </div>
         )}
 

--- a/src/custom/components/TransactionExecutedContent/styled.ts
+++ b/src/custom/components/TransactionExecutedContent/styled.ts
@@ -1,0 +1,45 @@
+import styled from 'styled-components/macro'
+import { TokenAmount } from '@cow/common/pure/TokenAmount'
+import { FiatAmount } from '@cow/common/pure/FiatAmount'
+
+export const ExecutedWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  padding-bottom: 1rem;
+
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    font-size: 0.8rem;
+  `};
+
+  img {
+    padding: 1rem;
+    margin-right: 10px;
+
+    ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+      padding: 0;
+      max-width: 60px;
+    `};
+  }
+
+  a {
+    margin: 0;
+    margin-top: 15px;
+    display: block;
+  }
+
+  > div > div {
+    margin-bottom: 5px;
+  }
+`
+
+export const StyledTokenAmount = styled(TokenAmount)`
+  font-size: 0.9rem;
+  white-space: nowrap;
+  font-weight: 600;
+`
+
+export const StyledFiatAmount = styled(FiatAmount)`
+  margin-left: 5px;
+  font-size: 12px;
+  font-weight: 600;
+`

--- a/src/custom/components/TransactionExecutedContent/styled.ts
+++ b/src/custom/components/TransactionExecutedContent/styled.ts
@@ -41,4 +41,5 @@ export const StyledTokenAmount = styled(TokenAmount)`
 export const StyledFiatAmount = styled(FiatAmount)`
   margin: 0;
   font-weight: 600;
+  font-size: 0.9rem;
 `

--- a/src/custom/components/TransactionExecutedContent/styled.ts
+++ b/src/custom/components/TransactionExecutedContent/styled.ts
@@ -39,7 +39,7 @@ export const StyledTokenAmount = styled(TokenAmount)`
 `
 
 export const StyledFiatAmount = styled(FiatAmount)`
-  margin-left: 5px;
+  margin: 0;
   font-size: 12px;
   font-weight: 600;
 `

--- a/src/custom/components/TransactionExecutedContent/styled.ts
+++ b/src/custom/components/TransactionExecutedContent/styled.ts
@@ -40,6 +40,5 @@ export const StyledTokenAmount = styled(TokenAmount)`
 
 export const StyledFiatAmount = styled(FiatAmount)`
   margin: 0;
-  font-size: 12px;
   font-weight: 600;
 `

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -211,3 +211,6 @@ export const FAQ_MENU_LINKS = [
   { title: 'Limit orders', url: '/faq/limit-order' },
   { title: 'Selling Native tokens', url: '/faq/sell-native' },
 ]
+
+// Min USD value to show surplus
+export const MIN_FIAT_SURPLUS_VALUE = 0.01

--- a/src/custom/state/orders/middleware.tsx
+++ b/src/custom/state/orders/middleware.tsx
@@ -17,7 +17,7 @@ import { isOrderInPendingTooLong, openNpsAppziSometimes } from 'utils/appzi'
 import { OrderObject, OrdersStateNetwork } from 'state/orders/reducer'
 import { timeSinceInSeconds } from '@cow/utils/time'
 import { getExplorerOrderLink } from 'utils/explorer'
-import { getExecutedSummary } from '@cow/common/pure/ExecutedSummary'
+import { ExecutedSummary } from '@cow/common/pure/ExecutedSummary'
 import { parseOrder } from '@cow/modules/limitOrders/containers/OrdersWidget/hooks/useLimitOrdersList'
 import { Order } from 'state/orders/actions'
 
@@ -120,10 +120,11 @@ export const popupMiddleware: Middleware<Record<string, unknown>, AppState> = (s
           // it's an OrderTxTypes.TXN, yes, but we still want to point to the explorer
           // because it's nicer there
           const parsedOrder = parseOrder(orderObject.order as Order)
+          const summaryComponent = <ExecutedSummary order={parsedOrder} />
 
           const popup = setPopupData(OrderTxTypes.METATXN, {
             id,
-            summary: getExecutedSummary(parsedOrder) || summary,
+            summary: summaryComponent || summary,
             status: OrderActions.OrderStatus.FULFILLED,
             descriptor: null,
           })


### PR DESCRIPTION
# Summary

Shows USD value of surplus in confirmation modal and executed order popup if the surplus USD value is larger then 0.01

Confirmation modal
![Screenshot 2023-04-19 at 13 42 11](https://user-images.githubusercontent.com/34926005/233078893-76da69bf-c5b3-4e9e-85e1-dd601b46b902.png)

Executed order popup
<img width="395" alt="Screenshot 2023-04-19 at 14 30 24" src="https://user-images.githubusercontent.com/34926005/233078957-e5a58e8e-d9c8-4274-b4bd-a6e6a46e70ca.png">

# To test
1. Create an order and wait until its executed
2. Don't close the confirmation modal
3. Once the order is executed you will see executed order summary after 4 seconds with USD estimation for surplus and also executed order toast popup also with usd estimation for surplus if its larger then 0.01 USD