### PR TITLE
fix: fix token with special symbols

### DIFF
--- a/src/cow-react/modules/trade/utils/parameterizeTradeRoute.ts
+++ b/src/cow-react/modules/trade/utils/parameterizeTradeRoute.ts
@@ -11,6 +11,6 @@ export function parameterizeTradeRoute(
 ): string {
   return route
     .replace('/:chainId?', chainId ? `/${chainId}` : '')
-    .replace('/:inputCurrencyId?', inputCurrencyId ? `/${inputCurrencyId}` : '/_')
-    .replace('/:outputCurrencyId?', outputCurrencyId ? `/${outputCurrencyId}` : '')
+    .replace('/:inputCurrencyId?', inputCurrencyId ? `/${encodeURIComponent(inputCurrencyId)}` : '/_')
+    .replace('/:outputCurrencyId?', outputCurrencyId ? `/${encodeURIComponent(outputCurrencyId)}` : '')
 }

--- a/src/cow-react/modules/trade/utils/parameterizeTradeRoute.ts
+++ b/src/cow-react/modules/trade/utils/parameterizeTradeRoute.ts
@@ -10,7 +10,7 @@ export function parameterizeTradeRoute(
   route: Routes
 ): string {
   return route
-    .replace('/:chainId?', chainId ? `/${chainId}` : '')
+    .replace('/:chainId?', chainId ? `/${encodeURIComponent(chainId)}` : '')
     .replace('/:inputCurrencyId?', inputCurrencyId ? `/${encodeURIComponent(inputCurrencyId)}` : '/_')
     .replace('/:outputCurrencyId?', outputCurrencyId ? `/${encodeURIComponent(outputCurrencyId)}` : '')
 }


### PR DESCRIPTION
# Summary

Fixes #2440 


# To Test
Try to use `0x5b6c539b224014a09b3388e51caaa8e354c959c8` token in mainnet