### PR TITLE
fix(approval-for-swap-buy-orders): use actual input amount for calculating approval needed

### DIFF
--- a/src/cow-react/modules/limitOrders/hooks/useHandleOrderPlacement.test.ts
+++ b/src/cow-react/modules/limitOrders/hooks/useHandleOrderPlacement.test.ts
@@ -2,15 +2,29 @@ import { renderHook } from '@testing-library/react-hooks'
 import { PriceImpact } from 'hooks/usePriceImpact'
 import { useHandleOrderPlacement } from './useHandleOrderPlacement'
 import { tradeFlow } from '@cow/modules/limitOrders/services/tradeFlow'
+import { safeBundleFlow } from '@cow/modules/limitOrders/services/safeBundleFlow'
 import { TradeFlowContext } from '@cow/modules/limitOrders/services/types'
 import { defaultLimitOrdersSettings } from '../state/limitOrdersSettingsAtom'
 import { limitOrdersRawStateAtom, updateLimitOrdersRawStateAtom } from '../state/limitOrdersRawStateAtom'
 import { useAtomValue, useUpdateAtom } from 'jotai/utils'
 import { withModalProvider } from '@cow/utils/withModalProvider'
+import { useSafeBundleFlowContext } from '@cow/modules/limitOrders/hooks/useSafeBundleFlowContext'
+import { useNeedsApproval } from '@cow/common/hooks/useNeedsApproval'
+import { useIsTxBundlingEnabled } from '@cow/common/hooks/useIsTxBundlingEnabled'
 
 jest.mock('@cow/modules/limitOrders/services/tradeFlow')
+jest.mock('@cow/modules/limitOrders/services/safeBundleFlow')
+
+jest.mock('@cow/modules/limitOrders/hooks/useSafeBundleFlowContext')
+jest.mock('@cow/common/hooks/useNeedsApproval')
+jest.mock('@cow/common/hooks/useIsTxBundlingEnabled')
 
 const mockTradeFlow = tradeFlow as jest.MockedFunction<typeof tradeFlow>
+const mockSafeBundleFlow = safeBundleFlow as jest.MockedFunction<typeof safeBundleFlow>
+
+const mockUseSafeBundleFlowContext = useSafeBundleFlowContext as jest.MockedFunction<typeof useSafeBundleFlowContext>
+const mockUseNeedsApproval = useNeedsApproval as jest.MockedFunction<typeof useNeedsApproval>
+const mockUseIsTxBundlingEnabled = useIsTxBundlingEnabled as jest.MockedFunction<typeof useIsTxBundlingEnabled>
 
 const tradeContextMock = { postOrderParams: { partiallyFillable: true } } as any as TradeFlowContext
 const priceImpactMock: PriceImpact = {
@@ -23,6 +37,10 @@ const recipient = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045'
 describe('useHandleOrderPlacement', () => {
   beforeEach(() => {
     mockTradeFlow.mockImplementation(() => Promise.resolve(null))
+    mockSafeBundleFlow.mockImplementation(() => Promise.resolve(null))
+    mockUseSafeBundleFlowContext.mockImplementation(() => null)
+    mockUseNeedsApproval.mockImplementation(() => false)
+    mockUseIsTxBundlingEnabled.mockImplementation(() => false)
   })
 
   it('When a limit order placed, then the recipient value should be deleted', async () => {

--- a/src/cow-react/modules/swap/hooks/useSwapButtonContext.ts
+++ b/src/cow-react/modules/swap/hooks/useSwapButtonContext.ts
@@ -1,5 +1,5 @@
 import { useGnosisSafeInfo, useWalletDetails, useWalletInfo } from '@cow/modules/wallet'
-import { useDerivedSwapInfo, useSwapActionHandlers, useSwapState } from 'state/swap/hooks'
+import { useDerivedSwapInfo, useSwapActionHandlers } from 'state/swap/hooks'
 import { useExpertModeManager } from 'state/user/hooks'
 import { useToggleWalletModal } from 'state/application/hooks'
 import { useSwapConfirmManager } from '@cow/modules/swap/hooks/useSwapConfirmManager'
@@ -20,7 +20,6 @@ import { PriceImpact } from 'hooks/usePriceImpact'
 import { useTradeApproveState } from '@cow/common/containers/TradeApprove/useTradeApproveState'
 import { useDetectNativeToken } from '@cow/modules/swap/hooks/useDetectNativeToken'
 import { useEthFlowContext } from '@cow/modules/swap/hooks/useEthFlowContext'
-import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
 import { useIsSmartContractWallet } from '@cow/common/hooks/useIsSmartContractWallet'
 import { useIsTradeUnsupported } from 'state/lists/hooks'
 import { useHandleSwap } from '@cow/modules/swap/hooks/useHandleSwap'
@@ -47,7 +46,6 @@ export function useSwapButtonContext(input: SwapButtonInput): SwapButtonsContext
     currenciesIds,
     inputError: swapInputError,
   } = useDerivedSwapInfo()
-  const { typedValue } = useSwapState()
   const [isExpertMode] = useExpertModeManager()
   const toggleWalletModal = useToggleWalletModal()
   const { openSwapConfirmModal } = useSwapConfirmManager()
@@ -78,7 +76,7 @@ export function useSwapButtonContext(input: SwapButtonInput): SwapButtonsContext
   const wrapInputError = useWrapUnwrapError(wrapType, wrapUnwrapAmount)
   const hasEnoughWrappedBalanceForSwap = useHasEnoughWrappedBalanceForSwap(wrapUnwrapAmount)
   const wrapCallback = useWrapCallback(wrapUnwrapAmount)
-  const inputAmount = tryParseCurrencyAmount(typedValue, currencyIn ?? undefined)
+  const inputAmount = trade?.inputAmount
   const approvalState = useTradeApproveState(inputAmount || null)
 
   const handleSwap = useHandleSwap(priceImpactParams)


### PR DESCRIPTION
# Summary

Closes #1594 

Fixed issue with approvals on SWAP for BUY tokens

# To Test

1. With a sell token with a partial approval (In this case, approved `4`)
![Screenshot 2023-05-12 at 11 40 16](https://github.com/cowprotocol/cowswap/assets/43217/a80c7db3-8436-43bf-9b11-c7905009ed4f)
2. Input a buy amount that results in selling more than the approved amount
* You should see the approve button
![Screenshot 2023-05-12 at 11 40 28](https://github.com/cowprotocol/cowswap/assets/43217/910858f8-24ec-4f7d-9f9f-4ff30832a2f2)
3. Input a buy amount that results in selling less than the approved amount
* You should not see the approve button
![Screenshot 2023-05-12 at 11 40 39](https://github.com/cowprotocol/cowswap/assets/43217/fa37bb40-fffb-443f-87c4-e5fc0aa749ed)

For sanity, check the same for sell orders:
4. Input a sell amount > approved amount
* You should see the approve button
![Screenshot 2023-05-12 at 11 41 01](https://github.com/cowprotocol/cowswap/assets/43217/b2a11b06-1da1-44b4-93a7-3c6c899eb153)
5. Input a sell amount <= approved amount
* You should not see the approve button
![Screenshot 2023-05-12 at 11 40 51](https://github.com/cowprotocol/cowswap/assets/43217/68d363fc-1bc3-4ef1-b7eb-c13ddb19c447)

There are no changes to Limit orders flow