### PR TITLE
fix(usd-price): handle individual token price query failure

### DIFF
--- a/apps/cowswap-frontend/src/modules/usdAmount/state/usdRawPricesAtom.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/state/usdRawPricesAtom.ts
@@ -78,20 +78,3 @@ export const setUsdPricesLoadingAtom = atom(null, (get, set, currencies: Token[]
     set(usdRawPricesAtom, newState)
   }
 })
-
-export const resetUsdPricesAtom = atom(null, (get, set, currencies: Token[]) => {
-  const currentState = get(usdRawPricesAtom)
-  const isLoading = false
-
-  const newState = currencies.reduce<UsdRawPrices>((acc, token) => {
-    const tokenAddress = token.address.toLowerCase()
-
-    acc[tokenAddress] = { currency: token, isLoading, price: null }
-
-    return acc
-  }, {})
-
-  if (!deepEqual(currentState, newState)) {
-    set(usdRawPricesAtom, newState)
-  }
-})

--- a/apps/cowswap-frontend/src/modules/usdAmount/updaters/UsdPricesUpdater.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/updaters/UsdPricesUpdater.ts
@@ -18,7 +18,6 @@ import { getCowProtocolNativePrice } from '../apis/getCowProtocolNativePrice'
 import { fetchCurrencyUsdPrice } from '../services/fetchCurrencyUsdPrice'
 import {
   currenciesUsdPriceQueueAtom,
-  resetUsdPricesAtom,
   setUsdPricesLoadingAtom,
   UsdRawPrices,
   usdRawPricesAtom,
@@ -38,7 +37,6 @@ export function UsdPricesUpdater() {
   const { chainId } = useWalletInfo()
   const setUsdPrices = useSetAtom(usdRawPricesAtom)
   const setUsdPricesLoading = useSetAtom(setUsdPricesLoadingAtom)
-  const resetUsdPrices = useSetAtom(resetUsdPricesAtom)
   const currenciesUsdPriceQueue = useAtomValue(currenciesUsdPriceQueueAtom)
 
   const queue = useMemo(() => Object.values(currenciesUsdPriceQueue), [currenciesUsdPriceQueue])
@@ -52,11 +50,7 @@ export function UsdPricesUpdater() {
 
       setUsdPricesLoading(debouncedQueue)
 
-      return processQueue(debouncedQueue, getUsdcPrice).catch((error) => {
-        resetUsdPrices(debouncedQueue)
-
-        return Promise.reject(error)
-      })
+      return processQueue(debouncedQueue, getUsdcPrice)
     },
     swrOptions
   )


### PR DESCRIPTION
# Summary

Fixes `medium` issue #2.3 from https://github.com/cowprotocol/cowswap/issues/3105#issuecomment-1711691412

When one of the price token queries failed, all of them were reset.

This changes handles it invididualy.

# To Test

1. On gnosis chain, get a shitcoin such as https://gnosisscan.io/token/0x0F1b956128aC17407C29C5600983C6CedF3B2820
2. Make sure you have a non-shitcoin with balance
3. Go to tokens page
* Shitcoint USD balance should not load
* Non-shitcoin USD balance should load
* You should see a debug log for the failed token
![image](https://github.com/cowprotocol/cowswap/assets/43217/d79f23a4-6c75-4be8-9a8c-05b0a798f288)
