### PR TITLE
chore: fix DEFAULT_USD_AMOUNT_STATE value

### DIFF
--- a/apps/cowswap-frontend/src/modules/usdAmount/hooks/useUsdAmount.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/hooks/useUsdAmount.ts
@@ -12,7 +12,7 @@ export interface UsdAmountInfo {
   isLoading: boolean
 }
 
-const DEFAULT_USD_AMOUNT_STATE = { value: null, isLoading: true }
+const DEFAULT_USD_AMOUNT_STATE = { value: null, isLoading: false }
 
 export function useUsdAmount(_amount: Nullish<CurrencyAmount<Currency>>): UsdAmountInfo {
   const amount = currencyAmountToTokenAmount(_amount)


### PR DESCRIPTION
# Summary

Just forgot to change the default isLoading value 🤦‍♂️

>one thing I noticed is that now when I pick both tokens but without inserting any amount, the price impact status is forever loading

![image](https://github.com/cowprotocol/cowswap/assets/7122625/70d631d3-e6c9-4c25-adcb-9fa56fe0eca5)

