### PR TITLE
fix: unsupported chain app crash

### DIFF
--- a/src/lib/hooks/useNativeCurrency.ts
+++ b/src/lib/hooks/useNativeCurrency.ts
@@ -4,13 +4,16 @@ import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { NativeCurrency } from '@uniswap/sdk-core'
 
 import { nativeOnChain } from 'legacy/constants/tokens'
+import { supportedChainId } from 'legacy/utils/supportedChainId'
 
 import { useWalletInfo } from 'modules/wallet'
 
 export const MAINNET_NATIVE_CURRENCY = nativeOnChain(SupportedChainId.MAINNET)
 
 export default function useNativeCurrency(): NativeCurrency {
-  const { chainId } = useWalletInfo()
+  const { chainId: _chainId } = useWalletInfo()
+  const chainId = supportedChainId(_chainId)
+
   return useMemo(
     () =>
       chainId

--- a/src/modules/trade/hooks/useIsNativeInOrOut.ts
+++ b/src/modules/trade/hooks/useIsNativeInOrOut.ts
@@ -3,6 +3,7 @@ import { useMemo } from 'react'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import { NATIVE_CURRENCY_BUY_TOKEN } from 'legacy/constants'
+import { supportedChainId } from 'legacy/utils/supportedChainId'
 
 import { useWalletInfo } from 'modules/wallet'
 
@@ -12,6 +13,10 @@ import { useTradeState } from './useTradeState'
 
 function getIsNativeToken(chainId: SupportedChainId, tokenId: string): boolean {
   const nativeToken = NATIVE_CURRENCY_BUY_TOKEN[chainId]
+
+  if (!supportedChainId(chainId)) {
+    return false
+  }
 
   return doesTokenMatchSymbolOrAddress(nativeToken, tokenId)
 }

--- a/src/modules/trade/hooks/useIsWrappedInOrOut.ts
+++ b/src/modules/trade/hooks/useIsWrappedInOrOut.ts
@@ -3,6 +3,7 @@ import { useMemo } from 'react'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import { WRAPPED_NATIVE_CURRENCY } from 'legacy/constants/tokens'
+import { supportedChainId } from 'legacy/utils/supportedChainId'
 
 import { useWalletInfo } from 'modules/wallet'
 
@@ -12,6 +13,10 @@ import { useTradeState } from './useTradeState'
 
 function getIsWrappedNativeToken(chainId: SupportedChainId, tokenId: string): boolean {
   const nativeToken = WRAPPED_NATIVE_CURRENCY[chainId]
+
+  if (!supportedChainId(chainId)) {
+    return false
+  }
 
   return doesTokenMatchSymbolOrAddress(nativeToken, tokenId)
 }


### PR DESCRIPTION
# Summary

Fixes the issue mentioned in #2675

# To test
- connect metamask wallet
- change to unsupported network
- there should be no app crash