### PR TITLE
fix(trade): check allowance before pending tx for approval state

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useApproveState.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useApproveState.ts
@@ -12,6 +12,7 @@ import { useHasPendingApproval } from 'legacy/state/enhancedTransactions/hooks'
 import { useWalletInfo } from 'modules/wallet'
 
 import { useSafeMemo } from 'common/hooks/useSafeMemo'
+import { FractionUtils } from 'utils/fractionUtils'
 
 function getCurrencyToApprove(amountToApprove: Nullish<CurrencyAmount<Currency>>): Token | undefined {
   if (!amountToApprove) return undefined
@@ -30,6 +31,10 @@ export function useApproveState(amountToApprove: Nullish<CurrencyAmount<Currency
   const approvalStateBase = useSafeMemo(() => {
     if (!amountToApprove || !spender || !currentAllowance) {
       return ApprovalState.UNKNOWN
+    }
+
+    if (FractionUtils.gte(currentAllowance, amountToApprove)) {
+      return ApprovalState.APPROVED
     }
 
     if (pendingApproval) {

--- a/apps/cowswap-frontend/src/utils/fractionUtils.ts
+++ b/apps/cowswap-frontend/src/utils/fractionUtils.ts
@@ -59,11 +59,11 @@ export class FractionUtils {
     return new Fraction(JSBI.add(quotient, JSBI.BigInt(remainder.toFixed(0, undefined, rounding))), 1)
   }
 
-  static gte(fraction: Fraction, value: BigintIsh): boolean {
+  static gte(fraction: Fraction, value: Fraction | BigintIsh): boolean {
     return fraction.equalTo(value) || fraction.greaterThan(value)
   }
 
-  static lte(fraction: Fraction, value: BigintIsh): boolean {
+  static lte(fraction: Fraction, value: Fraction | BigintIsh): boolean {
     return fraction.equalTo(value) || fraction.lessThan(value)
   }
 


### PR DESCRIPTION
# Summary

Context:
https://cowservices.slack.com/archives/C0361CDG8GP/p1693391059969019

This change doesn't fix the cause of the problem, but it allows to get rid of the problem just be page refreshing.

  # To Test

I wasn't able to reproduce it, but most likely the frontend didn't receive an event about approval tx mining.
