### PR TITLE
fix(twap): fix slippage value crash

### DIFF
--- a/src/modules/twap/containers/TwapFormWidget/index.tsx
+++ b/src/modules/twap/containers/TwapFormWidget/index.tsx
@@ -141,7 +141,7 @@ export function TwapFormWidget() {
           value={slippageValue}
           onUserInput={(value: number | null) => updateSettingsState({ slippageValue: value })}
           decimalsPlaces={2}
-          placeholder={DEFAULT_TWAP_SLIPPAGE.toFixed(1)}
+          placeholder={DEFAULT_TWAP_SLIPPAGE.toFixed(0)}
           max={50}
           label={LABELS_TOOLTIPS.slippage.label}
           tooltip={renderTooltip(LABELS_TOOLTIPS.slippage.tooltip)}

--- a/src/modules/twap/state/twapOrdersSettingsAtom.ts
+++ b/src/modules/twap/state/twapOrdersSettingsAtom.ts
@@ -58,6 +58,6 @@ export const twapOrderSlippageAtom = atom<Percent>((get) => {
 
   return slippageValue != null
     ? // Multiplying on 100 to allow decimals values (e.g 0.05)
-      new Percent(Math.round(slippageValue) * 100, 10000)
+      new Percent(Math.round(slippageValue * 100), 10000)
     : DEFAULT_TWAP_SLIPPAGE
 })

--- a/src/modules/twap/state/twapOrdersSettingsAtom.ts
+++ b/src/modules/twap/state/twapOrdersSettingsAtom.ts
@@ -58,6 +58,6 @@ export const twapOrderSlippageAtom = atom<Percent>((get) => {
 
   return slippageValue != null
     ? // Multiplying on 100 to allow decimals values (e.g 0.05)
-      new Percent(slippageValue * 100, 10000)
+      new Percent(Math.round(slippageValue) * 100, 10000)
     : DEFAULT_TWAP_SLIPPAGE
 })


### PR DESCRIPTION
# Summary

Closes #2832 

Fix slippage value crash

  # To Test

1. Open advanced orders
2. Insert a decimal value onto slippage, such as `34.34`
3. Click on another field
* The app should not crash
* Inserted value should be saved