### PR TITLE
feat(twap): reset USDT allowance

### DIFF
--- a/src/common/hooks/useNeedsZeroApproval.ts
+++ b/src/common/hooks/useNeedsZeroApproval.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+
+import { Erc20 } from '@cowprotocol/abis'
+import { CurrencyAmount, Token } from '@uniswap/sdk-core'
+
+import { Nullish } from 'types'
+
+import { shouldZeroApprove as shouldZeroApproveFn } from './useShouldZeroApprove/shouldZeroApprove'
+
+export function useNeedsZeroApproval(
+  erc20Contract: Nullish<Erc20>,
+  spender: Nullish<string>,
+  sellAmount: Nullish<CurrencyAmount<Token>>
+): boolean {
+  const [shouldZeroApprove, setShouldZeroApprove] = useState(false)
+
+  useEffect(() => {
+    if (!erc20Contract || !spender || !sellAmount) return
+
+    shouldZeroApproveFn({
+      tokenContract: erc20Contract,
+      spender: spender,
+      amountToApprove: sellAmount,
+      isBundle: true,
+    }).then(setShouldZeroApprove)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [erc20Contract?.address, sellAmount?.quotient?.toString(), spender])
+
+  return shouldZeroApprove
+}

--- a/src/modules/twap/containers/TwapFormWarnings/index.tsx
+++ b/src/modules/twap/containers/TwapFormWarnings/index.tsx
@@ -56,6 +56,7 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
   const shouldZeroApprove = useShouldZeroApprove(twapOrder?.sellAmount)
   const showZeroApprovalWarning = shouldZeroApprove && outputCurrencyAmount !== null
   const showApprovalBundlingBanner = primaryFormValidation && BUNDLE_APPROVAL_STATES.includes(primaryFormValidation)
+  const showFallbackHandlerWarning = !isConfirmationModal && canTrade && isFallbackHandlerRequired
 
   const setIsPriceImpactAccepted = useCallback(() => {
     updateTwapOrdersSettings({ isPriceImpactAccepted: !isPriceImpactAccepted })
@@ -89,7 +90,7 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
           return <SmallPartTimeWarning />
         }
 
-        if (!isConfirmationModal && canTrade && isFallbackHandlerRequired) {
+        if (showFallbackHandlerWarning) {
           return (
             <FallbackHandlerWarning
               isFallbackHandlerSetupAccepted={isFallbackHandlerSetupAccepted}

--- a/src/modules/twap/containers/TwapFormWarnings/index.tsx
+++ b/src/modules/twap/containers/TwapFormWarnings/index.tsx
@@ -54,8 +54,9 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
   )
 
   const shouldZeroApprove = useShouldZeroApprove(twapOrder?.sellAmount)
-  const showZeroApprovalWarning = shouldZeroApprove && outputCurrencyAmount !== null
-  const showApprovalBundlingBanner = primaryFormValidation && BUNDLE_APPROVAL_STATES.includes(primaryFormValidation)
+  const showZeroApprovalWarning = !isConfirmationModal && shouldZeroApprove && outputCurrencyAmount !== null
+  const showApprovalBundlingBanner =
+    !isConfirmationModal && primaryFormValidation && BUNDLE_APPROVAL_STATES.includes(primaryFormValidation)
   const showFallbackHandlerWarning = !isConfirmationModal && canTrade && isFallbackHandlerRequired
 
   const setIsPriceImpactAccepted = useCallback(() => {
@@ -67,6 +68,9 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
 
   return (
     <>
+      {showZeroApprovalWarning && <ZeroApprovalWarning currency={twapOrder?.sellAmount?.currency} />}
+      {showApprovalBundlingBanner && <BundleTxApprovalBanner />}
+
       {!isConfirmationModal && showPriceImpactWarning && (
         <NoImpactWarning
           withoutAccepting={false}
@@ -74,8 +78,6 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
           acceptCallback={() => setIsPriceImpactAccepted()}
         />
       )}
-      {showZeroApprovalWarning && <ZeroApprovalWarning currency={twapOrder?.sellAmount?.currency} />}
-      {showApprovalBundlingBanner && <BundleTxApprovalBanner />}
 
       {(() => {
         if (localFormValidation === TwapFormState.NOT_SAFE) {

--- a/src/modules/twap/containers/TwapFormWarnings/index.tsx
+++ b/src/modules/twap/containers/TwapFormWarnings/index.tsx
@@ -7,6 +7,10 @@ import { modifySafeHandlerAnalytics } from 'legacy/components/analytics/events/t
 import { NoImpactWarning } from 'modules/trade/pure/NoImpactWarning'
 import { useIsSafeViaWc, useWalletInfo } from 'modules/wallet'
 
+import { useShouldZeroApprove } from 'common/hooks/useShouldZeroApprove'
+import { BundleTxApprovalBanner } from 'common/pure/InlineBanner/banners'
+import { ZeroApprovalWarning } from 'common/pure/ZeroApprovalWarning'
+
 import {
   FallbackHandlerWarning,
   SmallPartTimeWarning,
@@ -14,10 +18,15 @@ import {
   UnsupportedWalletWarning,
 } from './warnings'
 
+import { useAdvancedOrdersDerivedState } from '../../../advancedOrders'
+import { TradeFormValidation, useGetTradeFormValidation } from '../../../tradeFormValidation'
 import { useIsFallbackHandlerRequired } from '../../hooks/useFallbackHandlerVerification'
 import { useTwapWarningsContext } from '../../hooks/useTwapWarningsContext'
 import { TwapFormState } from '../../pure/PrimaryActionButton/getTwapFormState'
+import { twapOrderAtom } from '../../state/twapOrderAtom'
 import { twapOrdersSettingsAtom, updateTwapOrdersSettingsAtom } from '../../state/twapOrdersSettingsAtom'
+
+const BUNDLE_APPROVAL_STATES = [TradeFormValidation.ApproveAndSwap, TradeFormValidation.ExpertApproveAndSwap]
 
 interface TwapFormWarningsProps {
   localFormValidation: TwapFormState | null
@@ -27,6 +36,9 @@ interface TwapFormWarningsProps {
 export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: TwapFormWarningsProps) {
   const { isFallbackHandlerSetupAccepted, isPriceImpactAccepted } = useAtomValue(twapOrdersSettingsAtom)
   const updateTwapOrdersSettings = useUpdateAtom(updateTwapOrdersSettingsAtom)
+  const twapOrder = useAtomValue(twapOrderAtom)
+  const { outputCurrencyAmount } = useAdvancedOrdersDerivedState()
+  const primaryFormValidation = useGetTradeFormValidation()
 
   const { chainId } = useWalletInfo()
   const isFallbackHandlerRequired = useIsFallbackHandlerRequired()
@@ -40,6 +52,10 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
     },
     [updateTwapOrdersSettings]
   )
+
+  const shouldZeroApprove = useShouldZeroApprove(twapOrder?.sellAmount)
+  const showZeroApprovalWarning = shouldZeroApprove && outputCurrencyAmount !== null
+  const showApprovalBundlingBanner = primaryFormValidation && BUNDLE_APPROVAL_STATES.includes(primaryFormValidation)
 
   const setIsPriceImpactAccepted = useCallback(() => {
     updateTwapOrdersSettings({ isPriceImpactAccepted: !isPriceImpactAccepted })
@@ -57,6 +73,8 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
           acceptCallback={() => setIsPriceImpactAccepted()}
         />
       )}
+      {showZeroApprovalWarning && <ZeroApprovalWarning currency={twapOrder?.sellAmount?.currency} />}
+      {showApprovalBundlingBanner && <BundleTxApprovalBanner />}
 
       {(() => {
         if (localFormValidation === TwapFormState.NOT_SAFE) {

--- a/src/modules/twap/hooks/useTwapOrderCreationContext.ts
+++ b/src/modules/twap/hooks/useTwapOrderCreationContext.ts
@@ -1,5 +1,4 @@
-import { Erc20 } from '@cowprotocol/abis'
-import { ComposableCoW } from '@cowprotocol/abis'
+import { ComposableCoW, Erc20 } from '@cowprotocol/abis'
 import { CurrencyAmount, Token } from '@uniswap/sdk-core'
 
 import { Nullish } from 'types'
@@ -11,11 +10,13 @@ import { useComposableCowContract } from 'modules/advancedOrders/hooks/useCompos
 import { useWalletInfo } from 'modules/wallet'
 
 import { useNeedsApproval } from 'common/hooks/useNeedsApproval'
+import { useNeedsZeroApproval } from 'common/hooks/useNeedsZeroApproval'
 import { useTradeSpenderAddress } from 'common/hooks/useTradeSpenderAddress'
 
 export interface TwapOrderCreationContext {
   composableCowContract: ComposableCoW
   needsApproval: boolean
+  needsZeroApproval: boolean
   spender: string
   currentBlockFactoryAddress: string
   erc20Contract: Erc20
@@ -29,9 +30,10 @@ export function useTwapOrderCreationContext(
   const needsApproval = useNeedsApproval(inputAmount)
   const erc20Contract = useTokenContract(inputAmount?.currency.address)
   const spender = useTradeSpenderAddress()
+  const needsZeroApproval = useNeedsZeroApproval(erc20Contract, spender, inputAmount)
   const currentBlockFactoryAddress = chainId ? CURRENT_BLOCK_FACTORY_ADDRESS[chainId] : null
 
   if (!composableCowContract || !erc20Contract || !spender || !currentBlockFactoryAddress) return null
 
-  return { composableCowContract, erc20Contract, needsApproval, spender, currentBlockFactoryAddress }
+  return { composableCowContract, erc20Contract, needsApproval, needsZeroApproval, spender, currentBlockFactoryAddress }
 }

--- a/src/modules/twap/services/__snapshots__/createTwapOrderTxs.test.ts.snap
+++ b/src/modules/twap/services/__snapshots__/createTwapOrderTxs.test.ts.snap
@@ -1,5 +1,64 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Create TWAP order When sell token is NOT approved AND token needs zero approval, then should generate 2 approvals and creation transactions 1`] = `
+Array [
+  "createWithContext",
+  Array [
+    Object {
+      "handler": "0x910d00a310f7Dc5B29FE73458F47f519be547D3d",
+      "salt": "0x00000000000000000000000000000000000000000000000000000015c90b9b2a",
+      "staticInput": "0x00000000000000000000000091056d4a53e1faa1a84306d4deaec71085394bc8000000000000000000000000b4fbf271143f4fbf7b91a5ded31805e42b2208d6000000000000000000000000b4fbf271143f4fbf7b91a5ded31805e42b2208d600000000000000000000000000000000000000000000000000000007c2d24d55000000000000000000000000000000000000000000000000000000000001046a00000000000000000000000000000000000000000000000000000000646b782c0000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000025800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    },
+    "0x0899c7DC280363d263Cc954506134F249CceC4a5",
+    "0x",
+    true,
+  ],
+]
+`;
+
+exports[`Create TWAP order When sell token is NOT approved AND token needs zero approval, then should generate 2 approvals and creation transactions 2`] = `
+Array [
+  "approve",
+  Array [
+    "0xB4FBF271143F4FBf7B91A5ded31805e42b222222",
+    "100000000000",
+  ],
+]
+`;
+
+exports[`Create TWAP order When sell token is NOT approved AND token needs zero approval, then should generate 2 approvals and creation transactions 3`] = `
+Array [
+  "approve",
+  Array [
+    "0xB4FBF271143F4FBf7B91A5ded31805e42b222222",
+    "0",
+  ],
+]
+`;
+
+exports[`Create TWAP order When sell token is NOT approved AND token needs zero approval, then should generate 2 approvals and creation transactions 4`] = `
+Array [
+  Object {
+    "data": "0xAPPROVE_TX_DATA",
+    "operation": 0,
+    "to": "0x91056D4A53E1faa1A84306D4deAEc71085394bC8",
+    "value": "0",
+  },
+  Object {
+    "data": "0xAPPROVE_TX_DATA",
+    "operation": 0,
+    "to": "0x91056D4A53E1faa1A84306D4deAEc71085394bC8",
+    "value": "0",
+  },
+  Object {
+    "data": "0xCREATE_COW_TX_DATA",
+    "operation": 0,
+    "to": "0xF487887DA5a4b4e3eC114FDAd97dc0F785d72738",
+    "value": "0",
+  },
+]
+`;
+
 exports[`Create TWAP order When sell token is NOT approved, then should generate approval and creation transactions 1`] = `
 Array [
   "createWithContext",

--- a/src/modules/twap/services/createTwapOrderTxs.test.ts
+++ b/src/modules/twap/services/createTwapOrderTxs.test.ts
@@ -46,6 +46,7 @@ describe('Create TWAP order', () => {
         address: COMPOSABLE_COW_ADDRESS[chainId],
       } as any,
       needsApproval: false,
+      needsZeroApproval: false,
       spender: '0xB4FBF271143F4FBf7B91A5ded31805e42b222222',
       currentBlockFactoryAddress: CURRENT_BLOCK_FACTORY_ADDRESS[chainId],
       erc20Contract: { interface: { encodeFunctionData: approveFn } } as any,
@@ -74,6 +75,21 @@ describe('Create TWAP order', () => {
     expect(approveFn.mock.calls[0]).toMatchSnapshot()
 
     expect(result.length).toBe(2)
+    expect(result).toMatchSnapshot()
+  })
+
+  it('When sell token is NOT approved AND token needs zero approval, then should generate 2 approvals and creation transactions', () => {
+    const paramsStruct = buildTwapOrderParamsStruct(chainId, order)
+    const result = createTwapOrderTxs(order, paramsStruct, { ...context, needsApproval: true, needsZeroApproval: true })
+
+    expect(createCowFn).toHaveBeenCalledTimes(1)
+    expect(createCowFn.mock.calls[0]).toMatchSnapshot()
+
+    expect(approveFn).toHaveBeenCalledTimes(2)
+    expect(approveFn.mock.calls[0]).toMatchSnapshot()
+    expect(approveFn.mock.calls[1]).toMatchSnapshot()
+
+    expect(result.length).toBe(3)
     expect(result).toMatchSnapshot()
   })
 })

--- a/src/modules/twap/services/createTwapOrderTxs.ts
+++ b/src/modules/twap/services/createTwapOrderTxs.ts
@@ -1,5 +1,4 @@
 import { MetaTransactionData } from '@safe-global/safe-core-sdk-types'
-import { CurrencyAmount } from '@uniswap/sdk-core'
 
 import { TwapOrderCreationContext } from '../hooks/useTwapOrderCreationContext'
 import { ConditionalOrderParams, TWAPOrder } from '../types'
@@ -52,11 +51,9 @@ export function createTwapOrderTxs(
 
   if (!needsZeroApproval) return txs
 
-  const zeroAmount = CurrencyAmount.fromRawAmount(sellAmount.currency, 0).toFixed(0)
-
   const zeroApproveTx = {
     to: sellAmount.currency.address,
-    data: erc20Contract.interface.encodeFunctionData('approve', [spender, zeroAmount]),
+    data: erc20Contract.interface.encodeFunctionData('approve', [spender, '0']),
     value: '0',
     operation: 0,
   }


### PR DESCRIPTION
# Summary

Closes #2801 

Applying same logic as SWAP and LIMIT to TWAP in regards to tokens that don't allow the allowance to be changed.

Adding warnings to TWAP form

![Screenshot 2023-07-10 at 10 42 10](https://github.com/cowprotocol/cowswap/assets/43217/859e9d2e-5b99-4a7f-afad-df3b70e57fe2)
![Screenshot 2023-07-10 at 10 34 57](https://github.com/cowprotocol/cowswap/assets/43217/7acee547-ec61-46b2-b079-59210025a6aa)

## ⚠️ Notes ⚠️ 
- Not certain whether it makes sense to have `token approval` bundle info for TWAP. After all, several operations here will be bundled, such as:
  1. Approval and order placement
  2. Update Safe handler and order placement
  3. Cancellation

# To Test

1. Pick a token which is affected, such as USDT
2. Approve less than infinite
3. Sell it in a TWAP order
* Warning banner should be displayed in the form
* Safe tx should show both approvals in sequence

Remaining TWAP operations should remain as is