### PR TITLE
fix: handle error in case erc1155 id cannot be converted to BigNumber

### DIFF
--- a/apps/cowswap-frontend/src/legacy/hooks/useENSAvatar.ts
+++ b/apps/cowswap-frontend/src/legacy/hooks/useENSAvatar.ts
@@ -12,7 +12,7 @@ import { fetchWithBackoff } from 'common/utils/fetch'
 import { useSingleCallResult } from 'lib/hooks/multicall'
 import uriToHttp from 'lib/utils/uriToHttp'
 
-import { useENSRegistrarContract, useENSResolverContract, useERC721Contract, useERC1155Contract } from './useContract'
+import { useENSRegistrarContract, useENSResolverContract, useERC1155Contract, useERC721Contract } from './useContract'
 import useDebounce from './useDebounce'
 import useENSName from './useENSName'
 
@@ -144,7 +144,7 @@ function useERC1155Uri(
   const uri = useSingleCallResult(contract, 'uri', idArgument)
   // ERC-1155 allows a generic {id} in the URL, so prepare to replace if relevant,
   //   in lowercase hexadecimal (with no 0x prefix) and leading zero padded to 64 hex characters.
-  const idHex = id ? hexZeroPad(BigNumber.from(id).toHexString(), 32).substring(2) : id
+  const idHex = getIdHex(id)
   return useMemo(
     () => ({
       uri: !enforceOwnership || balance.result?.[0] > 0 ? uri.result?.[0]?.replaceAll('{id}', idHex) : undefined,
@@ -152,4 +152,14 @@ function useERC1155Uri(
     }),
     [balance.loading, balance.result, enforceOwnership, uri.loading, uri.result, idHex]
   )
+}
+
+function getIdHex(id: string | undefined): string | undefined {
+  try {
+    return id ? hexZeroPad(BigNumber.from(id).toHexString(), 32).substring(2) : id
+  } catch (e) {
+    console.log(`Couldn't get id hex from id: ${id}`, e)
+
+    return undefined
+  }
 }


### PR DESCRIPTION
# Summary

Attempt to fix user reported error

![image](https://github.com/cowprotocol/cowswap/assets/43217/e71902cf-608c-48d7-b9b4-276a52996756)

This fix parts from the assumption that the ens NFT avatar is passing a bad value onto a BigNumber constructor.

# To Test

Unsure, as I have not been able to reproduce it yet

*Update*: User confirmed it fixes the problem \o/

# Background

User's setup:
- Brave + MM + Ledger, with ens name and ERC721 set as avatar
- User also tried on Chrome + Rabby + Ledger and faced the same issue

# The problem

User's avatar is set to `http://eip155:1/erc721:0xed5af388653567af2f388e6224dc7c4b3241c544/0000` (replaced the actual id with `0000` to preserve user's identity)

The hooks that processes the avatar URL is not expecting an url in this format https://github.com/cowprotocol/cowswap/blob/76c1c7c9d1c41934eb8b9762d00389b4917616b4/apps/cowswap-frontend/src/legacy/hooks/useENSAvatar.ts#L78C1-L78C1

When splitting it by `:`, we get 4 parts:

```
["http","//eip155","1/erc721","0xed5af388653567af2f388e6224dc7c4b3241c544/3329"]
```

Due to the unexpected format, we end up with the `id` being set to `erc721` instead of `0000`.
Down the line the id is converted to a BigNumber to be converted to a hexString.

That's when it fails, and that's what this fix does.

This fix does not, however, fixes the loading of the different format.
I'll leave that as a task on the backlog as the immediate issue is being addressed, and the user is able to connect to the interface without crashing.


