### PR TITLE
feat(hackathon-surplus): add missing link to surplus modal

### DIFF
--- a/src/common/pure/TransactionSubmittedContent/SurplusModal.tsx
+++ b/src/common/pure/TransactionSubmittedContent/SurplusModal.tsx
@@ -175,7 +175,6 @@ export function SurplusModal(props: SurplusModalProps) {
         <span>!</span>
       </strong>
       {showFiatValue && <FiatAmount amount={surplusFiatValue} accurate={false} />}
-      {/* TODO: add share data */}
       {surplusAmount && surplusToken && (
         <StyledExternalLink
           onClickOptional={onTweetShare}
@@ -191,7 +190,9 @@ export function SurplusModal(props: SurplusModalProps) {
       )}
       <p>
         CoW Swap is the only token exchange that gets you extra tokens.{' '}
-        <ExternalLink href={'https://cow.fi'}>Learn how ↗</ExternalLink>
+        <ExternalLink href={'https://blog.cow.fi/announcing-cow-swap-surplus-notifications-f679c77702ea'}>
+          Learn how ↗
+        </ExternalLink>
       </p>
     </Wrapper>
   )


### PR DESCRIPTION
# Summary

Add missing link to surplus modal

# To Test

1. Place order
* Once traded, surplus modal is displayed
* Surplus modal should contain link to blog post