### PR TITLE
fix: dont upload app-data in bundle-safe-flow

### DIFF
--- a/src/modules/swap/services/safeBundleFlow/safeBundleEthFlow.ts
+++ b/src/modules/swap/services/safeBundleFlow/safeBundleEthFlow.ts
@@ -124,13 +124,10 @@ export async function safeBundleEthFlow(
     )
     tradeFlowAnalytics.sign(swapFlowAnalyticsContext)
 
-    logTradeFlow(LOG_PREFIX, 'STEP 8: add app data to upload queue')
-    callbacks.uploadAppData({ chainId: context.chainId, orderId, appData: appDataInfo })
-
-    logTradeFlow(LOG_PREFIX, 'STEP 9: show UI of the successfully sent transaction')
+    logTradeFlow(LOG_PREFIX, 'STEP 8: show UI of the successfully sent transaction')
     swapConfirmManager.transactionSent(orderId)
   } catch (error) {
-    logTradeFlow(LOG_PREFIX, 'STEP 10: error', error)
+    logTradeFlow(LOG_PREFIX, 'STEP 9: error', error)
     const swapErrorMessage = getSwapErrorMessage(error)
 
     tradeFlowAnalytics.error(error, swapErrorMessage, swapFlowAnalyticsContext)

--- a/src/modules/swap/services/safeBundleFlow/safeBundleEthFlow.ts
+++ b/src/modules/swap/services/safeBundleFlow/safeBundleEthFlow.ts
@@ -34,7 +34,6 @@ export async function safeBundleEthFlow(
     spender,
     context,
     callbacks,
-    appDataInfo,
     swapConfirmManager,
     dispatch,
     orderParams,


### PR DESCRIPTION
# Summary

Addresses this comment https://github.com/cowprotocol/cowswap/pull/2986#discussion_r1282902069

I explain in the comments what is wrong :) 

# To Test
ETH Flow and Bundle ETH Flow (in safe app) should still work, and we should see the document in the explorer