### PR TITLE
fix: fix e2e

### DIFF
--- a/src/legacy/components/AmplitudeAnalytics/index.ts
+++ b/src/legacy/components/AmplitudeAnalytics/index.ts
@@ -7,9 +7,10 @@ import { Identify, identify, init, track } from '@amplitude/analytics-browser'
  * member of the organization on Amplitude to view details.
  */
 export function initializeAnalytics(isDevEnvironment = process.env.NODE_ENV === 'development') {
-  if (isDevEnvironment) return
-
   const API_KEY = process.env.REACT_APP_AMPLITUDE_KEY
+
+  if (isDevEnvironment || !API_KEY) return
+
   if (typeof API_KEY === 'undefined') {
     throw new Error(`REACT_APP_AMPLITUDE_KEY must be a defined environment variable`)
   }


### PR DESCRIPTION
# Summary

Restores a change that was lost in this PR https://github.com/cowprotocol/cowswap/pull/2707/files#r1238279108

The change was making amplitude env optional. If it is not present, the app breaks

## context

- https://cowservices.slack.com/archives/C0361CDG8GP/p1687870587361509
- 

# To Test

Check cypress e2e result