### PR TITLE
chore: allow enough balance check to return unknown state

### DIFF
--- a/apps/cowswap-frontend/src/api/gnosisProtocol/api.ts
+++ b/apps/cowswap-frontend/src/api/gnosisProtocol/api.ts
@@ -25,8 +25,8 @@ import { toErc20Address, toNativeBuyAddress } from 'legacy/utils/tokens'
 
 import { getAppData } from 'modules/appData'
 
-import { ApiErrorObject } from 'api/gnosisProtocol/errors/OperatorError'
-import GpQuoteError, { mapOperatorErrorToQuoteError } from 'api/gnosisProtocol/errors/QuoteError'
+import { ApiErrorCodes, ApiErrorObject } from 'api/gnosisProtocol/errors/OperatorError'
+import GpQuoteError, { GpQuoteErrorDetails, mapOperatorErrorToQuoteError } from 'api/gnosisProtocol/errors/QuoteError'
 
 import { LegacyFeeQuoteParams as FeeQuoteParams } from './legacy/types'
 
@@ -141,6 +141,16 @@ function _mapNewToLegacyParams(params: FeeQuoteParams): OrderQuoteRequest {
 export async function getQuote(params: FeeQuoteParams): Promise<OrderQuoteResponse> {
   const { chainId } = params
   const quoteParams = _mapNewToLegacyParams(params)
+  const { sellToken, buyToken } = quoteParams
+
+  if (sellToken === buyToken) {
+    return Promise.reject(
+      mapOperatorErrorToQuoteError({
+        errorType: ApiErrorCodes.SameBuyAndSellToken,
+        description: GpQuoteErrorDetails.SameBuyAndSellToken,
+      })
+    )
+  }
 
   return orderBookApi.getQuote(quoteParams, { chainId }).catch((error) => {
     if (isOrderbookTypedError(error)) {

--- a/apps/cowswap-frontend/src/api/gnosisProtocol/api.ts
+++ b/apps/cowswap-frontend/src/api/gnosisProtocol/api.ts
@@ -14,7 +14,7 @@ import {
   PriceQuality,
   TotalSurplus,
   OrderQuoteSideKindBuy,
-  OrderQuoteSideKindSell
+  OrderQuoteSideKindSell,
 } from '@cowprotocol/cow-sdk'
 
 import { orderBookApi } from 'cowSdk'
@@ -225,7 +225,7 @@ export async function getProfileData(chainId: ChainId, address: string): Promise
   }
 }
 
-export function getPriceQuality(props: { fast?: boolean; verifyQuote: boolean }): PriceQuality {
+export function getPriceQuality(props: { fast?: boolean; verifyQuote: boolean | undefined }): PriceQuality {
   const { fast = false, verifyQuote } = props
   if (fast) {
     return PriceQuality.FAST

--- a/apps/cowswap-frontend/src/api/gnosisProtocol/errors/QuoteError.ts
+++ b/apps/cowswap-frontend/src/api/gnosisProtocol/errors/QuoteError.ts
@@ -14,6 +14,7 @@ export enum GpQuoteErrorCodes {
   FeeExceedsFrom = 'FeeExceedsFrom',
   ZeroPrice = 'ZeroPrice',
   TransferEthToContract = 'TransferEthToContract',
+  SameBuyAndSellToken = 'SameBuyAndSellToken',
   UNHANDLED_ERROR = 'UNHANDLED_ERROR',
 }
 
@@ -25,6 +26,7 @@ export enum GpQuoteErrorDetails {
   FeeExceedsFrom = 'Current fee exceeds entered "from" amount.',
   ZeroPrice = 'Quoted price is zero. This is likely due to a significant price difference between the two tokens. Please try increasing amounts.',
   TransferEthToContract = 'Buying native currencies using smart contract wallets is not currently supported.',
+  SameBuyAndSellToken = 'You are trying to buy and sell the same token.',
   SellAmountDoesNotCoverFee = 'The selling amount for the order is lower than the fee.',
   UNHANDLED_ERROR = 'Quote fetch failed. This may be due to a server or network connectivity issue. Please try again later.',
 }
@@ -55,6 +57,13 @@ export function mapOperatorErrorToQuoteError(error?: ApiErrorObject): GpQuoteErr
         errorType: GpQuoteErrorCodes.TransferEthToContract,
         description: error.description,
       }
+
+    case ApiErrorCodes.SameBuyAndSellToken:
+      return {
+        errorType: GpQuoteErrorCodes.SameBuyAndSellToken,
+        description: GpQuoteErrorDetails.SameBuyAndSellToken,
+      }
+
     default:
       return { errorType: GpQuoteErrorCodes.UNHANDLED_ERROR, description: GpQuoteErrorDetails.UNHANDLED_ERROR }
   }

--- a/apps/cowswap-frontend/src/common/hooks/useNeedsApproval.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useNeedsApproval.ts
@@ -39,6 +39,5 @@ export function useNeedsApproval(amount: Nullish<CurrencyAmount<Currency>>): boo
     return false
   }
 
-  const enoughBalance = isEnoughAmount(amount, allowance)
-  return enoughBalance === false
+  return isEnoughAmount(amount, allowance) === false
 }

--- a/apps/cowswap-frontend/src/common/hooks/useNeedsApproval.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useNeedsApproval.ts
@@ -39,5 +39,6 @@ export function useNeedsApproval(amount: Nullish<CurrencyAmount<Currency>>): boo
     return false
   }
 
-  return !isEnoughAmount(amount, allowance)
+  const enoughBalance = isEnoughAmount(amount, allowance)
+  return enoughBalance === false
 }

