### PR TITLE
fix: add html space chars before banner token symbols

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/InlineBanner/banners.tsx
+++ b/apps/cowswap-frontend/src/common/pure/InlineBanner/banners.tsx
@@ -31,8 +31,8 @@ export function BundleTxWrapBanner({ nativeCurrencySymbol, wrappedCurrencySymbol
       <strong>Token wrapping bundling</strong>
       <p>
         For your convenience, CoW Swap will bundle all the necessary actions for this trade into a single transaction.
-        This includes the {nativeCurrencySymbol} wrapping and, if needed,
-        {wrappedCurrencySymbol} approval. Even if the trade fails, your wrapping and approval will be done!
+        This includes the&nbsp;{nativeCurrencySymbol}&nbsp;wrapping and, if needed,&nbsp;{wrappedCurrencySymbol}
+        &nbsp;approval. Even if the trade fails, your wrapping and approval will be done!
       </p>
     </InlineBanner>
   )


### PR DESCRIPTION
# Summary

Addresses minor issue #1 from https://github.com/cowprotocol/cowswap/issues/3105

# To Test

1. Load the Safe app
2. Pick native token as sell
* Banner should be displayed with spaces
![image](https://github.com/cowprotocol/cowswap/assets/43217/767a389f-6cb9-497f-b2ee-560b7c056249)
