### PR TITLE
fix: solve issue in safari being broken

### DIFF
--- a/src/modules/application/containers/App/RoutesApp.tsx
+++ b/src/modules/application/containers/App/RoutesApp.tsx
@@ -16,7 +16,7 @@ import { SwapPage } from 'pages/Swap'
 // Async routes
 const PrivacyPolicy = lazy(() => import(/* webpackChunkName: "privacy_policy" */ 'pages/PrivacyPolicy'))
 const LimitOrders = lazy(() => import(/* webpackChunkName: "limit_orders" */ 'pages/LimitOrders'))
-const AdvancedOrders = lazy(() => import(/* webpackChunkName: "limit_orders" */ 'pages/AdvancedOrders'))
+const AdvancedOrders = lazy(() => import(/* webpackChunkName: "advanced_orders" */ 'pages/AdvancedOrders'))
 const CookiePolicy = lazy(() => import(/* webpackChunkName: "cookie_policy" */ 'pages/CookiePolicy'))
 const TermsAndConditions = lazy(() => import(/* webpackChunkName: "terms" */ 'pages/TermsAndConditions'))
 const About = lazy(() => import(/* webpackChunkName: "about" */ 'pages/About'))

--- a/src/modules/twap/hooks/useCreateTwapOrder.ts
+++ b/src/modules/twap/hooks/useCreateTwapOrder.ts
@@ -33,7 +33,7 @@ import { addTwapOrderToListAtom } from '../state/twapOrdersListAtom'
 import { TwapOrderItem, TwapOrderStatus } from '../types'
 import { buildTwapOrderParamsStruct } from '../utils/buildTwapOrderParamsStruct'
 import { getConditionalOrderId } from '../utils/getConditionalOrderId'
-import { parseTwapErrorMessage } from '../utils/parseTwapError'
+import { getErrorMessage } from '../utils/parseTwapError'
 import { twapOrderToStruct } from '../utils/twapOrderToStruct'
 
 export function useCreateTwapOrder() {
@@ -133,7 +133,8 @@ export function useCreateTwapOrder() {
         tradeFlowAnalytics.sign(twapFlowAnalyticsContext)
         twapConversionAnalytics('signed', fallbackHandlerIsNotSet)
       } catch (error) {
-        const errorMessage = parseTwapErrorMessage(error)
+        console.error('[useCreateTwapOrder] error', error)
+        const errorMessage = getErrorMessage(error)
         tradeConfirmActions.onError(errorMessage)
         tradeFlowAnalytics.error(error, errorMessage, twapFlowAnalyticsContext)
         twapConversionAnalytics('rejected', fallbackHandlerIsNotSet)

--- a/src/modules/twap/utils/parseTwapError.ts
+++ b/src/modules/twap/utils/parseTwapError.ts
@@ -1,26 +1,17 @@
-enum TwapErrorCodes {
-  INVALID_ARGUMENT = 'INVALID_ARGUMENT',
-}
+const DEFAULT_ERROR_MESSAGE = 'Something went wrong creating your order'
 
-const TwapErrorMessages = {
-  DEFAULT: 'Something went wrong creating your order',
-}
+function getIvalidArgumentError(error: any): string | undefined {
+  if (error && error.message && error.message.includes('INVALID_ARGUMENT')) {
+    const matches = error.message.match(/argument="([^"]+)"/)
+    const invalidArgument = matches?.length ? matches[1] : ''
 
-function parseInvalidArgumentError(error: any) {
-  const regex = /(?<=\(argument=")[^"]+(?=",)/g
-  const matches = error.message.match(regex)
-  const invalidArgument = matches?.length ? matches[1] : ''
-  const str = invalidArgument ? `"${invalidArgument}" ` : ''
-
-  return `Invalid argument ${str}provided`
-}
-
-export function parseTwapErrorMessage(error: any) {
-  switch (error.code) {
-    case TwapErrorCodes.INVALID_ARGUMENT:
-      return parseInvalidArgumentError(error)
-
-    default:
-      return error.message || TwapErrorMessages.DEFAULT
+    if (invalidArgument) {
+      return `Invalid argument "${invalidArgument}" provided`
+    }
   }
+  return undefined
+}
+
+export function getErrorMessage(error: any): string {
+  return getIvalidArgumentError(error) || error.message || DEFAULT_ERROR_MESSAGE
 }


### PR DESCRIPTION
This PR fixes a nasty error in Safari where we couldn't navigate neither to TWAP nor to LIMIT_ORDERS.

This is what was happening:
![image](https://github.com/cowprotocol/cowswap/assets/2352112/b5e454a1-3793-4c05-a99f-c45293dc6925)

The error had to do with loading Safari throwing while chunk 
![image](https://github.com/cowprotocol/cowswap/assets/2352112/d1915a3e-f3af-4d60-b586-99ab46912c86)

After some digging, the error is related to Safari not supporting forward lookups, see https://stackoverflow.com/questions/51568821/works-in-chrome-but-breaks-in-safari-invalid-regular-expression-invalid-group

I found a place where we were using them, and changed the implementation. This solved the issue 🎉

# Where was introduced?
here: https://github.com/cowprotocol/cowswap/pull/2918/files

I tested the new implementation also works, and IMO is simpler

![Screenshot at Aug 03 13-43-17](https://github.com/cowprotocol/cowswap/assets/2352112/5763f763-5187-420c-a7d3-76a5624fd6c9)


# Reviews
I added some notes in the code with some additional changes in this PR

# To Test
Load TWAP orders from an old safari

![image](https://github.com/cowprotocol/cowswap/assets/2352112/bb31ffde-eae2-4ffd-9459-1e794bbe652d)
