### PR TITLE
feat(twap): display order group in history tab

### DIFF
--- a/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
+++ b/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
@@ -214,7 +214,7 @@ export function OrderRow({
   return (
     <TableRow
       data-id={order.id}
-      isChildOrder={isOpenOrdersTab && isChild}
+      isChildOrder={isChild}
       isOpenOrdersTab={isOpenOrdersTab}
       isRowSelectable={isRowSelectable}
     >

--- a/src/modules/ordersTable/utils/groupOrdersTable.ts
+++ b/src/modules/ordersTable/utils/groupOrdersTable.ts
@@ -1,4 +1,4 @@
-import { Order, PENDING_STATES } from 'legacy/state/orders/actions'
+import { Order } from 'legacy/state/orders/actions'
 
 import { ParsedOrder, parseOrder } from 'utils/orderUtils/parseOrder'
 
@@ -20,7 +20,6 @@ export function groupOrdersTable(allOrders: Order[]): OrderTableItem[] {
     const parsedOrder = parseOrder(order)
     const composableOrderId = order.composableCowInfo?.id
     const parentOrderId = order.composableCowInfo?.parentId
-    const isPending = PENDING_STATES.includes(order.status)
 
     // Parent
     if (composableOrderId) {
@@ -32,7 +31,7 @@ export function groupOrdersTable(allOrders: Order[]): OrderTableItem[] {
         group.parent = parsedOrder
       }
       // Child
-    } else if (parentOrderId && isPending) {
+    } else if (parentOrderId) {
       if (!groupsMap.has(parentOrderId)) {
         groupsMap.set(parentOrderId, { parent: null, children: [] })
       }

--- a/src/modules/twap/state/emulatedPartOrdersAtom.ts
+++ b/src/modules/twap/state/emulatedPartOrdersAtom.ts
@@ -1,6 +1,6 @@
 import { atom } from 'jotai'
 
-import { CONFIRMED_STATES, Order } from 'legacy/state/orders/actions'
+import { Order } from 'legacy/state/orders/actions'
 
 import { tokensByAddressAtom } from 'modules/tokensList/state/tokensListAtom'
 
@@ -26,9 +26,7 @@ export const emulatedPartOrdersAtom = atom<Order[]>((get) => {
     const enrichedOrder = emulatePartAsOrder(item, parent)
     const order = mapPartOrderToStoreOrder(item, enrichedOrder, isVirtualPart, parent, tokensByAddress)
 
-    if (!CONFIRMED_STATES.includes(order.status)) {
-      acc.push(order)
-    }
+    acc.push(order)
 
     return acc
   }, [])

--- a/src/modules/twap/state/emulatedTwapOrdersAtom.ts
+++ b/src/modules/twap/state/emulatedTwapOrdersAtom.ts
@@ -5,19 +5,19 @@ import { Order } from 'legacy/state/orders/actions'
 import { tokensByAddressAtom } from 'modules/tokensList/state/tokensListAtom'
 import { walletInfoAtom } from 'modules/wallet/api/state'
 
-import { openTwapOrdersAtom } from './twapOrdersListAtom'
+import { twapOrdersListAtom } from './twapOrdersListAtom'
 
 import { mapTwapOrderToStoreOrder } from '../utils/mapTwapOrderToStoreOrder'
 
 export const emulatedTwapOrdersAtom = atom<Order[]>((get) => {
   const { account, chainId } = get(walletInfoAtom)
-  const openOrders = get(openTwapOrdersAtom)
+  const allTwapOrders = get(twapOrdersListAtom)
   const tokensByAddress = get(tokensByAddressAtom)
   const accountLowerCase = account?.toLowerCase()
 
   if (!accountLowerCase) return []
 
-  return openOrders
+  return allTwapOrders
     .filter((order) => order.chainId === chainId && order.safeAddress.toLowerCase() === accountLowerCase)
     .map((order) => {
       return mapTwapOrderToStoreOrder(order, tokensByAddress)

--- a/src/modules/twap/state/twapOrdersListAtom.ts
+++ b/src/modules/twap/state/twapOrdersListAtom.ts
@@ -8,7 +8,7 @@ import { walletInfoAtom } from 'modules/wallet/api/state'
 
 import { deepEqual } from 'utils/deepEqual'
 
-import { TWAP_FINAL_STATUSES, TWAP_PENDING_STATUSES } from '../const'
+import { TWAP_FINAL_STATUSES } from '../const'
 import { TwapOrderItem, TwapOrderStatus } from '../types'
 import { updateTwapOrdersList } from '../utils/updateTwapOrdersList'
 
@@ -32,12 +32,6 @@ export const twapOrdersListAtom = atom<TwapOrderItem[]>((get) => {
   return orders
     .flat()
     .filter((order) => order.safeAddress.toLowerCase() === accountLowerCase && order.chainId === chainId)
-})
-
-export const openTwapOrdersAtom = atom<TwapOrderItem[]>((get) => {
-  const allTwapOrders = get(twapOrdersListAtom)
-
-  return allTwapOrders.filter((item) => TWAP_PENDING_STATUSES.includes(item.status))
 })
 
 export const updateTwapOrdersListAtom = atom(null, (get, set, nextState: TwapOrdersList) => {


### PR DESCRIPTION
# Summary

Fixes #2941

Now twap order always displays as a group with all parts inside.
Only when all parts are completed (canceled/expired/filled) then the whole twap order moves to the history.

<img width="1055" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/e5515419-dea5-4dba-9eee-c7d34d1954a8">

