### PR TITLE
fix: show hang in there until best quote is loaded

### DIFF
--- a/src/state/price/updater.ts
+++ b/src/state/price/updater.ts
@@ -12,7 +12,7 @@ import { Field } from 'state/swap/actions'
 import { useIsUnsupportedTokenGp } from 'state/lists/hooks'
 
 import useIsWindowVisible from 'hooks/useIsWindowVisible'
-import { useAllQuotes, useIsQuoteLoading, useSetQuoteError } from './hooks'
+import { useAllQuotes, useIsBestQuoteLoading, useSetQuoteError } from './hooks'
 import { useRefetchQuoteCallback } from 'hooks/useRefetchPriceCallback'
 import useDebounce from 'hooks/useDebounce'
 import useIsOnline from 'hooks/useIsOnline'
@@ -152,7 +152,7 @@ export default function FeesUpdater(): null {
     return quotesMap && sellCurrencyId ? quotesMap[sellCurrencyId] : undefined
   }, [quotesMap, sellCurrencyId])
 
-  const isLoading = useIsQuoteLoading()
+  const isLoading = useIsBestQuoteLoading()
   const isEthFlow = useIsEthFlow()
 
   const isUnsupportedTokenGp = useIsUnsupportedTokenGp()


### PR DESCRIPTION
# Summary

Fixes #2374

I'm not sure this is even needed because [this](https://github.com/cowprotocol/cowswap/pull/2254/files) seems to do exactly what we wanted, but just in case we can also do this, and as far as I could see this will show `Hang in there...` until the best quote is loaded