### PR TITLE
feat(safe): allow to sell all native

### DIFF
--- a/src/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
+++ b/src/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react'
 
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { Currency } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
 import { Trans } from '@lingui/macro'
 
@@ -11,7 +11,6 @@ import { MouseoverTooltip } from 'legacy/components/Tooltip'
 import { BalanceAndSubsidy } from 'legacy/hooks/useCowBalanceAndSubsidy'
 import { PriceImpact } from 'legacy/hooks/usePriceImpact'
 import { Field } from 'legacy/state/swap/actions'
-import { maxAmountSpend } from 'legacy/utils/maxAmountSpend'
 
 import { ReceiveAmount } from 'modules/swap/pure/ReceiveAmount'
 
@@ -37,6 +36,7 @@ export interface CurrencyInputPanelProps extends Partial<BuiltItProps> {
   inputTooltip?: string
   isRateLoading?: boolean
   showSetMax?: boolean
+  maxBalance?: CurrencyAmount<Currency> | undefined
   disableNonToken?: boolean
   allowsOffchainSigning: boolean
   currencyInfo: CurrencyInfo
@@ -56,6 +56,7 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
     priceImpactParams,
     disableNonToken = false,
     showSetMax = false,
+    maxBalance,
     inputDisabled = false,
     inputTooltip,
     onCurrencySelection,
@@ -92,14 +93,13 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
     [onUserInput, field]
   )
   const handleMaxInput = useCallback(() => {
-    const maxBalance = maxAmountSpend(balance || undefined)
     if (!maxBalance) {
       return
     }
 
     onUserInputDispatch(maxBalance.toExact())
     setMaxSellTokensAnalytics()
-  }, [balance, onUserInputDispatch])
+  }, [maxBalance, onUserInputDispatch])
 
   useEffect(() => {
     const areValuesSame = parseFloat(viewAmount) === parseFloat(typedValue)

--- a/src/legacy/hooks/useWrapCallback.ts
+++ b/src/legacy/hooks/useWrapCallback.ts
@@ -63,7 +63,7 @@ export function useHasEnoughWrappedBalanceForSwap(inputAmount?: CurrencyAmount<C
   const { account } = useWalletInfo()
   const wrappedBalance = useCurrencyBalance(account ?? undefined, currencies.INPUT?.wrapped)
 
-  // is an native currency trade but wrapped token has enough balance
+  // is a native currency trade but wrapped token has enough balance
   return !!(wrappedBalance && inputAmount && !wrappedBalance.lessThan(inputAmount))
 }
 

--- a/src/legacy/utils/maxAmountSpend.ts
+++ b/src/legacy/utils/maxAmountSpend.ts
@@ -3,13 +3,18 @@ import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import JSBI from 'jsbi'
 
 const MIN_NATIVE_CURRENCY_FOR_GAS: JSBI = JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(16)) // .01 ETH
+
 /**
  * Given some token amount, return the max that can be spent of it
  * @param currencyAmount to return max of
+ * @param canUseAllNative whether or not the use can use all the native currency, if native
  */
-export function maxAmountSpend(currencyAmount?: CurrencyAmount<Currency>): CurrencyAmount<Currency> | undefined {
+export function maxAmountSpend(
+  currencyAmount?: CurrencyAmount<Currency>,
+  canUseAllNative?: boolean
+): CurrencyAmount<Currency> | undefined {
   if (!currencyAmount) return undefined
-  if (currencyAmount.currency.isNative) {
+  if (currencyAmount.currency.isNative && !canUseAllNative) {
     if (JSBI.greaterThan(currencyAmount.quotient, MIN_NATIVE_CURRENCY_FOR_GAS)) {
       return CurrencyAmount.fromRawAmount(
         currencyAmount.currency,

--- a/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/src/modules/swap/containers/SwapWidget/index.tsx
@@ -43,7 +43,7 @@ import { useFillSwapDerivedState } from 'modules/swap/state/useSwapDerivedState'
 import useCurrencyBalance from 'modules/tokens/hooks/useCurrencyBalance'
 import { TradeWidget, TradeWidgetContainer, useSetupTradeState } from 'modules/trade'
 import { useWrappedToken } from 'modules/trade/hooks/useWrappedToken'
-import { useIsSafeViaWc, useWalletDetails, useWalletInfo } from 'modules/wallet'
+import { useIsSafeViaWc, useIsSafeWallet, useWalletDetails, useWalletInfo } from 'modules/wallet'
 
 import { useRateInfoParams } from 'common/hooks/useRateInfoParams'
 import { useShouldZeroApprove } from 'common/hooks/useShouldZeroApprove'
@@ -172,6 +172,8 @@ export function SwapWidget() {
   const showWrapBundlingBanner = BUTTON_STATES_TO_SHOW_BUNDLE_WRAP_BANNER.includes(swapButtonContext.swapButtonState)
 
   const isSafeViaWc = useIsSafeViaWc()
+  const isSafeWallet = useIsSafeWallet()
+
   const showSafeWcApprovalBundlingBanner =
     !showApprovalBundlingBanner && isSafeViaWc && swapButtonContext.swapButtonState === SwapButtonState.NeedApprove
 
@@ -180,6 +182,8 @@ export function SwapWidget() {
 
   // Show the same banner when approval is needed or selling native token
   const showSafeWcBundlingBanner = showSafeWcApprovalBundlingBanner || showSafeWcWrapBundlingBanner
+
+  const canSellAllNative = isSafeWallet
 
   const nativeCurrencySymbol = useNativeCurrency().symbol || 'ETH'
   const wrappedCurrencySymbol = useWrappedToken().symbol || 'WETH'
@@ -243,6 +247,7 @@ export function SwapWidget() {
     isTradePriceUpdating,
     priceImpact: priceImpactParams,
     disableQuotePolling: true,
+    canSellAllNative,
   }
 
   return (

--- a/src/modules/swap/hooks/useSwapButtonContext.ts
+++ b/src/modules/swap/hooks/useSwapButtonContext.ts
@@ -75,7 +75,7 @@ export function useSwapButtonContext(input: SwapButtonInput): SwapButtonsContext
   const isNativeInSwap = isNativeIn && !isWrappedOut
 
   const inputAmount = slippageAdjustedSellAmount || parsedAmount
-  const wrapUnwrapAmount = isNativeInSwap ? inputAmount?.wrapped : slippageAdjustedSellAmount || parsedAmount
+  const wrapUnwrapAmount = isNativeInSwap ? inputAmount?.wrapped : inputAmount
   const wrapType = useWrapType()
   const wrapInputError = useWrapUnwrapError(wrapType, wrapUnwrapAmount)
   const hasEnoughWrappedBalanceForSwap = useHasEnoughWrappedBalanceForSwap(wrapUnwrapAmount)

--- a/src/modules/trade/containers/TradeWidget/index.tsx
+++ b/src/modules/trade/containers/TradeWidget/index.tsx
@@ -122,6 +122,7 @@ export function TradeWidget(props: TradeWidgetProps) {
                   allowsOffchainSigning={allowsOffchainSigning}
                   currencyInfo={inputCurrencyInfo}
                   showSetMax={showSetMax}
+                  maxBalance={maxBalance}
                   topLabel={inputCurrencyInfo.label}
                 />
               </div>

--- a/src/modules/trade/containers/TradeWidget/index.tsx
+++ b/src/modules/trade/containers/TradeWidget/index.tsx
@@ -36,6 +36,7 @@ interface TradeWidgetParams {
   priceImpact: PriceImpact
   isRateLoading?: boolean
   disableQuotePolling?: boolean
+  canSellAllNative?: boolean
 }
 
 export interface TradeWidgetSlots {
@@ -73,6 +74,7 @@ export function TradeWidget(props: TradeWidgetProps) {
     priceImpact,
     recipient,
     disableQuotePolling = false,
+    canSellAllNative = false,
   } = params
 
   const { chainId } = useWalletInfo()
@@ -81,7 +83,7 @@ export function TradeWidget(props: TradeWidgetProps) {
 
   const currenciesLoadingInProgress = !inputCurrencyInfo.currency && !outputCurrencyInfo.currency
 
-  const maxBalance = maxAmountSpend(inputCurrencyInfo.balance || undefined)
+  const maxBalance = maxAmountSpend(inputCurrencyInfo.balance || undefined, canSellAllNative)
   const showSetMax = maxBalance?.greaterThan(0) && !inputCurrencyInfo.amount?.equalTo(maxBalance)
 
   // Disable too frequent tokens switching


### PR DESCRIPTION
# Summary

Based on [this thread](https://cowservices.slack.com/archives/C0361CDG8GP/p1686042726399249)

Allow to sell/wrap the exact full Native token amount when using Safe

Swap

https://github.com/cowprotocol/cowswap/assets/43217/5fe9e3bb-a67e-4232-8a1f-e6651ff17f35


Wrap

https://github.com/cowprotocol/cowswap/assets/43217/2417c096-54fb-41c2-ac5f-33b7d4048924

# To Test

1. Using the Safe connect as a Safe app
2. Pick native token as sell
3. Click on `max` button
* Exact full amount should be used
4. Repeat 1-3 using Safe via WC
* Same result
5. Repeat 1-3 with EOA
* Not all amount should be used

https://github.com/cowprotocol/cowswap/assets/43217/b4611a66-914f-4d83-ba29-c91b52577c7d

6. Repeat 1-3 with other SC wallet (such as Pillar, Argent...)
* Not all amount should be used