### PR TITLE
fix: disable limit orders state sync between tabs

### DIFF
--- a/src/jotaiStore.ts
+++ b/src/jotaiStore.ts
@@ -1,3 +1,20 @@
+import { createJSONStorage } from 'jotai/utils'
 import { createStore } from 'jotai/vanilla'
 
 export const jotaiStore = createStore()
+
+/**
+ * atomWithStorage() has build-in feature to persist state between all tabs
+ * To disable this feature we pass our own instance of storage
+ * https://github.com/pmndrs/jotai/pull/1004/files
+ *
+ * Important!
+ * In jotai@2.x they changed the fix above and now we have to patch subscribe method
+ */
+export const getJotaiIsolatedStorage = <T>() => {
+  const storage = createJSONStorage<T>(() => localStorage)
+
+  storage.subscribe = () => () => void 0
+
+  return storage
+}

--- a/src/modules/advancedOrders/state/advancedOrdersAtom.ts
+++ b/src/modules/advancedOrders/state/advancedOrdersAtom.ts
@@ -1,7 +1,9 @@
 import { atom } from 'jotai'
-import { atomWithStorage, createJSONStorage } from 'jotai/utils'
+import { atomWithStorage } from 'jotai/utils'
 
 import { OrderKind, SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import { getJotaiIsolatedStorage } from 'jotaiStore'
 
 import { DEFAULT_TRADE_DERIVED_STATE, TradeDerivedState } from 'modules/trade/types/TradeDerivedState'
 import { ExtendedTradeRawState, getDefaultTradeRawState } from 'modules/trade/types/TradeRawState'
@@ -27,12 +29,7 @@ export function getDefaultAdvancedOrdersState(chainId: SupportedChainId | null):
 export const advancedOrdersAtom = atomWithStorage<AdvancedOrdersRawState>(
   'advanced-orders-atom:v1',
   getDefaultAdvancedOrdersState(null),
-  /**
-   * atomWithStorage() has build-in feature to persist state between all tabs
-   * To disable this feature we pass our own instance of storage
-   * https://github.com/pmndrs/jotai/pull/1004/files
-   */
-  createJSONStorage(() => localStorage)
+  getJotaiIsolatedStorage()
 )
 
 export const updateAdvancedOrdersAtom = atom(null, (get, set, nextState: Partial<AdvancedOrdersRawState>) => {

--- a/src/modules/advancedOrders/state/advancedOrdersSettingsAtom.ts
+++ b/src/modules/advancedOrders/state/advancedOrdersSettingsAtom.ts
@@ -1,6 +1,8 @@
 import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 
+import { getJotaiIsolatedStorage } from 'jotaiStore'
+
 export interface AdvancedOrdersSettingsState {
   readonly showRecipient: boolean
 }
@@ -11,7 +13,8 @@ export const defaultAdvancedOrdersSettings: AdvancedOrdersSettingsState = {
 
 export const advancedOrdersSettingsAtom = atomWithStorage<AdvancedOrdersSettingsState>(
   'advanced-orders-settings-atom:v0',
-  defaultAdvancedOrdersSettings
+  defaultAdvancedOrdersSettings,
+  getJotaiIsolatedStorage()
 )
 
 export const updateAdvancedOrdersSettingsAtom = atom(

--- a/src/modules/limitOrders/state/limitOrdersRawStateAtom.ts
+++ b/src/modules/limitOrders/state/limitOrdersRawStateAtom.ts
@@ -1,7 +1,9 @@
 import { atom } from 'jotai'
-import { atomWithStorage, createJSONStorage } from 'jotai/utils'
+import { atomWithStorage } from 'jotai/utils'
 
 import { OrderKind, SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import { getJotaiIsolatedStorage } from 'jotaiStore'
 
 import { DEFAULT_TRADE_DERIVED_STATE, TradeDerivedState } from 'modules/trade/types/TradeDerivedState'
 import { ExtendedTradeRawState, getDefaultTradeRawState } from 'modules/trade/types/TradeRawState'
@@ -27,12 +29,7 @@ export function getDefaultLimitOrdersState(chainId: SupportedChainId | null): Li
 export const limitOrdersRawStateAtom = atomWithStorage<LimitOrdersRawState>(
   'limit-orders-atom:v4',
   getDefaultLimitOrdersState(null),
-  /**
-   * atomWithStorage() has build-in feature to persist state between all tabs
-   * To disable this feature we pass our own instance of storage
-   * https://github.com/pmndrs/jotai/pull/1004/files
-   */
-  createJSONStorage(() => localStorage)
+  getJotaiIsolatedStorage()
 )
 
 export const updateLimitOrdersRawStateAtom = atom(null, (get, set, nextState: Partial<LimitOrdersRawState>) => {

--- a/src/modules/limitOrders/state/limitOrdersSettingsAtom.ts
+++ b/src/modules/limitOrders/state/limitOrdersSettingsAtom.ts
@@ -1,6 +1,7 @@
 import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 
+import { getJotaiIsolatedStorage } from 'jotaiStore'
 import { Milliseconds, Timestamp } from 'types'
 
 import { defaultLimitOrderDeadline } from 'modules/limitOrders/pure/DeadlineSelector/deadlines'
@@ -24,7 +25,8 @@ export const defaultLimitOrdersSettings: LimitOrdersSettingsState = {
 
 export const limitOrdersSettingsAtom = atomWithStorage<LimitOrdersSettingsState>(
   'limit-orders-settings-atom:v2',
-  defaultLimitOrdersSettings
+  defaultLimitOrdersSettings,
+  getJotaiIsolatedStorage()
 )
 
 export const updateLimitOrdersSettingsAtom = atom(null, (get, set, nextState: Partial<LimitOrdersSettingsState>) => {

--- a/src/modules/twap/state/twapOrdersListAtom.ts
+++ b/src/modules/twap/state/twapOrdersListAtom.ts
@@ -1,5 +1,7 @@
 import { atom } from 'jotai'
-import { atomWithStorage, createJSONStorage } from 'jotai/utils'
+import { atomWithStorage } from 'jotai/utils'
+
+import { getJotaiIsolatedStorage } from 'jotaiStore'
 
 import store from 'legacy/state'
 import { deleteOrders } from 'legacy/state/orders/actions'
@@ -14,11 +16,7 @@ import { updateTwapOrdersList } from '../utils/updateTwapOrdersList'
 
 export type TwapOrdersList = { [key: string]: TwapOrderItem }
 
-export const twapOrdersAtom = atomWithStorage<TwapOrdersList>(
-  'twap-orders-list:v1',
-  {},
-  createJSONStorage(() => localStorage)
-)
+export const twapOrdersAtom = atomWithStorage<TwapOrdersList>('twap-orders-list:v1', {}, getJotaiIsolatedStorage())
 
 export const twapOrdersListAtom = atom<TwapOrderItem[]>((get) => {
   const { account, chainId } = get(walletInfoAtom)

--- a/src/modules/twap/state/twapOrdersSettingsAtom.ts
+++ b/src/modules/twap/state/twapOrdersSettingsAtom.ts
@@ -1,8 +1,9 @@
 import { atom } from 'jotai'
-import { atomWithStorage, createJSONStorage } from 'jotai/utils'
+import { atomWithStorage } from 'jotai/utils'
 
 import { Percent } from '@uniswap/sdk-core'
 
+import { getJotaiIsolatedStorage } from 'jotaiStore'
 import { Milliseconds } from 'types'
 
 import { DEFAULT_NUM_OF_PARTS, DEFAULT_ORDER_DEADLINE, DEFAULT_TWAP_SLIPPAGE } from '../const'
@@ -43,7 +44,7 @@ export const defaultTwapOrdersSettings: TwapOrdersSettingsState = {
 export const twapOrdersSettingsAtom = atomWithStorage<TwapOrdersSettingsState>(
   'twap-orders-settings-atom:v1',
   defaultTwapOrdersSettings,
-  createJSONStorage(() => localStorage)
+  getJotaiIsolatedStorage()
 )
 
 export const updateTwapOrdersSettingsAtom = atom(null, (get, set, nextState: Partial<TwapOrdersSettingsState>) => {

--- a/src/modules/twap/state/twapPartOrdersAtom.ts
+++ b/src/modules/twap/state/twapPartOrdersAtom.ts
@@ -1,7 +1,9 @@
 import { atom } from 'jotai'
-import { atomWithStorage, createJSONStorage } from 'jotai/utils'
+import { atomWithStorage } from 'jotai/utils'
 
 import { OrderParameters, SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import { getJotaiIsolatedStorage } from 'jotaiStore'
 
 import { walletInfoAtom } from 'modules/wallet/api/state'
 
@@ -26,7 +28,7 @@ const virtualFields: (keyof TwapPartOrderItem)[] = ['isCreatedInOrderBook', 'isC
 export const twapPartOrdersAtom = atomWithStorage<TwapPartOrders>(
   'twap-part-orders-list:v1',
   {},
-  createJSONStorage(() => localStorage)
+  getJotaiIsolatedStorage()
 )
 
 /**


### PR DESCRIPTION
# Summary
Context: https://cowservices.slack.com/archives/C0361CDG8GP/p1691675128738349

The bug was introduced in the recent jotai update: https://github.com/cowprotocol/cowswap/pull/2916

Before there was a solution to prevent sync jotai storages: https://github.com/pmndrs/jotai/pull/1004/files

In the `jotai@2.x` they removed this solution and now we have to patch storage to prevent the synchronization.