### PR TITLE
feat(permit): better gas limit estimation

### DIFF
--- a/apps/cowswap-frontend/src/modules/permit/const.ts
+++ b/apps/cowswap-frontend/src/modules/permit/const.ts
@@ -6,7 +6,7 @@ import ms from 'ms.macro'
 
 // PK used only for signing permit requests for quoting and identifying token 'permittability'
 // Do not use or try to send funds to it. Or do. It'll be your funds 🤷
-const PERMIT_PK = '0xd0683148c0c6116a3f47340cf088de2fd791304b57d723e46a7f54504edf2cf2'
+const PERMIT_PK = '0xc58a2a421ca71ca57ae698f1c32feeb0b0ccb434da0b8089d88d80fb918f3f9d' // address: 0xFf65D1DfCF256cf4A8D5F2fb8e70F936606B7474
 
 export const PERMIT_SIGNER = new Wallet(PERMIT_PK)
 

--- a/apps/cowswap-frontend/src/modules/permit/const.ts
+++ b/apps/cowswap-frontend/src/modules/permit/const.ts
@@ -16,6 +16,8 @@ export const PERMIT_GAS_LIMIT_MIN: Record<SupportedChainId, number> = {
   5: 36_000,
 }
 
+export const DEFAULT_PERMIT_GAS_LIMIT = '80000'
+
 export const DEFAULT_PERMIT_VALUE = MaxUint256.toString()
 
 export const DEFAULT_PERMIT_DURATION = ms`5 years`

--- a/apps/cowswap-frontend/src/modules/permit/utils/generatePermitHook.ts
+++ b/apps/cowswap-frontend/src/modules/permit/utils/generatePermitHook.ts
@@ -133,9 +133,14 @@ async function calculateGasLimit(
   }
 
   try {
+    // Query the actual gas estimate
     const actual = await provider.estimateGas({ data, from, to })
 
-    return actual.gt(DEFAULT_PERMIT_GAS_LIMIT) ? actual.toString() : DEFAULT_PERMIT_GAS_LIMIT
+    // Add 10% to actual value to account for minor differences with real account
+    const gasLimit = actual.add(actual.div(10))
+
+    // Pick the biggest between estimated and default
+    return gasLimit.gt(DEFAULT_PERMIT_GAS_LIMIT) ? gasLimit.toString() : DEFAULT_PERMIT_GAS_LIMIT
   } catch (e) {
     console.debug(`[calculatePermitGasLimit] Failed to estimateGas, using default`, e)
 

--- a/apps/cowswap-frontend/src/modules/permit/utils/generatePermitHook.ts
+++ b/apps/cowswap-frontend/src/modules/permit/utils/generatePermitHook.ts
@@ -123,21 +123,13 @@ async function calculateGasLimit(
   provider: Web3Provider,
   isUserAccount: boolean
 ): Promise<string> {
-  if (isUserAccount) {
-    // "Real" user account, use the default
-    // If we send a smaller gas limit than what was used in the quote, it won't matter
-    // If we send a bigger gas limit, the order will fail
-
-    // TODO: it might still happen that user's permit will cost more than the static account
-    return DEFAULT_PERMIT_GAS_LIMIT
-  }
-
   try {
     // Query the actual gas estimate
     const actual = await provider.estimateGas({ data, from, to })
 
     // Add 10% to actual value to account for minor differences with real account
-    const gasLimit = actual.add(actual.div(10))
+    // Do not add it if this is the real user's account
+    const gasLimit = !isUserAccount ? actual.add(actual.div(10)) : actual
 
     // Pick the biggest between estimated and default
     return gasLimit.gt(DEFAULT_PERMIT_GAS_LIMIT) ? gasLimit.toString() : DEFAULT_PERMIT_GAS_LIMIT


### PR DESCRIPTION
# Summary

Since we do not have a precise method for estimating the gas for the quote, this PR adds 2 attempts to mitigate it:

1. Estimate the gas cost before sending the quote + 10%
2. Pick the max between default gas limit (80k) and the estimated gas + 10%

## Examples:

Here I list examples simulating the permit with the call data included in the quote and order, respectively.
It matters because each is signed with a different account, with impacts the final gas usage.

### COW

* Quote request call data: https://dashboard.tenderly.co/leandro/project/simulator/fb7d7317-07ab-4293-a3f7-ccbaed163e9e/gas-usage
* Order request call data: https://dashboard.tenderly.co/leandro/project/simulator/3e844725-e0f5-4036-abf9-9f4ae62f0ee1/gas-usage
* Order: https://dev.explorer.cow.fi/orders/0x7cf2225078f92f34bd87e2bb8bd2fe1a874ace9b130ab1a45179abd9b7f8ea623c04c31cf33184bb29150dab05d44aa726818a62650b21e3?tab=overview

### AAVE

AAVE token is one of the more expensive gas wise permits I've seen so far.
The fees for the order were quite high!

* Quote request call data: https://dashboard.tenderly.co/leandro/project/simulator/89847d21-87eb-4499-a443-a1fc3aef5f49/gas-usage
* Order request call data: https://dashboard.tenderly.co/leandro/project/simulator/5202ffc0-755f-4846-84b3-f9556e852c56/gas-usage
* Order: https://dev.explorer.cow.fi/orders/0xce767b722873d0dbe535c5c2df2b69352602b493f7da7eef45b669058a5fa08d3c04c31cf33184bb29150dab05d44aa726818a62650b23f5?tab=overview

# To Test

1. Load the app in goerli or mainnet (gchain not yet sorted out)
2. Pick as sell token a permittable token, for which you have no allowance set yet
3. Sell it
* Should be requested to sign the allowance msg
* Should then be prompted to sign the order
* Order should be accepted by the backend
* If executed, allowance should be set to infinite

If you ever need to try again the same token for some reason, remove the `permitCache*` keys from local storage 
![image](https://github.com/cowprotocol/cowswap/assets/43217/825ca0ef-e366-4e6b-a98c-88a61f89d02c)

## Non-extensive list of permittable tokens (which work AFAICT)

### Goerli
- COW
- UNI

### Mainnet
- COW
- UNI
- AAVE
- 1INCH


# Questions

1. Is 10% too excessive?

In the very limited testing I did so far, seems like so, but we want to be ready for outliers where for some weird reason the static account uses much less gas than the user's account