### PR TITLE
fix(state): too large local-storage

### DIFF
--- a/src/legacy/state/index.ts
+++ b/src/legacy/state/index.ts
@@ -44,7 +44,7 @@ const reducers = {
   cowToken,
 }
 
-const PERSISTED_KEYS: string[] = ['user', 'transactions', 'orders', 'lists', 'gas', 'affiliate', 'profile', 'swap']
+const PERSISTED_KEYS: string[] = ['user', 'transactions', 'lists', 'gas', 'affiliate', 'profile', 'swap']
 
 const store = configureStore({
   reducer: reducers,


### PR DESCRIPTION
# Summary

Fixes #2690 

Removes `orders` from persisted state as maybe there is no need to do this.

# To test
- Test scenarios mentioned in the issue related
- If it doesn't fix at first, clear local-storage and try again
- Make sure orders table is same as on prod and other order related data