### PR TITLE
feat(hackathon-surplus): add surplus data to activity details

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "simple-sitemap-renderer": "^1.1.0",
     "styled-components": "^5.3.0",
     "styled-jsx": "5.1.2",
-    "swr": "^1.0.1",
+    "swr": "^2.2.0",
     "text-encoding-polyfill": "^0.6.7",
     "timeago.js": "^4.0.2",
     "tiny-invariant": "^1.2.0",

--- a/src/api/gnosisProtocol/api.ts
+++ b/src/api/gnosisProtocol/api.ts
@@ -1,17 +1,17 @@
 import {
-  OrderBookApiError,
-  PriceQuality,
-  SupportedChainId as ChainId,
+  Address,
   CowEnv,
-  OrderKind,
-  OrderQuoteRequest,
-  SigningScheme,
-  OrderQuoteResponse,
   EnrichedOrder,
   NativePriceResponse,
-  Trade,
+  OrderBookApiError,
+  OrderKind,
+  OrderQuoteRequest,
+  OrderQuoteResponse,
   PartialApiContext,
-  Address,
+  PriceQuality,
+  SigningScheme,
+  SupportedChainId as ChainId,
+  Trade,
 } from '@cowprotocol/cow-sdk'
 
 import { orderBookApi } from 'cowSdk'
@@ -199,4 +199,28 @@ export async function getProfileData(chainId: ChainId, address: string): Promise
   } else {
     return response.json()
   }
+}
+
+const NETWORK_TO_API_PREFIX = {
+  [ChainId.MAINNET]: 'mainnet',
+  [ChainId.GOERLI]: 'goerli',
+  [ChainId.GNOSIS_CHAIN]: 'xdai',
+}
+
+export type TotalSurplusData = {
+  totalSurplus: string
+}
+
+// TODO: Move to the SDK
+export async function getSurplusData(chainId: ChainId, address: string): Promise<TotalSurplusData> {
+  console.log(`[api:${API_NAME}] Get surplus data for`, chainId, address)
+
+  const baseUrl = `https://barn.api.cow.fi/${NETWORK_TO_API_PREFIX[chainId]}/api`
+  const url = `/v1/users/${address}/total_surplus`
+
+  const response = await fetch(baseUrl + url, {
+    headers: DEFAULT_HEADERS,
+  })
+
+  return response.json()
 }

--- a/src/modules/account/containers/AccountDetails/SurplusCard.tsx
+++ b/src/modules/account/containers/AccountDetails/SurplusCard.tsx
@@ -1,6 +1,9 @@
 import { MouseoverTooltipContent } from 'legacy/components/Tooltip'
 import { useHigherUSDValue } from 'legacy/hooks/useStablecoinPrice'
 import { ExternalLink } from 'legacy/theme'
+import { supportedChainId } from 'legacy/utils/supportedChainId'
+
+import { useWalletInfo } from 'modules/wallet'
 
 import { useSurplusAmount } from 'api/gnosisProtocol/hooks'
 import { FiatAmount } from 'common/pure/FiatAmount'
