### PR TITLE
fix(twap): load unknown tokens from blockchain

### DIFF
--- a/src/legacy/state/orders/updaters/GpOrdersUpdater.ts
+++ b/src/legacy/state/orders/updaters/GpOrdersUpdater.ts
@@ -11,7 +11,7 @@ import { useAddOrUpdateOrders, useClearOrdersStorage } from 'legacy/state/orders
 import { computeOrderSummary } from 'legacy/state/orders/updaters/utils'
 import { classifyOrder, OrderTransitionStatus } from 'legacy/state/orders/utils'
 
-import { useTokensForOrdersList } from 'modules/orders'
+import { useTokensForOrdersList, getTokensListFromOrders } from 'modules/orders'
 import { apiOrdersAtom } from 'modules/orders/state/apiOrdersAtom'
 import { useWalletInfo } from 'modules/wallet'
 
@@ -159,8 +159,9 @@ export function GpOrdersUpdater(): null {
           return
         }
 
+        const tokensToFetch = getTokensListFromOrders(gpOrders)
         // Merge fetched tokens with what's currently loaded
-        const reallyAllTokens = await getTokensForOrdersList(gpOrders)
+        const reallyAllTokens = await getTokensForOrdersList(tokensToFetch)
 
         // Build store order objects, for all orders which we found both input/output tokens
         // Don't add order for those we didn't

