### PR TITLE
chore: disable price impact under certain error conditions

### DIFF
--- a/src/modules/advancedOrders/containers/AdvancedOrdersWidget/index.tsx
+++ b/src/modules/advancedOrders/containers/AdvancedOrdersWidget/index.tsx
@@ -1,5 +1,5 @@
-import { useAtomValue } from 'jotai'
-import { useSetAtom } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
+import { PropsWithChildren, ReactNode } from 'react'
 
 import { OrderKind } from '@cowprotocol/cow-sdk'
 
@@ -9,7 +9,7 @@ import { useAdvancedOrdersActions } from 'modules/advancedOrders/hooks/useAdvanc
 import { useAdvancedOrdersDerivedState } from 'modules/advancedOrders/hooks/useAdvancedOrdersDerivedState'
 import { updateAdvancedOrdersAtom } from 'modules/advancedOrders/state/advancedOrdersAtom'
 import { advancedOrdersSettingsAtom } from 'modules/advancedOrders/state/advancedOrdersSettingsAtom'
-import { useTradePriceImpact, TradeWidget, TradeWidgetSlots } from 'modules/trade'
+import { TradeWidget, TradeWidgetSlots, useTradePriceImpact } from 'modules/trade'
 import { BulletListItem, UnlockWidgetScreen } from 'modules/trade/pure/UnlockWidgetScreen'
 import { useTradeQuote } from 'modules/tradeQuote'
 import { TWAP_LEARN_MORE_LINK } from 'modules/twap/const'
@@ -34,7 +34,18 @@ const UNLOCK_SCREEN = {
   buttonLink: TWAP_LEARN_MORE_LINK,
 }
 
