### PR TITLE
Surplus account styling 1

### DIFF
--- a/src/legacy/theme/baseTheme.tsx
+++ b/src/legacy/theme/baseTheme.tsx
@@ -169,6 +169,7 @@ export function themeVariables(darkMode: boolean, colorsTheme: Colors) {
     boxShadow2: '0 4px 12px 0 rgb(0 0 0 / 15%)',
     boxShadow3: `0 4px 12px 0 ${transparentize(0.9, colorsTheme.text3)}`,
     gradient1: `linear-gradient(145deg, ${colorsTheme.bg1}, ${colorsTheme.grey1})`,
+    gradient2: `linear-gradient(250deg, ${transparentize(0.92, colorsTheme.alert)} 10%, ${transparentize(0.92, colorsTheme.success)} 50%, ${transparentize(0.92, colorsTheme.success)} 100%);`,
     input: {
       bg1: darkMode ? '#07162D' : '#ECF1F8',
     },

--- a/src/legacy/theme/baseTheme.tsx
+++ b/src/legacy/theme/baseTheme.tsx
@@ -169,7 +169,10 @@ export function themeVariables(darkMode: boolean, colorsTheme: Colors) {
     boxShadow2: '0 4px 12px 0 rgb(0 0 0 / 15%)',
     boxShadow3: `0 4px 12px 0 ${transparentize(0.9, colorsTheme.text3)}`,
     gradient1: `linear-gradient(145deg, ${colorsTheme.bg1}, ${colorsTheme.grey1})`,
-    gradient2: `linear-gradient(250deg, ${transparentize(0.92, colorsTheme.alert)} 10%, ${transparentize(0.92, colorsTheme.success)} 50%, ${transparentize(0.92, colorsTheme.success)} 100%);`,
+    gradient2: `linear-gradient(250deg, ${transparentize(0.92, colorsTheme.alert)} 10%, ${transparentize(
+      0.92,
+      colorsTheme.success
+    )} 50%, ${transparentize(0.92, colorsTheme.success)} 100%);`,
     input: {
       bg1: darkMode ? '#07162D' : '#ECF1F8',
     },

--- a/src/legacy/theme/styled.d.ts
+++ b/src/legacy/theme/styled.d.ts
@@ -136,6 +136,7 @@ declare module 'styled-components' {
     boxShadow2: string
     boxShadow3: string
     gradient1: string
+    gradient2: string
     input: {
       bg1: Color
     }

--- a/src/modules/account/containers/AccountDetails/SurplusCard.tsx
+++ b/src/modules/account/containers/AccountDetails/SurplusCard.tsx
@@ -146,7 +146,7 @@ export function SurplusCard() {
         </div>
         <div>
           {/* TODO: add correct link */}
-          <ExternalLink href={'https://swap.cow.fi'}>Learn about surplus on CoW Swap ↗</ExternalLink>
+          <ExternalLink href={'https://blog.cow.fi/announcing-cow-swap-surplus-notifications-f679c77702ea'}>Learn about surplus on CoW Swap ↗</ExternalLink>
         </div>
       </InfoCard>
     </Wrapper>

--- a/src/modules/account/containers/AccountDetails/SurplusCard.tsx
+++ b/src/modules/account/containers/AccountDetails/SurplusCard.tsx
@@ -65,19 +65,28 @@ export function SurplusCard() {
 
     ${InfoCard} > div > span {
       display: flex;
+      flex-flow: column wrap;
       align-items: center;
       justify-content: center;
     }
 
     ${InfoCard} > div > span > i,
-    ${InfoCard} > div > a {
+    ${InfoCard} > div > a,
+    ${InfoCard} > div > span > p {
+      display: flex;
       font-size: 13px;
       font-style: normal;
       font-weight: 500;
       line-height: 1.1;
       width: 100%;
       text-align: center;
+      justify-content: center;
+      align-items: center;
       color: ${({ theme }) => transparentize(0.3, theme.text1)};
+    }
+
+    ${InfoCard} > div > span > p {
+      color: ${({ theme }) => theme.text1};
     }
 
     ${InfoCard} > div > span > b {
@@ -117,17 +126,17 @@ export function SurplusCard() {
       <InfoCard>
         <div>
           <span>
-            <i>Your total surplus</i> <QuestionHelper text={'TODO: insert tooltip'} />
+            <i>Your total surplus <QuestionHelper text={'TODO: insert tooltip'} /></i>
           </span>
           <span>
             {isLoading
-              ? 'Loading...'
+              ? <p>Loading...</p>
               : surplusAmount && (
                   <b>
                     +<TokenAmount amount={surplusAmount} tokenSymbol={surplusAmount?.currency} />
                   </b>
                 )}
-            {!surplusAmount && 'No surplus for the given time period'}
+            {!surplusAmount && <p>No surplus for the given time period</p>}
           </span>
           <small>{surplusUsdAmount && <FiatAmount amount={surplusUsdAmount} accurate={false} />}</small>
         </div>

--- a/src/modules/account/containers/AccountDetails/SurplusCard.tsx
+++ b/src/modules/account/containers/AccountDetails/SurplusCard.tsx
@@ -17,13 +17,21 @@ export function SurplusCard() {
   const surplusUsdAmount = useHigherUSDValue(surplusAmount)
 
   const Wrapper = styled.div`
-    margin: 0 auto 10px;
+    margin: 0 auto 24px;
     width: 100%;
     display: grid;
     align-items: center;
     justify-content: center;
-    grid-template-columns: repeat(2, 50%);
-    gap: 10px;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 24px;
+    box-sizing: border-box;
+    padding: 0 24px;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      display: flex;
+      flex-flow: column wrap;
+      padding: 0 16px;
+    `}
 
     ${InfoCard} {
       display: flex;
@@ -35,8 +43,9 @@ export function SurplusCard() {
       border-radius: 16px;
       padding: 20px 26px 26px;
       min-height: 210px;
-      width: 100%:
+      width: 100%;
       max-width: 100%;
+      margin: 0;
     }
 
     ${InfoCard} > div {

--- a/src/modules/account/containers/AccountDetails/SurplusCard.tsx
+++ b/src/modules/account/containers/AccountDetails/SurplusCard.tsx
@@ -33,7 +33,7 @@ export function SurplusCard() {
       gap: 0;
       background: ${({ theme }) => theme.gradient2};
       border-radius: 16px;
-      padding: 26px;
+      padding: 20px 26px 26px;
       min-height: 210px;
       width: 100%:
       max-width: 100%;
@@ -86,7 +86,7 @@ export function SurplusCard() {
     }
 
     ${InfoCard} > div > small {
-      font-size: 14px;
+      font-size: 15px;
       font-weight: 500;
       line-height: 1.1;
       color: ${({ theme }) => transparentize(0.5, theme.text1)};

--- a/src/modules/account/containers/AccountDetails/SurplusCard.tsx
+++ b/src/modules/account/containers/AccountDetails/SurplusCard.tsx
@@ -126,16 +126,20 @@ export function SurplusCard() {
       <InfoCard>
         <div>
           <span>
-            <i>Your total surplus <QuestionHelper text={'TODO: insert tooltip'} /></i>
+            <i>
+              Your total surplus <QuestionHelper text={'TODO: insert tooltip'} />
+            </i>
           </span>
           <span>
-            {isLoading
-              ? <p>Loading...</p>
-              : surplusAmount && (
-                  <b>
-                    +<TokenAmount amount={surplusAmount} tokenSymbol={surplusAmount?.currency} />
-                  </b>
-                )}
+            {isLoading ? (
+              <p>Loading...</p>
+            ) : (
+              surplusAmount && (
+                <b>
+                  +<TokenAmount amount={surplusAmount} tokenSymbol={surplusAmount?.currency} />
+                </b>
+              )
+            )}
             {!surplusAmount && <p>No surplus for the given time period</p>}
           </span>
           <small>{surplusUsdAmount && <FiatAmount amount={surplusUsdAmount} accurate={false} />}</small>

--- a/src/modules/account/containers/AccountDetails/SurplusCard.tsx
+++ b/src/modules/account/containers/AccountDetails/SurplusCard.tsx
@@ -1,9 +1,11 @@
-import { MouseoverTooltipContent } from 'legacy/components/Tooltip'
+import { transparentize } from 'polished'
+import styled from 'styled-components/macro'
+
+import QuestionHelper, { QuestionWrapper } from 'legacy/components/QuestionHelper'
 import { useHigherUSDValue } from 'legacy/hooks/useStablecoinPrice'
 import { ExternalLink } from 'legacy/theme'
 
 import { FiatAmount } from 'common/pure/FiatAmount'
-import { HelpCircle } from 'common/pure/HelpCircle'
 import { TokenAmount } from 'common/pure/TokenAmount'
 import { useTotalSurplus } from 'common/state/totalSurplusState'
 
@@ -14,27 +16,117 @@ export function SurplusCard() {
 
   const surplusUsdAmount = useHigherUSDValue(surplusAmount)
 
+  const Wrapper = styled.div`
+    margin: 0 auto 10px;
+    width: 100%;
+    display: grid;
+    align-items: center;
+    justify-content: center;
+    grid-template-columns: repeat(2, 50%);
+    gap: 10px;
+
+    ${InfoCard} {
+      display: flex;
+      flex-flow: column wrap;
+      align-items: center;
+      justify-content: center;
+      gap: 0;
+      background: ${({ theme }) => theme.gradient2};
+      border-radius: 16px;
+      padding: 26px;
+      min-height: 210px;
+      width: 100%:
+      max-width: 100%;
+    }
+
+    ${InfoCard} > div {
+      display: flex;
+      flex-flow: column wrap;
+      align-items: center;
+      justify-content: center;
+
+      &:first-child {
+        margin: 20px auto 0;
+      }
+
+      &:last-child {
+        margin: auto 0 0;
+      }
+    }
+
+    ${InfoCard} > div > span {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    ${InfoCard} > div > span > i,
+    ${InfoCard} > div > a {
+      font-size: 13px;
+      font-style: normal;
+      font-weight: 500;
+      line-height: 1.1;
+      width: 100%;
+      text-align: center;
+      color: ${({ theme }) => transparentize(0.3, theme.text1)};
+    }
+
+    ${InfoCard} > div > span > b {
+      font-size: 28px;
+      font-weight: bold;
+      color: ${({ theme }) => theme.success};
+      width: 100%;
+      text-align: center;
+      margin: 20px auto 0;
+      word-break: break-all;
+    }
+
+    ${InfoCard} > div > a {
+      margin: 20px auto 0;
+    }
+
+    ${InfoCard} > div > small {
+      font-size: 14px;
+      font-weight: 500;
+      line-height: 1.1;
+      color: ${({ theme }) => transparentize(0.5, theme.text1)};
+      margin: 3px auto 0;
+    }
+
+    ${QuestionWrapper} {
+      opacity: 0.5;
+      transition: opacity 0.2s ease-in-out;
+
+      &:hover {
+        opacity: 1;
+      }
+    }
+  `
+
   return (
-    <InfoCard>
-      <span>
-        Your total surplus{' '}
-        <MouseoverTooltipContent content={'TODO: insert tooltip'} wrap>
-          <HelpCircle size={14} />
-        </MouseoverTooltipContent>
-      </span>
-      <span>
-        {isLoading
-          ? 'Loading...'
-          : surplusAmount && (
-              <>
-                +<TokenAmount amount={surplusAmount} tokenSymbol={surplusAmount?.currency} />
-              </>
-            )}
-        {!surplusAmount && 'No surplus for the given time period'}
-      </span>
-      {surplusUsdAmount && <FiatAmount amount={surplusUsdAmount} accurate={false} />}
-      {/* TODO: add correct link */}
-      <ExternalLink href={'https://swap.cow.fi'}>Learn about surplus on CoW Swap ↗</ExternalLink>
-    </InfoCard>
+    <Wrapper>
+      <InfoCard>
+        <div>
+          <span>
+            <i>Your total surplus</i> <QuestionHelper text={'TODO: insert tooltip'} />
+          </span>
+          <span>
+            {isLoading
+              ? 'Loading...'
+              : surplusAmount && (
+                  <b>
+                    +<TokenAmount amount={surplusAmount} tokenSymbol={surplusAmount?.currency} />
+                  </b>
+                )}
+            {!surplusAmount && 'No surplus for the given time period'}
+          </span>
+          <small>{surplusUsdAmount && <FiatAmount amount={surplusUsdAmount} accurate={false} />}</small>
+        </div>
+        <div>
+          {/* TODO: add correct link */}
+          <ExternalLink href={'https://swap.cow.fi'}>Learn about surplus on CoW Swap ↗</ExternalLink>
+        </div>
+      </InfoCard>
+    </Wrapper>
   )
 }

--- a/src/modules/account/containers/AccountDetails/SurplusCard.tsx
+++ b/src/modules/account/containers/AccountDetails/SurplusCard.tsx
@@ -146,7 +146,9 @@ export function SurplusCard() {
         </div>
         <div>
           {/* TODO: add correct link */}
-          <ExternalLink href={'https://blog.cow.fi/announcing-cow-swap-surplus-notifications-f679c77702ea'}>Learn about surplus on CoW Swap ↗</ExternalLink>
+          <ExternalLink href={'https://blog.cow.fi/announcing-cow-swap-surplus-notifications-f679c77702ea'}>
+            Learn about surplus on CoW Swap ↗
+          </ExternalLink>
         </div>
       </InfoCard>
     </Wrapper>

--- a/src/modules/account/containers/AccountDetails/SurplusCard.tsx
+++ b/src/modules/account/containers/AccountDetails/SurplusCard.tsx
@@ -22,7 +22,7 @@ export function SurplusCard() {
     display: grid;
     align-items: center;
     justify-content: center;
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: 1fr;
     gap: 24px;
     box-sizing: border-box;
     padding: 0 24px;


### PR DESCRIPTION
# Summary

- Styles the surplus card in the account modal
<img width="393" alt="Screenshot 2023-07-03 at 13 54 27" src="https://github.com/cowprotocol/cowswap/assets/31534717/cb04faa1-e708-452f-8155-51e3394671be">
<img width="885" alt="Screenshot 2023-07-03 at 13 54 09" src="https://github.com/cowprotocol/cowswap/assets/31534717/3ebc8d8f-b6c3-4d5a-ad36-d525a34ff2a9">
<img width="897" alt="Screenshot 2023-07-03 at 13 53 54" src="https://github.com/cowprotocol/cowswap/assets/31534717/b6a4b88f-eab5-405b-b92a-6a4866f22b4b">



## Todo
- Add text for tooltip
- Decide on 2nd card 