### PR TITLE
fix(swap): reset state after network changes

### DIFF
--- a/apps/cowswap-frontend/src/legacy/hooks/useWrapCallback.ts
+++ b/apps/cowswap-frontend/src/legacy/hooks/useWrapCallback.ts
@@ -12,7 +12,7 @@ import { useTransactionAdder } from 'legacy/state/enhancedTransactions/hooks'
 import { calculateGasMargin } from 'legacy/utils/calculateGasMargin'
 import { getChainCurrencySymbols } from 'legacy/utils/gnosis_chain/hack'
 
-import { ExtendedTradeRawState } from 'modules/trade/types/TradeRawState'
+import { ExtendedTradeRawState, TradeRawState } from 'modules/trade/types/TradeRawState'
 
 import { formatTokenAmount } from 'utils/amountFormat'
 
@@ -42,6 +42,7 @@ export interface WrapUnwrapContext {
   wethContract: Contract
   amount: CurrencyAmount<Currency>
   addTransaction: TransactionAdder
+  tradeState: TradeRawState
   updateTradeState: (update: Partial<ExtendedTradeRawState>) => void
   closeModals: () => void
   openTransactionConfirmationModal: OpenSwapConfirmModalCallback
@@ -59,6 +60,7 @@ export async function wrapUnwrapCallback(
     openTransactionConfirmationModal,
     closeModals,
     updateTradeState,
+    tradeState,
   } = context
   const isNativeIn = amount.currency.isNative
   const amountHex = `0x${amount.quotient.toString(RADIX_HEX)}`
@@ -82,7 +84,7 @@ export async function wrapUnwrapCallback(
     useModals && closeModals()
 
     // Clean up form fields after successful wrap/unwrap
-    updateTradeState({ inputCurrencyAmount: '', outputCurrencyAmount: '' })
+    updateTradeState({ ...tradeState, inputCurrencyAmount: '', outputCurrencyAmount: '' })
 
     return txReceipt
   } catch (error: any) {

--- a/apps/cowswap-frontend/src/legacy/state/swap/reducer.ts
+++ b/apps/cowswap-frontend/src/legacy/state/swap/reducer.ts
@@ -88,10 +88,10 @@ export default createReducer<SwapState>(initialState, (builder) =>
         typedValue: typedValue ?? state.typedValue,
         chainId,
         [Field.INPUT]: {
-          currencyId: inputCurrencyId ?? state.INPUT.currencyId,
+          currencyId: inputCurrencyId ?? null,
         },
         [Field.OUTPUT]: {
-          currencyId: outputCurrencyId ?? state.OUTPUT.currencyId,
+          currencyId: outputCurrencyId ?? null,
         },
         recipient,
       }

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
@@ -15,6 +15,7 @@ import {
   limitOrdersWarningsAtom,
   updateLimitOrdersWarningsAtom,
 } from 'modules/limitOrders/state/limitOrdersWarningsAtom'
+import { useTradePriceImpact } from 'modules/trade'
 import { NoImpactWarning } from 'modules/trade/pure/NoImpactWarning'
 import { TradeFormValidation, useGetTradeFormValidation } from 'modules/tradeFormValidation'
 import { useTradeQuote } from 'modules/tradeQuote'
@@ -64,13 +65,21 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
   const localFormValidation = useLimitOrdersFormState()
   const primaryFormValidation = useGetTradeFormValidation()
   const rateImpact = useRateImpact()
-  const { chainId, account } = useWalletInfo()
+  const { account } = useWalletInfo()
   const { slippageAdjustedSellAmount, inputCurrency, inputCurrencyAmount, outputCurrency, outputCurrencyAmount } =
     useLimitOrdersDerivedState()
   const tradeQuote = useTradeQuote()
+  const priceImpactParams = useTradePriceImpact()
 
   const canTrade = localFormValidation === null && primaryFormValidation === null && !tradeQuote.error
-  const showPriceImpactWarning = canTrade && !tradeQuote.isLoading && !!chainId && !expertMode && !!account
+  const showPriceImpactWarning =
+    canTrade &&
+    !tradeQuote.isLoading &&
+    !expertMode &&
+    !!account &&
+    !priceImpactParams.loading &&
+    !priceImpactParams.priceImpact
+
   const showRateImpactWarning =
     canTrade &&
     !tradeQuote.isLoading &&

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useWrapNativeFlow.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useWrapNativeFlow.ts
@@ -39,10 +39,10 @@ function useWrapNativeContext(amount: Nullish<CurrencyAmount<Currency>>): WrapUn
   const { chainId } = useWalletInfo()
   const wethContract = useWETHContract()
   const addTransaction = useTransactionAdder()
-  const { updateState } = useTradeState()
+  const { updateState, state: tradeState } = useTradeState()
   const setWrapNativeState = useSetAtom(wrapNativeStateAtom)
 
-  if (!wethContract || !chainId || !amount || !updateState) {
+  if (!wethContract || !chainId || !amount || !updateState || !tradeState) {
     return null
   }
 
@@ -51,6 +51,7 @@ function useWrapNativeContext(amount: Nullish<CurrencyAmount<Currency>>): WrapUn
     wethContract,
     amount,
     addTransaction,
+    tradeState,
     updateTradeState: updateState,
     closeModals() {
       setWrapNativeState({ isOpen: false })

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useTwapWarningsContext.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useTwapWarningsContext.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 
+import { useTradePriceImpact } from 'modules/trade'
 import { TradeFormValidation, useGetTradeFormValidation } from 'modules/tradeFormValidation'
 import { useWalletInfo } from 'modules/wallet'
 
@@ -18,12 +19,14 @@ export interface TwapWarningsContext {
 export function useTwapWarningsContext(): TwapWarningsContext {
   const { account } = useWalletInfo()
   const primaryFormValidation = useGetTradeFormValidation()
+  const priceImpactParams = useTradePriceImpact()
 
   return useMemo(() => {
     // TODO: bind to settings
     const expertMode = false
     const canTrade = !primaryFormValidation || NOT_BLOCKING_VALIDATIONS.includes(primaryFormValidation)
-    const showPriceImpactWarning = canTrade && !expertMode
+    const showPriceImpactWarning =
+      canTrade && !expertMode && !priceImpactParams.loading && !priceImpactParams.priceImpact
     const walletIsNotConnected = !account
 
     return {
@@ -31,5 +34,5 @@ export function useTwapWarningsContext(): TwapWarningsContext {
       showPriceImpactWarning,
       walletIsNotConnected,
     }
-  }, [primaryFormValidation, account])
+  }, [primaryFormValidation, account, priceImpactParams])
 }


### PR DESCRIPTION
# Summary

Fixed #5 from `Medium` section in https://github.com/cowprotocol/cowswap/issues/3105

  # To Test

1. On Swap page select WETH -> USDC on Mainnet
2. Change network to Goerli
- [ ] AR: sell token is WETH, but token is USDC
- [ ] ER: sell token is WETH, but token is empty

  # Background

The bug was introduced in https://github.com/cowprotocol/cowswap/pull/3095