### PR TITLE
feat(verify-quote): add feature flag

### DIFF
--- a/src/common/hooks/featureFlags/useVerifiedQuotesEnabled.ts
+++ b/src/common/hooks/featureFlags/useVerifiedQuotesEnabled.ts
@@ -1,0 +1,18 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import { useFeatureFlags } from './useFeatureFlags'
+
+export function useVerifiedQuotesEnabled(chainId: SupportedChainId): boolean {
+  const { verifyQuotesMainnet, verifyQuotesGoerli, verifyQuotesGnosis } = useFeatureFlags()
+
+  switch (chainId) {
+    case SupportedChainId.MAINNET:
+      return !!verifyQuotesMainnet
+    case SupportedChainId.GNOSIS_CHAIN:
+      return !!verifyQuotesGnosis
+    case SupportedChainId.GOERLI:
+      return !!verifyQuotesGoerli
+    default:
+      return false
+  }
+}

--- a/src/legacy/state/price/updater.ts
+++ b/src/legacy/state/price/updater.ts
@@ -21,6 +21,7 @@ import { useWalletInfo } from 'modules/wallet'
 
 import { getPriceQuality } from 'api/gnosisProtocol/api'
 import { LegacyFeeQuoteParams as LegacyFeeQuoteParamsFull } from 'api/gnosisProtocol/legacy/types'
+import { useVerifiedQuotesEnabled } from 'common/hooks/featureFlags/useVerifiedQuotesEnabled'
 import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
 
 import { useAllQuotes, useIsBestQuoteLoading, useSetQuoteError } from './hooks'
@@ -120,6 +121,7 @@ function isRefetchQuoteRequired(
 
 export default function FeesUpdater(): null {
   const { chainId, account } = useWalletInfo()
+  const verifiedQuotesEnabled = useVerifiedQuotesEnabled(chainId)
 
   const { independentField, typedValue: rawTypedValue, recipient } = useSwapState()
   const {
@@ -205,7 +207,7 @@ export default function FeesUpdater(): null {
       userAddress: account,
       validTo,
       isEthFlow,
-      priceQuality: getPriceQuality({ verifyQuote: enoughBalance }),
+      priceQuality: getPriceQuality({ verifyQuote: enoughBalance && verifiedQuotesEnabled }),
     }
 
     // Don't refetch if offline.
@@ -277,6 +279,7 @@ export default function FeesUpdater(): null {
     buyTokenAddressInvalid,
     sellTokenAddressInvalid,
     enoughBalance,
+    verifiedQuotesEnabled,
   ])
 
   return null

--- a/src/modules/tradeQuote/hooks/useQuoteParams.ts
+++ b/src/modules/tradeQuote/hooks/useQuoteParams.ts
@@ -9,10 +9,13 @@ import { useDerivedTradeState } from 'modules/trade/hooks/useDerivedTradeState'
 import { useWalletInfo } from 'modules/wallet'
 
 import { getPriceQuality } from 'api/gnosisProtocol/api'
+import { useVerifiedQuotesEnabled } from 'common/hooks/featureFlags/useVerifiedQuotesEnabled'
 import { getAddress } from 'utils/getAddress'
 
 export function useQuoteParams(amount: string | null) {
   const { chainId, account } = useWalletInfo()
+  const verifiedQuotesEnabled = useVerifiedQuotesEnabled(chainId)
+
   const { state } = useDerivedTradeState()
 
   const { inputCurrency, outputCurrency, orderKind } = state || {}
@@ -40,7 +43,18 @@ export function useQuoteParams(amount: string | null) {
       toDecimals,
       fromDecimals,
       isEthFlow: false,
-      priceQuality: getPriceQuality({ verifyQuote: enoughBalance }),
+      priceQuality: getPriceQuality({ verifyQuote: enoughBalance && verifiedQuotesEnabled }),
     }
-  }, [amount, account, chainId, orderKind, enoughBalance, buyToken, fromDecimals, sellToken, toDecimals])
+  }, [
+    amount,
+    account,
+    chainId,
+    orderKind,
+    enoughBalance,
+    buyToken,
+    fromDecimals,
+    sellToken,
+    toDecimals,
+    verifiedQuotesEnabled,
+  ])
 }


### PR DESCRIPTION
# Summary

Adds 3 new feature flags for enabling the `verified` quotes. Each will control one chain. 

<img width="961" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/eeeccb68-9c05-4c1f-ba8e-3c085a3c0722">

This feature is meant to be killed once all chains have `verified` quotes enabled.

 # To Test
Right now Goerly and Gnosis chain are active, and mainnet is not. 

You can check that when the user has enough balance, and is in a network that has this flag enabled, it will make requests using the verified option (see https://github.com/cowprotocol/cowswap/pull/2945 on how to check if we used the verified option)