### PR TITLE
fix(usdt-approval): 🐛 fix wallet connect with safe causing same nonce to appear twice

### DIFF
--- a/src/common/hooks/useShouldZeroApprove/shouldZeroApprove.ts
+++ b/src/common/hooks/useShouldZeroApprove/shouldZeroApprove.ts
@@ -1,44 +1,71 @@
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import { Erc20 } from 'legacy/abis/types'
 import { ApprovalState } from 'legacy/hooks/useApproveCallback'
+import { Nullish } from 'types'
 
-interface ShouldZeroApproveParams {
-  approvalState: ApprovalState
-  tokenContract: Erc20 | null
-  spender: string | undefined
-  amountToApprove: CurrencyAmount<Currency> | undefined
+interface ShouldZeroApproveBaseParams {
+  tokenContract: Nullish<Erc20>
+  spender: Nullish<string>
+  amountToApprove: Nullish<CurrencyAmount<Currency>>
 }
+
+interface ShouldZeroApproveBundleParams extends ShouldZeroApproveBaseParams {
+  isBundle: true
+  approvalState?: undefined
+}
+
+interface ShouldZeroApproveNonBundleParams extends ShouldZeroApproveBaseParams {
+  approvalState: ApprovalState
+  isBundle?: undefined
+}
+
+type ShouldZeroApproveParams = ShouldZeroApproveBundleParams | ShouldZeroApproveNonBundleParams
 
 export async function shouldZeroApprove({
   approvalState,
   tokenContract,
   spender,
   amountToApprove,
+  isBundle,
 }: ShouldZeroApproveParams) {
-  const shouldApprove = approvalState === ApprovalState.NOT_APPROVED || approvalState === ApprovalState.PENDING
-  if (tokenContract && spender && amountToApprove) {
-    if (!shouldApprove) {
-      return false
-    }
-
-    try {
-      await tokenContract.estimateGas.approve(
-        spender,
-        amountToApprove.multiply(10 ** amountToApprove.currency.decimals).toExact()
-      )
-
-      return false
-    } catch (err) {
-      try {
-        await tokenContract.estimateGas.approve(spender, '0')
-        // Zero approval case
-        return true
-      } catch (err) {
-        // Actual error case
-        return false
-      }
-    }
-  } else {
+  if (!tokenContract) {
     return false
+  }
+
+  if (!spender) {
+    return false
+  }
+
+  if (!amountToApprove) {
+    return false
+  }
+
+  const shouldApprove =
+    isBundle || approvalState === ApprovalState.NOT_APPROVED || approvalState === ApprovalState.PENDING
+
+  if (!shouldApprove) {
+    return false
+  }
+
+  try {
+    // Check if the trade is possible via estimating gas.
+    await tokenContract.estimateGas.approve(
+      spender,
+      amountToApprove.multiply(10 ** amountToApprove.currency.decimals).toExact()
+    )
+
+    return false
+  } catch (err) {
+    try {
+      // Check for the trade has failed. Check if a trade with 0 amount is possible.
+      // If it is, then we need to first reset the allowance to 0.
+      await tokenContract.estimateGas.approve(spender, '0')
+
+      return true
+    } catch (err) {
+      // If the trade with 0 amount is also not possible, we have an actual error case.
+      // We can't do anything about it, so we just return false.
+      return false
+    }
   }
 }

--- a/src/common/hooks/useShouldZeroApprove/shouldZeroApprove.ts
+++ b/src/common/hooks/useShouldZeroApprove/shouldZeroApprove.ts
@@ -28,22 +28,9 @@ export async function shouldZeroApprove({
   amountToApprove,
   isBundle,
 }: ShouldZeroApproveParams) {
-  if (!tokenContract) {
-    return false
-  }
-
-  if (!spender) {
-    return false
-  }
-
-  if (!amountToApprove) {
-    return false
-  }
-
   const shouldApprove =
     isBundle || approvalState === ApprovalState.NOT_APPROVED || approvalState === ApprovalState.PENDING
-
-  if (!shouldApprove) {
+  if (!tokenContract || !spender || !amountToApprove || !shouldApprove) {
     return false
   }
 

--- a/src/common/hooks/useShouldZeroApprove/useShouldZeroApprove.ts
+++ b/src/common/hooks/useShouldZeroApprove/useShouldZeroApprove.ts
@@ -17,7 +17,12 @@ export function useShouldZeroApprove(amountToApprove: CurrencyAmount<Currency> |
   useEffect(() => {
     let isStale = false
     ;(async () => {
-      const result = await shouldZeroApproveFn({ approvalState, amountToApprove, tokenContract, spender })
+      const result = await shouldZeroApproveFn({
+        amountToApprove,
+        tokenContract,
+        spender,
+        approvalState,
+      })
 
       if (!isStale) {
         setShouldZeroApprove(result)

--- a/src/common/hooks/useZeroApprove.ts
+++ b/src/common/hooks/useZeroApprove.ts
@@ -4,18 +4,65 @@ import { useApproveCallback } from './useApproveCallback'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import { useSetAtom } from 'jotai'
 import { zeroApprovalState } from '../state/useZeroApprovalState'
+import { useSafeApiKit } from 'api/gnosisSafe/hooks/useSafeApiKit'
+import { SafeMultisigTransactionResponse } from '@safe-global/safe-core-sdk-types'
+import { useIsActiveWallet } from 'legacy/hooks/useIsActiveWallet'
+import { walletConnectConnection } from 'modules/wallet/web3-react/connection/walletConnect'
+import { useIsSafeWallet } from 'modules/wallet'
+
+function wait(ms = 1000) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+async function poll<T>(
+  fn: () => Promise<T | null>,
+  fnCondition: (result: T | null) => boolean,
+  ms: number
+): Promise<T | null> {
+  let result = await fn()
+
+  while (fnCondition(result)) {
+    await wait(ms)
+    result = await fn()
+  }
+
+  return result
+}
 
 export function useZeroApprove(currency: Currency) {
   const setZeroApprovalState = useSetAtom(zeroApprovalState)
   const spender = useTradeSpenderAddress()
   const amountToApprove = CurrencyAmount.fromRawAmount(currency, 0)
   const approveCallback = useApproveCallback(amountToApprove, spender)
+  const safeApiKit = useSafeApiKit()
+  const isWalletConnect = useIsActiveWallet(walletConnectConnection)
+  const isSafeWallet = useIsSafeWallet()
+
   return useCallback(async () => {
     try {
       setZeroApprovalState({ isApproving: true, currency })
-      await approveCallback()
+      const txReceipt = await approveCallback()
+
+      // For Wallet Connect based Safe Wallet connections, wait for transaction to be executed.
+      if (txReceipt && safeApiKit && isSafeWallet && isWalletConnect) {
+        await poll(
+          async () => {
+            try {
+              return await safeApiKit.getTransaction(txReceipt?.hash)
+            } catch {
+              return null
+            }
+          },
+          (transaction: SafeMultisigTransactionResponse | null) => {
+            return transaction ? !transaction.isExecuted : true
+          },
+          1000
+        )
+      }
     } finally {
       setZeroApprovalState({ isApproving: false })
     }
-  }, [approveCallback, setZeroApprovalState, currency])
+  }, [approveCallback, setZeroApprovalState, currency, safeApiKit, isSafeWallet, isWalletConnect])
 }

--- a/src/modules/operations/bundle/buildZeroApproveTx.ts
+++ b/src/modules/operations/bundle/buildZeroApproveTx.ts
@@ -1,0 +1,16 @@
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
+import { BuildApproveTxParams, buildApproveTx } from './buildApproveTx'
+
+type BuildZeroApproveTxParams = Omit<BuildApproveTxParams, 'amountToApprove'> & {
+  currency: Currency
+}
+
+/**
+ * Builds the zero approval tx, without sending it.
+ */
+export async function buildZeroApproveTx({ currency, ...params }: BuildZeroApproveTxParams) {
+  return buildApproveTx({
+    ...params,
+    amountToApprove: CurrencyAmount.fromRawAmount(currency, 0),
+  })
+}


### PR DESCRIPTION
# Summary

Fixes #2532

Safe has an issue with wallet connect where when we send two transactions back to back, they repeat the nonce, causing transaction to fail.

This change introduces a fix by;
* Check if we are dealing with a safe wallet in wallet connect
* If so, poll for safe transaction execution every second
* Proceed only when this happens

# To Test

1. Open CoW Swap
2. Connect to the Safe using WC option
3. Use Anxo's USDT https://goerli.etherscan.io/address/0x7b77F953e703E80CD97F6911385c0b1ceabC96Bc
4. Approve or trade to have some left over approvals (for example 5 USDT)
5. Enter an amount higher than the approval amount (for example 10 USDT)
6. Press on the Approve button and run TX
7. Second tx should not fail.

# Background
https://github.com/safe-global/safe-wallet-web/issues/2034
https://cowservices.slack.com/archives/C03DVQREAH0/p1684929286045829