### PR TITLE
feat(twap): do not show est. exec. price for twap parent orders

### DIFF
--- a/src/legacy/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/legacy/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -2,8 +2,7 @@ import { useUpdateAtom } from 'jotai/utils'
 import { useCallback, useEffect, useRef } from 'react'
 
 import { timestamp } from '@cowprotocol/contracts'
-import { SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
-import { OrderClass } from '@cowprotocol/cow-sdk'
+import { OrderClass, SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
 import { Currency, CurrencyAmount, Price } from '@uniswap/sdk-core'
 
 import { FeeInformation, PriceInformation } from 'types'
@@ -105,7 +104,7 @@ export function UnfillableOrdersUpdater(): null {
       order: Order,
       fee: FeeInformation | null,
       marketPrice: Price<Currency, Currency>,
-      estimatedExecutionPrice: Price<Currency, Currency>
+      estimatedExecutionPrice: Price<Currency, Currency> | null
     ) => {
       if (!fee?.amount) return
 

--- a/src/legacy/state/orders/utils.ts
+++ b/src/legacy/state/orders/utils.ts
@@ -228,7 +228,7 @@ export function getEstimatedExecutionPrice(
   order: Order,
   fillPrice: Price<Currency, Currency>,
   fee: string
-): Price<Currency, Currency> {
+): Price<Currency, Currency> | null {
   // Build CurrencyAmount and Price instances
   const feeAmount = CurrencyAmount.fromRawAmount(order.inputToken, fee)
   // Always use original amounts for building the limit price, as this will never change
@@ -238,6 +238,11 @@ export function getEstimatedExecutionPrice(
 
   if (order.class === OrderClass.MARKET) {
     return limitPrice
+  }
+
+  // Parent TWAP order, ignore
+  if (order?.composableCowInfo?.id) {
+    return null
   }
 
   // Check what's left to sell, discounting the surplus, if any

--- a/src/legacy/state/orders/utils.ts
+++ b/src/legacy/state/orders/utils.ts
@@ -13,6 +13,7 @@ import { serializeToken } from 'legacy/state/user/hooks'
 
 import { buildPriceFromCurrencyAmounts } from 'modules/utils/orderUtils/buildPriceFromCurrencyAmounts'
 
+import { getIsComposableCowParentOrder } from 'utils/orderUtils/getIsComposableCowParentOrder'
 import { getOrderSurplus } from 'utils/orderUtils/getOrderSurplus'
 
 export type OrderTransitionStatus =
@@ -241,7 +242,7 @@ export function getEstimatedExecutionPrice(
   }
 
   // Parent TWAP order, ignore
-  if (order?.composableCowInfo?.id) {
+  if (getIsComposableCowParentOrder(order)) {
     return null
   }
 

--- a/src/modules/orders/state/pendingOrdersPricesAtom.ts
+++ b/src/modules/orders/state/pendingOrdersPricesAtom.ts
@@ -4,7 +4,7 @@ import { Currency, CurrencyAmount, Price } from '@uniswap/sdk-core'
 
 export interface PendingOrderPrices {
   marketPrice: Price<Currency, Currency>
-  estimatedExecutionPrice: Price<Currency, Currency>
+  estimatedExecutionPrice: Price<Currency, Currency> | null
   lastUpdateTimestamp: number
   feeAmount: CurrencyAmount<Currency>
 }

--- a/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
+++ b/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
@@ -253,7 +253,7 @@ export function OrderRow({
       {isOpenOrdersTab && (
         <styledEl.PriceElement hasBackground onClick={toggleIsInverted}>
           {/*// TODO: gray out the price when it was updated too long ago*/}
-          {prices ? (
+          {prices && estimatedExecutionPrice ? (
             <styledEl.ExecuteCellWrapper>
               <EstimatedExecutionPrice
                 amount={executionPriceInverted}
@@ -268,7 +268,7 @@ export function OrderRow({
                 isUnfillable={isUnfillable}
               />
             </styledEl.ExecuteCellWrapper>
-          ) : prices === null || isOrderCreating ? (
+          ) : prices === null || !estimatedExecutionPrice || isOrderCreating ? (
             '-'
           ) : (
             <Loader size="14px" style={{ margin: '0 0 -2px 7px' }} />


### PR DESCRIPTION
# Summary

(Partially) Fixed #2713 

Do not show estimated execution price for twap parent orders

As for the children, it uses the exact same logic as limit fill or kill orders AFAICT.
If not working for limit, shouldn't work twap and vice versa.
Which means, both are broken 😓 

# To Test

1. Place TWAP order
* Parent twap order shouldn't have estimated exec. price