### PR TITLE
fix(surplus-pending-swap-buy-receipt): fix receipt for pending buy swap orders

### DIFF
--- a/src/utils/orderUtils/getOrderSurplus.ts
+++ b/src/utils/orderUtils/getOrderSurplus.ts
@@ -1,5 +1,6 @@
 // Util functions that only pertain to/deal with operator API related stuff
 import BigNumber from 'bignumber.js'
+import JSBI from 'jsbi'
 
 import { ZERO_BIG_NUMBER } from 'legacy/constants'
 import { Order } from 'legacy/state/orders/actions'
@@ -145,7 +146,7 @@ export function getOrderSurplus(order: Order): Surplus {
   // `executedSellAmount` already has `executedFeeAmount` discounted
   const { executedBuyAmount, executedSellAmount } = getOrderExecutedAmounts(order)
 
-  if (!executedBuyAmount || !executedSellAmount) {
+  if (JSBI.EQ(executedBuyAmount, 0) || JSBI.EQ(executedSellAmount, 0)) {
     return ZERO_SURPLUS
   }
 


### PR DESCRIPTION
# Summary

Closes #2702 

Fix surplus receipt for pending swap buy orders

![image](https://github.com/cowprotocol/cowswap/assets/43217/68207756-4d6f-4275-970b-b5cdcc18e790)

# To Test

1. Place a SWAP buy order
2. Go to limit orders table
3. Open the pending order receipt
* Surplus should be `-`

Repeat for other order types. Result should be the same.