### PR TITLE
chore: update quote updater

### DIFF
--- a/apps/cowswap-frontend/src/legacy/state/orders/updaters/UnfillableOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/updaters/UnfillableOrdersUpdater.ts
@@ -150,6 +150,9 @@ export function UnfillableOrdersUpdater(): null {
           account,
           amount: currencyAmount,
           balances: balancesRef.current,
+          spender: undefined, // Only the balance is relevant for determining if we should use verified quotes
+          allowances: undefined, // Only the balance is relevant for determining if we should use verified quotes
+          nativeBalance: undefined, // Not relevant either
         })
         const verifiedQuote = verifiedQuotesEnabled && enoughBalance
 

--- a/apps/cowswap-frontend/src/legacy/state/price/updater.ts
+++ b/apps/cowswap-frontend/src/legacy/state/price/updater.ts
@@ -1,6 +1,7 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
-import { OrderKind } from '@cowprotocol/cow-sdk'
+import { OrderKind, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
 import { DEFAULT_DECIMALS } from 'legacy/constants'
 import useDebounce from 'legacy/hooks/useDebounce'
@@ -22,13 +23,14 @@ import { useWalletInfo } from 'modules/wallet'
 import { getPriceQuality } from 'api/gnosisProtocol/api'
 import { LegacyFeeQuoteParams as LegacyFeeQuoteParamsFull } from 'api/gnosisProtocol/legacy/types'
 import { useVerifiedQuotesEnabled } from 'common/hooks/featureFlags/useVerifiedQuotesEnabled'
+import { useSafeEffect } from 'common/hooks/useSafeMemo'
 import tryParseCurrencyAmount from 'lib/utils/tryParseCurrencyAmount'
 
 import { useAllQuotes, useIsBestQuoteLoading, useSetQuoteError } from './hooks'
 import { QuoteInformationObject } from './reducer'
 
 export const TYPED_VALUE_DEBOUNCE_TIME = 350
-const REFETCH_CHECK_INTERVAL = 10000 // Every 10s
+const REFETCH_CHECK_INTERVAL = 30000 // Every 30s
 const RENEW_FEE_QUOTES_BEFORE_EXPIRATION_TIME = 30000 // Will renew the quote if there's less than 30 seconds left for the quote to expire
 const WAITING_TIME_BETWEEN_EQUAL_REQUESTS = 5000 // Prevents from sending the same request to often (max, every 5s)
 
@@ -58,16 +60,27 @@ function isExpiringSoon(quoteExpirationIsoDate: string, threshold: number): bool
  *
  * Quotes are only valid for a given token-pair and amount. If any of these parameter change, the fee needs to be re-fetched
  */
-function quoteUsingSameParameters(currentParams: FeeQuoteParams, quoteInfo: QuoteInformationObject): boolean {
+function quoteUsingSameParameters(
+  currentParams: FeeQuoteParams,
+  quoteInfo?: QuoteInformationObject
+): {
+  fastQuoteSameParams: boolean
+  bestQuoteSameParams: boolean
+} {
+  if (!quoteInfo) {
+    return { fastQuoteSameParams: false, bestQuoteSameParams: false }
+  }
+
   const {
     amount: currentAmount,
     sellToken: currentSellToken,
     buyToken: currentBuyToken,
     kind: currentKind,
+    priceQuality: currentPriceQuality,
     userAddress: currentUserAddress,
     receiver: currentReceiver,
   } = currentParams
-  const { amount, buyToken, sellToken, kind, userAddress, receiver } = quoteInfo
+  const { amount, buyToken, sellToken, kind, userAddress, receiver, priceQuality } = quoteInfo
   const hasSameReceiver = currentReceiver && receiver ? currentReceiver === receiver : true
 
   // cache the base quote params without quoteInfo user address to check
@@ -79,25 +92,43 @@ function quoteUsingSameParameters(currentParams: FeeQuoteParams, quoteInfo: Quot
     hasSameReceiver
   // 2 checks: if there's a quoteInfo user address (meaning quote was already calculated once) and one without
   // in case user is not connected
-  return userAddress ? currentUserAddress === userAddress && paramsWithoutAddress : paramsWithoutAddress
+
+  const sameParams = userAddress ? currentUserAddress === userAddress && paramsWithoutAddress : paramsWithoutAddress
+
+  return {
+    fastQuoteSameParams: sameParams,
+    bestQuoteSameParams: sameParams && priceQuality === currentPriceQuality,
+  }
 }
 
+const FETCH_QUOTES = { fetchBestQuote: true, fetchFastQuote: true }
+const DONT_FETCH_QUOTES = { fetchBestQuote: false, fetchFastQuote: false }
+const FETCH_BEST_QUOTE = { fetchBestQuote: true, fetchFastQuote: false }
 /**
  *  Decides if we need to refetch the fee information given the current parameters (selected by the user), and the current feeInfo (in the state)
  */
 function isRefetchQuoteRequired(
   isLoading: boolean,
-  currentParams: FeeQuoteParams,
+  bestQuoteSameParams: boolean,
+  fastQuoteSameParams: boolean,
   quoteInformation?: QuoteInformationObject
-): boolean {
+): {
+  fetchBestQuote: boolean
+  fetchFastQuote: boolean
+} {
   // If there's no quote/fee information, we always re-fetch
   if (!quoteInformation) {
-    return true
+    return FETCH_QUOTES
   }
 
-  if (!quoteUsingSameParameters(currentParams, quoteInformation)) {
-    // If the current parameters don't match the fee, the fee information is invalid and needs to be re-fetched
-    return true
+  if (!bestQuoteSameParams || !fastQuoteSameParams) {
+    // If the quote params are different, we always re-fetch
+    const thereIsPreviousPrice = !!quoteInformation?.price?.amount
+
+    return {
+      fetchBestQuote: !bestQuoteSameParams,
+      fetchFastQuote: !thereIsPreviousPrice || !fastQuoteSameParams,
+    }
   }
 
   // The query params are the same, so we only ask for a new quote if:
@@ -106,31 +137,139 @@ function isRefetchQuoteRequired(
   //  - The quote will expire soon
   if (wasQuoteCheckedRecently(quoteInformation.lastCheck)) {
     // Don't Re-fetch if it was queried recently
-    return false
+    return DONT_FETCH_QUOTES
   } else if (isLoading) {
     // Don't Re-fetch if there's another quote going on with the same params
     // It's better to wait for the timeout or resolution. Also prevents an issue of refreshing too fast with slow APIs
-    return false
+    return DONT_FETCH_QUOTES
   } else if (quoteInformation.fee) {
     // Re-fetch if the fee is expiring soon
-    return isExpiringSoon(quoteInformation.fee.expirationDate, RENEW_FEE_QUOTES_BEFORE_EXPIRATION_TIME)
+    const expiringSoon = isExpiringSoon(quoteInformation.fee.expirationDate, RENEW_FEE_QUOTES_BEFORE_EXPIRATION_TIME)
+    return expiringSoon ? FETCH_BEST_QUOTE : DONT_FETCH_QUOTES
   }
 
-  return false
+  return DONT_FETCH_QUOTES
 }
 
 export default function FeesUpdater(): null {
   const { chainId, account } = useWalletInfo()
-  const verifiedQuotesEnabled = useVerifiedQuotesEnabled(chainId)
-
-  const { independentField, typedValue: rawTypedValue, recipient } = useSwapState()
+  const refetchQuote = useRef(useRefetchQuoteCallback())
+  const setQuoteError = useSetQuoteError()
+  const isLoading = useIsBestQuoteLoading()
+  const isOnline = useIsOnline()
+  const quotesMap = useAllQuotes({ chainId })
   const {
     currencies: { INPUT: sellCurrency, OUTPUT: buyCurrency },
     currenciesIds: { INPUT: sellCurrencyId, OUTPUT: buyCurrencyId },
     parsedAmount,
   } = useDerivedSwapInfo()
+  const quoteInfo = useMemo(() => {
+    return quotesMap && sellCurrencyId ? quotesMap[sellCurrencyId] : undefined
+  }, [quotesMap, sellCurrencyId])
 
-  const enoughBalance = useEnoughBalanceAndAllowance({ account, amount: parsedAmount })
+  const quoteParams = useQuoteParams({
+    chainId,
+    account,
+    sellCurrency,
+    buyCurrency,
+    sellCurrencyId,
+    buyCurrencyId,
+    parsedAmount,
+  })
+  const lastQuoteParams = useRef(quoteParams)
+
+  // Update if any parameter is changing
+  useEffect(() => {
+    // Don't refetch if:
+    //  - window is not visible
+    //  - some parameter is missing
+    //  - it is a wrapping operation
+    if (!quoteParams) return
+
+    // Don't refetch if offline.
+    //  Also, make sure we update the error state
+    if (!isOnline) {
+      if (quoteInfo?.error !== 'offline-browser') {
+        setQuoteError({ ...quoteParams, error: 'offline-browser' })
+      }
+      return
+    } else {
+      // If we are online, we make sure we reset the offline-error
+      if (quoteInfo?.error === 'offline-browser') {
+        setQuoteError({ ...quoteParams, error: undefined })
+      }
+    }
+
+    // Callback to re-fetch both the fee and the price
+    const refetchQuoteIfRequired = () => {
+      if (sameQuoteParams(lastQuoteParams.current, quoteParams)) {
+        return
+      }
+
+      lastQuoteParams.current = quoteParams
+      // if no token is unsupported and needs refetching
+      const { bestQuoteSameParams, fastQuoteSameParams } = quoteUsingSameParameters(quoteParams, quoteInfo)
+      const { fetchBestQuote, fetchFastQuote } = isRefetchQuoteRequired(
+        isLoading,
+        bestQuoteSameParams,
+        fastQuoteSameParams,
+        quoteInfo
+      )
+
+      if (fetchBestQuote || fetchFastQuote) {
+        const isPriceRefresh = !fetchFastQuote
+
+        refetchQuote
+          .current({
+            quoteParams,
+            fetchFee: true, // TODO: Review this, because probably now doesn't make any sense to not query the fee in some situations. Actually the endpoint will change to one that returns fee and quote together
+            previousFee: quoteInfo?.fee,
+            isPriceRefresh,
+          })
+          .catch((error) => console.error('Error re-fetching the quote', error))
+      }
+    }
+
+    // Refetch fee and price if any parameter changes
+    refetchQuoteIfRequired()
+
+    // Periodically re-fetch the fee/price, even if the user don't change the parameters
+    // Note that refetchFee won't refresh if it doesn't need to (i.e. the quote is valid for a long time)
+    const intervalId = setInterval(() => {
+      refetchQuoteIfRequired()
+    }, REFETCH_CHECK_INTERVAL)
+
+    return () => clearInterval(intervalId)
+  }, [quoteParams, quoteInfo, isLoading, setQuoteError, isOnline])
+
+  return null
+}
+
+function useQuoteParams(params: {
+  chainId: SupportedChainId
+  account: string | undefined
+  sellCurrency: Currency | null | undefined
+  buyCurrency: Currency | null | undefined
+  sellCurrencyId: string | null | undefined
+  buyCurrencyId: string | null | undefined
+  parsedAmount: CurrencyAmount<Currency> | undefined
+}) {
+  const { chainId, account, parsedAmount, sellCurrency, buyCurrency, sellCurrencyId, buyCurrencyId } = params
+
+  const [quoteParams, setQuoteParams] = useState<FeeQuoteParams | undefined>()
+
+  const verifiedQuotesEnabled = useVerifiedQuotesEnabled(chainId)
+  const isEthFlow = useIsEoaEthFlow()
+  const isUnsupportedTokenGp = useIsUnsupportedTokenGp()
+
+  const { independentField, typedValue: rawTypedValue, recipient } = useSwapState()
+
+  const enoughBalance = useEnoughBalanceAndAllowance({
+    account,
+    amount: parsedAmount,
+    spender: undefined, // Not required for verifiedQuotes
+  })
+  // console.log('[FeesUpdater] enoughBalance veri', { enoughBalance, account, parsedAmount })
 
   const { address: ensRecipientAddress } = useENSAddress(recipient)
   const receiver = ensRecipientAddress || recipient
@@ -139,22 +278,7 @@ export default function FeesUpdater(): null {
   // Fee API calculation/call
   const typedValue = useDebounce(rawTypedValue, TYPED_VALUE_DEBOUNCE_TIME)
 
-  const quotesMap = useAllQuotes({ chainId })
-
-  const quoteInfo = useMemo(() => {
-    return quotesMap && sellCurrencyId ? quotesMap[sellCurrencyId] : undefined
-  }, [quotesMap, sellCurrencyId])
-
-  const isLoading = useIsBestQuoteLoading()
-  const isEthFlow = useIsEoaEthFlow()
-
-  const isUnsupportedTokenGp = useIsUnsupportedTokenGp()
-
-  const refetchQuote = useRefetchQuoteCallback()
-  const setQuoteError = useSetQuoteError()
-
   const isWindowVisible = useIsWindowVisible()
-  const isOnline = useIsOnline()
   const { validTo } = useOrderValidTo()
 
   // prevents things like "USDC" being used as an address
@@ -162,7 +286,7 @@ export default function FeesUpdater(): null {
   const buyTokenAddressInvalid = buyCurrency && !buyCurrency.isNative && !isAddress(buyCurrencyId)
 
   // Update if any parameter is changing
-  useEffect(() => {
+  useSafeEffect(() => {
     // Don't refetch if:
     //  - window is not visible
     //  - some parameter is missing
@@ -195,6 +319,12 @@ export default function FeesUpdater(): null {
     const fromDecimals = sellCurrency?.decimals ?? DEFAULT_DECIMALS
     const toDecimals = buyCurrency?.decimals ?? DEFAULT_DECIMALS
 
+    const unsupportedToken =
+      Boolean(isUnsupportedTokenGp(sellCurrencyId)) || Boolean(isUnsupportedTokenGp(buyCurrencyId))
+    if (unsupportedToken) {
+      return
+    }
+
     const quoteParams = {
       chainId,
       sellToken: sellCurrencyId,
@@ -207,60 +337,15 @@ export default function FeesUpdater(): null {
       userAddress: account,
       validTo,
       isEthFlow,
-      priceQuality: getPriceQuality({ verifyQuote: verifiedQuotesEnabled && enoughBalance }),
+      priceQuality: getPriceQuality({
+        verifyQuote: verifiedQuotesEnabled && enoughBalance,
+      }),
     }
 
-    // Don't refetch if offline.
-    //  Also, make sure we update the error state
-    if (!isOnline) {
-      if (quoteInfo?.error !== 'offline-browser') {
-        setQuoteError({ ...quoteParams, error: 'offline-browser' })
-      }
-      return
-    } else {
-      // If we are online, we make sure we reset the offline-error
-      if (quoteInfo?.error === 'offline-browser') {
-        setQuoteError({ ...quoteParams, error: undefined })
-      }
-    }
-
-    const unsupportedToken = isUnsupportedTokenGp(sellCurrencyId) || isUnsupportedTokenGp(buyCurrencyId)
-
-    // Callback to re-fetch both the fee and the price
-    const refetchQuoteIfRequired = () => {
-      // if no token is unsupported and needs refetching
-      const hasToRefetch = !unsupportedToken && isRefetchQuoteRequired(isLoading, quoteParams, quoteInfo)
-
-      if (hasToRefetch) {
-        // Decide if this is a new quote, or just a refresh
-        const thereIsPreviousPrice = !!quoteInfo?.price?.amount
-        const isPriceRefresh = quoteInfo
-          ? thereIsPreviousPrice && quoteUsingSameParameters(quoteParams, quoteInfo)
-          : false
-
-        refetchQuote({
-          quoteParams,
-          fetchFee: true, // TODO: Review this, because probably now doesn't make any sense to not query the feee in some situations. Actually the endpoint will change to one that returns fee and quote together
-          previousFee: quoteInfo?.fee,
-          isPriceRefresh,
-        }).catch((error) => console.error('Error re-fetching the quote', error))
-      }
-    }
-
-    // Refetch fee and price if any parameter changes
-    refetchQuoteIfRequired()
-
-    // Periodically re-fetch the fee/price, even if the user don't change the parameters
-    // Note that refetchFee won't refresh if it doesn't need to (i.e. the quote is valid for a long time)
-    const intervalId = setInterval(() => {
-      refetchQuoteIfRequired()
-    }, REFETCH_CHECK_INTERVAL)
-
-    return () => clearInterval(intervalId)
+    setQuoteParams(quoteParams)
   }, [
     isEthFlow,
     isWindowVisible,
-    isOnline,
     chainId,
     sellCurrencyId,
     buyCurrencyId,
@@ -268,11 +353,7 @@ export default function FeesUpdater(): null {
     typedValue,
     sellCurrency,
     buyCurrency,
-    quoteInfo,
-    refetchQuote,
     isUnsupportedTokenGp,
-    isLoading,
-    setQuoteError,
     account,
     receiver,
     validTo,
@@ -282,5 +363,29 @@ export default function FeesUpdater(): null {
     verifiedQuotesEnabled,
   ])
 
-  return null
+  return quoteParams
+}
+
+function sameQuoteParams(quoteParams1?: FeeQuoteParams, quoteParams2?: FeeQuoteParams) {
+  if (quoteParams1 === undefined) {
+    return quoteParams2 === undefined
+  }
+  if (quoteParams2 === undefined) {
+    return false
+  }
+
+  return (
+    quoteParams1.amount === quoteParams2.amount &&
+    quoteParams1.buyToken === quoteParams2.buyToken &&
+    quoteParams1.chainId === quoteParams2.chainId &&
+    quoteParams1.fromDecimals === quoteParams2.fromDecimals &&
+    quoteParams1.isBestQuote === quoteParams2.isBestQuote &&
+    quoteParams1.isEthFlow === quoteParams2.isEthFlow &&
+    quoteParams1.kind === quoteParams2.kind &&
+    quoteParams1.priceQuality === quoteParams2.priceQuality &&
+    quoteParams1.receiver === quoteParams2.receiver &&
+    quoteParams1.sellToken === quoteParams2.sellToken &&
+    quoteParams1.toDecimals === quoteParams2.toDecimals &&
+    quoteParams1.userAddress === quoteParams2.userAddress
+  )
 }

--- a/apps/cowswap-frontend/src/modules/tokens/hooks/useOnchainBalances.ts
+++ b/apps/cowswap-frontend/src/modules/tokens/hooks/useOnchainBalances.ts
@@ -39,9 +39,11 @@ export function useOnchainAllowances(params: OnchainAllowancesParams): TokenAmou
 }
 
 /**
- * Fetches
- * @param params
- * @returns
+ * Fetches the balances and allowances for the given account and tokens.
+ * Optionally you can pass a spender to check the allowance for the given account.
+ *
+ * @param params Parameters to fetch the balances and allowances
+ * @returns the balances and allowances for the given account and tokens
  */
 export function useOnchainBalancesAndAllowances(params: BalancesAndAllowancesParams): BalancesAndAllowances {
   const { account, spender, tokens, blocksPerFetchAllowance, blocksPerFetchBalance } = params

--- a/apps/cowswap-frontend/src/modules/tokens/types.ts
+++ b/apps/cowswap-frontend/src/modules/tokens/types.ts
@@ -39,10 +39,29 @@ export type TokenAmountsResult = {
 }
 
 export interface BalancesAndAllowancesParams {
+  /**
+   * Account to fetch the balances and allowances for
+   */
   account: string | undefined
+
+  /**
+   * Spender account to check the allowance for the given account. Undefined if the allowance is not required
+   */
   spender: string | undefined
+
+  /**
+   * List of tokens to get the balance and allowance for
+   */
   tokens: Token[]
+
+  /**
+   * Number of blocks to wait between each balance polling
+   */
   blocksPerFetchBalance?: number
+
+  /**
+   * Number of blocks to wait between each allowance polling
+   */
   blocksPerFetchAllowance?: number
 }
 

--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useQuoteParams.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useQuoteParams.ts
@@ -14,7 +14,7 @@ import { useVerifiedQuotesEnabled } from 'common/hooks/featureFlags/useVerifiedQ
 import { getAddress } from 'utils/getAddress'
 
 export function useQuoteParams(amount: string | null): LegacyFeeQuoteParams | undefined {
-  const { chainId, account } = useWalletInfo()
+  const { chainId, account, active } = useWalletInfo()
   const verifiedQuotesEnabled = useVerifiedQuotesEnabled(chainId)
 
   const { state } = useDerivedTradeState()
@@ -29,10 +29,11 @@ export function useQuoteParams(amount: string | null): LegacyFeeQuoteParams | un
   const enoughBalance = useEnoughBalanceAndAllowance({
     account,
     amount: (inputCurrency && amount && CurrencyAmount.fromRawAmount(inputCurrency, amount)) || undefined,
+    spender: undefined,
   })
 
   return useMemo(() => {
-    if (!sellToken || !buyToken || !amount || !orderKind) return
+    if (!sellToken || !buyToken || !amount || !orderKind || !active) return
 
     const params: LegacyFeeQuoteParams = {
       sellToken,
@@ -45,7 +46,9 @@ export function useQuoteParams(amount: string | null): LegacyFeeQuoteParams | un
       toDecimals,
       fromDecimals,
       isEthFlow: false,
-      priceQuality: getPriceQuality({ verifyQuote: verifiedQuotesEnabled && enoughBalance }),
+      priceQuality: getPriceQuality({
+        verifyQuote: verifiedQuotesEnabled && enoughBalance,
+      }),
     }
 
     return params
@@ -60,5 +63,6 @@ export function useQuoteParams(amount: string | null): LegacyFeeQuoteParams | un
     sellToken,
     toDecimals,
     verifiedQuotesEnabled,
+    active,
   ])
 }

--- a/apps/cowswap-frontend/src/modules/wallet/web3-react/updater.ts
+++ b/apps/cowswap-frontend/src/modules/wallet/web3-react/updater.ts
@@ -96,7 +96,6 @@ export function WalletUpdater() {
 
   // Update wallet info
   useEffect(() => {
-    console.log('[WalletUpdater] setWalletInfo', walletInfo)
     setWalletInfo(walletInfo)
   }, [walletInfo, setWalletInfo])
 


### PR DESCRIPTION
# Summary

This PR fixes the issue that was making our quotes to not use the `verified` price quality type.

This is an example where the UI will load the fast price, then the best quote, and when the balances are ready, if it can do a `verified` quote, it will do it:

<img width="1777" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/a1a0c729-17bd-447c-81ab-0bbeb518f66d">


Also fixed for Limit Orders:

<img width="1487" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/d7bac014-f979-40c9-94a2-cb29327cb20a">


## Additionally

- Does a small refactor in the updater, mainly to:
   - Split the logic that prepare the quote params from the actual polling logic (just to reduce the complexity of the method)
   - It avoids prefetching the same quote twice
- Document better the methods that have to do with fetching balances/allowances
- `quoteUsingSameParameters` will return the flag now for the "fast" and "best" quotes. Now they are not the same since the FAST don't care if the user has enough balance or not (priceQuality is not needed)
- Reduces the polling time for SWAPs
- A few other changes, 

# To Test
Check the quote API calls for:
- Selling an amount you have in your wallet: you should see we query using `verified` price quality
- Repeat with an amount above what you have in your wallet. It should not use `verified` price quality.
- Test also the same in limit orders page