### PR TITLE
fix: formatting issue breaking when reminder carries over

### DIFF
--- a/src/cow-react/common/pure/TokenAmount/index.tsx
+++ b/src/cow-react/common/pure/TokenAmount/index.tsx
@@ -53,9 +53,10 @@ export function TokenAmount({
       </>
     )
 
+  const roundedAmount = round ? FractionUtils.round(amount) : amount
   return (
     <Wrapper title={title} className={className} highlight={highlight}>
-      {formatTokenAmount(round ? FractionUtils.round(amount) : amount) || defaultValue}
+      {formatTokenAmount(roundedAmount) || defaultValue}
       <SymbolElement opacitySymbol={opacitySymbol}>{tokenSymbolElement}</SymbolElement>
     </Wrapper>
   )

--- a/src/cow-react/utils/amountFormat/index.test.ts
+++ b/src/cow-react/utils/amountFormat/index.test.ts
@@ -125,7 +125,7 @@ describe('Amounts formatting', () => {
       const result2 = formatFiatAmount(getAmount('60001444', 3))
 
       expect(result1).toBe('7,344,360.23')
-      expect(result2).toBe('60.00B')
+      expect(result2).toBe('60B')
     })
   })
 

--- a/src/cow-react/utils/amountFormat/index.ts
+++ b/src/cow-react/utils/amountFormat/index.ts
@@ -6,6 +6,7 @@ import { trimTrailingZeros } from '@cow/utils/trimTrailingZeros'
 import { FractionUtils } from '@cow/utils/fractionUtils'
 import { getPrecisionForAmount, getSuffixForAmount, lessThanPrecisionSymbol, trimHugeAmounts } from './utils'
 import { INTL_NUMBER_FORMAT } from '@cow/constants/intl'
+import JSBI from 'jsbi'
 
 export function formatFiatAmount(amount: Nullish<FractionLike>): string {
   return formatAmountWithPrecision(amount, FIAT_PRECISION)
@@ -38,16 +39,18 @@ export function formatAmountWithPrecision(
   const { quotient, remainder } = trimHugeAmounts(amountAsFraction)
 
   const decimalsSeparator = numberFormat.format(1.1)[1]
-  // Apply the language formatting for the amount
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat
-  const formattedQuotient = numberFormat.format(BigInt(trimTrailingZeros(quotient.toString(), decimalsSeparator)))
+
   // Trim the remainder up to precision
   const fixedRemainder = remainder.toFixed(precision, undefined, Rounding.ROUND_HALF_UP)
 
-  // toFixed() could round the remainder up, and the result could be 1.00 or greater
-  if (+fixedRemainder >= 1) {
-    return trimTrailingZeros(fixedRemainder)
-  }
+  // If rounding up means we carry over to the next integer, add 1 to quotient
+  const adjustedQuotient = +fixedRemainder >= 1 ? JSBI.add(quotient, JSBI.BigInt(1)) : quotient
+
+  // Apply the language formatting for the amount
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat
+  const formattedQuotient = numberFormat.format(
+    BigInt(trimTrailingZeros(adjustedQuotient.toString(), decimalsSeparator))
+  )
 
   const formattedRemainder = remainder.greaterThan(0)
     ? decimalsSeparator + trimTrailingZeros(fixedRemainder.slice(1)).slice(1)


### PR DESCRIPTION
# Summary

> Related to https://github.com/cowprotocol/cowswap/pull/2502

This PR fixes the issue reported by @MindyCoW regarding a wrong price when selling WETH.

The issue was on the formatting logic. It had a broken logic on what to do when there is a carry over of the remainder. 

For example, for `18,499.99999999` as in the example, the rounding for 6 decimals will be `18,500.000000`.
In the logic, it handles separately the quotient and reminder. 

The remainder is expressed in a decimal format, i.e. 0.99999999 in this case

When rounding UP --> 1.00000000

Then we arrive to the broken logic! we where returning this value (this is why we saw a price of 1).

## The fix
Detect when there's a carry over, and add it to the quotient. 

Before:
<img width="1089" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/d608f756-05e3-44d0-b4f5-c06f7d6b620b">

First fix (did the trick, but apparently we had an issue with clearing trailing zeros for the amounts)
<img width="1098" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/63062fae-de59-41e1-957f-376c6daaaa24">

The second fix improves the issue above. I prepared another PR with some tests, but I did it on top of the refactor (I just merged this branch there). See https://github.com/cowprotocol/cowswap/pull/2502

<img width="1129" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/60d31bf4-b66a-427f-a3d7-7b4e65e36d9e">




## Context
https://cowservices.slack.com/archives/C0361CDG8GP/p1684522612702239

# Test
- Place a limit order in mainnet, selling WETH for USDC at 18500 