### PR TITLE
fix(orders-table): display partially filled status before confirmed states

### DIFF
--- a/src/modules/ordersTable/pure/OrderStatusBox/getOrderStatusTitleAndColor.test.ts
+++ b/src/modules/ordersTable/pure/OrderStatusBox/getOrderStatusTitleAndColor.test.ts
@@ -1,0 +1,72 @@
+import { DefaultTheme } from 'styled-components/macro'
+import { instance, mock, when } from 'ts-mockito'
+
+import { OrderStatus } from 'legacy/state/orders/actions'
+
+import { ParsedOrder } from 'utils/orderUtils/parseOrder'
+
+import { getOrderStatusTitleAndColor } from './getOrderStatusTitleAndColor'
+
+describe('getOrderStatusTitleAndColor()', () => {
+  let themeMock: DefaultTheme
+  let orderMock: ParsedOrder
+
+  beforeEach(() => {
+    themeMock = mock<DefaultTheme>()
+
+    when(themeMock.text1).thenReturn('text1')
+    when(themeMock.text3).thenReturn('text3')
+    when(themeMock.warning).thenReturn('warning')
+    when(themeMock.danger).thenReturn('danger')
+    when(themeMock.success).thenReturn('success')
+
+    orderMock = mock<ParsedOrder>()
+  })
+
+  const getResult = () => getOrderStatusTitleAndColor(instance(orderMock), instance(themeMock))
+
+  describe('When order is in confirmed state', () => {
+    it('Then should not display isCancelling state', () => {
+      when(orderMock.status).thenReturn(OrderStatus.FULFILLED)
+      when(orderMock.isCancelling).thenReturn(true)
+
+      const result = getResult()
+
+      expect(result.title).toBe('Filled')
+      expect(result.color).toBe('success')
+    })
+
+    it('Then should display partiallyFilled state', () => {
+      when(orderMock.status).thenReturn(OrderStatus.CANCELLED)
+      when(orderMock.executionData).thenReturn({ partiallyFilled: true } as any)
+
+      const result = getResult()
+
+      expect(result.title).toBe('Partially Filled')
+      expect(result.color).toBe('success')
+    })
+  })
+
+  describe('When order is NOT in confirmed state', () => {
+    it('Then should display isCancelling state', () => {
+      when(orderMock.status).thenReturn(OrderStatus.PENDING)
+      when(orderMock.isCancelling).thenReturn(true)
+
+      const result = getResult()
+
+      expect(result.title).toBe('Cancelling...')
+      expect(result.color).toBe('text1')
+    })
+
+    it('Then should NOT display partiallyFilled state', () => {
+      when(orderMock.status).thenReturn(OrderStatus.PENDING)
+      when(orderMock.executionData).thenReturn({ partiallyFilled: true } as any)
+      when(orderMock.isCancelling).thenReturn(false)
+
+      const result = getResult()
+
+      expect(result.title).toBe('Open')
+      expect(result.color).toBe('text3')
+    })
+  })
+})

--- a/src/modules/ordersTable/pure/OrderStatusBox/getOrderStatusTitleAndColor.ts
+++ b/src/modules/ordersTable/pure/OrderStatusBox/getOrderStatusTitleAndColor.ts
@@ -1,0 +1,56 @@
+import { DefaultTheme } from 'styled-components/macro'
+
+import { CONFIRMED_STATES, OrderStatus } from 'legacy/state/orders/actions'
+
+import { ParsedOrder } from 'utils/orderUtils/parseOrder'
+
+const orderStatusTitleMap: { [key in OrderStatus]: string } = {
+  [OrderStatus.PENDING]: 'Open',
+  [OrderStatus.PRESIGNATURE_PENDING]: 'Signing',
+  [OrderStatus.FULFILLED]: 'Filled',
+  [OrderStatus.EXPIRED]: 'Expired',
+  [OrderStatus.CANCELLED]: 'Cancelled',
+  [OrderStatus.CREATING]: 'Creating',
+  [OrderStatus.FAILED]: 'Failed',
+  [OrderStatus.SCHEDULED]: 'Scheduled',
+}
+
+export function getOrderStatusTitleAndColor(order: ParsedOrder, theme: DefaultTheme): { title: string; color: string } {
+  // We consider the order fully filled for display purposes even if not 100% filled
+  // For this reason we use the flag to override the order status
+  if (order.executionData.fullyFilled || order.status === OrderStatus.FULFILLED) {
+    return {
+      title: orderStatusTitleMap[OrderStatus.FULFILLED],
+      color: theme.success,
+    }
+  }
+
+  if (CONFIRMED_STATES.includes(order.status)) {
+    // Partially filled is also not a real status
+    if (order.executionData.partiallyFilled) {
+      return {
+        title: 'Partially Filled',
+        color: theme.success,
+      }
+    }
+
+    return {
+      title: orderStatusTitleMap[order.status],
+      color: order.status === OrderStatus.EXPIRED ? theme.warning : theme.danger,
+    }
+  }
+
+  // Cancelling is not a real order status
+  if (order.isCancelling) {
+    return {
+      title: 'Cancelling...',
+      color: theme.text1,
+    }
+  }
+
+  // Finally, map order status to their display version
+  return {
+    title: orderStatusTitleMap[order.status],
+    color: order.status === OrderStatus.PENDING ? theme.text3 : theme.text1,
+  }
+}

