### PR TITLE
feat(limit-orders): remove beta limit orders label

### DIFF
--- a/src/modules/application/containers/TradeWidgetLinks/index.tsx
+++ b/src/modules/application/containers/TradeWidgetLinks/index.tsx
@@ -40,9 +40,6 @@ export function TradeWidgetLinks() {
           to={parameterizeTradeRoute(tradeContext, Routes.LIMIT_ORDER)}
         >
           <Trans>Limit</Trans>
-          <styledEl.Badge>
-            <Trans>Beta</Trans>
-          </styledEl.Badge>
         </styledEl.Link>
       </styledEl.MenuItem>
 

--- a/src/modules/limitOrders/pure/UnlockLimitOrders/index.tsx
+++ b/src/modules/limitOrders/pure/UnlockLimitOrders/index.tsx
@@ -30,7 +30,7 @@ export function UnlockLimitOrders({ handleUnlock }: { handleUnlock: () => void }
     <styledEl.Container>
       <styledEl.TitleSection>
         <h3>Want to try out limit orders?</h3>
-        <span>Unlock the BETA version!</span>
+        <span>Get started!</span>
       </styledEl.TitleSection>
 
       {BULLET_LIST_CONTENT && (
@@ -54,7 +54,7 @@ export function UnlockLimitOrders({ handleUnlock }: { handleUnlock: () => void }
           </ExternalLink>
         </span>
         <ButtonPrimary id="unlock-limit-orders-btn" onClick={handleUnlock}>
-          Unlock limit orders (BETA)
+          Get started with limit orders
         </ButtonPrimary>
       </styledEl.ControlSection>
     </styledEl.Container>


### PR DESCRIPTION
# Summary

As discussed [in this thread](https://cowservices.slack.com/archives/C036G0J90BU/p1686049136392099)

- Removing `beta` label from limit orders widget
- Updating `unlock` modal to `get started`

https://github.com/cowprotocol/cowswap/assets/43217/4d2ab09f-e07c-4f6e-a45a-b7d1a32c68de

# To Test

1. Open the app
* Limit orders should no longer have a `beta` label
2. Click on `limit`
* On the first time you should see the `get started` banner
* The banner should be identical to the previous except it no longer says `unlock`, but `get started`

Note: To see the banner again, open the dev console, go to local storage, remove the key `limit-orders-atom:v4` and refresh the page