### PR TITLE
fix(usdt-approval): :bug: fix modal not dismissing when close is clicked

### DIFF
--- a/src/common/containers/ZeroApprovalModal/ZeroApprovalModal.tsx
+++ b/src/common/containers/ZeroApprovalModal/ZeroApprovalModal.tsx
@@ -5,7 +5,7 @@ import { GpModal } from 'common/pure/Modal'
 import { useWeb3React } from '@web3-react/core'
 import { getStatusIcon } from 'modules/account/containers/AccountDetails'
 import { useZeroApprovalState } from 'common/state/useZeroApprovalState'
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 
 interface ZeroApprovalModalProps {
   onDismiss?: () => void
@@ -16,8 +16,12 @@ export function ZeroApprovalModal({ onDismiss = () => {} }: ZeroApprovalModalPro
   const walletDetails = useWalletDetails()
   const { connector } = useWeb3React()
   const { isApproving, currency } = useZeroApprovalState()
+  const [hasUserClosedModal, setHasUserClosedModal] = useState(false)
+
+  const shouldShow = isApproving && !hasUserClosedModal
 
   const handleDismiss = useCallback(() => {
+    setHasUserClosedModal(true)
     onDismiss()
   }, [onDismiss])
 
@@ -26,9 +30,9 @@ export function ZeroApprovalModal({ onDismiss = () => {} }: ZeroApprovalModalPro
   const symbol = currency?.symbol?.toUpperCase() ?? 'Unknown Currency' // This should never happen.
 
   return (
-    <GpModal isOpen={isApproving} onDismiss={handleDismiss}>
+    <GpModal isOpen={shouldShow} onDismiss={handleDismiss}>
       <ConfirmationPendingContent
-        onDismiss={onDismiss}
+        onDismiss={handleDismiss}
         statusIcon={getStatusIcon(connector, walletDetails, 56)}
         title={
           <>

--- a/src/common/containers/ZeroApprovalModal/ZeroApprovalModal.tsx
+++ b/src/common/containers/ZeroApprovalModal/ZeroApprovalModal.tsx
@@ -5,7 +5,7 @@ import { GpModal } from 'common/pure/Modal'
 import { useWeb3React } from '@web3-react/core'
 import { getStatusIcon } from 'modules/account/containers/AccountDetails'
 import { useZeroApprovalState } from 'common/state/useZeroApprovalState'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 interface ZeroApprovalModalProps {
   onDismiss?: () => void
@@ -24,6 +24,12 @@ export function ZeroApprovalModal({ onDismiss = () => {} }: ZeroApprovalModalPro
     setHasUserClosedModal(true)
     onDismiss()
   }, [onDismiss])
+
+  useEffect(() => {
+    if (!isApproving && hasUserClosedModal) {
+      setHasUserClosedModal(false)
+    }
+  }, [isApproving, hasUserClosedModal])
 
   const { walletName, ensName } = walletDetails
   const walletAddress = ensName || (account ? shortenAddress(account) : '')


### PR DESCRIPTION
# Summary

Fixes #2522

Missing explicit modal close logic. Added a state variable to also check for to not show modal when not desired.

# To Test


1. Go to CoW Swap on Goerli,
2. Use USDT https://goerli.etherscan.io/address/0x7b77F953e703E80CD97F6911385c0b1ceabC96Bc
3. Approve or trade to have some left over approvals (for example 5 USDT)
4. Open Swap orders page
5. Enter an amount higher than the approval amount (for example 10 USDT)
6. Press on the Approve button
7. Try closing the Reset modal
8. It should be possible.
