### PR TITLE
feat(twap): disable confirm button when form validation fails

### DIFF
--- a/src/modules/twap/containers/TwapConfirmModal/index.tsx
+++ b/src/modules/twap/containers/TwapConfirmModal/index.tsx
@@ -11,6 +11,7 @@ import { useRateInfoParams } from 'common/hooks/useRateInfoParams'
 import { TwapConfirmDetails } from './TwapConfirmDetails'
 
 import { useCreateTwapOrder } from '../../hooks/useCreateTwapOrder'
+import { useTwapFormState } from '../../hooks/useTwapFormState'
 import { useTwapWarningsContext } from '../../hooks/useTwapWarningsContext'
 import { partsStateAtom } from '../../state/partsStateAtom'
 import { twapOrderAtom } from '../../state/twapOrderAtom'
@@ -34,14 +35,14 @@ export function TwapConfirmModal({ fallbackHandlerIsNotSet }: TwapConfirmModalPr
   const slippage = useAtomValue(twapOrderSlippageAtom)
   const partsState = useAtomValue(partsStateAtom)
   const { showPriceImpactWarning } = useTwapWarningsContext()
+  const localFormValidation = useTwapFormState()
 
   const tradeConfirmActions = useTradeConfirmActions()
   const createTwapOrder = useCreateTwapOrder()
 
   const isInvertedState = useState(false)
 
-  // TODO: add conditions based on warnings
-  const isConfirmDisabled = false
+  const isConfirmDisabled = !!localFormValidation
 
   const priceImpact = useTradePriceImpact()
 

--- a/src/modules/twap/containers/TwapConfirmModal/index.tsx
+++ b/src/modules/twap/containers/TwapConfirmModal/index.tsx
@@ -16,6 +16,7 @@ import { useTwapWarningsContext } from '../../hooks/useTwapWarningsContext'
 import { partsStateAtom } from '../../state/partsStateAtom'
 import { twapOrderAtom } from '../../state/twapOrderAtom'
 import { twapOrderSlippageAtom } from '../../state/twapOrdersSettingsAtom'
+import { TwapFormWarnings } from '../TwapFormWarnings'
 
 interface TwapConfirmModalProps {
   fallbackHandlerIsNotSet: boolean
@@ -96,6 +97,7 @@ export function TwapConfirmModal({ fallbackHandlerIsNotSet }: TwapConfirmModalPr
             totalDuration={totalDuration}
           />
           {showPriceImpactWarning && <NoImpactWarning withoutAccepting={true} isAccepted={true} />}
+          <TwapFormWarnings localFormValidation={localFormValidation} isConfirmationModal />
         </>
       </TradeConfirmation>
     </TradeConfirmModal>

--- a/src/modules/twap/containers/TwapFormWarnings/index.tsx
+++ b/src/modules/twap/containers/TwapFormWarnings/index.tsx
@@ -21,9 +21,10 @@ import { twapOrdersSettingsAtom, updateTwapOrdersSettingsAtom } from '../../stat
 
 interface TwapFormWarningsProps {
   localFormValidation: TwapFormState | null
+  isConfirmationModal?: boolean
 }
 
-export function TwapFormWarnings({ localFormValidation }: TwapFormWarningsProps) {
+export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: TwapFormWarningsProps) {
   const { isFallbackHandlerSetupAccepted, isPriceImpactAccepted } = useAtomValue(twapOrdersSettingsAtom)
   const updateTwapOrdersSettings = useUpdateAtom(updateTwapOrdersSettingsAtom)
 
@@ -49,7 +50,7 @@ export function TwapFormWarnings({ localFormValidation }: TwapFormWarningsProps)
 
   return (
     <>
-      {showPriceImpactWarning && (
+      {!isConfirmationModal && showPriceImpactWarning && (
         <NoImpactWarning
           withoutAccepting={false}
           isAccepted={isPriceImpactAccepted}
@@ -70,7 +71,7 @@ export function TwapFormWarnings({ localFormValidation }: TwapFormWarningsProps)
           return <SmallPartTimeWarning />
         }
 
-        if (canTrade && isFallbackHandlerRequired) {
+        if (!isConfirmationModal && canTrade && isFallbackHandlerRequired) {
           return (
             <FallbackHandlerWarning
               isFallbackHandlerSetupAccepted={isFallbackHandlerSetupAccepted}


### PR DESCRIPTION
# Summary

Fixes #2772 

Disable confirm button in the modal when any form validation fails

⚠️ I was not able to reproduce the amount too small in the confirm button ⚠️ 

# To Test

1. Fill in twap form with a sell amount/#parts very little above the minimum
2. Proceed to confirmation modal
3. Wait until market price/USD price changes and sell amount per parts becomes < than minimum
* Confirm button should be disabled
* Warning should be displayed