### PR TITLE
feature(tx-bundling): warning banner

### DIFF
--- a/src/cow-react/common/pure/WarningBanner/banners.tsx
+++ b/src/cow-react/common/pure/WarningBanner/banners.tsx
@@ -1,0 +1,17 @@
+import Important from 'assets/cow-swap/important.svg'
+
+import { WarningBanner } from '@cow/common/pure/WarningBanner'
+
+export function BundleTxApprovalBanner() {
+  return (
+    <WarningBanner
+      icon={Important}
+      content={
+        <>
+          <strong>Token approval</strong>: For your convenience, token approval and order placement will be bundled into
+          a single transaction, streamlining your experience!
+        </>
+      }
+    />
+  )
+}

--- a/src/cow-react/common/pure/WarningBanner/banners.tsx
+++ b/src/cow-react/common/pure/WarningBanner/banners.tsx
@@ -1,6 +1,8 @@
+import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
 import Important from 'assets/cow-swap/important.svg'
-
 import { WarningBanner } from '@cow/common/pure/WarningBanner'
+import { TokenAmount } from '@cow/common/pure/TokenAmount'
+import { Nullish } from '@cow/types'
 
 export function BundleTxApprovalBanner() {
   return (
@@ -10,6 +12,31 @@ export function BundleTxApprovalBanner() {
         <>
           <strong>Token approval</strong>: For your convenience, token approval and order placement will be bundled into
           a single transaction, streamlining your experience!
+        </>
+      }
+    />
+  )
+}
+
+export type SmallVolumeWarningBannerProps = {
+  feePercentage: Nullish<Percent>
+  feeAmount: Nullish<CurrencyAmount<Currency>>
+}
+
+export function SmallVolumeWarningBanner({ feePercentage, feeAmount }: SmallVolumeWarningBannerProps) {
+  return (
+    <WarningBanner
+      content={
+        <>
+          Small orders are unlikely to be executed. For this order, network fees would be{' '}
+          <b>
+            {feePercentage?.toFixed(2)}% (
+            <TokenAmount amount={feeAmount} tokenSymbol={feeAmount?.currency} />)
+          </b>{' '}
+          of your sell amount! Therefore, your order is unlikely to execute.
+          {/*<br />*/}
+          {/* TODO: add link to somewhere */}
+          {/*<a href="/">Learn more ↗</a>*/}
         </>
       }
     />

--- a/src/cow-react/common/pure/WarningBanner/index.tsx
+++ b/src/cow-react/common/pure/WarningBanner/index.tsx
@@ -1,0 +1,43 @@
+import { ReactNode } from 'react'
+import styled from 'styled-components/macro'
+import SVG from 'react-inlinesvg'
+import Alert from '@src/assets/cow-swap/alert.svg'
+import { darken, transparentize } from 'polished'
+
+const Wrapper = styled.span`
+  display: flex;
+  align-items: center;
+  background: ${({ theme }) => (theme.darkMode ? transparentize(0.9, theme.alert) : transparentize(0.85, theme.alert))};
+  color: ${({ theme }) => darken(theme.darkMode ? 0 : 0.15, theme.alert)};
+  gap: 10px;
+  border-radius: 10px;
+  margin: 8px auto 0;
+  padding: 16px 12px;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.2;
+
+  > svg {
+    display: block;
+    width: 75px;
+  }
+
+  > svg > path {
+    fill: ${({ theme }) => theme.alert};
+  }
+`
+
+export type WarningBannerProps = {
+  content: ReactNode
+  icon?: string
+  className?: string
+}
+
+export function WarningBanner({ content, icon, className }: WarningBannerProps) {
+  return (
+    <Wrapper className={className}>
+      <SVG src={icon || Alert} description="Alert" />
+      <span>{content}</span>
+    </Wrapper>
+  )
+}

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
@@ -16,15 +16,11 @@ import styled from 'styled-components/macro'
 import { LimitOrdersFormState, useLimitOrdersFormState } from '@cow/modules/limitOrders/hooks/useLimitOrdersFormState'
 import { isFractionFalsy } from '@cow/utils/isFractionFalsy'
 import { useWalletInfo } from '@cow/modules/wallet'
-import * as styledEl from '@cow/modules/limitOrders/containers/LimitOrdersWidget/styled'
-import AlertTriangle from 'assets/cow-swap/alert.svg'
-import SVG from 'react-inlinesvg'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import { calculatePercentageInRelationToReference } from '@cow/modules/limitOrders/utils/calculatePercentageInRelationToReference'
 import { Nullish } from '@cow/types'
 import { HIGH_FEE_WARNING_PERCENTAGE } from '@cow/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice'
-import { TokenAmount } from '@cow/common/pure/TokenAmount'
-import { BundleTxApprovalBanner } from '@cow/common/pure/WarningBanner/banners'
+import { BundleTxApprovalBanner, SmallVolumeWarningBanner } from '@cow/common/pure/WarningBanner/banners'
 
 const FORM_STATES_TO_SHOW_BUNDLE_BANNER = [
   LimitOrdersFormState.ExpertApproveAndSwap,
@@ -111,23 +107,7 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
       )}
 
       {/*// TODO: must be replaced by <NotificationBanner>*/}
-      {showHighFeeWarning && (
-        <styledEl.SmallVolumeWarningBanner>
-          <SVG src={AlertTriangle} description="Alert" />
-          <span>
-            Small orders are unlikely to be executed. For this order, network fees would be{' '}
-            <b>
-              {feePercentage?.toFixed(2)}% (
-              <TokenAmount amount={feeAmount} tokenSymbol={feeAmount?.currency} />)
-            </b>{' '}
-            of your sell amount! Therefore, your order is unlikely to execute.
-            <br />
-            {/* TODO: add link to somewhere */}
-            {/*<a href="/">Learn more ↗</a>*/}
-          </span>
-        </styledEl.SmallVolumeWarningBanner>
-      )}
-
+      {showHighFeeWarning && <SmallVolumeWarningBanner feeAmount={feeAmount} feePercentage={feePercentage} />}
       {showApprovalBundlingBanner && <BundleTxApprovalBanner />}
     </div>
   ) : null

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
@@ -24,6 +24,7 @@ import { calculatePercentageInRelationToReference } from '@cow/modules/limitOrde
 import { Nullish } from '@cow/types'
 import { HIGH_FEE_WARNING_PERCENTAGE } from '@cow/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice'
 import { TokenAmount } from '@cow/common/pure/TokenAmount'
