### PR TITLE
chore: addd our own IPFS gateway

### DIFF
--- a/src/lib/utils/uriToHttp.ts
+++ b/src/lib/utils/uriToHttp.ts
@@ -1,3 +1,9 @@
+import { isProd, isBarn, isDev } from 'utils/environments'
+
+const IPFS_BASE_URLS_PUBLIC = ['https://cloudflare-ipfs.coms', 'https://ipfs.io']
+const IPFS_BASE_URLS =
+  isProd && isBarn && isDev ? ['https://ipfs.cow.fi', ...IPFS_BASE_URLS_PUBLIC] : IPFS_BASE_URLS_PUBLIC
+
 /**
  * Given a URI that may be ipfs, ipns, http, https, ar, or data protocol, return the fetch-able http(s) URLs for the same content
  * @param uri to convert to fetch-able http url
@@ -13,7 +19,7 @@ export default function uriToHttp(uri: string): string[] {
       return ['https' + uri.substr(4), uri]
     case 'ipfs':
       const hash = uri.match(/^ipfs:(\/\/)?(ipfs\/)?(.*)$/i)?.[3] // TODO: probably a bug on original code
-      return [`https://cloudflare-ipfs.com/ipfs/${hash}/`, `https://ipfs.io/ipfs/${hash}/`]
+      return IPFS_BASE_URLS.map((url) => `${url}/ipfs/${hash}`)
     case 'ipns':
       const name = uri.match(/^ipns:(\/\/)?(.*)$/i)?.[2]
       return [`https://cloudflare-ipfs.com/ipns/${name}/`, `https://ipfs.io/ipns/${name}/`]


### PR DESCRIPTION
# Summary

Adds our own IPFS gateway for IPFS file resolution.

This will be used only in DEV, STAGING and PROD, so in this PR link you will see it still uses Cloudlare.

# To Test
Try to add a token list using the following URL:

`ipfs:QmRwoui6ZnWMMFzZzJK28fe1ZTnKVmx6vxu6wBiCRnJ66y`

<img width="1869" alt="image" src="https://user-images.githubusercontent.com/2352112/236446723-cc6aa311-7e5f-4153-ad0c-a22ba0b23d29.png">


It should be able to fetch the list. 

In DEV, STAGING, BARN, PROD should use ipfs.cow.fi to resolve the IPFS links