### PR TITLE
feat(hackathon-surplus): add new surplus modal when order filled

### DIFF
--- a/src/common/pure/TransactionSubmittedContent/SurplusModal.tsx
+++ b/src/common/pure/TransactionSubmittedContent/SurplusModal.tsx
@@ -1,0 +1,48 @@
+import { OrderKind } from '@cowprotocol/cow-sdk'
+
+import { Order } from 'legacy/state/orders/actions'
+import { ExternalLink } from 'legacy/theme'
+
+import { useGetSurplusData } from 'common/hooks/useGetSurplusFiatValue'
+import { FiatAmount } from 'common/pure/FiatAmount'
+import { TokenAmount } from 'common/pure/TokenAmount'
+
+const SELL_SURPLUS_WORD = 'got'
+const BUY_SURPLUS_WORD = 'saved'
+
+export type SurplusModalProps = {
+  order: Order | undefined
+}
+
+export function SurplusModal(props: SurplusModalProps) {
+  const { order } = props
+
+  const { surplusFiatValue, showFiatValue, surplusToken, surplusAmount } = useGetSurplusData(order)
+
+  if (!order) {
+    return null
+  }
+
+  const surplusMsg = `You ${order.kind === OrderKind.SELL ? SELL_SURPLUS_WORD : BUY_SURPLUS_WORD} an extra`
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+      <h2>Swap completed</h2>
+      {/* TODO: add image */}
+      <span>--nice image here--</span>
+      <span>Great! {surplusMsg}</span>
+      <strong>
+        <TokenAmount amount={surplusAmount} tokenSymbol={surplusToken} />
+      </strong>
+      {showFiatValue && <FiatAmount amount={surplusFiatValue} accurate={false} />}
+      {/* TODO: add twitter button with styles */}
+      {/* TODO: add share data */}
+      <ExternalLink href="https://cow.fi">Share this win!</ExternalLink>
+      {/* TODO: add proper link */}
+      <span>
+        CoW Swap is the only token exchange that gets you extra tokens.{' '}
+        <ExternalLink href={'https://cow.fi'}>Learn how ↗</ExternalLink>
+      </span>
+    </div>
+  )
+}

