### PR TITLE
fix(twap): display local form validation first

### DIFF
--- a/src/modules/twap/containers/ActionButtons/index.tsx
+++ b/src/modules/twap/containers/ActionButtons/index.tsx
@@ -25,7 +25,7 @@ export function ActionButtons() {
 
   if (!tradeFormButtonContext) return null
 
-  if (!primaryFormValidation && localFormValidation) {
+  if (localFormValidation) {
     return <PrimaryActionButton state={localFormValidation} context={primaryActionContext} />
   }
 


### PR DESCRIPTION
# Summary
We should display local form validation before the global, because otherwise we can display a state "Approve and TWAP" when current wallet is not a Safe.

<img width="515" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/acf39be4-2b04-4eaa-924e-46c3b202ec2f">


  # To Test
No need to test