### PR TITLE
feature: Include UTM codes into onchain data

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@amplitude/analytics-browser": "^1.1.4",
     "@babel/runtime": "^7.17.0",
     "@coinbase/wallet-sdk": "^3.3.0",
-    "@cowprotocol/app-data": "v0.1.0-alpha.0",
+    "@cowprotocol/app-data": "v0.2.0",
     "@cowprotocol/contracts": "^1.3.1",
     "@cowprotocol/cow-runner-game": "^0.2.9",
     "@cowprotocol/cow-sdk": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@amplitude/analytics-browser": "^1.1.4",
     "@babel/runtime": "^7.17.0",
     "@coinbase/wallet-sdk": "^3.3.0",
-    "@cowprotocol/app-data": "v0.2.0",
+    "@cowprotocol/app-data": "v0.2.3",
     "@cowprotocol/contracts": "^1.3.1",
     "@cowprotocol/cow-runner-game": "^0.2.9",
     "@cowprotocol/cow-sdk": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@amplitude/analytics-browser": "^1.1.4",
     "@babel/runtime": "^7.17.0",
     "@coinbase/wallet-sdk": "^3.3.0",
-    "@cowprotocol/app-data": "v0.2.3",
+    "@cowprotocol/app-data": "v0.2.5",
     "@cowprotocol/contracts": "^1.3.1",
     "@cowprotocol/cow-runner-game": "^0.2.9",
     "@cowprotocol/cow-sdk": "^2.0.4",

--- a/src/cow-react/modules/utm/hooks.ts
+++ b/src/cow-react/modules/utm/hooks.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { UtmParams } from './types'
-import { useSetAtom } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 import { utmAtom } from './state'
 
 const UTM_SOURCE_PARAM = 'utm_source'
@@ -28,6 +28,10 @@ function getUtmParams(searchParams: URLSearchParams): UtmParams {
   }
 }
 
