### PR TITLE
feat(usdt-approval): :sparkles: add zero approval flow to limit orders

### DIFF
--- a/src/common/hooks/useShouldZeroApproveLimit.ts
+++ b/src/common/hooks/useShouldZeroApproveLimit.ts
@@ -1,0 +1,7 @@
+import { useLimitOrdersDerivedState } from 'modules/limitOrders/hooks/useLimitOrdersDerivedState'
+import { useShouldZeroApprove } from './useShouldZeroApprove/useShouldZeroApprove'
+
+export function useShouldZeroApproveLimit() {
+  const { inputCurrencyAmount } = useLimitOrdersDerivedState()
+  return useShouldZeroApprove(inputCurrencyAmount ?? undefined)
+}

--- a/src/common/hooks/useShouldZeroApproveSwap.ts
+++ b/src/common/hooks/useShouldZeroApproveSwap.ts
@@ -3,7 +3,5 @@ import { useShouldZeroApprove } from './useShouldZeroApprove'
 
 export function useShouldZeroApproveSwap() {
   const { parsedAmount } = useDerivedSwapInfo()
-  const shouldZeroApprove = useShouldZeroApprove(parsedAmount)
-
-  return shouldZeroApprove
+  return useShouldZeroApprove(parsedAmount)
 }

--- a/src/common/pure/ZeroApprovalWarning/ZeroApprovalWarning.tsx
+++ b/src/common/pure/ZeroApprovalWarning/ZeroApprovalWarning.tsx
@@ -2,13 +2,14 @@ import { HashLink } from 'react-router-hash-link'
 import { WarningCard } from '../WarningCard'
 import styled from 'styled-components/macro'
 import { Currency } from '@uniswap/sdk-core'
+import { Nullish } from 'types'
 
 const Link = styled(HashLink)`
   text-decoration: underline;
 `
 
 interface ZeroApprovalWarningProps {
-  currency: Currency | undefined | null
+  currency: Nullish<Currency>
 }
 
 // TODO: Replace with FAQ link once available.

--- a/src/common/pure/ZeroApprovalWarning/ZeroApprovalWarning.tsx
+++ b/src/common/pure/ZeroApprovalWarning/ZeroApprovalWarning.tsx
@@ -8,7 +8,7 @@ const Link = styled(HashLink)`
 `
 
 interface ZeroApprovalWarningProps {
-  currency: Currency | undefined
+  currency: Currency | undefined | null
 }
 
 // TODO: Replace with FAQ link once available.

--- a/src/common/state/useZeroApprovalState.ts
+++ b/src/common/state/useZeroApprovalState.ts
@@ -11,6 +11,5 @@ export const zeroApprovalState = atom<ZeroApprovalState>({
 })
 
 export function useZeroApprovalState() {
-  const state = useAtomValue(zeroApprovalState)
-  return state
+  return useAtomValue(zeroApprovalState)
 }

--- a/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
+++ b/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
@@ -57,7 +57,7 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
   const formState = useLimitOrdersFormState()
   const rateImpact = useRateImpact()
   const { chainId, account } = useWalletInfo()
-  const { inputCurrency, inputCurrencyAmount, outputCurrencyAmount } = useLimitOrdersDerivedState()
+  const { inputCurrency, inputCurrencyAmount, outputCurrency, outputCurrencyAmount } = useLimitOrdersDerivedState()
 
   const showPriceImpactWarning =
     !!chainId && !expertMode && !!account && !!priceImpact.error && formState === LimitOrdersFormState.CanTrade
@@ -68,6 +68,7 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
 
   const showApprovalBundlingBanner = !isConfirmScreen && FORM_STATES_TO_SHOW_BUNDLE_BANNER.includes(formState)
   const shouldZeroApprove = useShouldZeroApproveLimit()
+  const showZeroApprovalWarning = shouldZeroApprove && outputCurrency !== null // Show warning only when output currency is also present.
 
   const isSafeViaWc = useIsSafeViaWc()
   const showSafeWcBundlingBanner =
