### PR TITLE
refactor(twap): cache fallback handler verification result

### DIFF
--- a/src/modules/limitOrders/state/limitRateAtom.ts
+++ b/src/modules/limitOrders/state/limitRateAtom.ts
@@ -2,6 +2,8 @@ import { atom } from 'jotai'
 
 import { Currency, CurrencyAmount, Fraction } from '@uniswap/sdk-core'
 
+import { atomWithPartialUpdate } from 'utils/jotai/atomWithPartialUpdate'
+
 export interface LimitRateState {
   readonly isLoading: boolean
   readonly isLoadingMarketRate: boolean
@@ -29,12 +31,6 @@ export const initLimitRateState = () => ({
   typedValue: null,
 })
 
-export const limitRateAtom = atom<LimitRateState>(initLimitRateState())
-
-export const updateLimitRateAtom = atom(null, (get, set, nextState: Partial<LimitRateState>) => {
-  set(limitRateAtom, () => {
-    const prevState = get(limitRateAtom)
-
-    return { ...prevState, ...nextState }
-  })
-})
+export const { atom: limitRateAtom, updateAtom: updateLimitRateAtom } = atomWithPartialUpdate(
+  atom<LimitRateState>(initLimitRateState())
+)

--- a/src/modules/twap/hooks/useFallbackHandlerVerification.ts
+++ b/src/modules/twap/hooks/useFallbackHandlerVerification.ts
@@ -1,10 +1,15 @@
 import { useAtomValue } from 'jotai'
 
+import { useWalletInfo } from 'modules/wallet'
+
 import { ExtensibleFallbackVerification } from '../services/verifyExtensibleFallback'
 import { fallbackHandlerVerificationAtom } from '../state/fallbackHandlerVerificationAtom'
 
-export function useFallbackHandlerVerification() {
-  return useAtomValue(fallbackHandlerVerificationAtom)
+export function useFallbackHandlerVerification(): ExtensibleFallbackVerification | null {
+  const { account } = useWalletInfo()
+  const state = useAtomValue(fallbackHandlerVerificationAtom)
+
+  return account ? state[account] || null : null
 }
 
 export function useIsFallbackHandlerRequired(): boolean {

--- a/src/modules/twap/services/verifyExtensibleFallback.ts
+++ b/src/modules/twap/services/verifyExtensibleFallback.ts
@@ -5,9 +5,9 @@ import { getSignatureVerifierContract } from './getSignatureVerifierContract'
 import { ExtensibleFallbackContext } from '../hooks/useExtensibleFallbackContext'
 
 export enum ExtensibleFallbackVerification {
-  HAS_EXTENSIBLE_FALLBACK,
-  HAS_DOMAIN_VERIFIER,
-  HAS_NOTHING,
+  HAS_EXTENSIBLE_FALLBACK = 'HAS_EXTENSIBLE_FALLBACK',
+  HAS_DOMAIN_VERIFIER = 'HAS_DOMAIN_VERIFIER',
+  HAS_NOTHING = 'HAS_NOTHING',
 }
 
 /**

--- a/src/modules/twap/state/fallbackHandlerVerificationAtom.ts
+++ b/src/modules/twap/state/fallbackHandlerVerificationAtom.ts
@@ -1,5 +1,12 @@
-import { atom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
+
+import { atomWithPartialUpdate } from 'utils/jotai/atomWithPartialUpdate'
 
 import { ExtensibleFallbackVerification } from '../services/verifyExtensibleFallback'
 
-export const fallbackHandlerVerificationAtom = atom<ExtensibleFallbackVerification | null>(null)
+type FallbackVerificationsState = {
+  [walletAddress: string]: ExtensibleFallbackVerification
+}
+
+export const { atom: fallbackHandlerVerificationAtom, updateAtom: updateFallbackHandlerVerificationAtom } =
+  atomWithPartialUpdate(atomWithStorage<FallbackVerificationsState>('fallbackHandlerVerification:v1', {}))

--- a/src/modules/twap/updaters/FallbackHandlerVerificationUpdater.tsx
+++ b/src/modules/twap/updaters/FallbackHandlerVerificationUpdater.tsx
@@ -3,23 +3,33 @@ import { useEffect } from 'react'
 
 import { useAsyncMemo } from 'use-async-memo'
 
+import { useWalletInfo } from 'modules/wallet'
+
 import { useExtensibleFallbackContext } from '../hooks/useExtensibleFallbackContext'
+import { useFallbackHandlerVerification } from '../hooks/useFallbackHandlerVerification'
 import { verifyExtensibleFallback } from '../services/verifyExtensibleFallback'
-import { fallbackHandlerVerificationAtom } from '../state/fallbackHandlerVerificationAtom'
+import { updateFallbackHandlerVerificationAtom } from '../state/fallbackHandlerVerificationAtom'
 
 export function FallbackHandlerVerificationUpdater() {
-  const update = useSetAtom(fallbackHandlerVerificationAtom)
+  const { account } = useWalletInfo()
+  const update = useSetAtom(updateFallbackHandlerVerificationAtom)
+  const currentWalletVerification = useFallbackHandlerVerification()
 
   const extensibleFallbackContext = useExtensibleFallbackContext()
   const fallbackHandlerVerification = useAsyncMemo(
-    () => (extensibleFallbackContext ? verifyExtensibleFallback(extensibleFallbackContext) : null),
-    [extensibleFallbackContext],
+    () =>
+      extensibleFallbackContext && !currentWalletVerification
+        ? verifyExtensibleFallback(extensibleFallbackContext)
+        : null,
+    [currentWalletVerification, extensibleFallbackContext],
     null
   )
 
   useEffect(() => {
-    update(fallbackHandlerVerification)
-  }, [fallbackHandlerVerification, update])
+    if (!account || fallbackHandlerVerification === null) return
+
+    update({ [account]: fallbackHandlerVerification })
+  }, [fallbackHandlerVerification, update, account])
 
   return null
 }

--- a/src/modules/twap/updaters/FallbackHandlerVerificationUpdater.tsx
+++ b/src/modules/twap/updaters/FallbackHandlerVerificationUpdater.tsx
@@ -7,21 +7,22 @@ import { useWalletInfo } from 'modules/wallet'
 
 import { useExtensibleFallbackContext } from '../hooks/useExtensibleFallbackContext'
 import { useFallbackHandlerVerification } from '../hooks/useFallbackHandlerVerification'
-import { verifyExtensibleFallback } from '../services/verifyExtensibleFallback'
+import { ExtensibleFallbackVerification, verifyExtensibleFallback } from '../services/verifyExtensibleFallback'
 import { updateFallbackHandlerVerificationAtom } from '../state/fallbackHandlerVerificationAtom'
 
 export function FallbackHandlerVerificationUpdater() {
   const { account } = useWalletInfo()
   const update = useSetAtom(updateFallbackHandlerVerificationAtom)
-  const currentWalletVerification = useFallbackHandlerVerification()
+  const verification = useFallbackHandlerVerification()
+  const isFallbackHandlerRequired = verification !== ExtensibleFallbackVerification.HAS_DOMAIN_VERIFIER
 
   const extensibleFallbackContext = useExtensibleFallbackContext()
   const fallbackHandlerVerification = useAsyncMemo(
     () =>
-      extensibleFallbackContext && !currentWalletVerification
+      extensibleFallbackContext && isFallbackHandlerRequired
         ? verifyExtensibleFallback(extensibleFallbackContext)
         : null,
-    [currentWalletVerification, extensibleFallbackContext],
+    [isFallbackHandlerRequired, extensibleFallbackContext],
     null
   )
 

--- a/src/utils/jotai/atomWithPartialUpdate.ts
+++ b/src/utils/jotai/atomWithPartialUpdate.ts
@@ -1,0 +1,20 @@
+import { PrimitiveAtom, WritableAtom } from 'jotai'
+import { atom } from 'jotai/index'
+
+export function atomWithPartialUpdate<T>(anyAtom: PrimitiveAtom<T>): {
+  atom: typeof anyAtom
+  updateAtom: WritableAtom<null, [nextState: Partial<T>], void>
+} {
+  const updateAtom = atom(null, (get, set, nextState: Partial<T>) => {
+    set(anyAtom, () => {
+      const prevState = get(anyAtom)
+
+      return { ...prevState, ...nextState }
+    })
+  })
+
+  return {
+    atom: anyAtom,
+    updateAtom,
+  }
+}


### PR DESCRIPTION
# Summary

Fixes #2899

In `FallbackHandlerVerificationUpdater` once we detected, that fallback is set, we should:
 - cache the result in `localStorage`
 - don't execute `FallbackHandlerVerificationUpdater` logic again and use the cached value

I also added `atomWithPartialUpdate` helper to reduce boilerplate code

  # To Test

1. Set fallback handler in TWAP
