### PR TITLE
Fix flickery modal

### DIFF
--- a/apps/cowswap-frontend/src/modules/usdAmount/state/usdRawPricesAtom.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/state/usdRawPricesAtom.ts
@@ -41,9 +41,8 @@ export const removeCurrencyToUsdPriceFromQueue = atom(null, (get, set, currency:
   }
 })
 
-export const setUsdPricesLoadingAtom = atom(null, (get, set, currencies: Token[]) => {
+export const setUsdPricesLoadingAtom = atom(null, (get, set, currencies: Token[], isLoading: boolean) => {
   const currentState = get(usdRawPricesAtom)
-  const isLoading = true
 
   const newState = currencies.reduce<UsdRawPrices>((acc, token) => {
     const tokenAddress = token.address.toLowerCase()

--- a/apps/cowswap-frontend/src/modules/usdAmount/updaters/UsdPricesUpdater.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/updaters/UsdPricesUpdater.ts
@@ -17,7 +17,6 @@ import { getCowProtocolNativePrice } from '../apis/getCowProtocolNativePrice'
 import { fetchCurrencyUsdPrice } from '../services/fetchCurrencyUsdPrice'
 import {
   currenciesUsdPriceQueueAtom,
-  resetUsdPricesAtom,
   setUsdPricesLoadingAtom,
   UsdRawPrices,
   usdRawPricesAtom,
@@ -35,7 +34,6 @@ export function UsdPricesUpdater() {
   const { chainId } = useWalletInfo()
   const setUsdPrices = useSetAtom(usdRawPricesAtom)
   const setUsdPricesLoading = useSetAtom(setUsdPricesLoadingAtom)
-  const resetUsdPrices = useSetAtom(resetUsdPricesAtom)
   const currenciesUsdPriceQueue = useAtomValue(currenciesUsdPriceQueueAtom)
 
   const queue = useMemo(() => Object.values(currenciesUsdPriceQueue), [currenciesUsdPriceQueue])
@@ -45,10 +43,10 @@ export function UsdPricesUpdater() {
     () => {
       const getUsdcPrice = usdcPriceLoader(chainId)
 
-      setUsdPricesLoading(queue)
+      setUsdPricesLoading(queue, true)
 
       return processQueue(queue, getUsdcPrice).catch((error) => {
-        resetUsdPrices(queue)
+        setUsdPricesLoading(queue, false)
 
         return Promise.reject(error)
       })


### PR DESCRIPTION
# Summary

Attempt to solve the flickery modal. Not working yet, but some progress on the cause. 

I believe this hook returns `showSurplus` true/false/null if we start to get errors getting the USD estimation, or if the USD changes so we change from showing to not showing. 


I believe we should only calculate it once, and we shouln't recompute the surplus in real time to prevent this issues:
https://github.com/cowprotocol/cowswap/blob/2d36b975256d013e543fbcd43e74144fae146024/apps/cowswap-frontend/src/common/hooks/useGetSurplusFiatValue.ts#L23


I managed to reproduce by adding a random number and returning randomly true/false/null in https://github.com/cowprotocol/cowswap/blob/2d36b975256d013e543fbcd43e74144fae146024/apps/cowswap-frontend/src/common/hooks/useGetSurplusFiatValue.ts#L75 

See video:

https://github.com/cowprotocol/cowswap/assets/2352112/c5a55239-8480-4af8-bc02-4681c5630e4a


