### PR TITLE
feat(hackathon-surplus): do not show 0 surplus

### DIFF
--- a/src/modules/account/containers/AccountDetails/SurplusCard.tsx
+++ b/src/modules/account/containers/AccountDetails/SurplusCard.tsx
@@ -15,7 +15,8 @@ import { InfoCard, SurplusCardWrapper } from './styled'
 export function SurplusCard() {
   const { surplusAmount, isLoading } = useTotalSurplus()
 
-  const surplusUsdAmount = useHigherUSDValue(surplusAmount)
+  const showSurplusAmount = surplusAmount && surplusAmount.greaterThan(0)
+  const surplusUsdAmount = useHigherUSDValue(showSurplusAmount ? surplusAmount : undefined)
   const nativeSymbol = useNativeCurrency()?.symbol || 'ETH'
 
   // TODO: Remove these 2 lines once merged in DEVELOP (this change was cherry-picked from it, and it still needs these two lines because it doesn't have sasha refactor for supportedChainId)
@@ -38,14 +39,13 @@ export function SurplusCard() {
           <span>
             {isLoading ? (
               <p>Loading...</p>
+            ) : showSurplusAmount ? (
+              <b>
+                +<TokenAmount amount={surplusAmount} tokenSymbol={surplusAmount?.currency} />
+              </b>
             ) : (
-              surplusAmount && (
-                <b>
-                  +<TokenAmount amount={surplusAmount} tokenSymbol={surplusAmount?.currency} />
-                </b>
-              )
+              <p>No surplus for the given time period</p>
             )}
-            {!surplusAmount && <p>No surplus for the given time period</p>}
           </span>
           <small>{surplusUsdAmount && <FiatAmount amount={surplusUsdAmount} accurate={false} />}</small>
         </div>


### PR DESCRIPTION
# Summary

Closes #2829 

<img width="342" alt="Screenshot 2023-07-10 at 16 29 43" src="https://github.com/cowprotocol/cowswap/assets/43217/74f055f0-92de-4f7d-ae1e-be9f1cf229e0">


# To Test

1. Connect with account without trades OR surplus since March 2023
2. Open activity modal
* Should show msg as above

Other accounts/networks should still display the surplus amount - if any