### PR TITLE
fix(limit-orders): enable orders selection only when off-chain signing is supported

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/OrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/OrdersWidget/index.tsx
@@ -11,7 +11,7 @@ import { useValidatePageUrlParams } from './hooks/useValidatePageUrlParams'
 import { useCancelOrder } from '@cow/common/hooks/useCancelOrder'
 import { useAtomValue, useUpdateAtom } from 'jotai/utils'
 import { pendingOrdersPricesAtom } from '@cow/modules/orders/state/pendingOrdersPricesAtom'
-import { useWalletInfo } from '@cow/modules/wallet'
+import { useWalletDetails, useWalletInfo } from '@cow/modules/wallet'
 import { useGetSpotPrice } from '@cow/modules/orders/state/spotPricesAtom'
 import { useSelectReceiptOrder } from '@cow/modules/limitOrders/containers/OrdersReceiptModal/hooks'
 import { LimitOrderActions } from '@cow/modules/limitOrders/pure/Orders/types'
@@ -45,6 +45,7 @@ export function OrdersWidget() {
   const ordersList = useLimitOrdersList()
   const { chainId, account } = useWalletInfo()
   const getShowCancellationModal = useCancelOrder()
+  const { allowsOffchainSigning } = useWalletDetails()
   const pendingOrdersPrices = useAtomValue(pendingOrdersPricesAtom)
   const ordersToCancel = useAtomValue(ordersToCancelAtom)
   const updateOrdersToCancel = useUpdateAtom(updateOrdersToCancelAtom)
@@ -123,6 +124,7 @@ export function OrdersWidget() {
           orderActions={orderActions}
           getSpotPrice={getSpotPrice}
           selectedOrders={ordersToCancel}
+          allowsOffchainSigning={allowsOffchainSigning}
         >
           {isOpenOrdersTab && orders.length && <MultipleCancellationMenu pendingOrders={orders} />}
         </Orders>

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
@@ -183,6 +183,7 @@ const OrdersExplainerBanner = styled.div`
 
 export interface OrdersTableProps {
   isOpenOrdersTab: boolean
+  allowsOffchainSigning: boolean
   currentPageNumber: number
   chainId: SupportedChainId | undefined
   pendingOrdersPrices: PendingOrdersPrices
@@ -196,6 +197,7 @@ export interface OrdersTableProps {
 export function OrdersTable({
   isOpenOrdersTab,
   selectedOrders,
+  allowsOffchainSigning,
   chainId,
   orders,
   pendingOrdersPrices,
@@ -214,7 +216,7 @@ export function OrdersTable({
     document.body.dispatchEvent(new Event('mousedown', { bubbles: true }))
   }, [])
 
-  const isRowSelectable = selectedOrders !== null
+  const isRowSelectable = allowsOffchainSigning
 
   const selectedOrdersMap = useMemo(() => {
     if (!selectedOrders) return {}
@@ -243,6 +245,8 @@ export function OrdersTable({
 
   const allOrdersSelected = useMemo(() => {
     const cancellableOrders = ordersPage.filter(isOrderOffChainCancellable)
+
+    if (!cancellableOrders.length) return false
 
     return cancellableOrders.every((item) => selectedOrdersMap[item.id])
   }, [ordersPage, selectedOrdersMap])

--- a/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrdersTable.tsx
@@ -243,13 +243,13 @@ export function OrdersTable({
     localStorage.setItem('showOrdersExplainerBanner', showOrdersExplainerBanner.toString())
   }, [showOrdersExplainerBanner])
 
-  const allOrdersSelected = useMemo(() => {
-    const cancellableOrders = ordersPage.filter(isOrderOffChainCancellable)
+  const cancellableOrders = useMemo(() => ordersPage.filter(isOrderOffChainCancellable), [ordersPage])
 
+  const allOrdersSelected = useMemo(() => {
     if (!cancellableOrders.length) return false
 
     return cancellableOrders.every((item) => selectedOrdersMap[item.id])
-  }, [ordersPage, selectedOrdersMap])
+  }, [cancellableOrders, selectedOrdersMap])
 
   // React doesn't support indeterminate attribute
   // Because of it, we have to use element reference
@@ -272,6 +272,7 @@ export function OrdersTable({
                 <TableRowCheckboxWrapper>
                   <TableRowCheckbox
                     ref={checkboxRef}
+                    disabled={cancellableOrders.length === 0}
                     type="checkbox"
                     onChange={(event) =>
                       orderActions.toggleOrdersForCancellation(event.target.checked ? ordersPage : [])

--- a/src/cow-react/modules/limitOrders/pure/Orders/index.cosmos.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/index.cosmos.tsx
@@ -51,6 +51,7 @@ export default (
     currentPageNumber={1}
     orders={ordersMock}
     tabs={tabs}
+    allowsOffchainSigning={true}
     isOpenOrdersTab={true}
     isWalletConnected={true}
     selectedOrders={[]}

--- a/src/cow-react/modules/limitOrders/pure/Orders/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/index.tsx
@@ -145,6 +145,7 @@ export function Orders({
   isWalletConnected,
   selectedOrders,
   isOpenOrdersTab,
+  allowsOffchainSigning,
   balancesAndAllowances,
   orderActions,
   currentPageNumber,
@@ -200,6 +201,7 @@ export function Orders({
     return (
       <OrdersTable
         isOpenOrdersTab={isOpenOrdersTab}
+        allowsOffchainSigning={allowsOffchainSigning}
         selectedOrders={selectedOrders}
         pendingOrdersPrices={pendingOrdersPrices}
         currentPageNumber={currentPageNumber}


### PR DESCRIPTION
# Summary

Fixes #2347

<img width="392" alt="image" src="https://user-images.githubusercontent.com/7122625/233652195-d065f3f0-7d6f-4006-a354-c703dc56586b.png">
