### PR TITLE
feat(hackathon-surplus): do not show modal when too small amounts

### DIFF
--- a/src/common/hooks/useGetSurplusFiatValue.ts
+++ b/src/common/hooks/useGetSurplusFiatValue.ts
@@ -51,7 +51,6 @@ function shouldShowSurplus(
   fiatAmount: Nullish<CurrencyAmount<Currency>>,
   surplusAmount: Nullish<CurrencyAmount<Currency>>
 ): boolean | null {
-  console.log(`bug--shouldShowSurplus`, fiatAmount?.toFixed(2), surplusAmount?.toFixed(6))
   if (fiatAmount) {
     // When there's a fiat amount, use that to decide whether to display the modal
     return Number(fiatAmount.toFixed(3)) > MIN_FIAT_SURPLUS_VALUE_MODAL

--- a/src/common/hooks/useGetSurplusFiatValue.ts
+++ b/src/common/hooks/useGetSurplusFiatValue.ts
@@ -36,10 +36,30 @@ export function useGetSurplusData(order: Order | ParsedOrder | undefined): Outpu
   const surplusFiatValue = useCoingeckoUsdValue(surplusAmount)
   const showFiatValue = Number(surplusFiatValue?.toExact()) >= MIN_FIAT_SURPLUS_VALUE
 
+  const showSurplus = shouldShowSurplus(surplusFiatValue, surplusAmount)
+
   return {
     surplusFiatValue,
     showFiatValue,
     surplusToken,
     surplusAmount,
+    showSurplus,
   }
+}
+
+function shouldShowSurplus(
+  fiatAmount: Nullish<CurrencyAmount<Currency>>,
+  surplusAmount: Nullish<CurrencyAmount<Currency>>
+): boolean | null {
+  console.log(`bug--shouldShowSurplus`, fiatAmount?.toFixed(2), surplusAmount?.toFixed(6))
+  if (fiatAmount) {
+    // When there's a fiat amount, use that to decide whether to display the modal
+    return Number(fiatAmount.toFixed(3)) > MIN_FIAT_SURPLUS_VALUE_MODAL
+  } else if (surplusAmount) {
+    // If no fiat value, check whether surplus units are > MIN_SURPLUS_UNITS
+    return Number(surplusAmount.toFixed(3)) > MIN_SURPLUS_UNITS
+  }
+
+  // Otherwise, we don't know whether surplus should, return `null` to indicate that
+  return null
 }

--- a/src/common/hooks/useGetSurplusFiatValue.ts
+++ b/src/common/hooks/useGetSurplusFiatValue.ts
@@ -1,8 +1,10 @@
 import { useMemo } from 'react'
 
-import { Token, CurrencyAmount } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
-import { MIN_FIAT_SURPLUS_VALUE } from 'legacy/constants'
+import { Nullish } from 'types'
+
+import { MIN_FIAT_SURPLUS_VALUE, MIN_FIAT_SURPLUS_VALUE_MODAL, MIN_SURPLUS_UNITS } from 'legacy/constants'
 import { useCoingeckoUsdValue } from 'legacy/hooks/useStablecoinPrice'
 import { Order } from 'legacy/state/orders/actions'
 
@@ -10,15 +12,16 @@ import { getExecutedSummaryData } from 'utils/getExecutedSummaryData'
 import { ParsedOrder } from 'utils/orderUtils/parseOrder'
 
 type Output = {
-  surplusFiatValue: CurrencyAmount<Token> | null
-  surplusAmount: CurrencyAmount<Token> | undefined
-  surplusToken: Token | undefined
+  surplusFiatValue: Nullish<CurrencyAmount<Currency>>
+  surplusAmount: Nullish<CurrencyAmount<Currency>>
+  surplusToken: Nullish<Currency>
   showFiatValue: boolean
+  showSurplus: boolean | null
 }
 
 export function useGetSurplusData(order: Order | ParsedOrder | undefined): Output {
   const { surplusAmount, surplusToken } = useMemo(() => {
-    const output: { surplusToken?: Token; surplusAmount?: CurrencyAmount<Token> } = {}
+    const output: { surplusToken?: Currency; surplusAmount?: CurrencyAmount<Currency> } = {}
 
     if (order) {
       const summaryData = getExecutedSummaryData(order)

--- a/src/common/pure/TransactionSubmittedContent/SurplusModal.tsx
+++ b/src/common/pure/TransactionSubmittedContent/SurplusModal.tsx
@@ -150,7 +150,7 @@ export type SurplusModalProps = {
 export function SurplusModal(props: SurplusModalProps) {
   const { order } = props
 
-  const { surplusFiatValue, showFiatValue, surplusToken, surplusAmount } = useGetSurplusData(order)
+  const { surplusFiatValue, showFiatValue, surplusToken, surplusAmount, showSurplus } = useGetSurplusData(order)
 
   const onTweetShare = useCallback(() => {
     sendEvent({
@@ -159,7 +159,7 @@ export function SurplusModal(props: SurplusModalProps) {
     })
   }, [])
 
-  if (!order) {
+  if (!order || !showSurplus) {
     return null
   }
 

--- a/src/common/pure/TransactionSubmittedContent/index.tsx
+++ b/src/common/pure/TransactionSubmittedContent/index.tsx
@@ -47,6 +47,7 @@ export interface TransactionSubmittedContentProps {
   chainId: ChainId
   activityDerivedState: ActivityDerivedState | null
   currencyToAdd?: Nullish<Currency>
+  showSurplus?: boolean | null
 }
 
 export function TransactionSubmittedContent({
@@ -55,11 +56,11 @@ export function TransactionSubmittedContent({
   hash,
   currencyToAdd,
   activityDerivedState,
+  showSurplus,
 }: TransactionSubmittedContentProps) {
   const activityState = activityDerivedState && getActivityState(activityDerivedState)
   const showProgressBar = activityState === 'open' || activityState === 'filled'
   const { order } = activityDerivedState || {}
-  const showSurplus = activityState === 'filled'
 
   if (!supportedChainId(chainId)) {
     return null
@@ -71,9 +72,7 @@ export function TransactionSubmittedContent({
         <styledEl.Header>
           <styledEl.CloseIconWrapper onClick={onDismiss} />
         </styledEl.Header>
-        {showSurplus ? (
-          <SurplusModal order={order} />
-        ) : (
+        {(showSurplus && <SurplusModal order={order} />) || (
           <>
             <Text fontWeight={600} fontSize={28}>
               {getTitleStatus(activityDerivedState)}

--- a/src/legacy/constants/index.ts
+++ b/src/legacy/constants/index.ts
@@ -1,8 +1,7 @@
 import { ethFlowBarnJson, ethFlowProdJson } from '@cowprotocol/abis'
 import networksJson from '@cowprotocol/contracts/networks.json'
-import { IpfsConfig } from '@cowprotocol/cow-sdk'
-import { SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
-import { Token, Fraction, Percent } from '@uniswap/sdk-core'
+import { IpfsConfig, SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
+import { Fraction, Percent, Token } from '@uniswap/sdk-core'
 
 import BigNumber from 'bignumber.js'
 import ms from 'ms.macro'
@@ -211,3 +210,9 @@ export const FAQ_MENU_LINKS = [
 
 // Min USD value to show surplus
 export const MIN_FIAT_SURPLUS_VALUE = 0.01
+
+// Min FIAT value for displaying the surplus modal
+export const MIN_FIAT_SURPLUS_VALUE_MODAL = 1
+
+// Min surplus value in units for displaying the surplus modal when FIAT value is not available
+export const MIN_SURPLUS_UNITS = 0.1

--- a/src/modules/swap/containers/SurplusModalSetup/index.tsx
+++ b/src/modules/swap/containers/SurplusModalSetup/index.tsx
@@ -25,7 +25,6 @@ export function SurplusModalSetup() {
 
   useEffect(() => {
     // If we should NOT show the surplus, remove the orderId from the queue
-    console.log(`bug--SurplusModalSetup--useeffect`, { showSurplus, orderId })
     if (showSurplus === false && orderId) {
       removeOrderId(orderId)
     }

--- a/src/modules/swap/containers/SurplusModalSetup/index.tsx
+++ b/src/modules/swap/containers/SurplusModalSetup/index.tsx
@@ -1,9 +1,10 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 
 import { useOrder } from 'legacy/state/orders/hooks'
 
 import { useWalletInfo } from 'modules/wallet'
 
+import { useGetSurplusData } from 'common/hooks/useGetSurplusFiatValue'
 import { CowModal } from 'common/pure/Modal'
 import * as styledEl from 'common/pure/TransactionSubmittedContent/styled'
 import { SurplusModal } from 'common/pure/TransactionSubmittedContent/SurplusModal'
@@ -16,12 +17,21 @@ export function SurplusModalSetup() {
 
   const { chainId } = useWalletInfo()
   const order = useOrder({ id: orderId, chainId })
+  const { showSurplus } = useGetSurplusData(order)
 
   const onDismiss = useCallback(() => {
     orderId && removeOrderId(orderId)
   }, [orderId, removeOrderId])
 
-  const isOpen = !!orderId
+  useEffect(() => {
+    // If we should NOT show the surplus, remove the orderId from the queue
+    console.log(`bug--SurplusModalSetup--useeffect`, { showSurplus, orderId })
+    if (showSurplus === false && orderId) {
+      removeOrderId(orderId)
+    }
+  }, [orderId, removeOrderId, showSurplus])
+
+  const isOpen = !!orderId && showSurplus === true
 
   return (
     <CowModal isOpen={isOpen} onDismiss={onDismiss} maxHeight={90} maxWidth={470}>

--- a/src/utils/getExecutedSummaryData.ts
+++ b/src/utils/getExecutedSummaryData.ts
@@ -5,11 +5,7 @@ import { Order } from 'legacy/state/orders/actions'
 
 import { getFilledAmounts } from 'utils/orderUtils/getFilledAmounts'
 
-import { ParsedOrder, parseOrder } from './orderUtils/parseOrder'
-
-function isParsedOrder(order: Order | ParsedOrder): order is ParsedOrder {
-  return !!(order as ParsedOrder).executionData
-}
+import { isParsedOrder, ParsedOrder, parseOrder } from './orderUtils/parseOrder'
 
 export function getExecutedSummaryData(order: Order | ParsedOrder) {
   const parsedOrder = isParsedOrder(order) ? order : parseOrder(order)

--- a/src/utils/orderUtils/parseOrder.ts
+++ b/src/utils/orderUtils/parseOrder.ts
@@ -105,3 +105,7 @@ export const parseOrder = (order: Order): ParsedOrder => {
     executionData,
   }
 }
+
+export function isParsedOrder(order: Order | ParsedOrder): order is ParsedOrder {
+  return !!(order as ParsedOrder).executionData
+}


### PR DESCRIPTION
# Summary

## ⚠️ Pointing to a potentially already merged branch ⚠️ 
Will point to the right place once ready

Fixes https://github.com/cowprotocol/cowswap/issues/2847 and https://github.com/cowprotocol/cowswap/issues/2848

Show the modal according to the rules (slightly different from the issue descriptions)
- If FIAT surplus amount estimation available, show it if amount is > 1$
- Otherwise, show if surplus amount > 0.1 units

Revert old behaviour for confirmation modal when surplus is not displayed

# To Test

## With FIAT

1. Place order which generates > 1$ surplus
2. Do not close confirmation modal
* Surplus modal is displayed inside confirmation modal
3. Repeat `1` but close the confirmation modal
* Surplus modal is displayed as a new pop up modal
4. Place order which generates < 1$ surplus
5. Do not close confirmation modal
* Surplus modal is not displayed. Instead, old (current prod) flow is used: Progress bar follow by old surplus display
6. Repeat `4` but close the confirmation modal
* Surplus modal is not displayed

## Without FIAT

7. Place order on goerli (or somewhere where there's no FIAT values) with surplus of > 0.1 units
8. Do not close confirmation modal
* Surplus modal is displayed inside confirmation modal
9. Repeat `7` but close the confirmation modal
* Surplus modal is displayed as a new pop up modal
10. Place order which generates < 0.1 surplus units
11. Do not close confirmation modal
* Surplus modal is not displayed. Instead, old (current prod) flow is used: Progress bar follow by old surplus display
12. Repeat `10` but close the confirmation modal
* Surplus modal is not displayed