### PR TITLE
Fix Metamask issue

### DIFF
--- a/src/cow-react/modules/wallet/web3-react/connection/index.tsx
+++ b/src/cow-react/modules/wallet/web3-react/connection/index.tsx
@@ -119,7 +119,7 @@ export function ConnectWalletOptions({ tryActivation }: { tryActivation: TryActi
     } else {
       injectedOption = <OpenMetaMaskMobileOption />
     }
-  } else if (!isCoinbaseWallet) {
+  } else {
     if (isMetaMask) {
       injectedOption = <MetaMaskOption tryActivation={tryActivation} />
     } else {


### PR DESCRIPTION
# Summary

Fixes the issue found by @MindyCoW in one user session
The issue seems to be that when `window.ethereum.isCoinbaseWallet` is `true` we don't show Metamask option and we don't want that.