--- a/apps/cowswap-frontend/src/legacy/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -145,7 +145,7 @@ export function UnfillableOrdersUpdater(): null {
 
         const currencyAmount = CurrencyAmount.fromRawAmount(order.inputToken, order.sellAmount)
         const enoughBalance = hasEnoughBalanceAndAllowance({ account, amount: currencyAmount, balances })
-        const verifiedQuote = verifiedQuotesEnabled && enoughBalance === true
+        const verifiedQuote = verifiedQuotesEnabled && enoughBalance
 
         _getOrderPrice(chainId, order, verifiedQuote, strategy)
           .then((quote) => {
@@ -208,7 +208,12 @@ export function UnfillableOrdersUpdater(): null {
 /**
  * Thin wrapper around `getBestPrice` that builds the params and returns null on failure
  */
-async function _getOrderPrice(chainId: ChainId, order: Order, verifyQuote: boolean, strategy: GpPriceStrategy) {
+async function _getOrderPrice(
+  chainId: ChainId,
+  order: Order,
+  verifyQuote: boolean | undefined,
+  strategy: GpPriceStrategy
+) {
   let baseToken, quoteToken
 
   const amount = getRemainderAmount(order.kind, order)

--- a/apps/cowswap-frontend/src/legacy/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -145,8 +145,9 @@ export function UnfillableOrdersUpdater(): null {
 
         const currencyAmount = CurrencyAmount.fromRawAmount(order.inputToken, order.sellAmount)
         const enoughBalance = hasEnoughBalanceAndAllowance({ account, amount: currencyAmount, balances })
+        const verifiedQuote = verifiedQuotesEnabled && enoughBalance === true
 
-        _getOrderPrice(chainId, order, enoughBalance && verifiedQuotesEnabled, strategy)
+        _getOrderPrice(chainId, order, verifiedQuote, strategy)
           .then((quote) => {
             if (quote) {
               const [promisedPrice, promisedFee] = quote

--- a/apps/cowswap-frontend/src/legacy/state/price/updater.ts
+++ b/apps/cowswap-frontend/src/legacy/state/price/updater.ts
@@ -207,7 +207,7 @@ export default function FeesUpdater(): null {
       userAddress: account,
       validTo,
       isEthFlow,
-      priceQuality: getPriceQuality({ verifyQuote: enoughBalance && verifiedQuotesEnabled }),
+      priceQuality: getPriceQuality({ verifyQuote: verifiedQuotesEnabled && enoughBalance === true }),
     }
 
     // Don't refetch if offline.

--- a/apps/cowswap-frontend/src/legacy/state/price/updater.ts
+++ b/apps/cowswap-frontend/src/legacy/state/price/updater.ts
@@ -207,7 +207,7 @@ export default function FeesUpdater(): null {
       userAddress: account,
       validTo,
       isEthFlow,
-      priceQuality: getPriceQuality({ verifyQuote: verifiedQuotesEnabled && enoughBalance === true }),
+      priceQuality: getPriceQuality({ verifyQuote: verifiedQuotesEnabled && enoughBalance }),
     }
 
     // Don't refetch if offline.

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
@@ -174,7 +174,7 @@ export function OrderRow({
   const showCancellationModal = orderActions.getShowCancellationModal(order)
 
   const withWarning =
-    (!hasEnoughBalance || !hasEnoughAllowance) &&
+    (hasEnoughBalance === false || hasEnoughAllowance === false) &&
     // show the warning only for pending and scheduled orders
     (status === OrderStatus.PENDING || status === OrderStatus.SCHEDULED)
   const theme = useContext(ThemeContext)
@@ -353,10 +353,10 @@ export function OrderRow({
                     bgColor={theme.alert}
                     content={
                       <styledEl.WarningContent>
-                        {!hasEnoughBalance && (
+                        {hasEnoughBalance === false && (
                           <BalanceWarning symbol={inputTokenSymbol} isScheduled={isOrderScheduled} />
                         )}
-                        {!hasEnoughAllowance && (
+                        {hasEnoughAllowance === false && (
                           <AllowanceWarning symbol={inputTokenSymbol} isScheduled={isOrderScheduled} />
                         )}
                       </styledEl.WarningContent>

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/utils/getOrderParams.ts
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/utils/getOrderParams.ts
@@ -39,18 +39,12 @@ export function getOrderParams(
   const allowance = allowances[order.inputToken.address]?.value
 
   const [hasEnoughBalance, hasEnoughAllowance] = (() => {
-    if (order.partiallyFillable) {
-      // When balance or allowance are undefined (loading state), show as true
-      // When loaded, check there's at least PERCENTAGE_FOR_PARTIAL_FILLS of balance/allowance to consider it as enough
-      const amount = sellAmount.multiply(PERCENTAGE_FOR_PARTIAL_FILLS)
-      const hasEnoughBalance = isEnoughAmount(amount, balance)
-      const hasEnoughAllowance = isEnoughAmount(amount, allowance)
-      return [hasEnoughBalance, hasEnoughAllowance]
-    } else {
-      const hasEnoughBalance = isEnoughAmount(sellAmount, balance)
-      const hasEnoughAllowance = isEnoughAmount(sellAmount, allowance)
-      return [hasEnoughBalance, hasEnoughAllowance]
-    }
+    // Check there's at least PERCENTAGE_FOR_PARTIAL_FILLS of balance/allowance to consider it as enough
+    const amount = order.partiallyFillable ? sellAmount.multiply(PERCENTAGE_FOR_PARTIAL_FILLS) : sellAmount
+    const hasEnoughBalance = isEnoughAmount(amount, balance)
+    const hasEnoughAllowance = isEnoughAmount(amount, allowance)
+
+    return [hasEnoughBalance, hasEnoughAllowance]
   })()
 
   return {

--- a/apps/cowswap-frontend/src/modules/tokens/hooks/useEnoughBalance.ts
+++ b/apps/cowswap-frontend/src/modules/tokens/hooks/useEnoughBalance.ts
@@ -86,26 +86,40 @@ export function hasEnoughBalanceAndAllowance(params: EnoughBalanceParams): boole
   const token = amount?.currency.wrapped
   const tokenAddress = getAddress(token)
 
-  const enoughBalance = (() => {
-    const balance = tokenAddress ? balances[tokenAddress]?.value : undefined
-    const balanceAmount = isNativeCurrency ? nativeBalance : balance || undefined
-    return isEnoughAmount(amount, balanceAmount)
-  })()
-
-  const enoughAllowance = (() => {
-    if (!tokenAddress || !allowances) {
-      return undefined
-    }
-    if (isNativeCurrency) {
-      return true
-    }
-    const allowance = allowances[tokenAddress]?.value
-    return allowance && isEnoughAmount(amount, allowance)
-  })()
+  const enoughBalance = _enoughBalance(tokenAddress, amount, balances, isNativeCurrency, nativeBalance)
+  const enoughAllowance = _enoughAllowance(tokenAddress, amount, allowances, isNativeCurrency)
 
   if (enoughBalance === undefined || enoughAllowance === undefined) {
     return undefined
   }
 
   return enoughBalance && enoughAllowance
+}
+
+function _enoughBalance(
+  tokenAddress: string | null,
+  amount: CurrencyAmount<Currency>,
+  balances: TokenAmounts,
+  isNativeCurrency: boolean,
+  nativeBalance: CurrencyAmount<Currency> | undefined
+): boolean | undefined {
+  const balance = tokenAddress ? balances[tokenAddress]?.value : undefined
+  const balanceAmount = isNativeCurrency ? nativeBalance : balance || undefined
+  return isEnoughAmount(amount, balanceAmount)
+}
+
+function _enoughAllowance(
+  tokenAddress: string | null,
+  amount: CurrencyAmount<Currency>,
+  allowances: TokenAmounts | undefined,
+  isNativeCurrency: boolean
+): boolean | undefined {
+  if (!tokenAddress || !allowances) {
+    return undefined
+  }
+  if (isNativeCurrency) {
+    return true
+  }
+  const allowance = allowances[tokenAddress]?.value
+  return allowance && isEnoughAmount(amount, allowance)
 }

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
@@ -34,6 +34,7 @@ const quoteErrorTexts: Record<GpQuoteErrorCodes, string> = {
   [GpQuoteErrorCodes.InsufficientLiquidity]: 'Insufficient liquidity for this trade.',
   [GpQuoteErrorCodes.FeeExceedsFrom]: 'Sell amount is too small',
   [GpQuoteErrorCodes.ZeroPrice]: 'Invalid price. Try increasing input/output amount.',
+  [GpQuoteErrorCodes.SameBuyAndSellToken]: 'Tokens must be different',
 }
 
 const unsupportedTokenButton = (context: TradeFormButtonContext) => {

--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useQuoteParams.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useQuoteParams.ts
@@ -45,7 +45,7 @@ export function useQuoteParams(amount: string | null): LegacyFeeQuoteParams | un
       toDecimals,
       fromDecimals,
       isEthFlow: false,
-      priceQuality: getPriceQuality({ verifyQuote: verifiedQuotesEnabled && enoughBalance === true }),
+      priceQuality: getPriceQuality({ verifyQuote: verifiedQuotesEnabled && enoughBalance }),
     }
 
     return params

--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useQuoteParams.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useQuoteParams.ts
@@ -45,7 +45,7 @@ export function useQuoteParams(amount: string | null): LegacyFeeQuoteParams | un
       toDecimals,
       fromDecimals,
       isEthFlow: false,
-      priceQuality: getPriceQuality({ verifyQuote: enoughBalance && verifiedQuotesEnabled }),
+      priceQuality: getPriceQuality({ verifyQuote: verifiedQuotesEnabled && enoughBalance === true }),
     }
 
     return params

--- a/apps/cowswap-frontend/src/utils/isEnoughAmount.ts
+++ b/apps/cowswap-frontend/src/utils/isEnoughAmount.ts
@@ -3,10 +3,8 @@ import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 export function isEnoughAmount(
   sellAmount: CurrencyAmount<Currency>,
   targetAmount: CurrencyAmount<Currency> | undefined
-): boolean {
-  if (!targetAmount) return true
+): boolean | undefined {
+  if (!targetAmount) return undefined
 
-  if (targetAmount.equalTo(sellAmount)) return true
-
-  return sellAmount.lessThan(targetAmount)
+  return sellAmount.equalTo(targetAmount) || sellAmount.lessThan(targetAmount)
 }


### PR DESCRIPTION
# Summary

Handle the `UNKNOWN` state for the check that verifies if the user has enough balance (used for quotes)

The app will need to know the balance of the user to decide if its using verified quotes or not. 
The balance/allowance is fetched in an async call. Meaning that we can be in a state where we don't know if we have the balance or not. 

The app was defaulting to "Yes, it has balance" if we were not sure.

See image below:

![image](https://github.com/cowprotocol/cowswap/assets/2352112/0e279bba-3bdb-4f01-ba39-0956fc8174b6)

![image](https://github.com/cowprotocol/cowswap/assets/2352112/3e3e3298-2e16-48b3-85ce-2e541ee23a97)


Now we handle the undefined case, so we don't use `verified` quotes:
![image](https://github.com/cowprotocol/cowswap/assets/2352112/733b1d89-4cfd-4157-b8c1-0b82c8f0fad0)


## Bonus
I saw we were, in some cases making a request with the same sell token and buy token.

Its only temporal, probably due two the app being on a loading state. We will need to improve this part. 

I added a small improvement, so we just don't query the API in this case https://github.com/cowprotocol/cowswap/pull/3106/commits/4d4b932c6263699dfd416b71cd58552c70b37967 

# To Test
- Create 2 limit orders using all your balance (price should be so that at least one executes fully). They should use all your balance for a token
- Once 1 executes, the other will have no balance
- In this case, we should see we quote only `optimal` quotes (check network tab)