### PR TITLE
feat(safe-eth-flow): update info banner msg

### DIFF
--- a/src/common/pure/InlineBanner/banners.tsx
+++ b/src/common/pure/InlineBanner/banners.tsx
@@ -22,15 +22,20 @@ export function BundleTxApprovalBanner() {
   )
 }
 
-export function BundleTxWrapBanner() {
+export type BundleTxWrapBannerProps = {
+  nativeCurrencySymbol: string
+  wrappedCurrencySymbol: string
+}
+
+export function BundleTxWrapBanner({ nativeCurrencySymbol, wrappedCurrencySymbol }: BundleTxWrapBannerProps) {
   return (
     <InlineBanner
       type="information"
       content={
         <>
-          <strong>Token wrapping</strong>: For your convenience, native token wrapping, approval of the wrapped token
-          (if needed) and order placement will be bundled into a single transaction, streamlining your experience! Even
-          if the trade fails, your wrapping (and approval) will be done!
+          <strong>Token wrapping</strong>: For your convenience, CoW Swap will bundle all the necessary actions for this
+          trade into a single transaction. This includes the {nativeCurrencySymbol} wrapping and, if needed,{' '}
+          {wrappedCurrencySymbol} approval. Even if the trade fails, your wrapping and approval will be done!
         </>
       }
     />

--- a/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/src/modules/swap/containers/SwapWidget/index.tsx
@@ -42,6 +42,7 @@ import {
 import { useFillSwapDerivedState } from 'modules/swap/state/useSwapDerivedState'
 import useCurrencyBalance from 'modules/tokens/hooks/useCurrencyBalance'
 import { TradeWidget, TradeWidgetContainer, useSetupTradeState } from 'modules/trade'
+import { useWrappedToken } from 'modules/trade/hooks/useWrappedToken'
 import { useIsSafeViaWc, useWalletDetails, useWalletInfo } from 'modules/wallet'
 
 import { useRateInfoParams } from 'common/hooks/useRateInfoParams'
@@ -181,6 +182,7 @@ export function SwapWidget() {
   const showSafeWcBundlingBanner = showSafeWcApprovalBundlingBanner || showSafeWcWrapBundlingBanner
 
   const nativeCurrencySymbol = useNativeCurrency().symbol || 'ETH'
+  const wrappedCurrencySymbol = useWrappedToken().symbol || 'WETH'
 
   const swapWarningsTopProps: SwapWarningsTopProps = {
     trade,
@@ -194,6 +196,7 @@ export function SwapWidget() {
     showWrapBundlingBanner,
     showSafeWcBundlingBanner,
     nativeCurrencySymbol,
+    wrappedCurrencySymbol,
     setFeeWarningAccepted,
     setImpactWarningAccepted,
     shouldZeroApprove,

--- a/src/modules/swap/pure/warnings.tsx
+++ b/src/modules/swap/pure/warnings.tsx
@@ -26,6 +26,7 @@ export interface SwapWarningsTopProps {
   shouldZeroApprove: boolean
   showSafeWcBundlingBanner: boolean
   nativeCurrencySymbol: string
+  wrappedCurrencySymbol: string
   setFeeWarningAccepted(cb: (state: boolean) => boolean): void
   setImpactWarningAccepted(cb: (state: boolean) => boolean): void
 }
@@ -53,6 +54,7 @@ export const SwapWarningsTop = React.memo(function (props: SwapWarningsTopProps)
     showWrapBundlingBanner,
     showSafeWcBundlingBanner,
     nativeCurrencySymbol,
+    wrappedCurrencySymbol,
     setFeeWarningAccepted,
     setImpactWarningAccepted,
     shouldZeroApprove,
@@ -75,7 +77,9 @@ export const SwapWarningsTop = React.memo(function (props: SwapWarningsTopProps)
         />
       )}
       {showApprovalBundlingBanner && <BundleTxApprovalBanner />}
-      {showWrapBundlingBanner && <BundleTxWrapBanner />}
+      {showWrapBundlingBanner && (
+        <BundleTxWrapBanner nativeCurrencySymbol={nativeCurrencySymbol} wrappedCurrencySymbol={wrappedCurrencySymbol} />
+      )}
       {showSafeWcBundlingBanner && (
         <BundleTxSafeWcBanner nativeCurrencySymbol={nativeCurrencySymbol} supportsWrapping />
       )}


### PR DESCRIPTION
# Summary

Update info banner msg with the latest based on [this thread](https://cowservices.slack.com/archives/C053K0JJYBY/p1685954630482169)

![Screenshot 2023-06-06 at 11 02 35](https://github.com/cowprotocol/cowswap/assets/43217/f062d289-3d67-4a4d-a7ff-b4d515c341a1)

# To Test

1. Load app as a Safe app
2. Pick native as sell token and pick anything other than the native wrapped token as buy token
* The banner should be displayed with the text like above