@@ -13,6 +16,10 @@ export function SurplusCard() {
   const { surplusAmount, isLoading } = useSurplusAmount()
 
   const surplusUsdAmount = useHigherUSDValue(surplusAmount)
+
+  const { chainId } = useWalletInfo()
+
+  if (!supportedChainId(chainId)) return null
 
   return (
     <InfoCard>

--- a/src/modules/account/containers/AccountDetails/SurplusCard.tsx
+++ b/src/modules/account/containers/AccountDetails/SurplusCard.tsx
@@ -1,0 +1,40 @@
+import { MouseoverTooltipContent } from 'legacy/components/Tooltip'
+import { useHigherUSDValue } from 'legacy/hooks/useStablecoinPrice'
+import { ExternalLink } from 'legacy/theme'
+
+import { useSurplusAmount } from 'api/gnosisProtocol/hooks'
+import { FiatAmount } from 'common/pure/FiatAmount'
+import { HelpCircle } from 'common/pure/HelpCircle'
+import { TokenAmount } from 'common/pure/TokenAmount'
+
+import { InfoCard } from './styled'
+
+export function SurplusCard() {
+  const { surplusAmount, isLoading } = useSurplusAmount()
+
+  const surplusUsdAmount = useHigherUSDValue(surplusAmount)
+
+  return (
+    <InfoCard>
+      <span>
+        Your total surplus{' '}
+        <MouseoverTooltipContent content={'TODO: insert tooltip'} wrap>
+          <HelpCircle size={14} />
+        </MouseoverTooltipContent>
+      </span>
+      <span>
+        {isLoading
+          ? 'Loading...'
+          : surplusAmount && (
+              <>
+                +<TokenAmount amount={surplusAmount} tokenSymbol={surplusAmount?.currency} />
+              </>
+            )}
+        {!surplusAmount && 'No surplus for the given time period'}
+      </span>
+      {surplusUsdAmount && <FiatAmount amount={surplusUsdAmount} accurate={false} />}
+      {/* TODO: add correct link */}
+      <ExternalLink href={'https://swap.cow.fi'}>Learn about surplus on CoW Swap ↗</ExternalLink>
+    </InfoCard>
+  )
+}

--- a/src/modules/account/containers/AccountDetails/index.tsx
+++ b/src/modules/account/containers/AccountDetails/index.tsx
@@ -9,18 +9,19 @@ import { Trans } from '@lingui/macro'
 import Copy from 'legacy/components/Copy'
 import { MouseoverTooltip } from 'legacy/components/Tooltip'
 import UnsupporthedNetworkMessage from 'legacy/components/UnsupportedNetworkMessage'
-import { groupActivitiesByDay, useMultipleActivityDescriptors } from 'legacy/hooks/useRecentActivity'
-import { ActivityDescriptors } from 'legacy/hooks/useRecentActivity'
+import {
+  ActivityDescriptors,
+  groupActivitiesByDay,
+  useMultipleActivityDescriptors,
+} from 'legacy/hooks/useRecentActivity'
 import { ExternalLink } from 'legacy/theme'
-import { getEtherscanLink } from 'legacy/utils'
-import { getExplorerLabel, shortenAddress } from 'legacy/utils'
+import { getEtherscanLink, getExplorerLabel, shortenAddress } from 'legacy/utils'
 import { getExplorerAddressLink } from 'legacy/utils/explorer'
 import { supportedChainId } from 'legacy/utils/supportedChainId'
 import { isMobile } from 'legacy/utils/userAgent'
 
 import Activity from 'modules/account/containers/Transaction'
-import { ConnectionType, useWalletInfo, WalletDetails } from 'modules/wallet'
-import { useDisconnectWallet } from 'modules/wallet'
+import { ConnectionType, useDisconnectWallet, useWalletInfo, WalletDetails } from 'modules/wallet'
 import CoinbaseWalletIcon from 'modules/wallet/api/assets/coinbase.svg'
 import FortmaticIcon from 'modules/wallet/api/assets/formatic.png'
 import KeystoneImage from 'modules/wallet/api/assets/keystone.svg'
@@ -48,23 +49,24 @@ import { walletConnectConnection } from 'modules/wallet/web3-react/connection/wa
 import { walletConnectConnectionV2 } from 'modules/wallet/web3-react/connection/walletConnectV2'
 
 import {
-  NetworkCard,
-  Wrapper,
-  InfoCard,
-  AccountGroupingRow,
-  NoActivityMessage,
-  LowerSection,
-  WalletActions,
-  WalletSecondaryActions,
-  WalletNameAddress,
-  WalletWrapper,
-  WalletName,
-  WalletAction,
   AccountControl,
+  AccountGroupingRow,
   AddressLink,
   IconWrapper,
+  InfoCard,
+  LowerSection,
+  NetworkCard,
+  NoActivityMessage,
   TransactionListWrapper,
+  WalletAction,
+  WalletActions,
+  WalletName,
+  WalletNameAddress,
+  WalletSecondaryActions,
+  WalletWrapper,
+  Wrapper,
 } from './styled'
+import { SurplusCard } from './SurplusCard'
 
 import { CreationDateText } from '../Transaction/styled'
 
@@ -273,6 +275,8 @@ export function AccountDetails({
           </AccountControl>
         </AccountGroupingRow>
       </InfoCard>
+
+      <SurplusCard />
 
       {activityTotalCount ? (
         <LowerSection>

--- a/src/utils/amountFormat/index.ts
+++ b/src/utils/amountFormat/index.ts
@@ -45,10 +45,10 @@ export function formatAmountWithPrecision(
   const decimalsSeparator = numberFormat.format(1.1)[1]
 
   // Trim the remainder up to precision
-  const reminderWithPrecission = remainder.toFixed(precision, undefined, Rounding.ROUND_HALF_UP)
+  const reminderWithPrecision = remainder.toFixed(precision, undefined, Rounding.ROUND_HALF_UP)
 
   // If rounding up means we carry over to the next integer, add 1 to quotient
-  const adjustedQuotient = +reminderWithPrecission >= 1 ? JSBI.add(quotient, JSBI.BigInt(1)) : quotient
+  const adjustedQuotient = +reminderWithPrecision >= 1 ? JSBI.add(quotient, JSBI.BigInt(1)) : quotient
 
   // Apply the language formatting for the amount
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat
@@ -57,7 +57,7 @@ export function formatAmountWithPrecision(
   )
 
   // Remove trailing zeros
-  const reminderWithotTrailingZeros = trimTrailingZeros(reminderWithPrecission)
+  const reminderWithotTrailingZeros = trimTrailingZeros(reminderWithPrecision)
 
   // Make sure the reminder is internationalised
   const formattedRemainder =

--- a/yarn.lock
+++ b/yarn.lock
@@ -23002,10 +23002,12 @@ swarm-js@^0.1.40:
     tar "^4.0.2"
     xhr-request "^1.0.1"
 
-swr@^1.0.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/swr/-/swr-1.3.0.tgz#c6531866a35b4db37b38b72c45a63171faf9f4e8"
-  integrity sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==
+swr@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-2.2.0.tgz#575c6ac1bec087847f4c86a39ccbc0043c834d6a"
+  integrity sha512-AjqHOv2lAhkuUdIiBu9xbuettzAzWXmCEcLONNKJRba87WAefz8Ca9d6ds/SzrPc235n1IxWYdhJ2zF3MNUaoQ==
+  dependencies:
+    use-sync-external-store "^1.2.0"
 
 symbol-tree@^3.2.4:
   version "3.2.4"
@@ -24051,7 +24053,7 @@ use-sidecar@^1.0.1, use-sidecar@^1.0.5:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
 
-use-sync-external-store@1.2.0, use-sync-external-store@^1.0.0:
+use-sync-external-store@1.2.0, use-sync-external-store@^1.0.0, use-sync-external-store@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==


### PR DESCRIPTION
# Summary

First part of hackathon surplus project.

Using backend's new api: https://barn.api.cow.fi/xdai/api/v1/users/0x4CBc3B6B16Ac4218169078aDd37947B76127E10B/total_surplus

Add surplus data to activity details 
![image](https://github.com/cowprotocol/cowswap/assets/43217/ee0d72dd-0eb5-4c39-a529-7bd3f8377d5c)

Figma: https://www.figma.com/file/FrpBXkN4ZNuVhfXp4RJtI4/2023-Account-Modal?type=design&node-id=0-1&mode=design

# ⚠️ Notes ⚠️
- Styling not included
- API fn should be moved to SDK, will do so in an upcoming PR
- Right now only queries barn
- Tooltip missing
- Real link missing

# To Test

1. Connect wallet
2. Open activity details
* Surplus card should be displayed