### PR TITLE
fix(twap): load TWAP part details

### DIFF
--- a/apps/cowswap-frontend/src/cowSdk.ts
+++ b/apps/cowswap-frontend/src/cowSdk.ts
@@ -1,16 +1,14 @@
 import { MetadataApi } from '@cowprotocol/app-data'
-import { ORDER_BOOK_PROD_CONFIG, ORDER_BOOK_STAGING_CONFIG, OrderBookApi } from '@cowprotocol/cow-sdk'
+import { OrderBookApi } from '@cowprotocol/cow-sdk'
 
 import { isBarnBackendEnv } from 'legacy/utils/environments'
 
 const prodBaseUrls = process.env.REACT_APP_ORDER_BOOK_URLS
   ? JSON.parse(process.env.REACT_APP_ORDER_BOOK_URLS)
-  : isBarnBackendEnv
-  ? ORDER_BOOK_STAGING_CONFIG
-  : ORDER_BOOK_PROD_CONFIG
+  : undefined
 
 export const metadataApiSDK = new MetadataApi()
 export const orderBookApi = new OrderBookApi({
   env: isBarnBackendEnv ? 'staging' : 'prod',
-  baseUrls: prodBaseUrls,
+  ...(prodBaseUrls ? { baseUrls: prodBaseUrls } : undefined),
 })


### PR DESCRIPTION
# Summary

Fix for major issue #1 reported on https://github.com/cowprotocol/cowswap/issues/3105

When order book api urls are use in the constructor, it takes precedence over command overrides:

https://github.com/cowprotocol/cow-sdk/blob/28d42f0af0bdadacf05d18fa295834e2fd7657e1/src/order-book/api.ts#L399

Thus, when querying for `prod` orders (a MUST for TWAP on non-prod envs), the barn endpoint was being queried instead.
Which resulted in the parts info never being fetched.

# To Test

1. Load app inside the Safe
2. Place a TWAP order
* Parts info should load/update