### PR TITLE
chore: Add `widget-lib` and publish to NPM

### DIFF
--- a/jest.config.app.ts
+++ b/jest.config.app.ts
@@ -1,5 +1,7 @@
 import { getJestProjects } from '@nx/jest'
 
-export default {
+const config = {
   projects: getJestProjects(),
 }
+
+export default config

--- a/project.json
+++ b/project.json
@@ -33,7 +33,7 @@
       "executor": "@nx/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/{projectName}"],
       "options": {
-        "jestConfig": "jest.config.ts",
+        "jestConfig": "jest.config.app.ts",
         "passWithNoTests": true
       },
       "configurations": {

--- a/src/libs/ui-utils/package.json
+++ b/src/libs/ui-utils/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@cowprotocol/ui-utils",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "type": "commonjs"
 }

--- a/src/libs/widget-lib/.eslintrc.json
+++ b/src/libs/widget-lib/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/src/libs/widget-lib/README.md
+++ b/src/libs/widget-lib/README.md
@@ -52,10 +52,9 @@ nx test widget-lib
 
 # Build the library
 nx build widget-lib
-cp src/libs/widget-lib/README.md dist/libs/widget-lib # automate
 
 # Publish to NPM
-npm publish --access=public ./dist/libs/widget-lib
+nx publish widget-lib --ver 0.0.7 --tag latest
 ```
 
 ## Running unit tests

--- a/src/libs/widget-lib/README.md
+++ b/src/libs/widget-lib/README.md
@@ -1,0 +1,11 @@
+# widget-lib
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build widget-lib` to build the library.
+
+## Running unit tests
+
+Run `nx test widget-lib` to execute the unit tests via [Jest](https://jestjs.io).

--- a/src/libs/widget-lib/README.md
+++ b/src/libs/widget-lib/README.md
@@ -1,10 +1,62 @@
-# widget-lib
+# CoW Swap widget-lib
 
-This library was generated with [Nx](https://nx.dev).
+## Use it
 
-## Building
+Install dependency
 
-Run `nx build widget-lib` to build the library.
+```bash
+# Install the dependency using NPM
+npm install @cowprotocol/widget-lib --save
+
+# ...or alternativelly use YARN
+yarn add @cowprotocol/widget-lib
+```
+
+Create an empty div somewhere in your website:
+
+```html
+<div id="cowswap-widget"></div>
+```
+
+Import the widget and initialise it:
+
+```js
+import { cowSwapWidget } from '@cowprotocol/widget-lib'
+
+// Initialise the widget
+const widgetContainer = document.getElementById('cowswap-widget')
+cowSwapWidget({
+  container: widgetContainer
+})
+
+
+// Additionally, you can pass some additional params to customise your widget
+provider = /* instantiate your own web3 provider */
+cowSwapWidget({
+  container: widgetContainer,
+  width: 600
+  height: 640
+  urlParams: {
+    sell: { asset: 'DAI' },
+    buy: { asset: 'USDC', amount: '0.1' }
+  },
+  provider
+})
+```
+
+## Developers
+
+```bash
+# Test
+nx test widget-lib
+
+# Build the library
+nx build widget-lib
+cp src/libs/widget-lib/README.md dist/libs/widget-lib # automate
+
+# Publish to NPM
+npm publish --access=public ./dist/libs/widget-lib
+```
 
 ## Running unit tests
 

--- a/src/libs/widget-lib/jest.config.ts
+++ b/src/libs/widget-lib/jest.config.ts
@@ -6,5 +6,5 @@ export default {
     '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
-  coverageDirectory: '../../../coverage/src/libs/widget-lib',
+  coverageDirectory: '../../../coverage/libs/widget-lib',
 }

--- a/src/libs/widget-lib/jest.config.ts
+++ b/src/libs/widget-lib/jest.config.ts
@@ -1,0 +1,10 @@
+/* eslint-disable */
+export default {
+  displayName: 'widget-lib',
+  preset: '../../../jest.preset.js',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../coverage/src/libs/widget-lib',
+}

--- a/src/libs/widget-lib/package.json
+++ b/src/libs/widget-lib/package.json
@@ -1,5 +1,24 @@
 {
   "name": "@cowprotocol/widget-lib",
-  "version": "0.0.1",
-  "type": "commonjs"
+  "version": "0.0.2",
+  "type": "commonjs",
+  "description": "CoW Swap Widget Library. Allows you to easily embed a CoW Swap widget on your website.",
+  "main": "index.js",
+  "exports": {
+    "import": "./index.js",
+    "require": "./index.mjs"
+  },
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cowprotocol/cowswap"
+  },
+  "keywords": [
+    "cowprotocol",
+    "widget",
+    "cowswap",
+    "dex",
+    "widget-lib"
+  ],
+  "dependencies": {}
 }

--- a/src/libs/widget-lib/package.json
+++ b/src/libs/widget-lib/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@cowprotocol/widget-lib",
+  "version": "0.0.1",
+  "type": "commonjs"
+}

