### PR TITLE
chore(app-data): upload app-data document

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@cowprotocol/app-data": "v0.2.7",
     "@cowprotocol/contracts": "^1.3.1",
     "@cowprotocol/cow-runner-game": "^0.2.9",
-    "@cowprotocol/cow-sdk": "^2.3.0-rc.6",
+    "@cowprotocol/cow-sdk": "^2.3.0-rc.7",
     "@cowprotocol/ethflowcontract": "cowprotocol/ethflowcontract.git#v1.0.0-artifacts",
     "@davatar/react": "1.8.1",
     "@ethersproject/bignumber": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@cowprotocol/app-data": "v0.2.7",
     "@cowprotocol/contracts": "^1.3.1",
     "@cowprotocol/cow-runner-game": "^0.2.9",
-    "@cowprotocol/cow-sdk": "^2.3.0-rc.7",
+    "@cowprotocol/cow-sdk": "^2.3.0-rc.10",
     "@cowprotocol/ethflowcontract": "cowprotocol/ethflowcontract.git#v1.0.0-artifacts",
     "@davatar/react": "1.8.1",
     "@ethersproject/bignumber": "^5.7.0",

--- a/src/legacy/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/src/legacy/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -178,7 +178,16 @@ export function UnfillableOrdersUpdater(): null {
       isUpdating.current = false
       console.debug(`[UnfillableOrdersUpdater] Checked pending orders in ${Date.now() - startTime}ms`)
     }
