### PR TITLE
chore: remove flaky test

### DIFF
--- a/apps/cowswap-frontend/src/legacy/utils/retry.test.ts
+++ b/apps/cowswap-frontend/src/legacy/utils/retry.test.ts
@@ -42,12 +42,11 @@ describe('retry', () => {
     await expect(promise).resolves.toEqual('abc')
   })
 
-  async function checkTime(fn: () => Promise<any>, min: number, max: number) {
+  async function checkTime(fn: () => Promise<any>, min: number) {
     const time = new Date().getTime()
     await fn()
     const diff = new Date().getTime() - time
     expect(diff).toBeGreaterThanOrEqual(min)
-    expect(diff).toBeLessThanOrEqual(max)
   }
 
   it('waits random amount of time between min and max', async () => {
@@ -56,8 +55,7 @@ describe('retry', () => {
       promises.push(
         checkTime(
           () => expect(retry(makeFn(4, 'abc'), { n: 3, maxWait: 100, minWait: 50 }).promise).rejects.toThrow('failure'),
-          150,
-          406
+          150
         )
       )
     }

--- a/apps/cowswap-frontend/src/legacy/utils/retry.test.ts
+++ b/apps/cowswap-frontend/src/legacy/utils/retry.test.ts
@@ -42,7 +42,7 @@ describe('retry', () => {
     await expect(promise).resolves.toEqual('abc')
   })
 
-  async function checkTime(fn: () => Promise<any>, min: number) {
+  async function checkMinTime(fn: () => Promise<any>, min: number) {
     const time = new Date().getTime()
     await fn()
     const diff = new Date().getTime() - time
@@ -53,7 +53,7 @@ describe('retry', () => {
     const promises = []
     for (let i = 0; i < 10; i++) {
       promises.push(
-        checkTime(
+        checkMinTime(
           () => expect(retry(makeFn(4, 'abc'), { n: 3, maxWait: 100, minWait: 50 }).promise).rejects.toThrow('failure'),
           150
         )


### PR DESCRIPTION
# Summary

This PR is to address this issue: https://github.com/cowprotocol/cowswap/actions/runs/5879543762/job/15944156125 

Basically this test is not deterministic

![image](https://github.com/cowprotocol/cowswap/assets/2352112/ff56144f-6b5f-4a24-a110-8aea808b5d1f)

The issue is that it tries to assert the execution time is between some boundaries. I believe in this case we can assert the minimum time of execution, but the maximum is not possible, there might be some slow executions, for example, because of a Garbage Collection tasks or any other reason. 

BEcause of this, the tests can't be deterministic, so is best to only assert the minimum time is respected.


# To Test
Make sure the test work