### PR TITLE
feat(swap): suggest using TWAP

### DIFF
--- a/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/src/modules/swap/containers/SwapWidget/index.tsx
@@ -38,6 +38,7 @@ import {
 } from 'modules/swap/pure/warnings'
 import useCurrencyBalance from 'modules/tokens/hooks/useCurrencyBalance'
 import { TradeWidget, TradeWidgetContainer, useTradePriceImpact } from 'modules/trade'
+import { useTradeRouteContext } from 'modules/trade/hooks/useTradeRouteContext'
 import { useWrappedToken } from 'modules/trade/hooks/useWrappedToken'
 import { useIsSafeViaWc, useWalletDetails, useWalletInfo } from 'modules/wallet'
 
@@ -131,6 +132,8 @@ export function SwapWidget() {
     priceImpactParams,
   })
 
+  const tradeUrlParams = useTradeRouteContext()
+
   const rateInfoParams = useRateInfoParams(inputCurrencyInfo.amount, outputCurrencyInfo.amount)
 
   const confirmSwapProps: ConfirmSwapModalSetupProps = {
@@ -194,6 +197,7 @@ export function SwapWidget() {
     shouldZeroApprove,
     buyingFiatAmount,
     allowedSlippage,
+    tradeUrlParams,
   }
 
   const swapWarningsBottomProps: SwapWarningsBottomProps = {

--- a/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/src/modules/swap/containers/SwapWidget/index.tsx
@@ -180,6 +180,7 @@ export function SwapWidget() {
   const wrappedCurrencySymbol = useWrappedToken().symbol || 'WETH'
 
   const swapWarningsTopProps: SwapWarningsTopProps = {
+    chainId,
     trade,
     account,
     feeWarningAccepted,

--- a/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/src/modules/swap/containers/SwapWidget/index.tsx
@@ -196,7 +196,7 @@ export function SwapWidget() {
     setImpactWarningAccepted,
     shouldZeroApprove,
     buyingFiatAmount,
-    allowedSlippage,
+    priceImpact: priceImpactParams.priceImpact,
     tradeUrlParams,
   }
 

--- a/src/modules/swap/pure/banners/TwapSuggestionBanner.tsx
+++ b/src/modules/swap/pure/banners/TwapSuggestionBanner.tsx
@@ -30,7 +30,7 @@ export interface TwapSuggestionBannerProps {
 const PRICE_IMPACT_LIMIT = 1 // 1%
 const AMOUNT_LIMIT: Record<SupportedChainId, number> = {
   [SupportedChainId.MAINNET]: 50_000, // $50,000
-  [SupportedChainId.GNOSIS_CHAIN]: 5_000, // $5000
+  [SupportedChainId.GNOSIS_CHAIN]: 500, // $500
   [SupportedChainId.GOERLI]: 100, // $100
 }
 
@@ -53,7 +53,7 @@ export function TwapSuggestionBanner({
     <InlineBanner type="alert">
       <p>
         The price impact is {+priceImpact.toFixed(2)}%. Consider breaking up your order using{' '}
-        <StyledNavLink to={routePath}>Advanced orders</StyledNavLink>
+        <StyledNavLink to={routePath}>TWAP order</StyledNavLink>
       </p>
     </InlineBanner>
   )

--- a/src/modules/swap/pure/banners/TwapSuggestionBanner.tsx
+++ b/src/modules/swap/pure/banners/TwapSuggestionBanner.tsx
@@ -1,3 +1,4 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
 
 import { NavLink } from 'react-router-dom'
@@ -26,7 +27,11 @@ export interface TwapSuggestionBannerProps {
 }
 
 const PRICE_IMPACT_LIMIT = 1 // 1%
-const AMOUNT_LIMIT = 50_000 // $50,000
+const AMOUNT_LIMIT: Record<SupportedChainId, number> = {
+  [SupportedChainId.MAINNET]: 50_000, // $50,000
+  [SupportedChainId.GNOSIS_CHAIN]: 5_000, // $5000
+  [SupportedChainId.GOERLI]: 100, // $100
+}
 
 export function TwapSuggestionBanner({ priceImpact, buyingFiatAmount, tradeUrlParams }: TwapSuggestionBannerProps) {
   if (!priceImpact || priceImpact.lessThan(0)) return null
@@ -42,7 +47,7 @@ export function TwapSuggestionBanner({ priceImpact, buyingFiatAmount, tradeUrlPa
     <InlineBanner type="alert">
       <p>
         The price impact is {+priceImpact.toFixed(2)}%. Consider breaking up your order using{' '}
-        <StyledNavLink to={routePath}>TWAP orders</StyledNavLink>
+        <StyledNavLink to={routePath}>Advanced orders</StyledNavLink>
       </p>
     </InlineBanner>
   )

--- a/src/modules/swap/pure/banners/TwapSuggestionBanner.tsx
+++ b/src/modules/swap/pure/banners/TwapSuggestionBanner.tsx
@@ -1,25 +1,48 @@
 import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
 
+import { NavLink } from 'react-router-dom'
+import styled from 'styled-components/macro'
+
+import { TradeUrlParams } from 'modules/trade/types/TradeRawState'
+import { parameterizeTradeRoute } from 'modules/trade/utils/parameterizeTradeRoute'
+
+import { Routes } from 'common/constants/routes'
 import { InlineBanner } from 'common/pure/InlineBanner'
+
+const StyledNavLink = styled(NavLink)`
+  color: inherit;
+  display: inline;
+  text-decoration: underline;
+
+  &:hover {
+    text-decoration: none;
+  }
+`
 
 export interface TwapSuggestionBannerProps {
   slippage: Percent
   buyingFiatAmount: CurrencyAmount<Currency> | null
+  tradeUrlParams: TradeUrlParams
 }
 
 const TWAP_SUGGESTION_SLIPPAGE_LIMIT = 1 // 1%
 const TWAP_SUGGESTION_AMOUNT_LIMIT = 50_000 // $50,000
 
-export function TwapSuggestionBanner({ slippage, buyingFiatAmount }: TwapSuggestionBannerProps) {
+export function TwapSuggestionBanner({ slippage, buyingFiatAmount, tradeUrlParams }: TwapSuggestionBannerProps) {
   const shouldSuggestTwap =
     +slippage.toFixed(2) > TWAP_SUGGESTION_SLIPPAGE_LIMIT &&
     +(buyingFiatAmount?.toExact() || 0) > TWAP_SUGGESTION_AMOUNT_LIMIT
 
   if (!shouldSuggestTwap) return null
 
+  const routePath = parameterizeTradeRoute(tradeUrlParams, Routes.ADVANCED_ORDERS)
+
   return (
     <InlineBanner type="alert">
-      Your slippage is {+slippage.toFixed(2)}%. Consider breaking up your order using TWAP orders
+      <p>
+        Your slippage is {+slippage.toFixed(2)}%. Consider breaking up your order using{' '}
+        <StyledNavLink to={routePath}>TWAP orders</StyledNavLink>
+      </p>
     </InlineBanner>
   )
 }

--- a/src/modules/swap/pure/banners/TwapSuggestionBanner.tsx
+++ b/src/modules/swap/pure/banners/TwapSuggestionBanner.tsx
@@ -1,0 +1,25 @@
+import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
+
+import { InlineBanner } from 'common/pure/InlineBanner'
+
+export interface TwapSuggestionBannerProps {
+  slippage: Percent
+  buyingFiatAmount: CurrencyAmount<Currency> | null
+}
+
+const TWAP_SUGGESTION_SLIPPAGE_LIMIT = 1 // 1%
+const TWAP_SUGGESTION_AMOUNT_LIMIT = 50_000 // $50,000
+
+export function TwapSuggestionBanner({ slippage, buyingFiatAmount }: TwapSuggestionBannerProps) {
+  const shouldSuggestTwap =
+    +slippage.toFixed(2) > TWAP_SUGGESTION_SLIPPAGE_LIMIT &&
+    +(buyingFiatAmount?.toExact() || 0) > TWAP_SUGGESTION_AMOUNT_LIMIT
+
+  if (!shouldSuggestTwap) return null
+
+  return (
+    <InlineBanner type="alert">
+      Your slippage is {+slippage.toFixed(2)}%. Consider breaking up your order using TWAP orders
+    </InlineBanner>
+  )
+}

--- a/src/modules/swap/pure/banners/TwapSuggestionBanner.tsx
+++ b/src/modules/swap/pure/banners/TwapSuggestionBanner.tsx
@@ -21,6 +21,7 @@ const StyledNavLink = styled(NavLink)`
 `
 
 export interface TwapSuggestionBannerProps {
+  chainId: SupportedChainId
   priceImpact: Percent | undefined
   buyingFiatAmount: CurrencyAmount<Currency> | null
   tradeUrlParams: TradeUrlParams
@@ -33,11 +34,16 @@ const AMOUNT_LIMIT: Record<SupportedChainId, number> = {
   [SupportedChainId.GOERLI]: 100, // $100
 }
 
-export function TwapSuggestionBanner({ priceImpact, buyingFiatAmount, tradeUrlParams }: TwapSuggestionBannerProps) {
+export function TwapSuggestionBanner({
+  priceImpact,
+  buyingFiatAmount,
+  tradeUrlParams,
+  chainId,
+}: TwapSuggestionBannerProps) {
   if (!priceImpact || priceImpact.lessThan(0)) return null
 
   const shouldSuggestTwap =
-    +priceImpact.toFixed(2) > PRICE_IMPACT_LIMIT && +(buyingFiatAmount?.toExact() || 0) > AMOUNT_LIMIT
+    +priceImpact.toFixed(2) > PRICE_IMPACT_LIMIT && +(buyingFiatAmount?.toExact() || 0) > AMOUNT_LIMIT[chainId]
 
   if (!shouldSuggestTwap) return null
 

--- a/src/modules/swap/pure/banners/TwapSuggestionBanner.tsx
+++ b/src/modules/swap/pure/banners/TwapSuggestionBanner.tsx
@@ -20,18 +20,19 @@ const StyledNavLink = styled(NavLink)`
 `
 
 export interface TwapSuggestionBannerProps {
-  slippage: Percent
+  priceImpact: Percent | undefined
   buyingFiatAmount: CurrencyAmount<Currency> | null
   tradeUrlParams: TradeUrlParams
 }
 
-const TWAP_SUGGESTION_SLIPPAGE_LIMIT = 1 // 1%
-const TWAP_SUGGESTION_AMOUNT_LIMIT = 50_000 // $50,000
+const PRICE_IMPACT_LIMIT = 1 // 1%
+const AMOUNT_LIMIT = 50_000 // $50,000
 
-export function TwapSuggestionBanner({ slippage, buyingFiatAmount, tradeUrlParams }: TwapSuggestionBannerProps) {
+export function TwapSuggestionBanner({ priceImpact, buyingFiatAmount, tradeUrlParams }: TwapSuggestionBannerProps) {
+  if (!priceImpact || priceImpact.lessThan(0)) return null
+
   const shouldSuggestTwap =
-    +slippage.toFixed(2) > TWAP_SUGGESTION_SLIPPAGE_LIMIT &&
-    +(buyingFiatAmount?.toExact() || 0) > TWAP_SUGGESTION_AMOUNT_LIMIT
+    +priceImpact.toFixed(2) > PRICE_IMPACT_LIMIT && +(buyingFiatAmount?.toExact() || 0) > AMOUNT_LIMIT
 
   if (!shouldSuggestTwap) return null
 
@@ -40,7 +41,7 @@ export function TwapSuggestionBanner({ slippage, buyingFiatAmount, tradeUrlParam
   return (
     <InlineBanner type="alert">
       <p>
-        Your slippage is {+slippage.toFixed(2)}%. Consider breaking up your order using{' '}
+        The price impact is {+priceImpact.toFixed(2)}%. Consider breaking up your order using{' '}
         <StyledNavLink to={routePath}>TWAP orders</StyledNavLink>
       </p>
     </InlineBanner>

--- a/src/modules/swap/pure/warnings.tsx
+++ b/src/modules/swap/pure/warnings.tsx
@@ -9,6 +9,7 @@ import TradeGp from 'legacy/state/swap/TradeGp'
 
 import { CompatibilityIssuesWarning } from 'modules/trade/pure/CompatibilityIssuesWarning'
 import { NoImpactWarning } from 'modules/trade/pure/NoImpactWarning'
+import { TradeUrlParams } from 'modules/trade/types/TradeRawState'
 
 import { BundleTxApprovalBanner, BundleTxSafeWcBanner, BundleTxWrapBanner } from 'common/pure/InlineBanner/banners'
 import { ZeroApprovalWarning } from 'common/pure/ZeroApprovalWarning'
@@ -31,6 +32,7 @@ export interface SwapWarningsTopProps {
   wrappedCurrencySymbol: string
   buyingFiatAmount: CurrencyAmount<Currency> | null
   allowedSlippage: Percent
+  tradeUrlParams: TradeUrlParams
   setFeeWarningAccepted(cb: (state: boolean) => boolean): void
   setImpactWarningAccepted(cb: (state: boolean) => boolean): void
 }
@@ -64,6 +66,7 @@ export const SwapWarningsTop = React.memo(function (props: SwapWarningsTopProps)
     shouldZeroApprove,
     buyingFiatAmount,
     allowedSlippage,
+    tradeUrlParams,
   } = props
 
   console.debug('SWAP WARNING RENDER TOP: ', props)
@@ -90,7 +93,11 @@ export const SwapWarningsTop = React.memo(function (props: SwapWarningsTopProps)
         <BundleTxSafeWcBanner nativeCurrencySymbol={nativeCurrencySymbol} supportsWrapping />
       )}
 
-      <TwapSuggestionBanner slippage={allowedSlippage} buyingFiatAmount={buyingFiatAmount} />
+      <TwapSuggestionBanner
+        slippage={allowedSlippage}
+        buyingFiatAmount={buyingFiatAmount}
+        tradeUrlParams={tradeUrlParams}
+      />
     </>
   )
 }, genericPropsChecker)

--- a/src/modules/swap/pure/warnings.tsx
+++ b/src/modules/swap/pure/warnings.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
 
 import styled from 'styled-components/macro'
@@ -18,6 +19,7 @@ import { genericPropsChecker } from 'utils/genericPropsChecker'
 import { TwapSuggestionBanner } from './banners/TwapSuggestionBanner'
 
 export interface SwapWarningsTopProps {
+  chainId: SupportedChainId
   trade: TradeGp | undefined
   account: string | undefined
   feeWarningAccepted: boolean
@@ -50,6 +52,7 @@ const StyledNoImpactWarning = styled(NoImpactWarning)`
 
 export const SwapWarningsTop = React.memo(function (props: SwapWarningsTopProps) {
   const {
+    chainId,
     trade,
     account,
     feeWarningAccepted,
@@ -94,6 +97,7 @@ export const SwapWarningsTop = React.memo(function (props: SwapWarningsTopProps)
       )}
 
       <TwapSuggestionBanner
+        chainId={chainId}
         priceImpact={priceImpact}
         buyingFiatAmount={buyingFiatAmount}
         tradeUrlParams={tradeUrlParams}

--- a/src/modules/swap/pure/warnings.tsx
+++ b/src/modules/swap/pure/warnings.tsx
@@ -31,7 +31,7 @@ export interface SwapWarningsTopProps {
   nativeCurrencySymbol: string
   wrappedCurrencySymbol: string
   buyingFiatAmount: CurrencyAmount<Currency> | null
-  allowedSlippage: Percent
+  priceImpact: Percent | undefined
   tradeUrlParams: TradeUrlParams
   setFeeWarningAccepted(cb: (state: boolean) => boolean): void
   setImpactWarningAccepted(cb: (state: boolean) => boolean): void
@@ -65,7 +65,7 @@ export const SwapWarningsTop = React.memo(function (props: SwapWarningsTopProps)
     setImpactWarningAccepted,
     shouldZeroApprove,
     buyingFiatAmount,
-    allowedSlippage,
+    priceImpact,
     tradeUrlParams,
   } = props
 
@@ -94,7 +94,7 @@ export const SwapWarningsTop = React.memo(function (props: SwapWarningsTopProps)
       )}
 
       <TwapSuggestionBanner
-        slippage={allowedSlippage}
+        priceImpact={priceImpact}
         buyingFiatAmount={buyingFiatAmount}
         tradeUrlParams={tradeUrlParams}
       />

--- a/src/modules/swap/pure/warnings.tsx
+++ b/src/modules/swap/pure/warnings.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Currency } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
 
 import styled from 'styled-components/macro'
 
@@ -13,6 +13,8 @@ import { NoImpactWarning } from 'modules/trade/pure/NoImpactWarning'
 import { BundleTxApprovalBanner, BundleTxSafeWcBanner, BundleTxWrapBanner } from 'common/pure/InlineBanner/banners'
 import { ZeroApprovalWarning } from 'common/pure/ZeroApprovalWarning'
 import { genericPropsChecker } from 'utils/genericPropsChecker'
+
+import { TwapSuggestionBanner } from './banners/TwapSuggestionBanner'
 
 export interface SwapWarningsTopProps {
   trade: TradeGp | undefined
@@ -27,6 +29,8 @@ export interface SwapWarningsTopProps {
   showSafeWcBundlingBanner: boolean
   nativeCurrencySymbol: string
   wrappedCurrencySymbol: string
+  buyingFiatAmount: CurrencyAmount<Currency> | null
+  allowedSlippage: Percent
   setFeeWarningAccepted(cb: (state: boolean) => boolean): void
   setImpactWarningAccepted(cb: (state: boolean) => boolean): void
 }
@@ -58,6 +62,8 @@ export const SwapWarningsTop = React.memo(function (props: SwapWarningsTopProps)
     setFeeWarningAccepted,
     setImpactWarningAccepted,
     shouldZeroApprove,
+    buyingFiatAmount,
+    allowedSlippage,
   } = props
 
   console.debug('SWAP WARNING RENDER TOP: ', props)
@@ -83,6 +89,8 @@ export const SwapWarningsTop = React.memo(function (props: SwapWarningsTopProps)
       {showSafeWcBundlingBanner && (
         <BundleTxSafeWcBanner nativeCurrencySymbol={nativeCurrencySymbol} supportsWrapping />
       )}
+
+      <TwapSuggestionBanner slippage={allowedSlippage} buyingFiatAmount={buyingFiatAmount} />
     </>
   )
 }, genericPropsChecker)


### PR DESCRIPTION
# Summary

Spec: https://docs.google.com/presentation/d/1ujFpnYbZ2eeaPA3v8DXRctWnDHrdlkx-63qScYrwlVk/edit#slide=id.g25b719a5370_0_55

The banner is displayed when:
1. Slippage is above 1%
2. AND the buy amount is greater than $50000

<img width="400" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/996106c7-0ef4-4d2b-a951-0097a4534e06">

@fairlighteth I need your help with designing the banner 🙏 

