### PR TITLE
chore: set order-book API urls from env file if present

### DIFF
--- a/apps/cowswap-frontend/.env
+++ b/apps/cowswap-frontend/.env
@@ -5,6 +5,9 @@ REACT_APP_PRICE_FEED_1INCH_ENABLED=true
 REACT_APP_PRICE_FEED_0X_ENABLED=true
 REACT_APP_PRICE_FEED_COINGECKO_ENABLED=true
 
+# Order book API urls
+#REACT_APP_ORDER_BOOK_URLS='{"1":"https://YOUR_HOST","100":"https://YOUR_HOST","5":"https://YOUR_HOST"}'
+
 # AppData, build yours at https://explorer.cow.fi/appdata
 REACT_APP_FULL_APP_DATA_PRODUCTION='{"version":"0.7.0","appCode":"CoW Swap","environment":"production","metadata":{}}'
 REACT_APP_FULL_APP_DATA_ENS='{"version":"0.7.0","appCode":"CoW Swap","environment":"ens","metadata":{}}'

--- a/apps/cowswap-frontend/src/cowSdk.ts
+++ b/apps/cowswap-frontend/src/cowSdk.ts
@@ -1,9 +1,16 @@
 import { MetadataApi } from '@cowprotocol/app-data'
-import { OrderBookApi } from '@cowprotocol/cow-sdk'
+import { ORDER_BOOK_PROD_CONFIG, ORDER_BOOK_STAGING_CONFIG, OrderBookApi } from '@cowprotocol/cow-sdk'
 
 import { isBarnBackendEnv } from 'legacy/utils/environments'
+
+const prodBaseUrls = process.env.REACT_APP_ORDER_BOOK_URLS
+  ? JSON.parse(process.env.REACT_APP_ORDER_BOOK_URLS)
+  : isBarnBackendEnv
+  ? ORDER_BOOK_STAGING_CONFIG
+  : ORDER_BOOK_PROD_CONFIG
 
 export const metadataApiSDK = new MetadataApi()
 export const orderBookApi = new OrderBookApi({
   env: isBarnBackendEnv ? 'staging' : 'prod',
+  baseUrls: prodBaseUrls,
 })


### PR DESCRIPTION
@mfw78 is going to make a `docker compose` setup with the set of services: frontend, backend, etc.
For this purpose, we need the possibility to specify custom URLs for order-book API.