### PR TITLE
fix(swap-url-amounts): fix sellAmount and buyAmount url parameters for SWAP

### DIFF
--- a/cypress-custom/integration/limit-orders.test.ts
+++ b/cypress-custom/integration/limit-orders.test.ts
@@ -1,11 +1,5 @@
 const CHAIN_ID = 5
 
-function pickToken(symbol: string, role: 'input' | 'output') {
-  cy.get(`#${role}-currency-input .open-currency-select-button`).click()
-  cy.get('#token-search-input').type(symbol)
-  cy.get('#currency-list').get('div').contains(symbol).click({ force: true })
-}
-
 describe('Limit orders', () => {
   it('Confirmation modal must contains values that were entered while creating', () => {
     const inputAmount = 0.1
@@ -15,7 +9,7 @@ describe('Limit orders', () => {
     cy.visit(`/#/${CHAIN_ID}/limit-orders`)
     cy.get('#unlock-limit-orders-btn').click()
 
-    pickToken('USDC', 'output')
+    cy.limitPickToken('USDC', 'output')
 
     cy.get('#input-currency-input .token-amount-input').type(inputAmount.toString())
     cy.get('#rate-limit-amount-input').clear().type(rate.toString(), { force: true })

--- a/cypress-custom/integration/limit-orders.test.ts
+++ b/cypress-custom/integration/limit-orders.test.ts
@@ -22,4 +22,47 @@ describe('Limit orders', () => {
     )
     cy.get('#limit-orders-confirm #output-currency-preview .token-amount-input').should('contain.text', '200B')
   })
+
+  describe('url params', () => {
+    const SELL_TOKEN = 'WETH'
+    const BUY_TOKEN = 'DAI'
+
+    it('should accept sellAmount url param', () => {
+      cy.visit(`/#/${CHAIN_ID}/limit-orders/${SELL_TOKEN}?sellAmount=0.1`)
+      cy.get('#unlock-limit-orders-btn').click()
+      cy.get('#input-currency-input .token-amount-input').should('have.value', '0.1')
+    })
+
+    it('should not accept sellAmount when there is no sell token', () => {
+      cy.visit(`/#/${CHAIN_ID}/limit-orders/_/${BUY_TOKEN}?sellAmount=0.1`)
+      cy.get('#unlock-limit-orders-btn').click()
+      cy.get('#input-currency-input .token-amount-input').should('have.value', '')
+    })
+
+    it('should accept buyAmount url param', () => {
+      cy.visit(`/#/${CHAIN_ID}/limit-orders/_/${BUY_TOKEN}?buyAmount=0.1`)
+      cy.get('#unlock-limit-orders-btn').click()
+      cy.get('#output-currency-input .token-amount-input').should('have.value', '0.1')
+    })
+
+    it('should not accept buyAmount when there is no buy token', () => {
+      cy.visit(`/#/${CHAIN_ID}/limit-orders?buyAmount=0.1`)
+      cy.get('#unlock-limit-orders-btn').click()
+      cy.get('#output-currency-input .token-amount-input').should('have.value', '')
+    })
+
+    it('should accept both sellAmount and buyAmount url params', () => {
+      cy.visit(`/#/${CHAIN_ID}/limit-orders/${SELL_TOKEN}/${BUY_TOKEN}?sellAmount=0.1&buyAmount=0.2`)
+      cy.get('#unlock-limit-orders-btn').click()
+      cy.get('#input-currency-input .token-amount-input').should('have.value', '0.1')
+      cy.get('#output-currency-input .token-amount-input').should('have.value', '0.2')
+    })
+
+    it('should ignore invalid sellAmount and buyAmount url params', () => {
+      cy.visit(`/#/${CHAIN_ID}/limit-orders/${SELL_TOKEN}/${BUY_TOKEN}?sellAmount=rwe&buyAmount=aaa`)
+      cy.get('#unlock-limit-orders-btn').click()
+      cy.get('#input-currency-input .token-amount-input').should('have.value', '')
+      cy.get('#output-currency-input .token-amount-input').should('have.value', '')
+    })
+  })
 })

--- a/cypress-custom/integration/swap.test.ts
+++ b/cypress-custom/integration/swap.test.ts
@@ -52,4 +52,35 @@ describe('Swap (custom)', () => {
     cy.get('#switch-to-wrapped').should('contain', 'Switch to WETH').click()
     cy.get('#input-currency-input .token-symbol-container').should('contain', 'WETH')
   })
+
+  describe('url params', () => {
+    const SELL_TOKEN = 'WETH'
+    const BUY_TOKEN = 'DAI'
+
+    it('should accept sellAmount url param', () => {
+      cy.visit(`/${CHAIN_ID}/swap/${SELL_TOKEN}/${BUY_TOKEN}?sellAmount=0.5`)
+      cy.get('#input-currency-input .token-amount-input').should('have.value', '0.5')
+    })
+
+    it('should not accept sellAmount url param when there is no sell token', () => {
+      cy.visit(`/${CHAIN_ID}/swap/_/${BUY_TOKEN}?sellAmount=0.5`)
+      cy.get('#input-currency-input .token-amount-input').should('not.have.value')
+    })
+
+    it('should accept buyAmount url param', () => {
+      cy.visit(`/${CHAIN_ID}/swap/${SELL_TOKEN}/${BUY_TOKEN}?buyAmount=0.5`)
+      cy.get('#output-currency-input .token-amount-input').should('have.value', '0.5')
+    })
+
+    it('should not accept buyAmount url param when there is no buy token', () => {
+      cy.visit(`/${CHAIN_ID}/swap/${SELL_TOKEN}/_?buyAmount=0.5`)
+      cy.get('#output-currency-input .token-amount-input').should('not.have.value')
+    })
+
+    it('sellAmount should take precedence over buyAmount', () => {
+      cy.visit(`/${CHAIN_ID}/swap/${SELL_TOKEN}/${BUY_TOKEN}?sellAmount=0.5&buyAmount=0.6`)
+      cy.get('#input-currency-input .token-amount-input').should('have.value', '0.5')
+      cy.get('#output-currency-input .token-amount-input').should('not.have.value')
+    })
+  })
 })

--- a/cypress-custom/support/commands.d.ts
+++ b/cypress-custom/support/commands.d.ts
@@ -45,6 +45,13 @@ declare namespace Cypress {
     clickOutputToken(): Chainable<Subject>
 
     /**
+     * Pick the 'input' or 'output' token
+     *
+     * @example cy.limitPickToken('DAI', 'input')
+     */
+    limitPickToken(symbol: string, role: 'input' | 'output'): Chainable<Subject>
+
+    /**
      * Set a stubbing intercept on route specified
      *
      * @example cy.stubResponse({ url: '/api/v1/someEndpoint/', alias: 'endpoint', body: { foo: 'foo' } })

--- a/cypress-custom/support/commands.js
+++ b/cypress-custom/support/commands.js
@@ -36,6 +36,12 @@ function selectInput(tokenAddress) {
   _selectTokenFromSelector(tokenAddress, 'input')
 }
 
+function pickToken(symbol, role) {
+  cy.get(`#${role}-currency-input .open-currency-select-button`).click()
+  cy.get('#token-search-input').type(symbol)
+  cy.get('#currency-list').get('div').contains(symbol).click({ force: true })
+}
+
 function enterInputAmount(tokenAddress, amount, selectToken = false) {
   // Choose whether to also select token
   // or just input amount
@@ -64,4 +70,5 @@ Cypress.Commands.add('swapSelectInput', selectInput)
 Cypress.Commands.add('swapSelectOutput', selectOutput)
 Cypress.Commands.add('swapEnterInputAmount', enterInputAmount)
 Cypress.Commands.add('swapEnterOutputAmount', enterOutputAmount)
+Cypress.Commands.add('limitPickToken', pickToken)
 Cypress.Commands.add('stubResponse', stubResponse)

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -84,7 +84,7 @@ export default function Header() {
     const defaultTradeState = getDefaultTradeRawState(chainId || state.chainId || SupportedChainId.MAINNET)
     const networkWasChanged = chainId && state.chainId && chainId !== state.chainId
 
-    // When network was changed - use the deafult trade state
+    // When network was changed - use the default trade state
     const inputCurrencyId =
       (networkWasChanged
         ? defaultTradeState.inputCurrencyId

--- a/src/cow-react/modules/swap/hooks/useSwapRawState.ts
+++ b/src/cow-react/modules/swap/hooks/useSwapRawState.ts
@@ -2,7 +2,7 @@ import { TradeRawState } from '@cow/modules/trade/types/TradeRawState'
 import { useSwapState } from 'state/swap/hooks'
 import { useAppDispatch } from '@src/state/hooks'
 import { useCallback } from 'react'
-import { replaceSwapState, ReplaceSwapStatePayload } from '@src/state/swap/actions'
+import { updateSwapState, UpdateSwapStatePayload } from '@src/state/swap/actions'
 
 export function useSwapRawState(): TradeRawState {
   const swapState = useSwapState()
@@ -15,22 +15,19 @@ export function useSwapRawState(): TradeRawState {
   }
 }
 export function useUpdateSwapRawState(): (update: Partial<TradeRawState>) => void {
-  const swapState = useSwapState()
   const dispatch = useAppDispatch()
 
   return useCallback(
     (state: Partial<TradeRawState>) => {
-      const newState: ReplaceSwapStatePayload = {
-        typedValue: swapState.typedValue,
-        independentField: swapState.independentField,
-        chainId: state.chainId || swapState.chainId,
-        recipient: typeof state.recipient === 'undefined' ? swapState.recipient : state.recipient,
+      const newState: UpdateSwapStatePayload = {
+        chainId: state.chainId,
+        recipient: state.recipient,
         inputCurrencyId: state.inputCurrencyId || undefined,
         outputCurrencyId: state.outputCurrencyId || undefined,
       }
 
-      dispatch(replaceSwapState(newState))
+      dispatch(updateSwapState(newState))
     },
-    [swapState, dispatch]
+    [dispatch]
   )
 }

--- a/src/cow-react/modules/swap/hooks/useSwapRawState.ts
+++ b/src/cow-react/modules/swap/hooks/useSwapRawState.ts
@@ -2,7 +2,7 @@ import { TradeRawState } from '@cow/modules/trade/types/TradeRawState'
 import { useSwapState } from 'state/swap/hooks'
 import { useAppDispatch } from '@src/state/hooks'
 import { useCallback } from 'react'
-import { updateSwapState, UpdateSwapStatePayload } from '@src/state/swap/actions'
+import { replaceOnlyTradeRawState, ReplaceOnlyTradeRawStatePayload } from '@src/state/swap/actions'
 
 export function useSwapRawState(): TradeRawState {
   const swapState = useSwapState()
@@ -19,14 +19,14 @@ export function useUpdateSwapRawState(): (update: Partial<TradeRawState>) => voi
 
   return useCallback(
     (state: Partial<TradeRawState>) => {
-      const newState: UpdateSwapStatePayload = {
-        chainId: state.chainId,
-        recipient: state.recipient,
+      const newState: ReplaceOnlyTradeRawStatePayload = {
+        chainId: state.chainId ?? null,
+        recipient: state.recipient ?? null,
         inputCurrencyId: state.inputCurrencyId || undefined,
         outputCurrencyId: state.outputCurrencyId || undefined,
       }
 
-      dispatch(updateSwapState(newState))
+      dispatch(replaceOnlyTradeRawState(newState))
     },
     [dispatch]
   )

--- a/src/state/swap/actions.ts
+++ b/src/state/swap/actions.ts
@@ -5,7 +5,6 @@ export enum Field {
   OUTPUT = 'OUTPUT',
 }
 
-// Mod: interface for replaceSwapState() action. Added chainId parameter, field renamed to independentField
 export interface ReplaceSwapStatePayload {
   chainId: number | null
   independentField: Field
@@ -14,9 +13,11 @@ export interface ReplaceSwapStatePayload {
   outputCurrencyId?: string
   recipient: string | null
 }
+export interface UpdateSwapStatePayload extends Partial<ReplaceSwapStatePayload> {}
 
 export const selectCurrency = createAction<{ field: Field; currencyId: string }>('swap/selectCurrency')
 export const switchCurrencies = createAction<void>('swap/switchCurrencies')
 export const typeInput = createAction<{ field: Field; typedValue: string }>('swap/typeInput')
 export const replaceSwapState = createAction<ReplaceSwapStatePayload>('swap/replaceSwapState')
+export const updateSwapState = createAction<UpdateSwapStatePayload>('swap/updateSwapState')
 export const setRecipient = createAction<{ recipient: string | null }>('swap/setRecipient')

--- a/src/state/swap/actions.ts
+++ b/src/state/swap/actions.ts
@@ -5,19 +5,25 @@ export enum Field {
   OUTPUT = 'OUTPUT',
 }
 
-export interface ReplaceSwapStatePayload {
-  chainId: number | null
-  independentField: Field
-  typedValue: string
-  inputCurrencyId?: string
-  outputCurrencyId?: string
-  recipient: string | null
+export interface ReplaceOnlyTradeRawStatePayload {
+  readonly chainId: number | null
+  readonly inputCurrencyId?: string
+  readonly outputCurrencyId?: string
+  readonly recipient: string | null
 }
-export interface UpdateSwapStatePayload extends Partial<ReplaceSwapStatePayload> {}
+
+export interface ReplaceSwapStatePayload extends ReplaceOnlyTradeRawStatePayload {
+  readonly typedValue: string
+  readonly independentField: Field
+}
 
 export const selectCurrency = createAction<{ field: Field; currencyId: string }>('swap/selectCurrency')
 export const switchCurrencies = createAction<void>('swap/switchCurrencies')
 export const typeInput = createAction<{ field: Field; typedValue: string }>('swap/typeInput')
+
+/**
+ * Replaces only a subset of the state corresponding to TradeRawState.
+ */
+export const replaceOnlyTradeRawState = createAction<ReplaceOnlyTradeRawStatePayload>('swap/replaceOnlyTradeRawState')
 export const replaceSwapState = createAction<ReplaceSwapStatePayload>('swap/replaceSwapState')
-export const updateSwapState = createAction<UpdateSwapStatePayload>('swap/updateSwapState')
 export const setRecipient = createAction<{ recipient: string | null }>('swap/setRecipient')

--- a/src/state/swap/reducer.ts
+++ b/src/state/swap/reducer.ts
@@ -26,7 +26,7 @@ const initialState: SwapState = queryParametersToSwapState(parsedQueryString(), 
 
 export default createReducer<SwapState>(initialState, (builder) =>
   builder
-    // Mod: ranamed field => independentField, added chainId
+    // Mod: renamed field => independentField, added chainId
     .addCase(replaceSwapState, (state, { payload }) => {
       const {
         chainId,

--- a/src/state/swap/reducer.ts
+++ b/src/state/swap/reducer.ts
@@ -1,7 +1,15 @@
 import { createReducer } from '@reduxjs/toolkit'
 import { parsedQueryString } from 'hooks/useParsedQueryString'
 
-import { Field, replaceSwapState, selectCurrency, setRecipient, switchCurrencies, typeInput } from 'state/swap/actions'
+import {
+  Field,
+  replaceSwapState,
+  selectCurrency,
+  setRecipient,
+  switchCurrencies,
+  typeInput,
+  updateSwapState,
+} from 'state/swap/actions'
 import { queryParametersToSwapState } from 'state/swap/hooks'
 import { NATIVE_CURRENCY_BUY_TOKEN } from 'constants/index'
 import { WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
@@ -55,6 +63,36 @@ export default createReducer<SwapState>(initialState, (builder) =>
         independentField,
         typedValue,
         recipient,
+      }
+    })
+    .addCase(updateSwapState, (state, { payload }) => {
+      const {
+        chainId,
+        typedValue: originalTypedValue,
+        recipient,
+        independentField: originalIndependentField,
+        inputCurrencyId,
+        outputCurrencyId,
+      } = payload
+
+      const { independentField, typedValue } = getEthFlowOverridesOnSelect(
+        inputCurrencyId,
+        originalIndependentField ?? state.independentField,
+        originalTypedValue ?? state.typedValue,
+        state
+      )
+
+      return {
+        chainId: chainId ?? state.chainId,
+        [Field.INPUT]: {
+          currencyId: inputCurrencyId ?? state[Field.INPUT].currencyId,
+        },
+        [Field.OUTPUT]: {
+          currencyId: outputCurrencyId ?? state[Field.OUTPUT].currencyId,
+        },
+        independentField: independentField ?? state.independentField,
+        typedValue: typedValue ?? state.typedValue,
+        recipient: recipient ?? state.recipient,
       }
     })
     .addCase(selectCurrency, (state, { payload: { currencyId, field } }) => {

--- a/src/state/swap/reducer.ts
+++ b/src/state/swap/reducer.ts
@@ -3,12 +3,12 @@ import { parsedQueryString } from 'hooks/useParsedQueryString'
 
 import {
   Field,
+  replaceOnlyTradeRawState,
   replaceSwapState,
   selectCurrency,
   setRecipient,
   switchCurrencies,
   typeInput,
-  updateSwapState,
 } from 'state/swap/actions'
 import { queryParametersToSwapState } from 'state/swap/hooks'
 import { NATIVE_CURRENCY_BUY_TOKEN } from 'constants/index'
@@ -65,34 +65,19 @@ export default createReducer<SwapState>(initialState, (builder) =>
         recipient,
       }
     })
-    .addCase(updateSwapState, (state, { payload }) => {
-      const {
-        chainId,
-        typedValue: originalTypedValue,
-        recipient,
-        independentField: originalIndependentField,
-        inputCurrencyId,
-        outputCurrencyId,
-      } = payload
-
-      const { independentField, typedValue } = getEthFlowOverridesOnSelect(
-        inputCurrencyId,
-        originalIndependentField ?? state.independentField,
-        originalTypedValue ?? state.typedValue,
-        state
-      )
+    .addCase(replaceOnlyTradeRawState, (state, { payload }) => {
+      const { chainId, recipient, inputCurrencyId, outputCurrencyId } = payload
 
       return {
-        chainId: chainId ?? state.chainId,
+        ...state,
+        chainId,
         [Field.INPUT]: {
-          currencyId: inputCurrencyId ?? state[Field.INPUT].currencyId,
+          currencyId: inputCurrencyId ?? null,
         },
         [Field.OUTPUT]: {
-          currencyId: outputCurrencyId ?? state[Field.OUTPUT].currencyId,
+          currencyId: outputCurrencyId ?? null,
         },
-        independentField: independentField ?? state.independentField,
-        typedValue: typedValue ?? state.typedValue,
-        recipient: recipient ?? state.recipient,
+        recipient,
       }
     })
     .addCase(selectCurrency, (state, { payload: { currencyId, field } }) => {


### PR DESCRIPTION
# Summary

Closes #2449 

Fix `sellAmount` and `buyAmount` url params for Swap

# To Test

1. On Swap, make sure you have a sell token, insert in the url after the token(s): `?sellAmount=1`
* Sell amount input should be set to 1
2. On Swap, make sure you have a buy token, insert in the url after the token(s): `?buyAmount=4`
* Buy amount input should be set to 4

This change touches chainId/recipient (from URL only) related areas, so we also need regression tests for that

## Bonus!

Added new cypress tests for both swap and limit orders to check for `sellAmount` and `buyAmount` behaviour

# Background

The issue was introduced on https://github.com/cowprotocol/cowswap/pull/2317
When the URL params are set, the state was being updated properly [here](https://github.com/cowprotocol/cowswap/blob/1df31149f10cce2e12d81e23e4f0b3e6b5f9467c/src/cow-react/modules/swap/hooks/useSetupSwapAmountsFromUrl.ts#L16)
But then, when [the hook `useSetupTradeState`](https://github.com/cowprotocol/cowswap/blob/b072133c731d5a61b06d0af37a015b9682869896/src/cow-react/modules/trade/hooks/setupTradeState/useSetupTradeState.ts#L108) triggered, [it replaced the existing state with a stale version](https://github.com/cowprotocol/cowswap/blob/f5e962a33e35781b1c5546b9684dd42d9c238242/src/cow-react/modules/swap/hooks/useSwapRawState.ts#LL18C22-L18C22) which did not contain the changes from the previous hook `useEffect`

~So my solution was to add a new redux action to allow updating part of the state, rather than replacing everything at once~
*Update:* Previous iteration was not clearing out values when needed, to I created a new redux action to replace only the necessary subset