### PR TITLE
feat: disabled to readonly

### DIFF
--- a/src/common/pure/CurrencyAmountPreview/index.tsx
+++ b/src/common/pure/CurrencyAmountPreview/index.tsx
@@ -40,8 +40,8 @@ export function CurrencyAmountPreview(props: CurrencyPreviewProps) {
         id={id}
         className={className}
         withReceiveAmountInfo={false}
-        disabled={false}
-        inputDisabled={false}
+        pointerDisabled={false}
+        readOnly={false}
       >
         {topLabel && <styledEl.CurrencyTopLabel>{topLabel}</styledEl.CurrencyTopLabel>}
 

--- a/src/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
+++ b/src/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
@@ -119,7 +119,7 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
     <styledEl.NumericalInput
       className="token-amount-input"
       value={isChainIdUnsupported ? '' : typedValue}
-      disabled={inputDisabled}
+      readOnly={inputDisabled}
       onUserInput={onUserInputDispatch}
       $loading={areCurrenciesLoading}
     />
@@ -131,8 +131,8 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
         id={id}
         className={className}
         withReceiveAmountInfo={!!receiveAmountInfo}
-        disabled={disabled}
-        inputDisabled={inputDisabled}
+        pointerDisabled={disabled}
+        readOnly={inputDisabled}
       >
         {topLabel && <styledEl.CurrencyTopLabel>{topLabel}</styledEl.CurrencyTopLabel>}
 

--- a/src/common/pure/CurrencyInputPanel/styled.tsx
+++ b/src/common/pure/CurrencyInputPanel/styled.tsx
@@ -12,17 +12,17 @@ export const OuterWrapper = styled.div`
   flex-flow: column wrap;
 `
 
-export const Wrapper = styled.div<{ withReceiveAmountInfo: boolean; inputDisabled: boolean; disabled: boolean }>`
+export const Wrapper = styled.div<{ withReceiveAmountInfo: boolean; readOnly: boolean; pointerDisabled: boolean }>`
   display: flex;
   flex-flow: row wrap;
   align-content: space-between;
   gap: 10px;
   padding: 16px;
-  background: ${({ theme, inputDisabled }) => (inputDisabled ? 'transparent' : theme.input.bg1)};
-  border: ${({ theme, inputDisabled }) => (inputDisabled ? `1px solid ${theme.grey1}` : 'none')};
+  background: ${({ theme, readOnly }) => (readOnly ? 'transparent' : theme.input.bg1)};
+  border: ${({ theme, readOnly }) => (readOnly ? `1px solid ${theme.grey1}` : 'none')};
   border-radius: ${({ withReceiveAmountInfo }) => (withReceiveAmountInfo ? '16px 16px 0 0' : '16px')};
   min-height: 106px;
-  pointer-events: ${({ disabled }) => (disabled ? 'none' : '')};
+  pointer-events: ${({ pointerDisabled }) => (pointerDisabled ? 'none' : '')};
   max-width: 100%;
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
@@ -73,14 +73,6 @@ export const NumericalInput = styled(Input)<{ $loading: boolean }>`
   font-size: 28px;
   font-weight: 500;
   color: ${({ theme }) => theme.text1};
-
-  &[disabled] {
-    -webkit-text-fill-color: ${({ theme }) => theme.text1}; // safari fix
-  }
-
-  &[disabled]::selection {
-    background: transparent;
-  }
 
   &::placeholder {
     color: ${({ theme }) => transparentize(0.3, theme.text1)};

--- a/src/legacy/components/NumericalInput/index.tsx
+++ b/src/legacy/components/NumericalInput/index.tsx
@@ -46,6 +46,7 @@ const inputRegex = RegExp(`^\\d*(?:\\\\[.])?\\d*$`) // match escaped "." charact
 
 export const Input = React.memo(function InnerInput({
   value,
+  readOnly,
   onUserInput,
   placeholder,
   prependSymbol,
@@ -54,6 +55,7 @@ export const Input = React.memo(function InnerInput({
   ...rest
 }: {
   value: string | number
+  readOnly?: boolean
   onUserInput: (input: string) => void
   error?: boolean
   fontSize?: string
@@ -70,6 +72,7 @@ export const Input = React.memo(function InnerInput({
     <StyledInput
       {...rest}
       value={prependSymbol && value ? prependSymbol + value : value}
+      readOnly={readOnly}
       onFocus={(event) => {
         autofocus(event)
         onFocus?.(event)


### PR DESCRIPTION
# Summary

- Modifies the inputfield from having `disabled` to use `readonly` to prevent selection issues. Specifically on Safari.
- Needs to be tested on Safari > Update: tested and works.

<img width="569" alt="Screenshot 2023-08-03 at 13 50 29" src="https://github.com/cowprotocol/cowswap/assets/31534717/7ab023bb-297b-43f9-98c2-7a403c276c45">
