### PR TITLE
feat: add badges color functionality

### DIFF
--- a/apps/cowswap-frontend/src/legacy/theme/baseTheme.tsx
+++ b/apps/cowswap-frontend/src/legacy/theme/baseTheme.tsx
@@ -1,4 +1,4 @@
-import { transparentize, lighten } from 'polished'
+import { transparentize, lighten, darken } from 'polished'
 import { createGlobalStyle, css } from 'styled-components/macro'
 
 import Cursor1 from 'legacy/assets/cow-swap/cursor1.gif'
@@ -386,15 +386,34 @@ export const UniFixedGlobalStyle = css`
 
 export const UniThemedGlobalStyle = css`
   :root {
-    // CSS Variables
-    --cow-color-text1: ${({ theme }) => theme.text1};
-    --cow-color-text1-opacity-25: ${({ theme }) => theme.text1 + '40'};
+    // CSS Variables ===============================
+
+    // Colors
     --cow-color-white: ${({ theme }) => theme.white};
     --cow-color-blue: ${({ theme }) => theme.bg2};
     --cow-color-border: ${({ theme }) => theme.grey1};
     --cow-color-lightBlue: ${({ theme }) => theme.information};
-    --cow-color-lightBlue-opacity-90: ${({ theme }) => transparentize(0.9, theme.information)};
-    --cow-color-lightBlue-opacity-80: ${({ theme }) => transparentize(0.8, theme.information)};
+    --cow-color-lightBlue-opacity-90: ${({ theme }) => transparentize(0.1, theme.information)}; // 90% opacity
+    --cow-color-lightBlue-opacity-80: ${({ theme }) => transparentize(0.2, theme.information)}; // 80% opacity
+    --cow-color-yellow: ${({ theme }) => theme.alert};
+
+    // States
+    --cow-color-information: var(--cow-color-lightBlue);
+    --cow-color-information-bg: ${({ theme }) => (theme.darkMode ? transparentize(0.9, theme.information) : transparentize(0.85, theme.information))};
+    --cow-color-information-text: ${({ theme }) => (theme.darkMode ? lighten(0.2, theme.information) : darken(0.2, theme.information))};
+
+    --cow-color-alert: ${({ theme }) => theme.alert};
+    --cow-color-alert-bg: ${({ theme }) => (theme.darkMode ? transparentize(0.9, theme.alert) : transparentize(0.85, theme.alert))};
+    --cow-color-alert-text: ${({ theme }) => (theme.darkMode ? lighten(0.2, theme.alert) : darken(0.2, theme.alert))};
+
+    --cow-color-success: ${({ theme }) => theme.success};
+    --cow-color-success-bg: ${({ theme }) => (theme.darkMode ? transparentize(0.9, theme.success) : transparentize(0.85, theme.success))};
+    --cow-color-success-text: ${({ theme }) => (theme.darkMode ? lighten(0.2, theme.success) : darken(0.1, theme.success))};
+
+    // Text
+    --cow-color-text1: ${({ theme }) => theme.text1};
+    --cow-color-text1-inactive: ${({ theme }) => transparentize(0.4, theme.text1)};
+    --cow-color-text1-opacity-25: ${({ theme }) => transparentize(0.75, theme.text1)};
   }
 
   html {

--- a/apps/cowswap-frontend/src/modules/application/containers/TradeWidgetLinks/index.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/TradeWidgetLinks/index.tsx
@@ -59,7 +59,7 @@ const MenuItem = ({ routePath, item, isActive }: { routePath: string; item: Menu
     <styledEl.Link to={routePath}>
       <Trans>{item.label}</Trans>
       {item.featureGuard && (
-        <styledEl.Badge>
+        <styledEl.Badge type={'success'}>
           <Trans>NEW!</Trans>
         </styledEl.Badge>
       )}

--- a/apps/cowswap-frontend/src/modules/application/containers/TradeWidgetLinks/index.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/TradeWidgetLinks/index.tsx
@@ -59,7 +59,7 @@ const MenuItem = ({ routePath, item, isActive }: { routePath: string; item: Menu
     <styledEl.Link to={routePath}>
       <Trans>{item.label}</Trans>
       {item.featureGuard && (
-        <styledEl.Badge type={'success'}>
+        <styledEl.Badge>
           <Trans>NEW!</Trans>
         </styledEl.Badge>
       )}

--- a/apps/cowswap-frontend/src/modules/application/containers/TradeWidgetLinks/index.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/TradeWidgetLinks/index.tsx
@@ -59,8 +59,8 @@ const MenuItem = ({ routePath, item, isActive }: { routePath: string; item: Menu
     <styledEl.Link to={routePath}>
       <Trans>{item.label}</Trans>
       {item.featureGuard && (
-        <styledEl.Badge>
-          <Trans>Beta</Trans>
+        <styledEl.Badge type={'success'}>
+          <Trans>NEW!</Trans>
         </styledEl.Badge>
       )}
     </styledEl.Link>

--- a/apps/cowswap-frontend/src/modules/application/containers/TradeWidgetLinks/styled.ts
+++ b/apps/cowswap-frontend/src/modules/application/containers/TradeWidgetLinks/styled.ts
@@ -27,7 +27,7 @@ export const Badge = styled.div<{ type?: BadgeType }>`
   font-size: 9px;
   font-weight: inherit;
   text-transform: uppercase;
-  padding: ${({ type }) => (type === 'default' ? '0' : '4px 6px')};
+  padding: ${({ type }) => (!type || type === 'default' ? '0' : '4px 6px')};
   letter-spacing: 0.2px;
   font-weight: 600;
   transition: color 0.15s ease-in-out;

--- a/apps/cowswap-frontend/src/modules/application/containers/TradeWidgetLinks/styled.ts
+++ b/apps/cowswap-frontend/src/modules/application/containers/TradeWidgetLinks/styled.ts
@@ -2,20 +2,40 @@ import { transparentize } from 'polished'
 import { NavLink } from 'react-router-dom'
 import styled, { css } from 'styled-components/macro'
 
-export const Badge = styled.div`
-  background: transparent;
-  color: ${({ theme }) => transparentize(0.4, theme.text1)};
+type BadgeType = 'information' | 'success' | 'alert' | 'default';
+
+const badgeBackgrounds: Record<BadgeType, string> = {
+  information: 'var(--cow-color-information-bg)',
+  alert: 'var(--cow-color-alert-bg)',
+  success: 'var(--cow-color-success-bg)',
+  default: 'transparent', // text only
+};
+
+const badgeColors: Record<BadgeType, string> = {
+  information: 'var(--cow-color-information-text)',
+  alert: 'var(--cow-color-alert-text)',
+  success: 'var(--cow-color-success-text)',
+  default: 'var(--cow-color-text1-inactive)', // text only
+};
+
+export const Badge = styled.div<{ type?: BadgeType }>`
+  background: ${({ type }) => badgeBackgrounds[type || 'default']};
+  color: ${({ type }) => badgeColors[type || 'default']};
   border: 0;
   cursor: pointer;
   border-radius: 16px;
   font-size: 9px;
   font-weight: inherit;
   text-transform: uppercase;
-  padding: 0;
+  padding: ${({ type }) => (type === 'default' ? '0' : '4px 6px')};
   letter-spacing: 0.2px;
   font-weight: 600;
   transition: color 0.15s ease-in-out;
   margin: -8px 0 0 0;
+
+  a & {
+    color: ${({ type }) => badgeColors[type || 'default']};
+  }
 `
 
 export const Link = styled(NavLink)`
@@ -28,9 +48,8 @@ export const Link = styled(NavLink)`
   line-height: 1;
   transition: color 0.15s ease-in-out;
 
-  &:hover,
-  &:hover > ${Badge} {
-    color: ${({ theme }) => theme.text1};
+  &:hover {
+    color: inherit;
   }
 `
 
@@ -67,7 +86,7 @@ export const MenuItem = styled.div<{ isActive?: boolean }>`
       }
 
       ${Link} > ${Badge} {
-        margin: 0 0 0 3px;
+        display: none;
       }
     `}
 `


### PR DESCRIPTION
# Summary

- Adds alternative badges with the 'type' prop. 
- The default is without a prop and text only.
- On click of a menu item, the badge will be removed.
- Added CSS color variables (incrementally adding these over time).

## Future todo:
- Add CSS unused var linter
- Consolidate `BadgerType` with `BANNER_CONFIG` from `apps/cowswap-frontend/src/common/pure/InlineBanner/index.tsx` as the banner/badge styles are of similar nature and appearance. 

**Default text example (type = not passed as a prop)**
<img width="586" alt="Screenshot 2023-08-22 at 13 18 58" src="https://github.com/cowprotocol/cowswap/assets/31534717/9364d1d2-8e3f-4824-aab5-a6991ab296d8">

**Current state for the NEW! badge:**

https://github.com/cowprotocol/cowswap/assets/31534717/bd156f32-5eba-48dc-943d-f9c3d02c4abf


https://github.com/cowprotocol/cowswap/assets/31534717/4c635aca-f08e-43cc-9b3a-b1d41db2bdf4

