### PR TITLE
fix(snackbars): fix clickable area for closing

### DIFF
--- a/libs/snackbars/src/containers/SnackbarsWidget/index.tsx
+++ b/libs/snackbars/src/containers/SnackbarsWidget/index.tsx
@@ -26,9 +26,8 @@ const List = styled.div`
 
 const Host = styled.div`
   position: fixed;
-  top: 0;
-  right: 0;
-  padding: 20px;
+  top: 80px;
+  right: 20px;
   z-index: 6;
   min-width: 300px;
   max-width: 800px;
@@ -75,7 +74,7 @@ export function SnackbarsWidget() {
   )
 
   return (
-    <Host onClick={resetSnackbarsState}>
+    <Host>
       <List>
         {snackbars.map((snackbar) => {
           const icon = snackbar.icon
@@ -93,7 +92,7 @@ export function SnackbarsWidget() {
           )
         })}
       </List>
-      {snackbars.length > 0 && <Overlay />}
+      {snackbars.length > 0 && <Overlay onClick={resetSnackbarsState} />}
     </Host>
   )
 }

--- a/libs/snackbars/src/pure/SnackbarPopup/index.tsx
+++ b/libs/snackbars/src/pure/SnackbarPopup/index.tsx
@@ -11,6 +11,7 @@ const Wrapper = styled.div`
   position: relative;
   border-radius: 10px;
   padding: 20px 40px 20px 20px;
+  margin-bottom: 20px;
   overflow: hidden;
   border: 2px solid ${({ theme }) => theme.black};
   box-shadow: 2px 2px 0 ${({ theme }) => theme.black};


### PR DESCRIPTION
# Summary

1. Fixed clickable area for closing (before it was overlaying "Connect wallet" button)

<img width="362" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/2d80089b-6d85-4920-9ea9-bf8f94d4aecf">

2. Fixed displaying of multiple snackbars (before there were too close to each other)

<img width="431" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/76a158a4-97ce-4f3c-9aae-3f5313247248">

