### PR TITLE
feat: get quote for single part in TWAP

### DIFF
--- a/src/modules/tradeQuote/hooks/useQuoteParams.ts
+++ b/src/modules/tradeQuote/hooks/useQuoteParams.ts
@@ -1,18 +1,33 @@
+import { useAtomValue } from 'jotai'
 import { useMemo } from 'react'
 
 import { OrderKind } from '@cowprotocol/cow-sdk'
 
 import { useDerivedTradeState } from 'modules/trade/hooks/useDerivedTradeState'
+import { TradeType, useTradeTypeInfo } from 'modules/trade/hooks/useTradeTypeInfo'
+import { partsStateAtom } from 'modules/twap/state/partsStateAtom'
 import { useWalletInfo } from 'modules/wallet'
 
 import { getAddress } from 'utils/getAddress'
 
 export function useQuoteParams() {
+  const tradeTypeInfo = useTradeTypeInfo()
+
   const { chainId, account } = useWalletInfo()
   const { state } = useDerivedTradeState()
+  const { inputPartAmount } = useAtomValue(partsStateAtom)
 
   const { inputCurrency, inputCurrencyAmount, outputCurrency, outputCurrencyAmount, orderKind } = state || {}
-  const currencyAmount = orderKind === OrderKind.SELL ? inputCurrencyAmount : outputCurrencyAmount
+
+  const currencyAmount = useMemo(() => {
+    // For TWAP orders, we want to get quote only for single part amount
+    if (tradeTypeInfo && tradeTypeInfo.tradeType === TradeType.ADVANCED_ORDERS) {
+      return inputPartAmount
+    }
+
+    return orderKind === OrderKind.SELL ? inputCurrencyAmount : outputCurrencyAmount
+  }, [inputCurrencyAmount, inputPartAmount, orderKind, outputCurrencyAmount, tradeTypeInfo])
+
   const amount = currencyAmount?.quotient.toString()
 
   return useMemo(() => {

--- a/src/modules/twap/updaters/QuoteObserverUpdater.tsx
+++ b/src/modules/twap/updaters/QuoteObserverUpdater.tsx
@@ -1,31 +1,49 @@
+import { useAtomValue } from 'jotai'
 import { useMemo } from 'react'
 
+import { CurrencyAmount } from '@uniswap/sdk-core'
+
+import usePrevious from 'legacy/hooks/usePrevious'
 import { Field } from 'legacy/state/swap/actions'
 
 import { useDerivedTradeState } from 'modules/trade/hooks/useDerivedTradeState'
 import { useUpdateCurrencyAmount } from 'modules/trade/hooks/useUpdateCurrencyAmount'
 import { useTradeQuote } from 'modules/tradeQuote'
 
+import { partsStateAtom } from '../state/partsStateAtom'
+
 export function QuoteObserverUpdater() {
   const { state } = useDerivedTradeState()
-  const { response } = useTradeQuote()
+  const { response, isLoading } = useTradeQuote()
+  const { numberOfPartsValue } = useAtomValue(partsStateAtom)
+  const prevNumberOfParts = usePrevious(numberOfPartsValue)
 
   const updateCurrencyAmount = useUpdateCurrencyAmount()
   const outputCurrency = state?.outputCurrency
 
-  useMemo(() => {
-    if (!outputCurrency || !response) {
-      return
+  const value = useMemo(() => {
+    if (!response || !outputCurrency || !numberOfPartsValue || numberOfPartsValue !== prevNumberOfParts || isLoading) {
+      return null
     }
 
     const value = response.quote.buyAmount
+    const currencyValue = CurrencyAmount.fromRawAmount(outputCurrency, value)
+    const adjustedForParts = currencyValue.multiply(numberOfPartsValue)
+
+    return adjustedForParts.quotient.toString()
+  }, [isLoading, numberOfPartsValue, outputCurrency, prevNumberOfParts, response])
+
+  useMemo(() => {
+    if (!outputCurrency || !response || !value) {
+      return
+    }
 
     updateCurrencyAmount({
       amount: { isTyped: false, value },
       currency: outputCurrency,
       field: Field.OUTPUT,
     })
-  }, [outputCurrency, response, updateCurrencyAmount])
+  }, [outputCurrency, response, updateCurrencyAmount, value])
 
   return null
 }


### PR DESCRIPTION
# Summary

This PR adds quote fetching for single interval in TWAP orders
It contains two parts:
- updates the `useQuoteParams` hook to fetch only single interval input amount for TWAP orders
- updates the `QuoteObserverUpdater` in TWAP orders to multiply the received output amount with number of parts

# To test
Check the TWAP orders quote functionality