### PR TITLE
feat: add twap orders deadline selector

### DIFF
--- a/src/cow-react/common/pure/DeadlineSelector/deadlines.ts
+++ b/src/cow-react/common/pure/DeadlineSelector/deadlines.ts
@@ -1,6 +1,6 @@
 import ms from 'ms.macro'
 
-export interface LimitOrderDeadline {
+export interface OrderDeadline {
   title: string
   value: number
 }
@@ -8,14 +8,14 @@ export interface LimitOrderDeadline {
 export const MIN_CUSTOM_DEADLINE = ms`30min`
 export const MAX_CUSTOM_DEADLINE = Math.round(ms`1y` / 2) // 6 months
 
-export const defaultLimitOrderDeadline: LimitOrderDeadline = { title: '7 Days', value: ms`7d` }
+export const defaultOrderDeadline: OrderDeadline = { title: '1 Hour', value: ms`1 hour` }
 
-export const limitOrdersDeadlines: LimitOrderDeadline[] = [
+export const ordersDeadlines: OrderDeadline[] = [
   { title: '5 Minutes', value: ms`5m` },
   { title: '30 Minutes', value: ms`30m` },
-  { title: '1 Hour', value: ms`1 hour` },
+  defaultOrderDeadline,
   { title: '1 Day', value: ms`1d` },
   { title: '3 Days', value: ms`3d` },
-  defaultLimitOrderDeadline,
+  { title: '7 Days', value: ms`7d` },
   { title: '1 Month', value: ms`30d` },
 ]

--- a/src/cow-react/common/pure/DeadlineSelector/index.cosmos.tsx
+++ b/src/cow-react/common/pure/DeadlineSelector/index.cosmos.tsx
@@ -1,10 +1,10 @@
 import { DeadlineSelector } from './index'
-import { defaultLimitOrderDeadline } from '@cow/modules/limitOrders/pure/DeadlineSelector/deadlines'
+import { defaultOrderDeadline } from '@cow/common/pure/DeadlineSelector/deadlines'
 
 const Fixtures = {
   default: (
     <DeadlineSelector
-      deadline={defaultLimitOrderDeadline}
+      deadline={defaultOrderDeadline}
       customDeadline={null}
       selectDeadline={() => void 0}
       selectCustomDeadline={() => void 0}

--- a/src/cow-react/common/pure/DeadlineSelector/index.tsx
+++ b/src/cow-react/common/pure/DeadlineSelector/index.tsx
@@ -1,6 +1,6 @@
 import { Menu } from '@reach/menu-button'
-import { LimitOrderDeadline, limitOrdersDeadlines } from './deadlines'
-import { useEffect, useState } from 'react'
+import { OrderDeadline, ordersDeadlines } from './deadlines'
+import { ReactElement, useEffect, useState } from 'react'
 import { GpModal as Modal } from '@cow/common/pure/Modal'
 import { ChangeEventHandler, useCallback, useMemo, useRef } from 'react'
 import { ChevronDown } from 'react-feather'
@@ -13,7 +13,7 @@ import {
   getInputStartDate,
   getTimeZoneOffset,
   limitDateString,
-} from '@cow/modules/limitOrders/pure/DeadlineSelector/utils'
+} from '@cow/common/pure/DeadlineSelector/utils'
 
 const CUSTOM_DATE_OPTIONS: Intl.DateTimeFormatOptions = {
   year: '2-digit',
@@ -25,14 +25,19 @@ const CUSTOM_DATE_OPTIONS: Intl.DateTimeFormatOptions = {
 }
 
 export interface DeadlineSelectorProps {
-  deadline: LimitOrderDeadline | undefined
+  deadline: OrderDeadline | undefined
   customDeadline: number | null
-  selectDeadline(deadline: LimitOrderDeadline): void
+  selectDeadline(deadline: OrderDeadline): void
   selectCustomDeadline(deadline: number | null): void
+  label?: ReactElement | string
+  inline?: boolean
+  // TODO: update OrderClass type and use here
+  orderType?: string
+  minHeight?: string
 }
 
 export function DeadlineSelector(props: DeadlineSelectorProps) {
-  const { deadline, customDeadline, selectDeadline, selectCustomDeadline } = props
+  const { deadline, customDeadline, selectDeadline, selectCustomDeadline, orderType, label, inline, minHeight } = props
 
   const currentDeadlineNode = useRef<HTMLButtonElement | null>(null)
   const [[minDate, maxDate], setMinMax] = useState<[Date, Date]>(calculateMinMax)
@@ -62,7 +67,7 @@ export function DeadlineSelector(props: DeadlineSelectorProps) {
     }
   }, [maxDate, minDate, selectCustomDeadline, value])
 
-  const existingDeadline = useMemo(() => limitOrdersDeadlines.find((item) => item === deadline), [deadline])
+  const existingDeadline = useMemo(() => ordersDeadlines.find((item) => item === deadline), [deadline])
 
   const customDeadlineTitle = useMemo(() => {
     if (!customDeadline) {
@@ -72,7 +77,7 @@ export function DeadlineSelector(props: DeadlineSelectorProps) {
   }, [customDeadline])
 
   const setDeadline = useCallback(
-    (deadline: LimitOrderDeadline) => {
+    (deadline: OrderDeadline) => {
       selectDeadline(deadline)
       selectCustomDeadline(null) // reset custom deadline
       currentDeadlineNode.current?.click() // Close dropdown
@@ -115,17 +120,15 @@ export function DeadlineSelector(props: DeadlineSelectorProps) {
   }, [onDismiss, selectCustomDeadline, value])
 
   return (
-    <styledEl.Wrapper>
-      <styledEl.Label>
-        <Trans>Expiry</Trans>
-      </styledEl.Label>
+    <styledEl.Wrapper minHeight={minHeight} inline={inline}>
+      <styledEl.Label>{label || <Trans>Expiry</Trans>}</styledEl.Label>
       <Menu>
         <styledEl.Current ref={currentDeadlineNode as any} $custom={!!customDeadline}>
           <span>{customDeadline ? customDeadlineTitle : existingDeadline?.title}</span>
           <ChevronDown size="18" />
         </styledEl.Current>
         <styledEl.ListWrapper>
-          {limitOrdersDeadlines.map((item) => (
+          {ordersDeadlines.map((item) => (
             <li key={item.value}>
               <styledEl.ListItem onSelect={() => setDeadline(item)}>
                 <Trans>{item.title}</Trans>
@@ -149,7 +152,7 @@ export function DeadlineSelector(props: DeadlineSelectorProps) {
           </styledEl.ModalHeader>
           <styledEl.ModalContent>
             <styledEl.CustomLabel htmlFor="custom-deadline">
-              <Trans>Choose a custom deadline for your limit order:</Trans>
+              <Trans>Choose a custom deadline for your {orderType} order:</Trans>
               <styledEl.CustomInput
                 type="datetime-local"
                 id="custom-deadline"

--- a/src/cow-react/common/pure/DeadlineSelector/styled.tsx
+++ b/src/cow-react/common/pure/DeadlineSelector/styled.tsx
@@ -3,14 +3,28 @@ import { transparentize } from 'polished'
 import { MenuButton, MenuItem, MenuList } from '@reach/menu-button'
 import { X } from 'react-feather'
 
-export const Wrapper = styled.div`
+export const Wrapper = styled.div<{ inline?: boolean; minHeight?: string }>`
   background: ${({ theme }) => theme.grey1};
   border-radius: 16px;
   padding: 10px 16px;
-  min-height: 80px;
+  min-height: ${({ minHeight }) => minHeight || '80px'};
   justify-content: space-between;
   display: flex;
   flex-flow: row wrap;
+
+  ${({ inline }) =>
+    inline &&
+    `
+    justify-content: space-between;
+
+    > span {
+      flex: 1;
+    }
+
+    > button {
+      width: auto;
+    }
+  `}
 `
 
 export const Label = styled.span`

--- a/src/cow-react/common/pure/DeadlineSelector/utils.ts
+++ b/src/cow-react/common/pure/DeadlineSelector/utils.ts
@@ -1,4 +1,4 @@
-import { MAX_CUSTOM_DEADLINE, MIN_CUSTOM_DEADLINE } from '@cow/modules/limitOrders/pure/DeadlineSelector/deadlines'
+import { MAX_CUSTOM_DEADLINE, MIN_CUSTOM_DEADLINE } from '@cow/common/pure/DeadlineSelector/deadlines'
 
 export function limitDateString(date: Date | number): string {
   const _date = typeof date === 'number' ? new Date(date * 1000) : date

--- a/src/cow-react/modules/advancedOrders/containers/AdvancedOrdersWidget/index.tsx
+++ b/src/cow-react/modules/advancedOrders/containers/AdvancedOrdersWidget/index.tsx
@@ -1,6 +1,5 @@
 import { useSetupTradeState } from '@cow/modules/trade'
-import { TradeWidget } from '@cow/modules/trade/containers/TradeWidget'
-import React from 'react'
+import { TradeWidget, TradeWidgetSlots } from '@cow/modules/trade/containers/TradeWidget'
 import { CurrencyInfo } from '@cow/common/pure/CurrencyInputPanel/types'
 import { Field } from '@src/state/swap/actions'
 import {
@@ -9,6 +8,7 @@ import {
 } from '@cow/modules/advancedOrders/hooks/useAdvancedOrdersFullState'
 import { OrderKind } from '@cowprotocol/cow-sdk'
 import { useNavigateOnCurrencySelection } from '@cow/modules/trade/hooks/useNavigateOnCurrencySelection'
+import { DeadlineInput } from '../DeadlineInput'
 
 export function AdvancedOrdersWidget() {
   useSetupTradeState()
@@ -48,8 +48,13 @@ export function AdvancedOrdersWidget() {
   }
 
   // TODO
-  const slots = {
+  const slots: TradeWidgetSlots = {
     settingsWidget: <div></div>,
+    bottomContent: (
+      <>
+        <DeadlineInput />
+      </>
+    ),
   }
 
   // TODO

--- a/src/cow-react/modules/advancedOrders/containers/DeadlineInput/index.tsx
+++ b/src/cow-react/modules/advancedOrders/containers/DeadlineInput/index.tsx
@@ -1,17 +1,20 @@
+// eslint-disable-next-line no-restricted-imports
+import { Trans } from '@lingui/macro'
 import {
-  limitOrdersSettingsAtom,
-  updateLimitOrdersSettingsAtom,
-} from '@cow/modules/limitOrders/state/limitOrdersSettingsAtom'
+  advancedOrdersSettingsAtom,
+  updateAdvancedOrdersSettingsAtom,
+} from '@cow/modules/advancedOrders/state/advancedOrdersSettingsAtom'
 import { useSetAtom } from 'jotai'
 import { useAtomValue } from 'jotai/utils'
 import { useCallback, useMemo, useRef } from 'react'
 import { DeadlineSelector } from '@cow/common/pure/DeadlineSelector'
 import { OrderDeadline, ordersDeadlines } from '@cow/common/pure/DeadlineSelector/deadlines'
-import { OrderClass } from '@cowprotocol/cow-sdk'
+import QuestionHelper from 'components/QuestionHelper'
+import * as styledEl from './styled'
 
 export function DeadlineInput() {
-  const { deadlineMilliseconds, customDeadlineTimestamp } = useAtomValue(limitOrdersSettingsAtom)
-  const updateSettingsState = useSetAtom(updateLimitOrdersSettingsAtom)
+  const { deadlineMilliseconds, customDeadlineTimestamp } = useAtomValue(advancedOrdersSettingsAtom)
+  const updateSettingsState = useSetAtom(updateAdvancedOrdersSettingsAtom)
   const currentDeadlineNode = useRef<HTMLButtonElement>()
   const existingDeadline = useMemo(() => {
     return ordersDeadlines.find((item) => item.value === deadlineMilliseconds)
@@ -32,9 +35,20 @@ export function DeadlineInput() {
     [updateSettingsState]
   )
 
+  // TODO: update text
+  const label = (
+    <styledEl.LabelWrapper>
+      <span>Total time</span>
+      <QuestionHelper text={<Trans>This is some text here</Trans>} />
+    </styledEl.LabelWrapper>
+  )
+
   return (
     <DeadlineSelector
-      orderType={OrderClass.LIMIT}
+      inline
+      label={label}
+      orderType={'TWAP'}
+      minHeight="50px"
       deadline={existingDeadline}
       customDeadline={customDeadlineTimestamp}
       selectDeadline={selectDeadline}

--- a/src/cow-react/modules/advancedOrders/containers/DeadlineInput/styled.tsx
+++ b/src/cow-react/modules/advancedOrders/containers/DeadlineInput/styled.tsx
@@ -1,0 +1,6 @@
+import styled from 'styled-components/macro'
+
+export const LabelWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`

--- a/src/cow-react/modules/advancedOrders/state/advancedOrdersSettingsAtom.ts
+++ b/src/cow-react/modules/advancedOrders/state/advancedOrdersSettingsAtom.ts
@@ -1,0 +1,30 @@
+import { atomWithStorage } from 'jotai/utils'
+import { atom } from 'jotai'
+import { Milliseconds, Timestamp } from '@cow/types'
+import { defaultOrderDeadline } from '@cow/common/pure/DeadlineSelector/deadlines'
+
+export interface AdvancedOrdersSettingsState {
+  readonly deadlineMilliseconds: Milliseconds
+  readonly customDeadlineTimestamp: Timestamp | null
+}
+
+export const defaultAdvancedOrdersSettings: AdvancedOrdersSettingsState = {
+  deadlineMilliseconds: defaultOrderDeadline.value,
+  customDeadlineTimestamp: null,
+}
+
+export const advancedOrdersSettingsAtom = atomWithStorage<AdvancedOrdersSettingsState>(
+  'advanced-orders-settings-atom:v2',
+  defaultAdvancedOrdersSettings
+)
+
+export const updateAdvancedOrdersSettingsAtom = atom(
+  null,
+  (get, set, nextState: Partial<AdvancedOrdersSettingsState>) => {
+    set(advancedOrdersSettingsAtom, () => {
+      const prevState = get(advancedOrdersSettingsAtom)
+
+      return { ...prevState, ...nextState }
+    })
+  }
+)

--- a/src/cow-react/modules/limitOrders/state/limitOrdersSettingsAtom.ts
+++ b/src/cow-react/modules/limitOrders/state/limitOrdersSettingsAtom.ts
@@ -1,5 +1,5 @@
 import { atomWithStorage } from 'jotai/utils'
-import { defaultLimitOrderDeadline } from '@cow/modules/limitOrders/pure/DeadlineSelector/deadlines'
+import { defaultOrderDeadline } from '@cow/common/pure/DeadlineSelector/deadlines'
 import { atom } from 'jotai'
 import { Milliseconds, Timestamp } from '@cow/types'
 import { partiallyFillableOverrideAtom } from '@cow/modules/limitOrders/state/partiallyFillableOverride'
@@ -16,7 +16,7 @@ export const defaultLimitOrdersSettings: LimitOrdersSettingsState = {
   expertMode: false,
   showRecipient: false,
   partialFillsEnabled: true,
-  deadlineMilliseconds: defaultLimitOrderDeadline.value,
+  deadlineMilliseconds: defaultOrderDeadline.value,
   customDeadlineTimestamp: null,
 }
 

--- a/src/cow-react/modules/trade/containers/TradeWidget/index.tsx
+++ b/src/cow-react/modules/trade/containers/TradeWidget/index.tsx
@@ -30,7 +30,7 @@ interface TradeWidgetParams {
   isRateLoading?: boolean
 }
 
-interface TradeWidgetSlots {
+export interface TradeWidgetSlots {
   settingsWidget: JSX.Element
   lockScreen?: JSX.Element
   middleContent?: JSX.Element


### PR DESCRIPTION
# Summary

Fixes #2414
Since the design for this part is not finalised yet this includes just the basic functionality

- Adds deadline picker to TWAP order widget
- Refactors `DeadlineSelector` component from `limitOrder` to `common` since it will be reused and adds some parameters for customization
- Adds new `AdvancedOrdersSettingsState` part of the state