--- a/src/libs/widget-lib/package.json
+++ b/src/libs/widget-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/widget-lib",
-  "version": "0.0.2",
+  "version": "0.0.5",
   "type": "commonjs",
   "description": "CoW Swap Widget Library. Allows you to easily embed a CoW Swap widget on your website.",
   "main": "index.js",

--- a/src/libs/widget-lib/project.json
+++ b/src/libs/widget-lib/project.json
@@ -8,7 +8,7 @@
       "executor": "@nx/vite:build",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "outputPath": "dist/src/libs/widget-lib"
+        "outputPath": "dist/libs/widget-lib"
       }
     },
     "publish": {

--- a/src/libs/widget-lib/project.json
+++ b/src/libs/widget-lib/project.json
@@ -3,12 +3,19 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "src/libs/widget-lib/src",
   "projectType": "library",
+
   "targets": {
     "build": {
       "executor": "@nx/vite:build",
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/libs/widget-lib"
+      }
+    },
+    "docs": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "cp src/libs/widget-lib/README.md dist/libs/widget-lib"
       }
     },
     "publish": {

--- a/src/libs/widget-lib/project.json
+++ b/src/libs/widget-lib/project.json
@@ -1,0 +1,41 @@
+{
+  "name": "widget-lib",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "src/libs/widget-lib/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/vite:build",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/src/libs/widget-lib"
+      }
+    },
+    "publish": {
+      "command": "node tools/scripts/publish.mjs widget-lib {args.ver} {args.tag}",
+      "dependsOn": ["build"]
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["src/libs/widget-lib/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "src/libs/widget-lib/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    }
+  },
+  "tags": []
+}

--- a/src/libs/widget-lib/project.json
+++ b/src/libs/widget-lib/project.json
@@ -12,12 +12,6 @@
         "outputPath": "dist/libs/widget-lib"
       }
     },
