### PR TITLE
fix(usdt-approval): :bug: fix amountToApprove having a non bigint number

### DIFF
--- a/src/common/hooks/useShouldZeroApprove/shouldZeroApprove.ts
+++ b/src/common/hooks/useShouldZeroApprove/shouldZeroApprove.ts
@@ -36,10 +36,7 @@ export async function shouldZeroApprove({
 
   try {
     // Check if the trade is possible via estimating gas.
-    await tokenContract.estimateGas.approve(
-      spender,
-      amountToApprove.multiply(10 ** amountToApprove.currency.decimals).toExact()
-    )
+    await tokenContract.estimateGas.approve(spender, amountToApprove.quotient.toString())
 
     return false
   } catch (err) {


### PR DESCRIPTION
# Summary

Fixes #2548

Issue was caused by `toExact` method having some decimals left at the end, even though we multiply the `amountToApprove` with `10 ** decimals`.

Replacing that with `toFixed(0)` solves this issue.


# To Test

1. Open cow swap
2. Partially approve a token (any, not USDT). F.e. approve 1 WETH
3. Select WETH as a sell token
4. Select a but token, an amount to BUY --> value in the Sell field should be >1
5. Check the Swap form
6. Check the same steps for the Limit orders form
