### PR TITLE
ci: split PR ci and deployment to dev/barn/staging/prod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,9 @@
 name: CI
 
 on:
-  # build on PR creation/updates, also when pushing to main/develop, or create a release
+  # build on PR creation/updates
   pull_request:
     types: [opened, synchronize]
-  push:
-    branches: [main, develop]
-    tags: [v*]
-  workflow_dispatch: # Manually trigger it via UI/CLI/API
 
 env:
   REPO_NAME_SLUG: cowswap
@@ -136,39 +132,6 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login != github.repository_owner }}
         run: yarn lint
 
-  vercel-dev:
-    # Deploys to Vercel dev environment
-    name: Vercel dev
-    needs: [test, lint]
-    if: github.ref == 'refs/heads/develop'
-    uses: ./.github/workflows/vercel.yml
-    secrets: inherit
-    with:
-      env_name: dev
-
-  vercel-pre-prod:
-    # Deploys to Vercel staging and barn environments
-    name: Vercel pre-prod
-    needs: [test, lint]
-    if: startsWith(github.ref, 'refs/tags/v')
-    uses: ./.github/workflows/vercel.yml
-    secrets: inherit
-    strategy:
-      matrix:
-        env_name: [barn, staging] # deploys both in parallel
-    with:
-      env_name: ${{ matrix.env_name }}
-
-  vercel-prod:
-    # Deploys to Vercel prod environment
-    name: Vercel prod
-    needs: [test, lint]
-    if: github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/vercel.yml
-    secrets: inherit
-    with:
-      env_name: prod
-
   integration-tests:
     name: Cypress
     runs-on: ubuntu-latest
@@ -225,7 +188,7 @@ jobs:
       #       cypress-custom/videos
       #       cypress-custom/screenshots
 
-          
+
 
       # Open tmate ssh connection on failure for debugging
       # Uncomment when needed and push upstream

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,89 @@
+name: Deployment
+
+on:
+  # build when pushing to main/develop, or create a release
+  push:
+    branches: [main, develop]
+    tags: [v*]
+  workflow_dispatch: # Manually trigger it via UI/CLI/API
+
+env:
+  REPO_NAME_SLUG: cowswap
+  PR_NUMBER: ${{ github.event.number }}
+  NODE_VERSION: lts/gallium
+  REACT_APP_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+  REACT_APP_PINATA_API_KEY: ${{ secrets.REACT_APP_PINATA_API_KEY }}
+  REACT_APP_PINATA_SECRET_API_KEY: ${{ secrets.REACT_APP_PINATA_SECRET_API_KEY }}
+  REACT_APP_SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+  REACT_APP_BLOCKNATIVE_API_KEY: ${{ secrets.REACT_APP_BLOCKNATIVE_API_KEY }}
+  REACT_APP_GOOGLE_ANALYTICS_ID: ${{ secrets.REACT_APP_GOOGLE_ANALYTICS_ID }}
+  REACT_APP_AMPLITUDE_KEY: ${{ secrets.REACT_APP_AMPLITUDE_KEY }}
+
+jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
+
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules1-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules1-
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Cache generated files
+        id: cache-generated-files
+        uses: actions/cache@v3
+        with:
+          path: |
+            src/state/data
+            src/locales
+          key: ${{ runner.os }}-generatedFiles-${{ hashFiles('**/yarn.lock') }}
+
+  vercel-dev:
+    # Deploys to Vercel dev environment
+    name: Vercel dev
+    needs: [test, lint]
+    if: github.ref == 'refs/heads/develop'
+    uses: ./.github/workflows/vercel.yml
+    secrets: inherit
+    with:
+      env_name: dev
+
+  vercel-pre-prod:
+    # Deploys to Vercel staging and barn environments
+    name: Vercel pre-prod
+    needs: [test, lint]
+    if: startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/vercel.yml
+    secrets: inherit
+    strategy:
+      matrix:
+        env_name: [barn, staging] # deploys both in parallel
+    with:
+      env_name: ${{ matrix.env_name }}
+
+  vercel-prod:
+    # Deploys to Vercel prod environment
+    name: Vercel prod
+    needs: [test, lint]
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/vercel.yml
+    secrets: inherit
+    with:
+      env_name: prod


### PR DESCRIPTION
# Summary

Currently, we run Cypress/Unit tests/Lint on every deployment on dev/barn/staging/prod.
It seems unreasonable, all those steps we need only for PRs.