### PR TITLE
Release/1.41.0

### DIFF
--- a/src/api/gnosisProtocol/api.ts
+++ b/src/api/gnosisProtocol/api.ts
@@ -152,7 +152,18 @@ export async function getQuote(params: FeeQuoteParams): Promise<OrderQuoteRespon
 }
 
 export async function getOrder(chainId: ChainId, orderId: string, env?: CowEnv): Promise<EnrichedOrder | null> {
-  return orderBookApi.getOrder(orderId, { chainId, env })
+  const contextOverride = {
+    chainId,
+    // To avoid passing `undefined` and unintentionally setting the `env` to `barn`
+    // we check if the `env` is `undefined` and if it is we don't include it in the contextOverride
+    ...(env
+      ? {
+          env,
+        }
+      : undefined),
+  }
+
+  return orderBookApi.getOrder(orderId, contextOverride)
 }
 
 export async function getOrders(

--- a/src/common/hooks/useGetSurplusFiatValue.ts
+++ b/src/common/hooks/useGetSurplusFiatValue.ts
@@ -1,8 +1,10 @@
 import { useMemo } from 'react'
 
-import { Token, CurrencyAmount } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
-import { MIN_FIAT_SURPLUS_VALUE } from 'legacy/constants'
+import { Nullish } from 'types'
+
+import { MIN_FIAT_SURPLUS_VALUE, MIN_FIAT_SURPLUS_VALUE_MODAL, MIN_SURPLUS_UNITS } from 'legacy/constants'
 import { useCoingeckoUsdValue } from 'legacy/hooks/useStablecoinPrice'
 import { Order } from 'legacy/state/orders/actions'
 
@@ -10,15 +12,16 @@ import { getExecutedSummaryData } from 'utils/getExecutedSummaryData'
 import { ParsedOrder } from 'utils/orderUtils/parseOrder'
 
 type Output = {
-  surplusFiatValue: CurrencyAmount<Token> | null
-  surplusAmount: CurrencyAmount<Token> | undefined
-  surplusToken: Token | undefined
+  surplusFiatValue: Nullish<CurrencyAmount<Currency>>
+  surplusAmount: Nullish<CurrencyAmount<Currency>>
+  surplusToken: Nullish<Currency>
   showFiatValue: boolean
+  showSurplus: boolean | null
 }
 
 export function useGetSurplusData(order: Order | ParsedOrder | undefined): Output {
   const { surplusAmount, surplusToken } = useMemo(() => {
-    const output: { surplusToken?: Token; surplusAmount?: CurrencyAmount<Token> } = {}
+    const output: { surplusToken?: Currency; surplusAmount?: CurrencyAmount<Currency> } = {}
 
     if (order) {
       const summaryData = getExecutedSummaryData(order)
@@ -33,10 +36,29 @@ export function useGetSurplusData(order: Order | ParsedOrder | undefined): Outpu
   const surplusFiatValue = useCoingeckoUsdValue(surplusAmount)
   const showFiatValue = Number(surplusFiatValue?.toExact()) >= MIN_FIAT_SURPLUS_VALUE
 
+  const showSurplus = shouldShowSurplus(surplusFiatValue, surplusAmount)
+
   return {
     surplusFiatValue,
     showFiatValue,
     surplusToken,
     surplusAmount,
+    showSurplus,
   }
+}
+
+function shouldShowSurplus(
+  fiatAmount: Nullish<CurrencyAmount<Currency>>,
+  surplusAmount: Nullish<CurrencyAmount<Currency>>
+): boolean | null {
+  if (fiatAmount) {
+    // When there's a fiat amount, use that to decide whether to display the modal
+    return Number(fiatAmount.toFixed(3)) > MIN_FIAT_SURPLUS_VALUE_MODAL
+  } else if (surplusAmount) {
+    // If no fiat value, check whether surplus units are > MIN_SURPLUS_UNITS
+    return Number(surplusAmount.toFixed(3)) > MIN_SURPLUS_UNITS
+  }
+
+  // Otherwise, we don't know whether surplus should, return `null` to indicate that
+  return null
 }

--- a/src/common/pure/TransactionSubmittedContent/SurplusModal.tsx
+++ b/src/common/pure/TransactionSubmittedContent/SurplusModal.tsx
@@ -150,7 +150,7 @@ export type SurplusModalProps = {
 export function SurplusModal(props: SurplusModalProps) {
   const { order } = props
 
-  const { surplusFiatValue, showFiatValue, surplusToken, surplusAmount } = useGetSurplusData(order)
+  const { surplusFiatValue, showFiatValue, surplusToken, surplusAmount, showSurplus } = useGetSurplusData(order)
 
   const onTweetShare = useCallback(() => {
     sendEvent({
@@ -159,7 +159,7 @@ export function SurplusModal(props: SurplusModalProps) {
     })
   }, [])
 
-  if (!order) {
+  if (!order || !showSurplus) {
     return null
   }
 

--- a/src/common/pure/TransactionSubmittedContent/index.tsx
+++ b/src/common/pure/TransactionSubmittedContent/index.tsx
@@ -47,6 +47,7 @@ export interface TransactionSubmittedContentProps {
   chainId: ChainId
   activityDerivedState: ActivityDerivedState | null
   currencyToAdd?: Nullish<Currency>
+  showSurplus?: boolean | null
 }
 
 export function TransactionSubmittedContent({
@@ -55,11 +56,11 @@ export function TransactionSubmittedContent({
   hash,
   currencyToAdd,
   activityDerivedState,
+  showSurplus,
 }: TransactionSubmittedContentProps) {
   const activityState = activityDerivedState && getActivityState(activityDerivedState)
   const showProgressBar = activityState === 'open' || activityState === 'filled'
   const { order } = activityDerivedState || {}
-  const showSurplus = activityState === 'filled'
 
   if (!supportedChainId(chainId)) {
     return null
@@ -71,9 +72,7 @@ export function TransactionSubmittedContent({
         <styledEl.Header>
           <styledEl.CloseIconWrapper onClick={onDismiss} />
         </styledEl.Header>
-        {showSurplus ? (
-          <SurplusModal order={order} />
-        ) : (
+        {(showSurplus && <SurplusModal order={order} />) || (
           <>
             <Text fontWeight={600} fontSize={28}>
               {getTitleStatus(activityDerivedState)}

--- a/src/legacy/components/Header/NetworkSelector/NetworkSelectorMod.tsx
+++ b/src/legacy/components/Header/NetworkSelector/NetworkSelectorMod.tsx
@@ -352,10 +352,13 @@ export default function NetworkSelector() {
       // Don't set chainId as query parameter because swap and limit orders have different routing scheme
       if (tradeTypeInfo) return
 
+      const chainName = getChainNameFromId(chainId)
+      if (!chainName) return
+
       navigate(
         {
           pathname: location.pathname,
-          search: replaceURLParam(location.search, 'chain', getChainNameFromId(chainId)),
+          search: replaceURLParam(location.search, 'chain', chainName),
         },
         { replace: true }
       )

--- a/src/legacy/components/analytics/pixel/constants.ts
+++ b/src/legacy/components/analytics/pixel/constants.ts
@@ -1,3 +1,6 @@
+// TODO: Leaving true just for testing, then i will enable for PROD and ENS
+export const PIXEL_ENABLED = true // isProd || isEns
+
 export enum PIXEL_EVENTS {
   INIT = 'init',
   CONNECT_WALLET = 'connect_wallet',

--- a/src/legacy/components/analytics/pixel/facebook.ts
+++ b/src/legacy/components/analytics/pixel/facebook.ts
@@ -1,4 +1,5 @@
 import { PIXEL_EVENTS } from './constants'
+import { sendPixel } from './utils'
 
 const events = {
   [PIXEL_EVENTS.INIT]: 'InitiateCheckout',
@@ -6,6 +7,6 @@ const events = {
   [PIXEL_EVENTS.POST_TRADE]: 'Lead',
 }
 
-export const sendFacebookEvent = (event: PIXEL_EVENTS) => {
+export const sendFacebookEvent = sendPixel((event) => {
   window.fbq?.('track', events[event])
-}
+})

--- a/src/legacy/components/analytics/pixel/linkedin.ts
+++ b/src/legacy/components/analytics/pixel/linkedin.ts
@@ -1,4 +1,5 @@
 import { PIXEL_EVENTS } from './constants'
+import { sendPixel } from './utils'
 
 const events = {
   [PIXEL_EVENTS.INIT]: 10759506,
@@ -6,6 +7,6 @@ const events = {
   [PIXEL_EVENTS.POST_TRADE]: 10759522,
 }
 
-export const sendLinkedinEvent = (event: PIXEL_EVENTS) => {
+export const sendLinkedinEvent = sendPixel((event) => {
   window.lintrk?.('track', { conversion_id: events[event] })
-}
+})

--- a/src/legacy/components/analytics/pixel/microsoft.ts
+++ b/src/legacy/components/analytics/pixel/microsoft.ts
@@ -1,4 +1,5 @@
 import { PIXEL_EVENTS } from './constants'
+import { sendPixel } from './utils'
 
 const events = {
   [PIXEL_EVENTS.INIT]: 'page_view',
@@ -6,7 +7,7 @@ const events = {
   [PIXEL_EVENTS.POST_TRADE]: 'purchase',
 }
 
-export const sendMicrosoftEvent = (event: PIXEL_EVENTS) => {
+export const sendMicrosoftEvent = sendPixel((event) => {
   window.uetq = window.uetq || []
   window.uetq.push('event', events[event], {})
-}
+})

--- a/src/legacy/components/analytics/pixel/paved.ts
+++ b/src/legacy/components/analytics/pixel/paved.ts
@@ -1,4 +1,5 @@
 import { PIXEL_EVENTS } from './constants'
+import { sendPixel } from './utils'
 
 const events = {
   [PIXEL_EVENTS.INIT]: 'search',
@@ -6,6 +7,6 @@ const events = {
   [PIXEL_EVENTS.POST_TRADE]: 'purchase',
 }
 
-export const sendPavedEvent = (event: PIXEL_EVENTS) => {
+export const sendPavedEvent = sendPixel((event: PIXEL_EVENTS) => {
   window.pvd?.('event', events[event])
-}
+})

--- a/src/legacy/components/analytics/pixel/reddit.ts
+++ b/src/legacy/components/analytics/pixel/reddit.ts
@@ -1,4 +1,5 @@
 import { PIXEL_EVENTS } from './constants'
+import { sendPixel } from './utils'
 
 const events = {
   [PIXEL_EVENTS.INIT]: 'Lead',
@@ -6,6 +7,6 @@ const events = {
   [PIXEL_EVENTS.POST_TRADE]: 'Purchase',
 }
 
-export const sendRedditEvent = (event: PIXEL_EVENTS) => {
+export const sendRedditEvent = sendPixel((event) => {
   window.rdt?.('track', events[event])
-}
+})

--- a/src/legacy/components/analytics/pixel/twitter.ts
+++ b/src/legacy/components/analytics/pixel/twitter.ts
@@ -1,4 +1,5 @@
 import { PIXEL_EVENTS } from './constants'
+import { sendPixel } from './utils'
 
 const events = {
   [PIXEL_EVENTS.INIT]: 'tw-oddz2-oddz8',
@@ -6,6 +7,6 @@ const events = {
   [PIXEL_EVENTS.POST_TRADE]: 'tw-oddz2-oddzb',
 }
 
-export const sendTwitterEvent = (event: PIXEL_EVENTS) => {
+export const sendTwitterEvent = sendPixel((event: PIXEL_EVENTS) => {
   window.twq?.('event', events[event], {})
-}
+})

--- a/src/legacy/components/analytics/pixel/utils.ts
+++ b/src/legacy/components/analytics/pixel/utils.ts
@@ -1,0 +1,17 @@
+import { PIXEL_ENABLED, PIXEL_EVENTS } from './constants'
+
+type SendPixelFn = (event: PIXEL_EVENTS) => void
+
+export function sendPixel(sendFn: SendPixelFn): SendPixelFn {
+  return (event) => {
+    if (!PIXEL_ENABLED) {
+      return
+    }
+
+    try {
+      sendFn(event)
+    } catch (e: any) {
+      console.error('Error sending pixel event', e)
+    }
+  }
+}

--- a/src/legacy/constants/index.ts
+++ b/src/legacy/constants/index.ts
@@ -215,4 +215,4 @@ export const MIN_FIAT_SURPLUS_VALUE = 0.01
 export const MIN_FIAT_SURPLUS_VALUE_MODAL = 1
 
 // Min surplus value in units for displaying the surplus modal when FIAT value is not available
-export const MIN_SURPLUS_UNITS = 0.1
+export const MIN_SURPLUS_UNITS = 0.01

--- a/src/legacy/constants/index.ts
+++ b/src/legacy/constants/index.ts
@@ -1,8 +1,7 @@
 import { ethFlowBarnJson, ethFlowProdJson } from '@cowprotocol/abis'
 import networksJson from '@cowprotocol/contracts/networks.json'
-import { IpfsConfig } from '@cowprotocol/cow-sdk'
-import { SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
-import { Token, Fraction, Percent } from '@uniswap/sdk-core'
+import { IpfsConfig, SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
+import { Fraction, Percent, Token } from '@uniswap/sdk-core'
 
 import BigNumber from 'bignumber.js'
 import ms from 'ms.macro'
@@ -211,3 +210,9 @@ export const FAQ_MENU_LINKS = [
 
 // Min USD value to show surplus
 export const MIN_FIAT_SURPLUS_VALUE = 0.01
+
+// Min FIAT value for displaying the surplus modal
+export const MIN_FIAT_SURPLUS_VALUE_MODAL = 1
+
+// Min surplus value in units for displaying the surplus modal when FIAT value is not available
+export const MIN_SURPLUS_UNITS = 0.1

--- a/src/modules/advancedOrders/containers/AdvancedOrdersWidget/index.tsx
+++ b/src/modules/advancedOrders/containers/AdvancedOrdersWidget/index.tsx
@@ -71,6 +71,7 @@ export function AdvancedOrdersWidget({ children }: { children: JSX.Element }) {
     showRecipient: false,
     isTradePriceUpdating,
     priceImpact,
+    isExpertMode: false, // TODO: bind value
   }
 
   return (

--- a/src/modules/application/containers/TradeWidgetLinks/index.tsx
+++ b/src/modules/application/containers/TradeWidgetLinks/index.tsx
@@ -32,9 +32,15 @@ export function TradeWidgetLinks() {
       {menuItems.map((item) => {
         const routePath = parameterizeTradeRoute(tradeContext, item.route)
         const isActive = !!matchPath(location.pathname, routePath)
-        const menuItem = <MenuItem routePath={routePath} item={item} isActive={isActive} />
+        const menuItem = <MenuItem key={item.label} routePath={routePath} item={item} isActive={isActive} />
 
-        return item.featureGuard ? <FeatureGuard featureFlag={item.featureGuard}>{menuItem}</FeatureGuard> : menuItem
+        return item.featureGuard ? (
+          <FeatureGuard key={item.label} featureFlag={item.featureGuard}>
+            {menuItem}
+          </FeatureGuard>
+        ) : (
+          menuItem
+        )
       })}
     </styledEl.Wrapper>
   )

--- a/src/modules/limitOrders/containers/LimitOrdersWidget/limitOrdersPropsChecker.ts
+++ b/src/modules/limitOrders/containers/LimitOrdersWidget/limitOrdersPropsChecker.ts
@@ -19,7 +19,6 @@ export interface LimitOrdersProps {
 
   isUnlocked: boolean
   isRateLoading: boolean
-  isWrapOrUnwrap: boolean
   showRecipient: boolean
   isExpertMode: boolean
 
@@ -41,7 +40,6 @@ export function limitOrdersPropsChecker(a: LimitOrdersProps, b: LimitOrdersProps
     checkCurrencyInfo(a.outputCurrencyInfo, b.outputCurrencyInfo) &&
     a.isUnlocked === b.isUnlocked &&
     a.isRateLoading === b.isRateLoading &&
-    a.isWrapOrUnwrap === b.isWrapOrUnwrap &&
     a.showRecipient === b.showRecipient &&
     a.recipient === b.recipient &&
     a.widgetActions === b.widgetActions &&

--- a/src/modules/swap/containers/SurplusModalSetup/index.tsx
+++ b/src/modules/swap/containers/SurplusModalSetup/index.tsx
@@ -1,9 +1,10 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 
 import { useOrder } from 'legacy/state/orders/hooks'
 
 import { useWalletInfo } from 'modules/wallet'
 
+import { useGetSurplusData } from 'common/hooks/useGetSurplusFiatValue'
 import { CowModal } from 'common/pure/Modal'
 import * as styledEl from 'common/pure/TransactionSubmittedContent/styled'
 import { SurplusModal } from 'common/pure/TransactionSubmittedContent/SurplusModal'
@@ -16,12 +17,20 @@ export function SurplusModalSetup() {
 
   const { chainId } = useWalletInfo()
   const order = useOrder({ id: orderId, chainId })
+  const { showSurplus } = useGetSurplusData(order)
 
   const onDismiss = useCallback(() => {
     orderId && removeOrderId(orderId)
   }, [orderId, removeOrderId])
 
-  const isOpen = !!orderId
+  useEffect(() => {
+    // If we should NOT show the surplus, remove the orderId from the queue
+    if (showSurplus === false && orderId) {
+      removeOrderId(orderId)
+    }
+  }, [orderId, removeOrderId, showSurplus])
+
+  const isOpen = !!orderId && showSurplus === true
 
   return (
     <CowModal isOpen={isOpen} onDismiss={onDismiss} maxHeight={90} maxWidth={470}>

--- a/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/src/modules/swap/containers/SwapWidget/index.tsx
@@ -235,6 +235,7 @@ export function SwapWidget() {
     priceImpact: priceImpactParams,
     disableQuotePolling: true,
     canSellAllNative,
+    isExpertMode,
   }
 
   return (

--- a/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/src/modules/swap/containers/SwapWidget/index.tsx
@@ -37,7 +37,6 @@ import {
   SwapWarningsTop,
   SwapWarningsTopProps,
 } from 'modules/swap/pure/warnings'
-import { useFillSwapDerivedState } from 'modules/swap/state/useSwapDerivedState'
 import useCurrencyBalance from 'modules/tokens/hooks/useCurrencyBalance'
 import { TradeWidget, TradeWidgetContainer, useSetupTradeState, useTradePriceImpact } from 'modules/trade'
 import { useWrappedToken } from 'modules/trade/hooks/useWrappedToken'
@@ -59,7 +58,6 @@ const BUTTON_STATES_TO_SHOW_BUNDLE_WRAP_BANNER = [SwapButtonState.WrapAndSwap, S
 export function SwapWidget() {
   useSetupTradeState()
   useSetupSwapAmountsFromUrl()
-  useFillSwapDerivedState()
 
   const { chainId, account } = useWalletInfo()
   const {

--- a/src/modules/swap/index.ts
+++ b/src/modules/swap/index.ts
@@ -1,0 +1,2 @@
+export * from './containers/SwapWidget'
+export * from './updaters/SwapDerivedStateUpdater'

--- a/src/modules/swap/updaters/SwapDerivedStateUpdater.tsx
+++ b/src/modules/swap/updaters/SwapDerivedStateUpdater.tsx
@@ -1,0 +1,7 @@
+import { useFillSwapDerivedState } from '../state/useSwapDerivedState'
+
+export function SwapDerivedStateUpdater() {
+  useFillSwapDerivedState()
+
+  return null
+}

--- a/src/modules/trade/containers/TradeBasicConfirmDetails/LimitPriceRow.tsx
+++ b/src/modules/trade/containers/TradeBasicConfirmDetails/LimitPriceRow.tsx
@@ -20,7 +20,7 @@ export function LimitPriceRow(props: Props) {
 
   return (
     <RateWrapper onClick={() => setIsInverted((curr) => !curr)}>
-      <ConfirmDetailsItem tooltip="TODO: limit price tooltip text" label="Limit price (incl fee/slippage)">
+      <ConfirmDetailsItem tooltip="TODO: limit price tooltip text" label="Price protection">
         {price ? (
           <ExecutionPrice executionPrice={price} isInverted={isInverted} showBaseCurrency separatorSymbol="=" />
         ) : (

--- a/src/modules/trade/containers/TradeWidget/index.tsx
+++ b/src/modules/trade/containers/TradeWidget/index.tsx
@@ -8,6 +8,7 @@ import { maxAmountSpend } from 'legacy/utils/maxAmountSpend'
 import { TradeWidgetLinks } from 'modules/application/containers/TradeWidgetLinks'
 import { SetRecipientProps } from 'modules/swap/containers/SetRecipient'
 import { useIsWrapOrUnwrap } from 'modules/trade/hooks/useIsWrapOrUnwrap'
+import { TradeFormValidationUpdater } from 'modules/tradeFormValidation'
 import { TradeQuoteUpdater } from 'modules/tradeQuote'
 import { useWalletDetails, useWalletInfo } from 'modules/wallet'
 
@@ -20,6 +21,7 @@ import * as styledEl from './styled'
 import { TradeWidgetModals } from './TradeWidgetModals'
 
 import { PriceImpactUpdater } from '../../updaters/PriceImpactUpdater'
+import { WrapFlowActionButton } from '../WrapFlowActionButton'
 import { WrapNativeModal } from '../WrapNativeModal'
 
 export interface TradeWidgetActions {
@@ -36,6 +38,7 @@ interface TradeWidgetParams {
   compactView: boolean
   showRecipient: boolean
   isTradePriceUpdating: boolean
+  isExpertMode: boolean
   priceImpact: PriceImpact
   isRateLoading?: boolean
   disableQuotePolling?: boolean
@@ -61,7 +64,6 @@ export interface TradeWidgetProps {
 
 export const TradeWidgetContainer = styledEl.Container
 
-// TODO: add ImportTokenModal, TradeApproveWidget
 export function TradeWidget(props: TradeWidgetProps) {
   const { id, slots, inputCurrencyInfo, outputCurrencyInfo, actions, params, disableOutput } = props
   const { settingsWidget, lockScreen, middleContent, bottomContent } = slots
@@ -78,6 +80,7 @@ export function TradeWidget(props: TradeWidgetProps) {
     recipient,
     disableQuotePolling = false,
     canSellAllNative = false,
+    isExpertMode,
   } = params
 
   const { chainId } = useWalletInfo()
@@ -106,6 +109,7 @@ export function TradeWidget(props: TradeWidgetProps) {
       <TradeWidgetModals />
       <WrapNativeModal />
       <PriceImpactUpdater />
+      <TradeFormValidationUpdater isExpertMode={isExpertMode} />
 
       <styledEl.Container id={id}>
         <styledEl.ContainerBox>
@@ -130,7 +134,7 @@ export function TradeWidget(props: TradeWidgetProps) {
                   currencyInfo={inputCurrencyInfo}
                   showSetMax={showSetMax}
                   maxBalance={maxBalance}
-                  topLabel={inputCurrencyInfo.label}
+                  topLabel={isWrapOrUnwrap ? undefined : inputCurrencyInfo.label}
                 />
               </div>
               {!isWrapOrUnwrap && middleContent}
@@ -148,7 +152,7 @@ export function TradeWidget(props: TradeWidgetProps) {
                 <CurrencyInputPanel
                   id="output-currency-input"
                   disableNonToken={disableNonToken}
-                  inputDisabled={isEoaEthFlow || disableOutput}
+                  inputDisabled={isEoaEthFlow || isWrapOrUnwrap || disableOutput}
                   inputTooltip={
                     isEoaEthFlow
                       ? t`You cannot edit this field when selling ${inputCurrencyInfo?.currency?.symbol}`
@@ -160,16 +164,18 @@ export function TradeWidget(props: TradeWidgetProps) {
                   onCurrencySelection={onCurrencySelection}
                   onUserInput={onUserInput}
                   allowsOffchainSigning={allowsOffchainSigning}
-                  currencyInfo={outputCurrencyInfo}
+                  currencyInfo={
+                    isWrapOrUnwrap ? { ...outputCurrencyInfo, amount: inputCurrencyInfo.amount } : outputCurrencyInfo
+                  }
                   priceImpactParams={priceImpact}
-                  topLabel={outputCurrencyInfo.label}
+                  topLabel={isWrapOrUnwrap ? undefined : outputCurrencyInfo.label}
                 />
               </div>
               {!isWrapOrUnwrap && showRecipient && (
                 <styledEl.StyledRemoveRecipient recipient={recipient || ''} onChangeRecipient={onChangeRecipient} />
               )}
 
-              {bottomContent}
+              {isWrapOrUnwrap ? <WrapFlowActionButton /> : bottomContent}
             </>
           )}
         </styledEl.ContainerBox>

--- a/src/modules/trade/containers/WrapFlowActionButton/index.tsx
+++ b/src/modules/trade/containers/WrapFlowActionButton/index.tsx
@@ -1,0 +1,26 @@
+import { TradeFormButtons, useGetTradeFormValidation, useTradeFormButtonContext } from 'modules/tradeFormValidation'
+
+const doTradeText = ''
+const confirmText = ''
+const tradeCallbacks = { doTrade() {}, confirmTrade() {} }
+
+/**
+ * This component is used only to display a button for Wrap/Unwrap
+ * because of it, we just stub parameters above
+ */
+export function WrapFlowActionButton() {
+  const primaryFormValidation = useGetTradeFormValidation()
+  const tradeFormButtonContext = useTradeFormButtonContext(doTradeText, tradeCallbacks)
+
+  if (!tradeFormButtonContext) return null
+
+  return (
+    <TradeFormButtons
+      doTradeText={doTradeText}
+      confirmText={confirmText}
+      validation={primaryFormValidation}
+      context={tradeFormButtonContext}
+      isExpertMode={false}
+    />
+  )
+}

--- a/src/modules/tradeFormValidation/pure/TradeFormButtons/index.tsx
+++ b/src/modules/tradeFormValidation/pure/TradeFormButtons/index.tsx
@@ -20,7 +20,7 @@ export function TradeFormButtons(props: TradeFormButtonsProps) {
   const { validation, context, isExpertMode, isDisabled, doTradeText, confirmText } = props
 
   // When there are no validation errors
-  if (!validation) {
+  if (validation === null) {
     return (
       <TradeFormBlankButton
         id="do-trade-button"

--- a/src/pages/AdvancedOrders/index.tsx
+++ b/src/pages/AdvancedOrders/index.tsx
@@ -5,7 +5,6 @@ import { OrdersTableWidget } from 'modules/ordersTable'
 import { useTradeRouteContext } from 'modules/trade/hooks/useTradeRouteContext'
 import * as styledEl from 'modules/trade/pure/TradePageLayout'
 import { parameterizeTradeRoute } from 'modules/trade/utils/parameterizeTradeRoute'
-import { TradeFormValidationUpdater } from 'modules/tradeFormValidation'
 import { TwapFormWidget } from 'modules/twap'
 
 import { Routes as RoutesEnum } from 'common/constants/routes'
@@ -22,9 +21,6 @@ export default function AdvancedOrdersPage() {
 
   return (
     <>
-      {/*TODO: add isExpertMode value*/}
-      <TradeFormValidationUpdater isExpertMode={false} />
-
       {/*TODO: add isUnlocked value*/}
       <styledEl.PageWrapper isUnlocked={true}>
         <styledEl.PrimaryWrapper>

--- a/src/pages/LimitOrders/index.tsx
+++ b/src/pages/LimitOrders/index.tsx
@@ -22,7 +22,6 @@ export default function LimitOrderPage() {
       <InitialPriceUpdater />
       <ExecutionPriceUpdater />
       <TradeFormValidationUpdater isExpertMode={expertMode} />
-
       <styledEl.PageWrapper isUnlocked={isUnlocked}>
         <styledEl.PrimaryWrapper>
           <LimitOrdersWidget />

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -4,7 +4,7 @@ import { Navigate, useLocation, useParams } from 'react-router-dom'
 
 import { WRAPPED_NATIVE_CURRENCY as WETH } from 'legacy/constants/tokens'
 
-import { SwapWidget } from 'modules/swap/containers/SwapWidget'
+import { SwapWidget, SwapDerivedStateUpdater } from 'modules/swap'
 import { getDefaultTradeRawState } from 'modules/trade/types/TradeRawState'
 import { parameterizeTradeRoute } from 'modules/trade/utils/parameterizeTradeRoute'
 import { useWalletInfo } from 'modules/wallet'
@@ -18,7 +18,12 @@ export function SwapPage() {
     return <SwapPageRedirect />
   }
 
-  return <SwapWidget />
+  return (
+    <>
+      <SwapDerivedStateUpdater />
+      <SwapWidget />
+    </>
+  )
 }
 
 function SwapPageRedirect() {

--- a/src/utils/getExecutedSummaryData.ts
+++ b/src/utils/getExecutedSummaryData.ts
@@ -5,11 +5,7 @@ import { Order } from 'legacy/state/orders/actions'
 
 import { getFilledAmounts } from 'utils/orderUtils/getFilledAmounts'
 
-import { ParsedOrder, parseOrder } from './orderUtils/parseOrder'
-
-function isParsedOrder(order: Order | ParsedOrder): order is ParsedOrder {
-  return !!(order as ParsedOrder).executionData
-}
+import { isParsedOrder, ParsedOrder, parseOrder } from './orderUtils/parseOrder'
 
 export function getExecutedSummaryData(order: Order | ParsedOrder) {
   const parsedOrder = isParsedOrder(order) ? order : parseOrder(order)

--- a/src/utils/orderUtils/parseOrder.ts
+++ b/src/utils/orderUtils/parseOrder.ts
@@ -105,3 +105,7 @@ export const parseOrder = (order: Order): ParsedOrder => {
     executionData,
   }
 }
+
+export function isParsedOrder(order: Order | ParsedOrder): order is ParsedOrder {
+  return !!(order as ParsedOrder).executionData
+}


### PR DESCRIPTION
# Summary

adds a bunch of fixes after the STAGING tests

## Changelog
6a5fa725c feat(hackathon-surplus): do not show modal when too small amounts (#2857)
f48e89277 feat: change label text (#2862)
2731b743e chore: make pixel events more resilient (#2856)
3db9e0575 fix(twap): avoid sending `env` as `undefined` to getOrder query (#2864)
2bebaa8de fix: issue with loop in react (#2860)
dcd9f3ef6 feat(trade): generalise wrap/unwrap flow for all trade widgets (#2861)
8a37ec4d4 fix(swap): get rid of infinite updates in useFillSwapDerivedState (#2858)
