### PR TITLE
fix: fix mapping network name from URL query to chainId

### DIFF
--- a/apps/cowswap-frontend/src/utils/getCurrentChainIdFromUrl.test.ts
+++ b/apps/cowswap-frontend/src/utils/getCurrentChainIdFromUrl.test.ts
@@ -1,0 +1,56 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import { getCurrentChainIdFromUrl } from './getCurrentChainIdFromUrl'
+
+describe('getCurrentChainIdFromUrl()', () => {
+  it('When chainId presents in the url path, then it should taken as chainId', () => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        hash: '#/5/WETH',
+      },
+      writable: true,
+    })
+    const chainId = getCurrentChainIdFromUrl()
+
+    expect(chainId).toBe(SupportedChainId.GOERLI)
+  })
+
+  it('When chainId from the url path is not valid, then should take mainnet as default', () => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        hash: '#/999/WETH',
+      },
+      writable: true,
+    })
+
+    const chainId = getCurrentChainIdFromUrl()
+
+    expect(chainId).toBe(SupportedChainId.MAINNET)
+  })
+
+  it('When network name presents in the url query, then it should taken as chainId', () => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        hash: '#/WETH?chain=gnosis_chain',
+      },
+      writable: true,
+    })
+
+    const chainId = getCurrentChainIdFromUrl()
+
+    expect(chainId).toBe(SupportedChainId.GNOSIS_CHAIN)
+  })
+
+  it('When network name from the url query is not valid, then should take mainnet as default', () => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        hash: '#/WETH?chain=blabla',
+      },
+      writable: true,
+    })
+
+    const chainId = getCurrentChainIdFromUrl()
+
+    expect(chainId).toBe(SupportedChainId.MAINNET)
+  })
+})

--- a/apps/cowswap-frontend/src/utils/getCurrentChainIdFromUrl.ts
+++ b/apps/cowswap-frontend/src/utils/getCurrentChainIdFromUrl.ts
@@ -1,13 +1,20 @@
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
+const chainNameToIdMap: { [key: string]: SupportedChainId } = {
+  mainnet: SupportedChainId.MAINNET,
+  gnosis_chain: SupportedChainId.GNOSIS_CHAIN,
+  goerli: SupportedChainId.GOERLI,
+}
+
 export function getCurrentChainIdFromUrl(): SupportedChainId {
   // Trying to get chainId from URL (#/100/swap)
   // eslint-disable-next-line no-restricted-globals
   const { location } = window
   const urlChainIdMatch = location.hash.match(/^#\/(\d{1,9})\D/)
-  const chainId = +(
-    (urlChainIdMatch ? urlChainIdMatch[1] : new URLSearchParams(location.hash.split('?')[1]).get('chain')) || ''
-  )
+  const searchParams = new URLSearchParams(location.hash.split('?')[1])
+  const chainQueryParam = searchParams.get('chain')
+
+  const chainId = +(urlChainIdMatch?.[1] || chainNameToIdMap[chainQueryParam || ''] || '')
 
   if (chainId && chainId in SupportedChainId) return chainId
 


### PR DESCRIPTION
# Summary

Fixes https://cowservices.slack.com/archives/C0361CDG8GP/p1694180221933559

`getCurrentChainIdFromUrl()` wrongly assumed that `chain` query param is a number, but it's actually a string.

  # To Test

1. Open Account page with not connected wallet
2. Change network to Gnosis chain
3. Try to connect to Metamask
4. AR: App requests Metamask changing network to Mainnet
5. ER: App requests Metamask changing network to Gnosis chain or do nothing when Metamask is already connected to Gnosis chain
