### PR TITLE
ci: don't fail kanban actions when there are no linked issues

### DIFF
--- a/.github/workflows/kanban-in-progress.yml
+++ b/.github/workflows/kanban-in-progress.yml
@@ -14,11 +14,13 @@ jobs:
       - name: Find Linked Issues
         id: links
         uses: hossainemruz/linked-issues@main
+        continue-on-error: true
         with:
           pr_url: ${{github.event.pull_request.html_url}}
           format: IssueNumber
 
       - name: Move issue to In progress status
+        if: ${{ steps.links.outputs.issues != '' }}
         run: >
           curl 'https://api.zenhub.com/p2/workspaces/6246bc1e8d5e5b0010c77c74/repositories/475419392/issues/${{ steps.links.outputs.issues }}/moves' \
             -H 'content-type: application/json' \

--- a/.github/workflows/kanban-review.yml
+++ b/.github/workflows/kanban-review.yml
@@ -14,11 +14,13 @@ jobs:
       - name: Find Linked Issues
         id: links
         uses: hossainemruz/linked-issues@main
+        continue-on-error: true
         with:
           pr_url: ${{github.event.pull_request.html_url}}
           format: IssueNumber
 
       - name: Move issue to In progress status
+        if: ${{ steps.links.outputs.issues != '' }}
         run: >
           curl 'https://api.zenhub.com/p2/workspaces/6246bc1e8d5e5b0010c77c74/repositories/475419392/issues/${{ steps.links.outputs.issues }}/moves' \
             -H 'content-type: application/json' \


### PR DESCRIPTION
In some cases, it's ok when a PR doesn't have linked issues and we shouldn't add a noise to the build checks.

<img width="859" alt="image" src="https://user-images.githubusercontent.com/7122625/235095892-877560e0-f844-4c4a-98f9-7eca96880551.png">
