### PR TITLE
fix(usdt-approval): 🐛 fix wallet connect with safe causing same nonce to appear twice

### DIFF
--- a/src/common/hooks/useZeroApprove.ts
+++ b/src/common/hooks/useZeroApprove.ts
@@ -4,18 +4,65 @@ import { useApproveCallback } from './useApproveCallback'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import { useSetAtom } from 'jotai'
 import { zeroApprovalState } from '../state/useZeroApprovalState'
+import { useSafeApiKit } from 'api/gnosisSafe/hooks/useSafeApiKit'
+import { SafeMultisigTransactionResponse } from '@safe-global/safe-core-sdk-types'
+import { useIsActiveWallet } from 'legacy/hooks/useIsActiveWallet'
+import { walletConnectConnection } from 'modules/wallet/web3-react/connection/walletConnect'
+import { useIsSafeWallet } from 'modules/wallet'
+
+function wait(ms = 1000) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+async function poll<T>(
+  fn: () => Promise<T | null>,
+  fnCondition: (result: T | null) => boolean,
+  ms: number
+): Promise<T | null> {
+  let result = await fn()
+
+  while (fnCondition(result)) {
+    await wait(ms)
+    result = await fn()
+  }
+
+  return result
+}
 
 export function useZeroApprove(currency: Currency) {
   const setZeroApprovalState = useSetAtom(zeroApprovalState)
   const spender = useTradeSpenderAddress()
   const amountToApprove = CurrencyAmount.fromRawAmount(currency, 0)
   const approveCallback = useApproveCallback(amountToApprove, spender)
+  const safeApiKit = useSafeApiKit()
+  const isWalletConnect = useIsActiveWallet(walletConnectConnection)
+  const isSafeWallet = useIsSafeWallet()
+
   return useCallback(async () => {
     try {
       setZeroApprovalState({ isApproving: true, currency })
-      await approveCallback()
+      const txReceipt = await approveCallback()
+
+      // For Wallet Connect based Safe Wallet connections, wait for transaction to be executed.
+      if (txReceipt && safeApiKit && isSafeWallet && isWalletConnect) {
+        await poll(
+          async () => {
+            try {
+              return await safeApiKit.getTransaction(txReceipt?.hash)
+            } catch {
+              return null
+            }
+          },
+          (transaction: SafeMultisigTransactionResponse | null) => {
+            return transaction ? !transaction.isExecuted : true
+          },
+          1000
+        )
+      }
     } finally {
       setZeroApprovalState({ isApproving: false })
     }
-  }, [approveCallback, setZeroApprovalState, currency])
+  }, [approveCallback, setZeroApprovalState, currency, safeApiKit, isSafeWallet, isWalletConnect])
 }

--- a/src/common/utils/pollUntil.ts
+++ b/src/common/utils/pollUntil.ts
@@ -1,0 +1,16 @@
+import { wait } from './wait'
+
+export async function pollUntil<T>(
+  fn: () => Promise<T | null>,
+  fnCondition: (result: T | null) => boolean,
+  ms: number
+): Promise<T | null> {
+  let result = await fn()
+
+  while (fnCondition(result)) {
+    await wait(ms)
+    result = await fn()
+  }
+
+  return result
+}

--- a/src/common/utils/wait.ts
+++ b/src/common/utils/wait.ts
@@ -1,0 +1,3 @@
+export function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
# Summary

Fixes #2532

Safe has an issue with wallet connect where when we send two transactions back to back, they repeat the nonce, causing transaction to fail.

This change introduces a fix by;
* Check if we are dealing with a safe wallet in wallet connect
* If so, poll for safe transaction execution every second
* Proceed only when this happens

# To Test

1. Open CoW Swap
2. Connect to the Safe using WC option
3. Use Anxo's USDT https://goerli.etherscan.io/address/0x7b77F953e703E80CD97F6911385c0b1ceabC96Bc
4. Approve or trade to have some left over approvals (for example 5 USDT)
5. Enter an amount higher than the approval amount (for example 10 USDT)
6. Press on the Approve button and run TX
7. Second tx should not fail.

# Background
https://github.com/safe-global/safe-wallet-web/issues/2034
https://cowservices.slack.com/archives/C03DVQREAH0/p1684929286045829