### PR TITLE
ci: deploy on barn/staging automatically after creating a release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,19 +159,6 @@ jobs:
     with:
       env_name: dev
 
-  vercel-pre-prod:
-    # Deploys to Vercel staging and barn environments
-    name: Vercel pre-prod
-    needs: [test, lint]
-    if: startsWith(github.ref, 'refs/tags/v')
-    uses: ./.github/workflows/vercel.yml
-    secrets: inherit
-    strategy:
-      matrix:
-        env_name: [barn, staging] # deploys both in parallel
-    with:
-      env_name: ${{ matrix.env_name }}
-
   vercel-prod:
     # Deploys to Vercel prod environment
     name: Vercel prod

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: google-github-actions/release-please-action@v3
+        name: release
         with:
           release-type: node
           package-name: release-please-action
           default-branch: main
+        # Deploys to Vercel staging and barn environments
+      - uses: ./.github/workflows/vercel.yml
+        name: deploy
+        if: ${{ steps.release.outputs.release_created }}
+        secrets: inherit
+        strategy:
+          matrix:
+            env_name: [ barn, staging ] # deploys both in parallel
+        with:
+          env_name: ${{ matrix.env_name }}


### PR DESCRIPTION
# Summary

Reference: https://github.com/googleapis/release-please

With `release-please` we don't need to create a release and a tag manually, everything is automated.

How it works:
1. Merge new changes from a release branch into `main`
2. `release-please` creates a PR with a changelog and version bump ([example](https://github.com/cowprotocol/cowswap/pull/2620))
3. Merge this PR into `main`
4. After merging, `release-please` automatically creates a github release and deploy a new version to Barn/Staging ([example](https://github.com/cowprotocol/cowswap/releases/tag/v1.40.0))

So, as you can see, there are only two manual steps: 1 and 3. And it's just a merging PR's, you don't need to do manually:
 - bumping version in package.json
 - creating a tag
 - creating a github release