### PR TITLE
fix: change audits url in approval modal

### DIFF
--- a/src/components/TransactionConfirmationModal/index.tsx
+++ b/src/components/TransactionConfirmationModal/index.tsx
@@ -251,7 +251,7 @@ export function ConfirmationPendingContent({
               <li>
                 <SVG src={checkImage} /> Immutable contract with multiple&nbsp;
                 <ExternalLink
-                  href="https://github.com/cowprotocol/ethflowcontract/tree/main/audits"
+                  href="https://github.com/cowprotocol/contracts/tree/main/audits"
                   target={'_blank'}
                   rel={'noopener'}
                 >


### PR DESCRIPTION
# Summary

- Updates the audit URL in the token approval modal