### PR TITLE
fix: surplus modal flickering

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useGetSurplusFiatValue.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useGetSurplusFiatValue.ts
@@ -9,6 +9,7 @@ import { Order } from 'legacy/state/orders/actions'
 
 import { useUsdAmount } from 'modules/usdAmount'
 
+import { useSafeMemo } from 'common/hooks/useSafeMemo'
 import { getExecutedSummaryData } from 'utils/getExecutedSummaryData'
 import { ParsedOrder } from 'utils/orderUtils/parseOrder'
 
@@ -39,13 +40,16 @@ export function useGetSurplusData(order: Order | ParsedOrder | undefined): Outpu
 
   const showSurplus = shouldShowSurplus(surplusFiatValue, surplusAmount)
 
-  return {
-    surplusFiatValue,
-    showFiatValue,
-    surplusToken,
-    surplusAmount,
-    showSurplus,
-  }
+  return useSafeMemo(
+    () => ({
+      surplusFiatValue,
+      showFiatValue,
+      surplusToken,
+      surplusAmount,
+      showSurplus,
+    }),
+    [surplusFiatValue, showFiatValue, surplusToken, surplusAmount, showSurplus]
+  )
 }
 
 function shouldShowSurplus(


### PR DESCRIPTION
# Summary

Fixes `medium` issue #1 from https://github.com/cowprotocol/cowswap/issues/3105

Supersedes https://github.com/cowprotocol/cowswap/pull/3122

As far as I tested, it behaves ok.
It's not easy to reproduce.

# To Test

1. Place order which will generate surplus (increase price impact to 50%)
2. Do NOT close the confirmation modal
3. Wait for it to match
* Modal is displayed WITHOUT flickering