### PR TITLE
fix: upload app-data to the right network

### DIFF
--- a/src/modules/appData/services/index.ts
+++ b/src/modules/appData/services/index.ts
@@ -1,9 +1,17 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
 import { orderBookApi } from 'cowSdk'
 
 /**
  * Interface to upload appData document
  */
-export type UploadAppDataDoc = (appDataKeccak256: string, fullAppData: string) => Promise<void>
+export type UploadAppDataDoc = (props: UploadAppDataProps) => Promise<void>
+
+export interface UploadAppDataProps {
+  appDataKeccak256: string
+  fullAppData: string
+  chainId: SupportedChainId
+}
 
 /**
  * Upload appData document to orderbook API
@@ -14,6 +22,10 @@ export type UploadAppDataDoc = (appDataKeccak256: string, fullAppData: string) =
  * @throws Throws in case the fullAppData and the appDataKeccak256 don't match
 
  */
-export const uploadAppDataDocOrderbookApi: UploadAppDataDoc = async (appDataKeccak256, fullAppData) => {
-  orderBookApi.uploadAppData(appDataKeccak256, fullAppData)
+export const uploadAppDataDocOrderbookApi: UploadAppDataDoc = async (props) => {
+  const { appDataKeccak256, fullAppData, chainId } = props
+  orderBookApi.uploadAppData(appDataKeccak256, fullAppData, {
+    chainId,
+    env: 'prod', // Upload the appData to production always, since WatchTower will create the orders there
+  })
 }

--- a/src/modules/appData/updater/UploadToIpfsUpdater.ts
+++ b/src/modules/appData/updater/UploadToIpfsUpdater.ts
@@ -97,7 +97,7 @@ async function _actuallyUploadToIpfs(
   updatePending({ chainId, orderId, uploading: true })
 
   try {
-    await uploadAppDataDocOrderbookApi(appDataKeccak256, fullAppData)
+    await uploadAppDataDocOrderbookApi({ appDataKeccak256, fullAppData, chainId })
     removePending({ chainId, orderId })
   } catch (e: any) {
     console.error(`[UploadToIpfsUpdater] Failed to upload doc, will try again. Reason: ${e.message}`, e, fullAppData)


### PR DESCRIPTION
# Summary
Continuation on https://github.com/cowprotocol/cowswap/pull/2933

Although previous PRs were uploading the app-data for TWAP  orders, the document was uploaded to the wrong network (always mainnet)

This PR makes sure they are in the right network, and uses production API (never barn). The reason is that now we only upload documents for on-chain orders (off-chain orders sends the document already when posting the order to the API).

On-chain orders are indexed by the `WatchTower` who will post to the API.

`WatchTower` posts to production, never to Barn.


# To Test

1. Place a TWAP order
2. Make sure you can see the app-data in the explorer