### PR TITLE
feat(tx-bundling): add banner when approving for Save via WC

### DIFF
--- a/src/common/pure/InlineBanner/banners.tsx
+++ b/src/common/pure/InlineBanner/banners.tsx
@@ -2,15 +2,33 @@ import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
 import { InlineBanner } from './index'
 import { Nullish } from 'types'
 import { TokenAmount } from 'common/pure/TokenAmount'
+import { ExternalLink } from 'theme'
 
 export function BundleTxApprovalBanner() {
   return (
     <InlineBanner
-      type={'information'}
+      type="information"
       content={
         <>
           <strong>Token approval</strong>: For your convenience, token approval and order placement will be bundled into
           a single transaction, streamlining your experience!
+        </>
+      }
+    />
+  )
+}
+
+export function BundleTxSafeWcBanner() {
+  return (
+    <InlineBanner
+      type="information"
+      content={
+        <>
+          Use the Safe web app for streamlined trading: token approval and orders bundled in one go! Only available in
+          the{' '}
+          <ExternalLink href="https://app.safe.global/share/safe-app?appUrl=https%3A%2F%2Fswap.cow.fi&chain=eth">
+            CoW Swap Safe App↗
+          </ExternalLink>
         </>
       }
     />

--- a/src/common/pure/InlineBanner/banners.tsx
+++ b/src/common/pure/InlineBanner/banners.tsx
@@ -2,7 +2,7 @@ import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
 import { InlineBanner } from './index'
 import { Nullish } from 'types'
 import { TokenAmount } from 'common/pure/TokenAmount'
-import { ExternalLink } from 'theme'
+import { ExternalLink } from 'legacy/theme'
 
 export function BundleTxApprovalBanner() {
   return (

--- a/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
+++ b/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
@@ -15,9 +15,13 @@ import { PriceImpact } from 'legacy/hooks/usePriceImpact'
 import styled from 'styled-components/macro'
 import { LimitOrdersFormState, useLimitOrdersFormState } from 'modules/limitOrders/hooks/useLimitOrdersFormState'
 import { isFractionFalsy } from 'utils/isFractionFalsy'
-import { useWalletInfo } from 'modules/wallet'
+import { useIsSafeViaWc, useWalletInfo } from 'modules/wallet'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
-import { BundleTxApprovalBanner, SmallVolumeWarningBanner } from 'common/pure/InlineBanner/banners'
+import {
+  BundleTxApprovalBanner,
+  BundleTxSafeWcBanner,
+  SmallVolumeWarningBanner,
+} from 'common/pure/InlineBanner/banners'
 import { HIGH_FEE_WARNING_PERCENTAGE } from 'modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice'
 import { calculatePercentageInRelationToReference } from 'modules/limitOrders/utils/calculatePercentageInRelationToReference'
 import { Nullish } from 'types'
@@ -62,7 +66,16 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
 
   const showApprovalBundlingBanner = !isConfirmScreen && FORM_STATES_TO_SHOW_BUNDLE_BANNER.includes(formState)
 
-  const isVisible = showPriceImpactWarning || rateImpact < 0 || showHighFeeWarning || showApprovalBundlingBanner
+  const isSafeViaWc = useIsSafeViaWc()
+  const showSafeWcBundlingBanner =
+    !isConfirmScreen && !showApprovalBundlingBanner && isSafeViaWc && formState === LimitOrdersFormState.NotApproved
+
+  const isVisible =
+    showPriceImpactWarning ||
+    rateImpact < 0 ||
+    showHighFeeWarning ||
+    showApprovalBundlingBanner ||
+    showSafeWcBundlingBanner
 
   // Reset price impact flag when there is no price impact
   useEffect(() => {
@@ -75,7 +88,6 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
       updateLimitOrdersWarnings({ isRateImpactAccepted: false })
     }
   }, [updateLimitOrdersWarnings, isConfirmScreen])
-
   const onAcceptPriceImpact = useCallback(() => {
     updateLimitOrdersWarnings({ isPriceImpactAccepted: !isPriceImpactAccepted })
   }, [updateLimitOrdersWarnings, isPriceImpactAccepted])
@@ -109,6 +121,7 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
       {/*// TODO: must be replaced by <NotificationBanner>*/}
       {showHighFeeWarning && <SmallVolumeWarningBanner feeAmount={feeAmount} feePercentage={feePercentage} />}
       {showApprovalBundlingBanner && <BundleTxApprovalBanner />}
+      {showSafeWcBundlingBanner && <BundleTxSafeWcBanner />}
     </div>
   ) : null
 }

--- a/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/src/modules/swap/containers/SwapWidget/index.tsx
@@ -8,7 +8,7 @@ import {
 } from 'legacy/state/swap/hooks'
 import { useWrapType, WrapType } from 'legacy/hooks/useWrapCallback'
 import { useSwapCurrenciesAmounts } from 'modules/swap/hooks/useSwapCurrenciesAmounts'
-import { useWalletDetails, useWalletInfo } from 'modules/wallet'
+import { useIsSafeViaWc, useWalletDetails, useWalletInfo } from 'modules/wallet'
 import { useExpertModeManager, useUserSlippageTolerance } from 'legacy/state/user/hooks'
 import useCowBalanceAndSubsidy from 'legacy/hooks/useCowBalanceAndSubsidy'
 import { useShowRecipientControls } from 'modules/swap/hooks/useShowRecipientControls'
@@ -151,6 +151,10 @@ export function SwapWidget() {
 
   const showApprovalBundlingBanner = BUTTON_STATES_TO_SHOW_BUNDLE_BANNER.includes(swapButtonContext.swapButtonState)
 
+  const isSafeViaWc = useIsSafeViaWc()
+  const showSafeWcBundlingBanner =
+    !showApprovalBundlingBanner && isSafeViaWc && swapButtonContext.swapButtonState === SwapButtonState.NeedApprove
+
   const swapWarningsTopProps: SwapWarningsTopProps = {
     trade,
     account,
@@ -160,6 +164,7 @@ export function SwapWidget() {
     hideUnknownImpactWarning: !trade || isWrapUnwrapMode || !priceImpactParams.error || priceImpactParams.loading,
     isExpertMode,
     showApprovalBundlingBanner,
+    showSafeWcBundlingBanner,
     setFeeWarningAccepted,
     setImpactWarningAccepted,
     shouldZeroApprove,

--- a/src/modules/swap/pure/warnings.tsx
+++ b/src/modules/swap/pure/warnings.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 import { genericPropsChecker } from 'utils/genericPropsChecker'
 import { NoImpactWarning } from 'modules/trade/pure/NoImpactWarning'
 import styled from 'styled-components/macro'
-import { BundleTxApprovalBanner } from 'common/pure/InlineBanner/banners'
+import { BundleTxApprovalBanner, BundleTxSafeWcBanner } from 'common/pure/InlineBanner/banners'
 import { ZeroApprovalWarning } from 'common/pure/ZeroApprovalWarning'
 
 export interface SwapWarningsTopProps {
@@ -18,6 +18,7 @@ export interface SwapWarningsTopProps {
   isExpertMode: boolean
   showApprovalBundlingBanner: boolean
   shouldZeroApprove: boolean
+  showSafeWcBundlingBanner: boolean
   setFeeWarningAccepted(cb: (state: boolean) => boolean): void
   setImpactWarningAccepted(cb: (state: boolean) => boolean): void
 }
@@ -42,6 +43,7 @@ export const SwapWarningsTop = React.memo(function (props: SwapWarningsTopProps)
     isExpertMode,
     hideUnknownImpactWarning,
     showApprovalBundlingBanner,
+    showSafeWcBundlingBanner,
     setFeeWarningAccepted,
     setImpactWarningAccepted,
     shouldZeroApprove,
@@ -64,6 +66,7 @@ export const SwapWarningsTop = React.memo(function (props: SwapWarningsTopProps)
         />
       )}
       {showApprovalBundlingBanner && <BundleTxApprovalBanner />}
+      {showSafeWcBundlingBanner && <BundleTxSafeWcBanner />}
     </>
   )
 }, genericPropsChecker)

--- a/src/modules/wallet/web3-react/hooks/useWalletMetadata.ts
+++ b/src/modules/wallet/web3-react/hooks/useWalletMetadata.ts
@@ -108,3 +108,14 @@ export function useIsSafeWallet(): boolean {
 
   return GNOSIS_APP_NAMES.includes(walletName)
 }
+
+/**
+ * Detects whether the currently connected wallet is a Safe wallet
+ * but NOT loaded as a Safe App
+ */
+export function useIsSafeViaWc(): boolean {
+  const isSafeApp = useIsSafeApp()
+  const isSafeWallet = useIsSafeWallet()
+
+  return isSafeWallet && !isSafeApp
+}


### PR DESCRIPTION
# Summary

Adding a banner for Safe wallets connected via WC when doing approvals

| swap | limit |
|-|-|
| ![Screenshot 2023-05-19 at 13 54 44](https://github.com/cowprotocol/cowswap/assets/43217/38e6038e-d5fb-4bca-9c8e-80f2ca38d436) | <img width="486" alt="image" src="https://github.com/cowprotocol/cowswap/assets/43217/ebcf451e-be46-4cc5-98b5-50d2432d58e6"> |

# To Test

1. Connect to Safe via WC (desktop, mobile, etc)
2. Pick as sell token one that needs approval
* The info banner like in the imgs above should be displayed
* The link should open in a new page
* The link should lead to Safe App display page
<img width="993" alt="image" src="https://github.com/cowprotocol/cowswap/assets/43217/3057574a-102b-4bfd-9d44-d57056f17645">

* Should behave the same with Swap and Limit
* Should NOT show the banner when approval is not needed
* Should NOT show the banner when connected via any other mean/wallet