### PR TITLE
chore: make limit orders table warnings order type agnostic

### DIFF
--- a/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/cow-react/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -69,7 +69,7 @@ const BalanceWarning = (symbol: string) => (
       <strong>
         <TokenSymbol token={{ symbol }} />
       </strong>{' '}
-      balance to execute this limit order.
+      balance to execute this order.
       <br />
       <br />
       The order is still open and will become executable when you top up your{' '}
@@ -83,7 +83,7 @@ const BalanceWarning = (symbol: string) => (
 
 const AllowanceWarning = (symbol: string) => (
   <styledEl.WarningParagraph>
-    <h3>Insufficient approval for this limit order</h3>
+    <h3>Insufficient approval for this order</h3>
     <p>
       This order is still open and valid, but you haven’t given CoW Swap sufficient allowance to spend{' '}
       <strong>


### PR DESCRIPTION
# Summary

Made limit orders table warnings order type agnostic

From item 1 in https://github.com/cowprotocol/cowswap/pull/2462#issuecomment-1549553458

# To Test

1. Place a swap order and open limit orders page
* Order should be visible as pending in the table
2. Remove balance
* Low balance warning should be displayed without mentioning `limit`
3. Remove approval 
* Low approval warning should be displayed without mentioning `limit`
4. Repeat steps with limit order
* Result should be the same