+import { BundleTxApprovalBanner } from '@cow/common/pure/WarningBanner/banners'
 
 const FORM_STATES_TO_SHOW_BUNDLE_BANNER = [
   LimitOrdersFormState.ExpertApproveAndSwap,
@@ -127,12 +128,7 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
         </styledEl.SmallVolumeWarningBanner>
       )}
 
-      {showApprovalBundlingBanner && (
-        <styledEl.SmallVolumeWarningBanner>
-          <SVG src={AlertTriangle} description="Alert" />
-          <span>The next tx will bundle approval and order placement to make it easier, bla bla</span>
-        </styledEl.SmallVolumeWarningBanner>
-      )}
+      {showApprovalBundlingBanner && <BundleTxApprovalBanner />}
     </div>
   ) : null
 }

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
@@ -63,9 +63,9 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
 
   const showHighFeeWarning = feePercentage?.greaterThan(HIGH_FEE_WARNING_PERCENTAGE)
 
-  const isVisible = showPriceImpactWarning || rateImpact < 0 || showHighFeeWarning
-
   const showApprovalBundlingBanner = !isConfirmScreen && FORM_STATES_TO_SHOW_BUNDLE_BANNER.includes(formState)
+
+  const isVisible = showPriceImpactWarning || rateImpact < 0 || showHighFeeWarning || showApprovalBundlingBanner
 
   // Reset price impact flag when there is no price impact
   useEffect(() => {

--- a/src/cow-react/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
+++ b/src/cow-react/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
@@ -25,6 +25,11 @@ import { Nullish } from '@cow/types'
 import { HIGH_FEE_WARNING_PERCENTAGE } from '@cow/modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice'
 import { TokenAmount } from '@cow/common/pure/TokenAmount'
 
+const FORM_STATES_TO_SHOW_BUNDLE_BANNER = [
+  LimitOrdersFormState.ExpertApproveAndSwap,
+  LimitOrdersFormState.ApproveAndSwap,
+]
+
 export interface LimitOrdersWarningsProps {
   priceImpact: PriceImpact
   feeAmount?: Nullish<CurrencyAmount<Currency>>
@@ -59,6 +64,8 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
   const showHighFeeWarning = feePercentage?.greaterThan(HIGH_FEE_WARNING_PERCENTAGE)
 
   const isVisible = showPriceImpactWarning || rateImpact < 0 || showHighFeeWarning
+
+  const showApprovalBundlingBanner = !isConfirmScreen && FORM_STATES_TO_SHOW_BUNDLE_BANNER.includes(formState)
 
   // Reset price impact flag when there is no price impact
   useEffect(() => {
@@ -117,6 +124,13 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
             {/* TODO: add link to somewhere */}
             {/*<a href="/">Learn more ↗</a>*/}
           </span>
+        </styledEl.SmallVolumeWarningBanner>
+      )}
+
+      {showApprovalBundlingBanner && (
+        <styledEl.SmallVolumeWarningBanner>
+          <SVG src={AlertTriangle} description="Alert" />
+          <span>The next tx will bundle approval and order placement to make it easier, bla bla</span>
         </styledEl.SmallVolumeWarningBanner>
       )}
     </div>

--- a/src/cow-react/modules/swap/containers/SwapWidget/index.tsx
+++ b/src/cow-react/modules/swap/containers/SwapWidget/index.tsx
@@ -42,6 +42,9 @@ import useCurrencyBalance from '@cow/modules/tokens/hooks/useCurrencyBalance'
 import { TradeWidget, TradeWidgetContainer } from '@cow/modules/trade/containers/TradeWidget'
 import SettingsTab from '@src/components/Settings'
 import { useIsEthFlow } from '@cow/modules/swap/hooks/useIsEthFlow'
+import { SwapButtonState } from '@cow/modules/swap/helpers/getSwapButtonState'
+
+const BUTTON_STATES_TO_SHOW_BUNDLE_BANNER = [SwapButtonState.ApproveAndSwap, SwapButtonState.ExpertApproveAndSwap]
 
 export function SwapWidget() {
   useSetupTradeState()
@@ -144,6 +147,8 @@ export function SwapWidget() {
     ethFlowProps,
   }
 
+  const showApprovalBundlingBanner = BUTTON_STATES_TO_SHOW_BUNDLE_BANNER.includes(swapButtonContext.swapButtonState)
+
   const swapWarningsTopProps: SwapWarningsTopProps = {
     trade,
     account,
@@ -152,6 +157,7 @@ export function SwapWidget() {
     // don't show the unknown impact warning on: no trade, wrapping native, no error, or it's loading impact
     hideUnknownImpactWarning: !trade || isWrapUnwrapMode || !priceImpactParams.error || priceImpactParams.loading,
     isExpertMode,
+    showApprovalBundlingBanner,
     setFeeWarningAccepted,
     setImpactWarningAccepted,
   }

--- a/src/cow-react/modules/swap/pure/warnings.tsx
+++ b/src/cow-react/modules/swap/pure/warnings.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 import { genericPropsChecker } from '@cow/utils/genericPropsChecker'
 import { NoImpactWarning } from '@cow/modules/trade/pure/NoImpactWarning'
 import styled from 'styled-components/macro'
+import { TradeWarning } from '@cow/modules/trade/pure/TradeWarning'
 
 export interface SwapWarningsTopProps {
   trade: TradeGp | undefined
@@ -14,6 +15,7 @@ export interface SwapWarningsTopProps {
   impactWarningAccepted: boolean
   hideUnknownImpactWarning: boolean
   isExpertMode: boolean
+  showApprovalBundlingBanner: boolean
   setFeeWarningAccepted(cb: (state: boolean) => boolean): void
   setImpactWarningAccepted(cb: (state: boolean) => boolean): void
 }
@@ -37,6 +39,7 @@ export const SwapWarningsTop = React.memo(function (props: SwapWarningsTopProps)
     impactWarningAccepted,
     isExpertMode,
     hideUnknownImpactWarning,
+    showApprovalBundlingBanner,
     setFeeWarningAccepted,
     setImpactWarningAccepted,
   } = props
@@ -54,6 +57,13 @@ export const SwapWarningsTop = React.memo(function (props: SwapWarningsTopProps)
         <StyledNoImpactWarning
           isAccepted={impactWarningAccepted}
           acceptCallback={!isExpertMode && account ? () => setImpactWarningAccepted((state) => !state) : undefined}
+        />
+      )}
+      {showApprovalBundlingBanner && (
+        <TradeWarning
+          text="The next tx will bundle approval and order placement to make it easier, bla bl"
+          tooltipContent="TODO: insert a tooltip content here etc"
+          withoutAccepting
         />
       )}
     </>

--- a/src/cow-react/modules/swap/pure/warnings.tsx
+++ b/src/cow-react/modules/swap/pure/warnings.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 import { genericPropsChecker } from '@cow/utils/genericPropsChecker'
 import { NoImpactWarning } from '@cow/modules/trade/pure/NoImpactWarning'
 import styled from 'styled-components/macro'
-import { TradeWarning } from '@cow/modules/trade/pure/TradeWarning'
+import { BundleTxApprovalBanner } from '@cow/common/pure/WarningBanner/banners'
 
 export interface SwapWarningsTopProps {
   trade: TradeGp | undefined
@@ -59,13 +59,7 @@ export const SwapWarningsTop = React.memo(function (props: SwapWarningsTopProps)
           acceptCallback={!isExpertMode && account ? () => setImpactWarningAccepted((state) => !state) : undefined}
         />
       )}
-      {showApprovalBundlingBanner && (
-        <TradeWarning
-          text="The next tx will bundle approval and order placement to make it easier, bla bl"
-          tooltipContent="TODO: insert a tooltip content here etc"
-          withoutAccepting
-        />
-      )}
+      {showApprovalBundlingBanner && <BundleTxApprovalBanner />}
     </>
   )
 }, genericPropsChecker)


### PR DESCRIPTION
# Summary

## Update

- Using the latest content from [figma](https://www.figma.com/file/pYXF21s8v1S1LfxpWvudbM/2023---TX-Bundling-v1?type=design&node-id=0-1&t=AgeIUSNIEmrgiaSv-0)
- Unified into a single component
- Improved (a bit) the looks, but could still use some help
![image](https://github.com/cowprotocol/cowswap/assets/43217/70d766ae-6780-4cf4-83c3-34cd13508781)


## Original

Show (a terribly looking) warning banner on Swap and Limit

<img width="493" alt="image" src="https://github.com/cowprotocol/cowswap/assets/43217/67644735-adc6-426f-931e-10492f941096">
<img width="488" alt="image" src="https://github.com/cowprotocol/cowswap/assets/43217/ab2700f5-d542-40b2-a382-e6c84b34cf05">

Hoping to make it so ugly it hurts, and then @fairlighteth can help out 😬 

## Notes
- This PR is meant as a placeholder for where to display, and the logic to when to display it
- Text is obviously not final, happy to update

# To Test

1. On Safe, load app as a Safe app
2. On Swap, pick token that needs approval
* Should see the (horrible) banner
3. On Limit, pick token that needs approval
* Should see the (horrible) banner
4. Repeat on Expert mode
* Should have the same result
5. Non bundle txs should not see the banner