### PR TITLE
fix: 🐛  expert mode modal issues on android

### DIFF
--- a/src/cow-react/common/pure/ExpertModeModal/index.tsx
+++ b/src/cow-react/common/pure/ExpertModeModal/index.tsx
@@ -8,7 +8,7 @@ import { KeyboardEvent, useCallback, useEffect, useState } from 'react'
 
 const ModalContentWrapper = styled.div`
   display: flex;
-  flex-flow: column wrap;
+  flex-flow: column;
   align-items: center;
   justify-content: center;
   padding: 24px;

--- a/src/cow-react/common/pure/ExpertModeModal/index.tsx
+++ b/src/cow-react/common/pure/ExpertModeModal/index.tsx
@@ -94,7 +94,7 @@ export function ExpertModeModal(props: ExpertModeModalProps) {
   const [isButtonEnabled, setIsButtonEnabled] = useState(false)
 
   const onInput = useCallback((value: string) => {
-    setIsButtonEnabled(value === confirmWord)
+    setIsButtonEnabled(value.toLowerCase().trim() === confirmWord)
   }, [])
 
   const onKeyDown = useCallback(


### PR DESCRIPTION
# Summary

Fixes issues mentioned at https://github.com/cowprotocol/cowswap/pull/2344#issuecomment-1516435780

  # To Test

1. Open CoW Swap on Android
2. Go to Expert Mode toggle
3. Once you have the modal, it should accept non case sensitive text: confirm
4. Once you have the modal and you have your keyboard open, layout should not shift to right side
