### PR TITLE
fix(swap): get rid of infinite updates in useFillSwapDerivedState

### DIFF
--- a/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/src/modules/swap/containers/SwapWidget/index.tsx
@@ -37,7 +37,6 @@ import {
   SwapWarningsTop,
   SwapWarningsTopProps,
 } from 'modules/swap/pure/warnings'
-import { useFillSwapDerivedState } from 'modules/swap/state/useSwapDerivedState'
 import useCurrencyBalance from 'modules/tokens/hooks/useCurrencyBalance'
 import { TradeWidget, TradeWidgetContainer, useSetupTradeState, useTradePriceImpact } from 'modules/trade'
 import { useWrappedToken } from 'modules/trade/hooks/useWrappedToken'
@@ -59,7 +58,6 @@ const BUTTON_STATES_TO_SHOW_BUNDLE_WRAP_BANNER = [SwapButtonState.WrapAndSwap, S
 export function SwapWidget() {
   useSetupTradeState()
   useSetupSwapAmountsFromUrl()
-  useFillSwapDerivedState()
 
   const { chainId, account } = useWalletInfo()
   const {

--- a/src/modules/swap/index.ts
+++ b/src/modules/swap/index.ts
@@ -1,0 +1,2 @@
+export * from './containers/SwapWidget'
+export * from './updaters/SwapDerivedStateUpdater'

--- a/src/modules/swap/updaters/SwapDerivedStateUpdater.tsx
+++ b/src/modules/swap/updaters/SwapDerivedStateUpdater.tsx
@@ -1,0 +1,7 @@
+import { useFillSwapDerivedState } from '../state/useSwapDerivedState'
+
+export function SwapDerivedStateUpdater() {
+  useFillSwapDerivedState()
+
+  return null
+}

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -4,7 +4,7 @@ import { Navigate, useLocation, useParams } from 'react-router-dom'
 
 import { WRAPPED_NATIVE_CURRENCY as WETH } from 'legacy/constants/tokens'
 
-import { SwapWidget } from 'modules/swap/containers/SwapWidget'
+import { SwapWidget, SwapDerivedStateUpdater } from 'modules/swap'
 import { getDefaultTradeRawState } from 'modules/trade/types/TradeRawState'
 import { parameterizeTradeRoute } from 'modules/trade/utils/parameterizeTradeRoute'
 import { useWalletInfo } from 'modules/wallet'
@@ -18,7 +18,12 @@ export function SwapPage() {
     return <SwapPageRedirect />
   }
 
-  return <SwapWidget />
+  return (
+    <>
+      <SwapDerivedStateUpdater />
+      <SwapWidget />
+    </>
+  )
 }
 
 function SwapPageRedirect() {


### PR DESCRIPTION
# Summary

`useFillSwapDerivedState` hook was initialized in `SwapWidget` because of it there was tons of updates

  # To Test

1. Open Swap page
2. Select a pair of assets and input amount
3. Open tokens selection modal
- [ ] AR: tons of logs in console
- [ ] ER: only few logs in console
