### PR TITLE
Hide tally wallet for now

### DIFF
--- a/src/cow-react/abis/types/index.ts
+++ b/src/cow-react/abis/types/index.ts
@@ -10,5 +10,5 @@ export { GPv2Settlement__factory } from "./factories/GPv2Settlement__factory";
 export { MerkleDrop__factory } from "./factories/MerkleDrop__factory";
 export { TokenDistro__factory } from "./factories/TokenDistro__factory";
 export { VCow__factory } from "./factories/VCow__factory";
-export * from "@cow/abis/types/ethflow";
 export * from "@src/abis/types";
+export * from "@cow/abis/types/ethflow";

--- a/src/cow-react/modules/wallet/web3-react/connection/index.tsx
+++ b/src/cow-react/modules/wallet/web3-react/connection/index.tsx
@@ -1,6 +1,6 @@
 import { Connector } from '@web3-react/types'
 
-import { isChrome, isMobile } from 'utils/userAgent'
+import { /* isChrome, */ isMobile } from 'utils/userAgent'
 import { ALL_SUPPORTED_CHAIN_IDS } from 'constants/chains'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { getIsCoinbaseWallet, getIsInjected, getIsMetaMask } from '@cow/modules/wallet/api/utils/connection'
@@ -21,7 +21,7 @@ import { networkConnection } from './network'
 import { ZengoOption } from './zengo'
 import { AmbireOption } from './ambire'
 import { AlphaOption } from './alpha'
-import { tallyWalletConnection, TallyWalletOption } from './tally'
+import { tallyWalletConnection /* TallyWalletOption */ } from './tally'
 import { trustWalletConnection, TrustWalletOption } from './trust'
 import { InstallKeystoneOption, keystoneConnection, KeystoneOption } from './keystone'
 
@@ -106,11 +106,11 @@ export function ConnectWalletOptions({ tryActivation }: { tryActivation: TryActi
   const isCoinbaseWalletBrowser = isMobile && isCoinbaseWallet
   const isMetaMaskBrowser = isMobile && isMetaMask
   const isInjectedMobileBrowser = isCoinbaseWalletBrowser || isMetaMaskBrowser
-  const isChromeMobile = isMobile && isChrome
+  // const isChromeMobile = isMobile && isChrome
   const showKeystone = !isInjectedMobileBrowser && !isMobile && window.ethereum?.isMetaMask
 
   // Show Tally option only in Chrome (includes Brave too), but not on mobile or as an injected browser
-  const showTally = !isInjectedMobileBrowser && isChrome && !isChromeMobile
+  // const showTally = !isInjectedMobileBrowser && isChrome && !isChromeMobile
 
   let injectedOption
   if (!isInjected) {
@@ -141,7 +141,7 @@ export function ConnectWalletOptions({ tryActivation }: { tryActivation: TryActi
     (showKeystone && <KeystoneOption tryActivation={tryActivation} />) || (!isMobile && <InstallKeystoneOption />)
 
   // Injected
-  const tallyOption = (showTally && <TallyWalletOption tryActivation={tryActivation} />) ?? null
+  // const tallyOption = (showTally && <TallyWalletOption tryActivation={tryActivation} />) ?? null
   const trustOption = (!isInjectedMobileBrowser && <TrustWalletOption tryActivation={tryActivation} />) ?? null
 
   return (
@@ -153,7 +153,7 @@ export function ConnectWalletOptions({ tryActivation }: { tryActivation: TryActi
       {zengoOption}
       {ambireOption}
       {alphaOption}
-      {tallyOption}
+      {/* {tallyOption} */}
       {trustOption}
       {keystoneOption}
     </>

--- a/src/cow-react/modules/wallet/web3-react/connection/keystone.tsx
+++ b/src/cow-react/modules/wallet/web3-react/connection/keystone.tsx
@@ -11,7 +11,7 @@ import { Web3ReactConnection } from '../types'
 
 import { default as KeystoneImage } from '@cow/modules/wallet/api/assets/keystone.svg'
 
-const TOOLTIP_TEXT = 'Connect your Keystone wallet using Metamask'
+const TOOLTIP_TEXT = 'Connect your Keystone wallet using MetaMask'
 const TOOLTIP_INSTALL_TEXT = 'Install Metamask to use Keystone wallet'
 
 const keystoneCommonOption = {


### PR DESCRIPTION
# Summary

Small PR to hide the Tally wallet for now as requested by Biz Dev.
We might enable this wallet in the future so we want to keep the rest of the code.