### PR TITLE
fix: fix approval edge case

### DIFF
--- a/src/common/hooks/useShouldZeroApprove/useShouldZeroApprove.ts
+++ b/src/common/hooks/useShouldZeroApprove/useShouldZeroApprove.ts
@@ -18,10 +18,10 @@ export function useShouldZeroApprove(amountToApprove: CurrencyAmount<Currency> |
     let isStale = false
     ;(async () => {
       const result = await shouldZeroApproveFn({
+        approvalState: approvalState.approvalState,
         amountToApprove,
         tokenContract,
         spender,
-        approvalState,
       })
 
       if (!isStale) {

--- a/src/lib/hooks/swap/useSwapApproval.ts
+++ b/src/lib/hooks/swap/useSwapApproval.ts
@@ -26,9 +26,9 @@ function useSwapApprovalStates(
   const v2RouterAddress = chainId ? V2_ROUTER_ADDRESS[chainId] : undefined
   const v3RouterAddress = chainId ? V3_ROUTER_ADDRESS[chainId] : undefined
   const swapRouterAddress = chainId ? SWAP_ROUTER_ADDRESSES[chainId] : undefined
-  const v2 = useApprovalStateForSpender(amountToApprove, v2RouterAddress, useIsPendingApproval)
-  const v3 = useApprovalStateForSpender(amountToApprove, v3RouterAddress, useIsPendingApproval)
-  const v2V3 = useApprovalStateForSpender(amountToApprove, swapRouterAddress, useIsPendingApproval)
+  const v2 = useApprovalStateForSpender(amountToApprove, v2RouterAddress, useIsPendingApproval).approvalState
+  const v3 = useApprovalStateForSpender(amountToApprove, v3RouterAddress, useIsPendingApproval).approvalState
+  const v2V3 = useApprovalStateForSpender(amountToApprove, swapRouterAddress, useIsPendingApproval).approvalState
 
   return useMemo(() => ({ v2, v3, v2V3 }), [v2, v2V3, v3])
 }

--- a/src/lib/hooks/useApproval.ts
+++ b/src/lib/hooks/useApproval.ts
@@ -14,15 +14,45 @@ export enum ApprovalState {
   APPROVED = 'APPROVED',
 }
 
-export interface ApprovalStateForSpenderParams {
+export interface ApprovalStateForSpenderResult {
   approvalState: ApprovalState
+  currentAllowance?: CurrencyAmount<Token>
+}
+
+function toApprovalState(
+  amountToApprove: CurrencyAmount<Currency> | undefined,
+  spender: string | undefined,
+  currentAllowance?: CurrencyAmount<Token>,
+  pendingApproval?: boolean
+): ApprovalState {
+  // Unknown amount or spender
+  if (!amountToApprove || !spender) {
+    return ApprovalState.UNKNOWN
+  }
+
+  // Native ETH is always approved
+  if (amountToApprove.currency.isNative) {
+    return ApprovalState.APPROVED
+  }
+
+  // Unknown allowance
+  if (!currentAllowance) {
+    return ApprovalState.UNKNOWN
+  }
+
+  // Enough allowance
+  if (!currentAllowance.lessThan(amountToApprove)) {
+    return ApprovalState.APPROVED
+  }
+
+  return pendingApproval ? ApprovalState.PENDING : ApprovalState.NOT_APPROVED
 }
 
 export function useApprovalStateForSpender(
   amountToApprove: CurrencyAmount<Currency> | undefined,
   spender: string | undefined,
   useIsPendingApproval: (token?: Token, spender?: string) => boolean
-): ApprovalStateForSpenderParams {
+): ApprovalStateForSpenderResult {
   const { account } = useWalletInfo()
   const token = amountToApprove?.currency?.isToken ? amountToApprove.currency : undefined
 
@@ -30,25 +60,8 @@ export function useApprovalStateForSpender(
   const pendingApproval = useIsPendingApproval(token, spender)
 
   return useMemo(() => {
-    if (!amountToApprove || !spender) return { approvalState: ApprovalState.UNKNOWN }
-    if (amountToApprove.currency.isNative) return { approvalState: ApprovalState.APPROVED }
-    // we might not have enough data to know whether or not we need to approve
-    if (!currentAllowance)
-      return {
-        approvalState: ApprovalState.UNKNOWN,
-      }
-
-    // amountToApprove will be defined if currentAllowance is
-    const approvalState = currentAllowance.lessThan(amountToApprove)
-      ? pendingApproval
-        ? ApprovalState.PENDING
-        : ApprovalState.NOT_APPROVED
-      : ApprovalState.APPROVED
-
-    return {
-      approvalState,
-      currentAllowance,
-    }
+    const approvalState = toApprovalState(amountToApprove, spender, currentAllowance, pendingApproval)
+    return { approvalState, currentAllowance }
   }, [amountToApprove, currentAllowance, pendingApproval, spender])
 }
 


### PR DESCRIPTION
# Summary

Fixes #2538

It was a bit hard to debug this one, but here are the conclusions of what was happening:
- The check for the `shouldZeroApprove` was dependant on `approvalState` 
- When the user modifies the approval to set a number below the trade side, we actually don't change state. We where `NOT_APPROVED` when we where 0, we are still when we are 5 (cause we try to sell 20)
- This don't trigger the `useEffect` that would recompute the need of resetting the allowance

Consecuence:
- The app thinks we didn't approve, but we don't need to reset
- Next approval will be a failed transaction

Fix
- i just made the hook to return both the allowance and the state
- This way, the hook will return a new object when the user changes its allowance

## Test
1. Go to CoW Swap on Goerli,
2. Use USDT https://goerli.etherscan.io/address/0x7b77F953e703E80CD97F6911385c0b1ceabC96Bc
3. Make sure it is not appoved (revoke approval)
4. Open Swap orders page
5. Specify a trade with the Sell token = USDT, an amount, f.e., 20
5. Partially approve the  token amount (e.g.5)
6. Wait till the Approval TX is executed
7. Check the Swap form
