### PR TITLE
fix: version the storage name for the fallback handler

### DIFF
--- a/src/modules/twap/state/fallbackHandlerVerificationAtom.ts
+++ b/src/modules/twap/state/fallbackHandlerVerificationAtom.ts
@@ -9,4 +9,4 @@ type FallbackVerificationsState = {
 }
 
 export const { atom: fallbackHandlerVerificationAtom, updateAtom: updateFallbackHandlerVerificationAtom } =
-  atomWithPartialUpdate(atomWithStorage<FallbackVerificationsState>('fallbackHandlerVerification:v1', {}))
+  atomWithPartialUpdate(atomWithStorage<FallbackVerificationsState>('fallbackHandlerVerification:v2', {}))


### PR DESCRIPTION
# Summary

We are caching the result of the compatibility check for Safes and the Composable CoW framework

I noticed that the UI was allowing me to create orders but my domain verifier was pointing to the old composable cow contract.

The issue was JOITAI caching in my browser the result of the check, from the times where I had the old contracts. At that time I was compatible, but not any more.


It surprised me that, although we CACHE, we still do the call (but ignore the result). @shoom3301 you might want to double check that (although not too urgent any more)


Full context:
https://cowservices.slack.com/archives/C053B0162VD/p1692201999694339