### PR TITLE
feat: add rate info

### DIFF
--- a/src/modules/twap/containers/TwapFormWidget/index.tsx
+++ b/src/modules/twap/containers/TwapFormWidget/index.tsx
@@ -1,9 +1,13 @@
 import { useAtomValue } from 'jotai'
 import { useUpdateAtom } from 'jotai/utils'
 
+import { useAdvancedOrdersDerivedState } from 'modules/advancedOrders'
+import { useIsWrapOrUnwrap } from 'modules/trade/hooks/useIsWrapOrUnwrap'
 import { TradeNumberInput } from 'modules/trade/pure/TradeNumberInput'
 import { TradeTextBox } from 'modules/trade/pure/TradeTextBox'
 import { QuoteObserverUpdater } from 'modules/twap/updaters/QuoteObserverUpdater'
+
+import { useRateInfoParams } from 'common/hooks/useRateInfoParams'
 
 import * as styledEl from './styled'
 
@@ -21,12 +25,16 @@ import { deadlinePartsDisplay } from '../../utils/deadlinePartsDisplay'
 export function TwapFormWidget() {
   const { numberOfPartsValue, slippageValue, deadline, customDeadline, isCustomDeadline } =
     useAtomValue(twapOrdersSettingsAtom)
+  const { inputCurrencyAmount, outputCurrencyAmount } = useAdvancedOrdersDerivedState()
   const partsState = useAtomValue(partsStateAtom)
   const timeInterval = useAtomValue(twapTimeIntervalAtom)
   const updateState = useUpdateAtom(updateTwapOrdersSettingsAtom)
+  const isWrapOrUnwrap = useIsWrapOrUnwrap()
 
   const formActions = useTwapFormActions()
   const formState = useTwapFormState()
+
+  const rateInfoParams = useRateInfoParams(inputCurrencyAmount, outputCurrencyAmount)
 
   const deadlineState = {
     deadline,
@@ -37,6 +45,12 @@ export function TwapFormWidget() {
   return (
     <>
       <QuoteObserverUpdater />
+      {!isWrapOrUnwrap && (
+        <styledEl.Row>
+          <styledEl.StyledRateInfo label="Current market price" rateInfoParams={rateInfoParams} />
+        </styledEl.Row>
+      )}
+
       <styledEl.Row>
         <TradeNumberInput
           value={numberOfPartsValue}

--- a/src/modules/twap/containers/TwapFormWidget/styled.tsx
+++ b/src/modules/twap/containers/TwapFormWidget/styled.tsx
@@ -1,5 +1,7 @@
 import styled from 'styled-components/macro'
 
+import { RateInfo } from 'common/pure/RateInfo'
+
 export const Row = styled.div`
   display: flex;
   grid-gap: 10px;
@@ -14,4 +16,13 @@ export const DeadlineRow = styled(Row)`
   grid-gap: 0;
   background: ${({ theme }) => theme.grey1};
   border-radius: 16px;
+`
+
+export const StyledRateInfo = styled(RateInfo)`
+  padding: 10px;
+  gap: 4px;
+  font-size: 13px;
+  min-height: 24px;
+  display: grid;
+  grid-template-columns: max-content auto;
 `


### PR DESCRIPTION
# Summary

Adds rate info to TWAP orders widget.

<img width="525" alt="Screenshot 2023-05-30 at 12 15 51" src="https://github.com/cowprotocol/cowswap/assets/34926005/df0ccd67-48b2-4a5b-ae0d-6d12350551d7">

# To test
- go to advanced orders
- select token pair
- there should be a rate info 