-  }, [account, chainId, strategy, updateIsUnfillableFlag, isWindowVisible, balances, updatePendingOrderPrices])
+  }, [
+    account,
+    chainId,
+    strategy,
+    updateIsUnfillableFlag,
+    isWindowVisible,
+    balances,
+    updatePendingOrderPrices,
+    verifiedQuotesEnabled,
+  ])
 
   useEffect(() => {
     if (!chainId || !account || !isWindowVisible) {

--- a/src/mocks/tradeStateMock.ts
+++ b/src/mocks/tradeStateMock.ts
@@ -75,6 +75,7 @@ export const tradeContextMock: TradeFlowContext = {
   dispatch: (() => void 0) as any,
   allowsOffchainSigning: true,
   isGnosisSafeWallet: false,
+  uploadAppData: () => void 0,
 }
 
 export const priceImpactMock: PriceImpact = {

--- a/src/modules/appData/appData-module.md
+++ b/src/modules/appData/appData-module.md
@@ -23,4 +23,4 @@ This module will expose:
 
 - `useAppData()`: Exposes the app hash and the document associated to it.
 - `AppDataUpdater`: Component that makes sure the appData has the right content, required for `useAppData` hook to work
-- `useUploadAppData()`: Returns a function which can be invoked when an `appData` should be uploaded. This will be uploaded to IPFS. In case of errors, it will keep re-attempting.
+- `useUploadAppData()`: Returns a function which can be invoked when an `appData` should be uploaded. In case of errors, it will keep re-attempting.

--- a/src/modules/appData/appData-module.md
+++ b/src/modules/appData/appData-module.md
@@ -23,3 +23,4 @@ This module will expose:
 
 - `useAppData()`: Exposes the app hash and the document associated to it.
 - `AppDataUpdater`: Component that makes sure the appData has the right content, required for `useAppData` hook to work
+- `useUploadAppData()`: Returns a function which can be invoked when an `appData` should be uploaded. This will be uploaded to IPFS. In case of errors, it will keep re-attempting.

--- a/src/modules/appData/hooks.ts
+++ b/src/modules/appData/hooks.ts
@@ -1,4 +1,4 @@
-import { useAtomValue } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 import { useMemo } from 'react'
 
 import { DEFAULT_APP_CODE, SAFE_APP_CODE } from 'legacy/constants'
@@ -7,7 +7,7 @@ import { useIsSafeApp } from 'modules/wallet'
 
 import { isInjectedWidget } from 'common/utils/isInjectedWidget'
 
-import { appDataInfoAtom } from './state/atoms'
+import { addAppDataToUploadQueueAtom, appDataInfoAtom } from './state/atoms'
 import { AppDataInfo } from './types'
 
 import { injectedWidgetMetaDataAtom } from '../injectedWidget/state/injectedWidgetMetaDataAtom'
@@ -34,4 +34,8 @@ export function useAppCode(): string | null {
 
     return isSafeApp ? SAFE_APP_CODE : DEFAULT_APP_CODE
   }, [isSafeApp, injectedWidgetMetaData])
+}
+
+export function useUploadAppData() {
+  return useSetAtom(addAppDataToUploadQueueAtom)
 }

--- a/src/modules/appData/index.ts
+++ b/src/modules/appData/index.ts
@@ -1,4 +1,4 @@
 export { getAppData } from './utils/fullAppData'
 export { AppDataUpdater } from './updater/AppDataInfoUpdater'
-export { useAppData } from './hooks'
-export type { AppDataInfo } from './types'
+export { useAppData, useUploadAppData } from './hooks'
+export type { AppDataInfo, UploadAppDataParams } from './types'

--- a/src/modules/appData/services/index.ts
+++ b/src/modules/appData/services/index.ts
@@ -1,9 +1,19 @@
-export type UploadAppDataDoc = (appDataDoc: string) => Promise<string>
+import { orderBookApi } from 'cowSdk'
 
-export const uploadAppDataDocOrderbookApi: UploadAppDataDoc = async (appDataDoc) => {
-  // TODO: Implement logic to post the doc to the orderbook API
-  // https://cowservices.slack.com/archives/C0375NV72SC/p1690300109648539?thread_ts=1690297997.334099&cid=C0375NV72SC
-  console.log('POST api.cow.fi/v1/app_datas, with content', appDataDoc)
+/**
+ * Interface to upload appData document
+ */
+export type UploadAppDataDoc = (appDataKeccak256: string, fullAppData: string) => Promise<void>
 
-  return ''
+/**
+ * Upload appData document to orderbook API
+ * 
+ * @param appDataKeccak256 Keccak256 of the fullAppData passed as second parameter
+ * @param fullAppData Full appData content to upload
+ * 
+ * @throws Throws in case the fullAppData and the appDataKeccak256 don't match
+
+ */
+export const uploadAppDataDocOrderbookApi: UploadAppDataDoc = async (appDataKeccak256, fullAppData) => {
+  orderBookApi.uploadAppData(appDataKeccak256, fullAppData)
 }

--- a/src/modules/appData/services/index.ts
+++ b/src/modules/appData/services/index.ts
@@ -1,0 +1,9 @@
+export type UploadAppDataDoc = (appDataDoc: string) => Promise<string>
+
+export const uploadAppDataDocOrderbookApi: UploadAppDataDoc = async (appDataDoc) => {
+  // TODO: Implement logic to post the doc to the orderbook API
+  // https://cowservices.slack.com/archives/C0375NV72SC/p1690300109648539?thread_ts=1690297997.334099&cid=C0375NV72SC
+  console.log('POST api.cow.fi/v1/app_datas, with content', appDataDoc)
+
+  return ''
+}

--- a/src/modules/appData/state/atoms.ts
+++ b/src/modules/appData/state/atoms.ts
@@ -1,6 +1,15 @@
 import { atom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
 
-import { AppDataInfo } from '../types'
+import { buildDocFilterFn, buildInverseDocFilterFn } from './utils'
+
+import {
+  AppDataInfo,
+  AppDataPendingToUpload,
+  RemoveAppDataFromUploadQueueParams,
+  UpdateAppDataOnUploadQueueParams,
+  UploadAppDataParams,
+} from '../types'
 import { updateFullAppData } from '../utils/fullAppData'
 
 /**
@@ -11,5 +20,76 @@ export const appDataInfoAtom = atom<AppDataInfo | null, [AppDataInfo | null], un
   (_get, set, appDataInfo) => {
     set(appDataInfoAtom, appDataInfo)
     updateFullAppData(appDataInfo?.fullAppData ?? undefined)
+  }
+)
+
+/**
+ * Base atom that stores all appData pending to be uploaded
+ */
+export const appDataUploadQueueAtom = atomWithStorage<AppDataPendingToUpload>(
+  'appDataUploadQueue:v1', // local storage key
+  []
+)
+
+/**
+ * Write only atom to add an appData to upload queue
+ */
+export const addAppDataToUploadQueueAtom = atom(
+  null,
+  (get, set, { chainId, orderId, appData }: UploadAppDataParams) => {
+    set(appDataUploadQueueAtom, () => {
+      const docs = get(appDataUploadQueueAtom)
+
+      if (docs.some(buildDocFilterFn(chainId, orderId))) {
+        // Entry already in the queue, ignore
+        return docs
+      }
+
+      return [...docs, { chainId, orderId, ...appData, uploading: false, failedAttempts: 0 }]
+    })
+  }
+)
+
+/**
+ * Write only atom to update upload status of an appData on upload queue
+ */
+export const updateAppDataOnUploadQueueAtom = atom(
+  null,
+  (get, set, { chainId, orderId, uploading, lastAttempt, failedAttempts }: UpdateAppDataOnUploadQueueParams) => {
+    set(appDataUploadQueueAtom, () => {
+      const docs = get(appDataUploadQueueAtom)
+      const existingDocIndex = docs.findIndex(buildDocFilterFn(chainId, orderId))
+
+      if (existingDocIndex === -1) {
+        // Entry doesn't exist in the queue, ignore
+        return docs
+      }
+
+      // Create a copy of original docs
+      const updateDocs = docs.slice(0)
+
+      // Using the index, get the value
+      const existingDoc = docs[existingDocIndex]
+
+      // Replace existing doc at index with the updated version
+      updateDocs[existingDocIndex] = {
+        ...existingDoc,
+        uploading: uploading ?? existingDoc.uploading,
+        lastAttempt: lastAttempt ?? existingDoc.lastAttempt,
+        failedAttempts: failedAttempts ?? existingDoc.failedAttempts,
+      }
+
+      return updateDocs
+    })
+  }
+)
+
+/**
+ * Write only atom to remove appData from upload queue
+ */
+export const removeAppDataFromUploadQueueAtom = atom(
+  null,
+  (get, set, { chainId, orderId }: RemoveAppDataFromUploadQueueParams) => {
+    set(appDataUploadQueueAtom, () => get(appDataUploadQueueAtom).filter(buildInverseDocFilterFn(chainId, orderId)))
   }
 )

--- a/src/modules/appData/types.tsx
+++ b/src/modules/appData/types.tsx
@@ -21,3 +21,11 @@ export type AppDataKeyParams = {
 export type AppDataRecord = AppDataInfo & AppDataUploadStatus & AppDataKeyParams
 
 export type AppDataOrderClass = Parameters<typeof createOrderClassMetadata>[0]['orderClass']
+
+export type AppDataPendingToUpload = Array<AppDataRecord>
+
+export type UploadAppDataParams = AppDataKeyParams & {
+  appData: AppDataInfo
+}
+export type UpdateAppDataOnUploadQueueParams = AppDataKeyParams & Partial<AppDataUploadStatus>
+export type RemoveAppDataFromUploadQueueParams = AppDataKeyParams

--- a/src/modules/appData/updater/UploadToIpfsUpdater.ts
+++ b/src/modules/appData/updater/UploadToIpfsUpdater.ts
@@ -97,23 +97,10 @@ async function _actuallyUploadToIpfs(
   updatePending({ chainId, orderId, uploading: true })
 
   try {
-    // TODO: Remove the "|| appDataKeccak256" once tuploadAppDataDocOrderbookApi is implemented
-    const actualHash = (await uploadAppDataDocOrderbookApi(fullAppData)) || appDataKeccak256
-
+    await uploadAppDataDocOrderbookApi(appDataKeccak256, fullAppData)
     removePending({ chainId, orderId })
-
-    if (appDataKeccak256 !== actualHash) {
-      // TODO: add sentry error to track hard failure
-      console.error(
-        `[UploadToIpfsUpdater] Uploaded data hash (${actualHash}) differs from calculated (${appDataKeccak256}) for doc`,
-        fullAppData
-      )
-    } else {
-      console.debug(`[UploadToIpfsUpdater] Uploaded doc with hash ${actualHash}`, fullAppData)
-    }
   } catch (e: any) {
-    // TODO: add sentry error to track soft failure
-    console.warn(`[UploadToIpfsUpdater] Failed to upload doc, will try again. Reason: ${e.message}`, fullAppData)
+    console.error(`[UploadToIpfsUpdater] Failed to upload doc, will try again. Reason: ${e.message}`, e, fullAppData)
     updatePending({ chainId, orderId, uploading: false, failedAttempts: failedAttempts + 1, lastAttempt: Date.now() })
   }
 }

--- a/src/modules/appData/updater/UploadToIpfsUpdater.ts
+++ b/src/modules/appData/updater/UploadToIpfsUpdater.ts
@@ -1,0 +1,119 @@
+import { useAtomValue, useSetAtom } from 'jotai'
+import { useEffect, useRef } from 'react'
+
+import ms from 'ms.macro'
+
+import { uploadAppDataDocOrderbookApi } from '../services'
+import {
+  appDataUploadQueueAtom,
+  removeAppDataFromUploadQueueAtom,
+  updateAppDataOnUploadQueueAtom,
+} from '../state/atoms'
+import { AppDataKeyParams, AppDataRecord, UpdateAppDataOnUploadQueueParams } from '../types'
+
+const UPLOAD_CHECK_INTERVAL = ms`1 minute`
+const BASE_FOR_EXPONENTIAL_BACKOFF = 2 // in seconds, converted to milliseconds later
+const ONE_SECOND = ms`1s`
+const MAX_TIME_TO_WAIT = ms`5 minutes`
+
+export function UploadToIpfsUpdater(): null {
+  const toUpload = useAtomValue(appDataUploadQueueAtom)
+  const removePending = useSetAtom(removeAppDataFromUploadQueueAtom)
+  const updatePending = useSetAtom(updateAppDataOnUploadQueueAtom)
+
+  // Storing a reference to avoid re-render on every update
+  const refToUpload = useRef(toUpload)
+  refToUpload.current = toUpload
+
+  // Filtering only newly created and not yet attempted to upload docs
+  const newlyAdded = toUpload.filter(({ uploading, lastAttempt }) => !uploading && !lastAttempt)
+
+  useEffect(() => {
+    // Try to upload new docs as soon as they are added
+    newlyAdded.forEach((appDataRecord) => _uploadToIpfs(appDataRecord, updatePending, removePending))
+  }, [newlyAdded, removePending, updatePending])
+
+  useEffect(() => {
+    async function uploadPendingAppData() {
+      console.debug(`[UploadToIpfsUpdater] Iterating over ${refToUpload.current.length} appData on upload queue`)
+      refToUpload.current.forEach((appDataRecord) => _uploadToIpfs(appDataRecord, updatePending, removePending))
+    }
+
+    const intervalId = setInterval(uploadPendingAppData, UPLOAD_CHECK_INTERVAL)
+
+    return () => {
+      clearInterval(intervalId)
+    }
+  }, [removePending, updatePending])
+
+  return null
+}
+
+async function _uploadToIpfs(
+  appDataRecord: AppDataRecord,
+  updatePending: (params: UpdateAppDataOnUploadQueueParams) => void,
+  removePending: (params: AppDataKeyParams) => void
+) {
+  const { fullAppData, appDataKeccak256, chainId, orderId, uploading, failedAttempts, lastAttempt } = appDataRecord
+
+  if (!fullAppData || !appDataKeccak256) {
+    // No actual doc to upload, nothing to do here
+    removePending({ chainId, orderId })
+  } else if (_canUpload(uploading, failedAttempts, lastAttempt)) {
+    await _actuallyUploadToIpfs(appDataRecord, updatePending, removePending)
+  } else {
+    console.log(`[UploadToIpfsUpdater] Criteria not met, skipping ${chainId}-${orderId}`)
+  }
+}
+
+function _canUpload(uploading: boolean, attempts: number, lastAttempt?: number): boolean {
+  if (uploading) {
+    return false
+  }
+
+  if (lastAttempt) {
+    // Every attempt takes BASE_FOR_EXPONENTIAL_BACKOFF ˆ failedAttempts
+    const timeToWait = BASE_FOR_EXPONENTIAL_BACKOFF ** attempts * ONE_SECOND
+    // Don't wait more than MAX_TIME_TO_WAIT.
+    // Both are in milliseconds
+    const timeDelta = Math.min(timeToWait, MAX_TIME_TO_WAIT)
+
+    return lastAttempt + timeDelta <= Date.now()
+  }
+
+  return true
+}
+
+async function _actuallyUploadToIpfs(
+  appDataRecord: AppDataRecord,
+  updatePending: (params: UpdateAppDataOnUploadQueueParams) => void,
+  removePending: (params: AppDataKeyParams) => void
+) {
+  const { fullAppData, appDataKeccak256, chainId, orderId, failedAttempts } = appDataRecord
+
+  if (!fullAppData || !appDataKeccak256) return
+
+  // Update state to prevent it to be uploaded by another process in the meantime
+  updatePending({ chainId, orderId, uploading: true })
+
+  try {
+    // TODO: Remove the "|| appDataKeccak256" once tuploadAppDataDocOrderbookApi is implemented
+    const actualHash = (await uploadAppDataDocOrderbookApi(fullAppData)) || appDataKeccak256
+
+    removePending({ chainId, orderId })
+
+    if (appDataKeccak256 !== actualHash) {
+      // TODO: add sentry error to track hard failure
+      console.error(
+        `[UploadToIpfsUpdater] Uploaded data hash (${actualHash}) differs from calculated (${appDataKeccak256}) for doc`,
+        fullAppData
+      )
+    } else {
+      console.debug(`[UploadToIpfsUpdater] Uploaded doc with hash ${actualHash}`, fullAppData)
+    }
+  } catch (e: any) {
+    // TODO: add sentry error to track soft failure
+    console.warn(`[UploadToIpfsUpdater] Failed to upload doc, will try again. Reason: ${e.message}`, fullAppData)
+    updatePending({ chainId, orderId, uploading: false, failedAttempts: failedAttempts + 1, lastAttempt: Date.now() })
+  }
+}

--- a/src/modules/application/containers/App/Updaters.tsx
+++ b/src/modules/application/containers/App/Updaters.tsx
@@ -16,6 +16,7 @@ import FeesUpdater from 'legacy/state/price/updater'
 import SentryUpdater from 'legacy/state/sentry/updater'
 import UserUpdater from 'legacy/state/user/updater'
 
+import { UploadToIpfsUpdater } from 'modules/appData/updater/UploadToIpfsUpdater'
 import { InjectedWidgetUpdater } from 'modules/injectedWidget'
 import { EthFlowDeadlineUpdater, EthFlowSlippageUpdater } from 'modules/swap/state/EthFlow/updaters'
 import { TokensListUpdater } from 'modules/tokensList/updaters/TokensListUpdater'
@@ -45,6 +46,7 @@ export function Updaters() {
       <GasPriceStrategyUpdater />
       <LogsUpdater />
       <SentryUpdater />
+      <UploadToIpfsUpdater />
       <EthFlowSlippageUpdater />
       <EthFlowDeadlineUpdater />
       <SpotPricesUpdater />

--- a/src/modules/limitOrders/hooks/useTradeFlowContext.ts
+++ b/src/modules/limitOrders/hooks/useTradeFlowContext.ts
@@ -9,7 +9,7 @@ import { useDispatch } from 'react-redux'
 import { useGP2SettlementContract } from 'legacy/hooks/useContract'
 import { AppDispatch } from 'legacy/state'
 
-import { useAppData } from 'modules/appData'
+import { useAppData, useUploadAppData } from 'modules/appData'
 import { useRateImpact } from 'modules/limitOrders/hooks/useRateImpact'
 import { TradeFlowContext } from 'modules/limitOrders/services/types'
 import { limitOrdersSettingsAtom } from 'modules/limitOrders/state/limitOrdersSettingsAtom'
@@ -29,6 +29,7 @@ export function useTradeFlowContext(): TradeFlowContext | null {
   const settlementContract = useGP2SettlementContract()
   const dispatch = useDispatch<AppDispatch>()
   const appData = useAppData()
+  const uploadAppData = useUploadAppData()
   const quoteState = useTradeQuote()
   const rateImpact = useRateImpact()
   const settingsState = useAtomValue(limitOrdersSettingsAtom)
@@ -66,6 +67,7 @@ export function useTradeFlowContext(): TradeFlowContext | null {
     isGnosisSafeWallet,
     dispatch,
     provider,
+    uploadAppData,
     appData,
     rateImpact,
     postOrderParams: {

--- a/src/modules/limitOrders/pure/LimitOrdersDetails/index.cosmos.tsx
+++ b/src/modules/limitOrders/pure/LimitOrdersDetails/index.cosmos.tsx
@@ -38,6 +38,7 @@ const tradeContext: TradeFlowContext = {
   },
   rateImpact: 0,
   appData: {} as any,
+  uploadAppData: () => void 0,
   provider: {} as any,
   settlementContract: {} as any,
   chainId: 1,

--- a/src/modules/limitOrders/services/safeBundleFlow/index.ts
+++ b/src/modules/limitOrders/services/safeBundleFlow/index.ts
@@ -56,8 +56,18 @@ export async function safeBundleFlow(
   tradeFlowAnalytics.approveAndPresign(swapFlowAnalyticsContext)
   beforeTrade?.()
 
-  const { chainId, postOrderParams, provider, erc20Contract, spender, dispatch, settlementContract, safeAppsSdk } =
-    params
+  const {
+    chainId,
+    postOrderParams,
+    provider,
+    erc20Contract,
+    spender,
+    dispatch,
+    settlementContract,
+    safeAppsSdk,
+    appData,
+    uploadAppData,
+  } = params
 
   const validTo = calculateLimitOrdersDeadline(settingsState)
 
@@ -134,12 +144,14 @@ export async function safeBundleFlow(
       },
       dispatch
     )
-
     tradeFlowAnalytics.sign(swapFlowAnalyticsContext)
+
+    logTradeFlow(LOG_PREFIX, 'STEP 8: add app data to upload queue')
+    uploadAppData({ chainId, orderId, appData })
 
     return orderId
   } catch (error: any) {
-    logTradeFlow(LOG_PREFIX, 'STEP 8: ERROR: ', error)
+    logTradeFlow(LOG_PREFIX, 'STEP 9: ERROR: ', error)
     const swapErrorMessage = getSwapErrorMessage(error)
 
     tradeFlowAnalytics.error(error, swapErrorMessage, swapFlowAnalyticsContext)

--- a/src/modules/limitOrders/services/tradeFlow/index.ts
+++ b/src/modules/limitOrders/services/tradeFlow/index.ts
@@ -86,12 +86,15 @@ export async function tradeFlow(
       )
     }
 
-    logTradeFlow('LIMIT ORDER FLOW', 'STEP 7: Sign order')
+    logTradeFlow('LIMIT ORDER FLOW', 'STEP 7: add app data to upload queue')
+    params.uploadAppData({ chainId: params.chainId, orderId, appData: params.appData })
+
+    logTradeFlow('LIMIT ORDER FLOW', 'STEP 8: Sign order')
     tradeFlowAnalytics.sign(swapFlowAnalyticsContext)
 
     return orderId
   } catch (error: any) {
-    logTradeFlow('LIMIT ORDER FLOW', 'STEP 8: ERROR: ', error)
+    logTradeFlow('LIMIT ORDER FLOW', 'STEP 9: ERROR: ', error)
     const swapErrorMessage = getSwapErrorMessage(error)
 
     tradeFlowAnalytics.error(error, swapErrorMessage, swapFlowAnalyticsContext)

--- a/src/modules/limitOrders/services/types.ts
+++ b/src/modules/limitOrders/services/types.ts
@@ -6,7 +6,7 @@ import SafeAppsSDK from '@safe-global/safe-apps-sdk'
 import { AppDispatch } from 'legacy/state'
 import { PostOrderParams } from 'legacy/utils/trade'
 
-import { AppDataInfo } from 'modules/appData'
+import { AppDataInfo, UploadAppDataParams } from 'modules/appData'
 
 export interface TradeFlowContext {
   // signer changes creates redundant re-renders
@@ -17,6 +17,7 @@ export interface TradeFlowContext {
   dispatch: AppDispatch
   rateImpact: number
   appData: AppDataInfo
+  uploadAppData: (update: UploadAppDataParams) => void
   provider: Web3Provider
   allowsOffchainSigning: boolean
   isGnosisSafeWallet: boolean

--- a/src/modules/swap/hooks/useFlowContext.ts
+++ b/src/modules/swap/hooks/useFlowContext.ts
@@ -20,8 +20,8 @@ import { useUserTransactionTTL } from 'legacy/state/user/hooks'
 import { computeSlippageAdjustedAmounts } from 'legacy/utils/prices'
 import { PostOrderParams } from 'legacy/utils/trade'
 
-import type { AppDataInfo } from 'modules/appData'
-import { useAppData } from 'modules/appData'
+import { useAppData, useUploadAppData } from 'modules/appData'
+import type { AppDataInfo, UploadAppDataParams } from 'modules/appData'
 import { useIsSafeApprovalBundle } from 'modules/limitOrders/hooks/useIsSafeApprovalBundle'
 import { useIsEoaEthFlow } from 'modules/swap/hooks/useIsEoaEthFlow'
 import { SwapConfirmManager, useSwapConfirmManager } from 'modules/swap/hooks/useSwapConfirmManager'
@@ -78,6 +78,7 @@ interface BaseFlowContextSetup {
   swapConfirmManager: SwapConfirmManager
   flowType: FlowType
   closeModals: () => void
+  uploadAppData: (update: UploadAppDataParams) => void
   addOrderCallback: AddOrderCallback
   dispatch: AppDispatch
 }
@@ -92,6 +93,7 @@ export function useBaseFlowContextSetup(): BaseFlowContextSetup {
 
   const appData = useAppData()
   const closeModals = useCloseModals()
+  const uploadAppData = useUploadAppData()
   const addOrderCallback = useAddPendingOrder()
   const dispatch = useDispatch<AppDispatch>()
 
@@ -128,6 +130,7 @@ export function useBaseFlowContextSetup(): BaseFlowContextSetup {
     allowsOffchainSigning,
     swapConfirmManager,
     flowType,
+    uploadAppData,
     closeModals,
     addOrderCallback,
     dispatch,
@@ -173,6 +176,7 @@ export function getFlowContext({ baseProps, sellToken, kind }: BaseGetFlowContex
     swapConfirmManager,
     closeModals,
     addOrderCallback,
+    uploadAppData,
     dispatch,
     flowType,
   } = baseProps
@@ -252,6 +256,7 @@ export function getFlowContext({ baseProps, sellToken, kind }: BaseGetFlowContex
     callbacks: {
       closeModals,
       addOrderCallback,
+      uploadAppData,
     },
     dispatch,
     swapFlowAnalyticsContext,

--- a/src/modules/swap/services/ethFlow/index.ts
+++ b/src/modules/swap/services/ethFlow/index.ts
@@ -22,6 +22,7 @@ export async function ethFlow(
     swapConfirmManager,
     contract,
     callbacks,
+    appDataInfo,
     dispatch,
     orderParams: orderParamsOriginal,
     checkInFlightOrderIdExists,
@@ -64,6 +65,9 @@ export async function ethFlow(
     )
     // TODO: maybe move this into addPendingOrderStep?
     ethFlowContext.addTransaction({ hash: txReceipt.hash, ethFlow: { orderId: order.id, subType: 'creation' } })
+
+    logTradeFlow('ETH FLOW', 'STEP 6: add app data to upload queue')
+    callbacks.uploadAppData({ chainId: context.chainId, orderId, appData: appDataInfo })
 
     logTradeFlow('ETH FLOW', 'STEP 6: show UI of the successfully sent transaction', orderId)
     swapConfirmManager.transactionSent(orderId)

--- a/src/modules/swap/services/safeBundleFlow/safeBundleApprovalFlow.ts
+++ b/src/modules/swap/services/safeBundleFlow/safeBundleApprovalFlow.ts
@@ -36,6 +36,7 @@ export async function safeBundleApprovalFlow(
     callbacks,
     swapConfirmManager,
     dispatch,
+    appDataInfo,
     orderParams,
     settlementContract,
     safeAppsSdk,
@@ -117,10 +118,13 @@ export async function safeBundleApprovalFlow(
     )
     tradeFlowAnalytics.sign(swapFlowAnalyticsContext)
 
-    logTradeFlow(LOG_PREFIX, 'STEP 7: show UI of the successfully sent transaction')
+    logTradeFlow(LOG_PREFIX, 'STEP 7: add app data to upload queue')
+    callbacks.uploadAppData({ chainId: context.chainId, orderId, appData: appDataInfo })
+
+    logTradeFlow(LOG_PREFIX, 'STEP 8: show UI of the successfully sent transaction')
     swapConfirmManager.transactionSent(orderId)
   } catch (error) {
-    logTradeFlow(LOG_PREFIX, 'STEP 8: error', error)
+    logTradeFlow(LOG_PREFIX, 'STEP 9: error', error)
     const swapErrorMessage = getSwapErrorMessage(error)
 
     tradeFlowAnalytics.error(error, swapErrorMessage, swapFlowAnalyticsContext)

--- a/src/modules/swap/services/safeBundleFlow/safeBundleEthFlow.ts
+++ b/src/modules/swap/services/safeBundleFlow/safeBundleEthFlow.ts
@@ -36,6 +36,7 @@ export async function safeBundleEthFlow(
     callbacks,
     swapConfirmManager,
     dispatch,
+    appDataInfo,
     orderParams,
     settlementContract,
     safeAppsSdk,
@@ -123,10 +124,13 @@ export async function safeBundleEthFlow(
     )
     tradeFlowAnalytics.sign(swapFlowAnalyticsContext)
 
-    logTradeFlow(LOG_PREFIX, 'STEP 8: show UI of the successfully sent transaction')
+    logTradeFlow(LOG_PREFIX, 'STEP 8: add app data to upload queue')
+    callbacks.uploadAppData({ chainId: context.chainId, orderId, appData: appDataInfo })
+
+    logTradeFlow(LOG_PREFIX, 'STEP 9: show UI of the successfully sent transaction')
     swapConfirmManager.transactionSent(orderId)
   } catch (error) {
-    logTradeFlow(LOG_PREFIX, 'STEP 9: error', error)
+    logTradeFlow(LOG_PREFIX, 'STEP 10: error', error)
     const swapErrorMessage = getSwapErrorMessage(error)
 
     tradeFlowAnalytics.error(error, swapErrorMessage, swapFlowAnalyticsContext)

--- a/src/modules/swap/services/swapFlow/index.ts
+++ b/src/modules/swap/services/swapFlow/index.ts
@@ -65,11 +65,14 @@ export async function swapFlow(
       )
     }
 
-    logTradeFlow('SWAP FLOW', 'STEP 6: show UI of the successfully sent transaction', orderId)
+    logTradeFlow('SWAP FLOW', 'STEP 6: add app data to upload queue')
+    input.callbacks.uploadAppData({ chainId: input.context.chainId, orderId, appData: input.appDataInfo })
+
+    logTradeFlow('SWAP FLOW', 'STEP 7: show UI of the successfully sent transaction', orderId)
     input.swapConfirmManager.transactionSent(orderId)
     tradeFlowAnalytics.sign(input.swapFlowAnalyticsContext)
   } catch (error: any) {
-    logTradeFlow('SWAP FLOW', 'STEP 7: ERROR: ', error)
+    logTradeFlow('SWAP FLOW', 'STEP 8: ERROR: ', error)
     const swapErrorMessage = getSwapErrorMessage(error)
 
     tradeFlowAnalytics.error(error, swapErrorMessage, input.swapFlowAnalyticsContext)

--- a/src/modules/swap/services/types.ts
+++ b/src/modules/swap/services/types.ts
@@ -10,7 +10,7 @@ import { AddOrderCallback } from 'legacy/state/orders/hooks'
 import TradeGp from 'legacy/state/swap/TradeGp'
 import { PostOrderParams } from 'legacy/utils/trade'
 
-import { AppDataInfo } from 'modules/appData'
+import { AppDataInfo, UploadAppDataParams } from 'modules/appData'
 import { SwapConfirmManager } from 'modules/swap/hooks/useSwapConfirmManager'
 import { SwapFlowAnalyticsContext } from 'modules/trade/utils/analytics'
 
@@ -31,6 +31,7 @@ export interface BaseFlowContext {
   callbacks: {
     closeModals: () => void
     addOrderCallback: AddOrderCallback
+    uploadAppData: (params: UploadAppDataParams) => void
   }
   dispatch: AppDispatch
   swapFlowAnalyticsContext: SwapFlowAnalyticsContext

--- a/src/modules/twap/hooks/useCreateTwapOrder.ts
+++ b/src/modules/twap/hooks/useCreateTwapOrder.ts
@@ -14,7 +14,7 @@ import { getCowSoundSend } from 'legacy/utils/sound'
 import { getOrderSubmitSummary } from 'legacy/utils/trade'
 
 import { updateAdvancedOrdersAtom, useAdvancedOrdersDerivedState } from 'modules/advancedOrders'
-import { useAppData } from 'modules/appData'
+import { useAppData, useUploadAppData } from 'modules/appData'
 import { useTradeConfirmActions, useTradePriceImpact } from 'modules/trade'
 import { SwapFlowAnalyticsContext, tradeFlowAnalytics } from 'modules/trade/utils/analytics'
 import { useWalletInfo } from 'modules/wallet'
@@ -51,6 +51,7 @@ export function useCreateTwapOrder() {
   const updateAdvancedOrdersState = useSetAtom(updateAdvancedOrdersAtom)
 
   const tradeConfirmActions = useTradeConfirmActions()
+  const uploadAppData = useUploadAppData()
 
   const { priceImpact } = useTradePriceImpact()
   const { confirmPriceImpactWithoutFee } = useConfirmPriceImpactWithoutFee()
@@ -126,6 +127,7 @@ export function useCreateTwapOrder() {
         getCowSoundSend().play()
         dispatchPresignedOrderPosted(store, safeTxHash, summary, OrderClass.LIMIT, 'composable-order')
 
+        uploadAppData({ chainId, orderId, appData: appDataInfo })
         updateAdvancedOrdersState({ recipient: null, recipientAddress: null })
         tradeConfirmActions.onSuccess(safeTxHash)
         tradeFlowAnalytics.sign(twapFlowAnalyticsContext)
@@ -149,6 +151,7 @@ export function useCreateTwapOrder() {
       twapOrder,
       confirmPriceImpactWithoutFee,
       priceImpact,
+      uploadAppData,
       tradeConfirmActions,
       addTwapOrderToList,
       recipient,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2302,10 +2302,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/cow-runner-game/-/cow-runner-game-0.2.9.tgz#3f94b3f370bd114f77db8b1d238cba3ef4e9d644"
   integrity sha512-rX7HnoV+HYEEkBaqVUsAkGGo0oBrExi+d6Io+8nQZYwZk+IYLmS9jdcIObsLviM2h4YX8+iin6NuKl35AaiHmg==
 
-"@cowprotocol/cow-sdk@^2.3.0-rc.7":
-  version "2.3.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-2.3.0-rc.7.tgz#03861aa44730ed8189eea3b2c48ded041ee0311e"
-  integrity sha512-fj8wnab+0qUjmdFZr7tUDeZOBU0fR/TiSUsN9XI3qkddbe0qTZQpcWG0dYcD9/ceJ4k2hWZUTczepK0DeXaEXg==
+"@cowprotocol/cow-sdk@^2.3.0-rc.10":
+  version "2.3.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-2.3.0-rc.10.tgz#928851bbba1a1dbc9cb2f2c47372617ff9bade9f"
+  integrity sha512-mNPOiNBBQAOXiDaepaH2GBW6yVZWXm24gJglCxg1x7Ts7Tdow5pI3W7Jn63HFuS72qBoJioZWt9BXyisU+OZNw==
   dependencies:
     "@cowprotocol/contracts" "^1.4.0"
     "@ethersproject/abstract-signer" "^5.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2302,10 +2302,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/cow-runner-game/-/cow-runner-game-0.2.9.tgz#3f94b3f370bd114f77db8b1d238cba3ef4e9d644"
   integrity sha512-rX7HnoV+HYEEkBaqVUsAkGGo0oBrExi+d6Io+8nQZYwZk+IYLmS9jdcIObsLviM2h4YX8+iin6NuKl35AaiHmg==
 
-"@cowprotocol/cow-sdk@^2.3.0-rc.6":
-  version "2.3.0-rc.6"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-2.3.0-rc.6.tgz#6a61c892c44c3f7ff6375486e270555057dcad1c"
-  integrity sha512-pbwwZFSB7+CV1V93VsAkHLwjJJS+c6UYScKBHTtTXPlYgZ2xymb8ZEYu62AESE66swBBNO7hh1rOF9RR12VIUA==
+"@cowprotocol/cow-sdk@^2.3.0-rc.7":
+  version "2.3.0-rc.7"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-2.3.0-rc.7.tgz#03861aa44730ed8189eea3b2c48ded041ee0311e"
+  integrity sha512-fj8wnab+0qUjmdFZr7tUDeZOBU0fR/TiSUsN9XI3qkddbe0qTZQpcWG0dYcD9/ceJ4k2hWZUTczepK0DeXaEXg==
   dependencies:
     "@cowprotocol/contracts" "^1.4.0"
     "@ethersproject/abstract-signer" "^5.7.0"


### PR DESCRIPTION
# Summary

This  PR brings back the logic to upload the documents to IPFS

The logic was removed because we already post the information to the backend when we post an order. 

However, for example in TWAP orders we don't invoke the API directly, so we can't post the content of the AppData document. The same could happen in the future we don't post presign orders anymore (there was some conversations about it)

<img width="1638" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/e53b66e8-94ed-4f92-ab1d-e88895fb70ee">


Context:
https://cowservices.slack.com/archives/C0375NV72SC/p1690300421329999?thread_ts=1690297997.334099&cid=C0375NV72SC

## In which flows do we upload the document
For now, we do it for all! It doesn't harm, but is redundant, so I will do a follow-up PR to remove some flows.
This way, the come in two different PRs in case we need to revert in the future and add for example presign back.


# To Test

- Make a trade in any of the flows
- Filter in the console by `PUT api.cow.fi/v1/app_datas` 
- You should see the console log showing that it posted the document