-    "docs": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "cp src/libs/widget-lib/README.md dist/libs/widget-lib"
-      }
-    },
     "publish": {
       "command": "node tools/scripts/publish.mjs widget-lib {args.ver} {args.tag}",
       "dependsOn": ["build"]

--- a/src/libs/widget-lib/src/JsonRpcManager.ts
+++ b/src/libs/widget-lib/src/JsonRpcManager.ts
@@ -1,0 +1,73 @@
+import { EthereumProvider, JsonRpcRequest } from './types'
+
+const JSON_PRC_V = '2.0'
+const TARGET_ORIGIN = '*'
+const EVENTS = ['connect', 'disconnect', 'chainChanged', 'accountsChanged']
+
+export class JsonRpcManager {
+  ethereumProvider: EthereumProvider | null = null
+
+  requests: { [key: string]: JsonRpcRequest } = {}
+
+  constructor(private contentWindow: Window) {
+    window.addEventListener('message', this.processEvent)
+  }
+
+  disconnect() {
+    this.ethereumProvider = null
+    window.removeEventListener('message', this.processEvent)
+  }
+
+  onConnect(ethereumProvider: EthereumProvider) {
+    this.ethereumProvider = ethereumProvider
+
+    Object.keys(this.requests).forEach((key) => {
+      this.processRequest(this.requests[key])
+    })
+
+    this.requests = {}
+
+    EVENTS.forEach((event) => {
+      ethereumProvider.on(event, (params: unknown): void => {
+        this.postMessage({ method: event, params: [params] })
+      })
+    })
+  }
+
+  processRequest(request: JsonRpcRequest) {
+    if (!this.ethereumProvider) return
+
+    const request$ =
+      request.method === 'enable' //
+        ? this.ethereumProvider.enable()
+        : this.ethereumProvider.request(request)
+
+    request$
+      .then((result) => {
+        this.postMessage({ id: request.id, result })
+      })
+      .catch((error) => {
+        this.postMessage({ id: request.id, error })
+      })
+  }
+
+  private processEvent = (event: MessageEvent) => {
+    if (event.data.jsonrpc === '2.0') {
+      if (this.ethereumProvider) {
+        this.processRequest(event.data)
+      } else {
+        this.requests[event.data.id] = event.data
+      }
+    }
+  }
+
+  private postMessage(params: { [key: string]: unknown }) {
+    this.contentWindow.postMessage(
+      {
+        jsonrpc: JSON_PRC_V,
+        ...params,
+      },
+      TARGET_ORIGIN
+    )
+  }
+}

--- a/src/libs/widget-lib/src/consts.ts
+++ b/src/libs/widget-lib/src/consts.ts
@@ -1,0 +1,11 @@
+import { CowSwapWidgetEnv } from './types'
+
+export const DEFAULT_CHAIN = 1
+export const DEFAULT_WIDTH = 400
+export const DEFAULT_HEIGHT = 640
+
+export const COWSWAP_URLS: Record<CowSwapWidgetEnv, string> = {
+  local: 'http://localhost:3000',
+  barn: 'https://barn.cow.fi',
+  prod: 'http://swap.cow.fi',
+}

--- a/src/libs/widget-lib/src/cowSwapWidget.ts
+++ b/src/libs/widget-lib/src/cowSwapWidget.ts
@@ -1,0 +1,55 @@
+import { DEFAULT_HEIGHT, DEFAULT_WIDTH } from './consts'
+import { JsonRpcManager } from './JsonRpcManager'
+import { CowSwapWidgetParams, CowSwapWidgetUrlParams } from './types'
+import { buildTradeAmountsQuery, buildWidgetPath, buildWidgetUrl } from './utils'
+
+const COW_SWAP_WIDGET_KEY = '@cowprotocol/widget-lib'
+
+type UpdateWidgetCallback = (params: CowSwapWidgetUrlParams) => void
+
+export function cowSwapWidget(params: CowSwapWidgetParams): UpdateWidgetCallback {
+  const { container, provider } = params
+  const iframe = createIframe(params)
+
+  container.innerHTML = ''
+  container.appendChild(iframe)
+
+  const { contentWindow } = iframe
+
+  if (!contentWindow) throw new Error('Iframe does not contain a window!')
+
+  if (provider) {
+    const jsonRpcManager = new JsonRpcManager(contentWindow)
+
+    jsonRpcManager.onConnect(provider)
+  }
+
+  return (params: CowSwapWidgetUrlParams) => updateWidget(params, contentWindow)
+}
+
+function updateWidget(params: CowSwapWidgetUrlParams, contentWindow: Window) {
+  const pathname = buildWidgetPath(params)
+  const search = buildTradeAmountsQuery(params).toString()
+
+  contentWindow.postMessage(
+    {
+      key: COW_SWAP_WIDGET_KEY,
+      pathname,
+      search,
+    },
+    '*'
+  )
+}
+
+function createIframe(params: CowSwapWidgetParams): HTMLIFrameElement {
+  const { width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT } = params
+
+  const iframe = document.createElement('iframe')
+
+  iframe.src = buildWidgetUrl(params.urlParams ?? {})
+  iframe.width = `${width}px`
+  iframe.height = `${height}px`
+  iframe.style.border = '0'
+
+  return iframe
+}

--- a/src/libs/widget-lib/src/index.ts
+++ b/src/libs/widget-lib/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/widget'

--- a/src/libs/widget-lib/src/index.ts
+++ b/src/libs/widget-lib/src/index.ts
@@ -1,1 +1,3 @@
-export * from './lib/widget'
+export { cowSwapWidget } from './cowSwapWidget'
+export { COWSWAP_URLS } from './consts'
+export * from './types'

--- a/src/libs/widget-lib/src/lib/widget.spec.ts
+++ b/src/libs/widget-lib/src/lib/widget.spec.ts
@@ -1,7 +1,0 @@
-import { srcLibsWidgetLib } from './widget'
-
-describe('srcLibsWidgetLib', () => {
-  it('should work', () => {
-    expect(srcLibsWidgetLib()).toEqual('widget-lib')
-  })
-})

--- a/src/libs/widget-lib/src/lib/widget.spec.ts
+++ b/src/libs/widget-lib/src/lib/widget.spec.ts
@@ -1,0 +1,7 @@
+import { srcLibsWidgetLib } from './widget'
+
+describe('srcLibsWidgetLib', () => {
+  it('should work', () => {
+    expect(srcLibsWidgetLib()).toEqual('widget-lib')
+  })
+})

--- a/src/libs/widget-lib/src/lib/widget.ts
+++ b/src/libs/widget-lib/src/lib/widget.ts
@@ -1,0 +1,3 @@
+export function srcLibsWidgetLib(): string {
+  return 'widget-lib'
+}

--- a/src/libs/widget-lib/src/lib/widget.ts
+++ b/src/libs/widget-lib/src/lib/widget.ts
@@ -1,3 +1,0 @@
-export function srcLibsWidgetLib(): string {
-  return 'widget-lib'
-}

--- a/src/libs/widget-lib/src/types.ts
+++ b/src/libs/widget-lib/src/types.ts
@@ -1,0 +1,47 @@
+declare global {
+  interface Window {
+    ethereum?: EthereumProvider
+  }
+}
+
+export interface JsonRpcRequest {
+  id: number
+  method: string
+  params: unknown[]
+}
+
+// https://eips.ethereum.org/EIPS/eip-1193
+export interface EthereumProvider {
+  on(event: string, args: unknown): void
+  request<T>(params: JsonRpcRequest): Promise<T>
+  enable(): Promise<void>
+}
+
+export type CowSwapWidgetEnv = 'local' | 'prod' | 'barn'
+
+export type CowSwapTheme = 'dark' | 'light'
+
+interface TradeAsset {
+  asset: string
+  amount?: string
+}
+
+export interface TradeAssets {
+  sell: TradeAsset
+  buy: TradeAsset
+}
+
+export interface CowSwapWidgetUrlParams {
+  chainId?: number
+  env?: CowSwapWidgetEnv
+  tradeAssets?: TradeAssets
+  theme?: CowSwapTheme
+}
+
+export interface CowSwapWidgetParams {
+  container: HTMLElement
+  width?: number
+  height?: number
+  urlParams?: CowSwapWidgetUrlParams
+  provider?: EthereumProvider
+}

--- a/src/libs/widget-lib/src/utils.spec.ts
+++ b/src/libs/widget-lib/src/utils.spec.ts
@@ -1,0 +1,75 @@
+import { buildWidgetUrl } from './utils'
+
+describe('buildWidgetUrl', () => {
+  it('minimal config', () => {
+    const url = buildWidgetUrl({})
+    expect(url).toEqual('http://swap.cow.fi/#/1/swap/widget/?')
+  })
+
+  describe('env', () => {
+    it('local', () => {
+      const url = buildWidgetUrl({ env: 'local' })
+      expect(url).toEqual('http://localhost:3000/#/1/swap/widget/?')
+    })
+    it('prod', () => {
+      const url = buildWidgetUrl({ env: 'prod' })
+      expect(url).toEqual('http://swap.cow.fi/#/1/swap/widget/?')
+    })
+
+    it('barn', () => {
+      const url = buildWidgetUrl({ env: 'barn' })
+      expect(url).toEqual('https://barn.cow.fi/#/1/swap/widget/?')
+    })
+  })
+
+  describe('chainId', () => {
+    it('mainnet', () => {
+      const url = buildWidgetUrl({ chainId: 1 })
+      expect(url).toEqual('http://swap.cow.fi/#/1/swap/widget/?')
+    })
+    it('gnosis chain', () => {
+      const url = buildWidgetUrl({ chainId: 5 })
+      expect(url).toEqual('http://swap.cow.fi/#/5/swap/widget/?')
+    })
+  })
+
+  describe('theme', () => {
+    it('dark', () => {
+      const url = buildWidgetUrl({ theme: 'dark' })
+      expect(url).toEqual('http://swap.cow.fi/#/1/swap/widget/?theme=dark')
+    })
+    it('light', () => {
+      const url = buildWidgetUrl({ theme: 'light' })
+      expect(url).toEqual('http://swap.cow.fi/#/1/swap/widget/?theme=light')
+    })
+  })
+
+  describe('trade assets', () => {
+    it('without amounts', () => {
+      const url = buildWidgetUrl({ tradeAssets: { sell: { asset: 'WETH' }, buy: { asset: 'COW' } } })
+      expect(url).toEqual('http://swap.cow.fi/#/1/swap/widget/WETH/COW?')
+    })
+
+    it('with sell amount', () => {
+      const url = buildWidgetUrl({ tradeAssets: { sell: { asset: 'DAI', amount: '0.1' }, buy: { asset: 'USDC' } } })
+      expect(url).toEqual('http://swap.cow.fi/#/1/swap/widget/DAI/USDC?sellAmount=0.1')
+    })
+
+    it('with buy amount', () => {
+      const url = buildWidgetUrl({ tradeAssets: { sell: { asset: 'DAI' }, buy: { asset: 'USDC', amount: '0.1' } } })
+      expect(url).toEqual('http://swap.cow.fi/#/1/swap/widget/DAI/USDC?buyAmount=0.1')
+    })
+  })
+
+  describe('all config', () => {
+    it('dark', () => {
+      const url = buildWidgetUrl({
+        env: 'barn',
+        chainId: 100,
+        theme: 'light',
+        tradeAssets: { sell: { asset: 'DAI', amount: '0.1' }, buy: { asset: 'USDC', amount: '0.1' } },
+      })
+      expect(url).toEqual('https://barn.cow.fi/#/100/swap/widget/DAI/USDC?sellAmount=0.1&buyAmount=0.1&theme=light')
+    })
+  })
+})

--- a/src/libs/widget-lib/src/utils.ts
+++ b/src/libs/widget-lib/src/utils.ts
@@ -1,0 +1,43 @@
+import { COWSWAP_URLS, DEFAULT_CHAIN } from './consts'
+import { CowSwapWidgetUrlParams } from './types'
+
+export function buildWidgetUrl(params: CowSwapWidgetUrlParams): string {
+  const host = COWSWAP_URLS[params.env ?? 'prod']
+  const path = buildWidgetPath(params)
+  const query = buildTradeAmountsQuery(params)
+
+  return host + '/#' + path + '?' + query
+}
+
+export function buildWidgetPath(params: CowSwapWidgetUrlParams): string {
+  const { chainId = DEFAULT_CHAIN, tradeAssets } = params
+
+  const assetsPath = tradeAssets
+    ? [tradeAssets.sell.asset, tradeAssets.buy.asset].map(encodeURIComponent).join('/')
+    : ''
+
+  return `/${chainId}/swap/widget/${assetsPath}`
+}
+
+export function buildTradeAmountsQuery(params: CowSwapWidgetUrlParams): URLSearchParams {
+  const { tradeAssets, theme } = params
+  const query = new URLSearchParams()
+
+  if (tradeAssets) {
+    const { sell, buy } = tradeAssets
+
+    if (sell.amount) {
+      query.append('sellAmount', sell.amount)
+    }
+
+    if (buy.amount) {
+      query.append('buyAmount', buy.amount)
+    }
+  }
+
+  if (theme) {
+    query.append('theme', theme)
+  }
+
+  return query
+}

--- a/src/libs/widget-lib/tsconfig.json
+++ b/src/libs/widget-lib/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/src/libs/widget-lib/tsconfig.lib.json
+++ b/src/libs/widget-lib/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/src/libs/widget-lib/tsconfig.spec.json
+++ b/src/libs/widget-lib/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts", "src/lib/widget.ts"]
+}