--- a/src/legacy/state/orders/updaters/GpOrdersUpdater.ts
+++ b/src/legacy/state/orders/updaters/GpOrdersUpdater.ts
@@ -2,33 +2,21 @@ import { useSetAtom } from 'jotai'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 
 import { EnrichedOrder, EthflowData, OrderClass, SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
-import { getAddress } from '@ethersproject/address'
 import { Token } from '@uniswap/sdk-core'
 
-import { NATIVE_CURRENCY_BUY_ADDRESS, NATIVE_CURRENCY_BUY_TOKEN } from 'legacy/constants'
+import { NATIVE_CURRENCY_BUY_TOKEN } from 'legacy/constants'
 import { useAllTokens } from 'legacy/hooks/Tokens'
-import { useTokenLazy } from 'legacy/hooks/useTokenLazy'
 import { Order, OrderStatus } from 'legacy/state/orders/actions'
 import { useAddOrUpdateOrders, useClearOrdersStorage } from 'legacy/state/orders/hooks'
 import { computeOrderSummary } from 'legacy/state/orders/updaters/utils'
 import { classifyOrder, OrderTransitionStatus } from 'legacy/state/orders/utils'
 
+import { useTokensForOrdersList } from 'modules/orders'
 import { apiOrdersAtom } from 'modules/orders/state/apiOrdersAtom'
 import { useWalletInfo } from 'modules/wallet'
 
 import { useGpOrders } from 'api/gnosisProtocol/hooks'
-
-function _getTokenFromMapping(
-  address: string,
-  chainId: ChainId,
-  tokens: { [p: string]: Token | null }
-): Token | undefined | null {
-  if (address.toLowerCase() === NATIVE_CURRENCY_BUY_ADDRESS.toLowerCase()) {
-    return NATIVE_CURRENCY_BUY_TOKEN[chainId]
-  }
-  // Some tokens are checksummed, some are not. Search both ways
-  return tokens[getAddress(address)] || tokens[address]
-}
+import { getTokenFromMapping } from 'utils/orderUtils/getTokenFromMapping'
 
 // TODO: update this for ethflow states
 const statusMapping: Record<OrderTransitionStatus, OrderStatus | undefined> = {
@@ -44,7 +32,7 @@ const statusMapping: Record<OrderTransitionStatus, OrderStatus | undefined> = {
 function _transformGpOrderToStoreOrder(
   order: EnrichedOrder,
   chainId: ChainId,
-  allTokens: { [address: string]: Token | null }
+  allTokens: { [address: string]: Token }
 ): Order | undefined {
   const {
     uid: id,
@@ -62,7 +50,7 @@ function _transformGpOrderToStoreOrder(
   const isEthFlow = Boolean(ethflowData)
 
   const inputToken = _getInputToken(isEthFlow, chainId, sellToken, allTokens)
-  const outputToken = _getTokenFromMapping(buyToken, chainId, allTokens)
+  const outputToken = getTokenFromMapping(buyToken, chainId, allTokens)
 
   const apiStatus = classifyOrder(order)
   const status = statusMapping[apiStatus]
@@ -121,47 +109,12 @@ function _getInputToken(
   isEthFlow: boolean,
   chainId: ChainId,
   sellToken: string,
-  allTokens: { [address: string]: Token | null }
-): ReturnType<typeof _getTokenFromMapping> {
-  return isEthFlow ? NATIVE_CURRENCY_BUY_TOKEN[chainId] : _getTokenFromMapping(sellToken, chainId, allTokens)
+  allTokens: { [address: string]: Token }
+): ReturnType<typeof getTokenFromMapping> {
+  return isEthFlow ? NATIVE_CURRENCY_BUY_TOKEN[chainId] : getTokenFromMapping(sellToken, chainId, allTokens)
 }
 
-function _getMissingTokensAddresses(
-  orders: EnrichedOrder[],
-  tokens: Record<string, Token>,
-  chainId: ChainId
-): string[] {
-  const tokensToFetch = new Set<string>()
-
-  // Find out which tokens are not yet loaded in the UI
-  orders.forEach(({ sellToken, buyToken }) => {
-    if (!_getTokenFromMapping(sellToken, chainId, tokens)) tokensToFetch.add(sellToken)
-    if (!_getTokenFromMapping(buyToken, chainId, tokens)) tokensToFetch.add(buyToken)
-  })
-
-  return Array.from(tokensToFetch)
-}
-
-async function _fetchTokens(
-  tokensToFetch: string[],
-  getToken: (address: string) => Promise<Token | null>
-): Promise<Record<string, Token | null>> {
-  if (tokensToFetch.length === 0) {
-    return {}
-  }
-
-  const promises = tokensToFetch.map((address) => getToken(address))
-  const settledPromises = await Promise.allSettled(promises)
-
-  return settledPromises.reduce<Record<string, Token | null>>((acc, promiseResult) => {
-    if (promiseResult.status === 'fulfilled' && promiseResult.value) {
-      acc[promiseResult.value.address] = promiseResult.value
-    }
-    return acc
-  }, {})
-}
-
-function _filterOrders(orders: EnrichedOrder[], tokens: Record<string, Token | null>, chainId: ChainId): Order[] {
+function _filterOrders(orders: EnrichedOrder[], tokens: Record<string, Token>, chainId: ChainId): Order[] {
   return orders.reduce<Order[]>((acc, order) => {
     const storeOrder = _transformGpOrderToStoreOrder(order, chainId, tokens)
     if (storeOrder) {
@@ -189,9 +142,9 @@ export function GpOrdersUpdater(): null {
   const allTokens = useAllTokens()
   const tokensAreLoaded = useMemo(() => Object.keys(allTokens).length > 0, [allTokens])
   const addOrUpdateOrders = useAddOrUpdateOrders()
-  const getToken = useTokenLazy()
   const updateApiOrders = useSetAtom(apiOrdersAtom)
   const gpOrders = useGpOrders()
+  const getTokensForOrdersList = useTokensForOrdersList()
 
   // Using a ref to store allTokens to avoid re-fetching when new tokens are added
   // but still use the latest whenever the callback is invoked
@@ -200,31 +153,14 @@ export function GpOrdersUpdater(): null {
   allTokensRef.current = allTokens
 
   const updateOrders = useCallback(
-    async (chainId: ChainId, account: string): Promise<void> => {
-      const tokens = allTokensRef.current
-      console.debug(
-        `GpOrdersUpdater:: updating orders. Network ${chainId}, account ${account}, loaded tokens count ${
-          Object.keys(tokens).length
-        }`
-      )
+    async (chainId: ChainId): Promise<void> => {
       try {
         if (!gpOrders?.length) {
           return
         }
 
-        const tokensToFetch = _getMissingTokensAddresses(gpOrders, tokens, chainId)
-        console.debug(`GpOrdersUpdater::will try to fetch ${tokensToFetch.length} tokens`)
-
-        // Fetch them from the chain
-        const fetchedTokens = await _fetchTokens(tokensToFetch, getToken)
-        console.debug(
-          `GpOrdersUpdater::fetched ${Object.keys(fetchedTokens).filter(Boolean).length} out of ${
-            tokensToFetch.length
-          } tokens`
-        )
-
         // Merge fetched tokens with what's currently loaded
-        const reallyAllTokens = { ...tokens, ...fetchedTokens }
+        const reallyAllTokens = await getTokensForOrdersList(gpOrders)
 
         // Build store order objects, for all orders which we found both input/output tokens
         // Don't add order for those we didn't
@@ -237,7 +173,7 @@ export function GpOrdersUpdater(): null {
         console.error(`GpOrdersUpdater::Failed to fetch orders`, e)
       }
     },
-    [addOrUpdateOrders, gpOrders, getToken]
+    [addOrUpdateOrders, gpOrders, getTokensForOrdersList]
   )
 
   useEffect(() => {
@@ -246,7 +182,7 @@ export function GpOrdersUpdater(): null {
 
   useEffect(() => {
     if (account && chainId && tokensAreLoaded) {
-      updateOrders(chainId, account)
+      updateOrders(chainId)
     }
   }, [account, chainId, tokensAreLoaded, updateOrders])
 

--- a/src/modules/orders/hooks/useTokensForOrdersList.ts
+++ b/src/modules/orders/hooks/useTokensForOrdersList.ts
@@ -1,0 +1,73 @@
+import { useCallback, useRef } from 'react'
+
+import { EnrichedOrder, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { Token } from '@uniswap/sdk-core'
+
+import { useAllTokens } from 'legacy/hooks/Tokens'
+import { useTokenLazy } from 'legacy/hooks/useTokenLazy'
+
+import { TokensByAddress, TokenWithLogo } from 'modules/tokensList/state/tokensListAtom'
+import { useWalletInfo } from 'modules/wallet'
+
+import { getTokenFromMapping } from 'utils/orderUtils/getTokenFromMapping'
+
+export function useTokensForOrdersList(): (orders: EnrichedOrder[]) => Promise<TokensByAddress> {
+  const { chainId } = useWalletInfo()
+  const allTokens = useAllTokens()
+  const getToken = useTokenLazy()
+
+  // Using a ref to store allTokens to avoid re-fetching when new tokens are added
+  // but still use the latest whenever the callback is invoked
+  const allTokensRef = useRef(allTokens)
+  // Updated on every change
+  allTokensRef.current = allTokens
+
+  return useCallback(
+    async (orders: EnrichedOrder[]) => {
+      const tokens = allTokensRef.current
+      const tokensToFetch = _getMissingTokensAddresses(orders, tokens, chainId)
+      const fetchedTokens = await _fetchTokens(tokensToFetch, getToken)
+
+      // Merge fetched tokens with what's currently loaded
+      return { ...tokens, ...fetchedTokens }
+    },
+    [chainId, getToken]
+  )
+}
+
+function _getMissingTokensAddresses(
+  orders: EnrichedOrder[],
+  tokens: Record<string, Token>,
+  chainId: SupportedChainId
+): string[] {
+  const tokensToFetch = new Set<string>()
+
+  // Find out which tokens are not yet loaded in the UI
+  orders.forEach(({ sellToken, buyToken }) => {
+    if (!getTokenFromMapping(sellToken, chainId, tokens)) tokensToFetch.add(sellToken)
+    if (!getTokenFromMapping(buyToken, chainId, tokens)) tokensToFetch.add(buyToken)
+  })
+
+  return Array.from(tokensToFetch)
+}
+
+async function _fetchTokens(
+  tokensToFetch: string[],
+  getToken: (address: string) => Promise<Token | null>
+): Promise<TokensByAddress> {
+  if (tokensToFetch.length === 0) {
+    return {}
+  }
+
+  const promises = tokensToFetch.map((address) => getToken(address))
+  const settledPromises = await Promise.allSettled(promises)
+
+  return settledPromises.reduce<TokensByAddress>((acc, promiseResult) => {
+    if (promiseResult.status === 'fulfilled' && promiseResult.value) {
+      const { chainId, address, decimals, symbol, name } = promiseResult.value
+
+      acc[promiseResult.value.address] = new TokenWithLogo(undefined, chainId, address, decimals, symbol, name)
+    }
+    return acc
+  }, {})
+}

--- a/src/modules/orders/index.ts
+++ b/src/modules/orders/index.ts
@@ -1,1 +1,2 @@
 export * from './types'
+export * from './hooks/useTokensForOrdersList'

--- a/src/modules/orders/index.ts
+++ b/src/modules/orders/index.ts
@@ -1,2 +1,4 @@
 export * from './types'
 export * from './hooks/useTokensForOrdersList'
+export * from './hooks/useSWRProdOrders'
+export * from './utils/getTokensListFromOrders'

--- a/src/modules/orders/utils/getTokensListFromOrders.ts
+++ b/src/modules/orders/utils/getTokensListFromOrders.ts
@@ -1,0 +1,19 @@
+interface OrderTokensToFetch {
+  sellToken: string
+  buyToken: string
+}
+
+const isOrderToFetch = (input: any): input is OrderTokensToFetch => !!input.sellToken
+
+export function getTokensListFromOrders(orders: (OrderTokensToFetch | { order: OrderTokensToFetch })[]): string[] {
+  const set = new Set<string>()
+
+  orders.forEach((input) => {
+    const order = isOrderToFetch(input) ? input : input.order
+
+    set.add(order.sellToken)
+    set.add(order.buyToken)
+  })
+
+  return Array.from(set)
+}

--- a/src/modules/twap/hooks/useAllEmulatedOrders.ts
+++ b/src/modules/twap/hooks/useAllEmulatedOrders.ts
@@ -9,11 +9,13 @@ import { useIsSafeApp, useWalletInfo } from 'modules/wallet'
 
 import { useEmulatedPartOrders } from './useEmulatedPartOrders'
 import { useEmulatedTwapOrders } from './useEmulatedTwapOrders'
+import { useTwapOrdersTokens } from './useTwapOrdersTokens'
 
 export function useAllEmulatedOrders(): Order[] {
   const { chainId, account } = useWalletInfo()
-  const emulatedTwapOrders = useEmulatedTwapOrders()
-  const emulatedPartOrders = useEmulatedPartOrders()
+  const twapOrdersTokens = useTwapOrdersTokens()
+  const emulatedTwapOrders = useEmulatedTwapOrders(twapOrdersTokens)
+  const emulatedPartOrders = useEmulatedPartOrders(twapOrdersTokens)
   const isSafeApp = useIsSafeApp()
 
   const limitOrders = useOrders(chainId, account, OrderClass.LIMIT)

--- a/src/modules/twap/hooks/useEmulatedPartOrders.ts
+++ b/src/modules/twap/hooks/useEmulatedPartOrders.ts
@@ -3,7 +3,6 @@ import { useMemo } from 'react'
 
 import ms from 'ms.macro'
 
-import { useAllTokens } from 'legacy/hooks/Tokens'
 import useMachineTimeMs from 'legacy/hooks/useMachineTime'
 import { Order } from 'legacy/state/orders/actions'
 
@@ -16,8 +15,7 @@ import { mapPartOrderToStoreOrder } from '../utils/mapPartOrderToStoreOrder'
 
 const EMULATED_ORDERS_REFRESH_MS = ms`5s`
 
-export function useEmulatedPartOrders(): Order[] {
-  const tokensByAddress = useAllTokens()
+export function useEmulatedPartOrders(tokensByAddress: TokensByAddress | undefined): Order[] {
   const twapOrders = useAtomValue(twapOrdersAtom)
   const twapParticleOrders = useAtomValue(twapPartOrdersListAtom)
   // Update emulated part orders every 5 seconds to recalculate expired state
@@ -26,6 +24,7 @@ export function useEmulatedPartOrders(): Order[] {
   return useMemo(() => {
     // It's not possible, just to prevent react-hooks/exhaustive-deps errors
     if (!refresher) return []
+    if (!tokensByAddress) return []
 
     return emulatePartOrders(twapParticleOrders, twapOrders, tokensByAddress)
   }, [twapParticleOrders, twapOrders, tokensByAddress, refresher])

--- a/src/modules/twap/hooks/useEmulatedTwapOrders.ts
+++ b/src/modules/twap/hooks/useEmulatedTwapOrders.ts
@@ -3,10 +3,10 @@ import { useMemo } from 'react'
 
 import ms from 'ms.macro'
 
-import { useAllTokens } from 'legacy/hooks/Tokens'
 import useMachineTimeMs from 'legacy/hooks/useMachineTime'
 import { Order } from 'legacy/state/orders/actions'
 
+import { TokensByAddress } from 'modules/tokensList/state/tokensListAtom'
 import { useWalletInfo } from 'modules/wallet'
 
 import { twapOrdersListAtom } from '../state/twapOrdersListAtom'
@@ -14,8 +14,7 @@ import { mapTwapOrderToStoreOrder } from '../utils/mapTwapOrderToStoreOrder'
 
 const EMULATED_ORDERS_REFRESH_MS = ms`5s`
 
-export function useEmulatedTwapOrders(): Order[] {
-  const tokensByAddress = useAllTokens()
+export function useEmulatedTwapOrders(tokensByAddress: TokensByAddress | undefined): Order[] {
   const { account, chainId } = useWalletInfo()
   const allTwapOrders = useAtomValue(twapOrdersListAtom)
   // Update emulated twap orders every 5 seconds to recalculate expired state
@@ -26,6 +25,7 @@ export function useEmulatedTwapOrders(): Order[] {
   return useMemo(() => {
     // It's not possible, just to prevent react-hooks/exhaustive-deps errors
     if (!refresher) return []
+    if (!tokensByAddress) return []
 
     return allTwapOrders
       .filter((order) => order.chainId === chainId && order.safeAddress.toLowerCase() === accountLowerCase)

--- a/src/modules/twap/hooks/useTwapOrdersTokens.ts
+++ b/src/modules/twap/hooks/useTwapOrdersTokens.ts
@@ -1,0 +1,23 @@
+import { useAtomValue } from 'jotai/index'
+import { useMemo } from 'react'
+
+import { useAsyncMemo } from 'use-async-memo'
+
+import { useTokensForOrdersList, getTokensListFromOrders } from 'modules/orders'
+import { TokensByAddress } from 'modules/tokensList/state/tokensListAtom'
+
+import { twapOrdersListAtom } from '../state/twapOrdersListAtom'
+import { twapPartOrdersListAtom } from '../state/twapPartOrdersAtom'
+
+export function useTwapOrdersTokens(): TokensByAddress | undefined {
+  const allTwapOrders = useAtomValue(twapOrdersListAtom)
+  const twapPartOrders = useAtomValue(twapPartOrdersListAtom)
+
+  const getTokensForOrdersList = useTokensForOrdersList()
+
+  const tokensToFetch = useMemo(() => {
+    return getTokensListFromOrders([...allTwapOrders, ...twapPartOrders])
+  }, [allTwapOrders, twapPartOrders])
+
+  return useAsyncMemo(() => getTokensForOrdersList(tokensToFetch), [getTokensForOrdersList, tokensToFetch])
+}

--- a/src/utils/orderUtils/getTokenFromMapping.ts
+++ b/src/utils/orderUtils/getTokenFromMapping.ts
@@ -1,0 +1,19 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { getAddress } from '@ethersproject/address'
+import { Token } from '@uniswap/sdk-core'
+
+import { NATIVE_CURRENCY_BUY_TOKEN } from 'legacy/constants'
+
+import { getIsNativeToken } from '../getIsNativeToken'
+
+export function getTokenFromMapping(
+  address: string,
+  chainId: SupportedChainId,
+  tokens: { [p: string]: Token }
+): Token | null {
+  if (getIsNativeToken(chainId, address)) {
+    return NATIVE_CURRENCY_BUY_TOKEN[chainId]
+  }
+  // Some tokens are checksummed, some are not. Search both ways
+  return tokens[getAddress(address)] || tokens[address] || null
+}


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C053B0162VD/p1691651248930029

The cause of the bug:
Twap module naively loaded orders assuming all their tokens are in the CowSwap tokens list.

`GpOrdersUpdater` already contains the logic for fetching unknown tokens info from blockchain.
1. I've extracted that logic from `GpOrdersUpdater`: https://github.com/cowprotocol/cowswap/pull/3028/commits/ed08d60e63f53c3f032e5cac41c2f4f74676c7ed
2. Added it to `TWAP` module: https://github.com/cowprotocol/cowswap/pull/3028/commits/31f66a5c092c8838cc20d35a1da0904ffcf2271a

  # To Test

1. Open https://app.safe.global/apps/open?safe=eth:0x35a85f7440f2be30af569ccf08adb6b0207d110c&appUrl=https://barn.cow.fi/ (replace appUrl to vercel)
2. Navigate to Advanced orders
- [ ] App should not crash
