### PR TITLE
fix(swap): change quote amount for price impact calculation on Gnosis chain

### DIFF
--- a/src/legacy/hooks/useStablecoinPrice/index.ts
+++ b/src/legacy/hooks/useStablecoinPrice/index.ts
@@ -24,7 +24,7 @@ export const getUsdQuoteValidTo = () => Math.ceil(Date.now() / 1000) + 600
 const STABLECOIN_AMOUNT_OUT: { [chain in SupportedChainId]: CurrencyAmount<Token> } = {
   [SupportedChainId.MAINNET]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.MAINNET], 100e6),
   [SupportedChainId.GOERLI]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.GOERLI], 100e6),
-  [SupportedChainId.GNOSIS_CHAIN]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.GNOSIS_CHAIN], 10_000e6),
+  [SupportedChainId.GNOSIS_CHAIN]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.GNOSIS_CHAIN], 100e6),
 }
 
 /**


### PR DESCRIPTION
# Summary

Fixes #2958

The context: https://cowservices.slack.com/archives/C0361CDG8GP/p1690960269960949?thread_ts=1690570839.813469&cid=C0361CDG8GP

Important! The price impact still can be inaccurate but not so invalid as before