### PR TITLE
fix(swap): display correct value of slippage in min. price tooltip

### DIFF
--- a/src/legacy/utils/tooltips.ts
+++ b/src/legacy/utils/tooltips.ts
@@ -1,16 +1,11 @@
 import { Percent } from '@uniswap/sdk-core'
 
-import { PERCENTAGE_PRECISION } from 'legacy/constants'
-
-import { formatAmountWithPrecision } from 'utils/amountFormat'
+import { formatPercent } from 'utils/amountFormat'
 
 export function getMinimumReceivedTooltip(allowedSlippage: Percent, isExactIn: boolean): string {
-  const slippagePercent = allowedSlippage
-
   return `${
     isExactIn ? "Minimum tokens you'll receive." : "Maximum tokens you'll sell."
-  } This accounts for the current price and your chosen slippage (${formatAmountWithPrecision(
-    slippagePercent,
-    PERCENTAGE_PRECISION
+  } This accounts for the current price and your chosen slippage (${formatPercent(
+    allowedSlippage
   )}%). If the price moves beyond your slippage, you won't trade but also you won't pay any fees or gas.`
 }


### PR DESCRIPTION
# Summary

Fixes #2979

<img width="574" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/e20f8944-3e2a-4c77-b122-597e7f4ab285">

