### PR TITLE
fix(limit-orders): don't display trade related warnings when wrap/unwrap

### DIFF
--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -328,7 +328,7 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
                 </styledEl.FooterBox>
               )}
 
-              <LimitOrdersWarnings priceImpact={priceImpact} feeAmount={feeAmount} />
+              {!isWrapOrUnwrap && <LimitOrdersWarnings priceImpact={priceImpact} feeAmount={feeAmount} />}
 
               <styledEl.TradeButtonBox>
                 <TradeButtons


### PR DESCRIPTION
# Summary

Fixes #1721
