### PR TITLE
feat(twap): twap review order - pt4 - duration fields

### DIFF
--- a/src/modules/trade/pure/ConfirmDetailsItem/index.tsx
+++ b/src/modules/trade/pure/ConfirmDetailsItem/index.tsx
@@ -2,11 +2,10 @@ import { ReactNode } from 'react'
 
 import { CornerDownRight } from 'react-feather'
 
+import { InfoIcon } from 'legacy/components/InfoIcon'
 import { RowFixed } from 'legacy/components/Row'
-import { MouseoverTooltipContent } from 'legacy/components/Tooltip'
 
 import { TextWrapper } from 'modules/swap/pure/Row/styled'
-import { StyledInfoIcon } from 'modules/swap/pure/styled'
 
 import { Content, Row, Wrapper } from './styled'
 
@@ -30,11 +29,7 @@ export function ConfirmDetailsItem(props: ConfirmDetailsItemProps) {
           <Row>
             <RowFixed>
               {label && <TextWrapper>{label}</TextWrapper>}
-              {tooltip && (
-                <MouseoverTooltipContent content={tooltip} wrap>
-                  <StyledInfoIcon size={16} />
-                </MouseoverTooltipContent>
-              )}
+              {tooltip && <InfoIcon content={tooltip} />}
             </RowFixed>
 
             <Content>{children}</Content>

--- a/src/modules/trade/pure/ConfirmDetailsItem/index.tsx
+++ b/src/modules/trade/pure/ConfirmDetailsItem/index.tsx
@@ -10,7 +10,7 @@ import { StyledInfoIcon } from 'modules/swap/pure/styled'
 
 import { Content, Row, Wrapper } from './styled'
 
-type Props = {
+export type ConfirmDetailsItemProps = {
   children: ReactNode
   label?: string
   tooltip?: ReactNode
@@ -18,7 +18,7 @@ type Props = {
   fiatAmount?: string
 }
 
-export function ConfirmDetailsItem(props: Props) {
+export function ConfirmDetailsItem(props: ConfirmDetailsItemProps) {
   const { children, label, tooltip, withArrow = true } = props
 
   return (

--- a/src/modules/twap/containers/TwapConfirmModal/TwapConfirmDetails.tsx
+++ b/src/modules/twap/containers/TwapConfirmModal/TwapConfirmDetails.tsx
@@ -7,12 +7,13 @@ import { PartsState } from '../../state/partsStateAtom'
 
 export type TwapConfirmDetailsProps = {
   startTime: number | undefined
-  partDuration: number | undefined
+  partDuration: string
+  totalDuration: string
   partsState: PartsState
 }
 
 export const TwapConfirmDetails = React.memo(function TwapConfirmDetails(props: TwapConfirmDetailsProps) {
-  const { startTime, partDuration, partsState } = props
+  const { partDuration, totalDuration, partsState } = props
   const { numberOfPartsValue, inputPartAmount, inputFiatAmount, outputFiatAmount, outputPartAmount } = partsState
 
   const partsSuffix = ` part (1/${numberOfPartsValue})`
@@ -21,12 +22,16 @@ export const TwapConfirmDetails = React.memo(function TwapConfirmDetails(props: 
   return (
     <div>
       <span>TWAP order split in {numberOfPartsValue} equal parts</span>
+
+      {/* Sell amount per part */}
       <ReviewOrderModalAmountRow
         amount={inputPartAmount}
         fiatAmount={inputFiatAmount}
         tooltip="TODO: add tooltip"
         label={'Sell' + amountLabelSuffix}
       />
+
+      {/* Buy amount per part */}
       <ReviewOrderModalAmountRow
         amount={outputPartAmount}
         fiatAmount={outputFiatAmount}
@@ -34,17 +39,20 @@ export const TwapConfirmDetails = React.memo(function TwapConfirmDetails(props: 
         label={'Buy' + amountLabelSuffix}
         isAmountAccurate={false}
       />
-      {/*TODO: implement logic for time fields*/}
 
       {/* Start time */}
       {/*<ConfirmDetailsItem tooltip="TODO: add tooltip" label={'Start time first' + partsSuffix} withArrow={false}>*/}
       {/*  {startTime}*/}
       {/*</ConfirmDetailsItem>*/}
+
+      {/* Part duration */}
       <ConfirmDetailsItem tooltip="TODO: add tooltip" label="Part duration" withArrow={false}>
         {partDuration}
       </ConfirmDetailsItem>
+
+      {/* Total duration */}
       <ConfirmDetailsItem tooltip="TODO: add tooltip" label="Total duration" withArrow={false}>
-        {partDuration}
+        {totalDuration}
       </ConfirmDetailsItem>
     </div>
   )

--- a/src/modules/twap/containers/TwapConfirmModal/TwapConfirmDetails.tsx
+++ b/src/modules/twap/containers/TwapConfirmModal/TwapConfirmDetails.tsx
@@ -1,3 +1,5 @@
+import React from 'react'
+
 import { ConfirmDetailsItem } from 'modules/trade/pure/ConfirmDetailsItem'
 import { ReviewOrderModalAmountRow } from 'modules/trade/pure/ReviewOrderModalAmountRow'
 
@@ -9,8 +11,8 @@ export type TwapConfirmDetailsProps = {
   partsState: PartsState
 }
 
-export function TwapConfirmDetails(_props: TwapConfirmDetailsProps) {
-  const { startTime, partDuration, partsState } = _props
+export const TwapConfirmDetails = React.memo(function TwapConfirmDetails(props: TwapConfirmDetailsProps) {
+  const { startTime, partDuration, partsState } = props
   const { numberOfPartsValue, inputPartAmount, inputFiatAmount, outputFiatAmount, outputPartAmount } = partsState
 
   const partsSuffix = ` part (1/${numberOfPartsValue})`
@@ -44,4 +46,4 @@ export function TwapConfirmDetails(_props: TwapConfirmDetailsProps) {
       </ConfirmDetailsItem>
     </div>
   )
-}
+})

--- a/src/modules/twap/containers/TwapConfirmModal/TwapConfirmDetails.tsx
+++ b/src/modules/twap/containers/TwapConfirmModal/TwapConfirmDetails.tsx
@@ -4,11 +4,12 @@ import { ConfirmDetailsItem } from 'modules/trade/pure/ConfirmDetailsItem'
 import { ReviewOrderModalAmountRow } from 'modules/trade/pure/ReviewOrderModalAmountRow'
 
 import { PartsState } from '../../state/partsStateAtom'
+import { deadlinePartsDisplay } from '../../utils/deadlinePartsDisplay'
 
 export type TwapConfirmDetailsProps = {
   startTime: number | undefined
-  partDuration: string
-  totalDuration: string
+  partDuration: number | undefined
+  totalDuration: number | undefined
   partsState: PartsState
 }
 
@@ -18,6 +19,9 @@ export const TwapConfirmDetails = React.memo(function TwapConfirmDetails(props: 
 
   const partsSuffix = ` part (1/${numberOfPartsValue})`
   const amountLabelSuffix = ' amount per' + partsSuffix
+
+  const partDurationDisplay = partDuration ? deadlinePartsDisplay(partDuration, true) : ''
+  const totalDurationDisplay = totalDuration ? deadlinePartsDisplay(totalDuration, true) : ''
 
   return (
     <div>
@@ -47,12 +51,12 @@ export const TwapConfirmDetails = React.memo(function TwapConfirmDetails(props: 
 
       {/* Part duration */}
       <ConfirmDetailsItem tooltip="TODO: add tooltip" label="Part duration" withArrow={false}>
-        {partDuration}
+        {partDurationDisplay}
       </ConfirmDetailsItem>
 
       {/* Total duration */}
       <ConfirmDetailsItem tooltip="TODO: add tooltip" label="Total duration" withArrow={false}>
-        {totalDuration}
+        {totalDurationDisplay}
       </ConfirmDetailsItem>
     </div>
   )

--- a/src/modules/twap/containers/TwapConfirmModal/TwapConfirmDetails.tsx
+++ b/src/modules/twap/containers/TwapConfirmModal/TwapConfirmDetails.tsx
@@ -45,9 +45,9 @@ export const TwapConfirmDetails = React.memo(function TwapConfirmDetails(props: 
       />
 
       {/* Start time */}
-      {/*<ConfirmDetailsItem tooltip="TODO: add tooltip" label={'Start time first' + partsSuffix} withArrow={false}>*/}
-      {/*  {startTime}*/}
-      {/*</ConfirmDetailsItem>*/}
+      <ConfirmDetailsItem tooltip="TODO: add tooltip" label={'Start time first' + partsSuffix} withArrow={false}>
+        Now
+      </ConfirmDetailsItem>
 
       {/* Part duration */}
       <ConfirmDetailsItem tooltip="TODO: add tooltip" label="Part duration" withArrow={false}>

--- a/src/modules/twap/containers/TwapConfirmModal/TwapConfirmDetails.tsx
+++ b/src/modules/twap/containers/TwapConfirmModal/TwapConfirmDetails.tsx
@@ -35,9 +35,11 @@ export const TwapConfirmDetails = React.memo(function TwapConfirmDetails(props: 
         isAmountAccurate={false}
       />
       {/*TODO: implement logic for time fields*/}
-      <ConfirmDetailsItem tooltip="TODO: add tooltip" label={'Start time first' + partsSuffix} withArrow={false}>
-        {startTime}
-      </ConfirmDetailsItem>
+
+      {/* Start time */}
+      {/*<ConfirmDetailsItem tooltip="TODO: add tooltip" label={'Start time first' + partsSuffix} withArrow={false}>*/}
+      {/*  {startTime}*/}
+      {/*</ConfirmDetailsItem>*/}
       <ConfirmDetailsItem tooltip="TODO: add tooltip" label="Part duration" withArrow={false}>
         {partDuration}
       </ConfirmDetailsItem>

--- a/src/modules/twap/containers/TwapConfirmModal/index.tsx
+++ b/src/modules/twap/containers/TwapConfirmModal/index.tsx
@@ -13,6 +13,7 @@ import { useCreateTwapOrder } from '../../hooks/useCreateTwapOrder'
 import { partsStateAtom } from '../../state/partsStateAtom'
 import { twapOrderAtom } from '../../state/twapOrderAtom'
 import { twapOrderSlippage } from '../../state/twapOrdersSettingsAtom'
+import { deadlinePartsDisplay } from '../../utils/deadlinePartsDisplay'
 
 export function TwapConfirmModal() {
   const {
@@ -62,6 +63,10 @@ export function TwapConfirmModal() {
   // This already takes into account the full order
   const minReceivedAmount = twapOrder?.buyAmount
 
+  const { timeInterval, numOfParts } = twapOrder || {}
+  const partDuration = timeInterval ? deadlinePartsDisplay(timeInterval, true) : ''
+  const totalDuration = timeInterval && numOfParts ? deadlinePartsDisplay(timeInterval * numOfParts, true) : ''
+
   return (
     <TradeConfirmModal>
       <TradeConfirmation
@@ -82,8 +87,9 @@ export function TwapConfirmModal() {
           />
           <TwapConfirmDetails
             startTime={twapOrder?.startTime}
-            partDuration={twapOrder?.timeInterval}
+            partDuration={partDuration}
             partsState={partsState}
+            totalDuration={totalDuration}
           />
         </>
       </TradeConfirmation>

--- a/src/modules/twap/containers/TwapConfirmModal/index.tsx
+++ b/src/modules/twap/containers/TwapConfirmModal/index.tsx
@@ -13,7 +13,6 @@ import { useCreateTwapOrder } from '../../hooks/useCreateTwapOrder'
 import { partsStateAtom } from '../../state/partsStateAtom'
 import { twapOrderAtom } from '../../state/twapOrderAtom'
 import { twapOrderSlippage } from '../../state/twapOrdersSettingsAtom'
-import { deadlinePartsDisplay } from '../../utils/deadlinePartsDisplay'
 
 export function TwapConfirmModal() {
   const {
@@ -64,8 +63,9 @@ export function TwapConfirmModal() {
   const minReceivedAmount = twapOrder?.buyAmount
 
   const { timeInterval, numOfParts } = twapOrder || {}
-  const partDuration = timeInterval ? deadlinePartsDisplay(timeInterval, true) : ''
-  const totalDuration = timeInterval && numOfParts ? deadlinePartsDisplay(timeInterval * numOfParts, true) : ''
+
+  const partDuration = timeInterval
+  const totalDuration = timeInterval && numOfParts ? timeInterval * numOfParts : undefined
 
   return (
     <TradeConfirmModal>

--- a/src/modules/twap/utils/deadlinePartsDisplay.ts
+++ b/src/modules/twap/utils/deadlinePartsDisplay.ts
@@ -11,7 +11,7 @@ export function customDeadlineToSeconds(customDeadline: TwapOrdersDeadline['cust
   return minutesToSeconds
 }
 
-export function deadlinePartsDisplay(timeInterval: number): string {
+export function deadlinePartsDisplay(timeInterval: number, longLabels = false): string {
   const timeMs = ms(`${timeInterval * 1000}ms`)
 
   const days = Math.floor(timeMs / oneD)
@@ -20,10 +20,10 @@ export function deadlinePartsDisplay(timeInterval: number): string {
   const seconds = Math.floor((timeMs % oneM) / oneS)
 
   return [
-    [days, 'd'],
-    [hours, 'h'],
-    [minutes, 'm'],
-    [seconds, 's'],
+    [days, longLabels ? ' days' : 'd'],
+    [hours, longLabels ? ' hours' : 'h'],
+    [minutes, longLabels ? ' minutes' : 'm'],
+    [seconds, longLabels ? ' seconds' : 's'],
   ]
     .filter(([value]) => !!value)
     .map(([value, suffix]) => `${value}${suffix}`)


### PR DESCRIPTION
# Update

![image](https://github.com/cowprotocol/cowswap/assets/43217/2da19909-9c87-4a26-bb25-2b910dede3e0)

- Unhide Start time and hard code it to `now`

To be explained via tool tip

# Summary

Follow up to https://github.com/cowprotocol/cowswap/pull/2631
Implements part of https://github.com/cowprotocol/cowswap/issues/2577

Address PR comments from https://github.com/cowprotocol/cowswap/pull/2629

![image](https://github.com/cowprotocol/cowswap/assets/43217/cdb8681f-2544-45c8-bade-ffcda0e373e4)

Calculating:
- Part time
- Total time

Hiding:
- Start time

# To Test

1. On a Gnosis Safe with the handler already updated, go to advanced
2. Fill in the form
3. Click on review
* You should see the fields above properly filled and calculated

# Notes

1. Styling definitely not ready