### PR TITLE
fix(twap): approve infinite amount

### DIFF
--- a/apps/cowswap-frontend/src/modules/twap/services/__snapshots__/createTwapOrderTxs.test.ts.snap
+++ b/apps/cowswap-frontend/src/modules/twap/services/__snapshots__/createTwapOrderTxs.test.ts.snap
@@ -21,7 +21,7 @@ exports[`Create TWAP order When sell token is NOT approved AND token needs zero 
   "approve",
   [
     "0xB4FBF271143F4FBf7B91A5ded31805e42b222222",
-    "100000000000",
+    "115792089237316195423570985008687907853269984665640564039457584007913129639935",
   ],
 ]
 `;
@@ -80,7 +80,7 @@ exports[`Create TWAP order When sell token is NOT approved, then should generate
   "approve",
   [
     "0xB4FBF271143F4FBf7B91A5ded31805e42b222222",
-    "100000000000",
+    "115792089237316195423570985008687907853269984665640564039457584007913129639935",
   ],
 ]
 `;

--- a/apps/cowswap-frontend/src/modules/twap/services/createTwapOrderTxs.ts
+++ b/apps/cowswap-frontend/src/modules/twap/services/createTwapOrderTxs.ts
@@ -1,5 +1,5 @@
+import { MaxUint256 } from '@ethersproject/constants'
 import { MetaTransactionData } from '@safe-global/safe-core-sdk-types'
-import { MaxUint256 } from '@uniswap/sdk-core'
 
 import { TwapOrderCreationContext } from '../hooks/useTwapOrderCreationContext'
 import { ConditionalOrderParams, TWAPOrder } from '../types'

--- a/apps/cowswap-frontend/src/modules/twap/services/createTwapOrderTxs.ts
+++ b/apps/cowswap-frontend/src/modules/twap/services/createTwapOrderTxs.ts
@@ -1,4 +1,5 @@
 import { MetaTransactionData } from '@safe-global/safe-core-sdk-types'
+import { MaxUint256 } from '@uniswap/sdk-core'
 
 import { TwapOrderCreationContext } from '../hooks/useTwapOrderCreationContext'
 import { ConditionalOrderParams, TWAPOrder } from '../types'
@@ -20,7 +21,7 @@ export function createTwapOrderTxs(
   const { sellAmount } = order
 
   const sellTokenAddress = sellAmount.currency.address
-  const sellAmountAtoms = sellAmount.quotient.toString()
+  const sellAmountAtoms = MaxUint256.toString()
 
   const txs: MetaTransactionData[] = []
 


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C035N0YEB6J/p1695313030829809

Currently, TWAP orders are created with a limited approve amount (sell token amount). It creates some problems, so we need to make approves with "infinite" amounts.

<img width="683" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/157f7a45-b417-4118-aef6-7dbf1062a52e">


  # To Test

1. Create a TWAP order with a sell token with 0 allowance amount
2. Wait until the order gets filled
- [ ] allowance amount for the sell token should be "infinite" 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

Example of tx: https://goerli.etherscan.io/tx/0xbf20e4c60a56cc4ebea65a73b6c9814cfd0110354f27c9fda7c19bfcc2cd4a04
