### PR TITLE
fix(usd-amount): fallback to native_price API if Coingecko doesn't know the currency

### DIFF
--- a/apps/cowswap-frontend/src/modules/usdAmount/apis/getCoingeckoUsdPrice.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/apis/getCoingeckoUsdPrice.ts
@@ -47,6 +47,12 @@ export class CoingeckoRateLimitError extends Error {
   }
 }
 
+export class CoingeckoUnknownCurrency extends Error {
+  constructor() {
+    super('CoingeckoUnknownCurrency')
+  }
+}
+
 export async function getCoingeckoUsdPrice(currency: Token): Promise<Fraction | null> {
   const platform = COINGECK_PLATFORMS[currency.chainId as SupportedChainId]
 
@@ -72,6 +78,13 @@ export async function getCoingeckoUsdPrice(currency: Token): Promise<Fraction | 
     })
     .then((res: CoinGeckoUsdQuote) => {
       const value = res[currency.address.toLowerCase()]?.usd
-      return value !== undefined ? FractionUtils.fromNumber(value) : null
+
+      // If coingecko API returns an empty response
+      // It means Coingecko doesn't know about the currency
+      if (value === undefined) {
+        throw new CoingeckoUnknownCurrency()
+      }
+
+      return typeof value === 'number' ? FractionUtils.fromNumber(value) : null
     })
 }


### PR DESCRIPTION
# Summary

 Fixes: https://github.com/cowprotocol/cowswap/issues/3105#issuecomment-1710104792

Coingecko doesn't know about 1INCH token on Gnosis chain and returns an empty response `{}`.
In this case we should fallback to `native_price` API and don't try to use Coingecko for this currency again.

<img width="514" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/e460e043-0ca4-4812-97e0-a10fb433cf6b">


  # To Test

1. Select WXDAI -> 1INCH on Gnosis chain
- [ ] the USD amount for 1iNCH should be displayed
- [ ] unknown price impact warning should be hidden
