### PR TITLE
feat(twap): tooltips try2

### DIFF
--- a/src/modules/swap/containers/Row/RowSlippage/index.tsx
+++ b/src/modules/swap/containers/Row/RowSlippage/index.tsx
@@ -13,9 +13,16 @@ import { formatPercent } from 'utils/amountFormat'
 export interface RowSlippageProps {
   allowedSlippage: Percent
   showSettingOnClick?: boolean
+  slippageLabel?: React.ReactNode
+  slippageTooltip?: React.ReactNode
 }
 
-export function RowSlippage({ allowedSlippage, showSettingOnClick = true }: RowSlippageProps) {
+export function RowSlippage({
+  allowedSlippage,
+  showSettingOnClick = true,
+  slippageTooltip,
+  slippageLabel,
+}: RowSlippageProps) {
   const toggleSettings = useToggleSettingsMenu()
 
   const isEoaEthFlow = useIsEoaEthFlow()
@@ -27,9 +34,11 @@ export function RowSlippage({ allowedSlippage, showSettingOnClick = true }: RowS
       symbols: [nativeCurrency.symbol],
       showSettingOnClick,
       allowedSlippage,
+      slippageLabel,
+      slippageTooltip,
       displaySlippage: `${formatPercent(allowedSlippage)}%`,
     }),
-    [allowedSlippage, nativeCurrency, isEoaEthFlow, showSettingOnClick]
+    [isEoaEthFlow, nativeCurrency.symbol, showSettingOnClick, allowedSlippage, slippageLabel, slippageTooltip]
   )
 
   return <RowSlippageContent {...props} toggleSettings={toggleSettings} />

