### PR TITLE
fix(tx-bundling): fix tx bundling buy order approval

### DIFF
--- a/src/legacy/components/swap/ConfirmSwapModal/index.tsx
+++ b/src/legacy/components/swap/ConfirmSwapModal/index.tsx
@@ -71,7 +71,7 @@ export function ConfirmSwapModal({
     rateInfoParams,
   ])
 
-  const isSafeApprovalBundle = useIsSafeApprovalBundle(trade?.inputAmount)
+  const isSafeApprovalBundle = useIsSafeApprovalBundle(trade?.maximumAmountIn(allowedSlippage))
   const buttonText = useMemo(
     () =>
       isSafeApprovalBundle ? (

--- a/src/modules/swap/hooks/useFlowContext.ts
+++ b/src/modules/swap/hooks/useFlowContext.ts
@@ -99,13 +99,14 @@ export function useBaseFlowContextSetup(): BaseFlowContextSetup {
   const wethContract = useWETHContract()
   const swapConfirmManager = useSwapConfirmManager()
   const isEthFlow = useIsEthFlow()
-  const isSafeBundle = useIsSafeApprovalBundle(trade?.inputAmount)
-  const flowType = _getFlowType(isSafeBundle, isEthFlow)
 
   const { INPUT: inputAmountWithSlippage, OUTPUT: outputAmountWithSlippage } = computeSlippageAdjustedAmounts(
     trade,
     allowedSlippage
   )
+
+  const isSafeBundle = useIsSafeApprovalBundle(inputAmountWithSlippage)
+  const flowType = _getFlowType(isSafeBundle, isEthFlow)
 
   return {
     chainId,


### PR DESCRIPTION
# Summary

Closes #2483 

Fixes approval for tx bundling buy orders 

# To Test

1. Load as Safe app
2. On Swap, pick sell token which is partially approved
3. Input buy token amount in a way that: 
    1. the sell amount is less than the approved amount
    2. the max amount is more than the approved amount
* You should see the bundling label
![Screenshot 2023-05-18 at 17 52 20](https://github.com/cowprotocol/cowswap/assets/43217/9590c00b-7819-4ff0-88aa-ad7c4b56dc00)

4. Moving forward with the tx, Safe modal should appear
* It should be a bundle tx

* Sell orders should work as before
* Non bundling txs should work as before

## Notes
- Limit orders are not affected as they don't have slippage