### PR TITLE
fix(twap): display "Minimum sell size" banner only when there is a buy amount

### DIFF
--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/index.tsx
@@ -108,7 +108,7 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
           return <UnsupportedWalletWarning isSafeViaWc={isSafeViaWc} />
         }
 
-        if (chainId && localFormValidation === TwapFormState.SELL_AMOUNT_TOO_SMALL) {
+        if (localFormValidation === TwapFormState.SELL_AMOUNT_TOO_SMALL) {
           return <SmallPartVolumeWarning chainId={chainId} />
         }
 

--- a/apps/cowswap-frontend/src/modules/twap/pure/PrimaryActionButton/getTwapFormState.test.ts
+++ b/apps/cowswap-frontend/src/modules/twap/pure/PrimaryActionButton/getTwapFormState.test.ts
@@ -1,0 +1,52 @@
+import { CurrencyAmount } from '@uniswap/sdk-core'
+
+import { COW } from 'legacy/constants/tokens'
+import { WETH_GOERLI } from 'legacy/utils/goerli/constants'
+
+import { getTwapFormState, TwapFormState } from './getTwapFormState'
+
+import { ExtensibleFallbackVerification } from '../../services/verifyExtensibleFallback'
+import { TWAPOrder } from '../../types'
+
+const COW_GOERLI = COW[5]
+
+const twapOrder: TWAPOrder = {
+  sellAmount: CurrencyAmount.fromRawAmount(WETH_GOERLI, 10000000),
+  buyAmount: CurrencyAmount.fromRawAmount(COW_GOERLI, 10000000),
+  receiver: '0x00000000000000001',
+  numOfParts: 1,
+  startTime: 1000000,
+  timeInterval: 200,
+  span: 0,
+  appData: '0x000000',
+}
+
+describe('getTwapFormState()', () => {
+  describe('When sell fiat amount is under threshold', () => {
+    it('And order has buy amount, then should return SELL_AMOUNT_TOO_SMALL', () => {
+      const result = getTwapFormState({
+        isSafeApp: true,
+        verification: ExtensibleFallbackVerification.HAS_DOMAIN_VERIFIER,
+        twapOrder: { ...twapOrder },
+        sellAmountPartFiat: CurrencyAmount.fromRawAmount(WETH_GOERLI, 10000000),
+        chainId: 1,
+        partTime: 1000000,
+      })
+
+      expect(result).toEqual(TwapFormState.SELL_AMOUNT_TOO_SMALL)
+    })
+
+    it('And order does NOT have buy amount, then should return null', () => {
+      const result = getTwapFormState({
+        isSafeApp: true,
+        verification: ExtensibleFallbackVerification.HAS_DOMAIN_VERIFIER,
+        twapOrder: { ...twapOrder, buyAmount: CurrencyAmount.fromRawAmount(COW_GOERLI, 0) },
+        sellAmountPartFiat: CurrencyAmount.fromRawAmount(WETH_GOERLI, 10000000),
+        chainId: 1,
+        partTime: 1000000,
+      })
+
+      expect(result).toEqual(null)
+    })
+  })
+})

--- a/apps/cowswap-frontend/src/modules/twap/pure/PrimaryActionButton/getTwapFormState.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/pure/PrimaryActionButton/getTwapFormState.tsx
@@ -3,6 +3,8 @@ import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
 import { Nullish } from 'types'
 
+import { isFractionFalsy } from 'utils/isFractionFalsy'
+
 import { ExtensibleFallbackVerification } from '../../services/verifyExtensibleFallback'
 import { TWAPOrder } from '../../types'
 import { isPartTimeIntervalTooShort } from '../../utils/isPartTimeIntervalTooShort'
@@ -25,13 +27,13 @@ export enum TwapFormState {
 }
 
 export function getTwapFormState(props: TwapFormStateParams): TwapFormState | null {
-  const { isSafeApp, verification, sellAmountPartFiat, chainId, partTime } = props
+  const { twapOrder, isSafeApp, verification, sellAmountPartFiat, chainId, partTime } = props
 
   if (!isSafeApp) return TwapFormState.NOT_SAFE
 
   if (verification === null) return TwapFormState.LOADING_SAFE_INFO
 
-  if (isSellAmountTooSmall(sellAmountPartFiat, chainId)) {
+  if (!isFractionFalsy(twapOrder?.buyAmount) && isSellAmountTooSmall(sellAmountPartFiat, chainId)) {
     return TwapFormState.SELL_AMOUNT_TOO_SMALL
   }
 


### PR DESCRIPTION
# Summary

The banner sometimes is displayed when the buy token is not selected.

![image](https://github.com/cowprotocol/cowswap/assets/7122625/9721c975-ac5c-4f97-b0d1-ed58f955e193)


  # To Test

1. Select tokens pair
2. Set sell amount less than threshold ($5000 for mainnet)
- [ ] "Minimum sell size" is displayed
3. Change `appUrl` value in URL to `http://localhost:3000/#/100/swap/WXDAI/_` and navigate
- [ ] The page should be reloaded and opened in Swap
- [ ] Buy currency should be empty
4. Navigate to advanced orders
- [ ] AR: "Minimum sell size" is displayed
- [ ] ER: "Minimum sell size" is NOT displayed