--- a/src/modules/swap/pure/Row/RowSlippageContent/index.tsx
+++ b/src/modules/swap/pure/Row/RowSlippageContent/index.tsx
@@ -49,14 +49,27 @@ export interface RowSlippageContentProps extends RowSlippageProps {
   isEoaEthFlow: boolean
   symbols?: (string | undefined)[]
   wrappedSymbol?: string
-
+  slippageLabel?: React.ReactNode
+  slippageTooltip?: React.ReactNode
   styleProps?: RowStyleProps
 }
 
 // TODO: RowDeadlineContent and RowSlippageContent are very similar. Refactor and extract base component?
 
 export function RowSlippageContent(props: RowSlippageContentProps) {
-  const { showSettingOnClick, toggleSettings, displaySlippage, isEoaEthFlow, symbols, styleProps } = props
+  const {
+    showSettingOnClick,
+    toggleSettings,
+    displaySlippage,
+    isEoaEthFlow,
+    symbols,
+    slippageLabel,
+    slippageTooltip,
+    styleProps,
+  } = props
+
+  const tooltipContent =
+    slippageTooltip || (isEoaEthFlow ? getNativeSlippageTooltip(symbols) : getNonNativeSlippageTooltip())
 
   return (
     <StyledRowBetween {...styleProps}>
@@ -64,16 +77,13 @@ export function RowSlippageContent(props: RowSlippageContentProps) {
         <TextWrapper>
           {showSettingOnClick ? (
             <ClickableText onClick={toggleSettings}>
-              <SlippageTextContents isEoaEthFlow={isEoaEthFlow} />
+              <SlippageTextContents isEoaEthFlow={isEoaEthFlow} slippageLabel={slippageLabel} />
             </ClickableText>
           ) : (
-            <SlippageTextContents isEoaEthFlow={isEoaEthFlow} />
+            <SlippageTextContents isEoaEthFlow={isEoaEthFlow} slippageLabel={slippageLabel} />
           )}
         </TextWrapper>
-        <MouseoverTooltipContent
-          wrap
-          content={isEoaEthFlow ? getNativeSlippageTooltip(symbols) : getNonNativeSlippageTooltip()}
-        >
+        <MouseoverTooltipContent wrap content={tooltipContent}>
           <StyledInfoIcon size={16} />
         </MouseoverTooltipContent>
       </RowFixed>
@@ -88,12 +98,12 @@ export function RowSlippageContent(props: RowSlippageContentProps) {
   )
 }
 
-type SlippageTextContentsProps = { isEoaEthFlow: boolean }
+type SlippageTextContentsProps = { isEoaEthFlow: boolean; slippageLabel?: React.ReactNode }
 
-function SlippageTextContents({ isEoaEthFlow }: SlippageTextContentsProps) {
+function SlippageTextContents({ isEoaEthFlow, slippageLabel }: SlippageTextContentsProps) {
   return (
     <TransactionText>
-      <Trans>Slippage tolerance</Trans>
+      <Trans>{slippageLabel || 'Slippage tolerance'}</Trans>
       {isEoaEthFlow && <i>(modified)</i>}
     </TransactionText>
   )

--- a/src/modules/trade/containers/TradeBasicConfirmDetails/LimitPriceRow.tsx
+++ b/src/modules/trade/containers/TradeBasicConfirmDetails/LimitPriceRow.tsx
@@ -17,7 +17,7 @@ type Props = {
 }
 
 export function LimitPriceRow(props: Props) {
-  const { price, isInvertedState, limitPriceLabel = 'Limit price', limitPriceTooltip = 'Price protection' } = props
+  const { price, isInvertedState, limitPriceLabel = 'Limit price', limitPriceTooltip = 'The limit price' } = props
   const [isInverted, setIsInverted] = isInvertedState
 
   return (

--- a/src/modules/trade/containers/TradeBasicConfirmDetails/SlippageRow.tsx
+++ b/src/modules/trade/containers/TradeBasicConfirmDetails/SlippageRow.tsx
@@ -5,12 +5,19 @@ import { ConfirmDetailsItem } from 'modules/trade/pure/ConfirmDetailsItem'
 
 export type SlippageRowProps = {
   slippage: Percent
+  slippageLabel?: React.ReactNode
+  slippageTooltip?: React.ReactNode
 }
 
-export function SlippageRow({ slippage }: SlippageRowProps) {
+export function SlippageRow({ slippage, slippageLabel, slippageTooltip }: SlippageRowProps) {
   return (
     <ConfirmDetailsItem>
-      <RowSlippage allowedSlippage={slippage} showSettingOnClick={false} />
+      <RowSlippage
+        allowedSlippage={slippage}
+        showSettingOnClick={false}
+        slippageLabel={slippageLabel}
+        slippageTooltip={slippageTooltip}
+      />
     </ConfirmDetailsItem>
   )
 }

--- a/src/modules/trade/containers/TradeBasicConfirmDetails/index.tsx
+++ b/src/modules/trade/containers/TradeBasicConfirmDetails/index.tsx
@@ -30,6 +30,8 @@ type AdditionalProps = {
   minReceivedTooltip?: React.ReactNode
   limitPriceLabel?: React.ReactNode
   limitPriceTooltip?: React.ReactNode
+  slippageLabel?: React.ReactNode
+  slippageTooltip?: React.ReactNode
 }
 
 export function TradeBasicConfirmDetails(props: Props) {
@@ -56,7 +58,7 @@ export function TradeBasicConfirmDetails(props: Props) {
       />
 
       {/* Slippage */}
-      <SlippageRow slippage={slippage} />
+      <SlippageRow slippage={slippage} {...additionalProps} />
 
       {/* Limit Price */}
       <LimitPriceRow price={limitPrice} isInvertedState={isInvertedState} {...additionalProps} />

--- a/src/modules/twap/containers/TwapConfirmModal/index.tsx
+++ b/src/modules/twap/containers/TwapConfirmModal/index.tsx
@@ -101,6 +101,7 @@ export function TwapConfirmModal({ fallbackHandlerIsNotSet }: TwapConfirmModalPr
                   will not execute. CoW Swap will <strong>always</strong> improve on this price if possible.
                 </>
               ),
+              slippageLabel: 'Price protection',
             }}
           />
           <TwapConfirmDetails

--- a/src/modules/twap/containers/TwapConfirmModal/index.tsx
+++ b/src/modules/twap/containers/TwapConfirmModal/index.tsx
@@ -91,17 +91,29 @@ export function TwapConfirmModal({ fallbackHandlerIsNotSet }: TwapConfirmModalPr
             slippage={slippage}
             additionalProps={{
               priceLabel: 'Price (incl. fee)',
-              minReceivedLabel: 'Min received (incl. fee/slippage)',
-              minReceivedTooltip:
-                'This is the minimum amount that you will receive across your entire TWAP order, assuming all parts of the order execute.',
-              limitPriceLabel: 'Limit price (incl fee/slippage)',
-              limitPriceTooltip: (
+              slippageLabel: 'Price protection',
+              slippageTooltip: (
                 <>
-                  If CoW Swap cannot get this price or better after fees and slippage are taken into account, your TWAP
-                  will not execute. CoW Swap will <strong>always</strong> improve on this price if possible.
+                  <p>
+                    Since TWAP orders consist of multiple parts, prices are expected to fluctuate. However, to protect
+                    you against bad prices, CoW Swap will not execute your TWAP if the price dips below this percentage.
+                  </p>
+                  <p>
+                    This percentage only applies to dips; if prices are better than this percentage, CoW Swap will still
+                    execute your order.
+                  </p>
                 </>
               ),
-              slippageLabel: 'Price protection',
+              limitPriceLabel: 'Limit price',
+              limitPriceTooltip: (
+                <>
+                  If CoW Swap cannot get this price or better (taking into account fees and price protection tolerance),
+                  your TWAP will not execute. CoW Swap will <strong>always</strong> improve on this price if possible.
+                </>
+              ),
+              minReceivedLabel: 'Min received',
+              minReceivedTooltip:
+                'This is the minimum amount that you will receive across your entire TWAP order, assuming all parts of the order execute.',
             }}
           />
           <TwapConfirmDetails

--- a/src/modules/twap/containers/TwapFormWidget/tooltips.tsx
+++ b/src/modules/twap/containers/TwapFormWidget/tooltips.tsx
@@ -68,9 +68,7 @@ export const LABELS_TOOLTIPS: LabelTooltipItems = {
       </>
     ),
     tooltip: (
-      <>
-        Your TWAP order won't execute and is protected if the market price dips more than your set slippage tolerance.
-      </>
+      <>Your TWAP order won't execute and is protected if the market price dips more than your set price protection.</>
     ),
   },
   price: {


### PR DESCRIPTION
# Summary

- Re-apply #2843 
- Revert `limit price` to it's original name
- Change slippage label on TWAP review modal to `Price protection`

![image](https://github.com/cowprotocol/cowswap/assets/43217/76049250-ac22-4bde-b3e8-475b1e825430)

# To Test

1. Check tooltips on TWAP review modal