### PR TITLE
Reduce queries from unfillable updater

### DIFF
--- a/apps/cowswap-frontend/src/legacy/state/orders/consts.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/consts.ts
@@ -11,7 +11,7 @@ export const ContractDeploymentBlocks: Partial<Record<ChainId, number>> = {
 export const MARKET_OPERATOR_API_POLL_INTERVAL = ms`2s`
 // We can have lots of limit orders and it creates a high load, so we poll them no so ofter as market orders
 export const LIMIT_OPERATOR_API_POLL_INTERVAL = ms`15s`
-export const PENDING_ORDERS_PRICE_CHECK_POLL_INTERVAL = ms`15s`
+export const PENDING_ORDERS_PRICE_CHECK_POLL_INTERVAL = ms`30s`
 export const SPOT_PRICE_CHECK_POLL_INTERVAL = ms`15s`
 export const EXPIRED_ORDERS_CHECK_POLL_INTERVAL = ms`15s`
 

--- a/apps/cowswap-frontend/src/legacy/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -199,7 +199,6 @@ export function UnfillableOrdersUpdater(): null {
   updatePendingRef.current = updatePending
 
   useEffect(() => {
-    console.log('[UnfillableOrdersUpdater] Start interval', { updatePendingRef, chainId, account, isWindowVisible })
     if (!chainId || !account || !isWindowVisible) {
       console.debug('[UnfillableOrdersUpdater] No need to fetch unfillable orders')
       return

--- a/apps/cowswap-frontend/src/legacy/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -209,7 +209,7 @@ export function UnfillableOrdersUpdater(): null {
     updatePendingRef.current()
     const interval = setInterval(() => updatePendingRef.current(), PENDING_ORDERS_PRICE_CHECK_POLL_INTERVAL)
     return () => clearInterval(interval)
-  }, [updatePendingRef, chainId, account, isWindowVisible])
+  }, [chainId, account, isWindowVisible])
 
   return null
 }

--- a/apps/cowswap-frontend/src/legacy/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -190,17 +190,23 @@ export function UnfillableOrdersUpdater(): null {
     verifiedQuotesEnabled,
   ])
 
+  const updatePendingRef = useRef(updatePending)
   useEffect(() => {
+    updatePendingRef.current = updatePending
+  }, [updatePending])
+
+  useEffect(() => {
+    console.log('[UnfillableOrdersUpdater] Start interval', { updatePendingRef, chainId, account, isWindowVisible })
     if (!chainId || !account || !isWindowVisible) {
       console.debug('[UnfillableOrdersUpdater] No need to fetch unfillable orders')
       return
     }
 
     console.debug('[UnfillableOrdersUpdater] Periodically check for unfillable orders')
-    updatePending()
-    const interval = setInterval(updatePending, PENDING_ORDERS_PRICE_CHECK_POLL_INTERVAL)
+    updatePendingRef.current()
+    const interval = setInterval(updatePendingRef.current, PENDING_ORDERS_PRICE_CHECK_POLL_INTERVAL)
     return () => clearInterval(interval)
-  }, [updatePending, chainId, account, isWindowVisible])
+  }, [updatePendingRef, chainId, account, isWindowVisible])
 
   return null
 }

--- a/apps/cowswap-frontend/src/legacy/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -119,10 +119,13 @@ export function UnfillableOrdersUpdater(): null {
     [setIsOrderUnfillable, updateOrderMarketPriceCallback]
   )
 
+  const count = useRef(1)
   const updatePending = useCallback(() => {
     if (!chainId || !account || isUpdating.current || !isWindowVisible) {
       return
     }
+
+    console.log('[UnfillableOrdersUpdater] Update pending orders', count.current++)
 
     const startTime = Date.now()
     try {
@@ -204,7 +207,7 @@ export function UnfillableOrdersUpdater(): null {
 
     console.debug('[UnfillableOrdersUpdater] Periodically check for unfillable orders')
     updatePendingRef.current()
-    const interval = setInterval(updatePendingRef.current, PENDING_ORDERS_PRICE_CHECK_POLL_INTERVAL)
+    const interval = setInterval(() => updatePendingRef.current(), PENDING_ORDERS_PRICE_CHECK_POLL_INTERVAL)
     return () => clearInterval(interval)
   }, [updatePendingRef, chainId, account, isWindowVisible])
 

--- a/apps/cowswap-frontend/src/legacy/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -119,13 +119,12 @@ export function UnfillableOrdersUpdater(): null {
     [setIsOrderUnfillable, updateOrderMarketPriceCallback]
   )
 
-  const count = useRef(1)
+  const balancesRef = useRef(balances)
+  balancesRef.current = balances
   const updatePending = useCallback(() => {
     if (!chainId || !account || isUpdating.current || !isWindowVisible) {
       return
     }
-
-    console.log('[UnfillableOrdersUpdater] Update pending orders', count.current++)
 
     const startTime = Date.now()
     try {
@@ -147,7 +146,11 @@ export function UnfillableOrdersUpdater(): null {
         console.debug(`[UnfillableOrdersUpdater] Check order`, order)
 
         const currencyAmount = CurrencyAmount.fromRawAmount(order.inputToken, order.sellAmount)
-        const enoughBalance = hasEnoughBalanceAndAllowance({ account, amount: currencyAmount, balances })
+        const enoughBalance = hasEnoughBalanceAndAllowance({
+          account,
+          amount: currencyAmount,
+          balances: balancesRef.current,
+        })
         const verifiedQuote = verifiedQuotesEnabled && enoughBalance
 
         _getOrderPrice(chainId, order, verifiedQuote, strategy)
@@ -188,15 +191,12 @@ export function UnfillableOrdersUpdater(): null {
     strategy,
     updateIsUnfillableFlag,
     isWindowVisible,
-    balances,
     updatePendingOrderPrices,
     verifiedQuotesEnabled,
   ])
 
   const updatePendingRef = useRef(updatePending)
-  useEffect(() => {
-    updatePendingRef.current = updatePending
-  }, [updatePending])
+  updatePendingRef.current = updatePending
 
   useEffect(() => {
     console.log('[UnfillableOrdersUpdater] Start interval', { updatePendingRef, chainId, account, isWindowVisible })


### PR DESCRIPTION
# Summary

This PR reduces drastically the number of quotes we do. 

**Why?** 
Because the Unfillable Orders Updater was being "re-renderer" often. The re-rendering was making us to re-start the polling count (reset the timer), but also we were eagerly querying the quote!!

**Ok, but why so many re-renders**
It turns out, the updater had a `useEffect` who create the polling logic. This `useEffect` depended on a function to do the actual update. This function changes often. However, even if this function changes, we don't want to re-fetch again. 

**Soluton, proposed in this PR**
Instead of depending on the function itself, we depend on a reference to it.

This way, we don't need to re-render the `useEffect` and the polling works as expected. 


Before it would send hundreds of requests, specially in case we start to get some 404
![image](https://github.com/cowprotocol/cowswap/assets/2352112/aa2a4ce8-7976-47dd-a4e0-97f0c7cf8037)



Now we do way less in this case:
<img width="1619" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/5d94748c-1e60-4602-941d-39f2298ff25c">


