### PR TITLE
feat(form-fields): misc field forms adjustments

### DIFF
--- a/src/common/utils/autofocus.ts
+++ b/src/common/utils/autofocus.ts
@@ -1,0 +1,3 @@
+export function autofocus(e: React.FocusEvent<HTMLInputElement, Element>) {
+  e.target.select()
+}

--- a/src/legacy/components/AddressInputPanel/index.tsx
+++ b/src/legacy/components/AddressInputPanel/index.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, Context, ReactNode, useCallback, useContext } from 'react'
 
-import { Trans, t } from '@lingui/macro'
+import { t, Trans } from '@lingui/macro'
 import styled, { DefaultTheme, ThemeContext } from 'styled-components/macro'
 
 import { AutoColumn } from 'legacy/components/Column'
@@ -132,6 +132,7 @@ export function AddressInputPanel({
               pattern="^(0x[a-fA-F0-9]{40})$"
               onChange={handleInput}
               value={value}
+              onFocus={(e) => e.target.select()}
             />
           </AutoColumn>
         </InputContainer>

--- a/src/legacy/components/AddressInputPanel/index.tsx
+++ b/src/legacy/components/AddressInputPanel/index.tsx
@@ -11,6 +11,8 @@ import { getBlockExplorerUrl as getExplorerLink } from 'legacy/utils'
 
 import { useWalletInfo } from 'modules/wallet'
 
+import { autofocus } from 'common/utils/autofocus'
+
 const InputPanel = styled.div`
   ${({ theme }) => theme.flexColumnNoWrap}
   position: relative;
@@ -132,7 +134,7 @@ export function AddressInputPanel({
               pattern="^(0x[a-fA-F0-9]{40})$"
               onChange={handleInput}
               value={value}
-              onFocus={(e) => e.target.select()}
+              onFocus={autofocus}
             />
           </AutoColumn>
         </InputContainer>

--- a/src/legacy/components/NumericalInput/index.tsx
+++ b/src/legacy/components/NumericalInput/index.tsx
@@ -47,6 +47,7 @@ export const Input = React.memo(function InnerInput({
   onUserInput,
   placeholder,
   prependSymbol,
+  type,
   ...rest
 }: {
   value: string | number
@@ -86,7 +87,7 @@ export const Input = React.memo(function InnerInput({
       autoComplete="off"
       autoCorrect="off"
       // text-specific options
-      type="text"
+      type={type || 'text'}
       pattern="^[0-9]*[.,]?[0-9]*$"
       placeholder={placeholder || '0.0'}
       minLength={1}

--- a/src/legacy/components/NumericalInput/index.tsx
+++ b/src/legacy/components/NumericalInput/index.tsx
@@ -26,13 +26,13 @@ const StyledInput = styled.input<{ error?: boolean; fontSize?: string; align?: s
     -webkit-appearance: none;
   }
 
-  [type='number'] {
-    -moz-appearance: textfield;
+  input[type='number'] {
+    appearance: none;
   }
 
-  ::-webkit-outer-spin-button,
-  ::-webkit-inner-spin-button {
-    -webkit-appearance: none;
+  input[type='number']:focus,
+  input[type='number']:hover {
+    appearance: auto;
   }
 
   ::placeholder {

--- a/src/legacy/components/NumericalInput/index.tsx
+++ b/src/legacy/components/NumericalInput/index.tsx
@@ -67,6 +67,9 @@ export const Input = React.memo(function InnerInput({
     <StyledInput
       {...rest}
       value={prependSymbol && value ? prependSymbol + value : value}
+      onFocus={(e) => {
+        e.target.select()
+      }}
       onChange={(event) => {
         if (prependSymbol) {
           const value = event.target.value

--- a/src/legacy/components/NumericalInput/index.tsx
+++ b/src/legacy/components/NumericalInput/index.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 
 import styled from 'styled-components/macro'
 
+import { autofocus } from 'common/utils/autofocus'
+
 import { escapeRegExp } from '../../utils'
 
 const StyledInput = styled.input<{ error?: boolean; fontSize?: string; align?: string }>`
@@ -67,7 +69,7 @@ export const Input = React.memo(function InnerInput({
     <StyledInput
       {...rest}
       value={prependSymbol && value ? prependSymbol + value : value}
-      onFocus={(e) => e.target.select()}
+      onFocus={autofocus}
       onChange={(event) => {
         if (prependSymbol) {
           const value = event.target.value

--- a/src/legacy/components/NumericalInput/index.tsx
+++ b/src/legacy/components/NumericalInput/index.tsx
@@ -67,9 +67,7 @@ export const Input = React.memo(function InnerInput({
     <StyledInput
       {...rest}
       value={prependSymbol && value ? prependSymbol + value : value}
-      onFocus={(e) => {
-        e.target.select()
-      }}
+      onFocus={(e) => e.target.select()}
       onChange={(event) => {
         if (prependSymbol) {
           const value = event.target.value

--- a/src/modules/trade/pure/TradeNumberInput/index.tsx
+++ b/src/modules/trade/pure/TradeNumberInput/index.tsx
@@ -75,6 +75,8 @@ export function TradeNumberInput(props: TradeNumberInputProps) {
             onBlur={(e) => validateInput(e.target.value)}
             onUserInput={(value) => setDisplayedValue(value)}
             type="number"
+            min={min}
+            max={max}
           />
           {suffix && <Suffix>{suffix}</Suffix>}
         </span>

--- a/src/modules/trade/pure/TradeNumberInput/index.tsx
+++ b/src/modules/trade/pure/TradeNumberInput/index.tsx
@@ -74,6 +74,7 @@ export function TradeNumberInput(props: TradeNumberInputProps) {
             value={displayedValue}
             onBlur={(e) => validateInput(e.target.value)}
             onUserInput={(value) => setDisplayedValue(value)}
+            type="number"
           />
           {suffix && <Suffix>{suffix}</Suffix>}
         </span>

--- a/src/modules/trade/pure/TradeNumberInput/index.tsx
+++ b/src/modules/trade/pure/TradeNumberInput/index.tsx
@@ -11,6 +11,7 @@ export interface TradeNumberInputProps extends TradeWidgetFieldProps {
   decimalsPlaces?: number
   min?: number
   max?: number
+  step?: number
   placeholder?: string
   prefixComponent?: React.ReactElement
 }
@@ -24,6 +25,7 @@ export function TradeNumberInput(props: TradeNumberInputProps) {
     decimalsPlaces = 0,
     min,
     max = 100_000,
+    step = 1,
     prefixComponent,
   } = props
 
@@ -77,6 +79,7 @@ export function TradeNumberInput(props: TradeNumberInputProps) {
             type="number"
             min={min}
             max={max}
+            step={step}
           />
           {suffix && <Suffix>{suffix}</Suffix>}
         </span>

--- a/src/modules/twap/containers/TwapFormWidget/index.tsx
+++ b/src/modules/twap/containers/TwapFormWidget/index.tsx
@@ -156,6 +156,7 @@ export function TwapFormWidget() {
           </em>
         }
         suffix="%"
+        step={0.1}
       />
       <styledEl.Row>
         <TradeNumberInput

--- a/src/modules/twap/pure/CustomDeadlineSelector/index.tsx
+++ b/src/modules/twap/pure/CustomDeadlineSelector/index.tsx
@@ -66,12 +66,12 @@ export function CustomDeadlineSelector(props: CustomDeadlineSelectorProps) {
         <styledEl.ModalContent>
           <styledEl.FieldWrapper>
             <styledEl.FieldLabel>Hours</styledEl.FieldLabel>
-            <styledEl.Input onUserInput={onHoursChange} value={hoursValue} />
+            <styledEl.Input onUserInput={onHoursChange} value={hoursValue} type="number" />
           </styledEl.FieldWrapper>
 
           <styledEl.FieldWrapper>
             <styledEl.FieldLabel>Minutes</styledEl.FieldLabel>
-            <styledEl.Input onUserInput={onMinutesChange} value={minutesValue} />
+            <styledEl.Input onUserInput={onMinutesChange} value={minutesValue} type="number" />
           </styledEl.FieldWrapper>
         </styledEl.ModalContent>
 


### PR DESCRIPTION
# Summary

- Change some input fields from `text` to `number` (TWAP slippage and number of parts)
- Use `min` & `max` html validation for the same fields
- Make all form fields select its contents on focus/click

# To Test

1. On TWAP form, select the slippage field
2. With your keyboard, hit the `up` arrow
* Slippage should go it by `1`
3. Repeat with `number of parts` field
* Same result
4. Check the next on all forms (SWAP, LIMIT, ADVANCED)
5. Input a value in the input
6. Click away
7. Click on the input again
* The whole text/number should be selected