### PR TITLE
fix: display total time nicer

### DIFF
--- a/src/modules/twap/pure/DeadlineSelector/index.tsx
+++ b/src/modules/twap/pure/DeadlineSelector/index.tsx
@@ -7,6 +7,7 @@ import { renderTooltip } from 'legacy/components/Tooltip'
 import { TradeSelect, TradeSelectItem } from 'modules/trade/pure/TradeSelect'
 import { Content } from 'modules/trade/pure/TradeWidgetField/styled'
 import { LabelTooltip } from 'modules/twap'
+import { customDeadlineToSeconds, deadlinePartsDisplay } from 'modules/twap/utils/deadlinePartsDisplay'
 
 import { defaultCustomDeadline, TwapOrdersDeadline } from '../../state/twapOrdersSettingsAtom'
 import { CustomDeadlineSelector } from '../CustomDeadlineSelector'
@@ -64,7 +65,7 @@ export function DeadlineSelector(props: DeadlineSelectorProps) {
 
   const activeLabel = useMemo(() => {
     if (isCustomDeadline) {
-      return `${customDeadline.hours}h ${customDeadline.minutes}m`
+      return deadlinePartsDisplay(customDeadlineToSeconds(customDeadline))
     }
 
     return items.find((item) => item.value === deadline)?.label || ''


### PR DESCRIPTION
# Summary

Fixes #2683

# To test
- go to advanced orders
- insert in custom deadline 64 min
- it should show `1h 4m` instead