### PR TITLE
feat(usdt-approval): ✨ add zero approval flow to safe bundles

### DIFF
--- a/src/common/hooks/useShouldZeroApprove/shouldZeroApprove.ts
+++ b/src/common/hooks/useShouldZeroApprove/shouldZeroApprove.ts
@@ -1,44 +1,71 @@
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import { Erc20 } from 'legacy/abis/types'
 import { ApprovalState } from 'legacy/hooks/useApproveCallback'
+import { Nullish } from 'types'
 
-interface ShouldZeroApproveParams {
-  approvalState: ApprovalState
-  tokenContract: Erc20 | null
-  spender: string | undefined
-  amountToApprove: CurrencyAmount<Currency> | undefined
+interface ShouldZeroApproveBaseParams {
+  tokenContract: Nullish<Erc20>
+  spender: Nullish<string>
+  amountToApprove: Nullish<CurrencyAmount<Currency>>
 }
+
+interface ShouldZeroApproveBundleParams extends ShouldZeroApproveBaseParams {
+  isBundle: true
+  approvalState?: undefined
+}
+
+interface ShouldZeroApproveNonBundleParams extends ShouldZeroApproveBaseParams {
+  approvalState: ApprovalState
+  isBundle?: undefined
+}
+
+type ShouldZeroApproveParams = ShouldZeroApproveBundleParams | ShouldZeroApproveNonBundleParams
 
 export async function shouldZeroApprove({
   approvalState,
   tokenContract,
   spender,
   amountToApprove,
+  isBundle,
 }: ShouldZeroApproveParams) {
-  const shouldApprove = approvalState === ApprovalState.NOT_APPROVED || approvalState === ApprovalState.PENDING
-  if (tokenContract && spender && amountToApprove) {
-    if (!shouldApprove) {
-      return false
-    }
-
-    try {
-      await tokenContract.estimateGas.approve(
-        spender,
-        amountToApprove.multiply(10 ** amountToApprove.currency.decimals).toExact()
-      )
-
-      return false
-    } catch (err) {
-      try {
-        await tokenContract.estimateGas.approve(spender, '0')
-        // Zero approval case
-        return true
-      } catch (err) {
-        // Actual error case
-        return false
-      }
-    }
-  } else {
+  if (!tokenContract) {
     return false
+  }
+
+  if (!spender) {
+    return false
+  }
+
+  if (!amountToApprove) {
+    return false
+  }
+
+  const shouldApprove =
+    isBundle || approvalState === ApprovalState.NOT_APPROVED || approvalState === ApprovalState.PENDING
+
+  if (!shouldApprove) {
+    return false
+  }
+
+  try {
+    // Check if the trade is possible via estimating gas.
+    await tokenContract.estimateGas.approve(
+      spender,
+      amountToApprove.multiply(10 ** amountToApprove.currency.decimals).toExact()
+    )
+
+    return false
+  } catch (err) {
+    try {
+      // Check for the trade has failed. Check if a trade with 0 amount is possible.
+      // If it is, then we need to first reset the allowance to 0.
+      await tokenContract.estimateGas.approve(spender, '0')
+
+      return true
+    } catch (err) {
+      // If the trade with 0 amount is also not possible, we have an actual error case.
+      // We can't do anything about it, so we just return false.
+      return false
+    }
   }
 }

--- a/src/common/hooks/useShouldZeroApprove/shouldZeroApprove.ts
+++ b/src/common/hooks/useShouldZeroApprove/shouldZeroApprove.ts
@@ -28,22 +28,9 @@ export async function shouldZeroApprove({
   amountToApprove,
   isBundle,
 }: ShouldZeroApproveParams) {
-  if (!tokenContract) {
-    return false
-  }
-
-  if (!spender) {
-    return false
-  }
-
-  if (!amountToApprove) {
-    return false
-  }
-
   const shouldApprove =
     isBundle || approvalState === ApprovalState.NOT_APPROVED || approvalState === ApprovalState.PENDING
-
-  if (!shouldApprove) {
+  if (!tokenContract || !spender || !amountToApprove || !shouldApprove) {
     return false
   }
 

--- a/src/common/hooks/useShouldZeroApprove/useShouldZeroApprove.ts
+++ b/src/common/hooks/useShouldZeroApprove/useShouldZeroApprove.ts
@@ -17,7 +17,12 @@ export function useShouldZeroApprove(amountToApprove: CurrencyAmount<Currency> |
   useEffect(() => {
     let isStale = false
     ;(async () => {
-      const result = await shouldZeroApproveFn({ approvalState, amountToApprove, tokenContract, spender })
+      const result = await shouldZeroApproveFn({
+        amountToApprove,
+        tokenContract,
+        spender,
+        approvalState,
+      })
 
       if (!isStale) {
         setShouldZeroApprove(result)

--- a/src/modules/operations/bundle/buildZeroApproveTx.ts
+++ b/src/modules/operations/bundle/buildZeroApproveTx.ts
@@ -1,0 +1,16 @@
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
+import { BuildApproveTxParams, buildApproveTx } from './buildApproveTx'
+
+type BuildZeroApproveTxParams = Omit<BuildApproveTxParams, 'amountToApprove'> & {
+  currency: Currency
+}
+
+/**
+ * Builds the zero approval tx, without sending it.
+ */
+export async function buildZeroApproveTx({ currency, ...params }: BuildZeroApproveTxParams) {
+  return buildApproveTx({
+    ...params,
+    amountToApprove: CurrencyAmount.fromRawAmount(currency, 0),
+  })
+}


### PR DESCRIPTION
# Summary

Fixes #2508

This refactors parts of should zero approve logic and adds a zero approve transaction to the bundled transactions when using safe, as needed.

As bundled transactions don't prompt user twice, we show the warning but not the modal.

<img width="624" alt="Screenshot 2023-05-24 at 01 46 32" src="https://github.com/cowprotocol/cowswap/assets/5172699/3cbfee9b-a6a4-49d7-9917-e41eb6feebf2">
<img width="595" alt="Screenshot 2023-05-24 at 01 46 04" src="https://github.com/cowprotocol/cowswap/assets/5172699/69c62f46-b19b-4b3b-80a5-cb7f62757151">
<img width="500" alt="Screenshot 2023-05-24 at 01 48 35" src="https://github.com/cowprotocol/cowswap/assets/5172699/03e8a3c6-1431-4c90-bb67-0f2326826589">
<img width="520" alt="Screenshot 2023-05-24 at 01 48 30" src="https://github.com/cowprotocol/cowswap/assets/5172699/0e675e8b-fcc3-46d6-8d15-97f8afc4bea4">


# To Test

1. Open the CoW Swap app inside a Goerli safe
2. Use Anxo's USDT https://goerli.etherscan.io/address/0x7b77F953e703E80CD97F6911385c0b1ceabC96Bc
3. Approve or trade to have some left over approvals (for example 5 USDT)
4. Open Swap orders page
5. Enter an amount higher than the approval amount (for example 10 USDT)
6. Press on the Approve and Swap button
7. You should expect to see in the bundle two approvals and a warning beforehand.
