### PR TITLE
feat: get UTM codes from URL and add them to the app state and local …

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@amplitude/analytics-browser": "^1.1.4",
     "@babel/runtime": "^7.17.0",
     "@coinbase/wallet-sdk": "^3.3.0",
-    "@cowprotocol/app-data": "v0.1.0-alpha.0",
+    "@cowprotocol/app-data": "v0.2.5",
     "@cowprotocol/contracts": "^1.3.1",
     "@cowprotocol/cow-runner-game": "^0.2.9",
     "@cowprotocol/cow-sdk": "^2.0.4",

--- a/src/cow-react/modules/application/containers/App/index.tsx
+++ b/src/cow-react/modules/application/containers/App/index.tsx
@@ -13,10 +13,12 @@ import Footer from 'components/Footer'
 import RedirectAnySwapAffectedUsers from '@cow/pages/error/AnySwapAffectedUsers/RedirectAnySwapAffectedUsers'
 import { RoutesApp } from './RoutesApp'
 import * as styledEl from './styled'
+import { useInitializeUtm } from '@cow/modules/utm'
 
 export function App() {
   initializeAnalytics()
   useAnalyticsReporter()
+  useInitializeUtm()
 
   return (
     <ErrorBoundary>

--- a/src/cow-react/modules/utm/hooks.ts
+++ b/src/cow-react/modules/utm/hooks.ts
@@ -1,35 +1,53 @@
 import { useEffect } from 'react'
-import { useLocation } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { UtmParams } from './types'
 import { useSetAtom } from 'jotai'
 import { utmAtom } from './state'
 
-function getUtcParams(searchParams: URLSearchParams): UtmParams {
-  const utcSource = searchParams.get('utm_source') || undefined
-  const utcMedium = searchParams.get('utm_medium') || undefined
-  const utcCampaign = searchParams.get('utm_campaign') || undefined
-  const utcContent = searchParams.get('utm_content') || undefined
-  const utcTerm = searchParams.get('utm_term') || undefined
+const UTM_SOURCE_PARAM = 'utm_source'
+const UTM_MEDIUM_PARAM = 'utm_medium'
+const UTM_CAMPAIGN_PARAM = 'utm_campaign'
+const UTM_CONTENT_PARAM = 'utm_content'
+const UTM_TERM_PARAM = 'utm_term'
+
+const ALL_UTM_PARAMS = [UTM_SOURCE_PARAM, UTM_MEDIUM_PARAM, UTM_CAMPAIGN_PARAM, UTM_CONTENT_PARAM, UTM_TERM_PARAM]
+
+function getUtmParams(searchParams: URLSearchParams): UtmParams {
+  const utmSource = searchParams.get(UTM_SOURCE_PARAM) || undefined
+  const utmMedium = searchParams.get(UTM_MEDIUM_PARAM) || undefined
+  const utmCampaign = searchParams.get(UTM_CAMPAIGN_PARAM) || undefined
+  const utmContent = searchParams.get(UTM_CONTENT_PARAM) || undefined
+  const utmTerm = searchParams.get(UTM_TERM_PARAM) || undefined
 
   return {
-    utcSource,
-    utcMedium,
-    utcCampaign,
-    utcContent,
-    utcTerm,
+    utmSource,
+    utmMedium,
+    utmCampaign,
+    utmContent,
+    utmTerm,
   }
 }
 
 export function useInitializeUtm() {
-  const location = useLocation()
+  const navigate = useNavigate()
+  const { search, pathname } = useLocation()
+
   // get atom setter
   const setUtm = useSetAtom(utmAtom)
 
   useEffect(
     () => {
-      const searchParams = new URLSearchParams(location.search)
-      const utm = getUtcParams(searchParams)
-      setUtm(utm)
+      const searchParams = new URLSearchParams(search)
+      const utm = getUtmParams(searchParams)
+      console.log('UTM', utm, searchParams)
+      if (utm.utmCampaign || utm.utmCampaign || utm.utmContent || utm.utmMedium || utm.utmSource) {
+        // Only overrides the UTM if the URL includes any UTM param
+        setUtm(utm)
+      }
+
+      ALL_UTM_PARAMS.forEach((param) => searchParams.delete(param))
+      console.log('UTM 2', utm, searchParams)
+      navigate({ pathname, search: searchParams.toString() }, { replace: true })
     },
     // No dependencies: It only needs to be initialized once
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/cow-react/modules/utm/hooks.ts
+++ b/src/cow-react/modules/utm/hooks.ts
@@ -39,14 +39,13 @@ export function useInitializeUtm() {
     () => {
       const searchParams = new URLSearchParams(search)
       const utm = getUtmParams(searchParams)
-      console.log('UTM', utm, searchParams)
       if (utm.utmCampaign || utm.utmCampaign || utm.utmContent || utm.utmMedium || utm.utmSource) {
         // Only overrides the UTM if the URL includes any UTM param
         setUtm(utm)
       }
 
       ALL_UTM_PARAMS.forEach((param) => searchParams.delete(param))
-      console.log('UTM 2', utm, searchParams)
+
       navigate({ pathname, search: searchParams.toString() }, { replace: true })
     },
     // No dependencies: It only needs to be initialized once

--- a/src/cow-react/modules/utm/hooks.ts
+++ b/src/cow-react/modules/utm/hooks.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+import { UtmParams } from './types'
+import { useSetAtom } from 'jotai'
+import { utmAtom } from './state'
+
+function getUtcParams(searchParams: URLSearchParams): UtmParams {
+  const utcSource = searchParams.get('utm_source') || undefined
+  const utcMedium = searchParams.get('utm_medium') || undefined
+  const utcCampaign = searchParams.get('utm_campaign') || undefined
+  const utcContent = searchParams.get('utm_content') || undefined
+  const utcTerm = searchParams.get('utm_term') || undefined
+
+  return {
+    utcSource,
+    utcMedium,
+    utcCampaign,
+    utcContent,
+    utcTerm,
+  }
+}
+
+export function useInitializeUtm() {
+  const location = useLocation()
+  // get atom setter
+  const setUtm = useSetAtom(utmAtom)
+
+  useEffect(
+    () => {
+      const searchParams = new URLSearchParams(location.search)
+      const utm = getUtcParams(searchParams)
+      setUtm(utm)
+    },
+    // No dependencies: It only needs to be initialized once
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
+}

--- a/src/cow-react/modules/utm/index.ts
+++ b/src/cow-react/modules/utm/index.ts
@@ -1,0 +1,2 @@
+export * from './hooks'
+export * from './types'

--- a/src/cow-react/modules/utm/state.ts
+++ b/src/cow-react/modules/utm/state.ts
@@ -1,0 +1,4 @@
+import { UtmParams } from './types'
+import { atomWithStorage } from 'jotai/utils'
+
+export const utmAtom = atomWithStorage<UtmParams>('utm-atom:v1', {})

--- a/src/cow-react/modules/utm/state.ts
+++ b/src/cow-react/modules/utm/state.ts
@@ -1,4 +1,4 @@
 import { UtmParams } from './types'
 import { atomWithStorage } from 'jotai/utils'
 
-export const utmAtom = atomWithStorage<UtmParams>('utm-atom:v1', {})
+export const utmAtom = atomWithStorage<UtmParams | undefined>('utm-atom:v1', undefined)

--- a/src/cow-react/modules/utm/types.ts
+++ b/src/cow-react/modules/utm/types.ts
@@ -1,0 +1,7 @@
+export interface UtmParams {
+  utcSource?: string
+  utcMedium?: string
+  utcCampaign?: string
+  utcContent?: string
+  utcTerm?: string
+}

--- a/src/cow-react/modules/utm/types.ts
+++ b/src/cow-react/modules/utm/types.ts
@@ -1,7 +1,7 @@
 export interface UtmParams {
-  utcSource?: string
-  utcMedium?: string
-  utcCampaign?: string
-  utcContent?: string
-  utcTerm?: string
+  utmSource?: string
+  utmMedium?: string
+  utmCampaign?: string
+  utmContent?: string
+  utmTerm?: string
 }

--- a/src/hooks/useAppData.ts
+++ b/src/hooks/useAppData.ts
@@ -7,18 +7,20 @@ import { appDataInfoAtom } from 'state/appData/atoms'
 import { useAppCode } from 'hooks/useAppCode'
 import { OrderClass } from '@cowprotocol/cow-sdk'
 import { useUpdateAtom } from 'jotai/utils'
+import { UtmParams } from '@cow/modules/utm'
 
 export type UseAppDataParams = {
   chainId?: SupportedChainId
   slippageBips: string
   orderClass: OrderClass
+  utm: UtmParams | undefined
 }
 
 /**
  * Fetches and updates appDataInfo whenever a dependency changes
  * The hook can be called only from an updater
  */
-export function useAppData({ chainId, slippageBips, orderClass }: UseAppDataParams): void {
+export function useAppData({ chainId, slippageBips, orderClass, utm }: UseAppDataParams): void {
   // AppDataInfo, from Jotai
   const setAppDataInfo = useUpdateAtom(appDataInfoAtom)
   // AppCode is dynamic and based on how it's loaded (if used as a Gnosis Safe app)
@@ -31,12 +33,11 @@ export function useAppData({ chainId, slippageBips, orderClass }: UseAppDataPara
       return
     }
 
-    const params: BuildAppDataParams = { chainId, slippageBips, appCode, orderClass }
+    const params: BuildAppDataParams = { chainId, slippageBips, appCode, orderClass, utm }
 
     const updateAppData = async (): Promise<void> => {
       try {
         const { doc, calculatedAppData } = await buildAppData(params)
-
         console.debug(`[useAppData] appDataInfo`, JSON.stringify(doc), calculatedAppData)
 
         if (calculatedAppData?.appDataHash) {
@@ -53,5 +54,5 @@ export function useAppData({ chainId, slippageBips, orderClass }: UseAppDataPara
     }
 
     updateAppData()
-  }, [appCode, chainId, setAppDataInfo, slippageBips, orderClass])
+  }, [appCode, chainId, setAppDataInfo, slippageBips, orderClass, utm])
 }

--- a/src/state/appData/AppDataInfoUpdater.tsx
+++ b/src/state/appData/AppDataInfoUpdater.tsx
@@ -6,11 +6,13 @@ import { LIMIT_ORDER_SLIPPAGE } from '@cow/modules/limitOrders/const/trade'
 import { TradeType, useTradeTypeInfo } from '@cow/modules/trade'
 import { percentToBips } from 'utils/misc'
 import { useWalletInfo } from '@cow/modules/wallet'
+import { useUtm } from '@cow/modules/utm'
 
 export function AppDataUpdater() {
   const { chainId } = useWalletInfo()
   const { allowedSlippage: allowedSlippageSwap } = useDerivedSwapInfo()
   const tradeTypeInfo = useTradeTypeInfo()
+  const utm = useUtm()
 
   if (!chainId || !tradeTypeInfo) return null
 
@@ -19,11 +21,11 @@ export function AppDataUpdater() {
   const slippageBips = percentToBips(allowedSlippage)
   const orderClass = isSwapOrder ? OrderClass.MARKET : OrderClass.LIMIT
 
-  return <AppDataUpdaterMemo chainId={chainId} slippageBips={slippageBips} orderClass={orderClass} />
+  return <AppDataUpdaterMemo chainId={chainId} slippageBips={slippageBips} orderClass={orderClass} utm={utm} />
 }
 
-const AppDataUpdaterMemo = React.memo(({ chainId, slippageBips, orderClass }: UseAppDataParams) => {
-  useAppData({ chainId, slippageBips, orderClass })
+const AppDataUpdaterMemo = React.memo(({ chainId, slippageBips, orderClass, utm }: UseAppDataParams) => {
+  useAppData({ chainId, slippageBips, orderClass, utm })
 
   return null
 })

--- a/src/utils/appData.ts
+++ b/src/utils/appData.ts
@@ -2,13 +2,15 @@ import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { environmentName } from 'utils/environments'
 import { OrderClass } from '@cowprotocol/cow-sdk'
 import { metadataApiSDK } from '@cow/cowSdk'
+import { UtmParams } from '@cow/modules/utm'
 
 export type BuildAppDataParams = {
+  appCode: string
   chainId: SupportedChainId
   slippageBips: string
   orderClass: OrderClass
   referrerAccount?: string
-  appCode: string
+  utm: UtmParams | undefined
 }
 
 export async function buildAppData({
@@ -17,6 +19,7 @@ export async function buildAppData({
   referrerAccount,
   appCode,
   orderClass,
+  utm: utmParams,
 }: BuildAppDataParams) {
   const referrerParams =
     referrerAccount && chainId === SupportedChainId.MAINNET ? { address: referrerAccount } : undefined
@@ -26,7 +29,7 @@ export async function buildAppData({
 
   const doc = await metadataApiSDK.generateAppDataDoc({
     appDataParams: { appCode, environment: environmentName },
-    metadataParams: { referrerParams, quoteParams, orderClassParams },
+    metadataParams: { referrerParams, quoteParams, orderClassParams, utmParams },
   })
 
   const calculatedAppData = await metadataApiSDK.calculateAppDataHash(doc)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1320,10 +1320,10 @@
   dependencies:
     chalk "^4.1.0"
 
-"@cowprotocol/app-data@v0.1.0-alpha.0":
-  version "0.1.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-0.1.0-alpha.0.tgz#8499136d025e85494f762784e2e308bb3f88ec17"
-  integrity sha512-Dh6QD+rG1Tcv3mSwAkWv7bWCQVhYaJ0L8R/cqLrkVDwqwaxzBYHXLlnNnqC8IKThwvy9iMGM2hrDrYSAIAf/vA==
+"@cowprotocol/app-data@v0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-0.2.5.tgz#0df15508a2705aa21a415100f56b570ab68e5ad5"
+  integrity sha512-fwOPiITxSyhhveayhkVeNeoJ4RKfZWFtJ+24+v86WoXF7AloyVdH6Z8GUkXekWsxgFSrN+O+kewYsQeBZKXx3g==
   dependencies:
     ajv "^8.11.0"
     cross-fetch "^3.1.5"


### PR DESCRIPTION
# Summary

This PR gets UTM codes from URL and persist them into the local storage

This will add support for the following URL params
- utm_source
- utm_medium
- utm_campaign
- utm_content
- utm_term

Each parameter is independent and can be present or not. 
Also, it will clear the parameters from the URL once they are processed

This is connected to this PR https://github.com/cowprotocol/app-data/pull/25

Check the test section to see how to pass the params.

## Not included
This PR prepares for a follow up that will add this into the app-data based on https://github.com/cowprotocol/app-data/pull/25

# To Test

Use this URL:
https://swap-dev-git-utc-state-cowswap.vercel.app/#/swap?utm_source=twitter&utm_medium=email&utm_campaign=everyone-loves-cows-2023&utm_content=big-fat-button&utm_term=coincidence+of+wants

Check that the parameters will be updated in the local storage (only on page load, so if you want to override, you will need to open a new tab)

To do that, open devtools, and filter by UTM, you should see all the URL parameters there

<img width="1655" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/7433c544-6132-42d5-8c1a-e2f0496d356c">

They won't be lost on a refresh (only updated if new params are passed)