### PR TITLE
feat: clickable fill+status label for order receipt

### DIFF
--- a/src/modules/limitOrders/pure/OrderStatusBox/index.tsx
+++ b/src/modules/limitOrders/pure/OrderStatusBox/index.tsx
@@ -9,6 +9,7 @@ const Wrapper = styled.div<{
   cancelling?: boolean
   withWarning?: boolean
   widthAuto?: boolean
+  clickable?: boolean
 }>`
   --height: 28px;
   --statusColor: ${({ theme, status, cancelling, partiallyFilled }) =>
@@ -39,6 +40,7 @@ const Wrapper = styled.div<{
   font-weight: 600;
   height: var(--height);
   width: ${({ widthAuto }) => (widthAuto ? 'auto' : '100%')};
+  cursor: ${({ clickable }) => (clickable ? 'pointer' : '')};
 
   &::before {
     content: '';
@@ -55,9 +57,9 @@ const Wrapper = styled.div<{
   }
 `
 
-export type OrderStatusBoxProps = { order: ParsedOrder; widthAuto?: boolean; withWarning?: boolean }
+export type OrderStatusBoxProps = { order: ParsedOrder; widthAuto?: boolean; withWarning?: boolean; clickable?: boolean; onClick?: () => void }
 
-export function OrderStatusBox({ order, widthAuto, withWarning }: OrderStatusBoxProps) {
+export function OrderStatusBox({ order, widthAuto, withWarning, clickable, onClick }: OrderStatusBoxProps) {
   return (
     <Wrapper
       cancelling={order.isCancelling}
@@ -65,6 +67,8 @@ export function OrderStatusBox({ order, widthAuto, withWarning }: OrderStatusBox
       status={order.status}
       widthAuto={widthAuto}
       withWarning={withWarning}
+      clickable={clickable}
+      onClick={onClick}
     >
       {/* Status overrides for special cases */}
       {

--- a/src/modules/limitOrders/pure/OrderStatusBox/index.tsx
+++ b/src/modules/limitOrders/pure/OrderStatusBox/index.tsx
@@ -57,7 +57,13 @@ const Wrapper = styled.div<{
   }
 `
 
-export type OrderStatusBoxProps = { order: ParsedOrder; widthAuto?: boolean; withWarning?: boolean; clickable?: boolean; onClick?: () => void }
+export type OrderStatusBoxProps = {
+  order: ParsedOrder
+  widthAuto?: boolean
+  withWarning?: boolean
+  clickable?: boolean
+  onClick?: () => void
+}
 
 export function OrderStatusBox({ order, widthAuto, withWarning, clickable, onClick }: OrderStatusBoxProps) {
   return (

--- a/src/modules/limitOrders/pure/OrderStatusBox/index.tsx
+++ b/src/modules/limitOrders/pure/OrderStatusBox/index.tsx
@@ -61,11 +61,10 @@ export type OrderStatusBoxProps = {
   order: ParsedOrder
   widthAuto?: boolean
   withWarning?: boolean
-  clickable?: boolean
   onClick?: () => void
 }
 
-export function OrderStatusBox({ order, widthAuto, withWarning, clickable, onClick }: OrderStatusBoxProps) {
+export function OrderStatusBox({ order, widthAuto, withWarning, onClick }: OrderStatusBoxProps) {
   return (
     <Wrapper
       cancelling={order.isCancelling}
@@ -73,7 +72,7 @@ export function OrderStatusBox({ order, widthAuto, withWarning, clickable, onCli
       status={order.status}
       widthAuto={widthAuto}
       withWarning={withWarning}
-      clickable={clickable}
+      clickable={!!onClick}
       onClick={onClick}
     >
       {/* Status overrides for special cases */}

--- a/src/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -290,7 +290,7 @@ export function OrderRow({
       {/* Status label */}
       <styledEl.CellElement>
         <styledEl.StatusBox>
-          <OrderStatusBox order={order} withWarning={withWarning} clickable onClick={onClick} />
+          <OrderStatusBox order={order} withWarning={withWarning} clickable={!!onClick} onClick={onClick} />
           {withWarning && (
             <styledEl.WarningIndicator>
               <MouseoverTooltipContent

--- a/src/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -290,7 +290,7 @@ export function OrderRow({
       {/* Status label */}
       <styledEl.CellElement>
         <styledEl.StatusBox>
-          <OrderStatusBox order={order} withWarning={withWarning} clickable={!!onClick} onClick={onClick} />
+          <OrderStatusBox order={order} withWarning={withWarning} onClick={onClick} />
           {withWarning && (
             <styledEl.WarningIndicator>
               <MouseoverTooltipContent

--- a/src/modules/limitOrders/pure/Orders/OrderRow/index.tsx
+++ b/src/modules/limitOrders/pure/Orders/OrderRow/index.tsx
@@ -282,7 +282,7 @@ export function OrderRow({
       )} */}
 
       {/* Filled % */}
-      <styledEl.CellElement doubleRow>
+      <styledEl.CellElement doubleRow clickable onClick={onClick}>
         <b>{formattedPercentage}%</b>
         <styledEl.ProgressBar value={formattedPercentage}></styledEl.ProgressBar>
       </styledEl.CellElement>
@@ -290,7 +290,7 @@ export function OrderRow({
       {/* Status label */}
       <styledEl.CellElement>
         <styledEl.StatusBox>
-          <OrderStatusBox order={order} withWarning={withWarning} />
+          <OrderStatusBox order={order} withWarning={withWarning} clickable onClick={onClick} />
           {withWarning && (
             <styledEl.WarningIndicator>
               <MouseoverTooltipContent

--- a/src/modules/limitOrders/pure/Orders/OrderRow/styled.tsx
+++ b/src/modules/limitOrders/pure/Orders/OrderRow/styled.tsx
@@ -84,7 +84,7 @@ export const AmountItem = styled.div`
   }
 `
 
-export const CellElement = styled.div<{ doubleRow?: boolean; hasBackground?: boolean }>`
+export const CellElement = styled.div<{ clickable?: boolean; doubleRow?: boolean; hasBackground?: boolean }>`
   padding: 0 ${({ hasBackground }) => (hasBackground ? '10px' : '0')};
   font-size: 12px;
   font-weight: 500;
@@ -95,6 +95,7 @@ export const CellElement = styled.div<{ doubleRow?: boolean; hasBackground?: boo
   align-items: ${({ doubleRow }) => (doubleRow ? 'flex-start' : 'center')};
   text-align: left;
   background: ${({ theme, hasBackground }) => (hasBackground ? transparentize(0.92, theme.text3) : 'transparent')};
+  cursor: ${({ clickable }) => (clickable ? 'pointer' : '')};
 
   > b {
     font-weight: 500;


### PR DESCRIPTION
# Summary

This pull request enhances the user interface experience by making the STATUS label and the content under the FILLED column clickable, which upon interaction will open the Order Receipt.

**To verify the changes implemented in this PR, follow the steps:**
1. Either place an order or navigate to the order history.
2. Interact by clicking on the FILLED column content or the STATUS label.
3. The expected behavior is that the click should trigger the opening of the associated Order Receipt.

https://github.com/cowprotocol/cowswap/assets/31534717/ca95ed88-0e93-4309-9627-08ddf7536ab9

## Note:
Please take note that, if there is a yellow warning triangle icon displayed next to the status label, this specific element has been excluded from the clickable interaction.
<img width="336" alt="Screenshot 2023-05-26 at 17 57 29" src="https://github.com/cowprotocol/cowswap/assets/31534717/fb5ca4c1-a2c0-4535-afda-8275027a1779">

## Suggestion:
For future iterations, I would like to propose adding the 'warning content' to the Order Receipt. My rationale for this suggestion is that users may sometimes overlook the tooltip. By including the warning content in the Order Receipt as well, we decrease the likelihood of this information being missed by an user.

