### PR TITLE
fix(orders-storage): clear orders storage on unmount

### DIFF
--- a/src/legacy/state/orders/actions.ts
+++ b/src/legacy/state/orders/actions.ts
@@ -207,6 +207,8 @@ export const updateLastCheckedBlock = createAction<{ chainId: ChainId; lastCheck
   'order/updateLastCheckedBlock'
 )
 
+export const clearOrdersStorage = createAction('order/clearOrdersStorage')
+
 export type SetIsOrderUnfillableParams = {
   id: UID
   chainId: ChainId

--- a/src/legacy/state/orders/consts.ts
+++ b/src/legacy/state/orders/consts.ts
@@ -3,8 +3,6 @@ import { Percent } from '@uniswap/sdk-core'
 
 import ms from 'ms.macro'
 
-import { OrderTypeKeys } from './reducer'
-
 export const ContractDeploymentBlocks: Partial<Record<ChainId, number>> = {
   [ChainId.MAINNET]: 11469934,
   [ChainId.GNOSIS_CHAIN]: 13566914,
@@ -21,5 +19,4 @@ export const OUT_OF_MARKET_PRICE_DELTA_PERCENTAGE = new Percent(1, 100) // 1/100
 
 // Clear order's storage
 export const ORDER_STORAGE_KEY = 'redux_localstorage_simple_orders'
-export const ORDER_STATUSES_TO_CLEAR: OrderTypeKeys[] = ['expired', 'cancelled', 'fulfilled']
 export const MAX_ITEMS_PER_STATUS = 10

--- a/src/legacy/state/orders/consts.ts
+++ b/src/legacy/state/orders/consts.ts
@@ -18,5 +18,4 @@ export const EXPIRED_ORDERS_CHECK_POLL_INTERVAL = ms`15s`
 export const OUT_OF_MARKET_PRICE_DELTA_PERCENTAGE = new Percent(1, 100) // 1/100 => 0.01 => 1%
 
 // Clear order's storage
-export const ORDER_STORAGE_KEY = 'redux_localstorage_simple_orders'
 export const MAX_ITEMS_PER_STATUS = 10

--- a/src/legacy/state/orders/consts.ts
+++ b/src/legacy/state/orders/consts.ts
@@ -3,6 +3,8 @@ import { Percent } from '@uniswap/sdk-core'
 
 import ms from 'ms.macro'
 
+import { OrderTypeKeys } from './reducer'
+
 export const ContractDeploymentBlocks: Partial<Record<ChainId, number>> = {
   [ChainId.MAINNET]: 11469934,
   [ChainId.GNOSIS_CHAIN]: 13566914,
@@ -16,3 +18,8 @@ export const SPOT_PRICE_CHECK_POLL_INTERVAL = ms`15s`
 export const EXPIRED_ORDERS_CHECK_POLL_INTERVAL = ms`15s`
 
 export const OUT_OF_MARKET_PRICE_DELTA_PERCENTAGE = new Percent(1, 100) // 1/100 => 0.01 => 1%
+
+// Clear order's storage
+export const ORDER_STORAGE_KEY = 'redux_localstorage_simple_orders'
+export const ORDER_STATUSES_TO_CLEAR: OrderTypeKeys[] = ['expired', 'cancelled', 'fulfilled']
+export const MAX_ITEMS_PER_STATUS = 10

--- a/src/legacy/state/orders/hooks.ts
+++ b/src/legacy/state/orders/hooks.ts
@@ -16,6 +16,7 @@ import {
   AddOrUpdateOrdersParams,
   addPendingOrder,
   cancelOrdersBatch,
+  CONFIRMED_STATES,
   expireOrdersBatch,
   fulfillOrdersBatch,
   FulfillOrdersBatchParams,
@@ -32,7 +33,7 @@ import {
   updatePresignGnosisSafeTx,
   UpdatePresignGnosisSafeTxParams,
 } from './actions'
-import { MAX_ITEMS_PER_STATUS, ORDER_STATUSES_TO_CLEAR, ORDER_STORAGE_KEY } from './consts'
+import { MAX_ITEMS_PER_STATUS, ORDER_STORAGE_KEY } from './consts'
 import {
   getDefaultNetworkState,
   ORDER_LIST_KEYS,
@@ -452,7 +453,7 @@ export const useCleanOrdersStorageOnUnmount = () => {
         const orderListByChain: OrderLists = parsedState[chainId]
 
         // Iterate order statuses we want to clean up
-        ORDER_STATUSES_TO_CLEAR.forEach((status) => {
+        CONFIRMED_STATES.forEach((status) => {
           const orders = orderListByChain[status]
 
           // Sort by expiration time

--- a/src/legacy/state/orders/updaters/GpOrdersUpdater.ts
+++ b/src/legacy/state/orders/updaters/GpOrdersUpdater.ts
@@ -8,7 +8,7 @@ import { GP_ORDER_UPDATE_INTERVAL, NATIVE_CURRENCY_BUY_ADDRESS, NATIVE_CURRENCY_
 import { useAllTokens } from 'legacy/hooks/Tokens'
 import { useTokenLazy } from 'legacy/hooks/useTokenLazy'
 import { Order, OrderStatus } from 'legacy/state/orders/actions'
-import { useAddOrUpdateOrders } from 'legacy/state/orders/hooks'
+import { useAddOrUpdateOrders, useCleanOrdersStorageOnUnmount } from 'legacy/state/orders/hooks'
 import { computeOrderSummary } from 'legacy/state/orders/updaters/utils'
 import { classifyOrder, OrderTransitionStatus } from 'legacy/state/orders/utils'
 
@@ -202,6 +202,8 @@ function _filterOrders(
  * - Persist the new tokens and orders on redux
  */
 export function GpOrdersUpdater(): null {
+  useCleanOrdersStorageOnUnmount()
+
   const { account, chainId } = useWalletInfo()
   const allTokens = useAllTokens()
   const tokensAreLoaded = useMemo(() => Object.keys(allTokens).length > 0, [allTokens])

--- a/src/legacy/state/orders/updaters/GpOrdersUpdater.ts
+++ b/src/legacy/state/orders/updaters/GpOrdersUpdater.ts
@@ -8,7 +8,7 @@ import { GP_ORDER_UPDATE_INTERVAL, NATIVE_CURRENCY_BUY_ADDRESS, NATIVE_CURRENCY_
 import { useAllTokens } from 'legacy/hooks/Tokens'
 import { useTokenLazy } from 'legacy/hooks/useTokenLazy'
 import { Order, OrderStatus } from 'legacy/state/orders/actions'
-import { useAddOrUpdateOrders, useCleanOrdersStorage } from 'legacy/state/orders/hooks'
+import { useAddOrUpdateOrders, useClearOrdersStorage } from 'legacy/state/orders/hooks'
 import { computeOrderSummary } from 'legacy/state/orders/updaters/utils'
 import { classifyOrder, OrderTransitionStatus } from 'legacy/state/orders/utils'
 
@@ -202,7 +202,7 @@ function _filterOrders(
  * - Persist the new tokens and orders on redux
  */
 export function GpOrdersUpdater(): null {
-  useCleanOrdersStorage()
+  const clearOrderStorage = useClearOrdersStorage()
 
   const { account, chainId } = useWalletInfo()
   const allTokens = useAllTokens()
@@ -263,6 +263,14 @@ export function GpOrdersUpdater(): null {
       updateOrders(chainId, account)
     }
   }, [account, chainId, tokensAreLoaded, updateOrders])
+
+  useEffect(() => {
+    clearOrderStorage()
+
+    return function () {
+      clearOrderStorage()
+    }
+  }, [clearOrderStorage])
 
   return null
 }

--- a/src/legacy/state/orders/updaters/GpOrdersUpdater.ts
+++ b/src/legacy/state/orders/updaters/GpOrdersUpdater.ts
@@ -8,7 +8,7 @@ import { GP_ORDER_UPDATE_INTERVAL, NATIVE_CURRENCY_BUY_ADDRESS, NATIVE_CURRENCY_
 import { useAllTokens } from 'legacy/hooks/Tokens'
 import { useTokenLazy } from 'legacy/hooks/useTokenLazy'
 import { Order, OrderStatus } from 'legacy/state/orders/actions'
-import { useAddOrUpdateOrders, useCleanOrdersStorageOnUnmount } from 'legacy/state/orders/hooks'
+import { useAddOrUpdateOrders, useCleanOrdersStorage } from 'legacy/state/orders/hooks'
 import { computeOrderSummary } from 'legacy/state/orders/updaters/utils'
 import { classifyOrder, OrderTransitionStatus } from 'legacy/state/orders/utils'
 
@@ -202,7 +202,7 @@ function _filterOrders(
  * - Persist the new tokens and orders on redux
  */
 export function GpOrdersUpdater(): null {
-  useCleanOrdersStorageOnUnmount()
+  useCleanOrdersStorage()
 
   const { account, chainId } = useWalletInfo()
   const allTokens = useAllTokens()


### PR DESCRIPTION
# Summary

Fixes #2690

When the `GpOrdersUpdater` component is unmounted this hook will "clean up" parts of the orders state saved in a local-storage, by filtering out older orders of type `['expired', 'cancelled', 'fulfilled']` and taking only top 10 sorted by `expirationTime`.

# To test
- Make sure everything works as expected
- The mentioned issue shouldn't happen anymore