### PR TITLE
fix: rename title of TermsAndConditions page

### DIFF
--- a/src/cow-react/pages/TermsAndConditions/index.tsx
+++ b/src/cow-react/pages/TermsAndConditions/index.tsx
@@ -11,7 +11,7 @@ const Wrapper = styled(MarkdownPage)`
 export default function TermsAndConditions() {
   return (
     <>
-      <PageTitle title="ToC" />
+      <PageTitle title="Terms and conditions" />
       <Wrapper contentFile={contentFile} />
     </>
   )


### PR DESCRIPTION
# Summary

Fixes #1965
