### PR TITLE
feat(number-input-arrow): wire up number input arrows

### DIFF
--- a/src/modules/trade/pure/TradeNumberInput/index.tsx
+++ b/src/modules/trade/pure/TradeNumberInput/index.tsx
@@ -75,13 +75,13 @@ export function TradeNumberInput(props: TradeNumberInputProps) {
       const adjustedValue = quotient + filteredDecimals
       const parsedValue = adjustedValue ? parseFloat(adjustedValue) : null
 
-      if (parsedValue && max !== 0 && parsedValue > max) {
+      if (parsedValue && max !== undefined && parsedValue > max) {
         setDisplayedValue(max.toString())
         onUserInput(max)
         return
       }
 
-      if (min && (!parsedValue || parsedValue < min)) {
+      if (min !== undefined && (!parsedValue || parsedValue < min)) {
         setDisplayedValue(min.toString())
         onUserInput(min)
         return

--- a/src/modules/trade/pure/TradeNumberInput/index.tsx
+++ b/src/modules/trade/pure/TradeNumberInput/index.tsx
@@ -1,16 +1,21 @@
 import { useCallback, useEffect, useState } from 'react'
 
+import BigNumberJs from 'bignumber.js'
 import SVG from 'react-inlinesvg'
 
 import carretDown from 'legacy/assets/cow-swap/carret-down.svg'
 
 import { TradeWidgetField, TradeWidgetFieldProps } from 'modules/trade/pure/TradeWidgetField'
 
-import { NumericalInput, Suffix, ArrowsWrapper, InputWrapper } from './styled'
+import { ArrowsWrapper, InputWrapper, NumericalInput, Suffix } from './styled'
+
+export { NumericalInput } from './styled'
 
 export interface TradeNumberInputProps extends TradeWidgetFieldProps {
   value: number | null
+
   onUserInput(input: number | null): void
+
   suffix?: string
   decimalsPlaces?: number
   min?: number
@@ -22,16 +27,21 @@ export interface TradeNumberInputProps extends TradeWidgetFieldProps {
   prefixComponent?: React.ReactElement
 }
 
-export function InputArrows() {
+type InputArrowsProps = {
+  onClickUp: () => void
+  onClickDown: () => void
+}
+
+export function InputArrows({ onClickUp, onClickDown }: InputArrowsProps) {
   return (
     <ArrowsWrapper>
-      <span role="button" aria-label="Increase Value" aria-disabled="false">
+      <span role="button" aria-label="Increase Value" aria-disabled="false" onClick={onClickUp}>
         <span role="img" aria-label="up">
           <SVG src={carretDown} />
         </span>
       </span>
 
-      <span role="button" aria-label="Decrease Value" aria-disabled="false">
+      <span role="button" aria-label="Decrease Value" aria-disabled="false" onClick={onClickDown}>
         <span role="img" aria-label="down">
           <SVG src={carretDown} />
         </span>
@@ -92,6 +102,14 @@ export function TradeNumberInput(props: TradeNumberInputProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  const onClickUp = useCallback(() => {
+    validateInput(increaseValue(displayedValue, step, min))
+  }, [displayedValue, min, step, validateInput])
+
+  const onClickDown = useCallback(() => {
+    validateInput(decreaseValue(displayedValue, step, min))
+  }, [displayedValue, min, step, validateInput])
+
   return (
     <TradeWidgetField {...props} hasPrefix={!!prefixComponent}>
       <>
@@ -106,11 +124,46 @@ export function TradeNumberInput(props: TradeNumberInputProps) {
             max={max}
             step={step}
           />
-          {showUpDownArrows && <InputArrows />}
+          {showUpDownArrows && <InputArrows onClickUp={onClickUp} onClickDown={onClickDown} />}
           {suffix && <Suffix>{suffix}</Suffix>}
         </InputWrapper>
       </>
     </TradeWidgetField>
   )
 }
-export { NumericalInput } from './styled'
+
+/**
+ * Increase `value` by `step`
+ *
+ * If no `value`, use `min`
+ * If no `min`, use `step`
+ *
+ * Uses BigNumberJS for avoiding JS finicky float point math
+ */
+function increaseValue(value: string, step: number, min: number | undefined): string {
+  const n = new BigNumberJs(value)
+
+  if (!n.isNaN()) {
+    return n.plus(step).toString()
+  }
+
+  return min?.toString() || step.toString()
+}
+
+/**
+ * Decrease `value` by `step`
+ *
+ * If no `value`, use `min`
+ * If no `min`, use `step`
+
+ * Uses BigNumberJS for avoiding JS finicky float point math
+ */
+function decreaseValue(value: string, step: number, min: number | undefined) {
+  const n = new BigNumberJs(value)
+
+  if (!n.isNaN()) {
+    return n.minus(step).toString()
+  }
+
+  return min?.toString() || step.toString()
+}

--- a/src/modules/trade/pure/TradeNumberInput/index.tsx
+++ b/src/modules/trade/pure/TradeNumberInput/index.tsx
@@ -110,6 +110,17 @@ export function TradeNumberInput(props: TradeNumberInputProps) {
     validateInput(decreaseValue(displayedValue, step, min))
   }, [displayedValue, min, step, validateInput])
 
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'ArrowUp') {
+        onClickUp()
+      } else if (e.key === 'ArrowDown') {
+        onClickDown()
+      }
+    },
+    [onClickDown, onClickUp]
+  )
+
   return (
     <TradeWidgetField {...props} hasPrefix={!!prefixComponent}>
       <>
@@ -120,6 +131,7 @@ export function TradeNumberInput(props: TradeNumberInputProps) {
             value={displayedValue}
             onBlur={(e) => validateInput(e.target.value)}
             onUserInput={(value) => setDisplayedValue(value)}
+            onKeyDown={onKeyDown}
             min={min}
             max={max}
             step={step}

--- a/src/modules/twap/containers/TwapFormWidget/index.tsx
+++ b/src/modules/twap/containers/TwapFormWidget/index.tsx
@@ -1,5 +1,4 @@
-import { useAtomValue } from 'jotai'
-import { useSetAtom } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 import { useEffect, useState } from 'react'
 
 import {
@@ -146,6 +145,7 @@ export function TwapFormWidget() {
         onUserInput={(value: number | null) => updateSettingsState({ slippageValue: value })}
         decimalsPlaces={2}
         placeholder={DEFAULT_TWAP_SLIPPAGE.toFixed(1)}
+        min={0}
         max={MAX_TWAP_SLIPPAGE}
         label={LABELS_TOOLTIPS.slippage.label}
         tooltip={renderTooltip(LABELS_TOOLTIPS.slippage.tooltip)}


### PR DESCRIPTION
# Summary

Waterfalls onto https://github.com/cowprotocol/cowswap/pull/2970

Connecting the dots with the number input arrows

# Out of scope:
- Time picker input
- ~Keyboard events (up and down arrow keys)~ added

# To Test

1. On TWAP form, click on the price protection and number of parts field arrows 
![image](https://github.com/cowprotocol/cowswap/assets/43217/95276e66-adf1-4ef7-9fee-e1087dc083ef)

* It should increase by 0.1 on price protection
* It should increase by 1 on number of parts
* It should not go over 100 on price protection
* It should not go over 100'000 on number of parts
* It should not go under 0 on price protection
* It should not go under 2 on number of parts