### PR TITLE
feat(permit): feature flag

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/featureFlags/useIsPermitEnabled.ts
+++ b/apps/cowswap-frontend/src/common/hooks/featureFlags/useIsPermitEnabled.ts
@@ -1,0 +1,18 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import { useFeatureFlags } from './useFeatureFlags'
+
+export function useIsPermitEnabled(chainId: SupportedChainId | undefined): boolean {
+  const { permitEnabledMainnet, permitEnabledGoerli, permitEnabledGnosis } = useFeatureFlags()
+
+  switch (chainId) {
+    case SupportedChainId.MAINNET:
+      return !!permitEnabledMainnet
+    case SupportedChainId.GNOSIS_CHAIN:
+      return !!permitEnabledGnosis
+    case SupportedChainId.GOERLI:
+      return !!permitEnabledGoerli
+    default:
+      return false
+  }
+}

--- a/apps/cowswap-frontend/src/modules/permit/hooks/useIsTokenPermittable.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/useIsTokenPermittable.ts
@@ -9,6 +9,8 @@ import { Nullish } from 'types'
 
 import { useWalletInfo } from 'modules/wallet'
 
+import { useIsPermitEnabled } from 'common/hooks/featureFlags/useIsPermitEnabled'
+
 import { addPermitInfoForTokenAtom, permittableTokensAtom } from '../state/atoms'
 import { IsTokenPermittableResult } from '../types'
 import { checkIsTokenPermittable } from '../utils/checkIsTokenPermittable'
@@ -30,11 +32,13 @@ export function useIsTokenPermittable(token: Nullish<Currency>): IsTokenPermitta
   const isNative = token?.isNative
   const tokenName = token?.name || lowerCaseAddress || ''
 
+  const isPermitEnabled = useIsPermitEnabled(chainId)
+
   const addPermitInfo = useAddPermitInfo()
-  const permitInfo = usePermitInfo(chainId, lowerCaseAddress)
+  const permitInfo = usePermitInfo(chainId, isPermitEnabled ? lowerCaseAddress : undefined)
 
   useEffect(() => {
-    if (!chainId || !lowerCaseAddress || !provider || permitInfo !== undefined || isNative) {
+    if (!chainId || !isPermitEnabled || !lowerCaseAddress || !provider || permitInfo !== undefined || isNative) {
       return
     }
 


### PR DESCRIPTION
# Summary

Adding 3 feature flags:
- `permitEnabledMainnet`
- `permitEnabledGnosis`
- `permitEnabledGoerli`

![image](https://github.com/cowprotocol/cowswap/assets/43217/c4e073ed-34e9-4b99-8c15-86493f68b2ca)

# To Test

For testing in this PR and locally, the flag env used it `Test`
![image](https://github.com/cowprotocol/cowswap/assets/43217/599f0e81-569a-44e8-8036-3feed5e5ee11)

1. With the flag off for a given network, connect the app
2. Pick as sell token one that is permittable and has no allowance (you can reset it using revoke.cash)
3. Fill in the form
* Should request an approval tx
![image](https://github.com/cowprotocol/cowswap/assets/43217/8014323d-1884-4dc7-b47d-27a86608ecbf)

4. Turn the flag on
5. Refresh the app (for other flags it picks up after awhile without a refresh, but for this one it did not)
6. Pick the same sell token without approval
* Should not ask for approval and use the permit flow (assuming the token is permittable)