### PR TITLE
feat(twap-orders): refactor of quote (2)

### DIFF
--- a/src/modules/advancedOrders/hooks/useAdvancedOrdersActions.ts
+++ b/src/modules/advancedOrders/hooks/useAdvancedOrdersActions.ts
@@ -36,7 +36,6 @@ export function useAdvancedOrdersActions() {
         currency: inputCurrency,
         field,
       })
-      updateAdvancedOrdersState({ typedValue })
     },
     [inputCurrency, updateAdvancedOrdersState, updateCurrencyAmount]
   )

--- a/src/modules/advancedOrders/hooks/useAdvancedOrdersRawState.ts
+++ b/src/modules/advancedOrders/hooks/useAdvancedOrdersRawState.ts
@@ -1,10 +1,11 @@
 import { useAtomValue, useUpdateAtom } from 'jotai/utils'
-import { advancedOrdersAtom, AdvancedOrdersRawState, updateAdvancedOrdersAtom } from '../state/advancedOrdersAtom'
+import { advancedOrdersAtom, updateAdvancedOrdersAtom } from '../state/advancedOrdersAtom'
+import { ExtendedTradeRawState } from 'modules/trade/types/TradeRawState'
 
-export function useAdvancedOrdersRawState(): AdvancedOrdersRawState {
+export function useAdvancedOrdersRawState(): ExtendedTradeRawState {
   return useAtomValue(advancedOrdersAtom)
 }
 
-export function useUpdateAdvancedOrdersRawState(): (update: Partial<AdvancedOrdersRawState>) => void {
+export function useUpdateAdvancedOrdersRawState(): (update: Partial<ExtendedTradeRawState>) => void {
   return useUpdateAtom(updateAdvancedOrdersAtom)
 }

--- a/src/modules/advancedOrders/state/advancedOrdersAtom.ts
+++ b/src/modules/advancedOrders/state/advancedOrdersAtom.ts
@@ -4,21 +4,16 @@ import { atomWithStorage, createJSONStorage } from 'jotai/utils'
 import { atom } from 'jotai'
 import { DEFAULT_TRADE_DERIVED_STATE, TradeDerivedState } from 'modules/trade/types/TradeDerivedState'
 
-export interface AdvancedOrdersRawState extends ExtendedTradeRawState {
-  readonly typedValue: string | null
-}
-
-export function getDefaultAdvancedOrdersState(chainId: SupportedChainId | null): AdvancedOrdersRawState {
+export function getDefaultAdvancedOrdersState(chainId: SupportedChainId | null): ExtendedTradeRawState {
   return {
     ...getDefaultTradeRawState(chainId),
     inputCurrencyAmount: null,
     outputCurrencyAmount: null,
     orderKind: OrderKind.SELL,
-    typedValue: null,
   }
 }
 
-export const advancedOrdersAtom = atomWithStorage<AdvancedOrdersRawState>(
+export const advancedOrdersAtom = atomWithStorage<ExtendedTradeRawState>(
   'advanced-orders-atom:v1',
   getDefaultAdvancedOrdersState(null),
   /**
@@ -29,7 +24,7 @@ export const advancedOrdersAtom = atomWithStorage<AdvancedOrdersRawState>(
   createJSONStorage(() => localStorage)
 )
 
-export const updateAdvancedOrdersAtom = atom(null, (get, set, nextState: Partial<AdvancedOrdersRawState>) => {
+export const updateAdvancedOrdersAtom = atom(null, (get, set, nextState: Partial<ExtendedTradeRawState>) => {
   set(advancedOrdersAtom, () => {
     const prevState = get(advancedOrdersAtom)
 

--- a/src/modules/limitOrders/state/limitOrdersRawStateAtom.ts
+++ b/src/modules/limitOrders/state/limitOrdersRawStateAtom.ts
@@ -19,7 +19,6 @@ export function getDefaultLimitOrdersState(chainId: SupportedChainId | null): Li
     outputCurrencyAmount: null,
     orderKind: OrderKind.SELL,
     isUnlocked: false,
-    typedValue: null,
   }
 }
 

--- a/src/modules/trade/hooks/useBuildTradeDerivedState.ts
+++ b/src/modules/trade/hooks/useBuildTradeDerivedState.ts
@@ -14,7 +14,6 @@ export function useBuildTradeDerivedState(stateAtom: Atom<ExtendedTradeRawState>
 
   const recipient = rawState.recipient
   const orderKind = rawState.orderKind
-  const typedValue = rawState.typedValue
 
   const inputCurrency = useTokenBySymbolOrAddress(rawState.inputCurrencyId)
   const outputCurrency = useTokenBySymbolOrAddress(rawState.outputCurrencyId)
@@ -36,6 +35,5 @@ export function useBuildTradeDerivedState(stateAtom: Atom<ExtendedTradeRawState>
     outputCurrencyBalance,
     inputCurrencyFiatAmount,
     outputCurrencyFiatAmount,
-    typedValue,
   })
 }

--- a/src/modules/trade/types/TradeDerivedState.ts
+++ b/src/modules/trade/types/TradeDerivedState.ts
@@ -12,7 +12,6 @@ export interface TradeDerivedState {
   readonly outputCurrencyFiatAmount: CurrencyAmount<Currency> | null
   readonly recipient: string | null
   readonly orderKind: OrderKind
-  readonly typedValue: string | null
 }
 
 export const DEFAULT_TRADE_DERIVED_STATE: TradeDerivedState = {
@@ -26,5 +25,4 @@ export const DEFAULT_TRADE_DERIVED_STATE: TradeDerivedState = {
   outputCurrencyFiatAmount: null,
   recipient: null,
   orderKind: OrderKind.SELL,
-  typedValue: null,
 }

--- a/src/modules/trade/types/TradeRawState.ts
+++ b/src/modules/trade/types/TradeRawState.ts
@@ -18,7 +18,6 @@ export interface ExtendedTradeRawState extends TradeRawState {
   readonly inputCurrencyAmount: string | null
   readonly outputCurrencyAmount: string | null
   readonly orderKind: OrderKind
-  readonly typedValue: string | null
 }
 
 export type TradeCurrenciesIds = Pick<TradeRawState, 'inputCurrencyId' | 'outputCurrencyId'>

--- a/src/modules/tradeQuote/hooks/useQuoteParams.ts
+++ b/src/modules/tradeQuote/hooks/useQuoteParams.ts
@@ -1,6 +1,5 @@
 import { useMemo } from 'react'
 import { getAddress } from 'utils/getAddress'
-import { parseUnits } from 'ethers/lib/utils'
 import { useWalletInfo } from 'modules/wallet'
 import { OrderKind } from '@cowprotocol/cow-sdk'
 import { useDerivedTradeState } from 'modules/trade/hooks/useDerivedTradeState'
@@ -9,12 +8,11 @@ export function useQuoteParams() {
   const { chainId, account } = useWalletInfo()
   const { state } = useDerivedTradeState()
 
-  const inputCurrency = state?.inputCurrency
-  const outputCurrency = state?.outputCurrency
-  const typedValue = state?.typedValue
+  const { inputCurrency, inputCurrencyAmount, outputCurrency, outputCurrencyAmount, orderKind } = state || {}
+  const currencyAmount = orderKind === OrderKind.SELL ? inputCurrencyAmount : outputCurrencyAmount
 
   return useMemo(() => {
-    if (!inputCurrency || !outputCurrency || !typedValue) {
+    if (!inputCurrency || !outputCurrency || !currencyAmount) {
       return
     }
 
@@ -23,12 +21,10 @@ export function useQuoteParams() {
     const fromDecimals = inputCurrency?.decimals
     const toDecimals = outputCurrency?.decimals
 
-    const amount = parseUnits(typedValue, inputCurrency?.decimals)
-
     return {
       sellToken,
       buyToken,
-      amount,
+      amount: currencyAmount.numerator,
       chainId,
       receiver: account,
       kind: OrderKind.SELL,
@@ -36,5 +32,5 @@ export function useQuoteParams() {
       fromDecimals,
       isEthFlow: false,
     }
-  }, [inputCurrency, outputCurrency, typedValue, account, chainId])
+  }, [inputCurrency, outputCurrency, currencyAmount, account, chainId])
 }

--- a/src/modules/tradeQuote/hooks/useQuoteParams.ts
+++ b/src/modules/tradeQuote/hooks/useQuoteParams.ts
@@ -24,7 +24,7 @@ export function useQuoteParams() {
     return {
       sellToken,
       buyToken,
-      amount: currencyAmount.numerator,
+      amount: currencyAmount.quotient,
       chainId,
       receiver: account,
       kind: OrderKind.SELL,


### PR DESCRIPTION
# Summary

Removes `typedValue`
Updates `useQuoteParams` to use `inputCurrencyAmount` or `outputCurrencyAmount` instead of `typedValue`