### PR TITLE
chore(surplus): move styles from surplus to styled

### DIFF
--- a/src/modules/account/containers/AccountDetails/SurplusCard.tsx
+++ b/src/modules/account/containers/AccountDetails/SurplusCard.tsx
@@ -1,7 +1,4 @@
-import { transparentize } from 'polished'
-import styled from 'styled-components/macro'
-
-import QuestionHelper, { QuestionWrapper } from 'legacy/components/QuestionHelper'
+import QuestionHelper from 'legacy/components/QuestionHelper'
 import { useHigherUSDValue } from 'legacy/hooks/useStablecoinPrice'
 import { ExternalLink } from 'legacy/theme'
 import { supportedChainId } from 'legacy/utils/supportedChainId'
@@ -12,7 +9,7 @@ import { FiatAmount } from 'common/pure/FiatAmount'
 import { TokenAmount } from 'common/pure/TokenAmount'
 import { useTotalSurplus } from 'common/state/totalSurplusState'
 
-import { InfoCard } from './styled'
+import { InfoCard, SurplusCardWrapper } from './styled'
 
 export function SurplusCard() {
   const { surplusAmount, isLoading } = useTotalSurplus()
@@ -24,113 +21,8 @@ export function SurplusCard() {
   if (!supportedChainId(chainId)) return null
   // ------- end of TODO
 
-  const Wrapper = styled.div`
-    margin: 0 auto 24px;
-    width: 100%;
-    display: grid;
-    align-items: center;
-    justify-content: center;
-    grid-template-columns: 1fr;
-    gap: 24px;
-    box-sizing: border-box;
-    padding: 0 24px;
-
-    ${({ theme }) => theme.mediaWidth.upToSmall`
-      display: flex;
-      flex-flow: column wrap;
-      padding: 0 16px;
-    `}
-
-    ${InfoCard} {
-      display: flex;
-      flex-flow: column wrap;
-      align-items: center;
-      justify-content: center;
-      gap: 0;
-      background: ${({ theme }) => theme.gradient2};
-      border-radius: 16px;
-      padding: 20px 26px 26px;
-      min-height: 210px;
-      width: 100%;
-      max-width: 100%;
-      margin: 0;
-    }
-
-    ${InfoCard} > div {
-      display: flex;
-      flex-flow: column wrap;
-      align-items: center;
-      justify-content: center;
-
-      &:first-child {
-        margin: 20px auto 0;
-      }
-
-      &:last-child {
-        margin: auto 0 0;
-      }
-    }
-
-    ${InfoCard} > div > span {
-      display: flex;
-      flex-flow: column wrap;
-      align-items: center;
-      justify-content: center;
-    }
-
-    ${InfoCard} > div > span > i,
-    ${InfoCard} > div > a,
-    ${InfoCard} > div > span > p {
-      display: flex;
-      font-size: 13px;
-      font-style: normal;
-      font-weight: 500;
-      line-height: 1.1;
-      width: 100%;
-      text-align: center;
-      justify-content: center;
-      align-items: center;
-      color: ${({ theme }) => transparentize(0.3, theme.text1)};
-    }
-
-    ${InfoCard} > div > span > p {
-      color: ${({ theme }) => theme.text1};
-    }
-
-    ${InfoCard} > div > span > b {
-      font-size: 28px;
-      font-weight: bold;
-      color: ${({ theme }) => theme.success};
-      width: 100%;
-      text-align: center;
-      margin: 20px auto 0;
-      word-break: break-all;
-    }
-
-    ${InfoCard} > div > a {
-      margin: 20px auto 0;
-    }
-
-    ${InfoCard} > div > small {
-      font-size: 15px;
-      font-weight: 500;
-      line-height: 1.1;
-      color: ${({ theme }) => transparentize(0.5, theme.text1)};
-      margin: 3px auto 0;
-    }
-
-    ${QuestionWrapper} {
-      opacity: 0.5;
-      transition: opacity 0.2s ease-in-out;
-
-      &:hover {
-        opacity: 1;
-      }
-    }
-  `
-
   return (
-    <Wrapper>
+    <SurplusCardWrapper>
       <InfoCard>
         <div>
           <span>
@@ -159,6 +51,6 @@ export function SurplusCard() {
           </ExternalLink>
         </div>
       </InfoCard>
-    </Wrapper>
+    </SurplusCardWrapper>
   )
 }

--- a/src/modules/account/containers/AccountDetails/styled.ts
+++ b/src/modules/account/containers/AccountDetails/styled.ts
@@ -1,8 +1,10 @@
+import { transparentize } from 'polished'
 import styled from 'styled-components/macro'
 
 import { ButtonSecondary } from 'legacy/components/Button'
 import { YellowCard } from 'legacy/components/Card'
 import { CopyIcon, TransactionStatusText } from 'legacy/components/Copy'
+import { QuestionWrapper } from 'legacy/components/QuestionHelper'
 import { ExternalLink, StyledLink } from 'legacy/theme'
 
 import {
@@ -439,4 +441,109 @@ export const NetworkCard = styled(NetworkCardUni)`
   ${({ theme }) => theme.mediaWidth.upToSmall`
     margin: 0 auto 12px;
   `};
+`
+
+export const SurplusCardWrapper = styled.div`
+  margin: 0 auto 24px;
+  width: 100%;
+  display: grid;
+  align-items: center;
+  justify-content: center;
+  grid-template-columns: 1fr;
+  gap: 24px;
+  box-sizing: border-box;
+  padding: 0 24px;
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+      display: flex;
+      flex-flow: column wrap;
+      padding: 0 16px;
+    `}
+
+  ${InfoCard} {
+    display: flex;
+    flex-flow: column wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 0;
+    background: ${({ theme }) => theme.gradient2};
+    border-radius: 16px;
+    padding: 20px 26px 26px;
+    min-height: 210px;
+    width: 100%;
+    max-width: 100%;
+    margin: 0;
+  }
+
+  ${InfoCard} > div {
+    display: flex;
+    flex-flow: column wrap;
+    align-items: center;
+    justify-content: center;
+
+    &:first-child {
+      margin: 20px auto 0;
+    }
+
+    &:last-child {
+      margin: auto 0 0;
+    }
+  }
+
+  ${InfoCard} > div > span {
+    display: flex;
+    flex-flow: column wrap;
+    align-items: center;
+    justify-content: center;
+  }
+
+  ${InfoCard} > div > span > i,
+    ${InfoCard} > div > a,
+    ${InfoCard} > div > span > p {
+    display: flex;
+    font-size: 13px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 1.1;
+    width: 100%;
+    text-align: center;
+    justify-content: center;
+    align-items: center;
+    color: ${({ theme }) => transparentize(0.3, theme.text1)};
+  }
+
+  ${InfoCard} > div > span > p {
+    color: ${({ theme }) => theme.text1};
+  }
+
+  ${InfoCard} > div > span > b {
+    font-size: 28px;
+    font-weight: bold;
+    color: ${({ theme }) => theme.success};
+    width: 100%;
+    text-align: center;
+    margin: 20px auto 0;
+    word-break: break-all;
+  }
+
+  ${InfoCard} > div > a {
+    margin: 20px auto 0;
+  }
+
+  ${InfoCard} > div > small {
+    font-size: 15px;
+    font-weight: 500;
+    line-height: 1.1;
+    color: ${({ theme }) => transparentize(0.5, theme.text1)};
+    margin: 3px auto 0;
+  }
+
+  ${QuestionWrapper} {
+    opacity: 0.5;
+    transition: opacity 0.2s ease-in-out;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
 `


### PR DESCRIPTION
# Summary

I created this PR because I saw in the surplus component we were defining the surplus styled component inside the `render` function of the component. This is inefficient, because it will define it over and over in each rendering. 

On top of this, i just moved the styles close to the other styles (`./styled`)

# To Test

Nothing should change, you should see the surplus as before