### PR TITLE
chore: refactor explorer links and menu, add explorer in menu

### DIFF
--- a/src/common/pure/OrderSubmittedContent/index.tsx
+++ b/src/common/pure/OrderSubmittedContent/index.tsx
@@ -42,7 +42,7 @@ export function OrderSubmittedContent({ chainId, hash, onDismiss }: OrderSubmitt
         <Trans>Order Submitted</Trans>
       </Caption>
       {/*TODO: unify and fix explorer link. Refs: ExplorerLink, DisplayLink, EnhancedTransactionLink*/}
-      <ExternalLink href={getExplorerLink(chainId, hash, 'transaction')}>
+      <ExternalLink href={getExplorerLink(chainId, 'transaction', hash)}>
         <Trans>View on Explorer ↗</Trans>
       </ExternalLink>
       <ActionButton onClick={onDismiss}>

--- a/src/legacy/components/AddressInputPanel/index.tsx
+++ b/src/legacy/components/AddressInputPanel/index.tsx
@@ -115,7 +115,7 @@ export function AddressInputPanel({
                 {label ?? <Trans>Recipient</Trans>}
               </ThemedText.Black>
               {address && chainId && (
-                <ExternalLink href={getExplorerLink(chainId, name ?? address, 'address')} style={{ fontSize: '14px' }}>
+                <ExternalLink href={getExplorerLink(chainId, 'address', name ?? address)} style={{ fontSize: '14px' }}>
                   <Trans>(View on Explorer)</Trans>
                 </ExternalLink>
               )}

--- a/src/legacy/components/ExplorerLink/index.tsx
+++ b/src/legacy/components/ExplorerLink/index.tsx
@@ -1,22 +1,36 @@
+import { PropsWithChildren } from 'react'
+
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
 import { ExternalLink } from 'legacy/theme'
-import { BlockExplorerLinkType, getExplorerLabel, getEtherscanLink } from 'legacy/utils'
+import { getExplorerLabel, getEtherscanLink } from 'legacy/utils'
+import { getExplorerBaseUrl } from 'legacy/utils/explorer'
 import { supportedChainId } from 'legacy/utils/supportedChainId'
 
 import { useWalletInfo } from 'modules/wallet'
 
-interface Props {
-  id: string
-  type?: BlockExplorerLinkType
+interface PropsBase extends PropsWithChildren {
+  // type?: BlockExplorerLinkType
   label?: string
   className?: string
 }
+
+interface PropsWithId extends PropsBase {
+  type: 'transaction' | 'token' | 'address' | 'block' | 'token-transfer'
+  id: string
+}
+
+interface PropsWithoutId extends PropsBase {
+  type: 'cow-explorer-home'
+}
+
+export type Props = PropsWithId | PropsWithoutId
 
 /**
  * Creates a link to the relevant explorer: Etherscan, GP Explorer or Blockscout
  * @param props
  */
 export function ExplorerLink(props: Props) {
-  const { id, label, type = 'transaction', className } = props
   const { chainId: _chainId } = useWalletInfo()
   const chainId = supportedChainId(_chainId)
 
@@ -24,10 +38,45 @@ export function ExplorerLink(props: Props) {
     return null
   }
 
-  const linkLabel = label || getExplorerLabel(chainId, id, type)
+  const url = getUrl(chainId, props)
+  const { className } = props
+
+  const linkContent = getContent(chainId, props)
   return (
-    <ExternalLink className={className} href={getEtherscanLink(chainId, id, type)}>
-      {linkLabel} <span style={{ fontSize: '0.8em' }}>↗</span>
+    <ExternalLink className={className} href={url}>
+      {linkContent}
     </ExternalLink>
+  )
+}
+
+function getUrl(chainId: SupportedChainId, props: Props) {
+  const { type } = props
+
+  if (type === 'cow-explorer-home') {
+    return getExplorerBaseUrl(chainId)
+  }
+
+  // return
+  return getEtherscanLink(chainId, type, props.id)
+}
+
+function getLabel(chainId: SupportedChainId, props: Props) {
+  const { label, type } = props
+
+  const id = type !== 'cow-explorer-home' ? props.id : undefined
+
+  return label || getExplorerLabel(chainId, type, id)
+}
+function getContent(chainId: SupportedChainId, props: Props) {
+  if (props.children) {
+    return props.children
+  }
+
+  const linkLabel = getLabel(chainId, props)
+
+  return (
+    <>
+      {linkLabel} <span style={{ fontSize: '0.8em' }}>↗</span>
+    </>
   )
 }

--- a/src/legacy/components/ExplorerLink/index.tsx
+++ b/src/legacy/components/ExplorerLink/index.tsx
@@ -13,6 +13,7 @@ interface PropsBase extends PropsWithChildren {
   // type?: BlockExplorerLinkType
   label?: string
   className?: string
+  defaultChain?: SupportedChainId
 }
 
 interface PropsWithId extends PropsBase {
@@ -32,7 +33,7 @@ export type Props = PropsWithId | PropsWithoutId
  */
 export function ExplorerLink(props: Props) {
   const { chainId: _chainId } = useWalletInfo()
-  const chainId = supportedChainId(_chainId)
+  const chainId = supportedChainId(_chainId) || props.defaultChain
 
   if (!chainId) {
     return null

--- a/src/legacy/components/Popups/TransactionPopupMod.tsx
+++ b/src/legacy/components/Popups/TransactionPopupMod.tsx
@@ -40,7 +40,7 @@ export default function TransactionPopup({
         ) : (
           summary
         )}
-        {chainId && <ExplorerLink id={hash} />}
+        {chainId && <ExplorerLink id={hash} type="transaction" />}
       </AutoColumn>
     </RowNoFlex>
   )

--- a/src/legacy/components/SearchModal/ImportToken/index.tsx
+++ b/src/legacy/components/SearchModal/ImportToken/index.tsx
@@ -68,7 +68,7 @@ function CardComponent({ theme, key, token, chainId, list }: CardComponentProps)
           </ThemedText.DarkGray>
         </AutoColumn>
         {chainId && (
-          <ExternalLink href={getExplorerLink(chainId, token.address, 'address')}>
+          <ExternalLink href={getExplorerLink(chainId, 'address', token.address)}>
             <AddressText fontSize={12}>{token.address}</AddressText>
           </ExternalLink>
         )}

--- a/src/legacy/components/SearchModal/ManageTokens/ManageTokensMod.tsx
+++ b/src/legacy/components/SearchModal/ManageTokens/ManageTokensMod.tsx
@@ -88,7 +88,7 @@ export default function ManageTokens({ setModalView, setImportToken, ImportToken
         <RowBetween key={token.address} width="100%">
           <RowFixed>
             <CurrencyLogo currency={token} size={'20px'} />
-            <ExternalLink href={getExplorerLink(chainId, token.address, 'address')}>
+            <ExternalLink href={getExplorerLink(chainId, 'address', token.address)}>
               <ThemedText.Main ml={'10px'} fontWeight={600}>
                 <TokenSymbol token={token} /> {/* MOD */}
               </ThemedText.Main>
@@ -96,7 +96,7 @@ export default function ManageTokens({ setModalView, setImportToken, ImportToken
           </RowFixed>
           <RowFixed>
             <TrashIcon onClick={() => removeToken(chainId, token.address)} />
-            <ExternalLinkIcon href={getExplorerLink(chainId, token.address, 'address')} />
+            <ExternalLinkIcon href={getExplorerLink(chainId, 'address', token.address)} />
           </RowFixed>
         </RowBetween>
       ))

--- a/src/legacy/components/SearchModal/TokenImportCard/TokenImportCardMod.tsx
+++ b/src/legacy/components/SearchModal/TokenImportCard/TokenImportCardMod.tsx
@@ -51,7 +51,7 @@ const TokenImportCard = ({ list, token }: TokenImportCardProps) => {
           </ThemedText.DarkGray>
         </AutoColumn>
         {chainId && (
-          <ExternalLink href={getExplorerLink(chainId, token.address, 'address')}>
+          <ExternalLink href={getExplorerLink(chainId, 'address', token.address)}>
             <AddressText fontSize={12}>{token.address}</AddressText>
           </ExternalLink>
         )}

--- a/src/legacy/components/Tokens/TokensTableRow.tsx
+++ b/src/legacy/components/Tokens/TokensTableRow.tsx
@@ -199,7 +199,7 @@ const DataRow = ({
       <Cell>{fiatValue}</Cell>
 
       <Cell>
-        <ExtLink href={getBlockExplorerUrl(chainId, tokenData.address, 'token')}>
+        <ExtLink href={getBlockExplorerUrl(chainId, 'token', tokenData.address)}>
           <TableButton>
             <SVG src={EtherscanImage} title="View token contract" description="View token contract" />
           </TableButton>

--- a/src/legacy/components/TransactionConfirmationModal/DisplayLink.tsx
+++ b/src/legacy/components/TransactionConfirmationModal/DisplayLink.tsx
@@ -27,9 +27,9 @@ export function DisplayLink({ id, chainId }: DisplayLinkProps) {
       ? orderCreationHash
       : undefined
   const href = ethFlowHash
-    ? getBlockExplorerUrl(chainId, ethFlowHash, 'transaction')
-    : getEtherscanLink(chainId, id, 'transaction')
-  const label = getExplorerLabel(chainId, ethFlowHash || id, 'transaction')
+    ? getBlockExplorerUrl(chainId, 'transaction', ethFlowHash)
+    : getEtherscanLink(chainId, 'transaction', id)
+  const label = getExplorerLabel(chainId, 'transaction', ethFlowHash || id)
 
   return (
     <ExternalLinkCustom href={href}>

--- a/src/legacy/components/Version/index.tsx
+++ b/src/legacy/components/Version/index.tsx
@@ -15,7 +15,7 @@ import pkg from '../../../../package.json'
 function _getContractsUrls(chainId: ChainId, contractAddressMap: typeof GP_SETTLEMENT_CONTRACT_ADDRESS) {
   const contractAddress = contractAddressMap[chainId]
   if (!contractAddress) return '-'
-  return getEtherscanLink(chainId, contractAddress, 'address')
+  return getEtherscanLink(chainId, 'address', contractAddress)
 }
 
 const VERSIONS: Record<

--- a/src/legacy/components/swap/UnsupportedCurrencyFooter/UnsupportedCurrencyFooterMod.tsx
+++ b/src/legacy/components/swap/UnsupportedCurrencyFooter/UnsupportedCurrencyFooterMod.tsx
@@ -99,7 +99,7 @@ export default function UnsupportedCurrencyFooter({
                         <ThemedText.Body fontWeight={500}>{token.symbol}</ThemedText.Body>
                       </AutoRow>
                       {chainId && (
-                        <ExternalLink href={getEtherscanLink(chainId, token.address, 'address')}>
+                        <ExternalLink href={getEtherscanLink(chainId, 'address', token.address)}>
                           <AddressText>{token.address}</AddressText>
                         </ExternalLink>
                       )}

--- a/src/legacy/hooks/useActivityDerivedState.ts
+++ b/src/legacy/hooks/useActivityDerivedState.ts
@@ -93,7 +93,7 @@ export function getActivityLinkUrl(params: {
 
     if (transactionHash) {
       // It's an Ethereum transaction: Etherscan link
-      return getEtherscanLink(chainId, transactionHash, 'transaction')
+      return getEtherscanLink(chainId, 'transaction', transactionHash)
     } else if (safeTransaction && safeTransaction) {
       // It's a safe transaction: Gnosis Safe Web link
       const { safe, safeTxHash } = safeTransaction
@@ -102,7 +102,7 @@ export function getActivityLinkUrl(params: {
   } else if (order) {
     if (order.orderCreationHash && (order.status === OrderStatus.CREATING || order.status === OrderStatus.FAILED)) {
       // It's a EthFlow transaction: Etherscan link
-      return getEtherscanLink(chainId, order.orderCreationHash, 'transaction')
+      return getEtherscanLink(chainId, 'transaction', order.orderCreationHash)
     } else {
       // It's an order: GP Explorer link
       return getExplorerOrderLink(chainId, id)

--- a/src/legacy/utils/index.ts
+++ b/src/legacy/utils/index.ts
@@ -62,7 +62,7 @@ export function formattedFeeAmount(feeAmount: FeeAmount): number {
   return feeAmount / 10000
 }
 
-const GP_ORDER_ID_LENGTH = 114 // 112 (56 bytes in hex) + 2 (it's prefixed with "0x")
+const COW_ORDER_ID_LENGTH = 114 // 112 (56 bytes in hex) + 2 (it's prefixed with "0x")
 
 const ETHERSCAN_URLS: { [chainId in ChainId]: string } = {
   1: 'etherscan.io',
@@ -73,7 +73,13 @@ const ETHERSCAN_URLS: { [chainId in ChainId]: string } = {
   100: 'gnosisscan.io',
 }
 
-export type BlockExplorerLinkType = 'transaction' | 'token' | 'address' | 'block' | 'token-transfer'
+export type BlockExplorerLinkType =
+  | 'transaction'
+  | 'token'
+  | 'address'
+  | 'block'
+  | 'token-transfer'
+  | 'cow-explorer-home'
 
 function getEtherscanUrl(chainId: ChainId, data: string, type: BlockExplorerLinkType): string {
   const url = ETHERSCAN_URLS[chainId] || ETHERSCAN_URLS[1]
@@ -101,26 +107,28 @@ function getEtherscanUrl(chainId: ChainId, data: string, type: BlockExplorerLink
 }
 
 // Get the right block explorer URL by chainId
-export function getBlockExplorerUrl(chainId: ChainId, data: string, type: BlockExplorerLinkType): string {
+export function getBlockExplorerUrl(chainId: ChainId, type: BlockExplorerLinkType, data: string): string {
   return getEtherscanUrl(chainId, data, type)
 }
 
-export function isGpOrder(data: string, type: BlockExplorerLinkType) {
-  return type === 'transaction' && data.length === GP_ORDER_ID_LENGTH
+export function isCowOrder(type: BlockExplorerLinkType, data?: string) {
+  if (!data) return false
+
+  return type === 'transaction' && data.length === COW_ORDER_ID_LENGTH
 }
 
-export function getEtherscanLink(chainId: ChainId, data: string, type: BlockExplorerLinkType): string {
-  if (isGpOrder(data, type)) {
-    // Explorer for GP orders:
-    //    If a transaction has the size of the GP orderId, then it's a meta-tx
+export function getEtherscanLink(chainId: ChainId, type: BlockExplorerLinkType, data: string): string {
+  if (isCowOrder(type, data)) {
+    // Explorer for CoW orders:
+    //    If a transaction has the size of the CoW orderId, then it's a meta-tx
     return getExplorerOrderLink(chainId, data)
   } else {
     return getEtherscanUrl(chainId, data, type)
   }
 }
 
-export function getExplorerLabel(chainId: ChainId, data: string, type: BlockExplorerLinkType): string {
-  if (isGpOrder(data, type)) {
+export function getExplorerLabel(chainId: ChainId, type: BlockExplorerLinkType, data?: string): string {
+  if (isCowOrder(type, data) || type === 'cow-explorer-home') {
     return 'View on Explorer'
   } else if (chainId === ChainId.GNOSIS_CHAIN) {
     return 'View on Gnosisscan'

--- a/src/modules/account/containers/AccountDetails/index.tsx
+++ b/src/modules/account/containers/AccountDetails/index.tsx
@@ -187,7 +187,7 @@ export function AccountDetails({
   const disconnectWallet = useDisconnectWallet()
 
   const explorerOrdersLink = account && chainId && getExplorerAddressLink(chainId, account)
-  const explorerLabel = chainId && account ? getExplorerLabel(chainId, account, 'address') : undefined
+  const explorerLabel = chainId && account ? getExplorerLabel(chainId, 'address', account) : undefined
 
   const activities = useMultipleActivityDescriptors({ chainId, ids: pendingTransactions.concat(confirmedTransactions) })
   const activitiesGroupedByDate = groupActivitiesByDay(activities)
@@ -264,7 +264,7 @@ export function AccountDetails({
                 <AddressLink
                   hasENS={!!ENSName}
                   isENS={!!ENSName}
-                  href={getEtherscanLink(chainId, ENSName ? ENSName : account, 'address')}
+                  href={getEtherscanLink(chainId, 'address', ENSName ? ENSName : account)}
                 >
                   {explorerLabel} ↗
                 </AddressLink>

--- a/src/modules/mainMenu/constants/mainMenu.tsx
+++ b/src/modules/mainMenu/constants/mainMenu.tsx
@@ -1,3 +1,5 @@
+import { Globe as EXPLORER_IMG, Globe } from 'react-feather'
+
 import IMAGE_CODE from 'legacy/assets/cow-swap/code.svg'
 import IMAGE_COOKIE_POLICY from 'legacy/assets/cow-swap/cookie-policy.svg'
 import IMAGE_DISCORD from 'legacy/assets/cow-swap/discord.svg'
@@ -9,6 +11,7 @@ import IMAGE_PIE from 'legacy/assets/cow-swap/pie.svg'
 import IMAGE_PRIVACY_POLICY from 'legacy/assets/cow-swap/privacy-policy.svg'
 import IMAGE_TERMS_AND_CONDITIONS from 'legacy/assets/cow-swap/terms-and-conditions.svg'
 import IMAGE_TWITTER from 'legacy/assets/cow-swap/twitter.svg'
+import { ExplorerLink } from 'legacy/components/ExplorerLink'
 import { CONTRACTS_CODE_LINK, DISCORD_LINK, DOCS_LINK, DUNE_DASHBOARD_LINK, TWITTER_LINK } from 'legacy/constants'
 
 import { ADVANCED_ORDERS_FEATURE_FLAG } from 'constants/featureFlags'
@@ -20,6 +23,14 @@ import { BasicMenuLink, InternalLink, MainMenuItemId, MenuItemKind, MenuLink, Me
 
 export const isBasicMenuLink = (item: any): item is BasicMenuLink => {
   return !!(item.title && item.url)
+}
+
+function ExplorerMenuLink() {
+  return (
+    <ExplorerLink type="cow-explorer-home">
+      <Globe /> CoW Explorer
+    </ExplorerLink>
+  )
 }
 
 export const FAQ_MENU: InternalLink[] = [
@@ -43,17 +54,17 @@ export const MAIN_MENU: MenuTreeItem[] = [
     items: [
       {
         links: [
-          { id: MainMenuItemId.SWAP, kind: MenuItemKind.DYNAMIC_LINK, title: 'Swap', url: Routes.SWAP },
+          { id: MainMenuItemId.SWAP, kind: MenuItemKind.PARAMETRIZED_LINK, title: 'Swap', url: Routes.SWAP },
           {
             id: MainMenuItemId.LIMIT_ORDERS,
-            kind: MenuItemKind.DYNAMIC_LINK,
+            kind: MenuItemKind.PARAMETRIZED_LINK,
             title: 'Limit orders',
             url: Routes.LIMIT_ORDER,
           },
           FeatureFlag.get(ADVANCED_ORDERS_FEATURE_FLAG)
             ? {
                 id: MainMenuItemId.ADVANCED_ORDERS,
-                kind: MenuItemKind.DYNAMIC_LINK,
+                kind: MenuItemKind.PARAMETRIZED_LINK,
                 title: 'Advanced orders',
                 url: Routes.ADVANCED_ORDERS,
               }
@@ -95,6 +106,14 @@ export const MAIN_MENU: MenuTreeItem[] = [
             kind: MenuItemKind.EXTERNAL_LINK,
           },
           { id: MainMenuItemId.MORE_ABOUT, title: 'About', url: Routes.ABOUT, iconSVG: IMAGE_INFO },
+          {
+            id: MainMenuItemId.MORE_EXPLORER,
+            title: 'CoW Explorer',
+            url: DOCS_LINK,
+            iconSVG: EXPLORER_IMG.toString(),
+            kind: MenuItemKind.CUSTOM_LINK,
+            LinkComponent: ExplorerMenuLink,
+          },
           {
             id: MainMenuItemId.MORE_STATISTICS,
             title: 'Statistics',

--- a/src/modules/mainMenu/constants/mainMenu.tsx
+++ b/src/modules/mainMenu/constants/mainMenu.tsx
@@ -1,3 +1,5 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
 import { Globe } from 'react-feather'
 
 import IMAGE_CODE from 'legacy/assets/cow-swap/code.svg'
@@ -27,7 +29,7 @@ export const isBasicMenuLink = (item: any): item is BasicMenuLink => {
 
 function ExplorerMenuLink() {
   return (
-    <ExplorerLink type="cow-explorer-home">
+    <ExplorerLink type="cow-explorer-home" defaultChain={SupportedChainId.MAINNET}>
       <Globe /> CoW Explorer
     </ExplorerLink>
   )

--- a/src/modules/mainMenu/constants/mainMenu.tsx
+++ b/src/modules/mainMenu/constants/mainMenu.tsx
@@ -1,4 +1,4 @@
-import { Globe as EXPLORER_IMG, Globe } from 'react-feather'
+import { Globe } from 'react-feather'
 
 import IMAGE_CODE from 'legacy/assets/cow-swap/code.svg'
 import IMAGE_COOKIE_POLICY from 'legacy/assets/cow-swap/cookie-policy.svg'
@@ -107,12 +107,8 @@ export const MAIN_MENU: MenuTreeItem[] = [
           },
           { id: MainMenuItemId.MORE_ABOUT, title: 'About', url: Routes.ABOUT, iconSVG: IMAGE_INFO },
           {
-            id: MainMenuItemId.MORE_EXPLORER,
-            title: 'CoW Explorer',
-            url: DOCS_LINK,
-            iconSVG: EXPLORER_IMG.toString(),
-            kind: MenuItemKind.CUSTOM_LINK,
-            LinkComponent: ExplorerMenuLink,
+            kind: MenuItemKind.CUSTOM_ITEM,
+            Item: ExplorerMenuLink,
           },
           {
             id: MainMenuItemId.MORE_STATISTICS,

--- a/src/modules/mainMenu/pure/MenuTree/index.tsx
+++ b/src/modules/mainMenu/pure/MenuTree/index.tsx
@@ -9,7 +9,8 @@ import { ExternalLink as ExternalLinkComponent } from 'legacy/theme/components'
 
 import {
   DropDownItem,
-  DynamicLink,
+  ParametrizedLink,
+  CustomLink,
   ExternalLink,
   InternalLink,
   MainMenuContext,
@@ -44,7 +45,7 @@ function MenuImage(props: MenuImageProps) {
 }
 
 interface InternalExternalLinkProps {
-  link: InternalLink | ExternalLink | DynamicLink
+  link: InternalLink | ExternalLink | ParametrizedLink | CustomLink
   context: MainMenuContext
 }
 
@@ -52,9 +53,14 @@ function Link({ link, context }: InternalExternalLinkProps) {
   const { kind, title, url, iconSVG, icon } = link
   const menuImage = <MenuImage title={title} icon={icon} iconSVG={iconSVG} />
   const isExternal = kind === MenuItemKind.EXTERNAL_LINK
-  const isDynamic = kind === MenuItemKind.DYNAMIC_LINK
+  const isDynamic = kind === MenuItemKind.PARAMETRIZED_LINK
   const { handleMobileMenuOnClick, tradeContext } = context
   const internalUrl = isDynamic ? parameterizeTradeRoute(tradeContext, url as Routes) : url
+
+  if (link.kind === MenuItemKind.CUSTOM_LINK) {
+    const { LinkComponent } = link
+    return <>{LinkComponent()}</>
+  }
 
   if (isExternal) {
     return (
@@ -146,10 +152,12 @@ function MenuItemWithDropDown(props: MenuItemWithDropDownProps) {
       return <DropDown item={menuItem} context={context} />
 
     case undefined: // INTERNAL
-    case MenuItemKind.DYNAMIC_LINK:
+    case MenuItemKind.PARAMETRIZED_LINK:
     case MenuItemKind.EXTERNAL_LINK:
       // Render Internal/External links
       return <Link link={menuItem} context={context} />
+    case MenuItemKind.CUSTOM_LINK:
+      return <>{menuItem.LinkComponent}</>
     default:
       return null
   }

--- a/src/modules/mainMenu/pure/MenuTree/index.tsx
+++ b/src/modules/mainMenu/pure/MenuTree/index.tsx
@@ -10,7 +10,7 @@ import { ExternalLink as ExternalLinkComponent } from 'legacy/theme/components'
 import {
   DropDownItem,
   ParametrizedLink,
-  CustomLink,
+  CustomItem,
   ExternalLink,
   InternalLink,
   MainMenuContext,
@@ -45,22 +45,22 @@ function MenuImage(props: MenuImageProps) {
 }
 
 interface InternalExternalLinkProps {
-  link: InternalLink | ExternalLink | ParametrizedLink | CustomLink
+  link: InternalLink | ExternalLink | ParametrizedLink | CustomItem
   context: MainMenuContext
 }
 
 function Link({ link, context }: InternalExternalLinkProps) {
+  if (link.kind === MenuItemKind.CUSTOM_ITEM) {
+    const { Item: LinkComponent } = link
+    return <>{LinkComponent()}</>
+  }
+
   const { kind, title, url, iconSVG, icon } = link
   const menuImage = <MenuImage title={title} icon={icon} iconSVG={iconSVG} />
   const isExternal = kind === MenuItemKind.EXTERNAL_LINK
   const isDynamic = kind === MenuItemKind.PARAMETRIZED_LINK
   const { handleMobileMenuOnClick, tradeContext } = context
   const internalUrl = isDynamic ? parameterizeTradeRoute(tradeContext, url as Routes) : url
-
-  if (link.kind === MenuItemKind.CUSTOM_LINK) {
-    const { LinkComponent } = link
-    return <>{LinkComponent()}</>
-  }
 
   if (isExternal) {
     return (
@@ -156,8 +156,8 @@ function MenuItemWithDropDown(props: MenuItemWithDropDownProps) {
     case MenuItemKind.EXTERNAL_LINK:
       // Render Internal/External links
       return <Link link={menuItem} context={context} />
-    case MenuItemKind.CUSTOM_LINK:
-      return <>{menuItem.LinkComponent}</>
+    case MenuItemKind.CUSTOM_ITEM:
+      return <>{menuItem.Item}</>
     default:
       return null
   }

--- a/src/modules/mainMenu/types.ts
+++ b/src/modules/mainMenu/types.ts
@@ -6,7 +6,8 @@ export enum MenuItemKind {
   DROP_DOWN = 'DROP_DOWN',
   EXTERNAL_LINK = 'EXTERNAL_LINK',
   DARK_MODE_BUTTON = 'DARK_MODE_BUTTON',
-  DYNAMIC_LINK = 'DYNAMIC_LINK',
+  PARAMETRIZED_LINK = 'PARAMETRIZED_LINK',
+  CUSTOM_LINK = 'CUSTOM_LINK',
 }
 
 export enum MainMenuItemId {
@@ -24,6 +25,7 @@ export enum MainMenuItemId {
   ACCOUNT_TOKENS = 'ACCOUNT_TOKENS',
   MORE_DOCUMENTATION = 'MORE_DOCUMENTATION',
   MORE_ABOUT = 'MORE_ABOUT',
+  MORE_EXPLORER = 'MORE_EXPLORER',
   MORE_STATISTICS = 'MORE_STATISTICS',
   MORE_CONTRACT = 'MORE_CONTRACT',
   MORE_DISCORD = 'MORE_DISCORD',
@@ -40,7 +42,7 @@ export interface BasicMenuLink {
   title: string
   url: string
   icon?: string // If icon uses a regular <img /> tag
-  iconSVG?: string // If icon is a <SVG> inline component
+  iconSVG?: string
 }
 
 export interface InternalLink extends BasicMenuLink {
@@ -50,13 +52,18 @@ export interface InternalLink extends BasicMenuLink {
 export interface ExternalLink extends BasicMenuLink {
   kind: MenuItemKind.EXTERNAL_LINK
 }
-export interface DynamicLink extends BasicMenuLink {
-  kind: MenuItemKind.DYNAMIC_LINK
+export interface ParametrizedLink extends BasicMenuLink {
+  kind: MenuItemKind.PARAMETRIZED_LINK
   url: Routes
 }
 
+export interface CustomLink extends BasicMenuLink {
+  kind: MenuItemKind.CUSTOM_LINK
+  LinkComponent: () => React.ReactNode
+}
+
 export type DarkModeLink = { kind: MenuItemKind.DARK_MODE_BUTTON }
-export type MenuLink = InternalLink | ExternalLink | DarkModeLink | DynamicLink
+export type MenuLink = InternalLink | ExternalLink | DarkModeLink | ParametrizedLink | CustomLink
 
 export interface DropDownSubItem {
   sectionTitle?: string
@@ -69,7 +76,7 @@ export interface DropDownItem {
   items: DropDownSubItem[]
 }
 
-export type MenuTreeItem = InternalLink | ExternalLink | DropDownItem | DynamicLink
+export type MenuTreeItem = InternalLink | ExternalLink | DropDownItem | ParametrizedLink | CustomLink
 
 export interface MainMenuContext {
   darkMode: boolean

--- a/src/modules/mainMenu/types.ts
+++ b/src/modules/mainMenu/types.ts
@@ -7,7 +7,7 @@ export enum MenuItemKind {
   EXTERNAL_LINK = 'EXTERNAL_LINK',
   DARK_MODE_BUTTON = 'DARK_MODE_BUTTON',
   PARAMETRIZED_LINK = 'PARAMETRIZED_LINK',
-  CUSTOM_LINK = 'CUSTOM_LINK',
+  CUSTOM_ITEM = 'CUSTOM_ITEM',
 }
 
 export enum MainMenuItemId {
@@ -57,13 +57,13 @@ export interface ParametrizedLink extends BasicMenuLink {
   url: Routes
 }
 
-export interface CustomLink extends BasicMenuLink {
-  kind: MenuItemKind.CUSTOM_LINK
-  LinkComponent: () => React.ReactNode
+export interface CustomItem {
+  kind: MenuItemKind.CUSTOM_ITEM
+  Item: () => React.ReactNode
 }
 
 export type DarkModeLink = { kind: MenuItemKind.DARK_MODE_BUTTON }
-export type MenuLink = InternalLink | ExternalLink | DarkModeLink | ParametrizedLink | CustomLink
+export type MenuLink = InternalLink | ExternalLink | DarkModeLink | ParametrizedLink | CustomItem
 
 export interface DropDownSubItem {
   sectionTitle?: string
@@ -76,7 +76,7 @@ export interface DropDownItem {
   items: DropDownSubItem[]
 }
 
-export type MenuTreeItem = InternalLink | ExternalLink | DropDownItem | ParametrizedLink | CustomLink
+export type MenuTreeItem = InternalLink | ExternalLink | DropDownItem | ParametrizedLink | CustomItem
 
 export interface MainMenuContext {
   darkMode: boolean

--- a/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
+++ b/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
@@ -149,7 +149,7 @@ export function OrderRow({
   const creationTimeAgo = useTimeAgo(parsedCreationTime, TIME_AGO_UPDATE_INTERVAL)
   // TODO: set the real value when API returns it
   // const executedTimeAgo = useTimeAgo(expirationTime, TIME_AGO_UPDATE_INTERVAL)
-  const activityUrl = chainId && activityId ? getEtherscanLink(chainId, activityId, 'transaction') : undefined
+  const activityUrl = chainId && activityId ? getEtherscanLink(chainId, 'transaction', activityId) : undefined
 
   const [isInverted, setIsInverted] = useState(() => {
     // On mount, apply smart quote selection

--- a/src/modules/ordersTable/pure/ReceiptModal/IdField.tsx
+++ b/src/modules/ordersTable/pure/ReceiptModal/IdField.tsx
@@ -11,7 +11,7 @@ export type Props = {
 }
 
 export function IdField({ id, chainId }: Props) {
-  const activityUrl = getEtherscanLink(chainId, id, 'transaction')
+  const activityUrl = getEtherscanLink(chainId, 'transaction', id)
 
   return (
     <styledEl.Value>

--- a/src/pages/Account/Balances.tsx
+++ b/src/pages/Account/Balances.tsx
@@ -256,7 +256,7 @@ export default function Profile() {
               </ConvertWrapper>
 
               <CardActions>
-                <ExtLink href={getBlockExplorerUrl(chainId, V_COW_CONTRACT_ADDRESS[chainId], 'token')}>
+                <ExtLink href={getBlockExplorerUrl(chainId, 'token', V_COW_CONTRACT_ADDRESS[chainId])}>
                   View contract ↗
                 </ExtLink>
                 <CopyHelper toCopy={V_COW_CONTRACT_ADDRESS[chainId]}>
@@ -279,7 +279,7 @@ export default function Profile() {
             <CardActions>
               <ExtLink
                 title="View contract"
-                href={getBlockExplorerUrl(chainId, COW_CONTRACT_ADDRESS[chainId], 'token')}
+                href={getBlockExplorerUrl(chainId, 'token', COW_CONTRACT_ADDRESS[chainId])}
               >
                 View contract ↗
               </ExtLink>

--- a/src/pages/Account/LockedGnoVesting/index.tsx
+++ b/src/pages/Account/LockedGnoVesting/index.tsx
@@ -203,7 +203,7 @@ const LockedGnoVesting: React.FC<Props> = ({ openModal, closeModal, vested, allo
         </ConvertWrapper>
 
         <CardActions>
-          <ExtLink href={getBlockExplorerUrl(chainId, contractAddress, 'address')}>View contract ↗</ExtLink>
+          <ExtLink href={getBlockExplorerUrl(chainId, 'address', contractAddress)}>View contract ↗</ExtLink>
           <CopyHelper toCopy={contractAddress}>
             <div title="Click to copy contract address">Copy contract</div>
           </CopyHelper>


### PR DESCRIPTION
# Summary

Address the issue we didn't have a explorer link in the header


<img width="1452" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/2123beea-9a56-42e7-a2ff-9155e53976af">


## Implementation notes for reviewers
TBH i thought this would be a 5min thing, and it turned out I had to implement a few features in order to make it work. 

Let me drive you through the thinking process.

1. Our links are created by configuration of some const here https://github.com/cowprotocol/cowswap/blob/b383642deb7826f20c8525fe30133a73a3be4703/src/modules/mainMenu/constants/mainMenu.tsx#L108 

2. The link to the explorer can't be added as a static type, because the URL changes for example between different networks 

3. I decided to make a new type of Menu Item with an arbitrary component, this way we can make any dynamic logic. This new type is:
* https://github.com/cowprotocol/cowswap/blob/9f462640f2d779922963825e4794d8df213b1e37/src/modules/mainMenu/types.ts#L62 
* https://github.com/cowprotocol/cowswap/blob/9f462640f2d779922963825e4794d8df213b1e37/src/modules/mainMenu/types.ts#L10

4. Then I have to adapt the `<ExplorerLink />` component, because it was assumed we always use it for links with an `id` (a transaction, or address). In this case, i just want to send it to the home page of the explorer https://github.com/cowprotocol/cowswap/blob/9f462640f2d779922963825e4794d8df213b1e37/src/legacy/components/ExplorerLink/index.tsx#L56

*  Now you can see how we have some link types that require ID and some that doesn't https://github.com/cowprotocol/cowswap/blob/9f462640f2d779922963825e4794d8df213b1e37/src/legacy/components/ExplorerLink/index.tsx#L27

5. Additionally, the link HTML was not good in this case, because i needed to have some image and custom markup for the link, so i gave `children` support
https://github.com/cowprotocol/cowswap/blob/9f462640f2d779922963825e4794d8df213b1e37/src/legacy/components/ExplorerLink/index.tsx#L72

6. with all this, implementing the link is just to:
* add the item in the menu (in the right place): https://github.com/cowprotocol/cowswap/blob/9f462640f2d779922963825e4794d8df213b1e37/src/modules/mainMenu/constants/mainMenu.tsx#L110
* Pass the dynamic custom component https://github.com/cowprotocol/cowswap/blob/9f462640f2d779922963825e4794d8df213b1e37/src/modules/mainMenu/constants/mainMenu.tsx#L28


Most of the changes will be to adapt the link parameters, because the `id` is now optional, it should be last 

## EDIT: adding default network
Before @elena-zh opens an issue, i noticed the link was not displayed if the network is unsupported

Now i created a parameter to the `ExplorerLink` component so it can have a default network

<img width="2047" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/88b87016-e497-4ea8-a815-06ba7a44fc41">



 # To Test

1 .Check the link in the different networks
