### PR TITLE
fix(price-impact): display unknown price impact warning only when there is no data

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
@@ -15,6 +15,7 @@ import {
   limitOrdersWarningsAtom,
   updateLimitOrdersWarningsAtom,
 } from 'modules/limitOrders/state/limitOrdersWarningsAtom'
+import { useTradePriceImpact } from 'modules/trade'
 import { NoImpactWarning } from 'modules/trade/pure/NoImpactWarning'
 import { TradeFormValidation, useGetTradeFormValidation } from 'modules/tradeFormValidation'
 import { useTradeQuote } from 'modules/tradeQuote'
@@ -64,13 +65,21 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
   const localFormValidation = useLimitOrdersFormState()
   const primaryFormValidation = useGetTradeFormValidation()
   const rateImpact = useRateImpact()
-  const { chainId, account } = useWalletInfo()
+  const { account } = useWalletInfo()
   const { slippageAdjustedSellAmount, inputCurrency, inputCurrencyAmount, outputCurrency, outputCurrencyAmount } =
     useLimitOrdersDerivedState()
   const tradeQuote = useTradeQuote()
+  const priceImpactParams = useTradePriceImpact()
 
   const canTrade = localFormValidation === null && primaryFormValidation === null && !tradeQuote.error
-  const showPriceImpactWarning = canTrade && !tradeQuote.isLoading && !!chainId && !expertMode && !!account
+  const showPriceImpactWarning =
+    canTrade &&
+    !tradeQuote.isLoading &&
+    !expertMode &&
+    !!account &&
+    !priceImpactParams.loading &&
+    !priceImpactParams.priceImpact
+
   const showRateImpactWarning =
     canTrade &&
     !tradeQuote.isLoading &&

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useTwapWarningsContext.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useTwapWarningsContext.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 
+import { useTradePriceImpact } from 'modules/trade'
 import { TradeFormValidation, useGetTradeFormValidation } from 'modules/tradeFormValidation'
 import { useWalletInfo } from 'modules/wallet'
 
@@ -18,12 +19,14 @@ export interface TwapWarningsContext {
 export function useTwapWarningsContext(): TwapWarningsContext {
   const { account } = useWalletInfo()
   const primaryFormValidation = useGetTradeFormValidation()
+  const priceImpactParams = useTradePriceImpact()
 
   return useMemo(() => {
     // TODO: bind to settings
     const expertMode = false
     const canTrade = !primaryFormValidation || NOT_BLOCKING_VALIDATIONS.includes(primaryFormValidation)
-    const showPriceImpactWarning = canTrade && !expertMode
+    const showPriceImpactWarning =
+      canTrade && !expertMode && !priceImpactParams.loading && !priceImpactParams.priceImpact
     const walletIsNotConnected = !account
 
     return {
@@ -31,5 +34,5 @@ export function useTwapWarningsContext(): TwapWarningsContext {
       showPriceImpactWarning,
       walletIsNotConnected,
     }
-  }, [primaryFormValidation, account])
+  }, [primaryFormValidation, account, priceImpactParams])
 }


### PR DESCRIPTION
# Summary

Fix #3 from `Medium` section in https://github.com/cowprotocol/cowswap/issues/3105

During [the refactoring](https://github.com/cowprotocol/cowswap/pull/3074) I lost conditions for price impact warning.
Moved them back.

<img width="400" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/3dfdefab-8786-4c5e-91f3-316de2214fc0">

<img width="400" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/8fd15841-8ad1-4c19-869f-2efaf470284d">


  # To Test

1. Unknown price impact warning displaying in TWAP
2. Unknown price impact warning displaying in Limit orders
