### PR TITLE
fix(usdt-approval): :bug: fix swap zero approvals ignoring buy flow

### DIFF
--- a/src/common/hooks/useShouldZeroApproveSwap.ts
+++ b/src/common/hooks/useShouldZeroApproveSwap.ts
@@ -2,6 +2,6 @@ import { useDerivedSwapInfo } from 'legacy/state/swap/hooks'
 import { useShouldZeroApprove } from './useShouldZeroApprove'
 
 export function useShouldZeroApproveSwap() {
-  const { parsedAmount } = useDerivedSwapInfo()
-  return useShouldZeroApprove(parsedAmount)
+  const { v2Trade, allowedSlippage } = useDerivedSwapInfo()
+  return useShouldZeroApprove(v2Trade?.maximumAmountIn(allowedSlippage))
 }


### PR DESCRIPTION
# Summary

Fixes #2521

Swap specific zero approval checker was not relying on slippage adjusted amounts. Updated that part of the logic to make it work for both sides of the flow.

<img width="533" alt="Screenshot 2023-05-23 at 18 57 18" src="https://github.com/cowprotocol/cowswap/assets/5172699/1dbe7302-9648-4729-8a88-dc5a9057d816">
<img width="511" alt="Screenshot 2023-05-23 at 18 57 11" src="https://github.com/cowprotocol/cowswap/assets/5172699/274649c8-949d-4ba1-b8ca-ed336ac27034">


  # To Test

1. Go to CoW Swap on Goerli
2. Use USDT https://goerli.etherscan.io/address/0x7b77F953e703E80CD97F6911385c0b1ceabC96Bc
3. Approve or trade to have some left over approvals (for example 5 USDT)
4. Go to swap
5. Specify a Buy order: Enter an amount into the Buy field that makes USDT amount higher than the approval amount (for example 10 USDT)
6. You should see zero approval warning and flow