--- a/src/libs/widget-lib/vite.config.ts
+++ b/src/libs/widget-lib/vite.config.ts
@@ -1,0 +1,48 @@
+/// <reference types="vitest" />
+import { joinPathFragments } from '@nx/devkit'
+import { defineConfig } from 'vite'
+import dts from 'vite-plugin-dts'
+import viteTsConfigPaths from 'vite-tsconfig-paths'
+
+export default defineConfig({
+  cacheDir: '../../../node_modules/.vite/widget-lib',
+
+  plugins: [
+    dts({
+      entryRoot: 'src',
+      tsConfigFilePath: joinPathFragments(__dirname, 'tsconfig.lib.json'),
+      skipDiagnostics: true,
+    }),
+
+    viteTsConfigPaths({
+      root: '../../../',
+    }),
+  ],
+
+  // Uncomment this if you are using workers.
+  // worker: {
+  //  plugins: [
+  //    viteTsConfigPaths({
+  //      root: '../../../',
+  //    }),
+  //  ],
+  // },
+
+  // Configuration for building your library.
+  // See: https://vitejs.dev/guide/build.html#library-mode
+  build: {
+    lib: {
+      // Could also be a dictionary or array of multiple entry points.
+      entry: 'src/index.ts',
+      name: 'widget-lib',
+      fileName: 'index',
+      // Change this to the formats you want to support.
+      // Don't forgot to update your package.json as well.
+      formats: ['es', 'cjs'],
+    },
+    rollupOptions: {
+      // External packages that should not be bundled into your library.
+      external: [],
+    },
+  },
+})

