### PR TITLE
feat(number-input-arrow): add arrows to custom deadline input

### DIFF
--- a/src/modules/trade/pure/TradeNumberInput/index.tsx
+++ b/src/modules/trade/pure/TradeNumberInput/index.tsx
@@ -19,7 +19,12 @@ export interface TradeNumberInputProps extends TradeWidgetFieldProps {
   suffix?: string
   decimalsPlaces?: number
   min?: number
-  max?: number
+  /**
+   * max === undefined => use the default
+   * max === null => no max
+   * max === number => max value
+   */
+  max?: number | null
   step?: number
   placeholder?: string
   showUpDownArrows?: boolean
@@ -58,12 +63,14 @@ export function TradeNumberInput(props: TradeNumberInputProps) {
     placeholder = '0',
     decimalsPlaces = 0,
     min,
-    max = 100_000,
+    max: inputMax,
     step = 1,
     prefixComponent,
     showUpDownArrows = false,
     upDownArrowsLeftAlign = false,
   } = props
+
+  const max = inputMax === undefined ? 100_000 : inputMax
 
   const [displayedValue, setDisplayedValue] = useState(value === null ? '' : value.toString())
   const [isFocused, setIsFocused] = useState(false)
@@ -76,7 +83,7 @@ export function TradeNumberInput(props: TradeNumberInputProps) {
       const adjustedValue = quotient + filteredDecimals
       const parsedValue = adjustedValue ? parseFloat(adjustedValue) : null
 
-      if (parsedValue && max !== undefined && parsedValue > max) {
+      if (parsedValue && max !== null && parsedValue > max) {
         setDisplayedValue(max.toString())
         onUserInput(max)
         return
@@ -136,12 +143,10 @@ export function TradeNumberInput(props: TradeNumberInputProps) {
               setIsFocused(false)
             }}
             onFocus={() => setIsFocused(true)}
-            onUserInput={(value) => {
-              setDisplayedValue(value)
-            }}
+            onUserInput={setDisplayedValue}
             onKeyDown={onKeyDown}
             min={min}
-            max={max}
+            max={max || undefined}
             step={step}
           />
           {showUpDownArrows && <InputArrows onClickUp={onClickUp} onClickDown={onClickDown} />}

--- a/src/modules/twap/pure/CustomDeadlineSelector/index.tsx
+++ b/src/modules/twap/pure/CustomDeadlineSelector/index.tsx
@@ -81,7 +81,7 @@ export function CustomDeadlineSelector(props: CustomDeadlineSelectorProps) {
           <TradeNumberInput
             label="Minutes"
             onUserInput={onMinutesChange}
-            value={hoursValue}
+            value={minutesValue}
             showUpDownArrows
             min={0}
             max={null}

--- a/src/modules/twap/pure/CustomDeadlineSelector/index.tsx
+++ b/src/modules/twap/pure/CustomDeadlineSelector/index.tsx
@@ -49,6 +49,12 @@ export function CustomDeadlineSelector(props: CustomDeadlineSelectorProps) {
     })
   }
 
+  const _onDismiss = useCallback(() => {
+    setHoursValue(hours || 0)
+    setMinutesValue(minutes || 0)
+    onDismiss()
+  }, [hours, minutes, onDismiss])
+
   useEffect(() => {
     const totalTime = ms(`${hoursValue}h`) + ms(`${minutesValue}m`)
 
@@ -60,13 +66,13 @@ export function CustomDeadlineSelector(props: CustomDeadlineSelectorProps) {
   }, [hoursValue, minutesValue])
 
   return (
-    <Modal isOpen={isOpen} onDismiss={onDismiss}>
+    <Modal isOpen={isOpen} onDismiss={_onDismiss}>
       <styledEl.ModalWrapper>
         <styledEl.ModalHeader>
           <h3>
             <Trans>Define custom total time</Trans>
           </h3>
-          <styledEl.CloseIcon onClick={onDismiss} />
+          <styledEl.CloseIcon onClick={_onDismiss} />
         </styledEl.ModalHeader>
 
         <styledEl.ModalContent>
@@ -91,7 +97,7 @@ export function CustomDeadlineSelector(props: CustomDeadlineSelectorProps) {
         {error && <styledEl.ErrorText>{error}</styledEl.ErrorText>}
 
         <styledEl.ModalFooter>
-          <styledEl.CancelButton onClick={onDismiss}>
+          <styledEl.CancelButton onClick={_onDismiss}>
             <Trans>Cancel</Trans>
           </styledEl.CancelButton>
           <ButtonPrimary disabled={isDisabled} onClick={onApply}>

--- a/src/modules/twap/pure/CustomDeadlineSelector/index.tsx
+++ b/src/modules/twap/pure/CustomDeadlineSelector/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import { Trans } from '@lingui/macro'
 import ms from 'ms'
@@ -35,8 +35,8 @@ export function CustomDeadlineSelector(props: CustomDeadlineSelectorProps) {
 
   const [error, setError] = useState<string | null>(null)
 
-  const onHoursChange = (v: number | null) => setHoursValue(Number(v?.toString().replace(/\./g, '')))
-  const onMinutesChange = (v: number | null) => setMinutesValue(Number(v?.toString().replace(/\./g, '')))
+  const onHoursChange = useCallback((v: number | null) => setHoursValue(!v ? 0 : Math.round(v)), [])
+  const onMinutesChange = useCallback((v: number | null) => setMinutesValue(!v ? 0 : Math.round(v)), [])
 
   const noValues = !hoursValue && !minutesValue
   const isDisabled = !!error || noValues

--- a/src/modules/twap/pure/CustomDeadlineSelector/index.tsx
+++ b/src/modules/twap/pure/CustomDeadlineSelector/index.tsx
@@ -5,6 +5,8 @@ import ms from 'ms'
 
 import { ButtonPrimary } from 'legacy/components/Button'
 
+import { TradeNumberInput } from 'modules/trade/pure/TradeNumberInput'
+
 import { CowModal as Modal } from 'common/pure/Modal'
 
 import * as styledEl from './styled'
@@ -33,8 +35,8 @@ export function CustomDeadlineSelector(props: CustomDeadlineSelectorProps) {
 
   const [error, setError] = useState<string | null>(null)
 
-  const onHoursChange = (v: string) => setHoursValue(Number(v.replace(/\./g, '')))
-  const onMinutesChange = (v: string) => setMinutesValue(Number(v.replace(/\./g, '')))
+  const onHoursChange = (v: number | null) => setHoursValue(Number(v?.toString().replace(/\./g, '')))
+  const onMinutesChange = (v: number | null) => setMinutesValue(Number(v?.toString().replace(/\./g, '')))
 
   const noValues = !hoursValue && !minutesValue
   const isDisabled = !!error || noValues
@@ -68,15 +70,8 @@ export function CustomDeadlineSelector(props: CustomDeadlineSelectorProps) {
         </styledEl.ModalHeader>
 
         <styledEl.ModalContent>
-          <styledEl.FieldWrapper>
-            <styledEl.FieldLabel>Hours</styledEl.FieldLabel>
-            <styledEl.Input onUserInput={onHoursChange} value={hoursValue} type="number" />
-          </styledEl.FieldWrapper>
-
-          <styledEl.FieldWrapper>
-            <styledEl.FieldLabel>Minutes</styledEl.FieldLabel>
-            <styledEl.Input onUserInput={onMinutesChange} value={minutesValue} type="number" />
-          </styledEl.FieldWrapper>
+          <TradeNumberInput label="Hours" onUserInput={onHoursChange} value={hoursValue} showUpDownArrows min={0} />
+          <TradeNumberInput label="Minutes" onUserInput={onMinutesChange} value={hoursValue} showUpDownArrows min={0} />
         </styledEl.ModalContent>
 
         {error && <styledEl.ErrorText>{error}</styledEl.ErrorText>}

--- a/src/modules/twap/pure/CustomDeadlineSelector/index.tsx
+++ b/src/modules/twap/pure/CustomDeadlineSelector/index.tsx
@@ -70,8 +70,22 @@ export function CustomDeadlineSelector(props: CustomDeadlineSelectorProps) {
         </styledEl.ModalHeader>
 
         <styledEl.ModalContent>
-          <TradeNumberInput label="Hours" onUserInput={onHoursChange} value={hoursValue} showUpDownArrows min={0} />
-          <TradeNumberInput label="Minutes" onUserInput={onMinutesChange} value={hoursValue} showUpDownArrows min={0} />
+          <TradeNumberInput
+            label="Hours"
+            onUserInput={onHoursChange}
+            value={hoursValue}
+            showUpDownArrows
+            min={0}
+            max={null}
+          />
+          <TradeNumberInput
+            label="Minutes"
+            onUserInput={onMinutesChange}
+            value={hoursValue}
+            showUpDownArrows
+            min={0}
+            max={null}
+          />
         </styledEl.ModalContent>
 
         {error && <styledEl.ErrorText>{error}</styledEl.ErrorText>}

--- a/src/modules/twap/pure/CustomDeadlineSelector/styled.tsx
+++ b/src/modules/twap/pure/CustomDeadlineSelector/styled.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components/macro'
 
 import { ButtonSecondary } from 'legacy/components/Button'
 
-import { NumericalInput } from '../../../trade/pure/TradeNumberInput'
+import { NumericalInput } from 'modules/trade/pure/TradeNumberInput'
 
 export const ModalWrapper = styled.div`
   display: flex;
@@ -72,6 +72,7 @@ export const CancelButton = styled(ButtonSecondary)`
   }
 `
 
+// TODO: remove
 export const FieldWrapper = styled.div`
   background: ${({ theme }) => theme.grey1};
   border-radius: 12px;
@@ -81,8 +82,11 @@ export const FieldWrapper = styled.div`
   display: flex;
   justify-content: space-between;
 `
+// TODO: remove
 
 export const FieldLabel = styled.span``
+
+// TODO: remove
 export const Input = styled(NumericalInput)`
   max-width: 100px;
 `

--- a/src/modules/twap/pure/CustomDeadlineSelector/styled.tsx
+++ b/src/modules/twap/pure/CustomDeadlineSelector/styled.tsx
@@ -3,7 +3,8 @@ import styled from 'styled-components/macro'
 
 import { ButtonSecondary } from 'legacy/components/Button'
 
-import { NumericalInput } from 'modules/trade/pure/TradeNumberInput'
+import { NumericalInput } from 'modules/trade/pure/TradeNumberInput/styled'
+import { TradeWidgetFieldBox } from 'modules/trade/pure/TradeWidgetField/styled'
 
 export const ModalWrapper = styled.div`
   display: flex;
@@ -39,9 +40,22 @@ export const ModalFooter = styled.div`
 `
 
 export const ModalContent = styled.div`
-  display: flex;
-  flex-flow: row wrap;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  width: 100%;
   grid-gap: 6px;
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+      grid-template-columns: repeat(1, 1fr);
+    `};
+
+  > ${TradeWidgetFieldBox} {
+    flex-flow: row nowrap;
+  }
+
+  > ${TradeWidgetFieldBox} ${NumericalInput} {
+    width: 100%;
+  }
 `
 
 export const CloseIcon = styled(X)`
@@ -70,25 +84,6 @@ export const CancelButton = styled(ButtonSecondary)`
     color: ${({ theme }) => theme.text1};
     border: 1px solid ${({ theme }) => theme.text1};
   }
-`
-
-// TODO: remove
-export const FieldWrapper = styled.div`
-  background: ${({ theme }) => theme.grey1};
-  border-radius: 12px;
-  padding: 16px;
-  flex: 1;
-  width: auto;
-  display: flex;
-  justify-content: space-between;
-`
-// TODO: remove
-
-export const FieldLabel = styled.span``
-
-// TODO: remove
-export const Input = styled(NumericalInput)`
-  max-width: 100px;
 `
 
 export const ErrorText = styled.div`


### PR DESCRIPTION
# Summary

Waterfalls onto https://github.com/cowprotocol/cowswap/pull/3001

Add and wire up arrow keys to custom deadline inputs

![Screenshot 2023-08-04 at 09 18 37](https://github.com/cowprotocol/cowswap/assets/43217/25c16fcf-8a5a-4529-ad1f-84bf87108639)

## Notes

- Styles have been broken and need re-work. Out of the scope of this PR. @fairlighteth can you take care of it?

# To Test

1. On TWAP form, open the custom deadline modal
* Both fields should have arrows
* Arrows should change the values
* Up and down keys should change the values