@@ -105,7 +106,7 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
 
   return isVisible ? (
     <div className={className}>
-      {shouldZeroApprove && <ZeroApprovalWarning currency={inputCurrency} />}
+      {showZeroApprovalWarning && <ZeroApprovalWarning currency={inputCurrency} />}
       {showPriceImpactWarning && (
         <StyledNoImpactWarning
           withoutAccepting={isConfirmScreen}

--- a/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
+++ b/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
@@ -25,6 +25,8 @@ import {
 import { HIGH_FEE_WARNING_PERCENTAGE } from 'modules/limitOrders/pure/Orders/OrderRow/EstimatedExecutionPrice'
 import { calculatePercentageInRelationToReference } from 'modules/limitOrders/utils/calculatePercentageInRelationToReference'
 import { Nullish } from 'types'
+import { useShouldZeroApproveLimit } from 'common/hooks/useShouldZeroApproveLimit'
+import { ZeroApprovalWarning } from 'common/pure/ZeroApprovalWarning'
 
 const FORM_STATES_TO_SHOW_BUNDLE_BANNER = [
   LimitOrdersFormState.ExpertApproveAndSwap,
@@ -65,6 +67,7 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
   const showHighFeeWarning = feePercentage?.greaterThan(HIGH_FEE_WARNING_PERCENTAGE)
 
   const showApprovalBundlingBanner = !isConfirmScreen && FORM_STATES_TO_SHOW_BUNDLE_BANNER.includes(formState)
+  const shouldZeroApprove = useShouldZeroApproveLimit()
 
   const isSafeViaWc = useIsSafeViaWc()
   const showSafeWcBundlingBanner =
@@ -75,7 +78,8 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
     rateImpact < 0 ||
     showHighFeeWarning ||
     showApprovalBundlingBanner ||
-    showSafeWcBundlingBanner
+    showSafeWcBundlingBanner ||
+    shouldZeroApprove
 
   // Reset price impact flag when there is no price impact
   useEffect(() => {
@@ -101,6 +105,7 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
 
   return isVisible ? (
     <div className={className}>
+      {shouldZeroApprove && <ZeroApprovalWarning currency={inputCurrency} />}
       {showPriceImpactWarning && (
         <StyledNoImpactWarning
           withoutAccepting={isConfirmScreen}

--- a/src/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -35,6 +35,8 @@ import usePriceImpact from 'legacy/hooks/usePriceImpact'
 import { useRateInfoParams } from 'common/hooks/useRateInfoParams'
 import { useLimitOrdersWidgetActions } from 'modules/limitOrders/containers/LimitOrdersWidget/hooks/useLimitOrdersWidgetActions'
 import { useIsWrapOrUnwrap } from 'modules/trade/hooks/useIsWrapOrUnwrap'
+import { useShouldZeroApproveLimit } from 'common/hooks/useShouldZeroApproveLimit'
+import { ZeroApprovalModal } from 'common/containers/ZeroApprovalModal'
 
 export function LimitOrdersWidget() {
   useSetupTradeState()
@@ -159,6 +161,7 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
 
   const [showConfirmation, setShowConfirmation] = useState(false)
   const updateLimitOrdersState = useUpdateAtom(updateLimitOrdersRawStateAtom)
+  const shouldZeroApprove = useShouldZeroApproveLimit()
 
   console.debug('RENDER LIMIT ORDERS WIDGET', { inputCurrencyInfo, outputCurrencyInfo })
 
@@ -225,6 +228,7 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
         outputCurrencyInfo={outputCurrencyInfo}
       />
       <TradeApproveWidget />
+      {shouldZeroApprove && <ZeroApprovalModal />}
       {tradeContext && (
         <LimitOrdersConfirmModal
           isOpen={showConfirmation}


### PR DESCRIPTION
# Summary

Fixes #2506 

Adds zero approval flow to limit orders.

<img width="522" alt="Screenshot 2023-05-23 at 13 06 38" src="https://github.com/cowprotocol/cowswap/assets/5172699/c943dac8-d3f2-47e5-93fb-0c565cd7d334">
<img width="502" alt="Screenshot 2023-05-23 at 13 04 22" src="https://github.com/cowprotocol/cowswap/assets/5172699/1d20a6f9-ff0e-470e-82a0-9c3a62c30029">

# To Test

1. Go to CoW Swap on Goerli,
2. Use Anxo's USDT https://goerli.etherscan.io/address/0x7b77F953e703E80CD97F6911385c0b1ceabC96Bc
3. Approve or trade to have some left over approvals (for example 5 USDT)
4. Open Limit orders page
5. Enter an amount higher than the approval amount (for example 10 USDT)
6. You should have the two step approval flow
7. This flow should not be shown if it is not necessary (i.e. most other tokens, if you have enough USDT allowance to begin with etc.)
