### PR TITLE
feat(twap-orders): twap orders page skeleton + feature-flag

### DIFF
--- a/src/cow-react/constants/featureFlags.ts
+++ b/src/cow-react/constants/featureFlags.ts
@@ -4,3 +4,5 @@ export const limitOrdersFeatures = {
   DISPLAY_EST_EXECUTION_PRICE: false,
   DISPLAY_EXECUTION_TIME: false,
 }
+
+export const ADVANCED_ORDERS_FEATURE_FLAG = 'advanced-orders'

--- a/src/cow-react/constants/routes.ts
+++ b/src/cow-react/constants/routes.ts
@@ -3,6 +3,7 @@ export enum Routes {
   HOME = '/',
   SWAP = '/:chainId?/swap/:inputCurrencyId?/:outputCurrencyId?',
   LIMIT_ORDER = '/:chainId?/limit-orders/:inputCurrencyId?/:outputCurrencyId?',
+  ADVANCED_ORDERS = '/:chainId?/advanced-orders/:inputCurrencyId?/:outputCurrencyId?',
   SEND = '/send',
   ACCOUNT = '/account',
   ACCOUNT_TOKENS = '/account/tokens',

--- a/src/cow-react/modules/advancedOrders/containers/AdvancedOrdersWidget/index.tsx
+++ b/src/cow-react/modules/advancedOrders/containers/AdvancedOrdersWidget/index.tsx
@@ -1,0 +1,16 @@
+import { useSetupTradeState } from '@cow/modules/trade'
+import { useAdvancedOrdersState } from '@cow/modules/advancedOrders'
+
+export function AdvancedOrdersWidget() {
+  useSetupTradeState()
+
+  const state = useAdvancedOrdersState()
+
+  return (
+    <div>
+      <h3>Advanced orders</h3>
+      <div>inputCurrencyId: {state.inputCurrencyId}</div>
+      <div>outputCurrencyId: {state.outputCurrencyId}</div>
+    </div>
+  )
+}

--- a/src/cow-react/modules/advancedOrders/hooks/useAdvancedOrdersState.ts
+++ b/src/cow-react/modules/advancedOrders/hooks/useAdvancedOrdersState.ts
@@ -1,0 +1,10 @@
+import { useAtomValue, useUpdateAtom } from 'jotai/utils'
+import { advancedOrdersAtom, AdvancedOrdersState, updateAdvancedOrdersAtom } from '../state/advancedOrdersAtom'
+
+export function useAdvancedOrdersState(): AdvancedOrdersState {
+  return useAtomValue(advancedOrdersAtom)
+}
+
+export function useUpdateAdvancedOrdersState(): (update: Partial<AdvancedOrdersState>) => void {
+  return useUpdateAtom(updateAdvancedOrdersAtom)
+}

--- a/src/cow-react/modules/advancedOrders/index.ts
+++ b/src/cow-react/modules/advancedOrders/index.ts
@@ -1,0 +1,3 @@
+export * from './containers/AdvancedOrdersWidget'
+export * from './hooks/useAdvancedOrdersState'
+export * from './state/advancedOrdersAtom'

--- a/src/cow-react/modules/advancedOrders/state/advancedOrdersAtom.ts
+++ b/src/cow-react/modules/advancedOrders/state/advancedOrdersAtom.ts
@@ -1,0 +1,43 @@
+import { OrderKind, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { getDefaultTradeState } from '@cow/modules/trade/types/TradeState'
+import { atomWithStorage, createJSONStorage } from 'jotai/utils'
+import { atom } from 'jotai'
+
+export interface AdvancedOrdersState {
+  readonly chainId: number | null
+  readonly inputCurrencyId: string | null
+  readonly outputCurrencyId: string | null
+  readonly inputCurrencyAmount: string | null
+  readonly outputCurrencyAmount: string | null
+  readonly recipient: string | null
+  readonly orderKind: OrderKind
+}
+
+export function getDefaultAdvancedOrdersState(chainId: SupportedChainId | null): AdvancedOrdersState {
+  return {
+    ...getDefaultTradeState(chainId),
+    inputCurrencyAmount: null,
+    outputCurrencyAmount: null,
+    recipient: null,
+    orderKind: OrderKind.SELL,
+  }
+}
+
+export const advancedOrdersAtom = atomWithStorage<AdvancedOrdersState>(
+  'advanced-orders-atom:v1',
+  getDefaultAdvancedOrdersState(null),
+  /**
+   * atomWithStorage() has build-in feature to persist state between all tabs
+   * To disable this feature we pass our own instance of storage
+   * https://github.com/pmndrs/jotai/pull/1004/files
+   */
+  createJSONStorage(() => localStorage)
+)
+
+export const updateAdvancedOrdersAtom = atom(null, (get, set, nextState: Partial<AdvancedOrdersState>) => {
+  set(advancedOrdersAtom, () => {
+    const prevState = get(advancedOrdersAtom)
+
+    return { ...prevState, ...nextState }
+  })
+})

--- a/src/cow-react/modules/application/containers/App/RoutesApp.tsx
+++ b/src/cow-react/modules/application/containers/App/RoutesApp.tsx
@@ -16,6 +16,7 @@ import { ReactNode } from 'react'
 // Async routes
 const PrivacyPolicy = lazy(() => import(/* webpackChunkName: "privacy_policy" */ '@cow/pages/PrivacyPolicy'))
 const LimitOrders = lazy(() => import(/* webpackChunkName: "limit_orders" */ '@cow/pages/LimitOrders'))
+const AdvancedOrders = lazy(() => import(/* webpackChunkName: "limit_orders" */ '@cow/pages/AdvancedOrders'))
 const CookiePolicy = lazy(() => import(/* webpackChunkName: "cookie_policy" */ '@cow/pages/CookiePolicy'))
 const TermsAndConditions = lazy(() => import(/* webpackChunkName: "terms" */ '@cow/pages/TermsAndConditions'))
 const About = lazy(() => import(/* webpackChunkName: "about" */ '@cow/pages/About'))
@@ -50,6 +51,7 @@ function LazyRoute({ route, element, key }: LazyRouteProps) {
 
 const lazyRoutes: LazyRouteProps[] = [
   { route: RoutesEnum.LIMIT_ORDER, element: <LimitOrders /> },
+  { route: RoutesEnum.ADVANCED_ORDERS, element: <AdvancedOrders /> },
   { route: RoutesEnum.ABOUT, element: <About /> },
   { route: RoutesEnum.FAQ, element: <Faq /> },
   { route: RoutesEnum.FAQ_PROTOCOL, element: <ProtocolFaq /> },

--- a/src/cow-react/modules/application/containers/TradeWidgetLinks/index.tsx
+++ b/src/cow-react/modules/application/containers/TradeWidgetLinks/index.tsx
@@ -40,6 +40,15 @@ export function TradeWidgetLinks() {
           </styledEl.Badge>
         </styledEl.Link>
       </styledEl.MenuItem>
+
+      <styledEl.MenuItem>
+        <styledEl.Link
+          className={({ isActive }) => (isActive ? 'active' : undefined)}
+          to={parameterizeTradeRoute(tradeContext, Routes.ADVANCED_ORDERS)}
+        >
+          <Trans>Advanced</Trans>
+        </styledEl.Link>
+      </styledEl.MenuItem>
     </styledEl.Wrapper>
   )
 }

--- a/src/cow-react/modules/application/containers/TradeWidgetLinks/index.tsx
+++ b/src/cow-react/modules/application/containers/TradeWidgetLinks/index.tsx
@@ -5,6 +5,8 @@ import { useMemo } from 'react'
 import { useTradeState } from '@cow/modules/trade/hooks/useTradeState'
 import { parameterizeTradeRoute } from '@cow/modules/trade/utils/parameterizeTradeRoute'
 import * as styledEl from './styled'
+import { FeatureFlag } from '@cow/utils/featureFlags'
+import { ADVANCED_ORDERS_FEATURE_FLAG } from '@cow/constants/featureFlags'
 
 export function TradeWidgetLinks() {
   const { state } = useTradeState()
@@ -41,14 +43,16 @@ export function TradeWidgetLinks() {
         </styledEl.Link>
       </styledEl.MenuItem>
 
-      <styledEl.MenuItem>
-        <styledEl.Link
-          className={({ isActive }) => (isActive ? 'active' : undefined)}
-          to={parameterizeTradeRoute(tradeContext, Routes.ADVANCED_ORDERS)}
-        >
-          <Trans>Advanced</Trans>
-        </styledEl.Link>
-      </styledEl.MenuItem>
+      {FeatureFlag.get(ADVANCED_ORDERS_FEATURE_FLAG) && (
+        <styledEl.MenuItem>
+          <styledEl.Link
+            className={({ isActive }) => (isActive ? 'active' : undefined)}
+            to={parameterizeTradeRoute(tradeContext, Routes.ADVANCED_ORDERS)}
+          >
+            <Trans>Advanced</Trans>
+          </styledEl.Link>
+        </styledEl.MenuItem>
+      )}
     </styledEl.Wrapper>
   )
 }

--- a/src/cow-react/modules/mainMenu/constants/mainMenu.ts
+++ b/src/cow-react/modules/mainMenu/constants/mainMenu.ts
@@ -1,6 +1,6 @@
 import { Routes } from '@cow/constants/routes'
 import { CONTRACTS_CODE_LINK, DISCORD_LINK, DOCS_LINK, DUNE_DASHBOARD_LINK, TWITTER_LINK } from 'constants/index'
-import { BasicMenuLink, InternalLink, MainMenuItemId, MenuItemKind, MenuTreeItem } from '../types'
+import { BasicMenuLink, InternalLink, MainMenuItemId, MenuItemKind, MenuLink, MenuTreeItem } from '../types'
 
 // Assets
 import IMAGE_DOCS from 'assets/cow-swap/doc.svg'
@@ -14,6 +14,9 @@ import IMAGE_TWITTER from 'assets/cow-swap/twitter.svg'
 import IMAGE_PIE from 'assets/cow-swap/pie.svg'
 import IMAGE_SLICER from 'assets/cow-swap/ninja-cow.png'
 import IMAGE_GAME from 'assets/cow-swap/game.gif'
+import { FeatureFlag } from '@cow/utils/featureFlags'
+import { ADVANCED_ORDERS_FEATURE_FLAG } from '@cow/constants/featureFlags'
+import { isNotNullish } from '@cow/utils/isNotNullish'
 
 export const isBasicMenuLink = (item: any): item is BasicMenuLink => {
   return !!(item.title && item.url)
@@ -47,13 +50,15 @@ export const MAIN_MENU: MenuTreeItem[] = [
             title: 'Limit orders',
             url: Routes.LIMIT_ORDER,
           },
-          {
-            id: MainMenuItemId.ADVANCED_ORDERS,
-            kind: MenuItemKind.DYNAMIC_LINK,
-            title: 'Advanced orders',
-            url: Routes.ADVANCED_ORDERS,
-          },
-        ],
+          FeatureFlag.get(ADVANCED_ORDERS_FEATURE_FLAG)
+            ? {
+                id: MainMenuItemId.ADVANCED_ORDERS,
+                kind: MenuItemKind.DYNAMIC_LINK,
+                title: 'Advanced orders',
+                url: Routes.ADVANCED_ORDERS,
+              }
+            : null,
+        ].filter(isNotNullish) as MenuLink[],
       },
     ],
   },

