### PR TITLE
feat(permit): update outdated permits

### DIFF
--- a/apps/cowswap-frontend/src/modules/permit/utils/checkIsTokenPermittable.ts
+++ b/apps/cowswap-frontend/src/modules/permit/utils/checkIsTokenPermittable.ts
@@ -4,10 +4,9 @@ import type { Web3Provider } from '@ethersproject/providers'
 
 import { DAI_LIKE_PERMIT_TYPEHASH, Eip2612PermitUtils } from '@1inch/permit-signed-approvals-utils'
 
-import { PermitProviderConnector } from 'modules/wallet/utils/PermitProviderConnector'
-
 import { buildDaiLikePermitCallData, buildEip2162PermitCallData } from './buildPermitCallData'
 import { getPermitDeadline } from './getPermitDeadline'
+import { getPermitUtilsInstance } from './getPermitUtilsInstance'
 
 import { DEFAULT_PERMIT_VALUE, PERMIT_GAS_LIMIT_MIN, PERMIT_SIGNER } from '../const'
 import { CheckIsTokenPermittableParams, EstimatePermitResult } from '../types'
@@ -99,23 +98,6 @@ async function actuallyCheckTokenIsPermittable(params: CheckIsTokenPermittablePa
       return { error: e.message || e.toString() }
     }
   }
-}
-
-const PERMIT_UTILS_CACHE: Record<number, Eip2612PermitUtils> = {}
-
-function getPermitUtilsInstance(chainId: SupportedChainId, provider: Web3Provider): Eip2612PermitUtils {
-  const cached = PERMIT_UTILS_CACHE[chainId]
-
-  if (cached) {
-    return cached
-  }
-
-  const web3ProviderConnector = new PermitProviderConnector(provider, PERMIT_SIGNER)
-  const eip2612PermitUtils = new Eip2612PermitUtils(web3ProviderConnector)
-
-  PERMIT_UTILS_CACHE[chainId] = eip2612PermitUtils
-
-  return eip2612PermitUtils
 }
 
 // TODO: refactor and make DAI like tokens work