--- a/tools/scripts/publish.mjs
+++ b/tools/scripts/publish.mjs
@@ -7,11 +7,12 @@
  * You might need to authenticate with NPM before running this script.
  */
 
-import { execSync } from 'child_process'
-import { readFileSync, writeFileSync } from 'fs'
+import devkit from '@nx/devkit'
 import chalk from 'chalk'
 
-import devkit from '@nx/devkit'
+import { execSync } from 'child_process'
+import { readFileSync, writeFileSync } from 'fs'
+import path from 'path'
 const { readCachedProjectGraph } = devkit
 
 function invariant(condition, message) {
@@ -23,7 +24,7 @@ function invariant(condition, message) {
 
 // Executing publish script: node path/to/publish.mjs {name} --version {version} --tag {tag}
 // Default "tag" to "next" so we won't publish the "latest" tag by accident.
-const [, , name, version, tag = 'next'] = process.argv
+const [, , name, version, tag] = process.argv
 
 // A simple SemVer validation to validate the version
 const validVersion = /^\d+\.\d+\.\d+(-\w+\.\d+)?/
@@ -43,6 +44,9 @@ invariant(
   `Could not find "build.options.outputPath" of project "${name}". Is project.json configured  correctly?`
 )
 
+const rootLib = path.dirname(project.data.sourceRoot)
+const copyReadmeCommand = `cp ${rootLib}/README.md ${outputPath}`
+console.log(chalk.bold.greenBright(copyReadmeCommand))
 process.chdir(outputPath)
 
 // Updating the version in "package.json" before publishing
@@ -55,4 +59,7 @@ try {
 }
 
 // Execute "npm publish" to publish
-execSync(`npm publish --access public --tag ${tag}`)
+const publishCommand = `npm publish --access public --tag ${tag === 'undefined' ? 'next' : tag}`
+console.log(chalk.bold.greenBright(publishCommand))
+execSync(publishCommand)
+console.log('Published successfully 🎉')

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -25,7 +25,8 @@
     "types": ["react-spring", "jest"],
     "paths": {
       "@cowprotocol/ui": ["libs/ui/src/index.ts"],
-      "@cowprotocol/ui-utils": ["libs/ui-utils/src/index.ts"]
+      "@cowprotocol/ui-utils": ["libs/ui-utils/src/index.ts"],
+      "@cowprotocol/widget-lib": ["src/libs/widget-lib/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "cypress"]


### PR DESCRIPTION
# Summary

This PR adds the widget library to the monorepo (credits to @shoom3301 for implementing the main widget in https://shoom3301.github.io/cow-widget/)

This PR creates a publishable lib (meaning we can push it to NPM). We will also be able to use it in another monorepo project, which will make development easier.

The library has its own tests (i created tests just for the param to URL mapping (we could add more coverage if desired):

<img width="763" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/821b45cb-4fa6-4cb0-a4d3-dd4bb953d8a9">


Last but not least, it adds a way to publish this into production, for that read the lib README for instructions.
For that is uses a custom script that will: copy the README, write the version in the package.json, and publish into NPM


# To Test
Just run:
`nx test widget-lib`


To build:
`nx build widget-lib`, you will see the artifacts in `dist/widget-lib`

