### PR TITLE
feat(permit): limit orders

### DIFF
--- a/apps/cowswap-frontend/src/mocks/tradeStateMock.ts
+++ b/apps/cowswap-frontend/src/mocks/tradeStateMock.ts
@@ -50,6 +50,8 @@ export const outputCurrencyInfoMock: CurrencyInfo = {
 }
 
 export const tradeContextMock: TradeFlowContext = {
+  hasEnoughAllowance: undefined,
+  permitInfo: undefined,
   postOrderParams: {
     class: OrderClass.LIMIT,
     account: '0x000',
@@ -68,7 +70,6 @@ export const tradeContextMock: TradeFlowContext = {
     appData: getAppData(),
   },
   rateImpact: 0,
-  appData: {} as any,
   provider: {} as any,
   settlementContract: {} as any,
   chainId: 1,

--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useTradeFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useTradeFlowContext.ts
@@ -62,7 +62,6 @@ export function useTradeFlowContext(): TradeFlowContext | null {
     isGnosisSafeWallet,
     dispatch,
     provider,
-    appData,
     rateImpact,
     postOrderParams: {
       class: OrderClass.LIMIT,

--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useTradeFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useTradeFlowContext.ts
@@ -1,5 +1,6 @@
 import { useAtomValue } from 'jotai'
 
+import { GP_VAULT_RELAYER } from '@cowprotocol/common-const'
 import { useGP2SettlementContract } from '@cowprotocol/common-hooks'
 import { OrderClass } from '@cowprotocol/cow-sdk'
 import { useGnosisSafeInfo, useWalletDetails, useWalletInfo } from '@cowprotocol/wallet'
@@ -14,6 +15,8 @@ import { useAppData } from 'modules/appData'
 import { useRateImpact } from 'modules/limitOrders/hooks/useRateImpact'
 import { TradeFlowContext } from 'modules/limitOrders/services/types'
 import { limitOrdersSettingsAtom } from 'modules/limitOrders/state/limitOrdersSettingsAtom'
+import { useIsTokenPermittable } from 'modules/permit'
+import { useEnoughBalanceAndAllowance } from 'modules/tokens'
 import { useTradeQuote } from 'modules/tradeQuote'
 
 import { useLimitOrdersDerivedState } from './useLimitOrdersDerivedState'
@@ -30,6 +33,14 @@ export function useTradeFlowContext(): TradeFlowContext | null {
   const quoteState = useTradeQuote()
   const rateImpact = useRateImpact()
   const settingsState = useAtomValue(limitOrdersSettingsAtom)
+  const permitInfo = useIsTokenPermittable(state.inputCurrency)
+
+  const checkAllowanceAddress = GP_VAULT_RELAYER[chainId]
+  const { enoughAllowance: hasEnoughAllowance } = useEnoughBalanceAndAllowance({
+    account,
+    amount: state.slippageAdjustedSellAmount || undefined,
+    checkAllowanceAddress,
+  })
 
   if (
     !chainId ||
@@ -63,6 +74,8 @@ export function useTradeFlowContext(): TradeFlowContext | null {
     dispatch,
     provider,
     rateImpact,
+    permitInfo,
+    hasEnoughAllowance,
     postOrderParams: {
       class: OrderClass.LIMIT,
       kind: state.orderKind,

--- a/apps/cowswap-frontend/src/modules/limitOrders/pure/LimitOrdersDetails/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/pure/LimitOrdersDetails/index.cosmos.tsx
@@ -1,9 +1,7 @@
 import { SetStateAction } from 'jotai'
 
 import { COW, GNO } from '@cowprotocol/common-const'
-import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { OrderKind } from '@cowprotocol/cow-sdk'
-import { OrderClass } from '@cowprotocol/cow-sdk'
+import { OrderClass, OrderKind, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { CurrencyAmount } from '@uniswap/sdk-core'
 
 import { getAppData } from 'modules/appData'
@@ -18,6 +16,8 @@ const inputCurrency = COW[SupportedChainId.MAINNET]
 const outputCurrency = GNO[SupportedChainId.MAINNET]
 
 const tradeContext: TradeFlowContext = {
+  hasEnoughAllowance: undefined,
+  permitInfo: undefined,
   postOrderParams: {
     class: OrderClass.LIMIT,
     account: '0x000',
@@ -36,7 +36,6 @@ const tradeContext: TradeFlowContext = {
     appData: getAppData(),
   },
   rateImpact: 0,
-  appData: {} as any,
   provider: {} as any,
   settlementContract: {} as any,
   chainId: 1,

--- a/apps/cowswap-frontend/src/modules/limitOrders/services/tradeFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/services/tradeFlow/index.ts
@@ -5,14 +5,15 @@ import { PriceImpact } from 'legacy/hooks/usePriceImpact'
 import { partialOrderUpdate } from 'legacy/state/orders/utils'
 import { signAndPostOrder } from 'legacy/utils/trade'
 
+import { buildAppDataHooks, updateHooksOnAppData } from 'modules/appData'
 import { LOW_RATE_THRESHOLD_PERCENT } from 'modules/limitOrders/const/trade'
 import { PriceImpactDeclineError, TradeFlowContext } from 'modules/limitOrders/services/types'
 import { LimitOrdersSettingsState } from 'modules/limitOrders/state/limitOrdersSettingsAtom'
 import { calculateLimitOrdersDeadline } from 'modules/limitOrders/utils/calculateLimitOrdersDeadline'
+import { generatePermitHook } from 'modules/permit'
 import { presignOrderStep } from 'modules/swap/services/swapFlow/steps/presignOrderStep'
 import { addPendingOrderStep } from 'modules/trade/utils/addPendingOrderStep'
-import { tradeFlowAnalytics } from 'modules/trade/utils/analytics'
-import { SwapFlowAnalyticsContext } from 'modules/trade/utils/analytics'
+import { SwapFlowAnalyticsContext, tradeFlowAnalytics } from 'modules/trade/utils/analytics'
 import { logTradeFlow } from 'modules/trade/utils/logger'
 import { getSwapErrorMessage } from 'modules/trade/utils/swapErrorHelper'
 
@@ -23,7 +24,19 @@ export async function tradeFlow(
   confirmPriceImpactWithoutFee: (priceImpact: Percent) => Promise<boolean>,
   beforeTrade?: () => void
 ): Promise<string> {
-  const { account, recipientAddressOrName, sellToken, buyToken } = params.postOrderParams
+  const {
+    postOrderParams,
+    rateImpact,
+    permitInfo,
+    provider,
+    chainId,
+    hasEnoughAllowance,
+    allowsOffchainSigning,
+    settlementContract,
+    dispatch,
+    isGnosisSafeWallet,
+  } = params
+  const { account, recipientAddressOrName, sellToken, buyToken, appData } = postOrderParams
   const marketLabel = [sellToken.symbol, buyToken.symbol].join(',')
   const swapFlowAnalyticsContext: SwapFlowAnalyticsContext = {
     account,
@@ -34,10 +47,30 @@ export async function tradeFlow(
   }
 
   logTradeFlow('LIMIT ORDER FLOW', 'STEP 1: confirm price impact')
-  const isTooLowRate = params.rateImpact < LOW_RATE_THRESHOLD_PERCENT
+  const isTooLowRate = rateImpact < LOW_RATE_THRESHOLD_PERCENT
 
   if (!isTooLowRate && priceImpact.priceImpact && !(await confirmPriceImpactWithoutFee(priceImpact.priceImpact))) {
     throw new PriceImpactDeclineError()
+  }
+
+  if (permitInfo && !hasEnoughAllowance) {
+    // If token is permittable and there's not enough allowance, get th permit hook
+
+    // TODO: maybe we need a modal to inform the user what they need to sign?
+    const permitData = await generatePermitHook({
+      inputToken: sellToken,
+      provider,
+      account,
+      chainId,
+      permitInfo,
+    })
+
+    const hooks = buildAppDataHooks([permitData])
+
+    postOrderParams.appData = await updateHooksOnAppData(appData, hooks)
+  } else {
+    // Otherwise, remove hooks (if any) from appData to avoid stale data
+    postOrderParams.appData = await updateHooksOnAppData(appData, undefined)
   }
 
   logTradeFlow('LIMIT ORDER FLOW', 'STEP 2: send transaction')
@@ -49,40 +82,40 @@ export async function tradeFlow(
   try {
     logTradeFlow('LIMIT ORDER FLOW', 'STEP 3: sign and post order')
     const { id: orderId, order } = await signAndPostOrder({
-      ...params.postOrderParams,
-      signer: params.provider.getSigner(),
+      ...postOrderParams,
+      signer: provider.getSigner(),
       validTo,
     })
     logTradeFlow('LIMIT ORDER FLOW', 'STEP 4: add pending order step')
     addPendingOrderStep(
       {
         id: orderId,
-        chainId: params.chainId,
+        chainId: chainId,
         order: {
           ...order,
-          isHidden: !params.allowsOffchainSigning,
+          isHidden: !allowsOffchainSigning,
         },
       },
-      params.dispatch
+      dispatch
     )
 
     logTradeFlow('LIMIT ORDER FLOW', 'STEP 5: presign order (optional)')
-    const presignTx = await (params.allowsOffchainSigning
+    const presignTx = await (allowsOffchainSigning
       ? Promise.resolve(null)
-      : presignOrderStep(orderId, params.settlementContract))
+      : presignOrderStep(orderId, settlementContract))
 
     logTradeFlow('LIMIT ORDER FLOW', 'STEP 6: unhide SC order (optional)')
     if (presignTx) {
       partialOrderUpdate(
         {
-          chainId: params.chainId,
+          chainId,
           order: {
             id: order.id,
-            presignGnosisSafeTxHash: params.isGnosisSafeWallet ? presignTx.hash : undefined,
+            presignGnosisSafeTxHash: isGnosisSafeWallet ? presignTx.hash : undefined,
             isHidden: false,
           },
         },
-        params.dispatch
+        dispatch
       )
     }
 

--- a/apps/cowswap-frontend/src/modules/limitOrders/services/tradeFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/services/tradeFlow/index.ts
@@ -52,14 +52,10 @@ export async function tradeFlow(
     throw new PriceImpactDeclineError()
   }
 
-  logTradeFlow('LIMIT ORDER FLOW', 'STEP 2: send transaction')
-  tradeFlowAnalytics.trade(swapFlowAnalyticsContext)
-  beforeTrade?.()
-
   const validTo = calculateLimitOrdersDeadline(settingsState)
 
   try {
-    logTradeFlow('LIMIT ORDER FLOW', 'STEP 3: handle permit')
+    logTradeFlow('LIMIT ORDER FLOW', 'STEP 2: handle permit')
     postOrderParams.appData = await handlePermit({
       permitInfo,
       hasEnoughAllowance,
@@ -69,6 +65,10 @@ export async function tradeFlow(
       chainId,
       appData,
     })
+
+    logTradeFlow('LIMIT ORDER FLOW', 'STEP 3: send transaction')
+    tradeFlowAnalytics.trade(swapFlowAnalyticsContext)
+    beforeTrade?.()
 
     logTradeFlow('LIMIT ORDER FLOW', 'STEP 4: sign and post order')
     const { id: orderId, order } = await signAndPostOrder({

--- a/apps/cowswap-frontend/src/modules/limitOrders/services/types.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/services/types.ts
@@ -6,7 +6,6 @@ import SafeAppsSDK from '@safe-global/safe-apps-sdk'
 import { AppDispatch } from 'legacy/state'
 import { PostOrderParams } from 'legacy/utils/trade'
 
-import { AppDataInfo } from 'modules/appData'
 
 export interface TradeFlowContext {
   // signer changes creates redundant re-renders
@@ -16,7 +15,6 @@ export interface TradeFlowContext {
   chainId: SupportedChainId
   dispatch: AppDispatch
   rateImpact: number
-  appData: AppDataInfo
   provider: Web3Provider
   allowsOffchainSigning: boolean
   isGnosisSafeWallet: boolean

--- a/apps/cowswap-frontend/src/modules/limitOrders/services/types.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/services/types.ts
@@ -6,6 +6,7 @@ import SafeAppsSDK from '@safe-global/safe-apps-sdk'
 import { AppDispatch } from 'legacy/state'
 import { PostOrderParams } from 'legacy/utils/trade'
 
+import { PermitInfo } from 'modules/permit'
 
 export interface TradeFlowContext {
   // signer changes creates redundant re-renders
@@ -18,6 +19,8 @@ export interface TradeFlowContext {
   provider: Web3Provider
   allowsOffchainSigning: boolean
   isGnosisSafeWallet: boolean
+  permitInfo: PermitInfo | undefined
+  hasEnoughAllowance: boolean | undefined
 }
 
 export interface SafeBundleFlowContext extends TradeFlowContext {

--- a/apps/cowswap-frontend/src/modules/permit/index.ts
+++ b/apps/cowswap-frontend/src/modules/permit/index.ts
@@ -1,4 +1,5 @@
 export { useAccountAgnosticPermitHookData } from './hooks/useAccountAgnosticPermitHookData'
 export { generatePermitHook } from './utils/generatePermitHook'
 export { useIsTokenPermittable } from './hooks/useIsTokenPermittable'
+export { handlePermit } from './utils/handlePermit'
 export * from './types'

--- a/apps/cowswap-frontend/src/modules/permit/types.ts
+++ b/apps/cowswap-frontend/src/modules/permit/types.ts
@@ -5,6 +5,8 @@ import { Token } from '@uniswap/sdk-core'
 
 import { Eip2612PermitUtils } from '@1inch/permit-signed-approvals-utils'
 
+import { AppDataInfo } from 'modules/appData'
+
 export type PermitType = 'dai-like' | 'eip-2612'
 
 export type SupportedPermitInfo = {
@@ -30,6 +32,12 @@ export type PermitHookParams = {
   permitInfo: SupportedPermitInfo
   provider: Web3Provider
   account?: string
+}
+
+export type HandlePermitParams = Omit<PermitHookParams, 'permitInfo'> & {
+  permitInfo: IsTokenPermittableResult
+  hasEnoughAllowance: undefined | boolean
+  appData: AppDataInfo
 }
 
 export type PermitHookData = latest.CoWHook

--- a/apps/cowswap-frontend/src/modules/permit/utils/handlePermit.ts
+++ b/apps/cowswap-frontend/src/modules/permit/utils/handlePermit.ts
@@ -1,0 +1,36 @@
+import { AppDataInfo, buildAppDataHooks, updateHooksOnAppData } from 'modules/appData'
+import { generatePermitHook, HandlePermitParams } from 'modules/permit'
+
+/**
+ * Handle token permit
+ *
+ * Will request user signature if needed
+ * Can use cached permit if available
+ *
+ * If not needed, will remove any permit info from appData
+ *
+ * Returns the updated appData
+ */
+export async function handlePermit(params: HandlePermitParams): Promise<AppDataInfo> {
+  const { permitInfo, hasEnoughAllowance, inputToken, provider, account, chainId, appData } = params
+
+  if (permitInfo && !hasEnoughAllowance) {
+    // If token is permittable and there's not enough allowance, get the permit hook
+
+    // TODO: maybe we need a modal to inform the user what they need to sign?
+    const permitData = await generatePermitHook({
+      inputToken,
+      provider,
+      account,
+      chainId,
+      permitInfo,
+    })
+
+    const hooks = buildAppDataHooks([permitData])
+
+    return updateHooksOnAppData(appData, hooks)
+  } else {
+    // Otherwise, remove hooks (if any) from appData to avoid stale data
+    return updateHooksOnAppData(appData, undefined)
+  }
+}

--- a/apps/cowswap-frontend/src/modules/swap/services/swapFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/swapFlow/index.ts
@@ -5,8 +5,7 @@ import { PriceImpact } from 'legacy/hooks/usePriceImpact'
 import { partialOrderUpdate } from 'legacy/state/orders/utils'
 import { signAndPostOrder } from 'legacy/utils/trade'
 
-import { buildAppDataHooks, updateHooksOnAppData } from 'modules/appData'
-import { generatePermitHook } from 'modules/permit'
+import { handlePermit } from 'modules/permit'
 import { addPendingOrderStep } from 'modules/trade/utils/addPendingOrderStep'
 import { tradeFlowAnalytics } from 'modules/trade/utils/analytics'
 import { logTradeFlow } from 'modules/trade/utils/logger'
@@ -26,11 +25,16 @@ export async function swapFlow(
     return
   }
 
-  if (input.permitInfo && !input.hasEnoughAllowance) {
-    // If token is permittable and there's not enough allowance, get th permit hook
+  logTradeFlow('SWAP FLOW', 'STEP 2: send transaction')
+  tradeFlowAnalytics.trade(input.swapFlowAnalyticsContext)
+  input.swapConfirmManager.sendTransaction(input.context.trade)
 
-    // TODO: maybe we need a modal to inform the user what they need to sign?
-    const permitData = await generatePermitHook({
+  try {
+    logTradeFlow('SWAP FLOW', 'STEP 3: handle permit')
+    input.orderParams.appData = await handlePermit({
+      appData: input.orderParams.appData,
+      hasEnoughAllowance: input.hasEnoughAllowance,
+
       inputToken: input.context.trade.inputAmount.currency as Token,
       provider: input.orderParams.signer.provider as Web3Provider,
       account: input.orderParams.account,
@@ -38,20 +42,7 @@ export async function swapFlow(
       permitInfo: input.permitInfo,
     })
 
-    const hooks = buildAppDataHooks([permitData])
-
-    input.orderParams.appData = await updateHooksOnAppData(input.orderParams.appData, hooks)
-  } else {
-    // Otherwise, remove hooks (if any) from appData to avoid stale data
-    input.orderParams.appData = await updateHooksOnAppData(input.orderParams.appData, undefined)
-  }
-
-  logTradeFlow('SWAP FLOW', 'STEP 2: send transaction')
-  tradeFlowAnalytics.trade(input.swapFlowAnalyticsContext)
-  input.swapConfirmManager.sendTransaction(input.context.trade)
-
-  try {
-    logTradeFlow('SWAP FLOW', 'STEP 3: sign and post order')
+    logTradeFlow('SWAP FLOW', 'STEP 4: sign and post order')
     const { id: orderId, order } = await signAndPostOrder(input.orderParams).finally(() => {
       input.callbacks.closeModals()
     })
@@ -68,12 +59,12 @@ export async function swapFlow(
       input.dispatch
     )
 
-    logTradeFlow('SWAP FLOW', 'STEP 4: presign order (optional)')
+    logTradeFlow('SWAP FLOW', 'STEP 5: presign order (optional)')
     const presignTx = await (input.flags.allowsOffchainSigning
       ? Promise.resolve(null)
       : presignOrderStep(orderId, input.contract))
 
-    logTradeFlow('SWAP FLOW', 'STEP 5: unhide SC order (optional)')
+    logTradeFlow('SWAP FLOW', 'STEP 6: unhide SC order (optional)')
     if (presignTx) {
       partialOrderUpdate(
         {
@@ -88,11 +79,11 @@ export async function swapFlow(
       )
     }
 
-    logTradeFlow('SWAP FLOW', 'STEP 6: show UI of the successfully sent transaction', orderId)
+    logTradeFlow('SWAP FLOW', 'STEP 7: show UI of the successfully sent transaction', orderId)
     input.swapConfirmManager.transactionSent(orderId)
     tradeFlowAnalytics.sign(input.swapFlowAnalyticsContext)
   } catch (error: any) {
-    logTradeFlow('SWAP FLOW', 'STEP 7: ERROR: ', error)
+    logTradeFlow('SWAP FLOW', 'STEP 8: ERROR: ', error)
     const swapErrorMessage = getSwapErrorMessage(error)
 
     tradeFlowAnalytics.error(error, swapErrorMessage, input.swapFlowAnalyticsContext)

--- a/apps/cowswap-frontend/src/modules/swap/services/swapFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/swapFlow/index.ts
@@ -25,12 +25,8 @@ export async function swapFlow(
     return
   }
 
-  logTradeFlow('SWAP FLOW', 'STEP 2: send transaction')
-  tradeFlowAnalytics.trade(input.swapFlowAnalyticsContext)
-  input.swapConfirmManager.sendTransaction(input.context.trade)
-
   try {
-    logTradeFlow('SWAP FLOW', 'STEP 3: handle permit')
+    logTradeFlow('SWAP FLOW', 'STEP 2: handle permit')
     input.orderParams.appData = await handlePermit({
       appData: input.orderParams.appData,
       hasEnoughAllowance: input.hasEnoughAllowance,
@@ -41,6 +37,10 @@ export async function swapFlow(
       chainId: input.orderParams.chainId,
       permitInfo: input.permitInfo,
     })
+
+    logTradeFlow('SWAP FLOW', 'STEP 3: send transaction')
+    tradeFlowAnalytics.trade(input.swapFlowAnalyticsContext)
+    input.swapConfirmManager.sendTransaction(input.context.trade)
 
     logTradeFlow('SWAP FLOW', 'STEP 4: sign and post order')
     const { id: orderId, order } = await signAndPostOrder(input.orderParams).finally(() => {

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormValidationContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormValidationContext.ts
@@ -6,6 +6,7 @@ import { useGnosisSafeInfo, useIsBundlingSupported, useWalletDetails, useWalletI
 import { useIsTradeUnsupported } from 'legacy/state/lists/hooks'
 
 import { isUnsupportedTokenInQuote } from 'modules/limitOrders/utils/isUnsupportedTokenInQuote'
+import { useIsTokenPermittable } from 'modules/permit'
 import { useDerivedTradeState } from 'modules/trade/hooks/useDerivedTradeState'
 import { useIsWrapOrUnwrap } from 'modules/trade/hooks/useIsWrapOrUnwrap'
 import { useTradeQuote } from 'modules/tradeQuote'
@@ -32,6 +33,8 @@ export function useTradeFormValidationContext(): TradeFormValidationCommonContex
 
   const isSafeReadonlyUser = gnosisSafeInfo?.isReadOnly || false
 
+  const isPermitSupported = !!useIsTokenPermittable(inputCurrency)
+
   const commonContext = {
     account,
     isWrapUnwrap,
@@ -42,6 +45,7 @@ export function useTradeFormValidationContext(): TradeFormValidationCommonContex
     recipientEnsAddress,
     approvalState,
     tradeQuote,
+    isPermitSupported,
   }
 
   return useMemo(() => {

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
@@ -1,5 +1,4 @@
-import { isFractionFalsy } from '@cowprotocol/common-utils'
-import { isAddress } from '@cowprotocol/common-utils'
+import { isAddress, isFractionFalsy } from '@cowprotocol/common-utils'
 
 import { ApprovalState } from 'legacy/hooks/useApproveCallback/useApproveCallbackMod'
 
@@ -18,11 +17,13 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
     recipientEnsAddress,
     tradeQuote,
     account,
+    isPermitSupported,
   } = context
 
   const { inputCurrency, outputCurrency, inputCurrencyAmount, inputCurrencyBalance, recipient } = derivedTradeState
 
-  const approvalRequired = approvalState === ApprovalState.NOT_APPROVED || approvalState === ApprovalState.PENDING
+  const approvalRequired =
+    !isPermitSupported && (approvalState === ApprovalState.NOT_APPROVED || approvalState === ApprovalState.PENDING)
 
   const inputAmountIsNotSet = !inputCurrencyAmount || isFractionFalsy(inputCurrencyAmount)
 

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/types.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/types.ts
@@ -49,6 +49,7 @@ export interface TradeFormValidationCommonContext {
   isSupportedWallet: boolean
   isSwapUnsupported: boolean
   isSafeReadonlyUser: boolean
+  isPermitSupported: boolean
 }
 
 export interface TradeFormValidationContext extends TradeFormValidationLocalContext, TradeFormValidationCommonContext {}


### PR DESCRIPTION
# Summary

Add permit support to `fill or kill` limit orders

## NOTES

- Warning for out of allowance is not yet updated with permit!
- ⚠️ `Partial fills` not supported!!!

# To Test

1. On LIMIT, pick a permittable token as sell
2. Disable `partial fills`
3. Select an amount for which it's not approved
* Approval button should not be displayed
4. Place limit order
* Should be prompted to sign a permit
* After signing the permit, should be prompted for the order signature as usual
* Once executed, token allowance should be set to infinite