### PR TITLE
feat(smart-contract-orders): hide sc presign orders on start

### DIFF
--- a/src/modules/swap/services/safeBundleFlow/index.ts
+++ b/src/modules/swap/services/safeBundleFlow/index.ts
@@ -8,6 +8,7 @@ import { getSwapErrorMessage } from 'modules/trade/utils/swapErrorHelper'
 import { addPendingOrderStep } from 'modules/trade/utils/addPendingOrderStep'
 import { PriceImpact } from 'legacy/hooks/usePriceImpact'
 import { signAndPostOrder } from 'legacy/utils/trade'
+import { partialOrderUpdate } from 'legacy/state/orders/utils'
 import { tradeFlowAnalytics } from 'modules/trade/utils/analytics'
 
 const LOG_PREFIX = 'SAFE BUNDLE FLOW'
@@ -54,6 +55,18 @@ export async function safeBundleFlow(
       callbacks.closeModals()
     })
 
+    addPendingOrderStep(
+      {
+        id: orderId,
+        chainId: context.chainId,
+        order: {
+          ...order,
+          isHidden: true,
+        },
+      },
+      dispatch
+    )
+
     logTradeFlow(LOG_PREFIX, 'STEP 4: build presign tx')
     const presignTx = await buildPresignTx({ settlementContract, orderId })
 
@@ -65,14 +78,14 @@ export async function safeBundleFlow(
 
     const safeTx = await safeAppsSdk.txs.send({ txs: safeTransactionData })
 
-    logTradeFlow(LOG_PREFIX, 'STEP 6: add tx to store')
-    addPendingOrderStep(
+    logTradeFlow(LOG_PREFIX, 'STEP 6: add safe tx hash and unhide order')
+    partialOrderUpdate(
       {
-        id: orderId,
         chainId: context.chainId,
         order: {
-          ...order,
+          id: order.id,
           presignGnosisSafeTxHash: safeTx.safeTxHash,
+          isHidden: false,
         },
       },
       dispatch

--- a/src/modules/swap/services/swapFlow/index.ts
+++ b/src/modules/swap/services/swapFlow/index.ts
@@ -6,6 +6,7 @@ import { addPendingOrderStep } from 'modules/trade/utils/addPendingOrderStep'
 import { logTradeFlow } from 'modules/trade/utils/logger'
 import { getSwapErrorMessage } from 'modules/trade/utils/swapErrorHelper'
 import { PriceImpact } from 'legacy/hooks/usePriceImpact'
+import { partialOrderUpdate } from 'legacy/state/orders/utils'
 import { Percent } from '@uniswap/sdk-core'
 
 export async function swapFlow(
@@ -28,23 +29,37 @@ export async function swapFlow(
       input.callbacks.closeModals()
     })
 
-    logTradeFlow('SWAP FLOW', 'STEP 4: presign order (optional)')
-    const presignTx = await (input.flags.allowsOffchainSigning
-      ? Promise.resolve(null)
-      : presignOrderStep(orderId, input.contract))
-
-    logTradeFlow('SWAP FLOW', 'STEP 5: add pending order step')
     addPendingOrderStep(
       {
         id: orderId,
         chainId: input.context.chainId,
         order: {
           ...order,
-          presignGnosisSafeTxHash: input.flags.isGnosisSafeWallet && presignTx ? presignTx.hash : undefined,
+          isHidden: !input.flags.allowsOffchainSigning,
         },
       },
       input.dispatch
     )
+
+    logTradeFlow('SWAP FLOW', 'STEP 4: presign order (optional)')
+    const presignTx = await (input.flags.allowsOffchainSigning
+      ? Promise.resolve(null)
+      : presignOrderStep(orderId, input.contract))
+
+    logTradeFlow('SWAP FLOW', 'STEP 5: unhide SC order (optional)')
+    if (presignTx) {
+      partialOrderUpdate(
+        {
+          chainId: input.context.chainId,
+          order: {
+            id: order.id,
+            presignGnosisSafeTxHash: input.flags.isGnosisSafeWallet ? presignTx.hash : undefined,
+            isHidden: false,
+          },
+        },
+        input.dispatch
+      )
+    }
 
     logTradeFlow('SWAP FLOW', 'STEP 6: add app data to upload queue')
     input.callbacks.uploadAppData({ chainId: input.context.chainId, orderId, appData: input.appDataInfo })


### PR DESCRIPTION
# Summary

Continuation of https://github.com/cowprotocol/cowswap/pull/2462

Applying the same hiding logic to:
- Safe bundle flow for SWAP
- Regular SWAP presign
- Regular LIMIT presign

# To Test

## Safe SWAP bundle flow

1. Load app as Safe app, 
2. Configure a short expiration time (5min)
3. Pick sell token that needs approval
4. Go all the way until Safe confirmation modal is displayed
5. Cancel tx
* There should not be a pop up nor COW sound
* Order should not be pending in presign state
6. Open Explorer and look for you account
* There should be a pending presign tx
7. Wait for the order to expire on Swap page
* There should not be a expiration pop up nor sound
8. Back at the Swap, go all the way and this time place the tx/sign execute it
* There should be a pop up and sound
* Order should be pending in the corresponding state (presign or open if tx was already mined)

## Regular SWAP flow

1. Use any smart contract wallet
2. Configure a short expiration time (5min)
3. Go all the way until confirmation shows in the wallet
4. Cancel it
* There should not be a pop up nor COW sound
* Order should not be pending in presign state
5. Open Explorer and look for you account
* There should be a pending presign tx
6. Wait for the order to expire on Swap page
* There should not be a expiration pop up nor sound
7. Back at the Swap, go all the way and this time place the tx/sign execute it
* There should be a pop up and sound
* Order should be pending in the corresponding state (presign or open if tx was already mined)

## Regular LIMIT flow

1. Repeat steps from previous section but in the limit orders page
2. Results should be the same

---

EthFlow is unchanged
EOA flow should not change, but would be good to make sure it still behaves as before

