### PR TITLE
feat(hackathon-surplus): refresh surplus on swap trade

### DIFF
--- a/src/api/gnosisProtocol/hooks.ts
+++ b/src/api/gnosisProtocol/hooks.ts
@@ -111,4 +111,3 @@ function useTwapChildOrders(prodOrders: EnrichedOrder[] | undefined): OrderWithC
     return orderWithComposableCowInfo
   }, [twapParticleOrders, prodOrders])
 }
-

--- a/src/api/gnosisProtocol/hooks.ts
+++ b/src/api/gnosisProtocol/hooks.ts
@@ -2,10 +2,8 @@ import { useAtomValue } from 'jotai'
 import { useMemo } from 'react'
 
 import { EnrichedOrder } from '@cowprotocol/cow-sdk'
-import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
 import useSWR from 'swr'
-import { Nullish } from 'types'
 
 import { AMOUNT_OF_ORDERS_TO_FETCH } from 'legacy/constants'
 import { isBarnBackendEnv } from 'legacy/utils/environments'
@@ -17,9 +15,8 @@ import { TwapPartOrderItem, twapPartOrdersListAtom } from 'modules/twap/state/tw
 import { useWalletInfo } from 'modules/wallet'
 
 import { OrderWithComposableCowInfo } from 'common/types'
-import useNativeCurrency from 'lib/hooks/useNativeCurrency'
 
