### PR TITLE
fix(cypress): fix Cypress post nx changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,25 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: yarn
 
+      - name: Load dependencies
+        id: cache-node-modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules1-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules1-
+
+      - name: Load generated files
+        id: cache-generated-files
+        uses: actions/cache@v3
+        with:
+          path: |
+            src/types/v3
+            src/abis/types
+            src/state/data
+          key: ${{ runner.os }}-generatedFiles-${{ hashFiles('**/yarn.lock') }}
+
       # Install deps only
       - name: Cypress install dependencies
         id: cypress-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,11 +206,8 @@ jobs:
         id: cypress-run
         uses: cypress-io/github-action@v5.0.5
         with:
-          # Uncomment to test the production release. Right now, it doens't work the automatic "connection"
-          #   very likely it's related to Web3StatusMod!
-          #   when un-commenting this, we need to uncomment also the "Download website" I added in this PR and prevent cypres from buildig the project again
-          # start: yarn serve:ci
-          start: yarn start
+          build: yarn build
+          start: yarn serve
           wait-on: http://localhost:3000
           wait-on-timeout: 200
           command: yarn cypress:run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,11 +173,11 @@ jobs:
     name: Cypress
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
       - name: Increase watchers
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+
+      - name: Checkout code
+        uses: actions/checkout@v3
 
       - name: Set up node
         uses: actions/setup-node@v3
@@ -185,20 +185,36 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: yarn
 
-      # Install deps only
-      - name: Cypress install dependencies
-        id: cypress-deps
-        uses: cypress-io/github-action@v5.0.5
-        # Do not consider failure a failure. Well, sort of.
-        # See https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#steps-context
-        continue-on-error: true
+      # Load everything that's cached
+      - name: Load dependencies
+        id: cache-node-modules
+        uses: actions/cache@v3
         with:
-          runTests: false
+          path: node_modules
+          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules1-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules1-
 
+      - name: Load generated files
+        id: cache-generated-files
+        uses: actions/cache@v3
+        with:
+          path: |
+            src/types/v3
+            src/abis/types
+            src/state/data
+          key: ${{ runner.os }}-generatedFiles-${{ hashFiles('**/yarn.lock') }}
+
+      # Install everything that might be missing 🤷
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+        env:
+          # Do not install cypress binary
+          CYPRESS_INSTALL_BINARY: 0
+
+      # Cypress binary was not installed on previous step
       - name: Install Cypress binary
         id: cypress-bin
-        # Only run if previous step failed
-        if: steps.cypress-deps.outcome == 'failure'
         run: npx cypress install
 
       # Actually run tests, building repo
@@ -206,10 +222,6 @@ jobs:
         id: cypress-run
         uses: cypress-io/github-action@v5.0.5
         with:
-          # Uncomment to test the production release. Right now, it doens't work the automatic "connection"
-          #   very likely it's related to Web3StatusMod!
-          #   when un-commenting this, we need to uncomment also the "Download website" I added in this PR and prevent cypres from buildig the project again
-          # start: yarn serve:ci
           start: yarn start
           wait-on: http://localhost:3000
           wait-on-timeout: 200

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,7 @@ jobs:
           start: yarn start
           wait-on: http://localhost:3000
           wait-on-timeout: 200
+          command: yarn cypress:run
         env:
           CYPRESS_INTEGRATION_TEST_PRIVATE_KEY: ${{ secrets.CYPRESS_INTEGRATION_TEST_PRIVATE_KEY }}
           CYPRESS_INTEGRATION_TESTS_INFURA_KEY: ${{ secrets.CYPRESS_INTEGRATION_TESTS_INFURA_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,6 @@ jobs:
 
       # Open tmate ssh connection on failure for debugging
       # Uncomment when needed and push upstream
-#      - name: Setup tmate session
-#        uses: mxschmitt/action-tmate@v3
-#        if: ${{ failure() }}
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,6 @@ jobs:
 
       # Open tmate ssh connection on failure for debugging
       # Uncomment when needed and push upstream
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ failure() }}
+#      - name: Setup tmate session
+#        uses: mxschmitt/action-tmate@v3
+#        if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,8 +206,11 @@ jobs:
         id: cypress-run
         uses: cypress-io/github-action@v5.0.5
         with:
-          build: yarn build
-          start: yarn serve
+          # Uncomment to test the production release. Right now, it doens't work the automatic "connection"
+          #   very likely it's related to Web3StatusMod!
+          #   when un-commenting this, we need to uncomment also the "Download website" I added in this PR and prevent cypres from buildig the project again
+          # start: yarn serve:ci
+          start: yarn start
           wait-on: http://localhost:3000
           wait-on-timeout: 200
           command: yarn cypress:run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,25 +185,6 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: yarn
 
-      - name: Load dependencies
-        id: cache-node-modules
-        uses: actions/cache@v3
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules1-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules1-
-
-      - name: Load generated files
-        id: cache-generated-files
-        uses: actions/cache@v3
-        with:
-          path: |
-            src/types/v3
-            src/abis/types
-            src/state/data
-          key: ${{ runner.os }}-generatedFiles-${{ hashFiles('**/yarn.lock') }}
-
       # Install deps only
       - name: Cypress install dependencies
         id: cypress-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,7 @@ jobs:
         id: cypress-run
         uses: cypress-io/github-action@v5.0.5
         with:
+          install: false
           start: yarn start
           wait-on: http://localhost:3000
           wait-on-timeout: 200

--- a/cypress-custom/integration/search.test.ts
+++ b/cypress-custom/integration/search.test.ts
@@ -1,6 +1,6 @@
 describe('Search', () => {
   beforeEach(() => {
-    cy.visit('/')
+    cy.visit('/#/swap')
   })
 
   it('should be able to find a token by its name', () => {

--- a/cypress-custom/integration/search.test.ts
+++ b/cypress-custom/integration/search.test.ts
@@ -1,6 +1,6 @@
 describe('Search', () => {
   beforeEach(() => {
-    cy.visit('/#/swap')
+    cy.visit('/')
   })
 
   it('should be able to find a token by its name', () => {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "serve": "nx exec -- serve build -l 3000",
     "serve:ci": "nx exec -- serve website -l 3000",
     "cypress": "nx exec -- cypress open",
+    "cypress:run": "nx exec -- cypress run",
     "contracts:add:export": "nx exec -- node ./scripts/contracts_add_export.js",
     "contracts:compile:abi": "nx exec -- typechain --target ethers-v5 --out-dir src/abis/types './src/abis/**/*.json'",
     "contracts:compile:abi-ethflow": "nx exec -- typechain --target ethers-v5 --out-dir src/abis/types/ethflow \"./node_modules/@cowprotocol/ethflowcontract/artifacts/CoWSwapEthFlow.sol/*.json\"",


### PR DESCRIPTION
# Summary

Add and use custom `cypress:run` command to run it on CI.

Tests are all passing locally, but the default test command used in the [github action](https://github.com/cypress-io/github-action#custom-test-command) is not aware of `nx`.

This change uses the custom command to fix it.

  # To Test

1. Cypress tests should pass