### PR TITLE
chore(twap): testing tool to reset fallback handler

### DIFF
--- a/src/modules/twap/containers/ActionButtons/index.tsx
+++ b/src/modules/twap/containers/ActionButtons/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 
 import { useTradeConfirmActions } from 'modules/trade'
 import { TradeFormButtons, useGetTradeFormValidation } from 'modules/tradeFormValidation'
@@ -22,6 +22,14 @@ export function ActionButtons() {
   const confirmTrade = tradeConfirmActions.onOpen
 
   const tradeFormButtonContext = useTradeFormButtonContext('TWAP order', { doTrade: confirmTrade, confirmTrade })
+
+  // TODO: It's a temporary tool! Just for testing purposes
+  // TODO: must be removed before prod release
+  useEffect(() => {
+    ;(window as any)['resetFallbackHandler'] = () => {
+      setFallbackHandler('0x0000000000000000000000000000000000000000')
+    }
+  }, [setFallbackHandler])
 
   if (!tradeFormButtonContext) return null
 

--- a/src/modules/twap/hooks/useSetupFallbackHandler.ts
+++ b/src/modules/twap/hooks/useSetupFallbackHandler.ts
@@ -7,9 +7,12 @@ import { setupExtensibleFallbackHandler } from '../services/setupExtensibleFallb
 export function useSetupFallbackHandler() {
   const extensibleFallbackContext = useExtensibleFallbackContext()
 
-  return useCallback(() => {
-    if (!extensibleFallbackContext) return
+  return useCallback(
+    (domainVerifierAddress?: string) => {
+      if (!extensibleFallbackContext) return
 
-    setupExtensibleFallbackHandler(extensibleFallbackContext)
-  }, [extensibleFallbackContext])
+      setupExtensibleFallbackHandler(extensibleFallbackContext, domainVerifierAddress)
+    },
+    [extensibleFallbackContext]
+  )
 }

--- a/src/modules/twap/services/extensibleFallbackSetupTxs.ts
+++ b/src/modules/twap/services/extensibleFallbackSetupTxs.ts
@@ -6,7 +6,10 @@ import { getSignatureVerifierContract } from './getSignatureVerifierContract'
 
 import { ExtensibleFallbackContext } from '../hooks/useExtensibleFallbackContext'
 
-export async function extensibleFallbackSetupTxs(context: ExtensibleFallbackContext): Promise<MetaTransactionData[]> {
+export async function extensibleFallbackSetupTxs(
+  context: ExtensibleFallbackContext,
+  domainVerifierAddress?: string
+): Promise<MetaTransactionData[]> {
   const { chainId, safeAppsSdk, settlementContract } = context
 
   const { safeAddress } = await safeAppsSdk.safe.getInfo()
@@ -27,7 +30,7 @@ export async function extensibleFallbackSetupTxs(context: ExtensibleFallbackCont
     to: safeAddress,
     data: signatureVerifierContract.interface.encodeFunctionData('setDomainVerifier', [
       domainSeparator,
-      composableCowContractAddress,
+      domainVerifierAddress || composableCowContractAddress,
     ]),
     value: '0',
     operation: 0,

--- a/src/modules/twap/services/setupExtensibleFallbackHandler.ts
+++ b/src/modules/twap/services/setupExtensibleFallbackHandler.ts
@@ -5,11 +5,12 @@ import { extensibleFallbackSetupTxs } from './extensibleFallbackSetupTxs'
 import { ExtensibleFallbackContext } from '../hooks/useExtensibleFallbackContext'
 
 export async function setupExtensibleFallbackHandler(
-  context: ExtensibleFallbackContext
+  context: ExtensibleFallbackContext,
+  domainVerifierAddress?: string
 ): Promise<SendTransactionsResponse> {
   const { safeAppsSdk } = context
 
-  const txs = await extensibleFallbackSetupTxs(context)
+  const txs = await extensibleFallbackSetupTxs(context, domainVerifierAddress)
   const response = await safeAppsSdk.txs.send({ txs })
 
   // TODO: process the sent transaction


### PR DESCRIPTION
# Summary

It's just a testing tool for @elena-zh to reset fallback handler.

How to reset the fallback handler:
1. Open advanced orders page in Safe
2. Open browser console
3. Make sure, that CowSwap window is selected in the console context menu (top)
<img width="344" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/bfaa8a91-48c8-4659-ba12-6f01ae040953">

4. run `resetFallbackHandler()` in the console
<img width="256" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/3a878e07-83f2-419a-b81f-094a3905c8e0">

