### PR TITLE
fix: don't fetch tokens list ens hashes

### DIFF
--- a/apps/cowswap-frontend/src/legacy/hooks/useFetchListCallback.ts
+++ b/apps/cowswap-frontend/src/legacy/hooks/useFetchListCallback.ts
@@ -12,6 +12,15 @@ import { fetchTokenList } from 'legacy/state/lists/actions'
 
 import getTokenList from 'lib/hooks/useTokenList/fetchTokenList'
 
+const TOKENS_LISTS_ENS_HASHES: { [key: string]: string } = {
+  'tokenlist.aave.eth': '0xe301017012204aeb1d95ad5624a5299aa40dab01016b8a9c8401515ec063e9663d80f3776366',
+  'defi.cmc.eth': '0xe301017012201acd1250f6110108aaa17ed1ae463334655067138bc3270bbb44c71235cf6ffa',
+  'stablecoin.cmc.eth': '0xe30101701220f4b10385da995ae2d0925d328c7d82f21279000d10b4dcd8d409c0a9ef0c6cc1',
+  'synths.snx.eth': '0xe30101701220134dda0aa35ea0289bc5688fe82b3e2d153b8ffbfb150984666a80b7b0b8412e',
+  'wrapped.tokensoft.eth': '0xe30101701220a77c3f3999021e5a6e2551e36424e5270450ae259a9b1edde1ade5cd7c70ffa3',
+  't2crtokens.eth': '0xe3010170122062dd98ddd1b57a4e34c602b0fe40746cf71d427d24ab5689082480f9e8b97a12',
+}
+
 export function useFetchListCallback(): (listUrl: string, sendDispatch?: boolean) => Promise<TokenList> {
   const dispatch = useAppDispatch()
   const { chainId } = useWalletInfo()
@@ -21,7 +30,11 @@ export function useFetchListCallback(): (listUrl: string, sendDispatch?: boolean
     async (listUrl: string, sendDispatch = true) => {
       const requestId = nanoid()
       sendDispatch && dispatch(fetchTokenList.pending({ requestId, url: listUrl, chainId }))
-      return getTokenList(listUrl, (ensName: string) => resolveENSContentHash(ensName, MAINNET_PROVIDER))
+      return getTokenList(listUrl, (ensName: string) => {
+        const cachedHash = TOKENS_LISTS_ENS_HASHES[ensName]
+
+        return cachedHash ? Promise.resolve(cachedHash) : resolveENSContentHash(ensName, MAINNET_PROVIDER)
+      })
         .then((tokenList) => {
           // Mod: add chainId
           sendDispatch && dispatch(fetchTokenList.fulfilled({ url: listUrl, tokenList, requestId, chainId }))

--- a/apps/cowswap-frontend/src/legacy/hooks/useFetchListCallback.ts
+++ b/apps/cowswap-frontend/src/legacy/hooks/useFetchListCallback.ts
@@ -1,3 +1,5 @@
+import { useAtom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
 import { useCallback } from 'react'
 
 import { MAINNET_PROVIDER } from '@cowprotocol/common-const'
@@ -6,24 +8,29 @@ import { useWalletInfo } from '@cowprotocol/wallet'
 import { TokenList } from '@uniswap/token-lists'
 
 import { nanoid } from '@reduxjs/toolkit'
+import ms from 'ms.macro'
 
 import { useAppDispatch } from 'legacy/state/hooks'
 import { fetchTokenList } from 'legacy/state/lists/actions'
 
 import getTokenList from 'lib/hooks/useTokenList/fetchTokenList'
 
-const TOKENS_LISTS_ENS_HASHES: { [key: string]: string } = {
-  'tokenlist.aave.eth': '0xe301017012204aeb1d95ad5624a5299aa40dab01016b8a9c8401515ec063e9663d80f3776366',
-  'defi.cmc.eth': '0xe301017012201acd1250f6110108aaa17ed1ae463334655067138bc3270bbb44c71235cf6ffa',
-  'stablecoin.cmc.eth': '0xe30101701220f4b10385da995ae2d0925d328c7d82f21279000d10b4dcd8d409c0a9ef0c6cc1',
-  'synths.snx.eth': '0xe30101701220134dda0aa35ea0289bc5688fe82b3e2d153b8ffbfb150984666a80b7b0b8412e',
-  'wrapped.tokensoft.eth': '0xe30101701220a77c3f3999021e5a6e2551e36424e5270450ae259a9b1edde1ade5cd7c70ffa3',
-  't2crtokens.eth': '0xe3010170122062dd98ddd1b57a4e34c602b0fe40746cf71d427d24ab5689082480f9e8b97a12',
+const TOKENS_LIST_ENS_CACHE_TIMEOUT = ms`6h`
+
+interface TokensListEnsCache {
+  timestamp: number
+  value: string
 }
+
+const tokensListEnsCachesAtom = atomWithStorage<{ [ensName: string]: TokensListEnsCache }>('tokensListEnsCaches:v1', {})
+
+const isCacheValid = ({ timestamp }: TokensListEnsCache) => Date.now() - timestamp < TOKENS_LIST_ENS_CACHE_TIMEOUT
 
 export function useFetchListCallback(): (listUrl: string, sendDispatch?: boolean) => Promise<TokenList> {
   const dispatch = useAppDispatch()
   const { chainId } = useWalletInfo()
+
+  const [tokensListEnsCaches, setTokensListEnsCaches] = useAtom(tokensListEnsCachesAtom)
 
   // note: prevent dispatch if using for list search or unsupported list
   return useCallback(
@@ -31,9 +38,26 @@ export function useFetchListCallback(): (listUrl: string, sendDispatch?: boolean
       const requestId = nanoid()
       sendDispatch && dispatch(fetchTokenList.pending({ requestId, url: listUrl, chainId }))
       return getTokenList(listUrl, (ensName: string) => {
-        const cachedHash = TOKENS_LISTS_ENS_HASHES[ensName]
+        const cached = tokensListEnsCaches[ensName]
 
-        return cachedHash ? Promise.resolve(cachedHash) : resolveENSContentHash(ensName, MAINNET_PROVIDER)
+        if (cached) {
+          // Return cached value if it's not stale
+          if (isCacheValid(cached)) {
+            return Promise.resolve(cached.value)
+          } else {
+            // Otherwise, remove it from the cache
+            const cacheCopy = { ...tokensListEnsCaches }
+            delete cacheCopy[ensName]
+            setTokensListEnsCaches(cacheCopy)
+          }
+        }
+
+        return resolveENSContentHash(ensName, MAINNET_PROVIDER).then((value) => {
+          // Cache the fetched value
+          setTokensListEnsCaches({ ...tokensListEnsCaches, [ensName]: { timestamp: Date.now(), value } })
+
+          return value
+        })
       })
         .then((tokenList) => {
           // Mod: add chainId
@@ -47,6 +71,6 @@ export function useFetchListCallback(): (listUrl: string, sendDispatch?: boolean
           throw error
         })
     },
-    [chainId, dispatch]
+    [chainId, dispatch, setTokensListEnsCaches, tokensListEnsCaches]
   )
 }


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C0361CDG8GP/p1695653516539379

`useFetchListCallback` works very inefficiently in terms of Infura consumption, on every page load it does requests to resolve hashes of ENS names of tokens lists.
I just hardcoded hashes to avoid excessive Infura requests.
Checked for all networks, we actually use them only for mainnet.


Before (**56 requests**):
<img width="900" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/bcba5867-ff49-4ec8-8f54-4f5383475c16">

After (**20 requests**):
<img width="900" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/f776ee7c-f0f3-4309-9c3b-ebf3c5429b17">



  # To Test

1. Open dapp
2. Open dev tools with network tab
- [ ] AR: there are lots of requests with `resolveENSContentHash` initiator
- [ ] ER: there are no requests with `resolveENSContentHash` initiator

