### PR TITLE
feat(twap): small price protection warning

### DIFF
--- a/src/modules/twap/containers/TwapFormWarnings/index.tsx
+++ b/src/modules/twap/containers/TwapFormWarnings/index.tsx
@@ -17,14 +17,20 @@ import {
   SmallPartVolumeWarning,
   UnsupportedWalletWarning,
 } from './warnings'
+import { SmallPriceProtectionWarning } from './warnings/SmallPriceProtectionWarning'
 
 import { useAdvancedOrdersDerivedState } from '../../../advancedOrders'
 import { TradeFormValidation, useGetTradeFormValidation } from '../../../tradeFormValidation'
 import { useIsFallbackHandlerRequired } from '../../hooks/useFallbackHandlerVerification'
 import { useTwapWarningsContext } from '../../hooks/useTwapWarningsContext'
 import { TwapFormState } from '../../pure/PrimaryActionButton/getTwapFormState'
-import { twapOrderAtom } from '../../state/twapOrderAtom'
-import { twapOrdersSettingsAtom, updateTwapOrdersSettingsAtom } from '../../state/twapOrdersSettingsAtom'
+import { twapDeadlineAtom, twapOrderAtom } from '../../state/twapOrderAtom'
+import {
+  twapOrderSlippageAtom,
+  twapOrdersSettingsAtom,
+  updateTwapOrdersSettingsAtom,
+} from '../../state/twapOrdersSettingsAtom'
+import { isPriceProtectionNotEnough } from '../../utils/isPriceProtectionNotEnough'
 
 const BUNDLE_APPROVAL_STATES = [TradeFormValidation.ApproveAndSwap, TradeFormValidation.ExpertApproveAndSwap]
 
@@ -37,6 +43,8 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
   const { isFallbackHandlerSetupAccepted, isPriceImpactAccepted } = useAtomValue(twapOrdersSettingsAtom)
   const updateTwapOrdersSettings = useSetAtom(updateTwapOrdersSettingsAtom)
   const twapOrder = useAtomValue(twapOrderAtom)
+  const slippage = useAtomValue(twapOrderSlippageAtom)
+  const deadline = useAtomValue(twapDeadlineAtom)
   const { outputCurrencyAmount } = useAdvancedOrdersDerivedState()
   const primaryFormValidation = useGetTradeFormValidation()
 
@@ -57,7 +65,8 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
   const showZeroApprovalWarning = !isConfirmationModal && shouldZeroApprove && outputCurrencyAmount !== null
   const showApprovalBundlingBanner =
     !isConfirmationModal && primaryFormValidation && BUNDLE_APPROVAL_STATES.includes(primaryFormValidation)
-  const showFallbackHandlerWarning = !isConfirmationModal && canTrade && isFallbackHandlerRequired
+  const showTradeFormWarnings = !isConfirmationModal && canTrade
+  const showFallbackHandlerWarning = showTradeFormWarnings && isFallbackHandlerRequired
 
   const setIsPriceImpactAccepted = useCallback(() => {
     updateTwapOrdersSettings({ isPriceImpactAccepted: !isPriceImpactAccepted })
@@ -99,6 +108,10 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
               toggleFallbackHandlerSetupFlag={toggleFallbackHandlerSetupFlag}
             />
           )
+        }
+
+        if (showTradeFormWarnings && isPriceProtectionNotEnough(deadline, slippage)) {
+          return <SmallPriceProtectionWarning />
         }
 
         return null

--- a/src/modules/twap/containers/TwapFormWarnings/warnings/SmallPriceProtectionWarning.tsx
+++ b/src/modules/twap/containers/TwapFormWarnings/warnings/SmallPriceProtectionWarning.tsx
@@ -1,0 +1,13 @@
+import { InlineBanner } from 'common/pure/InlineBanner'
+
+export function SmallPriceProtectionWarning() {
+  return (
+    <InlineBanner>
+      <strong>Attention</strong>
+      <p>
+        Since prices can change significantly over time, we suggest increasing your price protection for orders with
+        long deadlines.
+      </p>
+    </InlineBanner>
+  )
+}

--- a/src/modules/twap/state/twapOrderAtom.ts
+++ b/src/modules/twap/state/twapOrderAtom.ts
@@ -12,9 +12,15 @@ import { twapOrderSlippageAtom, twapOrdersSettingsAtom } from './twapOrdersSetti
 import { TWAPOrder } from '../types'
 import { customDeadlineToSeconds } from '../utils/deadlinePartsDisplay'
 
+export const twapDeadlineAtom = atom<number>((get) => {
+  const { isCustomDeadline, customDeadline, deadline } = get(twapOrdersSettingsAtom)
+
+  return isCustomDeadline ? customDeadlineToSeconds(customDeadline) : deadline / 1000
+})
+
 export const twapTimeIntervalAtom = atom<number>((get) => {
-  const { numberOfPartsValue, isCustomDeadline, customDeadline, deadline } = get(twapOrdersSettingsAtom)
-  const seconds = isCustomDeadline ? customDeadlineToSeconds(customDeadline) : deadline / 1000
+  const { numberOfPartsValue } = get(twapOrdersSettingsAtom)
+  const seconds = get(twapDeadlineAtom)
 
   return Math.ceil(seconds / numberOfPartsValue)
 })

--- a/src/modules/twap/utils/isPriceProtectionNotEnough.ts
+++ b/src/modules/twap/utils/isPriceProtectionNotEnough.ts
@@ -1,0 +1,25 @@
+import { Percent } from '@uniswap/sdk-core'
+
+import ms from 'ms.macro'
+
+const oneDay = ms`1d` / 1000
+const oneWeek = ms`1w` / 1000
+const oneMonth = ms`30d` / 1000
+
+export function isPriceProtectionNotEnough(deadline: number, slippagePercent: Percent): boolean {
+  const slippage = +slippagePercent.toFixed(2)
+
+  if (deadline <= oneDay) {
+    return slippage < 10
+  }
+
+  if (deadline < oneWeek) {
+    return slippage < 20
+  }
+
+  if (deadline < oneMonth) {
+    return slippage < 30
+  }
+
+  return slippage < 50
+}


### PR DESCRIPTION
# Summary

Fixes #2895

Spec: https://www.notion.so/cownation/FE-TWAP-Orders-c9f6bd5c23bd4c749147611dcb63daac?pvs=4#b719e9b8c73644f8919418125cb5c18e

<img width="484" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/37a9f439-41d6-4299-8932-10435b964da2">

1. One month = 30 days
2. I've replaced the word `slippage` with `price protection`
3. The design is different from the screenshot from Notion, but I think it should like it is, because recently Michel unified all warnings