### PR TITLE
fix(twap): don't mix twap states between browser tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,5 @@
 # Changelog
 
-## [1.42.0](https://github.com/cowprotocol/cowswap/compare/v1.41.0...v1.42.0) (2023-07-18)
-
-
-### Features
-
-* **form-fields:** misc field forms adjustments ([#2881](https://github.com/cowprotocol/cowswap/issues/2881)) ([c06e24e](https://github.com/cowprotocol/cowswap/commit/c06e24e01d1d95e9cbf1b08bcdd1a0cec1b7e462))
-* **twap:** add recipient to advanced orders ([#2877](https://github.com/cowprotocol/cowswap/issues/2877)) ([e4a61e9](https://github.com/cowprotocol/cowswap/commit/e4a61e9fd5bba44bbab8b1b72d19ff0503238245))
-* **twap:** display orders grouping ([#2866](https://github.com/cowprotocol/cowswap/issues/2866)) ([0712e86](https://github.com/cowprotocol/cowswap/commit/0712e86eb9bbed20b17eed71d61b2aeb45077a43))
-* **twap:** expand/collapse twap order table ([#2884](https://github.com/cowprotocol/cowswap/issues/2884)) ([0e08d12](https://github.com/cowprotocol/cowswap/commit/0e08d127dd4ce2b9fe0e789609fb9fd6c6bf4921))
-* **twap:** tooltips try2 ([#2872](https://github.com/cowprotocol/cowswap/issues/2872)) ([b244004](https://github.com/cowprotocol/cowswap/commit/b2440044564cfcff19c5abe6adf80e87fa44b381))
-
-
-### Bug Fixes
-
-* **trade:** fix UnsupportedToken state displaying conditions ([#2878](https://github.com/cowprotocol/cowswap/issues/2878)) ([1b3107f](https://github.com/cowprotocol/cowswap/commit/1b3107f3d95fabd3d0786d51f808a654fb986b1a))
-* **twap:** increase max slippage up to 100% ([#2897](https://github.com/cowprotocol/cowswap/issues/2897)) ([8fdc58b](https://github.com/cowprotocol/cowswap/commit/8fdc58ba6de2c2e77113c614b64936d3f7f95cd8))
-
 ## [1.41.0](https://github.com/cowprotocol/cowswap/compare/v1.40.6...v1.41.0) (2023-07-12)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/cowswap",
-  "version": "1.42.0",
+  "version": "1.42.0-rc.0",
   "description": "CoW Swap",
   "main": "index.js",
   "author": "",

--- a/src/modules/twap/state/twapOrdersListAtom.ts
+++ b/src/modules/twap/state/twapOrdersListAtom.ts
@@ -1,5 +1,5 @@
 import { atom } from 'jotai'
-import { atomWithStorage } from 'jotai/utils'
+import { atomWithStorage, createJSONStorage } from 'jotai/utils'
 
 import store from 'legacy/state'
 import { deleteOrders } from 'legacy/state/orders/actions'
@@ -14,7 +14,11 @@ import { updateTwapOrdersList } from '../utils/updateTwapOrdersList'
 
 export type TwapOrdersList = { [key: string]: TwapOrderItem }
 
-export const twapOrdersAtom = atomWithStorage<TwapOrdersList>('twap-orders-list:v1', {})
+export const twapOrdersAtom = atomWithStorage<TwapOrdersList>(
+  'twap-orders-list:v1',
+  {},
+  createJSONStorage(() => localStorage)
+)
 
 export const twapOrdersListAtom = atom<TwapOrderItem[]>((get) => {
   const { account, chainId } = get(walletInfoAtom)

--- a/src/modules/twap/state/twapPartOrdersAtom.ts
+++ b/src/modules/twap/state/twapPartOrdersAtom.ts
@@ -1,5 +1,5 @@
 import { atom } from 'jotai'
-import { atomWithStorage } from 'jotai/utils'
+import { atomWithStorage, createJSONStorage } from 'jotai/utils'
 
 import { OrderParameters, SupportedChainId } from '@cowprotocol/cow-sdk'
 
@@ -18,7 +18,11 @@ export interface TwapPartOrderItem {
 }
 export type TwapPartOrders = { [twapOrderHash: string]: TwapPartOrderItem[] }
 
-export const twapPartOrdersAtom = atomWithStorage<TwapPartOrders>('twap-part-orders-list:v1', {})
+export const twapPartOrdersAtom = atomWithStorage<TwapPartOrders>(
+  'twap-part-orders-list:v1',
+  {},
+  createJSONStorage(() => localStorage)
+)
 
 /**
  * The only goal of this function is protection from isCreatedInOrderBook flag overriding


### PR DESCRIPTION
# Summary

![image](https://github.com/cowprotocol/cowswap/assets/7122625/94693dbf-7a6e-4209-b072-8b4b13404bf9)


  # To Test

1. Open Advanced orders in Safe app
2. Create a TWAP order with 3 children
2. Open a new CowSwap tab (without Safe) in Advanced orders
3. AR: 
- [ ] Children count is zero
4. ER:
- [ ] Children count is 3
