### PR TITLE
feat(wallet-connect): add env for specifying the WC v1 bridge

### DIFF
--- a/.env
+++ b/.env
@@ -33,6 +33,9 @@ REACT_APP_NETWORK_URL_1=https://mainnet.infura.io/v3/586e7e6b7c7e437aa41f5da496a
 REACT_APP_NETWORK_URL_5=https://goerli.infura.io/v3/586e7e6b7c7e437aa41f5da496a749f5
 REACT_APP_NETWORK_URL_100=https://rpc.gnosischain.com
 
+# Wallet Connect
+# REACT_APP_WALLET_CONNECT_V1_BRIDGE='https://safe-walletconnect.safe.global'
+
 # Wallets
 REACT_APP_PORTIS_ID="c0e2bf01-4b08-4fd5-ac7b-8e26b58cd236"
 REACT_APP_FORTMATIC_KEY="pk_live_6AED76CA755EFDC7"

--- a/.env.production
+++ b/.env.production
@@ -29,6 +29,9 @@ REACT_APP_NETWORK_URL_5=https://goerli.infura.io/v3/586e7e6b7c7e437aa41f5da496a7
 #REACT_APP_NETWORK_URL_100=https://rpc.gnosischain.com/oe-only
 REACT_APP_NETWORK_URL_100=https://rpc.gnosischain.com
 
+# Wallet Connect
+# REACT_APP_WALLET_CONNECT_V1_BRIDGE='https://safe-walletconnect.safe.global'
+
 # Wallets
 REACT_APP_PORTIS_ID="c0e2bf01-4b08-4fd5-ac7b-8e26b58cd236"
 REACT_APP_FORTMATIC_KEY="pk_live_9E53F9A29112A9FC"

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -41,6 +41,7 @@ jobs:
           REACT_APP_GOOGLE_ANALYTICS_ID=${{ secrets.REACT_APP_GOOGLE_ANALYTICS_ID }}
           REACT_APP_AMPLITUDE_KEY=${{ secrets.REACT_APP_AMPLITUDE_KEY }}
           REACT_APP_LAUNCH_DARKLY_KEY=${{ secrets.REACT_APP_LAUNCH_DARKLY_KEY }}
+          REACT_APP_WALLET_CONNECT_V1_BRIDGE=${{ secrets.REACT_APP_WALLET_CONNECT_V1_BRIDGE }}
           vercel build -t ${{ secrets.VERCEL_TOKEN }} --prod
 
       - name: Get the version

--- a/README.md
+++ b/README.md
@@ -182,6 +182,16 @@ The plan:
 
 `emergency.js` is not cached by browser and loaded before all.
 
+## Wallet Connect
+
+The app uses a Wallet Connect v1 bridge.
+
+You can define your own bridge by setting the following environment variable:
+
+```ini
+REACT_APP_WALLET_CONNECT_V1_BRIDGE='https://bridge.walletconnect.org'
+```
+
 ## Documentation
 
 1. [Oveall Architecture](docs/architecture-overview.md)

--- a/src/modules/wallet/web3-react/connection/walletConnect.tsx
+++ b/src/modules/wallet/web3-react/connection/walletConnect.tsx
@@ -42,7 +42,7 @@ const [web3WalletConnect, web3WalletConnectHooks] = initializeConnector<WalletCo
       options: {
         rpc: RPC_URLS,
         qrcode: true,
-        bridge: 'https://safe-walletconnect.safe.global',
+        bridge: process.env.REACT_APP_WALLET_CONNECT_V1_BRIDGE || 'https://safe-walletconnect.safe.global',
       },
       onError,
     })


### PR DESCRIPTION
# Summary

Allows to modify the wallet connect bridge from an environment variable 

# To Test

1. Go to https://swap-dev-git-add-env-for-wallet-connect-v1-cowswap.vercel.app/#/1/swap/WETH

2. Click to connect with wallet connect

<img width="1381" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/49401767-1649-41e6-9b01-1e47b7b5e4af">

3. Copy the  code

<img width="960" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/c5a34085-d66d-48f2-b1f8-68df7579b5cb">

4. Inspect the URL, it should have the right bridge in the params. I've modified the envs so, just  heck it matches:


<img width="544" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/f0e42f94-e622-4d7f-b419-6ba93c14a981">

You should see
<img width="1427" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/1c5463a7-951a-4b3a-b3f7-0f77d57ef611">