--- a/apps/cowswap-frontend/src/modules/permit/utils/generatePermitHook.ts
+++ b/apps/cowswap-frontend/src/modules/permit/utils/generatePermitHook.ts
@@ -77,9 +77,9 @@ async function generatePermitHookRaw(
   const deadline = getPermitDeadline()
   const value = DEFAULT_PERMIT_VALUE
 
-  const callDataPromise =
+  const callData =
     permitInfo.type === 'eip-2612'
-      ? buildEip2162PermitCallData({
+      ? await buildEip2162PermitCallData({
           eip2162Utils,
           callDataParams: [
             {
@@ -94,7 +94,7 @@ async function generatePermitHookRaw(
             tokenAddress,
           ],
         })
-      : buildDaiLikePermitCallData({
+      : await buildDaiLikePermitCallData({
           eip2162Utils,
           callDataParams: [
             {
@@ -110,8 +110,6 @@ async function generatePermitHookRaw(
             tokenAddress,
           ],
         })
-
-  const callData = await callDataPromise
 
   const gasLimit = await calculateGasLimit(callData, owner, tokenAddress, provider, !!account)
 

--- a/apps/cowswap-frontend/src/modules/permit/utils/generatePermitHook.ts
+++ b/apps/cowswap-frontend/src/modules/permit/utils/generatePermitHook.ts
@@ -22,12 +22,7 @@ export async function generatePermitHook(params: PermitHookParams): Promise<Perm
 
   // Always get the nonce for the real account, to know whether the cache should be invalidated
   // Static account should never need to pre-check the nonce as it'll never change once cached
-  const nonce = account
-    ? await eip2162Utils.getTokenNonce(inputToken.address, account).then((nonce) => {
-        console.log(`bug-getTokenNonce`, account, nonce)
-        return nonce
-      })
-    : undefined
+  const nonce = account ? await eip2162Utils.getTokenNonce(inputToken.address, account) : undefined
 
   const cachedResult = load(permitKey, nonce)
   if (cachedResult) {
@@ -159,7 +154,6 @@ type CachedData = PermitHookData & {
  */
 function save(key: string, nonce: number | undefined, data: PermitHookData): void {
   const cachedData: CachedData = { nonce, ...data }
-  console.debug(`bug-save: caching`, key, nonce, data)
 
   localStorage.setItem(key, JSON.stringify(cachedData))
 }
@@ -174,7 +168,6 @@ function load(key: string, nonce: number | undefined): PermitHookData | undefine
   const cachedData = localStorage.getItem(key)
 
   if (!cachedData) {
-    console.debug(`bug-load: nothing cached`, key, nonce)
     return undefined
   }
 
@@ -191,15 +184,12 @@ function load(key: string, nonce: number | undefined): PermitHookData | undefine
       // Remove cache key
       localStorage.removeItem(key)
 
-      console.debug(`bug-load: stale cache`, key, nonce, storedNonce)
       return undefined
     }
 
-    console.debug(`bug-load: loaded data`, key, nonce, storedNonce, permitHookData)
     // Cache is valid, return it
     return permitHookData
   } catch {
-    console.debug(`bug-load: failed to parse`, key, nonce, cachedData)
     // Failed to parse stored data, return nothing
     return undefined
   }

--- a/apps/cowswap-frontend/src/modules/permit/utils/generatePermitHook.ts
+++ b/apps/cowswap-frontend/src/modules/permit/utils/generatePermitHook.ts
@@ -142,7 +142,7 @@ async function calculateGasLimit(
 function getCacheKey(params: PermitHookParams): string {
   const { inputToken, chainId, account } = params
 
-  return `${CACHE_PREFIX}${inputToken.address.toLowerCase()}-${chainId}${account ? `-${account}` : ''}`
+  return `${CACHE_PREFIX}${inputToken.address.toLowerCase()}-${chainId}${account ? `-${account.toLowerCase()}` : ''}`
 }
 
 type CachedData = PermitHookData & {

--- a/apps/cowswap-frontend/src/modules/permit/utils/generatePermitHook.ts
+++ b/apps/cowswap-frontend/src/modules/permit/utils/generatePermitHook.ts
@@ -3,10 +3,9 @@ import { Web3Provider } from '@ethersproject/providers'
 
 import { Eip2612PermitUtils } from '@1inch/permit-signed-approvals-utils'
 
-import { PermitProviderConnector } from 'modules/wallet/utils/PermitProviderConnector'
-
 import { buildDaiLikePermitCallData, buildEip2162PermitCallData } from './buildPermitCallData'
 import { getPermitDeadline } from './getPermitDeadline'
+import { getPermitUtilsInstance } from './getPermitUtilsInstance'
 
 import { DEFAULT_PERMIT_GAS_LIMIT, DEFAULT_PERMIT_VALUE, PERMIT_SIGNER } from '../const'
 import { PermitHookData, PermitHookParams } from '../types'
@@ -14,17 +13,26 @@ import { PermitHookData, PermitHookParams } from '../types'
 const CACHE_PREFIX = 'permitCache:v0-'
 const REQUESTS_CACHE: { [permitKey: string]: Promise<PermitHookData> } = {}
 
-function getCacheKey(params: PermitHookParams): string {
-  const { inputToken, chainId, account } = params
-
-  return `${CACHE_PREFIX}${inputToken.address.toLowerCase()}-${chainId}${account ? `-${account}` : ''}`
-}
-
 export async function generatePermitHook(params: PermitHookParams): Promise<PermitHookData> {
   const permitKey = getCacheKey(params)
 
-  const cachedResult = localStorage.getItem(permitKey)
-  if (cachedResult) return JSON.parse(cachedResult)
+  const { chainId, provider, account, inputToken } = params
+
+  const eip2162Utils = getPermitUtilsInstance(chainId, provider, account)
+
+  // Always get the nonce for the real account, to know whether the cache should be invalidated
+  // Static account should never need to pre-check the nonce as it'll never change once cached
+  const nonce = account
+    ? await eip2162Utils.getTokenNonce(inputToken.address, account).then((nonce) => {
+        console.log(`bug-getTokenNonce`, account, nonce)
+        return nonce
+      })
+    : undefined
+
+  const cachedResult = load(permitKey, nonce)
+  if (cachedResult) {
+    return cachedResult
+  }
 
   const cachedRequest = REQUESTS_CACHE[permitKey]
 
@@ -37,10 +45,12 @@ export async function generatePermitHook(params: PermitHookParams): Promise<Perm
     }
   }
 
-  const request = generatePermitHookRaw(params).then((permitHookData) => {
-    const permitHook = JSON.stringify(permitHookData)
+  const request = generatePermitHookRaw({ ...params, eip2162Utils, preFetchedNonce: nonce }).then((permitHookData) => {
+    // Store permit in the cache
+    save(permitKey, nonce, permitHookData)
 
-    localStorage.setItem(permitKey, permitHook)
+    // Remove consumed request to avoid stale data
+    delete REQUESTS_CACHE[permitKey]
 
     return permitHookData
   })
@@ -50,21 +60,18 @@ export async function generatePermitHook(params: PermitHookParams): Promise<Perm
   return request
 }
 
-async function generatePermitHookRaw(params: PermitHookParams): Promise<PermitHookData> {
-  const { inputToken, chainId, permitInfo, provider, account } = params
+async function generatePermitHookRaw(
+  params: PermitHookParams & { eip2162Utils: Eip2612PermitUtils; preFetchedNonce: number | undefined }
+): Promise<PermitHookData> {
+  const { inputToken, chainId, permitInfo, provider, account, eip2162Utils, preFetchedNonce } = params
   const tokenAddress = inputToken.address
   const tokenName = inputToken.name || tokenAddress
 
-  // TODO: verify whether cached result is still valid and renew it if needed
-
-  const web3ProviderConnector = new PermitProviderConnector(provider, account ? undefined : PERMIT_SIGNER)
-  const eip2612PermitUtils = new Eip2612PermitUtils(web3ProviderConnector)
-
   const owner = account || PERMIT_SIGNER.address
 
-  // TODO: check whether cached permit nonce matches current nonce and update it in case it doesnt
-
-  const nonce = await eip2612PermitUtils.getTokenNonce(tokenAddress, owner)
+  // Only fetch the nonce in case it wasn't pre-fetched before
+  // That's the case for static account
+  const nonce = preFetchedNonce === undefined ? await eip2162Utils.getTokenNonce(tokenAddress, owner) : preFetchedNonce
 
   const spender = GP_VAULT_RELAYER[chainId]
   const deadline = getPermitDeadline()
@@ -73,7 +80,7 @@ async function generatePermitHookRaw(params: PermitHookParams): Promise<PermitHo
   const callDataPromise =
     permitInfo.type === 'eip-2612'
       ? buildEip2162PermitCallData({
-          eip2162Utils: eip2612PermitUtils,
+          eip2162Utils,
           callDataParams: [
             {
               owner,
@@ -88,7 +95,7 @@ async function generatePermitHookRaw(params: PermitHookParams): Promise<PermitHo
           ],
         })
       : buildDaiLikePermitCallData({
-          eip2162Utils: eip2612PermitUtils,
+          eip2162Utils,
           callDataParams: [
             {
               holder: owner,
@@ -136,5 +143,66 @@ async function calculateGasLimit(
     console.debug(`[calculatePermitGasLimit] Failed to estimateGas, using default`, e)
 
     return DEFAULT_PERMIT_GAS_LIMIT
+  }
+}
+
+function getCacheKey(params: PermitHookParams): string {
+  const { inputToken, chainId, account } = params
+
+  return `${CACHE_PREFIX}${inputToken.address.toLowerCase()}-${chainId}${account ? `-${account}` : ''}`
+}
+
+type CachedData = PermitHookData & {
+  nonce: number | undefined
+}
+
+/**
+ * Stores data based on `key` and `nonce`
+ */
+function save(key: string, nonce: number | undefined, data: PermitHookData): void {
+  const cachedData: CachedData = { nonce, ...data }
+  console.debug(`bug-save: caching`, key, nonce, data)
+
+  localStorage.setItem(key, JSON.stringify(cachedData))
+}
+
+/**
+ * Loads stored data if still valid
+ *
+ * Validity is based on `nonce` and only applies to real accounts
+ * Static data never gets invalidated
+ */
+function load(key: string, nonce: number | undefined): PermitHookData | undefined {
+  const cachedData = localStorage.getItem(key)
+
+  if (!cachedData) {
+    console.debug(`bug-load: nothing cached`, key, nonce)
+    return undefined
+  }
+
+  try {
+    const parsedData: CachedData = JSON.parse(cachedData)
+
+    // Extract nonce out of cached data
+    const { nonce: storedNonce, ...permitHookData } = parsedData
+
+    // TODO: if one is defined while the other is not, should also ignore the cache
+    if (nonce !== undefined && storedNonce !== undefined && storedNonce < nonce) {
+      // When both nonces exist and stored is < than new, data is outdated
+
+      // Remove cache key
+      localStorage.removeItem(key)
+
+      console.debug(`bug-load: stale cache`, key, nonce, storedNonce)
+      return undefined
+    }
+
+    console.debug(`bug-load: loaded data`, key, nonce, storedNonce, permitHookData)
+    // Cache is valid, return it
+    return permitHookData
+  } catch {
+    console.debug(`bug-load: failed to parse`, key, nonce, cachedData)
+    // Failed to parse stored data, return nothing
+    return undefined
   }
 }

--- a/apps/cowswap-frontend/src/modules/permit/utils/getPermitDeadline.ts
+++ b/apps/cowswap-frontend/src/modules/permit/utils/getPermitDeadline.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_PERMIT_DURATION } from '../const'
 
 export function getPermitDeadline() {
-  return Math.ceil(Date.now() / 1000) + DEFAULT_PERMIT_DURATION
+  return Math.ceil((Date.now() + DEFAULT_PERMIT_DURATION) / 1000)
 }

--- a/apps/cowswap-frontend/src/modules/permit/utils/getPermitUtilsInstance.ts
+++ b/apps/cowswap-frontend/src/modules/permit/utils/getPermitUtilsInstance.ts
@@ -1,0 +1,32 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import type { Web3Provider } from '@ethersproject/providers'
+
+import { Eip2612PermitUtils } from '@1inch/permit-signed-approvals-utils'
+
+import { PermitProviderConnector } from 'modules/wallet/utils/PermitProviderConnector'
+
+import { PERMIT_SIGNER } from '../const'
+
+const PERMIT_UTILS_CACHE: Record<number, Eip2612PermitUtils> = {}
+
+export function getPermitUtilsInstance(
+  chainId: SupportedChainId,
+  provider: Web3Provider,
+  account?: string | undefined
+): Eip2612PermitUtils {
+  const cached = PERMIT_UTILS_CACHE[chainId]
+
+  // Only cache if there's no account to prevent stale signers
+  if (!account && cached) {
+    return cached
+  }
+
+  const web3ProviderConnector = new PermitProviderConnector(provider, account ? undefined : PERMIT_SIGNER)
+  const eip2612PermitUtils = new Eip2612PermitUtils(web3ProviderConnector)
+
+  if (!account) {
+    PERMIT_UTILS_CACHE[chainId] = eip2612PermitUtils
+  }
+
+  return eip2612PermitUtils
+}

--- a/apps/cowswap-frontend/src/modules/permit/utils/getPermitUtilsInstance.ts
+++ b/apps/cowswap-frontend/src/modules/permit/utils/getPermitUtilsInstance.ts
@@ -7,25 +7,38 @@ import { PermitProviderConnector } from 'modules/wallet/utils/PermitProviderConn
 
 import { PERMIT_SIGNER } from '../const'
 
-const PERMIT_UTILS_CACHE: Record<number, Eip2612PermitUtils> = {}
+/**
+ * Cache by network. Here we don't care about the provider as a static account will be used for the signature
+ */
+const CHAIN_UTILS_CACHE = new Map<number, Eip2612PermitUtils>()
+/**
+ * Cache by provider. Here we cache per provider as each account should have its own instance
+ */
+const PROVIDER_UTILS_CACHE = new Map<Web3Provider, Eip2612PermitUtils>()
 
 export function getPermitUtilsInstance(
   chainId: SupportedChainId,
   provider: Web3Provider,
   account?: string | undefined
 ): Eip2612PermitUtils {
-  const cached = PERMIT_UTILS_CACHE[chainId]
+  const chainCache = CHAIN_UTILS_CACHE.get(chainId)
 
-  // Only cache if there's no account to prevent stale signers
-  if (!account && cached) {
-    return cached
+  if (!account && chainCache) {
+    return chainCache
+  }
+  const providerCache = PROVIDER_UTILS_CACHE.get(provider)
+
+  if (providerCache) {
+    return providerCache
   }
 
   const web3ProviderConnector = new PermitProviderConnector(provider, account ? undefined : PERMIT_SIGNER)
   const eip2612PermitUtils = new Eip2612PermitUtils(web3ProviderConnector)
 
   if (!account) {
-    PERMIT_UTILS_CACHE[chainId] = eip2612PermitUtils
+    CHAIN_UTILS_CACHE.set(chainId, eip2612PermitUtils)
+  } else {
+    PROVIDER_UTILS_CACHE.set(provider, eip2612PermitUtils)
   }
 
   return eip2612PermitUtils


### PR DESCRIPTION
# Summary

Updates outdated permits based on permit nonce at order placement time.

Should no longer need to reset the local storage.

## Note

Not yet tested on limit orders, might not work as expected. Will do that next.

# To Test

1. Load the app in goerli or mainnet (gchain not yet sorted out)
2. Pick as sell token a permittable token, for which you have no allowance set yet
3. Sell it
* Should be requested to sign the allowance msg. **Keep track of the `nonce` for later**
![Screenshot 2023-09-21 at 17 53 10](https://github.com/cowprotocol/cowswap/assets/43217/3656f82f-2504-41c6-9782-12efe8187dc4)

* Should then be prompted to sign the order
* Order should be accepted by the backend
* If executed, allowance should be set to infinite
4. Reset token allowance
5. Repeat steps 1 to 3
* Result should be the same, including being requested to sign the allowance msg
* Nonce in the signature request should be bumped

If you ever need to test again the same token for some reason, remove the `permitCache*` keys from local storage 
![image](https://github.com/cowprotocol/cowswap/assets/43217/825ca0ef-e366-4e6b-a98c-88a61f89d02c)

Although after this change you should not need to.

## Non-extensive list of permittable tokens (which work AFAICT)

### Goerli
- COW
- UNI

### Mainnet
- COW
- UNI
- AAVE
- 1INCH
