### PR TITLE
chore: make pixel events more resilient

### DIFF
--- a/src/legacy/components/Header/NetworkSelector/NetworkSelectorMod.tsx
+++ b/src/legacy/components/Header/NetworkSelector/NetworkSelectorMod.tsx
@@ -352,10 +352,13 @@ export default function NetworkSelector() {
       // Don't set chainId as query parameter because swap and limit orders have different routing scheme
       if (tradeTypeInfo) return
 
+      const chainName = getChainNameFromId(chainId)
+      if (!chainName) return
+
       navigate(
         {
           pathname: location.pathname,
-          search: replaceURLParam(location.search, 'chain', getChainNameFromId(chainId)),
+          search: replaceURLParam(location.search, 'chain', chainName),
         },
         { replace: true }
       )

--- a/src/legacy/components/analytics/pixel/constants.ts
+++ b/src/legacy/components/analytics/pixel/constants.ts
@@ -1,3 +1,6 @@
+// TODO: Leaving true just for testing, then i will enable for PROD and ENS
+export const PIXEL_ENABLED = true // isProd || isEns
+
 export enum PIXEL_EVENTS {
   INIT = 'init',
   CONNECT_WALLET = 'connect_wallet',

--- a/src/legacy/components/analytics/pixel/facebook.ts
+++ b/src/legacy/components/analytics/pixel/facebook.ts
@@ -1,4 +1,5 @@
 import { PIXEL_EVENTS } from './constants'
+import { sendPixel } from './utils'
 
 const events = {
   [PIXEL_EVENTS.INIT]: 'InitiateCheckout',
@@ -6,6 +7,6 @@ const events = {
   [PIXEL_EVENTS.POST_TRADE]: 'Lead',
 }
 
-export const sendFacebookEvent = (event: PIXEL_EVENTS) => {
+export const sendFacebookEvent = sendPixel((event) => {
   window.fbq?.('track', events[event])
-}
+})

--- a/src/legacy/components/analytics/pixel/linkedin.ts
+++ b/src/legacy/components/analytics/pixel/linkedin.ts
@@ -1,4 +1,5 @@
 import { PIXEL_EVENTS } from './constants'
+import { sendPixel } from './utils'
 
 const events = {
   [PIXEL_EVENTS.INIT]: 10759506,
@@ -6,6 +7,6 @@ const events = {
   [PIXEL_EVENTS.POST_TRADE]: 10759522,
 }
 
-export const sendLinkedinEvent = (event: PIXEL_EVENTS) => {
+export const sendLinkedinEvent = sendPixel((event) => {
   window.lintrk?.('track', { conversion_id: events[event] })
-}
+})

--- a/src/legacy/components/analytics/pixel/microsoft.ts
+++ b/src/legacy/components/analytics/pixel/microsoft.ts
@@ -1,4 +1,5 @@
 import { PIXEL_EVENTS } from './constants'
+import { sendPixel } from './utils'
 
 const events = {
   [PIXEL_EVENTS.INIT]: 'page_view',
@@ -6,7 +7,7 @@ const events = {
   [PIXEL_EVENTS.POST_TRADE]: 'purchase',
 }
 
-export const sendMicrosoftEvent = (event: PIXEL_EVENTS) => {
+export const sendMicrosoftEvent = sendPixel((event) => {
   window.uetq = window.uetq || []
   window.uetq.push('event', events[event], {})
-}
+})

--- a/src/legacy/components/analytics/pixel/paved.ts
+++ b/src/legacy/components/analytics/pixel/paved.ts
@@ -1,4 +1,5 @@
 import { PIXEL_EVENTS } from './constants'
+import { sendPixel } from './utils'
 
 const events = {
   [PIXEL_EVENTS.INIT]: 'search',
@@ -6,6 +7,6 @@ const events = {
   [PIXEL_EVENTS.POST_TRADE]: 'purchase',
 }
 
-export const sendPavedEvent = (event: PIXEL_EVENTS) => {
+export const sendPavedEvent = sendPixel((event: PIXEL_EVENTS) => {
   window.pvd?.('event', events[event])
-}
+})

--- a/src/legacy/components/analytics/pixel/reddit.ts
+++ b/src/legacy/components/analytics/pixel/reddit.ts
@@ -1,4 +1,5 @@
 import { PIXEL_EVENTS } from './constants'
+import { sendPixel } from './utils'
 
 const events = {
   [PIXEL_EVENTS.INIT]: 'Lead',
@@ -6,6 +7,6 @@ const events = {
   [PIXEL_EVENTS.POST_TRADE]: 'Purchase',
 }
 
-export const sendRedditEvent = (event: PIXEL_EVENTS) => {
+export const sendRedditEvent = sendPixel((event) => {
   window.rdt?.('track', events[event])
-}
+})

--- a/src/legacy/components/analytics/pixel/twitter.ts
+++ b/src/legacy/components/analytics/pixel/twitter.ts
@@ -1,4 +1,5 @@
 import { PIXEL_EVENTS } from './constants'
+import { sendPixel } from './utils'
 
 const events = {
   [PIXEL_EVENTS.INIT]: 'tw-oddz2-oddz8',
@@ -6,6 +7,6 @@ const events = {
   [PIXEL_EVENTS.POST_TRADE]: 'tw-oddz2-oddzb',
 }
 
-export const sendTwitterEvent = (event: PIXEL_EVENTS) => {
+export const sendTwitterEvent = sendPixel((event: PIXEL_EVENTS) => {
   window.twq?.('event', events[event], {})
-}
+})

--- a/src/legacy/components/analytics/pixel/utils.ts
+++ b/src/legacy/components/analytics/pixel/utils.ts
@@ -1,0 +1,17 @@
+import { PIXEL_ENABLED, PIXEL_EVENTS } from './constants'
+
+type SendPixelFn = (event: PIXEL_EVENTS) => void
+
+export function sendPixel(sendFn: SendPixelFn): SendPixelFn {
+  return (event) => {
+    if (!PIXEL_ENABLED) {
+      return
+    }
+
+    try {
+      sendFn(event)
+    } catch (e: any) {
+      console.error('Error sending pixel event', e)
+    }
+  }
+}


### PR DESCRIPTION
# Summary

Pixels and any other analytics in the app should not break the user flow in case of an error.

This PR makes sure that if we have an error reporting Pixel (facebook, twitter, etc), we just log it and it doesn't propagate.

Additionally, this PR enables the pixel reporting for PRODUCTION and ENS (well, in the PR is enabled for testing purposes, but will be disabled before merging as stated in the code comment)

This PR tries to solve the issue reported by Elena:
![image](https://github.com/cowprotocol/cowswap/assets/2352112/3651f725-c71a-4c25-98d9-2434391ca1b2)


# To Test
@elena-zh can you check if this is fixing the issue?