### PR TITLE
chore: update sdk to last closed version

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@cowprotocol/app-data": "v0.2.7",
     "@cowprotocol/contracts": "^1.3.1",
     "@cowprotocol/cow-runner-game": "^0.2.9",
-    "@cowprotocol/cow-sdk": "^2.3.0-rc.10",
+    "@cowprotocol/cow-sdk": "^2.3.0",
     "@cowprotocol/ethflowcontract": "cowprotocol/ethflowcontract.git#v1.0.0-artifacts",
     "@davatar/react": "1.8.1",
     "@ethersproject/bignumber": "^5.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2302,10 +2302,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/cow-runner-game/-/cow-runner-game-0.2.9.tgz#3f94b3f370bd114f77db8b1d238cba3ef4e9d644"
   integrity sha512-rX7HnoV+HYEEkBaqVUsAkGGo0oBrExi+d6Io+8nQZYwZk+IYLmS9jdcIObsLviM2h4YX8+iin6NuKl35AaiHmg==
 
-"@cowprotocol/cow-sdk@^2.3.0-rc.10":
-  version "2.3.0-rc.10"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-2.3.0-rc.10.tgz#928851bbba1a1dbc9cb2f2c47372617ff9bade9f"
-  integrity sha512-mNPOiNBBQAOXiDaepaH2GBW6yVZWXm24gJglCxg1x7Ts7Tdow5pI3W7Jn63HFuS72qBoJioZWt9BXyisU+OZNw==
+"@cowprotocol/cow-sdk@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-2.3.0.tgz#9e6bd0871364e8d5962e97cf52d067479fd171b1"
+  integrity sha512-wuG8vTbA9eCjLtLFc39O8OT9CpJrD0GJraJknHh5JJgxDnHeYHngb8FjHzZ8QnQkYOCUaBrbhYhOUzOpHlkqVQ==
   dependencies:
     "@cowprotocol/contracts" "^1.4.0"
     "@ethersproject/abstract-signer" "^5.7.0"


### PR DESCRIPTION
# Summary

Update SDK to use the last closed version. Technical has the same code as RC.10, just closing the version after testing it works