### PR TITLE
fix: make (Trust) wallet icon round on modals

### DIFF
--- a/src/modules/account/containers/AccountDetails/styled.ts
+++ b/src/modules/account/containers/AccountDetails/styled.ts
@@ -3,17 +3,16 @@ import styled from 'styled-components/macro'
 import { ButtonSecondary } from 'legacy/components/Button'
 import { YellowCard } from 'legacy/components/Card'
 import { CopyIcon, TransactionStatusText } from 'legacy/components/Copy'
-import { StyledLink } from 'legacy/theme'
-import { ExternalLink } from 'legacy/theme'
+import { ExternalLink, StyledLink } from 'legacy/theme'
 
 import {
   StatusLabelWrapper,
   Summary,
-  TransactionWrapper,
-  TransactionStatusText as ActivityDetailsText,
   SummaryInner,
-  TransactionInnerDetail,
   TextAlert,
+  TransactionInnerDetail,
+  TransactionStatusText as ActivityDetailsText,
+  TransactionWrapper,
 } from '../../containers/Transaction/styled'
 
 export const WalletName = styled.div`
@@ -36,6 +35,8 @@ export const IconWrapper = styled.div<{ size?: number }>`
   ${({ theme }) => theme.mediaWidth.upToMedium`
     align-items: flex-end;
   `};
+  border-radius: ${({ size }) => (size ? size + 'px' : '32px')};
+  overflow: hidden;
 `
 
 export const TransactionListWrapper = styled.div`


### PR DESCRIPTION
# Summary

Part of https://github.com/cowprotocol/cowswap/pull/2578

Fix for this issue

https://github.com/cowprotocol/cowswap/assets/43217/25542df0-cb2b-4e80-9c33-c3c7362862dc

Now it looks like this


https://github.com/cowprotocol/cowswap/assets/43217/46d93d1f-58d8-4d25-a041-b5e313fefbcc



  # To Test

1. Connect with Trust wallet via WC as a non-expert user
2. Perform any operation that adds a modal (approve, order placement)
* The spinning image at the top should be rounded
3. Repeat steps with other wallets
* The same result