--- a/src/common/pure/TransactionSubmittedContent/SurplusModal.tsx
+++ b/src/common/pure/TransactionSubmittedContent/SurplusModal.tsx
@@ -32,7 +32,7 @@ export function SurplusModal(props: SurplusModalProps) {
       <span>--nice image here--</span>
       <span>Great! {surplusMsg}</span>
       <strong>
-        <TokenAmount amount={surplusAmount} tokenSymbol={surplusToken} />
+        <TokenAmount amount={surplusAmount} tokenSymbol={surplusToken} />!
       </strong>
       {showFiatValue && <FiatAmount amount={surplusFiatValue} accurate={false} />}
       {/* TODO: add twitter button with styles */}

--- a/src/common/pure/TransactionSubmittedContent/index.tsx
+++ b/src/common/pure/TransactionSubmittedContent/index.tsx
@@ -21,6 +21,7 @@ import AddToMetamask from 'modules/wallet/web3-react/containers/AddToMetamask'
 import { Routes } from 'common/constants/routes'
 
 import * as styledEl from './styled'
+import { SurplusModal } from './SurplusModal'
 
 const activityStatusLabels: Partial<Record<ActivityStatus, string>> = {
   [ActivityStatus.CONFIRMED]: 'Confirmed',
@@ -58,6 +59,7 @@ export function TransactionSubmittedContent({
   const activityState = activityDerivedState && getActivityState(activityDerivedState)
   const showProgressBar = activityState === 'open' || activityState === 'filled'
   const { order } = activityDerivedState || {}
+  const showSurplus = activityState === 'filled'
 
   if (!supportedChainId(chainId)) {
     return null
@@ -69,26 +71,32 @@ export function TransactionSubmittedContent({
         <styledEl.Header>
           <styledEl.CloseIconWrapper onClick={onDismiss} />
         </styledEl.Header>
-        <Text fontWeight={600} fontSize={28}>
-          {getTitleStatus(activityDerivedState)}
-        </Text>
-        <DisplayLink id={hash} chainId={chainId} />
-        <EthFlowStepper order={order} />
-        {/*TODO: refactor OrderProgressBar to make it pure*/}
-        {activityDerivedState && showProgressBar && (
-          <OrderProgressBar hash={hash} activityDerivedState={activityDerivedState} chainId={chainId} />
-        )}
-        <styledEl.ButtonGroup>
-          {/*TODO: refactor AddToMetamask to make it pure*/}
-          <AddToMetamask shortLabel currency={currencyToAdd} />
+        {showSurplus ? (
+          <SurplusModal order={order} />
+        ) : (
+          <>
+            <Text fontWeight={600} fontSize={28}>
+              {getTitleStatus(activityDerivedState)}
+            </Text>
+            <DisplayLink id={hash} chainId={chainId} />
+            <EthFlowStepper order={order} />
+            {/*TODO: refactor OrderProgressBar to make it pure*/}
+            {activityDerivedState && showProgressBar && (
+              <OrderProgressBar hash={hash} activityDerivedState={activityDerivedState} chainId={chainId} />
+            )}
+            <styledEl.ButtonGroup>
+              {/*TODO: refactor AddToMetamask to make it pure*/}
+              <AddToMetamask shortLabel currency={currencyToAdd} />
 
-          <styledEl.ButtonCustom>
-            <Link to={Routes.PLAY_COWRUNNER} onClick={onDismiss}>
-              <styledEl.StyledIcon src={GameIcon} alt="Play CowGame" />
-              Play the CoW Runner Game!
-            </Link>
-          </styledEl.ButtonCustom>
-        </styledEl.ButtonGroup>
+              <styledEl.ButtonCustom>
+                <Link to={Routes.PLAY_COWRUNNER} onClick={onDismiss}>
+                  <styledEl.StyledIcon src={GameIcon} alt="Play CowGame" />
+                  Play the CoW Runner Game!
+                </Link>
+              </styledEl.ButtonCustom>
+            </styledEl.ButtonGroup>
+          </>
+        )}
       </styledEl.Section>
     </styledEl.Wrapper>
   )

--- a/src/legacy/components/TransactionConfirmationModal/index.tsx
+++ b/src/legacy/components/TransactionConfirmationModal/index.tsx
@@ -2,10 +2,11 @@ import React, { ReactNode } from 'react'
 
 import { Currency } from '@uniswap/sdk-core'
 
-import { useActivityDerivedState } from 'legacy/hooks/useActivityDerivedState'
+import { getActivityState, useActivityDerivedState } from 'legacy/hooks/useActivityDerivedState'
 import { useMultipleActivityDescriptors } from 'legacy/hooks/useRecentActivity'
 import { handleFollowPendingTxPopupAtom, useUpdateAtom } from 'legacy/state/application/atoms'
 
+import { ActivityDerivedState } from 'modules/account/containers/Transaction'
 import { useWalletInfo } from 'modules/wallet'
 
 import { GpModal } from 'common/pure/Modal'
@@ -44,6 +45,8 @@ export function TransactionConfirmationModal({
 
   if (!chainId) return null
 
+  const width = getWidth(hash, activityDerivedState)
+
   const _onDismiss =
     !attemptingTxn && hash
       ? () => {
@@ -53,7 +56,7 @@ export function TransactionConfirmationModal({
       : onDismiss
 
   return (
-    <GpModal isOpen={isOpen} onDismiss={_onDismiss} maxHeight={90} maxWidth={hash ? 850 : 470}>
+    <GpModal isOpen={isOpen} onDismiss={_onDismiss} maxHeight={90} maxWidth={width}>
       {attemptingTxn ? (
         <LegacyConfirmationPendingContent
           chainId={chainId}
@@ -70,8 +73,18 @@ export function TransactionConfirmationModal({
           currencyToAdd={currencyToAdd}
         />
       ) : (
-        content && content()
+        content?.()
       )}
     </GpModal>
   )
+}
+
+function getWidth(hash: string | undefined, activityDerivedState: ActivityDerivedState | null): number {
+  if (activityDerivedState && getActivityState(activityDerivedState) === 'filled') {
+    return 400
+  }
+  if (hash) {
+    return 850
+  }
+  return 470
 }


### PR DESCRIPTION
# Summary

Continuing hackathon surplus project

Follow up to https://github.com/cowprotocol/cowswap/pull/2751

Display the new surplus modal when the order is filled

As you can see, it's very close to the design, only some minor stylings missing

|This|Design|
|-|-|
| ![Screenshot 2023-06-29 at 16 58 56](https://github.com/cowprotocol/cowswap/assets/43217/2b04e575-d6ef-4237-9ed3-6bcbf0ee153b) | ![image](https://github.com/cowprotocol/cowswap/assets/43217/01337017-2f35-4baa-b7b3-d21cb0264a69) |

# ⚠️ Notes ⚠️
- Styling not included
- Share button has no data
- Link to `learn more` is missing
- Modal must be open after order placement to see it

# To Test

1. Place order
2. Keep order confirmation modal open
* Once order is filled, the new modal should be displayed