### PR TITLE
fix(twap): hide learn more link

### DIFF
--- a/src/modules/advancedOrders/containers/AdvancedOrdersWidget/index.tsx
+++ b/src/modules/advancedOrders/containers/AdvancedOrdersWidget/index.tsx
@@ -32,7 +32,7 @@ const UNLOCK_SCREEN = {
   orderType: 'TWAP',
   buttonText: 'Unlock TWAP orders (BETA)',
   // TODO: add actual link before deploy to PROD
-  buttonLink: 'http://google.com',
+  buttonLink: '',
 }
 
 export function AdvancedOrdersWidget({ children }: { children: JSX.Element }) {
@@ -87,7 +87,6 @@ export function AdvancedOrdersWidget({ children }: { children: JSX.Element }) {
     bottomContent: children,
     lockScreen: isUnlocked ? undefined : (
       <UnlockWidgetScreen
-        showLink={false}
         items={TWAP_BULLET_LIST_CONTENT}
         buttonLink={UNLOCK_SCREEN.buttonLink}
         title={UNLOCK_SCREEN.title}

--- a/src/modules/advancedOrders/containers/AdvancedOrdersWidget/index.tsx
+++ b/src/modules/advancedOrders/containers/AdvancedOrdersWidget/index.tsx
@@ -87,6 +87,7 @@ export function AdvancedOrdersWidget({ children }: { children: JSX.Element }) {
     bottomContent: children,
     lockScreen: isUnlocked ? undefined : (
       <UnlockWidgetScreen
+        showLink={false}
         items={TWAP_BULLET_LIST_CONTENT}
         buttonLink={UNLOCK_SCREEN.buttonLink}
         title={UNLOCK_SCREEN.title}

--- a/src/modules/advancedOrders/containers/AdvancedOrdersWidget/index.tsx
+++ b/src/modules/advancedOrders/containers/AdvancedOrdersWidget/index.tsx
@@ -27,7 +27,7 @@ export const TWAP_BULLET_LIST_CONTENT: BulletListItem[] = [
 ]
 
 const UNLOCK_SCREEN = {
-  title: 'Unlock the Power of Advanced Orders:',
+  title: 'Unlock the Power of Advanced Orders',
   subtitle: 'Begin with TWAP Today!',
   orderType: 'TWAP',
   buttonText: 'Unlock TWAP orders (BETA)',

--- a/src/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -47,7 +47,6 @@ export const LIMIT_BULLET_LIST_CONTENT: BulletListItem[] = [
         NOW with&nbsp;<b>partial fills</b>&nbsp;support!
       </span>
     ),
-    isNew: true,
   },
 ]
 

--- a/src/modules/trade/pure/UnlockWidgetScreen/index.tsx
+++ b/src/modules/trade/pure/UnlockWidgetScreen/index.tsx
@@ -16,10 +16,9 @@ type UnlockWidgetProps = {
   handleUnlock: () => void
   title: string
   subtitle: string
-  buttonLink: string
+  buttonLink?: string
   orderType: string
   buttonText: string
-  showLink?: boolean
 }
 
 export function UnlockWidgetScreen({
@@ -30,7 +29,6 @@ export function UnlockWidgetScreen({
   items,
   title,
   subtitle,
-  showLink = true,
 }: UnlockWidgetProps) {
   return (
     <styledEl.Container>
@@ -53,7 +51,7 @@ export function UnlockWidgetScreen({
       )}
 
       <styledEl.ControlSection>
-        {showLink && (
+        {buttonLink && (
           <span>
             Learn more about <ExternalLink href={buttonLink}>{orderType} orders ↗</ExternalLink>
           </span>

--- a/src/modules/trade/pure/UnlockWidgetScreen/index.tsx
+++ b/src/modules/trade/pure/UnlockWidgetScreen/index.tsx
@@ -19,6 +19,7 @@ type UnlockWidgetProps = {
   buttonLink: string
   orderType: string
   buttonText: string
+  showLink?: boolean
 }
 
 export function UnlockWidgetScreen({
@@ -29,6 +30,7 @@ export function UnlockWidgetScreen({
   items,
   title,
   subtitle,
+  showLink = true,
 }: UnlockWidgetProps) {
   return (
     <styledEl.Container>
@@ -51,9 +53,11 @@ export function UnlockWidgetScreen({
       )}
 
       <styledEl.ControlSection>
-        <span>
-          Learn more about <ExternalLink href={buttonLink}>{orderType} orders ↗</ExternalLink>
-        </span>
+        {showLink && (
+          <span>
+            Learn more about <ExternalLink href={buttonLink}>{orderType} orders ↗</ExternalLink>
+          </span>
+        )}
         <ButtonPrimary id={`unlock-${orderType}-orders-btn`} onClick={handleUnlock}>
           {buttonText}
         </ButtonPrimary>

--- a/src/modules/trade/pure/UnlockWidgetScreen/styled.ts
+++ b/src/modules/trade/pure/UnlockWidgetScreen/styled.ts
@@ -14,15 +14,15 @@ export const TitleSection = styled.div`
   margin: 24px auto 42px;
 
   > h3 {
-    font-weight: 500;
+    font-weight: 400;
     font-size: inherit;
     margin: 0 0 4px;
+    color: ${({ theme }) => transparentize(0.2, theme.text1)};
   }
 
   > strong {
     font-weight: 800;
     font-size: 22px;
-    color: ${({ theme }) => transparentize(0.3, theme.text1)};
     margin: 0;
   }
 `


### PR DESCRIPTION
# Summary

Hides learn more text from Unlock screen on advanced orders
Source https://cowservices.slack.com/archives/C0361CDG8GP/p1688740674594089


<img width="519" alt="Screenshot 2023-07-07 at 16 47 09" src="https://github.com/cowprotocol/cowswap/assets/34926005/e381ff60-f9e2-438a-8fa5-4daa240c10b1">

# To test
- go to advanced orders
- make sure there is no learn more link in Unlock screen