--- a/src/cow-react/modules/mainMenu/constants/mainMenu.ts
+++ b/src/cow-react/modules/mainMenu/constants/mainMenu.ts
@@ -47,6 +47,12 @@ export const MAIN_MENU: MenuTreeItem[] = [
             title: 'Limit orders',
             url: Routes.LIMIT_ORDER,
           },
+          {
+            id: MainMenuItemId.ADVANCED_ORDERS,
+            kind: MenuItemKind.DYNAMIC_LINK,
+            title: 'Advanced orders',
+            url: Routes.ADVANCED_ORDERS,
+          },
         ],
       },
     ],

--- a/src/cow-react/modules/mainMenu/types.ts
+++ b/src/cow-react/modules/mainMenu/types.ts
@@ -11,6 +11,7 @@ export enum MenuItemKind {
 export enum MainMenuItemId {
   SWAP = 'SWAP',
   LIMIT_ORDERS = 'LIMIT_ORDERS',
+  ADVANCED_ORDERS = 'ADVANCED_ORDERS',
   FAQ_OVERVIEW = 'FAQ_OVERVIEW',
   FAQ_PROTOCOL = 'FAQ_PROTOCOL',
   FAQ_TOKEN = 'FAQ_TOKEN',

--- a/src/cow-react/modules/trade/hooks/useTradeState.ts
+++ b/src/cow-react/modules/trade/hooks/useTradeState.ts
@@ -6,6 +6,7 @@ import { useAtomValue, useUpdateAtom } from 'jotai/utils'
 import { limitOrdersAtom, updateLimitOrdersAtom } from '@cow/modules/limitOrders/state/limitOrdersAtom'
 import { useSwapState } from 'state/swap/hooks'
 import { useAppDispatch } from 'state/hooks'
+import { useAdvancedOrdersState, useUpdateAdvancedOrdersState } from '@cow/modules/advancedOrders'
 
 export function useSwapTradeState(): TradeState {
   const swapState = useSwapState()
@@ -26,8 +27,11 @@ export function useTradeState(): { state?: TradeState; updateState?: (state: Tra
   const dispatch = useAppDispatch()
   const tradeTypeInfo = useTradeTypeInfo()
 
-  const limitOrdersState = useAtomValue(limitOrdersAtom)
+  const limitOrdersState = useLimitOrdersTradeState()
   const updateLimitOrdersState = useUpdateAtom(updateLimitOrdersAtom)
+
+  const advancedOrdersState = useAdvancedOrdersState()
+  const updateAdvancedOrdersState = useUpdateAdvancedOrdersState()
 
   const swapState = useSwapState()
   const swapTradeState = useSwapTradeState()
@@ -57,6 +61,13 @@ export function useTradeState(): { state?: TradeState; updateState?: (state: Tra
       }
     }
 
+    if (tradeTypeInfo.tradeType === TradeType.ADVANCED_ORDERS) {
+      return {
+        state: advancedOrdersState,
+        updateState: updateAdvancedOrdersState,
+      }
+    }
+
     return {
       state: limitOrdersState,
       updateState: updateLimitOrdersState,
@@ -67,6 +78,8 @@ export function useTradeState(): { state?: TradeState; updateState?: (state: Tra
     JSON.stringify(tradeTypeInfo),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     JSON.stringify(limitOrdersState),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    JSON.stringify(advancedOrdersState),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     JSON.stringify(swapTradeState),
     updateSwapState,

--- a/src/cow-react/pages/AdvancedOrders/index.tsx
+++ b/src/cow-react/pages/AdvancedOrders/index.tsx
@@ -1,0 +1,5 @@
+import { AdvancedOrdersWidget } from '@cow/modules/advancedOrders'
+
+export default function AdvancedOrdersPage() {
+  return <AdvancedOrdersWidget />
+}

--- a/src/cow-react/utils/isNotNullish.ts
+++ b/src/cow-react/utils/isNotNullish.ts
@@ -1,0 +1,5 @@
+import { Nullish } from '@cow/types'
+
+export function isNotNullish<T>(input: Nullish<T>): input is T {
+  return input !== null && input !== undefined
+}

--- a/src/state/appData/AppDataInfoUpdater.tsx
+++ b/src/state/appData/AppDataInfoUpdater.tsx
@@ -14,10 +14,10 @@ export function AppDataUpdater() {
 
   if (!chainId || !tradeTypeInfo) return null
 
-  const isLimitOrders = tradeTypeInfo.tradeType === TradeType.LIMIT_ORDER
-  const allowedSlippage = isLimitOrders ? LIMIT_ORDER_SLIPPAGE : allowedSlippageSwap
+  const isSwapOrder = tradeTypeInfo.tradeType === TradeType.SWAP
+  const allowedSlippage = isSwapOrder ? allowedSlippageSwap : LIMIT_ORDER_SLIPPAGE
   const slippageBips = percentToBips(allowedSlippage)
-  const orderClass = isLimitOrders ? OrderClass.LIMIT : OrderClass.MARKET
+  const orderClass = isSwapOrder ? OrderClass.MARKET : OrderClass.LIMIT
 
   return <AppDataUpdaterMemo chainId={chainId} slippageBips={slippageBips} orderClass={orderClass} />
 }


### PR DESCRIPTION
# Summary

1. Added a new route `/1/advanced-orders/COW/DAI`
2. Hide the route under feature-flag `localStorage.setItem('advanced-orders', '1')`

The router is empty in this PR and will be filled in next PRs