### PR TITLE
feat(TWAP): handle TWAP errors

### DIFF
--- a/src/modules/twap/utils/parseTwapError.ts
+++ b/src/modules/twap/utils/parseTwapError.ts
@@ -1,0 +1,25 @@
+enum TwapErrorCodes {
+  INVALID_ARGUMENT = 'INVALID_ARGUMENT',
+}
+
+const TwapErrorMessages = {
+  DEFAULT: 'Something went wrong creating your order',
+}
+
+function parseInvalidArgumentError(error: any) {
+  const regex = /(?<=\(argument=")[^"]+(?=",)/g
+  const matches = error.message.match(regex)
+  const invalidAgument = matches?.length ? matches[1] : ''
+
+  return `Invalid argument "${invalidAgument}" provided`
+}
+
+export function parseTwapErrorMessage(error: any) {
+  switch (error.code) {
+    case TwapErrorCodes.INVALID_ARGUMENT:
+      return parseInvalidArgumentError(error)
+
+    default:
+      return TwapErrorMessages.DEFAULT
+  }
+}

--- a/src/modules/twap/utils/parseTwapError.ts
+++ b/src/modules/twap/utils/parseTwapError.ts
@@ -9,9 +9,10 @@ const TwapErrorMessages = {
 function parseInvalidArgumentError(error: any) {
   const regex = /(?<=\(argument=")[^"]+(?=",)/g
   const matches = error.message.match(regex)
-  const invalidAgument = matches?.length ? matches[1] : ''
+  const invalidArgument = matches?.length ? matches[1] : ''
+  const str = invalidArgument ? `"${invalidArgument}" ` : ''
 
-  return `Invalid argument "${invalidAgument}" provided`
+  return `Invalid argument ${str}provided`
 }
 
 export function parseTwapErrorMessage(error: any) {
@@ -20,6 +21,6 @@ export function parseTwapErrorMessage(error: any) {
       return parseInvalidArgumentError(error)
 
     default:
-      return TwapErrorMessages.DEFAULT
+      return error.message || TwapErrorMessages.DEFAULT
   }
 }


### PR DESCRIPTION
# Summary

Fixes #2670

Adds error handling for TWAP
- Shows a popup on error
- Parses invalid argument message and shows client friendly error message

**Example of error un-parsed**
```javascript
invalid address (argument="address", value="order.sellAmount.currency.address", code=INVALID_ARGUMENT, version=address/5.7.0) (argument="sellToken", value="order.sellAmount.currency.address", code=INVALID_ARGUMENT, version=abi/5.7.0)
````

**Parsed**
![Screenshot 2023-07-20 at 11 44 55](https://github.com/cowprotocol/cowswap/assets/34926005/701057ca-baf7-4bc4-a008-a10664a5d196)


# To test
- I'm not sure how, I've set invalid params in code while implementing this