### PR TITLE
fix(twap): avoid sending `env` as `undefined` to getOrder query

### DIFF
--- a/src/api/gnosisProtocol/api.ts
+++ b/src/api/gnosisProtocol/api.ts
@@ -152,7 +152,18 @@ export async function getQuote(params: FeeQuoteParams): Promise<OrderQuoteRespon
 }
 
 export async function getOrder(chainId: ChainId, orderId: string, env?: CowEnv): Promise<EnrichedOrder | null> {
-  return orderBookApi.getOrder(orderId, { chainId, env })
+  const contextOverride = {
+    chainId,
+    // To avoid passing `undefined` and unintentionally setting the `env` to `barn`
+    // we check if the `env` is `undefined` and if it is we don't include it in the contextOverride
+    ...(env
+      ? {
+          env,
+        }
+      : undefined),
+  }
+
+  return orderBookApi.getOrder(orderId, contextOverride)
 }
 
 export async function getOrders(


### PR DESCRIPTION
# Summary

Avoid sending `env` as `undefined` to getOrder query
Without this, instead of the default behaviour, the SDK defaults to `barn` endpoint

# To Test

1. Load the app
2. Observe network requests
* Since this is a PR env, there should be no /orders/<order id> requests to `api.cow.fi` endpoint
* Once deployed to `staging`, there should be no /orders/<order id> requests to `barn.api.cow.fi` endpoint