### PR TITLE
chore: change goerli tokens list url after removing custom folder

### DIFF
--- a/src/constants/lists.ts
+++ b/src/constants/lists.ts
@@ -23,8 +23,8 @@ const KLEROS_LIST = 't2crtokens.eth'
 const BA_LIST = 'https://raw.githubusercontent.com/The-Blockchain-Association/sec-notice-list/master/ba-sec-list.json'
 
 // Goerli Default
-// TODO: WARINING!!! REMOVE custom after merging in develop
-const GOERLI_LIST = RAW_CODE_LINK + '/main/src/custom/tokens/goerli-token-list.json'
+// TODO: change develop -> main after release
+const GOERLI_LIST = RAW_CODE_LINK + '/develop/src/tokens/goerli-token-list.json'
 
 // XDAI Default
 const HONEY_SWAP_XDAI = 'https://tokens.honeyswap.org'


### PR DESCRIPTION
# Summary

Reference: https://github.com/cowprotocol/cowswap/pull/2345/commits/5ba7bbd0e227f8f9b35ad006434f1b0c3e51ddbf

Since the `custom` folder is deleted, `goerli-token-list.json` file was moved to `src/tokens`:
https://raw.githubusercontent.com/cowprotocol/cowswap/develop/src/tokens/goerli-token-list.json

Just after the next release on prod, the previous link will become invalid and the token list on georli won't be loaded.
To avoid this, the link to the goerli tokens list is changed.
