### PR TITLE
Add USD estimation in recent activity

### DIFF
--- a/src/cow-react/modules/account/containers/Transaction/styled.ts
+++ b/src/cow-react/modules/account/containers/Transaction/styled.ts
@@ -5,6 +5,7 @@ import { RowFixed } from 'components/Row'
 import { transparentize } from 'polished'
 import { StyledLogo } from 'components/CurrencyLogo'
 import { RateWrapper } from '@cow/common/pure/RateInfo'
+import { FiatAmount } from '@cow/common/pure/FiatAmount'
 
 export const TransactionWrapper = styled.div`
   width: 100%;
@@ -494,4 +495,14 @@ export const ActivityVisual = styled.div`
 
 export const CancelTxLink = styled(ExternalLink)`
   margin-left: 10px;
+`
+
+export const StyledFiatAmount = styled(FiatAmount)`
+  font-weight: 600;
+  font-size: 12px;
+  margin: 0;
+`
+
+export const FiatWrapper = styled.span`
+  margin-left: 5px;
 `


### PR DESCRIPTION
# Summary

Adds USD estimation of surplus for each order in recent activity.

![Screenshot 2023-04-20 at 13 31 28](https://user-images.githubusercontent.com/34926005/233354404-5f1e93da-b682-47ee-8496-653a503e71a1.png)