+export function useUtm(): UtmParams | undefined {
+  return useAtomValue(utmAtom)
+}
+
 export function useInitializeUtm() {
   const navigate = useNavigate()
   const { search, pathname } = useLocation()
@@ -40,13 +44,13 @@ export function useInitializeUtm() {
       const searchParams = new URLSearchParams(search)
       const utm = getUtmParams(searchParams)
       if (utm.utmCampaign || utm.utmCampaign || utm.utmContent || utm.utmMedium || utm.utmSource) {
-        // Only overrides the UTM if the URL includes any UTM param
+        // Only overrides the UTM if the URL includes at least one UTM param
         setUtm(utm)
+
+        // Clear params from URL
+        ALL_UTM_PARAMS.forEach((param) => searchParams.delete(param))
+        navigate({ pathname, search: searchParams.toString() }, { replace: true })
       }
-
-      ALL_UTM_PARAMS.forEach((param) => searchParams.delete(param))
-
-      navigate({ pathname, search: searchParams.toString() }, { replace: true })
     },
     // No dependencies: It only needs to be initialized once
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/cow-react/modules/utm/hooks.ts
+++ b/src/cow-react/modules/utm/hooks.ts
@@ -32,6 +32,18 @@ export function useUtm(): UtmParams | undefined {
   return useAtomValue(utmAtom)
 }
 
+function cleanUpParams(searchParams: URLSearchParams): boolean {
+  let cleanedParams = false
+  ALL_UTM_PARAMS.forEach((param) => {
+    if (searchParams.has(param)) {
+      searchParams.delete(param)
+      cleanedParams = true
+    }
+  })
+
+  return cleanedParams
+}
+
 export function useInitializeUtm() {
   const navigate = useNavigate()
   const { search, pathname } = useLocation()
@@ -46,9 +58,11 @@ export function useInitializeUtm() {
       if (utm.utmCampaign || utm.utmCampaign || utm.utmContent || utm.utmMedium || utm.utmSource) {
         // Only overrides the UTM if the URL includes at least one UTM param
         setUtm(utm)
+      }
 
-        // Clear params from URL
-        ALL_UTM_PARAMS.forEach((param) => searchParams.delete(param))
+      // Clear params from URL and redirect
+      const cleanedParams = cleanUpParams(searchParams)
+      if (cleanedParams) {
         navigate({ pathname, search: searchParams.toString() }, { replace: true })
       }
     },

--- a/src/cow-react/modules/utm/state.ts
+++ b/src/cow-react/modules/utm/state.ts
@@ -1,4 +1,4 @@
 import { UtmParams } from './types'
 import { atomWithStorage } from 'jotai/utils'
 
-export const utmAtom = atomWithStorage<UtmParams>('utm-atom:v1', {})
+export const utmAtom = atomWithStorage<UtmParams | undefined>('utm-atom:v1', undefined)

--- a/src/hooks/useAppData.ts
+++ b/src/hooks/useAppData.ts
@@ -38,8 +38,6 @@ export function useAppData({ chainId, slippageBips, orderClass, utm }: UseAppDat
     const updateAppData = async (): Promise<void> => {
       try {
         const { doc, calculatedAppData } = await buildAppData(params)
-        console.log('UTM doc', { utm, doc, calculatedAppData })
-
         console.debug(`[useAppData] appDataInfo`, JSON.stringify(doc), calculatedAppData)
 
         if (calculatedAppData?.appDataHash) {

--- a/src/hooks/useAppData.ts
+++ b/src/hooks/useAppData.ts
@@ -7,18 +7,20 @@ import { appDataInfoAtom } from 'state/appData/atoms'
 import { useAppCode } from 'hooks/useAppCode'
 import { OrderClass } from '@cowprotocol/cow-sdk'
 import { useUpdateAtom } from 'jotai/utils'
+import { UtmParams } from '@cow/modules/utm'
 
 export type UseAppDataParams = {
   chainId?: SupportedChainId
   slippageBips: string
   orderClass: OrderClass
+  utm?: UtmParams
 }
 
 /**
  * Fetches and updates appDataInfo whenever a dependency changes
  * The hook can be called only from an updater
  */
-export function useAppData({ chainId, slippageBips, orderClass }: UseAppDataParams): void {
+export function useAppData({ chainId, slippageBips, orderClass, utm }: UseAppDataParams): void {
   // AppDataInfo, from Jotai
   const setAppDataInfo = useUpdateAtom(appDataInfoAtom)
   // AppCode is dynamic and based on how it's loaded (if used as a Gnosis Safe app)
@@ -31,7 +33,7 @@ export function useAppData({ chainId, slippageBips, orderClass }: UseAppDataPara
       return
     }
 
-    const params: BuildAppDataParams = { chainId, slippageBips, appCode, orderClass }
+    const params: BuildAppDataParams = { chainId, slippageBips, appCode, orderClass, utm }
 
     const updateAppData = async (): Promise<void> => {
       try {

--- a/src/hooks/useAppData.ts
+++ b/src/hooks/useAppData.ts
@@ -13,7 +13,7 @@ export type UseAppDataParams = {
   chainId?: SupportedChainId
   slippageBips: string
   orderClass: OrderClass
-  utm?: UtmParams
+  utm: UtmParams | undefined
 }
 
 /**
@@ -38,6 +38,7 @@ export function useAppData({ chainId, slippageBips, orderClass, utm }: UseAppDat
     const updateAppData = async (): Promise<void> => {
       try {
         const { doc, calculatedAppData } = await buildAppData(params)
+        console.log('UTM doc', { utm, doc, calculatedAppData })
 
         console.debug(`[useAppData] appDataInfo`, JSON.stringify(doc), calculatedAppData)
 
@@ -55,5 +56,5 @@ export function useAppData({ chainId, slippageBips, orderClass, utm }: UseAppDat
     }
 
     updateAppData()
-  }, [appCode, chainId, setAppDataInfo, slippageBips, orderClass])
+  }, [appCode, chainId, setAppDataInfo, slippageBips, orderClass, utm])
 }

--- a/src/state/appData/AppDataInfoUpdater.tsx
+++ b/src/state/appData/AppDataInfoUpdater.tsx
@@ -24,8 +24,8 @@ export function AppDataUpdater() {
   return <AppDataUpdaterMemo chainId={chainId} slippageBips={slippageBips} orderClass={orderClass} utm={utm} />
 }
 
-const AppDataUpdaterMemo = React.memo(({ chainId, slippageBips, orderClass }: UseAppDataParams) => {
-  useAppData({ chainId, slippageBips, orderClass })
+const AppDataUpdaterMemo = React.memo(({ chainId, slippageBips, orderClass, utm }: UseAppDataParams) => {
+  useAppData({ chainId, slippageBips, orderClass, utm })
 
   return null
 })

--- a/src/state/appData/AppDataInfoUpdater.tsx
+++ b/src/state/appData/AppDataInfoUpdater.tsx
@@ -6,11 +6,13 @@ import { LIMIT_ORDER_SLIPPAGE } from '@cow/modules/limitOrders/const/trade'
 import { TradeType, useTradeTypeInfo } from '@cow/modules/trade'
 import { percentToBips } from 'utils/misc'
 import { useWalletInfo } from '@cow/modules/wallet'
+import { useUtm } from '@cow/modules/utm'
 
 export function AppDataUpdater() {
   const { chainId } = useWalletInfo()
   const { allowedSlippage: allowedSlippageSwap } = useDerivedSwapInfo()
   const tradeTypeInfo = useTradeTypeInfo()
+  const utm = useUtm()
 
   if (!chainId || !tradeTypeInfo) return null
 
@@ -19,7 +21,7 @@ export function AppDataUpdater() {
   const slippageBips = percentToBips(allowedSlippage)
   const orderClass = isSwapOrder ? OrderClass.MARKET : OrderClass.LIMIT
 
-  return <AppDataUpdaterMemo chainId={chainId} slippageBips={slippageBips} orderClass={orderClass} />
+  return <AppDataUpdaterMemo chainId={chainId} slippageBips={slippageBips} orderClass={orderClass} utm={utm} />
 }
 
 const AppDataUpdaterMemo = React.memo(({ chainId, slippageBips, orderClass }: UseAppDataParams) => {

--- a/src/utils/appData.ts
+++ b/src/utils/appData.ts
@@ -19,20 +19,13 @@ export async function buildAppData({
   referrerAccount,
   appCode,
   orderClass,
-  utm,
+  utm: utmParams,
 }: BuildAppDataParams) {
   const referrerParams =
     referrerAccount && chainId === SupportedChainId.MAINNET ? { address: referrerAccount } : undefined
 
   const quoteParams = { slippageBips }
   const orderClassParams = { orderClass }
-  const utmParams = utm
-    ? {
-        utm: {
-          ...utm,
-        },
-      }
-    : undefined
 
   const doc = await metadataApiSDK.generateAppDataDoc({
     appDataParams: { appCode, environment: environmentName },

--- a/src/utils/appData.ts
+++ b/src/utils/appData.ts
@@ -2,13 +2,15 @@ import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { environmentName } from 'utils/environments'
 import { OrderClass } from '@cowprotocol/cow-sdk'
 import { metadataApiSDK } from '@cow/cowSdk'
+import { UtmParams } from '@cow/modules/utm'
 
 export type BuildAppDataParams = {
+  appCode: string
   chainId: SupportedChainId
   slippageBips: string
   orderClass: OrderClass
   referrerAccount?: string
-  appCode: string
+  utm?: UtmParams
 }
 
 export async function buildAppData({

--- a/src/utils/appData.ts
+++ b/src/utils/appData.ts
@@ -10,7 +10,7 @@ export type BuildAppDataParams = {
   slippageBips: string
   orderClass: OrderClass
   referrerAccount?: string
-  utm?: UtmParams
+  utm: UtmParams | undefined
 }
 
 export async function buildAppData({
@@ -19,16 +19,24 @@ export async function buildAppData({
   referrerAccount,
   appCode,
   orderClass,
+  utm,
 }: BuildAppDataParams) {
   const referrerParams =
     referrerAccount && chainId === SupportedChainId.MAINNET ? { address: referrerAccount } : undefined
 
   const quoteParams = { slippageBips }
   const orderClassParams = { orderClass }
+  const utmParams = utm
+    ? {
+        utm: {
+          ...utm,
+        },
+      }
+    : undefined
 
   const doc = await metadataApiSDK.generateAppDataDoc({
     appDataParams: { appCode, environment: environmentName },
-    metadataParams: { referrerParams, quoteParams, orderClassParams },
+    metadataParams: { referrerParams, quoteParams, orderClassParams, utmParams },
   })
 
   const calculatedAppData = await metadataApiSDK.calculateAppDataHash(doc)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1320,10 +1320,10 @@
   dependencies:
     chalk "^4.1.0"
 
-"@cowprotocol/app-data@v0.1.0-alpha.0":
-  version "0.1.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-0.1.0-alpha.0.tgz#8499136d025e85494f762784e2e308bb3f88ec17"
-  integrity sha512-Dh6QD+rG1Tcv3mSwAkWv7bWCQVhYaJ0L8R/cqLrkVDwqwaxzBYHXLlnNnqC8IKThwvy9iMGM2hrDrYSAIAf/vA==
+"@cowprotocol/app-data@v0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-0.2.0.tgz#e4486f836d56db5f1f412dd0f4c30bdf3e6da2de"
+  integrity sha512-eKW076hXsLzLT4bCc7PTTSOoVGhs6RKaTHZWcIFr/CIMjIaLekN8BkcuVqmyEe5nYVuyjMqSYWa0MZSmKM8jkw==
   dependencies:
     ajv "^8.11.0"
     cross-fetch "^3.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1320,10 +1320,10 @@
   dependencies:
     chalk "^4.1.0"
 
-"@cowprotocol/app-data@v0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-0.2.3.tgz#7ab5cc291948897f55bf99ee283946ac9e4257da"
-  integrity sha512-vKP94GiUXjXsZt8lAdEPQcYlxNaY33uFne2sA7jCnInhhXfpF79QCd2ag90xRBT37ZvcJ/FuzkcY6ORdANxaUg==
+"@cowprotocol/app-data@v0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-0.2.5.tgz#0df15508a2705aa21a415100f56b570ab68e5ad5"
+  integrity sha512-fwOPiITxSyhhveayhkVeNeoJ4RKfZWFtJ+24+v86WoXF7AloyVdH6Z8GUkXekWsxgFSrN+O+kewYsQeBZKXx3g==
   dependencies:
     ajv "^8.11.0"
     cross-fetch "^3.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1320,10 +1320,10 @@
   dependencies:
     chalk "^4.1.0"
 
-"@cowprotocol/app-data@v0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-0.2.0.tgz#e4486f836d56db5f1f412dd0f4c30bdf3e6da2de"
-  integrity sha512-eKW076hXsLzLT4bCc7PTTSOoVGhs6RKaTHZWcIFr/CIMjIaLekN8BkcuVqmyEe5nYVuyjMqSYWa0MZSmKM8jkw==
+"@cowprotocol/app-data@v0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-0.2.3.tgz#7ab5cc291948897f55bf99ee283946ac9e4257da"
+  integrity sha512-vKP94GiUXjXsZt8lAdEPQcYlxNaY33uFne2sA7jCnInhhXfpF79QCd2ag90xRBT37ZvcJ/FuzkcY6ORdANxaUg==
   dependencies:
     ajv "^8.11.0"
     cross-fetch "^3.1.5"


### PR DESCRIPTION
# Summary

This PR it's the third an last PR from the series to add UTM codes in on-chain data.

Previous PRs:
- 1/3: cowprotocol/app-data#25 
- 2/3: https://github.com/cowprotocol/cowswap/pull/2453

This PR will include the UTM data into the document that is attached to the order. This way, its possible to attache UTM campaign codes to ochain data

<img width="1263" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/79022ab4-cfab-4198-a060-c3b90f9e0e89">


# Note to Marketing and Analytics

There's an option now to provide some URL parameters so they can be attached to next future trades.

It will be attached as long as the user don't delete the `localStorage` from their browser.

All the parameters are optional, and we should be mindful that creating too many different variation will create more app-data codes, making things harder to track, so this should not be abused

Here is an example
https://swap-dev-git-utc-into-app-data-cowswap.vercel.app/#/1/swap/WETH?utm_source=github&utm_medium=web&utm_campaign=test-utm-code&utm_content=pr&utm_term=coincidence+of+wants

For the meaning of this UTM code, please read: https://agencyanalytics.com/blog/utm-tracking


EXAMPLE: https://dev.explorer.cow.fi/goerli/orders/0xa7bfb81ea83bbafa4306a32bc4c508e150f543b483f918f2bdac650bc334e93a79063d9173c09887d536924e2f6eadbabac099f5645e633b?tab=overview

# To Test

> Use params `?utm_source=github&utm_medium=web&utm_campaign=test-utm-code&utm_content=pr&utm_term=coincidence+of+wants`

1. Go to 
https://swap-dev-git-utc-into-app-data-cowswap.vercel.app/#/1/swap/WETH?utm_source=github&utm_medium=web&utm_campaign=test-utm-code&utm_content=pr&utm_term=coincidence+of+wants


2. Create a new trade.
3. Check the data in the explorer, the data should be there

You can check local storage too 
<img width="1180" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/8148c043-9935-4721-bf73-8fe766f7294e">
