### PR TITLE
fix: limit wrap/unwrap switch arrow

### DIFF
--- a/src/modules/trade/hooks/useSwitchTokensPlaces.ts
+++ b/src/modules/trade/hooks/useSwitchTokensPlaces.ts
@@ -25,15 +25,16 @@ export function useSwitchTokensPlaces(stateOverride: Partial<ExtendedTradeRawSta
 
   return useCallback(() => {
     if (!inputCurrencyId || !outputCurrencyId || !updateState) return
-    if (isWrapOrUnwrap) return
+    if (!isWrapOrUnwrap) {
+      updateState({
+        inputCurrencyId: outputCurrencyId,
+        outputCurrencyId: inputCurrencyId,
+        inputCurrencyAmount: FractionUtils.serializeFractionToJSON(outputCurrencyAmount),
+        outputCurrencyAmount: FractionUtils.serializeFractionToJSON(inputCurrencyAmount),
+        ...stateOverride,
+      })
+    }
 
-    updateState({
-      inputCurrencyId: outputCurrencyId,
-      outputCurrencyId: inputCurrencyId,
-      inputCurrencyAmount: FractionUtils.serializeFractionToJSON(outputCurrencyAmount),
-      outputCurrencyAmount: FractionUtils.serializeFractionToJSON(inputCurrencyAmount),
-      ...stateOverride,
-    })
     tradeNavigate(chainId, { inputCurrencyId: outputCurrencyId, outputCurrencyId: inputCurrencyId })
   }, [
     updateState,


### PR DESCRIPTION
# Summary

Reported while testing 1.40.0 release https://github.com/cowprotocol/cowswap/pull/2602#issuecomment-1579076559

Already fixed in another PR, which was not included in the release: https://github.com/cowprotocol/cowswap/pull/2591/commits/486611b8c79d2c16f27f6f18ef00671a833f5e54#diff-893ba8596fd34f05c70e2e8bd8da0fa895da4495b11a2fb3d4c042592dba5f92R38

# To Test

1. Go to limit orders, pick native and wrapped native as sell/buy tokens
2. Click on the middle arrow
* Tokens should swap
3. Pick a different pair and click on the arrow
* Tokens should swap
4. Repeat on swap
* Tokens should swap