### PR TITLE
chore: refactor and simplify pixel logic

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/analytics/events/transactionEvents.ts
+++ b/apps/cowswap-frontend/src/legacy/components/analytics/events/transactionEvents.ts
@@ -1,13 +1,7 @@
 import { OrderClass } from '@cowprotocol/cow-sdk'
 
 import { sendEvent } from '../googleAnalytics'
-import { PIXEL_EVENTS } from '../pixel/constants'
-import { sendFacebookEvent } from '../pixel/facebook'
-import { sendLinkedinEvent } from '../pixel/linkedin'
-import { sendMicrosoftEvent } from '../pixel/microsoft'
-import { sendPavedEvent } from '../pixel/paved'
-import { sendRedditEvent } from '../pixel/reddit'
-import { sendTwitterEvent } from '../pixel/twitter'
+import { PixelEvent, sendAllPixels } from '../pixel'
 import { AnalyticsOrderType, Category } from '../types'
 
 const LABEL_FROM_CLASS: Record<AnalyticsOrderType, string> = {
@@ -86,12 +80,7 @@ export function signTradeAnalytics(orderClass: AnalyticsOrderType, label?: strin
 export type OrderType = 'Posted' | 'Executed' | 'Canceled' | 'Expired'
 export function orderAnalytics(action: OrderType, orderClass: AnalyticsOrderType, label?: string) {
   if (action === 'Posted') {
-    sendFacebookEvent(PIXEL_EVENTS.POST_TRADE)
-    sendLinkedinEvent(PIXEL_EVENTS.POST_TRADE)
-    sendTwitterEvent(PIXEL_EVENTS.POST_TRADE)
-    sendRedditEvent(PIXEL_EVENTS.POST_TRADE)
-    sendPavedEvent(PIXEL_EVENTS.POST_TRADE)
-    sendMicrosoftEvent(PIXEL_EVENTS.POST_TRADE)
+    sendAllPixels(PixelEvent.POST_TRADE)
   }
 
   sendEvent({

--- a/apps/cowswap-frontend/src/legacy/components/analytics/hooks/useAnalyticsReporter.ts
+++ b/apps/cowswap-frontend/src/legacy/components/analytics/hooks/useAnalyticsReporter.ts
@@ -17,13 +17,14 @@ import { useGetMarketDimension } from './useGetMarketDimension'
 
 import { googleAnalytics } from '../googleAnalytics'
 import { GOOGLE_ANALYTICS_CLIENT_ID_STORAGE_KEY } from '../index'
-import { PIXEL_EVENTS } from '../pixel/constants'
-import { sendFacebookEvent } from '../pixel/facebook'
-import { sendLinkedinEvent } from '../pixel/linkedin'
-import { sendMicrosoftEvent } from '../pixel/microsoft'
-import { sendPavedEvent } from '../pixel/paved'
-import { sendRedditEvent } from '../pixel/reddit'
-import { sendTwitterEvent } from '../pixel/twitter'
+import { PixelEvent, sendAllPixels } from '../pixel'
+import {
+  enablePixelFacebook,
+  enablePixelMicrosoft,
+  enablePixelPaved,
+  enablePixelReddit,
+  enablePixelTwitter,
+} from '../pixel'
 import { Dimensions } from '../types'
 
 export function sendTiming(timingCategory: any, timingVar: any, timingValue: any, timingLabel: any) {
@@ -87,12 +88,7 @@ export function useAnalyticsReporter() {
 
     // Handle pixel tracking on wallet connection
     if (!prevAccount && account) {
-      sendFacebookEvent(PIXEL_EVENTS.CONNECT_WALLET)
-      sendLinkedinEvent(PIXEL_EVENTS.CONNECT_WALLET)
-      sendTwitterEvent(PIXEL_EVENTS.CONNECT_WALLET)
-      sendRedditEvent(PIXEL_EVENTS.CONNECT_WALLET)
-      sendPavedEvent(PIXEL_EVENTS.CONNECT_WALLET)
-      sendMicrosoftEvent(PIXEL_EVENTS.CONNECT_WALLET)
+      sendAllPixels(PixelEvent.CONNECT_WALLET)
     }
   }, [account, walletName, prevAccount])
 
@@ -113,12 +109,18 @@ export function useAnalyticsReporter() {
   // Handle initiate pixel tracking
   useEffect(() => {
     if (!initiatedPixel) {
-      sendFacebookEvent(PIXEL_EVENTS.INIT)
-      sendLinkedinEvent(PIXEL_EVENTS.INIT)
-      sendTwitterEvent(PIXEL_EVENTS.INIT)
-      sendRedditEvent(PIXEL_EVENTS.INIT)
-      sendPavedEvent(PIXEL_EVENTS.INIT)
-      sendMicrosoftEvent(PIXEL_EVENTS.INIT)
+      // Init all pixels
+      const enablePixelFunctions = [
+        enablePixelFacebook,
+        enablePixelMicrosoft,
+        enablePixelPaved,
+        enablePixelReddit,
+        enablePixelTwitter,
+      ]
+      enablePixelFunctions.forEach((enablePixel) => enablePixel())
+
+      // Sent
+      sendAllPixels(PixelEvent.INIT)
 
       initiatedPixel = true
     }

--- a/apps/cowswap-frontend/src/legacy/components/analytics/pixel/constants.ts
+++ b/apps/cowswap-frontend/src/legacy/components/analytics/pixel/constants.ts
@@ -1,9 +1,3 @@
 import { isEns, isProd } from 'legacy/utils/environments'
 
 export const PIXEL_ENABLED = isProd || isEns
-
-export enum PIXEL_EVENTS {
-  INIT = 'init',
-  CONNECT_WALLET = 'connect_wallet',
-  POST_TRADE = 'post_trade',
-}

--- a/apps/cowswap-frontend/src/legacy/components/analytics/pixel/facebook.ts
+++ b/apps/cowswap-frontend/src/legacy/components/analytics/pixel/facebook.ts
@@ -1,12 +1,17 @@
-import { PIXEL_EVENTS } from './constants'
+import { enablePixel } from './sendAllPixels'
+import { PixelEvent, PixelEventMap } from './types'
 import { sendPixel } from './utils'
 
-const events = {
-  [PIXEL_EVENTS.INIT]: 'InitiateCheckout',
-  [PIXEL_EVENTS.CONNECT_WALLET]: 'Contact',
-  [PIXEL_EVENTS.POST_TRADE]: 'Lead',
+const events: PixelEventMap<string> = {
+  [PixelEvent.INIT]: 'InitiateCheckout',
+  [PixelEvent.CONNECT_WALLET]: 'Contact',
+  [PixelEvent.POST_TRADE]: 'Lead',
 }
 
-export const sendFacebookEvent = sendPixel((event) => {
+const sendFacebookEvent = sendPixel((event) => {
   window.fbq?.('track', events[event])
 })
+
+export function enablePixelFacebook() {
+  enablePixel(events, sendFacebookEvent)
+}

--- a/apps/cowswap-frontend/src/legacy/components/analytics/pixel/index.ts
+++ b/apps/cowswap-frontend/src/legacy/components/analytics/pixel/index.ts
@@ -1,0 +1,9 @@
+export { sendAllPixels } from './sendAllPixels'
+export * from './types'
+
+// Register
+export { enablePixelFacebook } from './facebook'
+export { enablePixelPaved } from './paved'
+export { enablePixelReddit } from './reddit'
+export { enablePixelTwitter } from './twitter'
+export { enablePixelMicrosoft } from './microsoft'

--- a/apps/cowswap-frontend/src/legacy/components/analytics/pixel/linkedin.ts
+++ b/apps/cowswap-frontend/src/legacy/components/analytics/pixel/linkedin.ts
@@ -1,12 +1,17 @@
-import { PIXEL_EVENTS } from './constants'
+import { enablePixel } from './sendAllPixels'
+import { PixelEvent, PixelEventMap } from './types'
 import { sendPixel } from './utils'
 
-const events = {
-  [PIXEL_EVENTS.INIT]: 10759506,
-  [PIXEL_EVENTS.CONNECT_WALLET]: 10759514,
-  [PIXEL_EVENTS.POST_TRADE]: 10759522,
+const events: PixelEventMap<number> = {
+  [PixelEvent.INIT]: 10759506,
+  [PixelEvent.CONNECT_WALLET]: 10759514,
+  [PixelEvent.POST_TRADE]: 10759522,
 }
 
-export const sendLinkedinEvent = sendPixel((event) => {
+const sendLinkedinEvent = sendPixel((event) => {
   window.lintrk?.('track', { conversion_id: events[event] })
 })
+
+export function enablePixelLinkedin() {
+  enablePixel(events, sendLinkedinEvent)
+}

--- a/apps/cowswap-frontend/src/legacy/components/analytics/pixel/microsoft.ts
+++ b/apps/cowswap-frontend/src/legacy/components/analytics/pixel/microsoft.ts
@@ -1,13 +1,18 @@
-import { PIXEL_EVENTS } from './constants'
+import { enablePixel } from './sendAllPixels'
+import { PixelEvent, PixelEventMap } from './types'
 import { sendPixel } from './utils'
 
-const events = {
-  [PIXEL_EVENTS.INIT]: 'page_view',
-  [PIXEL_EVENTS.CONNECT_WALLET]: 'begin_checkout',
-  [PIXEL_EVENTS.POST_TRADE]: 'purchase',
+const events: PixelEventMap<string> = {
+  [PixelEvent.INIT]: 'page_view',
+  [PixelEvent.CONNECT_WALLET]: 'begin_checkout',
+  [PixelEvent.POST_TRADE]: 'purchase',
 }
 
-export const sendMicrosoftEvent = sendPixel((event) => {
+const sendMicrosoftEvent = sendPixel((event) => {
   window.uetq = window.uetq || []
   window.uetq.push('event', events[event], {})
 })
+
+export function enablePixelMicrosoft() {
+  enablePixel(events, sendMicrosoftEvent)
+}

--- a/apps/cowswap-frontend/src/legacy/components/analytics/pixel/paved.ts
+++ b/apps/cowswap-frontend/src/legacy/components/analytics/pixel/paved.ts
@@ -1,12 +1,17 @@
-import { PIXEL_EVENTS } from './constants'
+import { enablePixel } from './sendAllPixels'
+import { PixelEvent, PixelEventMap } from './types'
 import { sendPixel } from './utils'
 
-const events = {
-  [PIXEL_EVENTS.INIT]: 'search',
-  [PIXEL_EVENTS.CONNECT_WALLET]: 'sign_up',
-  [PIXEL_EVENTS.POST_TRADE]: 'purchase',
+const events: PixelEventMap<string> = {
+  [PixelEvent.INIT]: 'search',
+  [PixelEvent.CONNECT_WALLET]: 'sign_up',
+  [PixelEvent.POST_TRADE]: 'purchase',
 }
 
-export const sendPavedEvent = sendPixel((event: PIXEL_EVENTS) => {
+const sendPavedEvent = sendPixel((event) => {
   window.pvd?.('event', events[event])
 })
+
+export function enablePixelPaved() {
+  enablePixel(events, sendPavedEvent)
+}

--- a/apps/cowswap-frontend/src/legacy/components/analytics/pixel/reddit.ts
+++ b/apps/cowswap-frontend/src/legacy/components/analytics/pixel/reddit.ts
@@ -1,12 +1,17 @@
-import { PIXEL_EVENTS } from './constants'
+import { enablePixel } from './sendAllPixels'
+import { PixelEvent, PixelEventMap } from './types'
 import { sendPixel } from './utils'
 
-const events = {
-  [PIXEL_EVENTS.INIT]: 'Lead',
-  [PIXEL_EVENTS.CONNECT_WALLET]: 'SignUp',
-  [PIXEL_EVENTS.POST_TRADE]: 'Purchase',
+const events: PixelEventMap<string> = {
+  [PixelEvent.INIT]: 'Lead',
+  [PixelEvent.CONNECT_WALLET]: 'SignUp',
+  [PixelEvent.POST_TRADE]: 'Purchase',
 }
 
-export const sendRedditEvent = sendPixel((event) => {
+const sendRedditEvent = sendPixel((event) => {
   window.rdt?.('track', events[event])
 })
+
+export function enablePixelReddit() {
+  enablePixel(events, sendRedditEvent)
+}

--- a/apps/cowswap-frontend/src/legacy/components/analytics/pixel/sendAllPixels.ts
+++ b/apps/cowswap-frontend/src/legacy/components/analytics/pixel/sendAllPixels.ts
@@ -1,0 +1,35 @@
+import { PixelEvent, PixelEventMap, SendPixel } from './types'
+
+const sendPixelCallbacks: Map<PixelEvent, SendPixel[]> = new Map()
+
+/**
+ * Sends all the enabled pixels for the given event
+ *
+ * @param event event to send
+ */
+export function sendAllPixels(event: PixelEvent): void {
+  const callbacks = sendPixelCallbacks.get(event)
+  if (!callbacks) return
+
+  callbacks.forEach((callback) => callback(event))
+}
+
+function _enablePixel(event: PixelEvent, sendPixel: SendPixel) {
+  let callbacks = sendPixelCallbacks.get(event)
+  if (!callbacks) {
+    callbacks = []
+    sendPixelCallbacks.set(event, callbacks)
+  }
+
+  callbacks.push(sendPixel)
+}
+
+/**
+ * Register a pixel callback for the given set of events events
+ */
+export function enablePixel(eventMap: PixelEventMap<any>, sendPixel: SendPixel) {
+  Object.keys(eventMap).forEach((event) => {
+    const e = event as PixelEvent
+    _enablePixel(e, sendPixel)
+  })
+}

--- a/apps/cowswap-frontend/src/legacy/components/analytics/pixel/twitter.ts
+++ b/apps/cowswap-frontend/src/legacy/components/analytics/pixel/twitter.ts
@@ -1,12 +1,17 @@
-import { PIXEL_EVENTS } from './constants'
+import { enablePixel } from './sendAllPixels'
+import { PixelEvent, PixelEventMap } from './types'
 import { sendPixel } from './utils'
 
-const events = {
-  [PIXEL_EVENTS.INIT]: 'tw-oddz2-oddz8',
-  [PIXEL_EVENTS.CONNECT_WALLET]: 'tw-oddz2-oddza',
-  [PIXEL_EVENTS.POST_TRADE]: 'tw-oddz2-oddzb',
+const events: PixelEventMap<string> = {
+  [PixelEvent.INIT]: 'tw-oddz2-oddz8',
+  [PixelEvent.CONNECT_WALLET]: 'tw-oddz2-oddza',
+  [PixelEvent.POST_TRADE]: 'tw-oddz2-oddzb',
 }
 
-export const sendTwitterEvent = sendPixel((event: PIXEL_EVENTS) => {
+export const sendTwitterEvent = sendPixel((event) => {
   window.twq?.('event', events[event], {})
 })
+
+export function enablePixelTwitter() {
+  enablePixel(events, sendTwitterEvent)
+}

--- a/apps/cowswap-frontend/src/legacy/components/analytics/pixel/types.ts
+++ b/apps/cowswap-frontend/src/legacy/components/analytics/pixel/types.ts
@@ -1,0 +1,9 @@
+export enum PixelEvent {
+  INIT = 'init',
+  CONNECT_WALLET = 'connect_wallet',
+  POST_TRADE = 'post_trade',
+}
+
+export type SendPixel = (event: PixelEvent) => void
+
+export type PixelEventMap<T> = Record<PixelEvent, T>

--- a/apps/cowswap-frontend/src/legacy/components/analytics/pixel/utils.ts
+++ b/apps/cowswap-frontend/src/legacy/components/analytics/pixel/utils.ts
@@ -1,8 +1,7 @@
-import { PIXEL_ENABLED, PIXEL_EVENTS } from './constants'
+import { PIXEL_ENABLED } from './constants'
+import { SendPixel } from './types'
 
-type SendPixelFn = (event: PIXEL_EVENTS) => void
-
-export function sendPixel(sendFn: SendPixelFn): SendPixelFn {
+export function sendPixel(sendFn: SendPixel): SendPixel {
   return (event) => {
     if (!PIXEL_ENABLED) {
       return


### PR DESCRIPTION
# Summary

Marketing is not using all these pixels, so we can remove them.
Before I do so, because they might come back, I did a preparatory PR to refactor, so we can easily remove them and add it back later. 

Also, makes it easier to maintain and control the pixels you want to use.

## Register pixels
Now the pixels have a register function, which allows to register the sendPixel function for a set of events

There's common types that makes it easier to work with. 

## Send All Pixels
It allows to send all the pixels for a certain events. It will delegate into all the registered pixels for that event.


## Registration
The registration happens now in a single place, in the pixel initialization. This way is now the single point where we control the pixels we use.

I will remove in the next PR all the elements for the list, so the list is empty (to allow to tree-shake the code now)

# To Test
Everything works as before.