### PR TITLE
fix: upload appData to ETH flow

### DIFF
--- a/src/modules/appData/services/index.ts
+++ b/src/modules/appData/services/index.ts
@@ -24,6 +24,6 @@ export interface UploadAppDataProps {
 
  */
 export const uploadAppDataDocOrderbookApi: UploadAppDataDoc = async (props) => {
-  const { appDataKeccak256, fullAppData, chainId } = props
-  orderBookApi.uploadAppData(appDataKeccak256, fullAppData, { chainId })
+  const { appDataKeccak256, fullAppData, chainId, env } = props
+  orderBookApi.uploadAppData(appDataKeccak256, fullAppData, { chainId, env })
 }

--- a/src/modules/appData/services/index.ts
+++ b/src/modules/appData/services/index.ts
@@ -1,4 +1,4 @@
-import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { CowEnv, SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import { orderBookApi } from 'cowSdk'
 
@@ -11,6 +11,7 @@ export interface UploadAppDataProps {
   appDataKeccak256: string
   fullAppData: string
   chainId: SupportedChainId
+  env?: CowEnv
 }
 
 /**
@@ -24,8 +25,5 @@ export interface UploadAppDataProps {
  */
 export const uploadAppDataDocOrderbookApi: UploadAppDataDoc = async (props) => {
   const { appDataKeccak256, fullAppData, chainId } = props
-  orderBookApi.uploadAppData(appDataKeccak256, fullAppData, {
-    chainId,
-    env: 'prod', // Upload the appData to production always, since WatchTower will create the orders there
-  })
+  orderBookApi.uploadAppData(appDataKeccak256, fullAppData, { chainId })
 }

--- a/src/modules/appData/types.tsx
+++ b/src/modules/appData/types.tsx
@@ -1,10 +1,11 @@
 import { LatestAppDataDocVersion, createOrderClassMetadata } from '@cowprotocol/app-data'
-import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { CowEnv, SupportedChainId } from '@cowprotocol/cow-sdk'
 
 export type AppDataInfo = {
   doc: LatestAppDataDocVersion
   fullAppData: string
   appDataKeccak256: string
+  env?: CowEnv
 }
 
 type AppDataUploadStatus = {

--- a/src/modules/appData/updater/UploadToIpfsUpdater.ts
+++ b/src/modules/appData/updater/UploadToIpfsUpdater.ts
@@ -89,7 +89,7 @@ async function _actuallyUploadToIpfs(
   updatePending: (params: UpdateAppDataOnUploadQueueParams) => void,
   removePending: (params: AppDataKeyParams) => void
 ) {
-  const { fullAppData, appDataKeccak256, chainId, orderId, failedAttempts } = appDataRecord
+  const { fullAppData, appDataKeccak256, chainId, orderId, failedAttempts, env } = appDataRecord
 
   if (!fullAppData || !appDataKeccak256) return
 
@@ -97,7 +97,7 @@ async function _actuallyUploadToIpfs(
   updatePending({ chainId, orderId, uploading: true })
 
   try {
-    await uploadAppDataDocOrderbookApi({ appDataKeccak256, fullAppData, chainId })
+    await uploadAppDataDocOrderbookApi({ appDataKeccak256, fullAppData, chainId, env })
     removePending({ chainId, orderId })
   } catch (e: any) {
     console.error(`[UploadToIpfsUpdater] Failed to upload doc, will try again. Reason: ${e.message}`, e, fullAppData)

--- a/src/modules/appData/updater/useAppDataUpdater.ts
+++ b/src/modules/appData/updater/useAppDataUpdater.ts
@@ -1,7 +1,7 @@
 import { useSetAtom } from 'jotai'
 import { useEffect } from 'react'
 
-import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { CowEnv, SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import { UtmParams } from 'modules/utm'
 
@@ -43,7 +43,7 @@ export function useAppDataUpdater({ chainId, slippageBips, orderClass, utm }: Us
         const { doc, fullAppData, appDataKeccak256 } = await buildAppData(params)
         console.debug(`[useAppData] appDataInfo`, fullAppData)
 
-        setAppDataInfo({ doc, fullAppData, appDataKeccak256 })
+        setAppDataInfo({ doc, fullAppData, appDataKeccak256, env: getEnvByClass(orderClass) })
       } catch (e: any) {
         console.error(`[useAppData] failed to build appData, falling back to default`, params, e)
         setAppDataInfo(getAppData())
@@ -52,4 +52,11 @@ export function useAppDataUpdater({ chainId, slippageBips, orderClass, utm }: Us
 
     updateAppData()
   }, [appCode, chainId, setAppDataInfo, slippageBips, orderClass, utm])
+}
+function getEnvByClass(orderClass: string): CowEnv | undefined {
+  if (orderClass === 'twap') {
+    return 'prod' // Upload the appData to production always, since WatchTower will create the orders there
+  }
+
+  return undefined
 }

--- a/src/modules/swap/hooks/useFlowContext.ts
+++ b/src/modules/swap/hooks/useFlowContext.ts
@@ -20,8 +20,8 @@ import { useUserTransactionTTL } from 'legacy/state/user/hooks'
 import { computeSlippageAdjustedAmounts } from 'legacy/utils/prices'
 import { PostOrderParams } from 'legacy/utils/trade'
 
-import { useAppData } from 'modules/appData'
-import type { AppDataInfo } from 'modules/appData'
+import { useAppData, useUploadAppData } from 'modules/appData'
+import type { AppDataInfo, UploadAppDataParams } from 'modules/appData'
 import { useIsSafeApprovalBundle } from 'modules/limitOrders/hooks/useIsSafeApprovalBundle'
 import { useIsEoaEthFlow } from 'modules/swap/hooks/useIsEoaEthFlow'
 import { SwapConfirmManager, useSwapConfirmManager } from 'modules/swap/hooks/useSwapConfirmManager'
@@ -78,6 +78,7 @@ interface BaseFlowContextSetup {
   swapConfirmManager: SwapConfirmManager
   flowType: FlowType
   closeModals: () => void
+  uploadAppData: (update: UploadAppDataParams) => void
   addOrderCallback: AddOrderCallback
   dispatch: AppDispatch
 }
@@ -92,6 +93,7 @@ export function useBaseFlowContextSetup(): BaseFlowContextSetup {
 
   const appData = useAppData()
   const closeModals = useCloseModals()
+  const uploadAppData = useUploadAppData()
   const addOrderCallback = useAddPendingOrder()
   const dispatch = useDispatch<AppDispatch>()
 
@@ -127,6 +129,7 @@ export function useBaseFlowContextSetup(): BaseFlowContextSetup {
     ensRecipientAddress,
     allowsOffchainSigning,
     swapConfirmManager,
+    uploadAppData,
     flowType,
     closeModals,
     addOrderCallback,
@@ -173,6 +176,7 @@ export function getFlowContext({ baseProps, sellToken, kind }: BaseGetFlowContex
     swapConfirmManager,
     closeModals,
     addOrderCallback,
+    uploadAppData,
     dispatch,
     flowType,
   } = baseProps
@@ -252,6 +256,7 @@ export function getFlowContext({ baseProps, sellToken, kind }: BaseGetFlowContex
     callbacks: {
       closeModals,
       addOrderCallback,
+      uploadAppData,
     },
     dispatch,
     swapFlowAnalyticsContext,

--- a/src/modules/swap/services/ethFlow/index.ts
+++ b/src/modules/swap/services/ethFlow/index.ts
@@ -22,6 +22,7 @@ export async function ethFlow(
     swapConfirmManager,
     contract,
     callbacks,
+    appDataInfo,
     dispatch,
     orderParams: orderParamsOriginal,
     checkInFlightOrderIdExists,
@@ -64,6 +65,9 @@ export async function ethFlow(
     )
     // TODO: maybe move this into addPendingOrderStep?
     ethFlowContext.addTransaction({ hash: txReceipt.hash, ethFlow: { orderId: order.id, subType: 'creation' } })
+
+    logTradeFlow('ETH FLOW', 'STEP 6: add app data to upload queue')
+    callbacks.uploadAppData({ chainId: context.chainId, orderId, appData: appDataInfo })
 
     logTradeFlow('ETH FLOW', 'STEP 7: show UI of the successfully sent transaction', orderId)
     swapConfirmManager.transactionSent(orderId)

--- a/src/modules/swap/services/safeBundleFlow/safeBundleEthFlow.ts
+++ b/src/modules/swap/services/safeBundleFlow/safeBundleEthFlow.ts
@@ -34,6 +34,7 @@ export async function safeBundleEthFlow(
     spender,
     context,
     callbacks,
+    appDataInfo,
     swapConfirmManager,
     dispatch,
     orderParams,
@@ -123,10 +124,13 @@ export async function safeBundleEthFlow(
     )
     tradeFlowAnalytics.sign(swapFlowAnalyticsContext)
 
-    logTradeFlow(LOG_PREFIX, 'STEP 8: show UI of the successfully sent transaction')
+    logTradeFlow(LOG_PREFIX, 'STEP 8: add app data to upload queue')
+    callbacks.uploadAppData({ chainId: context.chainId, orderId, appData: appDataInfo })
+
+    logTradeFlow(LOG_PREFIX, 'STEP 9: show UI of the successfully sent transaction')
     swapConfirmManager.transactionSent(orderId)
   } catch (error) {
-    logTradeFlow(LOG_PREFIX, 'STEP 9: error', error)
+    logTradeFlow(LOG_PREFIX, 'STEP 10: error', error)
     const swapErrorMessage = getSwapErrorMessage(error)
 
     tradeFlowAnalytics.error(error, swapErrorMessage, swapFlowAnalyticsContext)

--- a/src/modules/swap/services/types.ts
+++ b/src/modules/swap/services/types.ts
@@ -10,7 +10,7 @@ import { AddOrderCallback } from 'legacy/state/orders/hooks'
 import TradeGp from 'legacy/state/swap/TradeGp'
 import { PostOrderParams } from 'legacy/utils/trade'
 
-import { AppDataInfo } from 'modules/appData'
+import { AppDataInfo, UploadAppDataParams } from 'modules/appData'
 import { SwapConfirmManager } from 'modules/swap/hooks/useSwapConfirmManager'
 import { SwapFlowAnalyticsContext } from 'modules/trade/utils/analytics'
 
@@ -31,6 +31,7 @@ export interface BaseFlowContext {
   callbacks: {
     closeModals: () => void
     addOrderCallback: AddOrderCallback
+    uploadAppData: (params: UploadAppDataParams) => void
   }
   dispatch: AppDispatch
   swapFlowAnalyticsContext: SwapFlowAnalyticsContext

--- a/src/modules/twap/hooks/useCreateTwapOrder.ts
+++ b/src/modules/twap/hooks/useCreateTwapOrder.ts
@@ -127,7 +127,14 @@ export function useCreateTwapOrder() {
         getCowSoundSend().play()
         dispatchPresignedOrderPosted(store, safeTxHash, summary, OrderClass.LIMIT, 'composable-order')
 
-        uploadAppData({ chainId, orderId, appData: appDataInfo })
+        uploadAppData({
+          chainId,
+          orderId,
+          appData: {
+            ...appDataInfo,
+            env: 'prod', // Upload the appData to production always, since WatchTower will create the orders there
+          },
+        })
         updateAdvancedOrdersState({ recipient: null, recipientAddress: null })
         tradeConfirmActions.onSuccess(safeTxHash)
         tradeFlowAnalytics.sign(twapFlowAnalyticsContext)

--- a/src/modules/twap/hooks/useCreateTwapOrder.ts
+++ b/src/modules/twap/hooks/useCreateTwapOrder.ts
@@ -127,14 +127,7 @@ export function useCreateTwapOrder() {
         getCowSoundSend().play()
         dispatchPresignedOrderPosted(store, safeTxHash, summary, OrderClass.LIMIT, 'composable-order')
 
-        uploadAppData({
-          chainId,
-          orderId,
-          appData: {
-            ...appDataInfo,
-            env: 'prod', // Upload the appData to production always, since WatchTower will create the orders there
-          },
-        })
+        uploadAppData({ chainId, orderId, appData: appDataInfo })
         updateAdvancedOrdersState({ recipient: null, recipientAddress: null })
         tradeConfirmActions.onSuccess(safeTxHash)
         tradeFlowAnalytics.sign(twapFlowAnalyticsContext)


### PR DESCRIPTION
# Summary

Fixes https://github.com/cowprotocol/explorer/issues/572

Uploads the appData for ETH Flow orders.


Proof:
<img width="1265" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/72265f89-c9f1-4078-911b-46321cb43903">

https://dev.explorer.cow.fi/goerli/orders/0xe0b07c25e2db3921163f048f0a75f12a2497dfa0088f5afa08473568a2ab69f6d02de8da0b71e1b59489794f423fabba2adc4d93ffffffff?tab=overview


# Where is the doc uploaded
To the API, and depending on the flow (order class) we will need to upload it to a different place. 

- TWAP --> Production, since the orders are created by WatchTower
- ETH FLOW ---> Barn/Production depending on the environment. This is because, there's a separation of the 2 contracts, and this is how we can know where the order was created. The service that creates the order will take this into account, so we need to do the same when we upload its meta-data


# To Test
Place an ETH Flow order and check in Explorer its app-data

Probably good to test TWAP appData uploading is not broken