### PR TITLE
fix(swap): use symbol instead of address for native tokens

### DIFF
--- a/src/legacy/state/price/updater.ts
+++ b/src/legacy/state/price/updater.ts
@@ -20,7 +20,6 @@ import { useWalletInfo } from 'modules/wallet'
 
 import { LegacyFeeQuoteParams as LegacyFeeQuoteParamsFull } from 'api/gnosisProtocol/legacy/types'
 import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
-import { getAddress } from 'utils/getAddress'
 
 import { useAllQuotes, useIsBestQuoteLoading, useSetQuoteError } from './hooks'
 import { QuoteInformationObject } from './reducer'
@@ -123,10 +122,8 @@ export default function FeesUpdater(): null {
   const { independentField, typedValue: rawTypedValue, recipient } = useSwapState()
   const {
     currencies: { INPUT: sellCurrency, OUTPUT: buyCurrency },
+    currenciesIds: { INPUT: sellCurrencyId, OUTPUT: buyCurrencyId },
   } = useDerivedSwapInfo()
-
-  const sellCurrencyId = getAddress(sellCurrency)?.toLowerCase()
-  const buyCurrencyId = getAddress(buyCurrency)?.toLowerCase()
 
   const { address: ensRecipientAddress } = useENSAddress(recipient)
   const receiver = ensRecipientAddress || recipient

--- a/src/legacy/state/swap/hooks.tsx
+++ b/src/legacy/state/swap/hooks.tsx
@@ -283,6 +283,7 @@ export function useDerivedSwapInfo(): DerivedSwapInfo {
     [inputCurrency, outputCurrency]
   )
 
+  // TODO: be careful! For native tokens we use symbol instead of address
   const currenciesIds: { [field in Field]?: string | null } = useMemo(
     () => ({
       [Field.INPUT]: currencies.INPUT?.isNative ? currencies.INPUT.symbol : currencies.INPUT?.address?.toLowerCase(),


### PR DESCRIPTION
# Summary

Fixes #2960

The bug was introduced since the recent refactoring: https://github.com/cowprotocol/cowswap/pull/2927
There is a nuance for native tokens `useDerivedSwapInfo`. Added TODO for it