### PR TITLE
fix: fix app crashing while calculating price impact

### DIFF
--- a/src/cow-react/abis/types/index.ts
+++ b/src/cow-react/abis/types/index.ts
@@ -10,5 +10,5 @@ export { GPv2Settlement__factory } from "./factories/GPv2Settlement__factory";
 export { MerkleDrop__factory } from "./factories/MerkleDrop__factory";
 export { TokenDistro__factory } from "./factories/TokenDistro__factory";
 export { VCow__factory } from "./factories/VCow__factory";
-export * from "@src/abis/types";
 export * from "@cow/abis/types/ethflow";
+export * from "@src/abis/types";

--- a/src/cow-react/common/services/getQuoteCurrency/index.ts
+++ b/src/cow-react/common/services/getQuoteCurrency/index.ts
@@ -4,6 +4,7 @@ import { DAI, USDC_MAINNET, USDT } from 'constants/tokens'
 import { DAI_GOERLI, USDT_GOERLI, USDC_GOERLI } from 'utils/goerli/constants'
 import { USDC_GNOSIS_CHAIN, USDT_GNOSIS_CHAIN, WXDAI } from 'utils/gnosis_chain/constants'
 import { NATIVE_CURRENCY_BUY_ADDRESS } from 'constants/index'
+import { isSupportedChain } from 'utils/supportedChainId'
 
 // TODO: Find a solution for using API: https://www.coingecko.com/en/categories/stablecoins
 const STABLE_COINS: { [key in SupportedChainId]: string[] } = {
@@ -45,7 +46,7 @@ export function getQuoteCurrencyByStableCoin(
   inputCurrency: Currency | null,
   outputCurrency: Currency | null
 ): Currency | null {
-  if (!chainId || !inputCurrency || !outputCurrency) return null
+  if (!chainId || !isSupportedChain(chainId) || !inputCurrency || !outputCurrency) return null
 
   const stableCoins = STABLE_COINS[chainId]
 

--- a/src/cow-react/modules/limitOrders/updaters/MarketPriceUpdater/hooks/useFetchMarketPrice/useHandleResponse.ts
+++ b/src/cow-react/modules/limitOrders/updaters/MarketPriceUpdater/hooks/useFetchMarketPrice/useHandleResponse.ts
@@ -32,6 +32,8 @@ export function handleLimitOrderQuoteResponse(
   const sellAmount = CurrencyAmount.fromRawAmount(inputCurrency, sellAmountRaw)
   const buyAmount = CurrencyAmount.fromRawAmount(outputCurrency, buyAmountRaw)
 
+  if (sellAmount.equalTo(0) || buyAmount.equalTo(0)) return
+
   const price = FractionUtils.fractionLikeToFraction(new Price({ baseAmount: sellAmount, quoteAmount: buyAmount }))
   const marketRateWithSlippage = price.subtract(price.multiply(LIMIT_ORDERS_PRICE_SLIPPAGE.divide(100)))
 

--- a/src/cow-react/modules/limitOrders/utils/calculateExecutionPrice.ts
+++ b/src/cow-react/modules/limitOrders/utils/calculateExecutionPrice.ts
@@ -44,7 +44,8 @@ export function convertAmountToCurrency(
 export function calculateExecutionPrice(params: ExecutionPriceParams): Price<Currency, Currency> | null {
   const { inputCurrencyAmount, outputCurrencyAmount, feeAmount, marketRate } = params
 
-  if (!inputCurrencyAmount || !outputCurrencyAmount || !feeAmount || !marketRate) return null
+  if (!inputCurrencyAmount || !outputCurrencyAmount || !feeAmount || !marketRate || inputCurrencyAmount.equalTo(0))
+    return null
 
   if (inputCurrencyAmount.currency !== feeAmount.currency) return null
 

--- a/src/hooks/usePriceImpact/useFallbackPriceImpact.ts
+++ b/src/hooks/usePriceImpact/useFallbackPriceImpact.ts
@@ -101,7 +101,7 @@ export default function useFallbackPriceImpact({
     if (quoteError) {
       setImpact(undefined)
       setError(quoteError)
-    } else if (!loading && abIn && abOut && baOut) {
+    } else if (!loading && abIn && abIn !== '0' && abOut && baOut) {
       // AB Trade is a SELL - we pass the inputAMount as the initial value
       // else we pass the outputAmount as the initialValue
       // Final value is the output of the BA trade as we always SELL in BA

--- a/src/utils/price.ts
+++ b/src/utils/price.ts
@@ -77,6 +77,7 @@ export function getValidParams(params: LegacyPriceQuoteParams) {
   return { ...params, baseToken, quoteToken }
 }
 
+// TODO: the function throws error, when initialValue = '0'
 export function calculateFallbackPriceImpact(initialValue: string, finalValue: string) {
   const initialValueBn = new BigNumberJs(initialValue)
   const finalValueBn = new BigNumberJs(finalValue)


### PR DESCRIPTION
# Summary

Fixes #2467, #2510

<img width="745" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/bc147e46-09ec-408c-b596-4cc5b5711456">

The function `calculateFallbackPriceImpact` throws an error when `initialValue` equals `"0"` (because of the division on zero).
Since the function is called only from `useFallbackPriceImpact` hook, the check for `!== "0"` is added here.

# Background
I was able to reproduce it only when applied the issue reporters `localStorage` snapshot.
My assumption is:
 - the reporter has cached some `wrong values` in his `localStorage`
 - those `wrong values` influence on price impact calculations and cause calling `useFallbackPriceImpact` (normally it shouldn't be called, since it's a fallback)
 - `calculateFallbackPriceImpact` didn't consider a case when `initialValue` is zero as string
 
 UPD:
 Elena found one more issue related to `"0"` value: https://github.com/cowprotocol/cowswap/pull/2505#issuecomment-1557009718. `calculateExecutionPrice` also fails when `inputCurrencyAmount` is zero