### PR TITLE
feat: add account address to ga tracking

### DIFF
--- a/src/components/analytics/hooks/useAnalyticsReporter.ts
+++ b/src/components/analytics/hooks/useAnalyticsReporter.ts
@@ -72,9 +72,9 @@ export function useAnalyticsReporter() {
     // custom dimension 2 - walletname
     googleAnalytics.setDimension(Dimensions.walletName, account ? walletName : 'Not connected')
 
-    // Set userId and also dimensions because ReactGA.set might not be working
-    googleAnalytics.setDimension(Dimensions.userAddress, account)
-    ReactGA.set({ userId: account })
+    // Set userId and also new dimension because ReactGA.set might not be working
+    googleAnalytics.setDimension(Dimensions.userAddress, `"${account}"`)
+    ReactGA.set({ userId: `"${account}"` })
 
     // Handle pixel tracking on wallet connection
     if (!prevAccount && account) {

--- a/src/components/analytics/hooks/useAnalyticsReporter.ts
+++ b/src/components/analytics/hooks/useAnalyticsReporter.ts
@@ -18,6 +18,7 @@ import { sendTwitterEvent } from '../pixel/twitter'
 import { sendRedditEvent } from '../pixel/reddit'
 import { sendPavedEvent } from '../pixel/paved'
 import { sendMicrosoftEvent } from '../pixel/microsoft'
+import ReactGA from 'react-ga4'
 
 export function sendTiming(timingCategory: any, timingVar: any, timingValue: any, timingLabel: any) {
   return googleAnalytics.gaCommandSendTiming(timingCategory, timingVar, timingValue, timingLabel)
@@ -70,6 +71,10 @@ export function useAnalyticsReporter() {
   useEffect(() => {
     // custom dimension 2 - walletname
     googleAnalytics.setDimension(Dimensions.walletName, account ? walletName : 'Not connected')
+
+    // Set userId and also dimensions because ReactGA.set might not be working
+    googleAnalytics.setDimension(Dimensions.userAddress, account)
+    ReactGA.set({ userId: account })
 
     // Handle pixel tracking on wallet connection
     if (!prevAccount && account) {

--- a/src/components/analytics/provider/index.ts
+++ b/src/components/analytics/provider/index.ts
@@ -8,6 +8,7 @@ const DIMENSION_MAP = {
   [Dimensions.chainId]: 'dimension1',
   [Dimensions.walletName]: 'dimension2',
   [Dimensions.customBrowserType]: 'dimension3',
+  [Dimensions.userAddress]: 'dimension4',
 }
 
 type DimensionKey = keyof typeof DIMENSION_MAP
@@ -19,7 +20,12 @@ export class GAProvider {
   dimensions: { [key in DimensionKey]: any }
 
   constructor() {
-    this.dimensions = { chainId: '', walletName: '', customBrowserType: '' }
+    this.dimensions = {
+      chainId: '',
+      walletName: '',
+      customBrowserType: '',
+      userAddress: '',
+    }
   }
 
   public sendEvent(event: string | UaEventOptions, params?: any) {

--- a/src/components/analytics/types.ts
+++ b/src/components/analytics/types.ts
@@ -27,4 +27,5 @@ export enum Dimensions {
   chainId = 'chainId',
   walletName = 'walletName',
   customBrowserType = 'customBrowserType',
+  userAddress = 'userAddress',
 }

--- a/src/cow-react/pages/PrivacyPolicy/PrivacyPolicy.md
+++ b/src/cow-react/pages/PrivacyPolicy/PrivacyPolicy.md
@@ -46,6 +46,7 @@ We may collect and process Personal Data about your use of our website or websit
 - Behaviour: subpage, duration, and revisit;
 - The date and time of access to the website, The Internet protocol address (“IP address”);
 - The Internet service provider of the accessing system;
+- Connected wallet type and wallet address;
 - session by device; and
 - Any other similar data and information that may be used in the event of attacks on our information technology systems.
 


### PR DESCRIPTION
# Summary

Adds functionality to track user address as a dimension and also as user id.
The weird value ``"${account}"`` is because in google analytics it will be parsed as a number if we just pass the `account`
![Screenshot 2023-05-11 at 12 32 04](https://github.com/cowprotocol/cowswap/assets/34926005/66638255-5476-4892-9da8-10d7fa36cd63)

# To test
The way I tested this is by GA debug extension, there should be dimension4 in events once you connect your wallet
![Screenshot 2023-05-11 at 12 49 56](https://github.com/cowprotocol/cowswap/assets/34926005/0d34250a-88d4-45b3-bd0a-9a6a6e998000)

And also in the GA console
![Screenshot 2023-05-11 at 12 47 40](https://github.com/cowprotocol/cowswap/assets/34926005/05aa4592-f558-46ca-aa28-f83a2b1de63b)
![Screenshot 2023-05-11 at 12 47 54](https://github.com/cowprotocol/cowswap/assets/34926005/3daa8feb-c1b9-4bd0-a9ee-84e0103f28b1)
