### PR TITLE
feat: pass sellAmount to TwapSuggestionBanner on TWAP page link

### DIFF
--- a/src/modules/swap/pure/banners/TwapSuggestionBanner.tsx
+++ b/src/modules/swap/pure/banners/TwapSuggestionBanner.tsx
@@ -25,6 +25,7 @@ export interface TwapSuggestionBannerProps {
   priceImpact: Percent | undefined
   buyingFiatAmount: CurrencyAmount<Currency> | null
   tradeUrlParams: TradeUrlParams
+  sellAmount: string | undefined
 }
 
 const PRICE_IMPACT_LIMIT = 1 // 1%
@@ -39,6 +40,7 @@ export function TwapSuggestionBanner({
   buyingFiatAmount,
   tradeUrlParams,
   chainId,
+  sellAmount,
 }: TwapSuggestionBannerProps) {
   if (!priceImpact || priceImpact.lessThan(0)) return null
 
@@ -47,7 +49,7 @@ export function TwapSuggestionBanner({
 
   if (!shouldSuggestTwap) return null
 
-  const routePath = parameterizeTradeRoute(tradeUrlParams, Routes.ADVANCED_ORDERS)
+  const routePath = parameterizeTradeRoute(tradeUrlParams, Routes.ADVANCED_ORDERS) + `?sellAmount=${sellAmount}`
 
   return (
     <InlineBanner type="alert">

--- a/src/modules/swap/pure/banners/TwapSuggestionBanner.tsx
+++ b/src/modules/swap/pure/banners/TwapSuggestionBanner.tsx
@@ -4,6 +4,7 @@ import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
 import { NavLink } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
+import { TRADE_URL_SELL_AMOUNT_KEY } from 'modules/trade/const/tradeUrl'
 import { TradeUrlParams } from 'modules/trade/types/TradeRawState'
 import { parameterizeTradeRoute } from 'modules/trade/utils/parameterizeTradeRoute'
 
@@ -49,7 +50,8 @@ export function TwapSuggestionBanner({
 
   if (!shouldSuggestTwap) return null
 
-  const routePath = parameterizeTradeRoute(tradeUrlParams, Routes.ADVANCED_ORDERS) + `?sellAmount=${sellAmount}`
+  const routePath =
+    parameterizeTradeRoute(tradeUrlParams, Routes.ADVANCED_ORDERS) + `?${TRADE_URL_SELL_AMOUNT_KEY}=${sellAmount}`
 
   return (
     <InlineBanner type="alert">

--- a/src/modules/swap/pure/warnings.tsx
+++ b/src/modules/swap/pure/warnings.tsx
@@ -99,12 +99,12 @@ export const SwapWarningsTop = React.memo(function (props: SwapWarningsTopProps)
 
       <FeatureGuard featureFlag="advancedOrdersEnabled">
         <TwapSuggestionBanner
-          chainId={chainId}
-          priceImpact={priceImpact}
-          buyingFiatAmount={buyingFiatAmount}
-          tradeUrlParams={tradeUrlParams}
-        />
-      </FeatureGuard>
+        chainId={chainId}
+        priceImpact={priceImpact}
+        buyingFiatAmount={buyingFiatAmount}
+        tradeUrlParams={tradeUrlParams}
+        sellAmount={trade?.inputAmount.toFixed(trade?.inputAmount?.currency?.decimals || 18)}
+      /></FeatureGuard>
     </>
   )
 }, genericPropsChecker)

--- a/src/modules/swap/pure/warnings.tsx
+++ b/src/modules/swap/pure/warnings.tsx
@@ -99,12 +99,13 @@ export const SwapWarningsTop = React.memo(function (props: SwapWarningsTopProps)
 
       <FeatureGuard featureFlag="advancedOrdersEnabled">
         <TwapSuggestionBanner
-        chainId={chainId}
-        priceImpact={priceImpact}
-        buyingFiatAmount={buyingFiatAmount}
-        tradeUrlParams={tradeUrlParams}
-        sellAmount={trade?.inputAmount.toFixed(trade?.inputAmount?.currency?.decimals || 18)}
-      /></FeatureGuard>
+          chainId={chainId}
+          priceImpact={priceImpact}
+          buyingFiatAmount={buyingFiatAmount}
+          tradeUrlParams={tradeUrlParams}
+          sellAmount={trade?.inputAmount.toFixed(trade?.inputAmount?.currency?.decimals || 18)}
+        />
+      </FeatureGuard>
     </>
   )
 }, genericPropsChecker)

--- a/src/modules/trade/updaters/RecipientAddressUpdater.tsx
+++ b/src/modules/trade/updaters/RecipientAddressUpdater.tsx
@@ -9,7 +9,9 @@ export function RecipientAddressUpdater() {
   const { address: recipientAddress } = useENSAddress(state?.recipient)
 
   useEffect(() => {
-    if (state?.recipientAddress !== recipientAddress) updateState?.({ recipientAddress })
+    if (state?.recipientAddress !== recipientAddress) {
+      updateState?.({ recipientAddress })
+    }
   }, [recipientAddress, state?.recipientAddress, updateState])
 
   return null


### PR DESCRIPTION
# Summary

Make the TWAP banner suggestion on SWAP orders to include the sell amount in the link

![image](https://github.com/cowprotocol/cowswap/assets/43217/075e1ad6-5a70-4f95-95dd-f12bb478043f)

https://github.com/cowprotocol/cowswap/assets/43217/ad33428b-90c7-440e-a270-46eef2e50799

# To Test

1. On SWAP fill in the sell order with significant slippage as to see the TWAP banner
2. Click on the TWAP link
* The sell amount should be kept when moving to the new tab