### PR TITLE
fix: select bg color

### DIFF
--- a/src/common/pure/CurrencyInputPanel/styled.tsx
+++ b/src/common/pure/CurrencyInputPanel/styled.tsx
@@ -79,7 +79,7 @@ export const NumericalInput = styled(Input)<{ $loading: boolean }>`
   }
 
   &[disabled]::selection {
-    background: transparent;
+    // background: transparent;
   }
 
   &::placeholder {


### PR DESCRIPTION
# Summary

Removes the CSS rule that was making it look like we couldn't select text and copy.
<img width="802" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/90be6518-8321-47b0-ac23-a321335d706c">


# To Test
Check in DEV and in this PR.

In this PR you can select the BUY AMOUNT, in DEV not


# Help needed
@fairlighteth do you know why we added that style, is it safe to remove? 

I believe it was introduced in https://github.com/cowprotocol/cowswap/pull/2785

https://github.com/cowprotocol/cowswap/pull/2785/files#diff-d6265dd8435202beadab3f5719c5682e9f891550df3a5f9be5bf467044fefd70R77