-export function AdvancedOrdersWidget({ children, updaters }: { children: JSX.Element; updaters?: JSX.Element }) {
+export type AdvancedOrdersWidgetParams = {
+  disablePriceImpact: boolean
+}
+
+export type AdvancedOrdersWidgetProps = PropsWithChildren<{
+  updaters?: ReactNode
+  params: AdvancedOrdersWidgetParams
+}>
+
+export function AdvancedOrdersWidget({ children, updaters, params }: AdvancedOrdersWidgetProps) {
+  const { disablePriceImpact } = params
+
   const {
     inputCurrency,
     outputCurrency,
@@ -93,7 +104,7 @@ export function AdvancedOrdersWidget({ children, updaters }: { children: JSX.Ele
     ),
   }
 
-  const params = {
+  const tradeWidgetParams = {
     recipient,
     compactView: true,
     disableNativeSelling: true,
@@ -101,6 +112,7 @@ export function AdvancedOrdersWidget({ children, updaters }: { children: JSX.Ele
     isTradePriceUpdating,
     priceImpact,
     isExpertMode: false, // TODO: bind value
+    disablePriceImpact,
   }
 
   return (
@@ -110,7 +122,7 @@ export function AdvancedOrdersWidget({ children, updaters }: { children: JSX.Ele
         disableOutput={true}
         slots={slots}
         actions={actions}
-        params={params}
+        params={tradeWidgetParams}
         inputCurrencyInfo={inputCurrencyInfo}
         outputCurrencyInfo={outputCurrencyInfo}
       />

--- a/src/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/src/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -31,6 +31,8 @@ import { DeadlineInput } from '../DeadlineInput'
 import { LimitOrdersConfirmModal } from '../LimitOrdersConfirmModal'
 import { RateInput } from '../RateInput'
 import { SettingsWidget } from '../SettingsWidget'
+import { LimitOrdersFormState, useLimitOrdersFormState } from '../../hooks/useLimitOrdersFormState'
+import { TradeFormValidation, useGetTradeFormValidation } from 'modules/tradeFormValidation'
 
 export const LIMIT_BULLET_LIST_CONTENT: BulletListItem[] = [
   { content: 'Set any limit price and time horizon' },
@@ -111,6 +113,9 @@ export function LimitOrdersWidget() {
     receiveAmountInfo: null,
   }
 
+  const localFormValidation = useLimitOrdersFormState()
+  const primaryFormValidation = useGetTradeFormValidation()
+
   const props: LimitOrdersProps = {
     inputCurrencyInfo,
     outputCurrencyInfo,
@@ -127,6 +132,8 @@ export function LimitOrdersWidget() {
     settingsState,
     feeAmount,
     widgetActions,
+    localFormValidation,
+    primaryFormValidation,
   }
 
   return <LimitOrders {...props} />
@@ -149,6 +156,8 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
     tradeContext,
     settingsState,
     feeAmount,
+    localFormValidation,
+    primaryFormValidation,
   } = props
 
   const inputCurrency = inputCurrencyInfo.currency
@@ -225,6 +234,12 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
     ),
   }
 
+  const disablePriceImpact =
+    localFormValidation === LimitOrdersFormState.FeeExceedsFrom ||
+    primaryFormValidation === TradeFormValidation.QuoteErrors ||
+    primaryFormValidation === TradeFormValidation.CurrencyNotSupported ||
+    primaryFormValidation === TradeFormValidation.WrapUnwrapFlow
+
   const params = {
     disableNonToken: false,
     compactView: false,
@@ -234,6 +249,7 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
     showRecipient,
     isTradePriceUpdating,
     priceImpact,
+    disablePriceImpact,
   }
 
   return (

--- a/src/modules/limitOrders/containers/LimitOrdersWidget/limitOrdersPropsChecker.ts
+++ b/src/modules/limitOrders/containers/LimitOrdersWidget/limitOrdersPropsChecker.ts
@@ -12,6 +12,8 @@ import { RateInfoParams } from 'common/pure/RateInfo'
 import { areFractionsEqual } from 'utils/areFractionsEqual'
 import { genericPropsChecker } from 'utils/genericPropsChecker'
 import { getAddress } from 'utils/getAddress'
+import { LimitOrdersFormState } from '../../hooks/useLimitOrdersFormState'
+import { TradeFormValidation } from '../../../tradeFormValidation'
 
 export interface LimitOrdersProps {
   inputCurrencyInfo: CurrencyInfo
@@ -32,6 +34,9 @@ export interface LimitOrdersProps {
   settingsState: LimitOrdersSettingsState
   feeAmount: CurrencyAmount<Currency> | null
   widgetActions: TradeWidgetActions
+
+  localFormValidation: LimitOrdersFormState | null
+  primaryFormValidation: TradeFormValidation | null
 }
 
 export function limitOrdersPropsChecker(a: LimitOrdersProps, b: LimitOrdersProps): boolean {
@@ -49,7 +54,9 @@ export function limitOrdersPropsChecker(a: LimitOrdersProps, b: LimitOrdersProps
     checkPriceImpact(a.priceImpact, b.priceImpact) &&
     checkTradeFlowContext(a.tradeContext, b.tradeContext) &&
     genericPropsChecker(a.settingsState, b.settingsState) &&
-    checkCurrencyAmount(a.feeAmount, b.feeAmount)
+    checkCurrencyAmount(a.feeAmount, b.feeAmount) &&
+    a.localFormValidation === b.localFormValidation &&
+    a.primaryFormValidation === b.primaryFormValidation
   )
 }
 

--- a/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/src/modules/swap/containers/SwapWidget/index.tsx
@@ -232,6 +232,8 @@ export function SwapWidget() {
     ),
   }
 
+  const disablePriceImpact = isFeeGreater
+
   const params = {
     isEoaEthFlow,
     compactView: true,
@@ -241,6 +243,7 @@ export function SwapWidget() {
     priceImpact: priceImpactParams,
     disableQuotePolling: true,
     isExpertMode,
+    disablePriceImpact,
   }
 
   return (

--- a/src/modules/trade/containers/TradeWidget/index.tsx
+++ b/src/modules/trade/containers/TradeWidget/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import { ReactNode, useEffect } from 'react'
 
 import { t } from '@lingui/macro'
 
@@ -46,14 +46,15 @@ interface TradeWidgetParams {
   priceImpact: PriceImpact
   disableQuotePolling?: boolean
   disableNativeSelling?: boolean
+  disablePriceImpact: boolean
 }
 
 export interface TradeWidgetSlots {
-  settingsWidget: JSX.Element
-  lockScreen?: JSX.Element
-  middleContent?: JSX.Element
-  bottomContent?: JSX.Element
-  updaters?: JSX.Element
+  settingsWidget: ReactNode
+  lockScreen?: ReactNode
+  middleContent?: ReactNode
+  bottomContent?: ReactNode
+  updaters?: ReactNode
 }
 
 export interface TradeWidgetProps {
@@ -84,6 +85,7 @@ export function TradeWidget(props: TradeWidgetProps) {
     disableQuotePolling = false,
     isExpertMode,
     disableNativeSelling = false,
+    disablePriceImpact,
   } = params
 
   const { chainId } = useWalletInfo()
@@ -176,7 +178,7 @@ export function TradeWidget(props: TradeWidgetProps) {
                   currencyInfo={
                     isWrapOrUnwrap ? { ...outputCurrencyInfo, amount: inputCurrencyInfo.amount } : outputCurrencyInfo
                   }
-                  priceImpactParams={priceImpact}
+                  priceImpactParams={!disablePriceImpact ? priceImpact : undefined}
                   topLabel={isWrapOrUnwrap ? undefined : outputCurrencyInfo.label}
                   {...currencyInputCommonProps}
                 />


### PR DESCRIPTION
# Summary

Disable price impact display when:

- [SWAP, LIMIT, TWAP] Fee is greater than sell amount
- [LIMIT, TWAP] Quote errors
- [LIMIT, TWAP] Currency not supported
- [LIMIT] Wrap/unwrap

# To Test

1. On Swap, pick a pair and select a small sell amount
* No price impact is displayed
2. Repeat for TWAP and LIMIT
* No price impact is displayed
3. Select native and wrapped native (or vice-versa) on LIMIT
* No price impact is displayed