### PR TITLE
3023/shorten urls

### DIFF
--- a/cypress-custom/integration/limit-orders.test.ts
+++ b/cypress-custom/integration/limit-orders.test.ts
@@ -7,7 +7,7 @@ function unlock() {
 }
 
 function navigate(path = '', unlockLimitOrders = true) {
-  cy.visit(`/#/${CHAIN_ID}/limit-orders${path}`)
+  cy.visit(`/#/${CHAIN_ID}/limit${path}`)
 
   if (unlockLimitOrders) {
     unlock()

--- a/src/common/constants/routes.ts
+++ b/src/common/constants/routes.ts
@@ -5,8 +5,8 @@ export const TRADE_WIDGET_PREFIX = isInjectedWidget() ? '/widget' : ''
 export const Routes = {
   HOME: '/',
   SWAP: `/:chainId?${TRADE_WIDGET_PREFIX}/swap/:inputCurrencyId?/:outputCurrencyId?`,
-  LIMIT_ORDER: `/:chainId?${TRADE_WIDGET_PREFIX}/limit-orders/:inputCurrencyId?/:outputCurrencyId?`,
-  ADVANCED_ORDERS: `/:chainId?${TRADE_WIDGET_PREFIX}/advanced-orders/:inputCurrencyId?/:outputCurrencyId?`,
+  LIMIT_ORDER: `/:chainId?${TRADE_WIDGET_PREFIX}/limit/:inputCurrencyId?/:outputCurrencyId?`,
+  ADVANCED_ORDERS: `/:chainId?${TRADE_WIDGET_PREFIX}/advanced/:inputCurrencyId?/:outputCurrencyId?`,
   SEND: '/send',
   ACCOUNT: '/account',
   ACCOUNT_TOKENS: '/account/tokens',

--- a/src/common/constants/routes.ts
+++ b/src/common/constants/routes.ts
@@ -7,6 +7,8 @@ export const Routes = {
   SWAP: `/:chainId?${TRADE_WIDGET_PREFIX}/swap/:inputCurrencyId?/:outputCurrencyId?`,
   LIMIT_ORDER: `/:chainId?${TRADE_WIDGET_PREFIX}/limit/:inputCurrencyId?/:outputCurrencyId?`,
   ADVANCED_ORDERS: `/:chainId?${TRADE_WIDGET_PREFIX}/advanced/:inputCurrencyId?/:outputCurrencyId?`,
+  LONG_LIMIT_ORDER: `/:chainId?${TRADE_WIDGET_PREFIX}/limit-orders/:inputCurrencyId?/:outputCurrencyId?`,
+  LONG_ADVANCED_ORDERS: `/:chainId?${TRADE_WIDGET_PREFIX}/advanced-orders/:inputCurrencyId?/:outputCurrencyId?`,
   SEND: '/send',
   ACCOUNT: '/account',
   ACCOUNT_TOKENS: '/account/tokens',

--- a/src/legacy/pages/Swap/redirects.tsx
+++ b/src/legacy/pages/Swap/redirects.tsx
@@ -1,4 +1,4 @@
-import { Navigate, useLocation } from 'react-router-dom'
+import { Navigate } from 'react-router-dom'
 
 // Redirects to swap but only replace the pathname
 export function RedirectPathToSwapOnly() {
@@ -6,6 +6,5 @@ export function RedirectPathToSwapOnly() {
 }
 
 export function RedirectToPath({ path }: { path: string }) {
-  const location = useLocation()
-  return <Navigate to={{ ...location, pathname: path }} />
+  return <Navigate to={path} />
 }

--- a/src/legacy/pages/Swap/redirects.tsx
+++ b/src/legacy/pages/Swap/redirects.tsx
@@ -1,41 +1,11 @@
-import { useEffect } from 'react'
-
-import { Navigate, useLocation, useParams } from 'react-router-dom'
-
-import { useAppDispatch } from 'legacy/state/hooks'
-
-import { ApplicationModal, setOpenModal } from '../../state/application/reducer'
+import { Navigate, useLocation } from 'react-router-dom'
 
 // Redirects to swap but only replace the pathname
 export function RedirectPathToSwapOnly() {
-  const location = useLocation()
-  return <Navigate to={{ ...location, pathname: '/swap' }} />
+  return <RedirectToPath path={'/swap'} />
 }
 
-// Redirects from the /swap/:outputCurrency path to the /swap?outputCurrency=:outputCurrency format
-export function RedirectToSwap() {
-  const { outputCurrency } = useParams<{ outputCurrency: string }>()
+export function RedirectToPath({ path }: { path: string }) {
   const location = useLocation()
-  const { search } = location
-
-  return (
-    <Navigate
-      to={{
-        ...location,
-        pathname: '/swap',
-        search:
-          search && search.length > 1
-            ? `${search}&outputCurrency=${outputCurrency}`
-            : `?outputCurrency=${outputCurrency}`,
-      }}
-    />
-  )
-}
-
-export function OpenClaimAddressModalAndRedirectToSwap() {
-  const dispatch = useAppDispatch()
-  useEffect(() => {
-    dispatch(setOpenModal(ApplicationModal.ADDRESS_CLAIM))
-  }, [dispatch])
-  return <RedirectPathToSwapOnly />
+  return <Navigate to={{ ...location, pathname: path }} />
 }

--- a/src/modules/application/containers/App/RoutesApp.tsx
+++ b/src/modules/application/containers/App/RoutesApp.tsx
@@ -1,12 +1,11 @@
-import { lazy, Suspense } from 'react'
-import { ReactNode } from 'react'
+import { lazy, ReactNode, Suspense } from 'react'
 
 import { Navigate, Route, Routes } from 'react-router-dom'
 
 import { Loading } from 'legacy/components/FlashingLoading'
 import Loader from 'legacy/components/Loader'
 import { DISCORD_LINK, DOCS_LINK, DUNE_DASHBOARD_LINK, TWITTER_LINK } from 'legacy/constants'
-import { RedirectPathToSwapOnly } from 'legacy/pages/Swap/redirects'
+import { RedirectPathToSwapOnly, RedirectToPath } from 'legacy/pages/Swap/redirects'
 
 import { Routes as RoutesEnum, RoutesValues } from 'common/constants/routes'
 import Account, { AccountOverview } from 'pages/Account'
@@ -54,7 +53,9 @@ function LazyRoute({ route, element, key }: LazyRouteProps) {
 
 const lazyRoutes: LazyRouteProps[] = [
   { route: RoutesEnum.LIMIT_ORDER, element: <LimitOrders /> },
+  { route: RoutesEnum.LONG_LIMIT_ORDER, element: <RedirectToPath path={'/limit'} /> },
   { route: RoutesEnum.ADVANCED_ORDERS, element: <AdvancedOrders /> },
+  { route: RoutesEnum.LONG_ADVANCED_ORDERS, element: <RedirectToPath path={'/advanced'} /> },
   { route: RoutesEnum.ABOUT, element: <About /> },
   { route: RoutesEnum.FAQ, element: <Faq /> },
   { route: RoutesEnum.FAQ_PROTOCOL, element: <ProtocolFaq /> },

--- a/src/modules/application/containers/TradeWidgetLinks/index.tsx
+++ b/src/modules/application/containers/TradeWidgetLinks/index.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react'
+
 import { Trans } from '@lingui/macro'
 import { matchPath, useLocation } from 'react-router-dom'
 
@@ -16,7 +18,7 @@ interface MenuItemConfig {
   onClick?: () => void
 }
 
-const menuItems: MenuItemConfig[] = [
+const MENU_ITEMS: MenuItemConfig[] = [
   { route: Routes.SWAP, label: 'Swap' },
   { route: Routes.LIMIT_ORDER, label: 'Limit' },
   {
@@ -30,24 +32,26 @@ export function TradeWidgetLinks() {
   const tradeContext = useTradeRouteContext()
   const location = useLocation()
 
-  return (
-    <styledEl.Wrapper>
-      {menuItems.map((item) => {
-        const routePath = parameterizeTradeRoute(tradeContext, item.route)
-        const isActive = !!matchPath(location.pathname, routePath)
+  const buildMenuItem = useCallback(
+    (item: MenuItemConfig) => {
+      const routePath = parameterizeTradeRoute(tradeContext, item.route)
 
-        const menuItem = <MenuItem key={item.label} routePath={routePath} item={item} isActive={isActive} />
+      const isActive = !!matchPath(location.pathname, routePath)
 
-        return item.featureGuard ? (
-          <FeatureGuard key={item.label} featureFlag={item.featureGuard}>
-            {menuItem}
-          </FeatureGuard>
-        ) : (
-          menuItem
-        )
-      })}
-    </styledEl.Wrapper>
+      const menuItem = <MenuItem key={item.label} routePath={routePath} item={item} isActive={isActive} />
+
+      return item.featureGuard ? (
+        <FeatureGuard key={item.label} featureFlag={item.featureGuard}>
+          {menuItem}
+        </FeatureGuard>
+      ) : (
+        menuItem
+      )
+    },
+    [location.pathname, tradeContext]
   )
+
+  return <styledEl.Wrapper>{MENU_ITEMS.map(buildMenuItem)}</styledEl.Wrapper>
 }
 
 const MenuItem = ({ routePath, item, isActive }: { routePath: string; item: MenuItemConfig; isActive: boolean }) => (

--- a/src/modules/limitOrders/hooks/useSetupLimitOrderAmountsFromUrl.ts
+++ b/src/modules/limitOrders/hooks/useSetupLimitOrderAmountsFromUrl.ts
@@ -19,7 +19,7 @@ import { getIntOrFloat } from 'utils/getIntOrFloat'
 /**
  * Parse sell/buy amount from URL and apply to Limit orders widget
  * Example:
- * /#/1/limit-orders/WETH/COW?sellAmount=4&buyAmount=360000
+ * /#/1/limit/WETH/COW?sellAmount=4&buyAmount=360000
  *
  * In case when both sellAmount and buyAmount specified, the price will be automatically calculated
  */

--- a/src/modules/trade/hooks/setupTradeState/useResetStateWithSymbolDuplication.ts
+++ b/src/modules/trade/hooks/setupTradeState/useResetStateWithSymbolDuplication.ts
@@ -16,12 +16,12 @@ Please select the token you need from the UI or use the address of the token ins
 
 /**
  * Case: when user opened a link with a token symbol and there are more than one token with the same symbol
- * Example: /limit-orders/UST/WETH
+ * Example: /limit/UST/WETH
  * https://etherscan.io/token/0xa47c8bf37f92abed4a126bda807a7b7498661acd - Symbol: UST
  * https://etherscan.io/token/0xa693b19d2931d498c5b318df961919bb4aee87a5 - Symbol: UST
  * In this case we just reset state to default, because:
  * if user selected a token with symbol duplication from cowswap Dapp, then Dapp puts a token address in the URL
- * Example: /limit-orders/0xa47c8bf37f92abed4a126bda807a7b7498661acd/WETH
+ * Example: /limit/0xa47c8bf37f92abed4a126bda807a7b7498661acd/WETH
  * @see useOnCurrencySelection.ts
  */
 export function useResetStateWithSymbolDuplication(state: TradeRawState | null): void {

--- a/src/modules/trade/hooks/useTradeTypeInfo.ts
+++ b/src/modules/trade/hooks/useTradeTypeInfo.ts
@@ -25,8 +25,8 @@ function useMatchTradeRoute(route: string): PathMatch<'chainId'> | null {
 
 export function useTradeTypeInfo(): TradeTypeInfo | null {
   const swapMatch = useMatchTradeRoute('swap')
-  const limitOrderMatch = useMatchTradeRoute('limit-orders')
-  const advancedOrdersMatch = useMatchTradeRoute('advanced-orders')
+  const limitOrderMatch = useMatchTradeRoute('limit')
+  const advancedOrdersMatch = useMatchTradeRoute('advanced')
 
   return useMemo(() => {
     if (swapMatch) return { tradeType: TradeType.SWAP, route: Routes.SWAP }

--- a/src/modules/trade/utils/parameterizeTradeRoute.ts
+++ b/src/modules/trade/utils/parameterizeTradeRoute.ts
@@ -4,7 +4,7 @@ import { RoutesValues } from 'common/constants/routes'
 
 /**
  * When input currency is not set and user select output currency, we build a link like:
- * /limit-orders/_/DAI
+ * /limit/_/DAI
  */
 export function parameterizeTradeRoute(
   { chainId, inputCurrencyId, outputCurrencyId }: TradeUrlParams,

--- a/src/pages/Faq/LimitOrdersFaq.tsx
+++ b/src/pages/Faq/LimitOrdersFaq.tsx
@@ -2,11 +2,11 @@ import { PageName } from 'legacy/components/AmplitudeAnalytics/constants'
 import { Trace } from 'legacy/components/AmplitudeAnalytics/Trace'
 
 import { PageTitle } from 'modules/application/containers/PageTitle'
-import { Page, Content } from 'modules/application/pure/Page'
+import { Content, Page } from 'modules/application/pure/Page'
 
 import { useToC } from './hooks'
 import { FaqMenu } from './Menu'
-import { ExternalLinkFaq, Wrapper } from './styled'
+import { ExternalLinkFaq, InternalLinkFaq, Wrapper } from './styled'
 
 import { Footer } from '.'
 
@@ -176,10 +176,8 @@ export default function LimitOrderFAQ() {
             </p>
             <p>
               If you miss the MOOOO sound, you can always check your order history in{' '}
-              <ExternalLinkFaq href="https://swap.cow.fi/#/1/limit-orders/WETH?tab=history&page=1">
-                CoW Swap
-              </ExternalLinkFaq>{' '}
-              and in the <ExternalLinkFaq href="https://explorer.cow.fi">CoW Explorer</ExternalLinkFaq>.
+              <InternalLinkFaq to="/limit">CoW Swap</InternalLinkFaq> and in the{' '}
+              <ExternalLinkFaq href="https://explorer.cow.fi">CoW Explorer</ExternalLinkFaq>.
             </p>
 
             <h3 id="why-isnt-my-order-getting-filled">

--- a/src/pages/Faq/styled.tsx
+++ b/src/pages/Faq/styled.tsx
@@ -2,11 +2,16 @@ import { transparentize } from 'polished'
 import styled from 'styled-components/macro'
 
 import { ButtonPrimary } from 'legacy/components/Button'
-import { ExternalLink as ExternalLinkTheme } from 'legacy/theme'
+import { ExternalLink as ExternalLinkTheme, StyledInternalLink } from 'legacy/theme'
 
 import { Content } from 'modules/application/pure/Page'
 
 export const ExternalLinkFaq = styled(ExternalLinkTheme)`
+  text-decoration: underline;
+  font-weight: normal;
+`
+
+export const InternalLinkFaq = styled(StyledInternalLink)`
   text-decoration: underline;
   font-weight: normal;
 `


### PR DESCRIPTION
# Summary

Closes #3023 

Shortened urls:
- `limit-orders` -> `limit`
- `advanced-orders` -> `advanced`

Added a redirect from older versions to the new ones

# To Test

1. Open the limit orders page
* Url should be `limit`
2. Change it to `limit-orders`
* It should redirect to `limit`
3. Repeat for advanced orders page