### PR TITLE
feat(injected-widget): set app-data appCode from integrator

### DIFF
--- a/src/libs/widget-lib/docs/README.md
+++ b/src/libs/widget-lib/docs/README.md
@@ -28,6 +28,7 @@ const widgetContainer = document.getElementById('cowswap-widget')
 
 const params: CowSwapWidgetParams = {
   container: widgetContainer,
+  metaData: { appKey: 'YOUR_APP_ID', url: 'https://YOUR_APP_URL' },
   width: 600,
   height: 640,
 }
@@ -45,13 +46,17 @@ cowSwapWidget(params, settings)
 ## Wallet provider
 
 You can pass the wallet provider from your application to seamlessly use the widget as part of your application.
-Also, you can not specify the provider, in this case the widget will work in standalone mode with the ability to connect any wallet supported in CowSwap.
+Also, you can not specify the provider, in this case the widget will work in standalone mode with the ability to connect
+any wallet supported in CowSwap.
 
 A provider must comply with [EIP-1193](https://eips.ethereum.org/EIPS/eip-11930) and implement the interface:
+
 ```typescript
 interface EthereumProvider {
   on(event: string, args: unknown): void
+
   request<T>(params: JsonRpcRequest): Promise<T>
+
   enable(): Promise<void>
 }
 
@@ -69,6 +74,7 @@ import { cowSwapWidget, CowSwapWidgetParams } from '@cowprotocol/widget-lib'
 
 const params: CowSwapWidgetParams = {
   container: document.getElementById('cowswap-widget'),
+  metaData: { appKey: 'YOUR_APP_ID', url: 'https://YOUR_APP_URL' },
   width: 600,
   height: 640,
   provider: window.ethereum // <-------
@@ -81,12 +87,13 @@ cowSwapWidget(params, {})
 
 ### `CowSwapWidgetParams`
 
-| Parameter   | Type               | Description                                                                |
-|-------------|--------------------|----------------------------------------------------------------------------|
-| `width`     | `number`           | The width of the widget in pixels.                                         |
-| `height`    | `number`           | The height of the widget in pixels.                                        |
-| `container` | `HTMLElement`      | The container in which the widget will be displayed.                       |
-| `provider`  | `EthereumProvider` | (Optional) The Ethereum provider to be used for interacting with a wallet. |
+| Parameter   | Type                    | Description                                                                                                                                          |
+|-------------|-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `width`     | `number`                | The width of the widget in pixels.                                                                                                                   |
+| `height`    | `number`                | The height of the widget in pixels.                                                                                                                  |
+| `container` | `HTMLElement`           | The container in which the widget will be displayed.                                                                                                 |
+| `metaData`  | `CowSwapWidgetMetaData` | Information about the application in which the widget is embedded. This information will help identify the source of orders and requests from users. |
+| `provider`  | `EthereumProvider`      | (Optional) The Ethereum provider to be used for interacting with a wallet.                                                                           |
 
 ### `CowSwapWidgetSettings`
 
@@ -97,13 +104,13 @@ cowSwapWidget(params, {})
 
 ### `CowSwapWidgetUrlParams`
 
-| Parameter     | Type               | Description                                                                                            |
-|---------------|--------------------|--------------------------------------------------------------------------------------------------------|
-| `chainId`     | `number`           | The blockchain ID on which the trade will take place.                                                  |
-| `tradeType`   | `string`           | The type of trade. Can be `swap` or `limit-orders`.                                                    |
-| `env`         | `CowSwapWidgetEnv` | The environment of the widget (`'local'` or `'prod'`). |
-| `theme`       | `CowSwapTheme`     | (Optional) The theme of the widget (`'dark'` for dark theme or `'light'` for light theme).             |
-| `tradeAssets` | `TradeAssets`      | (Optional) An object containing information about the selling and buying assets.                       |
+| Parameter     | Type               | Description                                                                                |
+|---------------|--------------------|--------------------------------------------------------------------------------------------|
+| `chainId`     | `number`           | The blockchain ID on which the trade will take place.                                      |
+| `tradeType`   | `string`           | The type of trade. Can be `swap` or `limit-orders`.                                        |
+| `env`         | `CowSwapWidgetEnv` | The environment of the widget (`'local'` or `'prod'`).                                     |
+| `theme`       | `CowSwapTheme`     | (Optional) The theme of the widget (`'dark'` for dark theme or `'light'` for light theme). |
+| `tradeAssets` | `TradeAssets`      | (Optional) An object containing information about the selling and buying assets.           |
 
 ```typescript
 interface TradeAsset {
@@ -119,12 +126,11 @@ export interface TradeAssets {
 
 ### `CowSwapWidgetAppParams`
 
-| Parameter             | Type               | Description                                                                      |
-|-----------------------|--------------------|----------------------------------------------------------------------------------|
-| `logoUrl`             | `boolean`          | The width of the widget in pixels.                                               |
-| `hideLogo`            | `boolean`          | The height of the widget in pixels.                                              |
-| `hideNetworkSelector` | `boolean`          | The container in which the widget will be displayed.                             |
-
+| Parameter             | Type      | Description                                          |
+|-----------------------|-----------|------------------------------------------------------|
+| `logoUrl`             | `boolean` | The width of the widget in pixels.                   |
+| `hideLogo`            | `boolean` | The height of the widget in pixels.                  |
+| `hideNetworkSelector` | `boolean` | The container in which the widget will be displayed. |
 
 ## Widget updating
 
@@ -135,6 +141,7 @@ import { cowSwapWidget, CowSwapWidgetParams, CowSwapWidgetSettings } from '@cowp
 
 const params: CowSwapWidgetParams = {
   container: document.getElementById('cowswap-widget'),
+  metaData: { appKey: 'YOUR_APP_ID', url: 'https://YOUR_APP_URL' },
   width: 600,
   height: 640,
 }
@@ -162,14 +169,16 @@ updateWidget({
 
 ## Widget URL
 
-Most of the widget parameters are controlled via the URL, which means that you can create the URL yourself and embed the iframe.
+Most of the widget parameters are controlled via the URL, which means that you can create the URL yourself and embed the
+iframe.
 An example of URL:
+
 ```
 https://swap.cow.fi/#/100/swap/WXDAI/GNO?sellAmount=200&theme=dark
 ```
 
-
 ## Backlog
+
 1. [ ] Customizing the theme palette
 2. [ ] Set custom tokens list from URL or JSON
 3. [ ] Forward integrator meta-data to Appzi

--- a/src/libs/widget-lib/src/demo/index.ts
+++ b/src/libs/widget-lib/src/demo/index.ts
@@ -29,6 +29,10 @@ function init(provider?: EthereumProvider) {
       height: 640,
       container: document.getElementById('widgetContainer') as HTMLElement,
       provider,
+      metaData: {
+        appKey: 'CowSwapWidgetDemoApp',
+        url: 'https://swap.cow.fi/assets/injected-widget/',
+      },
     },
     { urlParams, appParams }
   )

--- a/src/libs/widget-lib/src/types.ts
+++ b/src/libs/widget-lib/src/types.ts
@@ -44,9 +44,15 @@ export interface CowSwapWidgetSettings {
   appParams: CowSwapWidgetAppParams
 }
 
+export interface CowSwapWidgetMetaData {
+  appKey: string
+  url: string
+}
+
 export interface CowSwapWidgetParams {
   width: number
   height: number
   container: HTMLElement
+  metaData: CowSwapWidgetMetaData
   provider?: EthereumProvider
 }

--- a/src/modules/appData/hooks.ts
+++ b/src/modules/appData/hooks.ts
@@ -1,11 +1,16 @@
 import { useAtomValue, useUpdateAtom } from 'jotai/utils'
+import { useMemo } from 'react'
 
 import { DEFAULT_APP_CODE, SAFE_APP_CODE } from 'legacy/constants'
 
 import { useIsSafeApp } from 'modules/wallet'
 
+import { isInjectedWidget } from 'common/utils/isInjectedWidget'
+
 import { addAppDataToUploadQueueAtom, appDataInfoAtom } from './state/atoms'
 import { AppDataInfo } from './types'
+
+import { injectedWidgetMetaDataAtom } from '../injectedWidget/state/injectedWidgetMetaDataAtom'
 
 const APP_CODE = process.env.REACT_APP_APP_CODE
 
@@ -17,13 +22,20 @@ export function useAppData(): AppDataInfo | null {
   return useAtomValue(appDataInfoAtom)
 }
 
-export function useAppCode(): string {
+export function useAppCode(): string | null {
+  const injectedWidgetMetaData = useAtomValue(injectedWidgetMetaDataAtom)
   const isSafeApp = useIsSafeApp()
 
-  if (APP_CODE) {
-    // appCode coming from env var has priority
-    return APP_CODE
-  }
+  return useMemo(() => {
+    if (isInjectedWidget()) {
+      return injectedWidgetMetaData?.appKey || null
+    }
 
-  return isSafeApp ? SAFE_APP_CODE : DEFAULT_APP_CODE
+    if (APP_CODE) {
+      // appCode coming from env var has priority
+      return APP_CODE
+    }
+
+    return isSafeApp ? SAFE_APP_CODE : DEFAULT_APP_CODE
+  }, [isSafeApp, injectedWidgetMetaData])
 }

--- a/src/modules/appData/updater/useAppDataUpdater.ts
+++ b/src/modules/appData/updater/useAppDataUpdater.ts
@@ -29,7 +29,7 @@ export function useAppDataUpdater({ chainId, slippageBips, orderClass, utm }: Us
   const appCode = useAppCode()
 
   useEffect(() => {
-    if (!chainId) {
+    if (!chainId || !appCode) {
       // reset values when there is no price estimation or network changes
       setAppDataInfo(null)
       return

--- a/src/modules/injectedWidget/state/injectedWidgetMetaDataAtom.ts
+++ b/src/modules/injectedWidget/state/injectedWidgetMetaDataAtom.ts
@@ -1,0 +1,8 @@
+import { atom } from 'jotai'
+
+export interface InjectedWidgetMetaData {
+  appKey: string
+  url: string
+}
+
+export const injectedWidgetMetaDataAtom = atom<InjectedWidgetMetaData | null>(null)

--- a/src/modules/injectedWidget/updaters/InjectedWidgetUpdater.ts
+++ b/src/modules/injectedWidget/updaters/InjectedWidgetUpdater.ts
@@ -1,34 +1,92 @@
 import { useUpdateAtom } from 'jotai/utils'
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 
 import { useNavigate } from 'react-router-dom'
 
 import { deepEqual } from 'utils/deepEqual'
 
+import { injectedWidgetMetaDataAtom } from '../state/injectedWidgetMetaDataAtom'
 import { injectedWidgetParamsAtom } from '../state/injectedWidgetParamsAtom'
 
 const COW_SWAP_WIDGET_EVENT_KEY = 'cowSwapWidget'
 
+const messagesCache: { [method: string]: unknown } = {}
+
+const getEventMethod = (event: MessageEvent) =>
+  (event.data.key === COW_SWAP_WIDGET_EVENT_KEY && (event.data.method as string)) || null
+
+const cacheMessages = (event: MessageEvent) => {
+  const method = getEventMethod(event)
+
+  if (!method) return
+
+  messagesCache[method] = event.data
+}
+
+/**
+ * To avoid delays, immediately send an activation message and start listening messages
+ */
+;(function initInjectedWidget() {
+  const isInIframe = window.top !== window.self
+
+  if (!window.top || !isInIframe) return
+
+  window.addEventListener('message', cacheMessages)
+
+  window.top.postMessage(
+    {
+      key: COW_SWAP_WIDGET_EVENT_KEY,
+      method: 'activate',
+    },
+    '*'
+  )
+})()
+
 export function InjectedWidgetUpdater() {
   const updateParams = useUpdateAtom(injectedWidgetParamsAtom)
+  const updateMetaData = useUpdateAtom(injectedWidgetMetaDataAtom)
   const navigate = useNavigate()
   const prevData = useRef(null)
 
-  useEffect(() => {
-    window.addEventListener('message', (event) => {
-      const method = event.data.method
-
-      if (event.data.key !== COW_SWAP_WIDGET_EVENT_KEY || !method) return
-
+  const processEvent = useCallback(
+    (method: string, data: any) => {
       if (method === 'update') {
-        if (prevData.current && deepEqual(prevData.current, event.data)) return
+        if (prevData.current && deepEqual(prevData.current, data)) return
 
-        prevData.current = event.data
-        updateParams(event.data.appParams)
-        navigate(event.data.urlParams)
+        prevData.current = data
+        updateParams(data.appParams)
+        navigate(data.urlParams)
       }
+
+      if (method === 'metaData') {
+        updateMetaData(data.metaData)
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
+
+  // Once app is loaded
+  useEffect(() => {
+    // Stop listening of message outside of React
+    window.removeEventListener('message', cacheMessages)
+
+    // Process all cached messages
+    Object.keys(messagesCache).forEach((method) => {
+      processEvent(method, messagesCache[method])
+
+      delete messagesCache[method]
     })
-  }, [navigate, updateParams])
+
+    // Start listening messages inside of React
+    window.addEventListener('message', (event) => {
+      const method = getEventMethod(event)
+
+      if (!method) return
+
+      processEvent(method, event.data)
+    })
+  }, [processEvent])
 
   return null
 }


### PR DESCRIPTION
# Summary

To distinguish orders related to an app that has the widget integrated, we pass `CowSwapWidgetMetaData` in the Widget and use it for `app-data`