### PR TITLE
feat(hackathon-surplus): add tooltip for activity modal surplus

### DIFF
--- a/src/modules/account/containers/AccountDetails/SurplusCard.tsx
+++ b/src/modules/account/containers/AccountDetails/SurplusCard.tsx
@@ -15,7 +15,8 @@ import { InfoCard, SurplusCardWrapper } from './styled'
 export function SurplusCard() {
   const { surplusAmount, isLoading } = useTotalSurplus()
 
-  const surplusUsdAmount = useHigherUSDValue(surplusAmount)
+  const showSurplusAmount = surplusAmount && surplusAmount.greaterThan(0)
+  const surplusUsdAmount = useHigherUSDValue(showSurplusAmount ? surplusAmount : undefined)
   const nativeSymbol = useNativeCurrency()?.symbol || 'ETH'
 
   // TODO: Remove these 2 lines once merged in DEVELOP (this change was cherry-picked from it, and it still needs these two lines because it doesn't have sasha refactor for supportedChainId)
@@ -38,14 +39,13 @@ export function SurplusCard() {
           <span>
             {isLoading ? (
               <p>Loading...</p>
+            ) : showSurplusAmount ? (
+              <b>
+                +<TokenAmount amount={surplusAmount} tokenSymbol={surplusAmount?.currency} />
+              </b>
             ) : (
-              surplusAmount && (
-                <b>
-                  +<TokenAmount amount={surplusAmount} tokenSymbol={surplusAmount?.currency} />
-                </b>
-              )
+              <p>No surplus for the given time period</p>
             )}
-            {!surplusAmount && <p>No surplus for the given time period</p>}
           </span>
           <small>{surplusUsdAmount && <FiatAmount amount={surplusUsdAmount} accurate={false} />}</small>
         </div>

--- a/src/modules/account/containers/AccountDetails/SurplusCard.tsx
+++ b/src/modules/account/containers/AccountDetails/SurplusCard.tsx
@@ -8,6 +8,7 @@ import { useWalletInfo } from 'modules/wallet'
 import { FiatAmount } from 'common/pure/FiatAmount'
 import { TokenAmount } from 'common/pure/TokenAmount'
 import { useTotalSurplus } from 'common/state/totalSurplusState'
+import useNativeCurrency from 'lib/hooks/useNativeCurrency'
 
 import { InfoCard, SurplusCardWrapper } from './styled'
 
@@ -15,6 +16,7 @@ export function SurplusCard() {
   const { surplusAmount, isLoading } = useTotalSurplus()
 
   const surplusUsdAmount = useHigherUSDValue(surplusAmount)
+  const nativeSymbol = useNativeCurrency()?.symbol || 'ETH'
 
   // TODO: Remove these 2 lines once merged in DEVELOP (this change was cherry-picked from it, and it still needs these two lines because it doesn't have sasha refactor for supportedChainId)
   const { chainId } = useWalletInfo()
@@ -27,7 +29,10 @@ export function SurplusCard() {
         <div>
           <span>
             <i>
-              Your total surplus <QuestionHelper text={'TODO: insert tooltip'} />
+              Your total surplus{' '}
+              <QuestionHelper
+                text={`The total surplus CoW Swap has generated for you in ${nativeSymbol} across all your trades since March 2023`}
+              />
             </i>
           </span>
           <span>
@@ -45,7 +50,6 @@ export function SurplusCard() {
           <small>{surplusUsdAmount && <FiatAmount amount={surplusUsdAmount} accurate={false} />}</small>
         </div>
         <div>
-          {/* TODO: add correct link */}
           <ExternalLink href={'https://blog.cow.fi/announcing-cow-swap-surplus-notifications-f679c77702ea'}>
             Learn about surplus on CoW Swap ↗
           </ExternalLink>


### PR DESCRIPTION
# Summary

Closes: #2828 

Added the missing tooltip

<img width="414" alt="Screenshot 2023-07-10 at 16 05 09" src="https://github.com/cowprotocol/cowswap/assets/43217/8611e9fa-bd77-4fe7-9a3c-aa46128d24c9">
<img width="475" alt="Screenshot 2023-07-10 at 16 04 47" src="https://github.com/cowprotocol/cowswap/assets/43217/290c0f82-b2b7-4383-96b2-97fdffc8e16d">

# To Test

1. Connect wallet that had any surplus since March 2023
2. Hover over question mark icon like images above
* Should show the text as above