-import { getOrders, getSurplusData } from './api'
+import { getOrders } from './api'
 
 /**
  * TODO: refactor this hook
@@ -115,33 +112,3 @@ function useTwapChildOrders(prodOrders: EnrichedOrder[] | undefined): OrderWithC
   }, [twapParticleOrders, prodOrders])
 }
 
-export type UseSurplusAmountResult = {
-  surplusAmount: Nullish<CurrencyAmount<Currency>>
-  isLoading: boolean
-  error: string
-}
-
-export function useSurplusAmount(): UseSurplusAmountResult {
-  const { chainId, account } = useWalletInfo()
-  const nativeCurrency = useNativeCurrency()
-
-  const {
-    data: surplusAmount,
-    isLoading,
-    error,
-  } = useSWR<CurrencyAmount<Currency> | null>(['totalSurplus', chainId, account], async () => {
-    if (!chainId || !account) {
-      return null
-    }
-
-    const surplusData = await getSurplusData(chainId, account)
-
-    if (!surplusData?.totalSurplus) {
-      return null
-    }
-
-    return CurrencyAmount.fromRawAmount(nativeCurrency, surplusData.totalSurplus)
-  })
-
-  return { surplusAmount, isLoading, error }
-}

--- a/src/common/state/totalSurplusState.ts
+++ b/src/common/state/totalSurplusState.ts
@@ -1,0 +1,58 @@
+import { atom, useAtomValue } from 'jotai'
+import { useUpdateAtom } from 'jotai/utils'
+
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
+
+import useSWR from 'swr'
+import { Nullish } from 'types'
+
+import { useWalletInfo } from 'modules/wallet'
+
+import { getSurplusData } from 'api/gnosisProtocol/api'
+import useNativeCurrency from 'lib/hooks/useNativeCurrency'
+
+export type TotalSurplusState = {
+  surplusAmount: Nullish<CurrencyAmount<Currency>>
+  isLoading: boolean
+  error: string
+}
+
+const totalSurplusAtom = atom<TotalSurplusState>({
+  surplusAmount: null,
+
+  isLoading: false,
+
+  error: '',
+})
+
+export function TotalSurplusUpdater(): null {
+  const { chainId, account } = useWalletInfo()
+  const nativeCurrency = useNativeCurrency()
+  const setTotalSurplus = useUpdateAtom(totalSurplusAtom)
+
+  const {
+    data: surplusAmount,
+    isLoading,
+    error,
+  } = useSWR<CurrencyAmount<Currency> | null>(
+    // Don't load if required params are missing: https://swr.vercel.app/docs/conditional-fetching
+    chainId && account ? ['getSurplusData', chainId, account] : null,
+    async ([, chainId, account]: [string, number, string]) => {
+      const surplusData = await getSurplusData(chainId, account)
+
+      if (!surplusData?.totalSurplus) {
+        return null
+      }
+
+      return CurrencyAmount.fromRawAmount(nativeCurrency, surplusData.totalSurplus)
+    }
+  )
+
+  setTotalSurplus({ surplusAmount, isLoading, error })
+
+  return null
+}
+
+export function useTotalSurplus(): TotalSurplusState {
+  return useAtomValue(totalSurplusAtom)
+}

--- a/src/common/state/totalSurplusState/atoms.ts
+++ b/src/common/state/totalSurplusState/atoms.ts
@@ -1,0 +1,12 @@
+import { atom } from 'jotai'
+
+import { TotalSurplusState } from './types'
+
+export const totalSurplusAtom = atom<TotalSurplusState>({
+  surplusAmount: null,
+  isLoading: false,
+  error: '',
+  refetch: null,
+})
+
+export const totalSurplusRefetchAtom = atom((get) => get(totalSurplusAtom).refetch)

--- a/src/common/state/totalSurplusState/hooks.ts
+++ b/src/common/state/totalSurplusState/hooks.ts
@@ -1,0 +1,12 @@
+import { useAtomValue } from 'jotai'
+
+import { totalSurplusAtom, totalSurplusRefetchAtom } from './atoms'
+import { TotalSurplusState } from './types'
+
+export function useTotalSurplus(): TotalSurplusState {
+  return useAtomValue(totalSurplusAtom)
+}
+
+export function useTriggerTotalSurplusUpdateCallback(): (() => void) | null {
+  return useAtomValue(totalSurplusRefetchAtom)
+}

--- a/src/common/state/totalSurplusState/index.ts
+++ b/src/common/state/totalSurplusState/index.ts
@@ -1,0 +1,2 @@
+export { TotalSurplusUpdater } from './updaters'
+export { useTriggerTotalSurplusUpdateCallback, useTotalSurplus } from './hooks'

--- a/src/common/state/totalSurplusState/types.ts
+++ b/src/common/state/totalSurplusState/types.ts
@@ -1,0 +1,10 @@
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
+
+import { Nullish } from 'types'
+
+export type TotalSurplusState = {
+  surplusAmount: Nullish<CurrencyAmount<Currency>>
+  isLoading: boolean
+  error: string
+  refetch: (() => void) | null
+}

--- a/src/common/state/totalSurplusState/updaters.ts
+++ b/src/common/state/totalSurplusState/updaters.ts
@@ -1,5 +1,5 @@
 import { useUpdateAtom } from 'jotai/utils'
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
@@ -41,7 +41,9 @@ export function TotalSurplusUpdater(): null {
     fetcher
   )
 
-  setTotalSurplus({ surplusAmount, isLoading, error, refetch })
+  useEffect(() => {
+    setTotalSurplus({ surplusAmount, isLoading, error, refetch })
+  }, [error, isLoading, refetch, setTotalSurplus, surplusAmount])
 
   return null
 }

--- a/src/common/state/totalSurplusState/updaters.ts
+++ b/src/common/state/totalSurplusState/updaters.ts
@@ -1,32 +1,16 @@
-import { atom, useAtomValue } from 'jotai'
 import { useUpdateAtom } from 'jotai/utils'
 import { useCallback } from 'react'
 
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
 import useSWR from 'swr'
-import { Nullish } from 'types'
 
 import { useWalletInfo } from 'modules/wallet'
 
 import { getSurplusData } from 'api/gnosisProtocol/api'
 import useNativeCurrency from 'lib/hooks/useNativeCurrency'
 
-export type TotalSurplusState = {
-  surplusAmount: Nullish<CurrencyAmount<Currency>>
-  isLoading: boolean
-  error: string
-  refetch: (() => void) | null
-}
-
-const totalSurplusAtom = atom<TotalSurplusState>({
-  surplusAmount: null,
-  isLoading: false,
-  error: '',
-  refetch: null,
-})
-
-const totalSurplusRefetchAtom = atom((get) => get(totalSurplusAtom).refetch)
+import { totalSurplusAtom } from './atoms'
 
 export function TotalSurplusUpdater(): null {
   const { chainId, account } = useWalletInfo()
@@ -60,12 +44,4 @@ export function TotalSurplusUpdater(): null {
   setTotalSurplus({ surplusAmount, isLoading, error, refetch })
 
   return null
-}
-
-export function useTotalSurplus(): TotalSurplusState {
-  return useAtomValue(totalSurplusAtom)
-}
-
-export function useTriggerTotalSurplusUpdateCallback(): (() => void) | null {
-  return useAtomValue(totalSurplusRefetchAtom)
 }

--- a/src/legacy/state/orders/updaters/PendingOrdersUpdater.ts
+++ b/src/legacy/state/orders/updaters/PendingOrdersUpdater.ts
@@ -32,6 +32,7 @@ import { useWalletInfo } from 'modules/wallet'
 
 import { getOrder, OrderID } from 'api/gnosisProtocol'
 import { removeOrdersToCancelAtom } from 'common/hooks/useMultipleOrdersCancellation/state'
+import { useTriggerTotalSurplusUpdateCallback } from 'common/state/totalSurplusState'
 import { timeSinceInSeconds } from 'utils/time'
 
 /**
@@ -143,6 +144,7 @@ interface UpdateOrdersParams {
   cancelOrdersBatch: CancelOrdersBatchCallback
   presignOrders: PresignOrdersCallback
   addOrderToSurplusQueue: (orderId: string) => void
+  triggerTotalSurplusUpdate: (() => void) | null
   updatePresignGnosisSafeTx: UpdatePresignGnosisSafeTxCallback
   getSafeInfo: GetSafeInfo
 }
@@ -158,6 +160,7 @@ async function _updateOrders({
   cancelOrdersBatch,
   presignOrders,
   addOrderToSurplusQueue,
+  triggerTotalSurplusUpdate,
   updatePresignGnosisSafeTx,
   getSafeInfo,
 }: UpdateOrdersParams): Promise<void> {
@@ -231,6 +234,8 @@ async function _updateOrders({
         addOrderToSurplusQueue(id)
       }
     })
+    // trigger total surplus update
+    triggerTotalSurplusUpdate?.()
   }
 
   // Update the presign Gnosis Safe Tx info (if applies)
@@ -278,6 +283,7 @@ export function PendingOrdersUpdater(): null {
   const addOrUpdateOrders = useAddOrUpdateOrders()
   const presignOrders = usePresignOrders()
   const addOrderToSurplusQueue = useAddOrderToSurplusQueue()
+  const triggerTotalSurplusUpdate = useTriggerTotalSurplusUpdateCallback()
   const updatePresignGnosisSafeTx = useUpdatePresignGnosisSafeTx()
   const getSafeInfo = useGetSafeInfo()
 
@@ -310,6 +316,7 @@ export function PendingOrdersUpdater(): null {
           cancelOrdersBatch,
           presignOrders,
           addOrderToSurplusQueue,
+          triggerTotalSurplusUpdate,
           updatePresignGnosisSafeTx,
           getSafeInfo,
         }).finally(() => {
@@ -325,6 +332,7 @@ export function PendingOrdersUpdater(): null {
       cancelOrdersBatch,
       presignOrders,
       addOrderToSurplusQueue,
+      triggerTotalSurplusUpdate,
       updatePresignGnosisSafeTx,
       getSafeInfo,
     ]

--- a/src/modules/account/containers/AccountDetails/SurplusCard.tsx
+++ b/src/modules/account/containers/AccountDetails/SurplusCard.tsx
@@ -5,15 +5,15 @@ import { supportedChainId } from 'legacy/utils/supportedChainId'
 
 import { useWalletInfo } from 'modules/wallet'
 
-import { useSurplusAmount } from 'api/gnosisProtocol/hooks'
 import { FiatAmount } from 'common/pure/FiatAmount'
 import { HelpCircle } from 'common/pure/HelpCircle'
 import { TokenAmount } from 'common/pure/TokenAmount'
+import { useTotalSurplus } from 'common/state/totalSurplusState'
 
 import { InfoCard } from './styled'
 
 export function SurplusCard() {
-  const { surplusAmount, isLoading } = useSurplusAmount()
+  const { surplusAmount, isLoading } = useTotalSurplus()
 
   const surplusUsdAmount = useHigherUSDValue(surplusAmount)
 

--- a/src/modules/application/containers/App/Updaters.tsx
+++ b/src/modules/application/containers/App/Updaters.tsx
@@ -5,23 +5,24 @@ import GasUpdater from 'legacy/state/gas/updater'
 import ListsUpdater from 'legacy/state/lists/updater'
 import LogsUpdater from 'legacy/state/logs/updater'
 import {
-  GpOrdersUpdater,
   CancelledOrdersUpdater,
+  ExpiredOrdersUpdater,
+  GpOrdersUpdater,
   PendingOrdersUpdater,
   UnfillableOrdersUpdater,
-  ExpiredOrdersUpdater,
 } from 'legacy/state/orders/updaters'
 import { SpotPricesUpdater } from 'legacy/state/orders/updaters/SpotPricesUpdater'
 import FeesUpdater from 'legacy/state/price/updater'
 import SentryUpdater from 'legacy/state/sentry/updater'
 import UserUpdater from 'legacy/state/user/updater'
 
-import { UploadToIpfsUpdater, AppDataUpdater } from 'modules/appData'
+import { AppDataUpdater, UploadToIpfsUpdater } from 'modules/appData'
 import { InjectedWidgetUpdater } from 'modules/injectedWidget'
-import { EthFlowSlippageUpdater, EthFlowDeadlineUpdater } from 'modules/swap/state/EthFlow/updaters'
+import { EthFlowDeadlineUpdater, EthFlowSlippageUpdater } from 'modules/swap/state/EthFlow/updaters'
 import { TokensListUpdater } from 'modules/tokensList/updaters/TokensListUpdater'
 import { WalletUpdater } from 'modules/wallet'
 
+import { TotalSurplusUpdater } from 'common/state/totalSurplusState'
 import { ThemeFromUrlUpdater } from 'common/updaters/ThemeFromUrlUpdater'
 import { MulticallUpdater } from 'lib/state/multicall'
 
@@ -52,6 +53,7 @@ export function Updaters() {
       <SpotPricesUpdater />
       <ThemeFromUrlUpdater />
       <InjectedWidgetUpdater />
+      <TotalSurplusUpdater />
     </>
   )
 }


### PR DESCRIPTION
# Summary

Build on top of https://github.com/cowprotocol/cowswap/pull/2773

This change is based on this comment https://github.com/cowprotocol/cowswap/pull/2751#discussion_r1248046192

Re-fetch data when there's a trade

Also moved data into jotai state so there's no re-fetch when activity modal is opened

# To Test

1. Connect wallet
2. Place order
3. Open activity details
4. Keep notice of the surplus amount
* When order trades, surplus amount should be updated