--- a/src/modules/ordersTable/pure/OrderStatusBox/index.tsx
+++ b/src/modules/ordersTable/pure/OrderStatusBox/index.tsx
@@ -56,6 +56,14 @@ function getOrderStatusTitleAndColor(order: ParsedOrder, theme: DefaultTheme): {
   }
 
   if (CONFIRMED_STATES.includes(order.status)) {
+    // Partially filled is also not a real status
+    if (order.executionData.partiallyFilled) {
+      return {
+        title: 'Partially Filled',
+        color: theme.success,
+      }
+    }
+
     return {
       title: orderStatusTitleMap[order.status],
       color: order.status === OrderStatus.EXPIRED ? theme.warning : theme.danger,
@@ -67,14 +75,6 @@ function getOrderStatusTitleAndColor(order: ParsedOrder, theme: DefaultTheme): {
     return {
       title: 'Cancelling...',
       color: theme.text1,
-    }
-  }
-
-  // Partially filled is also not a real status
-  if (order.executionData.partiallyFilled) {
-    return {
-      title: 'Partially Filled',
-      color: theme.success,
     }
   }
 

--- a/src/modules/ordersTable/pure/OrderStatusBox/index.tsx
+++ b/src/modules/ordersTable/pure/OrderStatusBox/index.tsx
@@ -1,12 +1,10 @@
 import { useContext } from 'react'
 
-import styled, { ThemeContext, DefaultTheme } from 'styled-components/macro'
-
-import { CONFIRMED_STATES, OrderStatus } from 'legacy/state/orders/actions'
-
-import { orderStatusTitleMap } from 'modules/ordersTable/pure/OrdersTableContainer/OrderRow'
+import styled, { ThemeContext } from 'styled-components/macro'
 
 import { ParsedOrder } from 'utils/orderUtils/parseOrder'
+
+import { getOrderStatusTitleAndColor } from './getOrderStatusTitleAndColor'
 
 const Wrapper = styled.div<{
   color: string
@@ -44,46 +42,6 @@ const Wrapper = styled.div<{
     border-radius: ${({ withWarning }) => (withWarning ? '9px 0 0 9px' : '9px')};
   }
 `
-
-function getOrderStatusTitleAndColor(order: ParsedOrder, theme: DefaultTheme): { title: string; color: string } {
-  // We consider the order fully filled for display purposes even if not 100% filled
-  // For this reason we use the flag to override the order status
-  if (order.executionData.fullyFilled || order.status === OrderStatus.FULFILLED) {
-    return {
-      title: orderStatusTitleMap[OrderStatus.FULFILLED],
-      color: theme.success,
-    }
-  }
-
-  if (CONFIRMED_STATES.includes(order.status)) {
-    // Partially filled is also not a real status
-    if (order.executionData.partiallyFilled) {
-      return {
-        title: 'Partially Filled',
-        color: theme.success,
-      }
-    }
-
-    return {
-      title: orderStatusTitleMap[order.status],
-      color: order.status === OrderStatus.EXPIRED ? theme.warning : theme.danger,
-    }
-  }
-
-  // Cancelling is not a real order status
-  if (order.isCancelling) {
-    return {
-      title: 'Cancelling...',
-      color: theme.text1,
-    }
-  }
-
-  // Finally, map order status to their display version
-  return {
-    title: orderStatusTitleMap[order.status],
-    color: order.status === OrderStatus.PENDING ? theme.text3 : theme.text1,
-  }
-}
 
 export type OrderStatusBoxProps = {
   order: ParsedOrder

--- a/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
+++ b/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
@@ -45,17 +45,6 @@ import * as styledEl from './styled'
 
 import { OrderParams } from '../utils/getOrderParams'
 
-export const orderStatusTitleMap: { [key in OrderStatus]: string } = {
-  [OrderStatus.PENDING]: 'Open',
-  [OrderStatus.PRESIGNATURE_PENDING]: 'Signing',
-  [OrderStatus.FULFILLED]: 'Filled',
-  [OrderStatus.EXPIRED]: 'Expired',
-  [OrderStatus.CANCELLED]: 'Cancelled',
-  [OrderStatus.CREATING]: 'Creating',
-  [OrderStatus.FAILED]: 'Failed',
-  [OrderStatus.SCHEDULED]: 'Scheduled',
-}
-
 const TIME_AGO_UPDATE_INTERVAL = 3000
 
 function CurrencyAmountItem({ amount }: { amount: CurrencyAmount<Currency> }) {


### PR DESCRIPTION
# Summary

Fixes #2928

There are two commits:
1. Actually the fix of the issue
2. Moving the function to a new file + tests

<img width="1075" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/e7ff211c-4f22-4c28-9bab-4d7e5cf41de5">
