### PR TITLE
feat(twap): display order id on receipt for twap part orders

### DIFF
--- a/src/modules/ordersTable/pure/ReceiptModal/index.tsx
+++ b/src/modules/ordersTable/pure/ReceiptModal/index.tsx
@@ -79,6 +79,8 @@ export function ReceiptModal({
     return null
   }
 
+  const isTwapParentOrder = !!twapOrder && !isTwapPartOrder
+
   const inputLabel = order.kind === OrderKind.SELL ? 'You sell' : 'You sell at most'
   const outputLabel = order.kind === OrderKind.SELL ? 'You receive at least' : 'You receive exactly'
   const safeTxParams = twapOrder?.safeTxParams
@@ -170,7 +172,7 @@ export function ReceiptModal({
             </styledEl.Field>
 
             {/*TODO: add a link to explorer when it will support TWAP orders*/}
-            {!twapOrder && (
+            {!isTwapParentOrder && (
               <styledEl.Field>
                 {order.executionData.activityId && (
                   <>

--- a/src/modules/ordersTable/pure/ReceiptModal/index.tsx
+++ b/src/modules/ordersTable/pure/ReceiptModal/index.tsx
@@ -62,6 +62,8 @@ const tooltips: { [key: string]: string | JSX.Element } = {
   ),
 }
 
+const TWAP_PART_ORDER_EXISTS_STATES = new Set([OrderStatus.PENDING, OrderStatus.FULFILLED, OrderStatus.EXPIRED])
+
 // TODO: add cosmos fixture for this component
 export function ReceiptModal({
   isOpen,
@@ -79,7 +81,7 @@ export function ReceiptModal({
     return null
   }
 
-  const isTwapParentOrder = !!twapOrder && !isTwapPartOrder
+  const twapPartOrderExists = isTwapPartOrder && TWAP_PART_ORDER_EXISTS_STATES.has(order.status)
 
   const inputLabel = order.kind === OrderKind.SELL ? 'You sell' : 'You sell at most'
   const outputLabel = order.kind === OrderKind.SELL ? 'You receive at least' : 'You receive exactly'
@@ -172,7 +174,7 @@ export function ReceiptModal({
             </styledEl.Field>
 
             {/*TODO: add a link to explorer when it will support TWAP orders*/}
-            {!isTwapParentOrder && (
+            {(!twapOrder || twapPartOrderExists) && (
               <styledEl.Field>
                 {order.executionData.activityId && (
                   <>


### PR DESCRIPTION
# Summary

Quick fix, adding order id field to twap part orders on receipt modal

TWAP part order now has it
![Screenshot 2023-07-07 at 10 42 48](https://github.com/cowprotocol/cowswap/assets/43217/b0329a24-42c3-4778-a0c3-d9001889ffaa)

TWAP parent remains without
![Screenshot 2023-07-07 at 10 43 02](https://github.com/cowprotocol/cowswap/assets/43217/ca159dc9-3a11-4d23-9d08-72dfadd47742)

# To Test

1. On orders table, open a twap part order
* Order id filed should be present and link to explorer