### PR TITLE
fix(eth-flow): additionally check eth-flow order id in smart-contract

### DIFF
--- a/apps/cowswap-frontend/src/legacy/hooks/useContract.ts
+++ b/apps/cowswap-frontend/src/legacy/hooks/useContract.ts
@@ -9,7 +9,6 @@ import {
   Erc721,
   Erc1155,
   Weth,
-  CoWSwapEthFlowJson,
   ArgentWalletDetectorAbi,
   Eip2612Abi,
   EnsPublicResolverAbi,
@@ -26,6 +25,7 @@ import {
   CoWSwapEthFlow,
   vCowAbi,
   UniswapInterfaceMulticall,
+  CoWSwapEthFlowAbi,
 } from '@cowswap/abis'
 import { Contract } from '@ethersproject/contracts'
 import type { JsonRpcProvider } from '@ethersproject/providers'
@@ -114,8 +114,6 @@ export function useInterfaceMulticall() {
   return useContract<UniswapInterfaceMulticall>(MULTICALL_ADDRESS, MulticallABI, false) as UniswapInterfaceMulticall
 }
 
-const COWSWAP_ETHFLOW_ABI = CoWSwapEthFlowJson.abi
-
 export function useEthFlowContract(): CoWSwapEthFlow | null {
   const { chainId } = useWalletInfo()
 
@@ -123,7 +121,7 @@ export function useEthFlowContract(): CoWSwapEthFlow | null {
 
   const contractAddress = chainId ? COWSWAP_ETHFLOW_CONTRACT_ADDRESS[contractEnv][chainId] : undefined
 
-  return useContract<CoWSwapEthFlow>(contractAddress, COWSWAP_ETHFLOW_ABI, true)
+  return useContract<CoWSwapEthFlow>(contractAddress, CoWSwapEthFlowAbi, true)
 }
 
 export function useGP2SettlementContract(): GPv2Settlement | null {

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useCheckEthFlowOrderExists.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useCheckEthFlowOrderExists.ts
@@ -10,7 +10,7 @@ export interface EthFlowOrderExistsCallback {
   (orderId: string, orderDigest: string): Promise<boolean>
 }
 
-export function useIsEthFlowOrderExists(): EthFlowOrderExistsCallback {
+export function useCheckEthFlowOrderExists(): EthFlowOrderExistsCallback {
   const ethFlowInFlightOrderIds = useAtomValue(ethFlowInFlightOrderIdsAtom)
   const ethFlowContract = useEthFlowContract()
 

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useEthFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useEthFlowContext.ts
@@ -10,7 +10,7 @@ import { FlowType, getFlowContext, useBaseFlowContextSetup } from 'modules/swap/
 import { EthFlowContext } from 'modules/swap/services/types'
 import { addInFlightOrderIdAtom } from 'modules/swap/state/EthFlow/ethFlowInFlightOrderIdsAtom'
 
-import { useIsEthFlowOrderExists } from './useIsEthFlowOrderExists'
+import { useCheckEthFlowOrderExists } from './useCheckEthFlowOrderExists'
 
 export function useEthFlowContext(): EthFlowContext | null {
   const contract = useEthFlowContract()
@@ -19,7 +19,7 @@ export function useEthFlowContext(): EthFlowContext | null {
 
   const addInFlightOrderId = useSetAtom(addInFlightOrderIdAtom)
 
-  const isEthFlowOrderExists = useIsEthFlowOrderExists()
+  const checkEthFlowOrderExists = useCheckEthFlowOrderExists()
 
   const baseContext = getFlowContext({
     baseProps,
@@ -33,7 +33,7 @@ export function useEthFlowContext(): EthFlowContext | null {
     ...baseContext,
     contract,
     addTransaction,
-    isEthFlowOrderExists,
+    checkEthFlowOrderExists,
     addInFlightOrderId,
   }
 }

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useEthFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useEthFlowContext.ts
@@ -1,5 +1,4 @@
-import { useAtomValue, useSetAtom } from 'jotai'
-import { useCallback } from 'react'
+import { useSetAtom } from 'jotai'
 
 import { OrderKind } from '@cowprotocol/cow-sdk'
 
@@ -9,23 +8,18 @@ import { useTransactionAdder } from 'legacy/state/enhancedTransactions/hooks'
 
 import { FlowType, getFlowContext, useBaseFlowContextSetup } from 'modules/swap/hooks/useFlowContext'
 import { EthFlowContext } from 'modules/swap/services/types'
-import {
-  addInFlightOrderIdAtom,
-  ethFlowInFlightOrderIdsAtom,
-} from 'modules/swap/state/EthFlow/ethFlowInFlightOrderIdsAtom'
+import { addInFlightOrderIdAtom } from 'modules/swap/state/EthFlow/ethFlowInFlightOrderIdsAtom'
+
+import { useIsEthFlowOrderExists } from './useIsEthFlowOrderExists'
 
 export function useEthFlowContext(): EthFlowContext | null {
   const contract = useEthFlowContract()
   const baseProps = useBaseFlowContextSetup()
   const addTransaction = useTransactionAdder()
 
-  const ethFlowInFlightOrderIds = useAtomValue(ethFlowInFlightOrderIdsAtom)
   const addInFlightOrderId = useSetAtom(addInFlightOrderIdAtom)
 
-  const checkInFlightOrderIdExists = useCallback(
-    (orderId: string) => ethFlowInFlightOrderIds.includes(orderId),
-    [ethFlowInFlightOrderIds]
-  )
+  const isEthFlowOrderExists = useIsEthFlowOrderExists()
 
   const baseContext = getFlowContext({
     baseProps,
@@ -39,7 +33,7 @@ export function useEthFlowContext(): EthFlowContext | null {
     ...baseContext,
     contract,
     addTransaction,
-    checkInFlightOrderIdExists,
+    isEthFlowOrderExists,
     addInFlightOrderId,
   }
 }

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useIsEthFlowOrderExists.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useIsEthFlowOrderExists.ts
@@ -1,0 +1,39 @@
+import { useAtomValue } from 'jotai'
+import { useCallback } from 'react'
+
+import { ZERO_ADDRESS } from 'legacy/constants/misc'
+import { useEthFlowContract } from 'legacy/hooks/useContract'
+
+import { ethFlowInFlightOrderIdsAtom } from '../state/EthFlow/ethFlowInFlightOrderIdsAtom'
+
+export interface EthFlowOrderExistsCallback {
+  (orderId: string, orderDigest: string): Promise<boolean>
+}
+
+export function useIsEthFlowOrderExists(): EthFlowOrderExistsCallback {
+  const ethFlowInFlightOrderIds = useAtomValue(ethFlowInFlightOrderIdsAtom)
+  const ethFlowContract = useEthFlowContract()
+
+  return useCallback(
+    async (orderId: string, orderDigest: string) => {
+      if (ethFlowInFlightOrderIds.includes(orderId)) {
+        return true
+      }
+
+      if (ethFlowContract) {
+        try {
+          const { owner } = await ethFlowContract.callStatic.orders(orderDigest)
+
+          return owner.toLowerCase() !== ZERO_ADDRESS
+        } catch (e) {
+          console.error('Eth-flow order existing check error: ', e)
+
+          return false
+        }
+      }
+
+      return false
+    },
+    [ethFlowInFlightOrderIds, ethFlowContract]
+  )
+}

--- a/apps/cowswap-frontend/src/modules/swap/services/ethFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/ethFlow/index.ts
@@ -25,7 +25,7 @@ export async function ethFlow(
     appDataInfo,
     dispatch,
     orderParams: orderParamsOriginal,
-    isEthFlowOrderExists,
+    checkEthFlowOrderExists,
     addInFlightOrderId,
   } = ethFlowContext
 
@@ -40,7 +40,7 @@ export async function ethFlow(
   swapConfirmManager.sendTransaction(context.trade)
 
   logTradeFlow('ETH FLOW', 'STEP 3: Get Unique Order Id (prevent collisions)')
-  const { orderId, orderParams } = await calculateUniqueOrderId(orderParamsOriginal, contract, isEthFlowOrderExists)
+  const { orderId, orderParams } = await calculateUniqueOrderId(orderParamsOriginal, contract, checkEthFlowOrderExists)
 
   try {
     logTradeFlow('ETH FLOW', 'STEP 4: sign order')

--- a/apps/cowswap-frontend/src/modules/swap/services/ethFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/ethFlow/index.ts
@@ -25,7 +25,7 @@ export async function ethFlow(
     appDataInfo,
     dispatch,
     orderParams: orderParamsOriginal,
-    checkInFlightOrderIdExists,
+    isEthFlowOrderExists,
     addInFlightOrderId,
   } = ethFlowContext
 
@@ -40,11 +40,7 @@ export async function ethFlow(
   swapConfirmManager.sendTransaction(context.trade)
 
   logTradeFlow('ETH FLOW', 'STEP 3: Get Unique Order Id (prevent collisions)')
-  const { orderId, orderParams } = await calculateUniqueOrderId(
-    orderParamsOriginal,
-    contract,
-    checkInFlightOrderIdExists
-  )
+  const { orderId, orderParams } = await calculateUniqueOrderId(orderParamsOriginal, contract, isEthFlowOrderExists)
 
   try {
     logTradeFlow('ETH FLOW', 'STEP 4: sign order')

--- a/apps/cowswap-frontend/src/modules/swap/services/ethFlow/steps/calculateUniqueOrderId.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/ethFlow/steps/calculateUniqueOrderId.ts
@@ -10,7 +10,7 @@ import { logTradeFlow } from 'modules/trade/utils/logger'
 
 import { MAX_VALID_TO_EPOCH } from 'utils/time'
 
-import { EthFlowOrderExistsCallback } from '../../../hooks/useIsEthFlowOrderExists'
+import { EthFlowOrderExistsCallback } from '../../../hooks/useCheckEthFlowOrderExists'
 
 export interface UniqueOrderIdResult {
   orderId: string
@@ -35,7 +35,7 @@ function incrementFee(params: PostOrderParams): PostOrderParams {
 export async function calculateUniqueOrderId(
   orderParams: PostOrderParams,
   ethFlowContract: CoWSwapEthFlow,
-  isEthFlowOrderExists: EthFlowOrderExistsCallback
+  checkEthFlowOrderExists: EthFlowOrderExistsCallback
 ): Promise<UniqueOrderIdResult> {
   logTradeFlow('ETH FLOW', '[EthFlow::calculateUniqueOrderId] - Calculate unique order Id', orderParams)
   const { chainId } = orderParams
@@ -61,11 +61,11 @@ export async function calculateUniqueOrderId(
     sellAmount: orderParams.inputAmount.quotient.toString(),
     fee: orderParams.feeAmount?.quotient.toString(),
   }
-  if (await isEthFlowOrderExists(orderId, orderDigest)) {
+  if (await checkEthFlowOrderExists(orderId, orderDigest)) {
     logTradeFlow('ETH FLOW', '[calculateUniqueOrderId] ❌ Collision detected: ' + orderId, logParams)
 
     // Recursive call, increment one fee until we get an unique order Id
-    return calculateUniqueOrderId(incrementFee(orderParams), ethFlowContract, isEthFlowOrderExists)
+    return calculateUniqueOrderId(incrementFee(orderParams), ethFlowContract, checkEthFlowOrderExists)
   }
 
   logTradeFlow('ETH FLOW', '[calculateUniqueOrderId] ✅ Order Id is Unique' + orderId, logParams)

--- a/apps/cowswap-frontend/src/modules/swap/services/ethFlow/steps/calculateUniqueOrderId.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/ethFlow/steps/calculateUniqueOrderId.ts
@@ -10,6 +10,8 @@ import { logTradeFlow } from 'modules/trade/utils/logger'
 
 import { MAX_VALID_TO_EPOCH } from 'utils/time'
 
+import { EthFlowOrderExistsCallback } from '../../../hooks/useIsEthFlowOrderExists'
+
 export interface UniqueOrderIdResult {
   orderId: string
   orderParams: PostOrderParams // most cases, will be the same as the ones in the parameter, but it might be modified to make the order unique
@@ -33,7 +35,7 @@ function incrementFee(params: PostOrderParams): PostOrderParams {
 export async function calculateUniqueOrderId(
   orderParams: PostOrderParams,
   ethFlowContract: CoWSwapEthFlow,
-  checkInFlightOrderIdExists: (orderId: string) => boolean
+  isEthFlowOrderExists: EthFlowOrderExistsCallback
 ): Promise<UniqueOrderIdResult> {
   logTradeFlow('ETH FLOW', '[EthFlow::calculateUniqueOrderId] - Calculate unique order Id', orderParams)
   const { chainId } = orderParams
@@ -59,11 +61,11 @@ export async function calculateUniqueOrderId(
     sellAmount: orderParams.inputAmount.quotient.toString(),
     fee: orderParams.feeAmount?.quotient.toString(),
   }
-  if (checkInFlightOrderIdExists(orderId)) {
+  if (await isEthFlowOrderExists(orderId, orderDigest)) {
     logTradeFlow('ETH FLOW', '[calculateUniqueOrderId] ❌ Collision detected: ' + orderId, logParams)
 
     // Recursive call, increment one fee until we get an unique order Id
-    return calculateUniqueOrderId(incrementFee(orderParams), ethFlowContract, checkInFlightOrderIdExists)
+    return calculateUniqueOrderId(incrementFee(orderParams), ethFlowContract, isEthFlowOrderExists)
   }
 
   logTradeFlow('ETH FLOW', '[calculateUniqueOrderId] ✅ Order Id is Unique' + orderId, logParams)

--- a/apps/cowswap-frontend/src/modules/swap/services/types.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/types.ts
@@ -14,8 +14,8 @@ import { AppDataInfo, UploadAppDataParams } from 'modules/appData'
 import { SwapConfirmManager } from 'modules/swap/hooks/useSwapConfirmManager'
 import { SwapFlowAnalyticsContext } from 'modules/trade/utils/analytics'
 
+import { EthFlowOrderExistsCallback } from '../hooks/useCheckEthFlowOrderExists'
 import { FlowType } from '../hooks/useFlowContext'
-import { EthFlowOrderExistsCallback } from '../hooks/useIsEthFlowOrderExists'
 
 export interface BaseFlowContext {
   context: {
@@ -48,7 +48,7 @@ export type SwapFlowContext = BaseFlowContext & {
 export type EthFlowContext = BaseFlowContext & {
   contract: CoWSwapEthFlow
   addTransaction: ReturnType<typeof useTransactionAdder>
-  isEthFlowOrderExists: EthFlowOrderExistsCallback
+  checkEthFlowOrderExists: EthFlowOrderExistsCallback
   addInFlightOrderId: (orderId: string) => void
 }
 

--- a/apps/cowswap-frontend/src/modules/swap/services/types.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/types.ts
@@ -15,6 +15,7 @@ import { SwapConfirmManager } from 'modules/swap/hooks/useSwapConfirmManager'
 import { SwapFlowAnalyticsContext } from 'modules/trade/utils/analytics'
 
 import { FlowType } from '../hooks/useFlowContext'
+import { EthFlowOrderExistsCallback } from '../hooks/useIsEthFlowOrderExists'
 
 export interface BaseFlowContext {
   context: {
@@ -47,7 +48,7 @@ export type SwapFlowContext = BaseFlowContext & {
 export type EthFlowContext = BaseFlowContext & {
   contract: CoWSwapEthFlow
   addTransaction: ReturnType<typeof useTransactionAdder>
-  checkInFlightOrderIdExists: (orderId: string) => boolean
+  isEthFlowOrderExists: EthFlowOrderExistsCallback
   addInFlightOrderId: (orderId: string) => void
 }
 

--- a/libs/abis/src/abis/CoWSwapEthFlow.json
+++ b/libs/abis/src/abis/CoWSwapEthFlow.json
@@ -1,0 +1,152 @@
+[
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract IERC20",
+            "name": "buyToken",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "receiver",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "sellAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "buyAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "appData",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "feeAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint32",
+            "name": "validTo",
+            "type": "uint32"
+          },
+          {
+            "internalType": "bool",
+            "name": "partiallyFillable",
+            "type": "bool"
+          },
+          {
+            "internalType": "int64",
+            "name": "quoteId",
+            "type": "int64"
+          }
+        ],
+        "internalType": "struct EthFlowOrder.Data",
+        "name": "order",
+        "type": "tuple"
+      }
+    ],
+    "name": "createOrder",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract IERC20",
+            "name": "buyToken",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "receiver",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "sellAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "buyAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "appData",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "feeAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint32",
+            "name": "validTo",
+            "type": "uint32"
+          },
+          {
+            "internalType": "bool",
+            "name": "partiallyFillable",
+            "type": "bool"
+          },
+          {
+            "internalType": "int64",
+            "name": "quoteId",
+            "type": "int64"
+          }
+        ],
+        "internalType": "struct EthFlowOrder.Data",
+        "name": "order",
+        "type": "tuple"
+      }
+    ],
+    "name": "invalidateOrder",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "orders",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint32",
+        "name": "validTo",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/libs/abis/src/index.ts
+++ b/libs/abis/src/index.ts
@@ -22,8 +22,6 @@ import _ArgentWalletContractAbi from './abis-legacy/argent-wallet-contract.json'
 
 import _ArgentWalletDetectorAbi from './abis-legacy/argent-wallet-detector.json'
 
-import _CoWSwapEthFlowJson from '@cowprotocol/ethflowcontract/artifacts/CoWSwapEthFlow.sol/CoWSwapEthFlow.json'
-
 import _Eip2612Abi from './abis-legacy/eip_2612.json'
 
 import _EnsPublicResolverAbi from './abis-legacy/ens-public-resolver.json'
@@ -74,7 +72,6 @@ export const ethFlowBarnJson = _ethFlowBarnJson
 export const ethFlowProdJson = _ethFlowProdJson
 export const ArgentWalletContractAbi = _ArgentWalletContractAbi
 export const ArgentWalletDetectorAbi = _ArgentWalletDetectorAbi
-export const CoWSwapEthFlowJson = _CoWSwapEthFlowJson
 export const Eip2612Abi = _Eip2612Abi
 export const EnsPublicResolverAbi = _EnsPublicResolverAbi
 export const EnsAbi = _EnsAbi

--- a/libs/abis/src/index.ts
+++ b/libs/abis/src/index.ts
@@ -11,6 +11,8 @@ import _MerkleDropAbi from './abis/MerkleDrop.json'
 
 import _TokenDistroAbi from './abis/TokenDistro.json'
 
+import _CoWSwapEthFlowAbi from './abis/CoWSwapEthFlow.json'
+
 import _ethFlowBarnJson from '@cowprotocol/ethflowcontract/networks.barn.json'
 
 import _ethFlowProdJson from '@cowprotocol/ethflowcontract/networks.prod.json'
@@ -46,6 +48,7 @@ export const vCowAbi = _vCowAbi
 export const SignatureVerifierMuxerAbi = _SignatureVerifierMuxerAbi
 export const MerkleDropAbi = _MerkleDropAbi
 export const TokenDistroAbi = _TokenDistroAbi
+export const CoWSwapEthFlowAbi = _CoWSwapEthFlowAbi
 
 export * from './generated/custom'
 export type { GPv2Order } from './generated/custom/ComposableCoW'


### PR DESCRIPTION
# Summary

Issue:
https://docs.google.com/document/d/1sIwsE9sCuEMZoNuBVXxpdxLrW-s-tF75AEnAMUX05I0/edit#heading=h.z0cmq0qselmp

I've checked the system based on `ethFlowInFlightOrderIdsAtom` and it works well.
Anyway, I've added an additional check with static call `orders[orderDigest]`.

  # To Test

I wasn't able to reproduce the issue because the previous solution worked well. But, I've mocked it and checked that the new approach with static call also works.