### PR TITLE
fix: update only current account pending orders

### DIFF
--- a/apps/cowswap-frontend/src/legacy/hooks/useRecentActivity.ts
+++ b/apps/cowswap-frontend/src/legacy/hooks/useRecentActivity.ts
@@ -279,9 +279,9 @@ export function groupActivitiesByDay(activities: ActivityDescriptors[]): Activit
   })
 }
 
-export function useRecentActivityLastPendingOrder() {
-  const { chainId } = useWalletInfo()
-  const pending = useCombinedPendingOrders({ chainId })
+export function useRecentActivityLastPendingOrder(): Order | null {
+  const { chainId, account } = useWalletInfo()
+  const pending = useCombinedPendingOrders({ chainId, account })
 
   return useMemo(() => {
     if (!pending.length) {

--- a/apps/cowswap-frontend/src/legacy/state/orders/hooks.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/hooks.ts
@@ -234,7 +234,13 @@ export const useOrdersById = ({ chainId, ids }: GetOrdersByIdParams): OrdersMap 
   }, [allOrders, ids])
 }
 
-export const useCombinedPendingOrders = ({ chainId }: GetOrdersParams): Order[] => {
+export const useCombinedPendingOrders = ({
+  chainId,
+  account,
+}: {
+  chainId: SupportedChainId
+  account: string | undefined
+}): Order[] => {
   const state = useSelector<
     AppState,
     | {
@@ -257,13 +263,15 @@ export const useCombinedPendingOrders = ({ chainId }: GetOrdersParams): Order[] 
   })
 
   return useMemo(() => {
-    if (!state) return []
+    if (!state || !account) return []
 
     const { pending, presignaturePending, creating } = state
     const allPending = Object.values(pending).concat(Object.values(presignaturePending)).concat(Object.values(creating))
 
-    return allPending.map(_deserializeOrder).filter(isTruthy)
-  }, [state])
+    return allPending.map(_deserializeOrder).filter((order) => {
+      return order?.owner.toLowerCase() === account.toLowerCase()
+    }) as Order[]
+  }, [state, account])
 }
 
 /**

--- a/apps/cowswap-frontend/src/legacy/state/orders/updaters/PendingOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/updaters/PendingOrdersUpdater.ts
@@ -268,8 +268,10 @@ export function PendingOrdersUpdater(): null {
   const { chainId, account } = useWalletInfo()
   const removeOrdersToCancel = useSetAtom(removeOrdersToCancelAtom)
 
-  const pending = useCombinedPendingOrders({ chainId })
-  const isUpdating = useRef(false) // TODO: Implement using SWR or retry/cancellable promises
+  const pending = useCombinedPendingOrders({ chainId, account })
+  // TODO: Implement using SWR or retry/cancellable promises
+  const isUpdatingMarket = useRef(false)
+  const isUpdatingLimit = useRef(false)
 
   // Ref, so we don't rerun useEffect
   const pendingRef = useRef(pending)
@@ -299,6 +301,8 @@ export function PendingOrdersUpdater(): null {
       if (!account) {
         return []
       }
+
+      const isUpdating = orderClass === OrderClass.LIMIT ? isUpdatingLimit : isUpdatingMarket
 
       if (!isUpdating.current) {
         isUpdating.current = true
@@ -349,6 +353,9 @@ export function PendingOrdersUpdater(): null {
       () => updateOrders(chainId, account, OrderClass.LIMIT),
       LIMIT_OPERATOR_API_POLL_INTERVAL
     )
+
+    updateOrders(chainId, account, OrderClass.MARKET)
+    updateOrders(chainId, account, OrderClass.LIMIT)
 
     return () => {
       clearInterval(marketInterval)

--- a/apps/cowswap-frontend/src/legacy/state/orders/updaters/SpotPricesUpdater.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/updaters/SpotPricesUpdater.ts
@@ -25,8 +25,8 @@ type MarketRecord = Record<
   }
 >
 
-function useMarkets(chainId: SupportedChainId): MarketRecord {
-  const pending = useCombinedPendingOrders({ chainId })
+function useMarkets(chainId: SupportedChainId, account: string | undefined): MarketRecord {
+  const pending = useCombinedPendingOrders({ chainId, account })
 
   return useSafeMemo(() => {
     return pending.reduce<Record<string, { chainId: number; inputCurrency: Token; outputCurrency: Token }>>(
@@ -115,11 +115,11 @@ function useUpdatePending(props: UseUpdatePendingProps) {
  * Queries the spot price for given markets at every SPOT_PRICE_CHECK_POLL_INTERVAL
  */
 export function SpotPricesUpdater(): null {
-  const { chainId } = useWalletInfo()
+  const { chainId, account } = useWalletInfo()
 
   const isWindowVisible = useIsWindowVisible()
   const updateSpotPrices = useSetAtom(updateSpotPricesAtom)
-  const markets = useMarkets(chainId)
+  const markets = useMarkets(chainId, account)
   const isUpdating = useRef(false) // TODO: Implement using SWR or retry/cancellable promises
   const updatePending = useUpdatePending({ isUpdating, markets, updateSpotPrices })
 

--- a/apps/cowswap-frontend/src/legacy/state/orders/updaters/SpotPricesUpdater.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/updaters/SpotPricesUpdater.ts
@@ -55,18 +55,25 @@ function useMarkets(chainId: SupportedChainId, account: string | undefined): Mar
 }
 
 interface UseUpdatePendingProps {
+  isWindowVisibleRef: React.MutableRefObject<boolean>
   isUpdating: React.MutableRefObject<boolean>
   markets: MarketRecord
   updateSpotPrices: (update: UpdateSpotPriceAtom) => void
 }
 
 function useUpdatePending(props: UseUpdatePendingProps) {
-  const { isUpdating, markets, updateSpotPrices } = props
+  const { isWindowVisibleRef, isUpdating, markets, updateSpotPrices } = props
+
   return useCallback(async () => {
     if (isUpdating.current) {
       console.debug('[SpotPricesUpdater] Update in progress, skipping')
       return
     }
+
+    if (!isWindowVisibleRef.current) {
+      return
+    }
+
     console.debug('[SpotPricesUpdater] Starting update')
 
     // Lock updates
@@ -118,20 +125,18 @@ export function SpotPricesUpdater(): null {
   const { chainId, account } = useWalletInfo()
 
   const isWindowVisible = useIsWindowVisible()
+  const isWindowVisibleRef = useRef(isWindowVisible)
+
   const updateSpotPrices = useSetAtom(updateSpotPricesAtom)
   const markets = useMarkets(chainId, account)
   const isUpdating = useRef(false) // TODO: Implement using SWR or retry/cancellable promises
-  const updatePending = useUpdatePending({ isUpdating, markets, updateSpotPrices })
+  const updatePending = useUpdatePending({ isWindowVisibleRef, isUpdating, markets, updateSpotPrices })
+
+  isWindowVisibleRef.current = isWindowVisible
 
   useEffect(() => {
-    if (!chainId || !isWindowVisible) {
-      console.debug('[SpotPricesUpdater] No need to update spot prices')
-      return
-    }
-
-    console.debug('[SpotPricesUpdater] Periodically check spot prices')
-
     updatePending()
+
     const interval = setInterval(updatePending, SPOT_PRICE_CHECK_POLL_INTERVAL)
 
     return () => clearInterval(interval)


### PR DESCRIPTION
# Summary

Accidentally found that we do lots of excessive `native_price` requests.

1. `useCombinedPendingOrders` didn't filter orders by the current account, so we updated orders from other accounts
2. `SpotPricesUpdater` didn't check `isWindowVisible` inside of the interval calls

Another problem was found in `PendingOrdersUpdater`.
Here we used `isUpdating` ref to prevent updating while there is another pending update.
But, we run two intervals for limit and market orders.
So, when market orders are updating in progress we can't update limit orders and the opposite.

<img width="764" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/8593f015-b532-4441-838a-bfea0cf21e0b">


  # To Test

1. Create 2 orders from account 0x00001 and keep them pending
2. Switch to account 0x00002 where no pending accounts
3. Monitor network for periodical `native_price` requests
- [ ] AR: there are `native_price` requests
- [ ] ER: no `native_price` requests

