### PR TITLE
Widget poc

### DIFF
--- a/public/widget.html
+++ b/public/widget.html
@@ -23,10 +23,8 @@
     const COWSWAP_DOMAIN = 'https://swap.cowswap.fi'
     const WIDGET_PATH = '/#/widget'
 
-    function getiFrameUrl() {
-      const isLocal = document.location.host.startsWith('localhost:')      
-      const isPR = document.location.host.endsWith('vercel.app')
-
+    function getiFrameUrl(props) {
+      const { isLocal, isPR } = props
       if (isLocal || isPR) {
         return WIDGET_PATH
       }
@@ -37,12 +35,14 @@
 
     // TODO: Npm package :) 
     function renderCowSwapWidget(props) {
+      const isLocal = document.location.host.startsWith('localhost:')      
+      const isPR = document.location.host.endsWith('vercel.app')
       const { id, width, height } = props
       const widgetWrapper = document.getElementById(id);
       const iframe = document.createElement('iframe');  
       iframe.width = width
       iframe.height = height
-      iframe.src = getiFrameUrl()
+      iframe.src = getiFrameUrl({ isLocal, isPR })
       widgetWrapper.appendChild(iframe)
 
       // Add button to widgetWrapper

--- a/public/widget.html
+++ b/public/widget.html
@@ -21,16 +21,28 @@
   <script>
     const POST_MESSAGE_TYPE = 'cowswap-widget'
     const COWSWAP_DOMAIN = 'https://swap.cowswap.fi'
+    const WIDGET_PATH = '/#/widget'
+
+    function getiFrameUrl() {
+      const isLocal = document.location.host.startsWith('localhost:')      
+      const isPR = document.location.host.endsWith('vercel.app')
+
+      if (isLocal || isPR) {
+        return WIDGET_PATH
+      }
+
+      
+      return COWSWAP_DOMAIN + WIDGET_PATH
+    }
+
     // TODO: Npm package :) 
     function renderCowSwapWidget(props) {
-      const isLocal = document.location.host.startsWith('localhost:')
-
       const { id, width, height } = props
       const widgetWrapper = document.getElementById(id);
       const iframe = document.createElement('iframe');  
       iframe.width = width
       iframe.height = height
-      iframe.src = (isLocal ? '' : COWSWAP_DOMAIN) + '/#/widget'
+      iframe.src = getiFrameUrl()
       widgetWrapper.appendChild(iframe)
 
       // Add button to widgetWrapper

--- a/public/widget.html
+++ b/public/widget.html
@@ -19,6 +19,8 @@
   <div id="cowswap-widget"></div>
 
   <script>
+    const POST_MESSAGE_TYPE = 'cowswap-widget'
+    const COWSWAP_DOMAIN = 'https://swap.cowswap.fi'
     // TODO: Npm package :) 
     function renderCowSwapWidget(props) {
       const isLocal = document.location.host.startsWith('localhost:')
@@ -28,14 +30,41 @@
       const iframe = document.createElement('iframe');  
       iframe.width = width
       iframe.height = height
-      iframe.src = isLocal ? '/#/widget' : 'https://cowswap.exchange/#/widget'
+      iframe.src = (isLocal ? '' : COWSWAP_DOMAIN) + '/#/widget'
       widgetWrapper.appendChild(iframe)
+
+      // Add button to widgetWrapper
+      const button = document.createElement('button')
+      button.innerText = '🐮 Send message!'
+      button.onclick = () => {
+        iframe.contentWindow.postMessage({
+          type: 'cowswap-widget',
+          method: 'time'
+        }, '*')
+      }
+      widgetWrapper.appendChild(button)
+
+
+      window.addEventListener(
+        "message",
+        (event) => {
+          const sourceIsIframe = event.source === iframe.contentWindow
+          const trustedOrigin = isLocal ? true : event.origin === COWSWAP_DOMAIN
+
+          if (!sourceIsIframe || !trustedOrigin || event.type !== 'message' || !event.data || event.data.type !== POST_MESSAGE_TYPE) {
+            return
+          }
+
+          console.log('WIDGET:HOST Receive message', event.data)
+        },
+        false
+      );
     }
 
     renderCowSwapWidget({
       id: 'cowswap-widget',
       width: 600,
-      height: 400,
+      height: 600,
     })
 
   </script>

--- a/public/widget.html
+++ b/public/widget.html
@@ -1,84 +1,89 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <title>Widget Example</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      #cowswap-widget {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+    </style>
+  </head>
 
-<head>
-  <title>Widget Example</title>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <style>
-    #cowswap-widget{
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-  </style>
-</head>
+  <body>
+    <h1>🐮 Example of CoW Swap Widget</h1>
+    <div id="cowswap-widget"></div>
 
-<body>
-  <h1>🐮 Example of CoW Swap Widget</h1>
-  <div id="cowswap-widget"></div>
+    <script>
+      const POST_MESSAGE_TYPE = 'cowswap-widget'
+      const COWSWAP_DOMAIN = 'https://swap.cowswap.fi'
+      const WIDGET_PATH = '/#/widget'
 
-  <script>
-    const POST_MESSAGE_TYPE = 'cowswap-widget'
-    const COWSWAP_DOMAIN = 'https://swap.cowswap.fi'
-    const WIDGET_PATH = '/#/widget'
+      function getiFrameUrl(props) {
+        const { isLocal, isPR } = props
+        if (isLocal || isPR) {
+          return WIDGET_PATH
+        }
 
-    function getiFrameUrl(props) {
-      const { isLocal, isPR } = props
-      if (isLocal || isPR) {
-        return WIDGET_PATH
+        return COWSWAP_DOMAIN + WIDGET_PATH
       }
 
-      
-      return COWSWAP_DOMAIN + WIDGET_PATH
-    }
+      // TODO: Npm package :)
+      function renderCowSwapWidget(props) {
+        const isLocal = document.location.host.startsWith('localhost:')
+        const isPR = document.location.host.endsWith('vercel.app')
+        const { id, width, height } = props
+        const widgetWrapper = document.getElementById(id)
+        const iframe = document.createElement('iframe')
+        iframe.width = width
+        iframe.height = height
+        iframe.src = getiFrameUrl({ isLocal, isPR })
+        widgetWrapper.appendChild(iframe)
 
-    // TODO: Npm package :) 
-    function renderCowSwapWidget(props) {
-      const isLocal = document.location.host.startsWith('localhost:')      
-      const isPR = document.location.host.endsWith('vercel.app')
-      const { id, width, height } = props
-      const widgetWrapper = document.getElementById(id);
-      const iframe = document.createElement('iframe');  
-      iframe.width = width
-      iframe.height = height
-      iframe.src = getiFrameUrl({ isLocal, isPR })
-      widgetWrapper.appendChild(iframe)
+        // Add button to widgetWrapper
+        const button = document.createElement('button')
+        button.innerText = '🐮 Send message!'
+        button.onclick = () => {
+          iframe.contentWindow.postMessage(
+            {
+              type: 'cowswap-widget',
+              method: 'time',
+            },
+            '*'
+          )
+        }
+        widgetWrapper.appendChild(button)
 
-      // Add button to widgetWrapper
-      const button = document.createElement('button')
-      button.innerText = '🐮 Send message!'
-      button.onclick = () => {
-        iframe.contentWindow.postMessage({
-          type: 'cowswap-widget',
-          method: 'time'
-        }, '*')
+        window.addEventListener(
+          'message',
+          (event) => {
+            const sourceIsIframe = event.source === iframe.contentWindow
+            const trustedOrigin = isLocal ? true : event.origin === COWSWAP_DOMAIN
+
+            if (
+              !sourceIsIframe ||
+              !trustedOrigin ||
+              event.type !== 'message' ||
+              !event.data ||
+              event.data.type !== POST_MESSAGE_TYPE
+            ) {
+              return
+            }
+
+            console.log('WIDGET:HOST Receive message', event.data)
+          },
+          false
+        )
       }
-      widgetWrapper.appendChild(button)
 
-
-      window.addEventListener(
-        "message",
-        (event) => {
-          const sourceIsIframe = event.source === iframe.contentWindow
-          const trustedOrigin = isLocal ? true : event.origin === COWSWAP_DOMAIN
-
-          if (!sourceIsIframe || !trustedOrigin || event.type !== 'message' || !event.data || event.data.type !== POST_MESSAGE_TYPE) {
-            return
-          }
-
-          console.log('WIDGET:HOST Receive message', event.data)
-        },
-        false
-      );
-    }
-
-    renderCowSwapWidget({
-      id: 'cowswap-widget',
-      width: 600,
-      height: 600,
-    })
-
-  </script>
-</body>
+      renderCowSwapWidget({
+        id: 'cowswap-widget',
+        width: 600,
+        height: 600,
+      })
+    </script>
+  </body>
 </html>

--- a/public/widget.html
+++ b/public/widget.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>Widget Example</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    #cowswap-widget{
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>🐮 Example of CoW Swap Widget</h1>
+  <div id="cowswap-widget"></div>
+
+  <script>
+    // TODO: Npm package :) 
+    function renderCowSwapWidget(props) {
+      const isLocal = document.location.host.startsWith('localhost:')
+
+      const { id, width, height } = props
+      const widgetWrapper = document.getElementById(id);
+      const iframe = document.createElement('iframe');  
+      iframe.width = width
+      iframe.height = height
+      iframe.src = isLocal ? '/#/widget' : 'https://cowswap.exchange/#/widget'
+      widgetWrapper.appendChild(iframe)
+    }
+
+    renderCowSwapWidget({
+      id: 'cowswap-widget',
+      width: 600,
+      height: 400,
+    })
+
+  </script>
+</body>
+</html>

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -4,6 +4,7 @@ export enum Routes {
   SWAP = '/:chainId?/swap/:inputCurrencyId?/:outputCurrencyId?',
   LIMIT_ORDER = '/:chainId?/limit-orders/:inputCurrencyId?/:outputCurrencyId?',
   ADVANCED_ORDERS = '/:chainId?/advanced-orders/:inputCurrencyId?/:outputCurrencyId?',
+  WIDGET = '/:chainId?/widget/:inputCurrencyId?/:outputCurrencyId?',
   SEND = '/send',
   ACCOUNT = '/account',
   ACCOUNT_TOKENS = '/account/tokens',

--- a/src/modules/application/containers/App/RoutesApp.tsx
+++ b/src/modules/application/containers/App/RoutesApp.tsx
@@ -12,6 +12,7 @@ import { Routes as RoutesEnum } from 'constants/routes'
 import Account, { AccountOverview } from 'pages/Account'
 import AnySwapAffectedUsers from 'pages/error/AnySwapAffectedUsers'
 import { SwapPage } from 'pages/Swap'
+import { WidgetPage } from 'pages/Widget'
 
 // Async routes
 const PrivacyPolicy = lazy(() => import(/* webpackChunkName: "privacy_policy" */ 'pages/PrivacyPolicy'))
@@ -78,6 +79,9 @@ export function RoutesApp() {
         </Route>
         <Route path="claim" element={<Navigate to={RoutesEnum.ACCOUNT} />} />
         <Route path="profile" element={<Navigate to={RoutesEnum.ACCOUNT} />} />
+
+        {/*Widget*/}
+        <Route path={RoutesEnum.WIDGET} element={<WidgetPage />} />
 
         {/*Swap*/}
         <Route path={RoutesEnum.SWAP} element={<SwapPage />} />

--- a/src/modules/application/containers/App/index.tsx
+++ b/src/modules/application/containers/App/index.tsx
@@ -9,7 +9,7 @@ import ApeModeQueryParamReader from 'legacy/hooks/useApeModeQueryParamReader'
 import DarkModeQueryParamReader from 'legacy/theme'
 
 import { useInitializeUtm } from 'modules/utm'
-import { useIsStandaloneWidget } from 'modules/widget'
+import { isStandaloneWidget } from 'modules/widget'
 
 import RedirectAnySwapAffectedUsers from 'pages/error/AnySwapAffectedUsers/RedirectAnySwapAffectedUsers'
 
@@ -20,7 +20,7 @@ export function App() {
   initializeAnalytics()
   useAnalyticsReporter()
   useInitializeUtm()
-  const isTandaloneWidget = useIsStandaloneWidget()
+  const isTandaloneWidgetMode = isStandaloneWidget()
 
   return (
     <ErrorBoundary>
@@ -28,7 +28,7 @@ export function App() {
       <DarkModeQueryParamReader />
       <ApeModeQueryParamReader />
       <styledEl.AppWrapper>
-        {!isTandaloneWidget && (
+        {!isTandaloneWidgetMode && (
           <>
             <URLWarning />
             <styledEl.HeaderWrapper>
@@ -41,7 +41,7 @@ export function App() {
           <RoutesApp />
           <styledEl.Marginer />
         </styledEl.BodyWrapper>
-        {!isTandaloneWidget && (
+        {!isTandaloneWidgetMode && (
           <>
             <styledEl.FooterWrapper>
               <Footer />

--- a/src/modules/application/containers/App/index.tsx
+++ b/src/modules/application/containers/App/index.tsx
@@ -9,6 +9,7 @@ import ApeModeQueryParamReader from 'legacy/hooks/useApeModeQueryParamReader'
 import DarkModeQueryParamReader from 'legacy/theme'
 
 import { useInitializeUtm } from 'modules/utm'
+import { useIsStandaloneWidget } from 'modules/widget'
 
 import RedirectAnySwapAffectedUsers from 'pages/error/AnySwapAffectedUsers/RedirectAnySwapAffectedUsers'
 
@@ -19,6 +20,7 @@ export function App() {
   initializeAnalytics()
   useAnalyticsReporter()
   useInitializeUtm()
+  const isTandaloneWidget = useIsStandaloneWidget()
 
   return (
     <ErrorBoundary>
@@ -26,18 +28,26 @@ export function App() {
       <DarkModeQueryParamReader />
       <ApeModeQueryParamReader />
       <styledEl.AppWrapper>
-        <URLWarning />
-        <styledEl.HeaderWrapper>
-          <Header />
-        </styledEl.HeaderWrapper>
+        {!isTandaloneWidget && (
+          <>
+            <URLWarning />
+            <styledEl.HeaderWrapper>
+              <Header />
+            </styledEl.HeaderWrapper>
+          </>
+        )}
         <styledEl.BodyWrapper>
           <TopLevelModals />
           <RoutesApp />
           <styledEl.Marginer />
         </styledEl.BodyWrapper>
-        <styledEl.FooterWrapper>
-          <Footer />
-        </styledEl.FooterWrapper>
+        {!isTandaloneWidget && (
+          <>
+            <styledEl.FooterWrapper>
+              <Footer />
+            </styledEl.FooterWrapper>
+          </>
+        )}
       </styledEl.AppWrapper>
     </ErrorBoundary>
   )

--- a/src/modules/application/containers/TradeWidgetLinks/index.tsx
+++ b/src/modules/application/containers/TradeWidgetLinks/index.tsx
@@ -8,42 +8,54 @@ import { Routes } from 'constants/routes'
 
 import * as styledEl from './styled'
 
-export function TradeWidgetLinks() {
+export interface TradeWidgetLinksProps {
+  showSwap?: boolean
+  showLimit?: boolean
+  showAdvanced?: boolean
+}
+
+export function TradeWidgetLinks(props?: TradeWidgetLinksProps) {
+  const { showSwap = true, showLimit = true, showAdvanced = true } = props ?? {}
   const tradeContext = useTradeRouteContext()
 
   return (
     <styledEl.Wrapper>
-      <styledEl.MenuItem>
-        <styledEl.Link
-          className={({ isActive }) => (isActive ? 'active' : undefined)}
-          to={parameterizeTradeRoute(tradeContext, Routes.SWAP)}
-        >
-          <Trans>Swap</Trans>
-        </styledEl.Link>
-      </styledEl.MenuItem>
-
-      <styledEl.MenuItem>
-        <styledEl.Link
-          className={({ isActive }) => (isActive ? 'active' : undefined)}
-          to={parameterizeTradeRoute(tradeContext, Routes.LIMIT_ORDER)}
-        >
-          <Trans>Limit</Trans>
-        </styledEl.Link>
-      </styledEl.MenuItem>
-
-      <FeatureGuard featureFlag="advancedOrdersEnabled">
+      {showSwap && (
         <styledEl.MenuItem>
           <styledEl.Link
             className={({ isActive }) => (isActive ? 'active' : undefined)}
-            to={parameterizeTradeRoute(tradeContext, Routes.ADVANCED_ORDERS)}
+            to={parameterizeTradeRoute(tradeContext, Routes.SWAP)}
           >
-            <Trans>Advanced</Trans>
-            <styledEl.Badge>
-              <Trans>Beta</Trans>
-            </styledEl.Badge>
+            <Trans>Swap</Trans>
           </styledEl.Link>
         </styledEl.MenuItem>
-      </FeatureGuard>
+      )}
+
+      {showLimit && (
+        <styledEl.MenuItem>
+          <styledEl.Link
+            className={({ isActive }) => (isActive ? 'active' : undefined)}
+            to={parameterizeTradeRoute(tradeContext, Routes.LIMIT_ORDER)}
+          >
+            <Trans>Limit</Trans>
+          </styledEl.Link>
+        </styledEl.MenuItem>
+      )}
+      {showAdvanced && (
+        <FeatureGuard featureFlag="advancedOrdersEnabled">
+          <styledEl.MenuItem>
+            <styledEl.Link
+              className={({ isActive }) => (isActive ? 'active' : undefined)}
+              to={parameterizeTradeRoute(tradeContext, Routes.ADVANCED_ORDERS)}
+            >
+              <Trans>Advanced</Trans>
+              <styledEl.Badge>
+                <Trans>Beta</Trans>
+              </styledEl.Badge>
+            </styledEl.Link>
+          </styledEl.MenuItem>
+        </FeatureGuard>
+      )}
     </styledEl.Wrapper>
   )
 }

--- a/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/src/modules/swap/containers/SwapWidget/index.tsx
@@ -58,7 +58,12 @@ const BUTTON_STATES_TO_SHOW_BUNDLE_APPROVAL_BANNER = [
 ]
 const BUTTON_STATES_TO_SHOW_BUNDLE_WRAP_BANNER = [SwapButtonState.WrapAndSwap, SwapButtonState.ExpertWrapAndSwap]
 
-export function SwapWidget() {
+export interface SwapWidgetProps {
+  isStandaloneWidget?: boolean
+}
+
+export function SwapWidget(props?: SwapWidgetProps) {
+  const { isStandaloneWidget = false } = props ?? {}
   useSetupTradeState()
   useSetupSwapAmountsFromUrl()
   useFillSwapDerivedState()
@@ -261,6 +266,7 @@ export function SwapWidget() {
           params={params}
           inputCurrencyInfo={inputCurrencyInfo}
           outputCurrencyInfo={outputCurrencyInfo}
+          isStandaloneWidget={isStandaloneWidget}
         />
         <NetworkAlert />
       </TradeWidgetContainer>

--- a/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/src/modules/swap/containers/SwapWidget/index.tsx
@@ -44,7 +44,7 @@ import useCurrencyBalance from 'modules/tokens/hooks/useCurrencyBalance'
 import { TradeWidget, TradeWidgetContainer, useSetupTradeState } from 'modules/trade'
 import { useWrappedToken } from 'modules/trade/hooks/useWrappedToken'
 import { useIsSafeViaWc, useIsSafeWallet, useWalletDetails, useWalletInfo } from 'modules/wallet'
-import { useIsStandaloneWidget } from 'modules/widget'
+import { isStandaloneWidget } from 'modules/widget'
 
 import { useRateInfoParams } from 'common/hooks/useRateInfoParams'
 import { useShouldZeroApprove } from 'common/hooks/useShouldZeroApprove'
@@ -85,7 +85,7 @@ export function SwapWidget() {
   const showRecipientControls = useShowRecipientControls(recipient)
   const isEoaEthFlow = useIsEoaEthFlow()
   const shouldZeroApprove = useShouldZeroApprove(slippageAdjustedSellAmount)
-  const isStandaloneWidget = useIsStandaloneWidget()
+  const isStandaloneWidgetMode = isStandaloneWidget()
 
   const isWrapUnwrapMode = wrapType !== WrapType.NOT_APPLICABLE
   const priceImpactParams = usePriceImpact({
@@ -263,7 +263,7 @@ export function SwapWidget() {
           params={params}
           inputCurrencyInfo={inputCurrencyInfo}
           outputCurrencyInfo={outputCurrencyInfo}
-          isStandaloneWidget={isStandaloneWidget}
+          isStandaloneWidget={isStandaloneWidgetMode}
         />
         <NetworkAlert />
       </TradeWidgetContainer>

--- a/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/src/modules/swap/containers/SwapWidget/index.tsx
@@ -44,6 +44,7 @@ import useCurrencyBalance from 'modules/tokens/hooks/useCurrencyBalance'
 import { TradeWidget, TradeWidgetContainer, useSetupTradeState } from 'modules/trade'
 import { useWrappedToken } from 'modules/trade/hooks/useWrappedToken'
 import { useIsSafeViaWc, useIsSafeWallet, useWalletDetails, useWalletInfo } from 'modules/wallet'
+import { useIsStandaloneWidget } from 'modules/widget'
 
 import { useRateInfoParams } from 'common/hooks/useRateInfoParams'
 import { useShouldZeroApprove } from 'common/hooks/useShouldZeroApprove'
@@ -58,12 +59,7 @@ const BUTTON_STATES_TO_SHOW_BUNDLE_APPROVAL_BANNER = [
 ]
 const BUTTON_STATES_TO_SHOW_BUNDLE_WRAP_BANNER = [SwapButtonState.WrapAndSwap, SwapButtonState.ExpertWrapAndSwap]
 
-export interface SwapWidgetProps {
-  isStandaloneWidget?: boolean
-}
-
-export function SwapWidget(props?: SwapWidgetProps) {
-  const { isStandaloneWidget = false } = props ?? {}
+export function SwapWidget() {
   useSetupTradeState()
   useSetupSwapAmountsFromUrl()
   useFillSwapDerivedState()
@@ -89,6 +85,7 @@ export function SwapWidget(props?: SwapWidgetProps) {
   const showRecipientControls = useShowRecipientControls(recipient)
   const isEoaEthFlow = useIsEoaEthFlow()
   const shouldZeroApprove = useShouldZeroApprove(slippageAdjustedSellAmount)
+  const isStandaloneWidget = useIsStandaloneWidget()
 
   const isWrapUnwrapMode = wrapType !== WrapType.NOT_APPLICABLE
   const priceImpactParams = usePriceImpact({

--- a/src/modules/trade/containers/TradeWidget/index.tsx
+++ b/src/modules/trade/containers/TradeWidget/index.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useMemo } from 'react'
 
 import { t } from '@lingui/macro'
 
 import { PriceImpact } from 'legacy/hooks/usePriceImpact'
 import { maxAmountSpend } from 'legacy/utils/maxAmountSpend'
 
-import { TradeWidgetLinks } from 'modules/application/containers/TradeWidgetLinks'
+import { TradeWidgetLinks, TradeWidgetLinksProps } from 'modules/application/containers/TradeWidgetLinks'
 import { SetRecipientProps } from 'modules/swap/containers/SetRecipient'
 import { useIsWrapOrUnwrap } from 'modules/trade/hooks/useIsWrapOrUnwrap'
 import { TradeQuoteUpdater } from 'modules/tradeQuote'
@@ -56,13 +56,23 @@ export interface TradeWidgetProps {
   actions: TradeWidgetActions
   params: TradeWidgetParams
   disableOutput?: boolean
+  isStandaloneWidget?: boolean
 }
 
 export const TradeWidgetContainer = styledEl.Container
 
 // TODO: add ImportTokenModal, TradeApproveWidget
 export function TradeWidget(props: TradeWidgetProps) {
-  const { id, slots, inputCurrencyInfo, outputCurrencyInfo, actions, params, disableOutput } = props
+  const {
+    id,
+    slots,
+    inputCurrencyInfo,
+    outputCurrencyInfo,
+    actions,
+    params,
+    disableOutput,
+    isStandaloneWidget = false,
+  } = props
   const { settingsWidget, lockScreen, middleContent, bottomContent } = slots
 
   const { onCurrencySelection, onUserInput, onSwitchTokens, onChangeRecipient } = actions
@@ -90,6 +100,10 @@ export function TradeWidget(props: TradeWidgetProps) {
 
   // Disable too frequent tokens switching
   const throttledOnSwitchTokens = useThrottleFn(onSwitchTokens, 500)
+  const tradeWidgetLinksProps: TradeWidgetLinksProps | undefined = useMemo(
+    () => (isStandaloneWidget ? { showSwap: false, showLimit: false, showAdvanced: false } : undefined),
+    [isStandaloneWidget]
+  )
 
   /**
    * Reset recipient value only once at App start
@@ -108,7 +122,7 @@ export function TradeWidget(props: TradeWidgetProps) {
       <styledEl.Container id={id}>
         <styledEl.ContainerBox>
           <styledEl.Header>
-            <TradeWidgetLinks />
+            <TradeWidgetLinks {...tradeWidgetLinksProps} />
             {!lockScreen && settingsWidget}
           </styledEl.Header>
 

--- a/src/modules/widget/hooks.ts
+++ b/src/modules/widget/hooks.ts
@@ -1,0 +1,3 @@
+export function useIsStandaloneWidget() {
+  return window.location.hash.includes('/widget')
+}

--- a/src/modules/widget/index.ts
+++ b/src/modules/widget/index.ts
@@ -1,0 +1,1 @@
+export { useIsStandaloneWidget } from './hooks'

--- a/src/modules/widget/index.ts
+++ b/src/modules/widget/index.ts
@@ -1,1 +1,1 @@
-export { useIsStandaloneWidget } from './hooks'
+export { isStandaloneWidget } from './utils'

--- a/src/modules/widget/utils.ts
+++ b/src/modules/widget/utils.ts
@@ -1,3 +1,3 @@
-export function useIsStandaloneWidget() {
+export function isStandaloneWidget() {
   return window.location.hash.includes('/widget')
 }

--- a/src/pages/Widget/index.tsx
+++ b/src/pages/Widget/index.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+
+import { Navigate, useLocation, useParams } from 'react-router-dom'
+
+import { WRAPPED_NATIVE_CURRENCY as WETH } from 'legacy/constants/tokens'
+
+import { SwapWidget } from 'modules/swap/containers/SwapWidget'
+import { getDefaultTradeRawState } from 'modules/trade/types/TradeRawState'
+import { parameterizeTradeRoute } from 'modules/trade/utils/parameterizeTradeRoute'
+import { useWalletInfo } from 'modules/wallet'
+
+import { Routes } from 'constants/routes'
+
+export function WidgetPage() {
+  const params = useParams()
+
+  if (!params.chainId) {
+    return <WidgetPageRedirect />
+  }
+
+  return <SwapWidget isStandaloneWidget={true} />
+}
+
+function WidgetPageRedirect() {
+  const { chainId } = useWalletInfo()
+  const location = useLocation()
+
+  if (!chainId) return null
+
+  const defaultState = getDefaultTradeRawState(chainId)
+  const searchParams = new URLSearchParams(location.search)
+  const inputCurrencyId = searchParams.get('inputCurrency') || defaultState.inputCurrencyId || WETH[chainId]?.symbol
+  const outputCurrencyId = searchParams.get('outputCurrency') || defaultState.outputCurrencyId || undefined
+
+  searchParams.delete('inputCurrency')
+  searchParams.delete('outputCurrency')
+  searchParams.delete('chain')
+
+  const pathname = parameterizeTradeRoute(
+    { chainId: String(chainId), inputCurrencyId, outputCurrencyId },
+    Routes.WIDGET
+  )
+
+  return <Navigate to={{ ...location, pathname, search: searchParams.toString() }} />
+}

--- a/src/pages/Widget/index.tsx
+++ b/src/pages/Widget/index.tsx
@@ -18,7 +18,7 @@ export function WidgetPage() {
     return <WidgetPageRedirect />
   }
 
-  return <SwapWidget isStandaloneWidget={true} />
+  return <SwapWidget />
 }
 
 function WidgetPageRedirect() {

--- a/src/pages/Widget/index.tsx
+++ b/src/pages/Widget/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { Navigate, useLocation, useParams } from 'react-router-dom'
+import styled from 'styled-components/macro'
 
 import { WRAPPED_NATIVE_CURRENCY as WETH } from 'legacy/constants/tokens'
 
@@ -11,6 +12,10 @@ import { useWalletInfo } from 'modules/wallet'
 
 import { Routes } from 'constants/routes'
 
+const Wrapper = styled.div`
+  margin-top: 20px;
+`
+
 export function WidgetPage() {
   const params = useParams()
 
@@ -18,7 +23,11 @@ export function WidgetPage() {
     return <WidgetPageRedirect />
   }
 
-  return <SwapWidget />
+  return (
+    <Wrapper>
+      <SwapWidget />
+    </Wrapper>
+  )
 }
 
 function WidgetPageRedirect() {

--- a/src/pages/Widget/index.tsx
+++ b/src/pages/Widget/index.tsx
@@ -76,8 +76,6 @@ export function WidgetPage() {
     window.addEventListener('message', receiveMessage)
 
     // Send a periodic message
-    window.parent.postMessage('hello', '*')
-
     const intervalId = setInterval(() => {
       postMessage({
         method: 'areYouThere',


### PR DESCRIPTION
# Summary

This experiments with adding a widget as an iframe.

Basically creates:
- New routes "/#!/widget" 
- In this new URL, it will be hiding the header and footer
- This is how we could now load CoW Swap to this URL and make sure we we use all but the parts we don't want
- It will also hides other types of trading from the widget

PoC

<img width="1548" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/7d382a98-6cbc-4718-905e-4f7780392643">




  