### PR TITLE
fix(twap): don't redirect to swap when feature-flag value is not defined

### DIFF
--- a/src/common/hooks/useIsAdvancedOrdersEnabled.ts
+++ b/src/common/hooks/useIsAdvancedOrdersEnabled.ts
@@ -1,6 +1,6 @@
 import { useFeatureFlags } from './featureFlags/useFeatureFlags'
 
-export function useIsAdvancedOrdersEnabled(): boolean {
+export function useIsAdvancedOrdersEnabled(): boolean | undefined {
   const { advancedOrdersEnabled } = useFeatureFlags()
 
   return advancedOrdersEnabled

--- a/src/modules/mainMenu/hooks.ts
+++ b/src/modules/mainMenu/hooks.ts
@@ -6,7 +6,7 @@ import { MenuTreeItem } from './types'
 import { buildMainMenuTreeItems } from './utils'
 
 export function useMenuItems(): MenuTreeItem[] {
-  const isAdvancedOrdersEnabled = useIsAdvancedOrdersEnabled()
+  const isAdvancedOrdersEnabled = !!useIsAdvancedOrdersEnabled()
 
   return useMemo(() => buildMainMenuTreeItems({ isAdvancedOrdersEnabled }), [isAdvancedOrdersEnabled])
 }

--- a/src/pages/AdvancedOrders/index.tsx
+++ b/src/pages/AdvancedOrders/index.tsx
@@ -20,6 +20,10 @@ export default function AdvancedOrdersPage() {
 
   const allEmulatedOrders = useEmulatedOrders()
 
+  if (isAdvancedOrdersEnabled === undefined) {
+    return null
+  }
+
   if (!isAdvancedOrdersEnabled) {
     // To prevent direct access when the flag is off
     return <Navigate to={parameterizeTradeRoute(tradeContext, RoutesEnum.SWAP)} />


### PR DESCRIPTION
# Summary

The `Advanced orders` page redirects to `Swap page` at the first time because we initially don't have a value for a feature-flag and consider it as `false`.

After this fix we will render nothing and don't redirect while loading feature-flags info.