### PR TITLE
feat(permit): quote by order type

### DIFF
--- a/apps/cowswap-frontend/src/modules/advancedOrders/hooks/useAdvancedOrdersDerivedState.ts
+++ b/apps/cowswap-frontend/src/modules/advancedOrders/hooks/useAdvancedOrdersDerivedState.ts
@@ -1,11 +1,12 @@
 import { useAtomValue, useSetAtom } from 'jotai'
 import { useEffect } from 'react'
 
+import { TradeType } from 'modules/trade'
 import { useBuildTradeDerivedState } from 'modules/trade/hooks/useBuildTradeDerivedState'
 
 import {
-  AdvancedOrdersDerivedState,
   advancedOrdersAtom,
+  AdvancedOrdersDerivedState,
   advancedOrdersDerivedStateAtom,
 } from '../state/advancedOrdersAtom'
 
@@ -21,6 +22,6 @@ export function useFillAdvancedOrdersDerivedState() {
   const isUnlocked = rawState.isUnlocked
 
   useEffect(() => {
-    updateDerivedState({ ...derivedState, isUnlocked })
+    updateDerivedState({ ...derivedState, isUnlocked, tradeType: TradeType.ADVANCED_ORDERS })
   }, [derivedState, isUnlocked, updateDerivedState])
 }

--- a/apps/cowswap-frontend/src/modules/appData/utils/buildAppDataHooks.ts
+++ b/apps/cowswap-frontend/src/modules/appData/utils/buildAppDataHooks.ts
@@ -9,7 +9,7 @@ export function buildAppDataHooks(
   }
 
   return {
-    ...{ pre: preInteractionHooks || undefined },
-    ...{ post: postInteractionHooks || undefined },
+    ...(preInteractionHooks ? { pre: preInteractionHooks } : undefined),
+    ...(postInteractionHooks ? { post: postInteractionHooks } : undefined),
   }
 }

--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useLimitOrdersDerivedState.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useLimitOrdersDerivedState.ts
@@ -2,10 +2,11 @@ import { useAtomValue, useSetAtom } from 'jotai'
 import { useEffect } from 'react'
 
 import {
-  limitOrdersRawStateAtom,
   LimitOrdersDerivedState,
   limitOrdersDerivedStateAtom,
+  limitOrdersRawStateAtom,
 } from 'modules/limitOrders/state/limitOrdersRawStateAtom'
+import { TradeType } from 'modules/trade'
 import { useBuildTradeDerivedState } from 'modules/trade/hooks/useBuildTradeDerivedState'
 
 export function useLimitOrdersDerivedState(): LimitOrdersDerivedState {
@@ -20,6 +21,6 @@ export function useFillLimitOrdersDerivedState() {
   const derivedState = useBuildTradeDerivedState(limitOrdersRawStateAtom)
 
   useEffect(() => {
-    updateDerivedState({ ...derivedState, isUnlocked })
+    updateDerivedState({ ...derivedState, isUnlocked, tradeType: TradeType.LIMIT_ORDER })
   }, [derivedState, updateDerivedState, isUnlocked])
 }

--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useTradeFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useTradeFlowContext.ts
@@ -17,6 +17,7 @@ import { TradeFlowContext } from 'modules/limitOrders/services/types'
 import { limitOrdersSettingsAtom } from 'modules/limitOrders/state/limitOrdersSettingsAtom'
 import { useIsTokenPermittable } from 'modules/permit'
 import { useEnoughBalanceAndAllowance } from 'modules/tokens'
+import { TradeType } from 'modules/trade'
 import { useTradeQuote } from 'modules/tradeQuote'
 
 import { useLimitOrdersDerivedState } from './useLimitOrdersDerivedState'
@@ -33,7 +34,7 @@ export function useTradeFlowContext(): TradeFlowContext | null {
   const quoteState = useTradeQuote()
   const rateImpact = useRateImpact()
   const settingsState = useAtomValue(limitOrdersSettingsAtom)
-  const permitInfo = useIsTokenPermittable(state.inputCurrency)
+  const permitInfo = useIsTokenPermittable(state.inputCurrency, TradeType.LIMIT_ORDER)
 
   const checkAllowanceAddress = GP_VAULT_RELAYER[chainId]
   const { enoughAllowance: hasEnoughAllowance } = useEnoughBalanceAndAllowance({

--- a/apps/cowswap-frontend/src/modules/permit/const.ts
+++ b/apps/cowswap-frontend/src/modules/permit/const.ts
@@ -4,6 +4,8 @@ import { Wallet } from '@ethersproject/wallet'
 
 import ms from 'ms.macro'
 
+import { TradeType } from '../trade'
+
 // PK used only for signing permit requests for quoting and identifying token 'permittability'
 // Do not use or try to send funds to it. Or do. It'll be your funds 🤷
 const PERMIT_PK = '0xc58a2a421ca71ca57ae698f1c32feeb0b0ccb434da0b8089d88d80fb918f3f9d' // address: 0xFf65D1DfCF256cf4A8D5F2fb8e70F936606B7474
@@ -21,3 +23,9 @@ export const DEFAULT_PERMIT_GAS_LIMIT = '80000'
 export const DEFAULT_PERMIT_VALUE = MaxUint256.toString()
 
 export const DEFAULT_PERMIT_DURATION = ms`5 years`
+
+export const ORDER_TYPE_SUPPORTS_PERMIT: Record<TradeType, boolean> = {
+  [TradeType.SWAP]: true,
+  [TradeType.LIMIT_ORDER]: false,
+  [TradeType.ADVANCED_ORDERS]: false,
+}

--- a/apps/cowswap-frontend/src/modules/permit/hooks/useAccountAgnosticPermitHookData.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/useAccountAgnosticPermitHookData.ts
@@ -39,9 +39,9 @@ function usePermitHookParams(): PermitHookParams | undefined {
   const { provider } = useWeb3React()
 
   const { state } = useDerivedTradeState()
-  const { inputCurrency } = state || {}
+  const { inputCurrency, tradeType } = state || {}
 
-  const permitInfo = useIsTokenPermittable(inputCurrency)
+  const permitInfo = useIsTokenPermittable(inputCurrency, tradeType)
 
   return useSafeMemo(() => {
     if (!inputCurrency || !provider || !permitInfo) return undefined

--- a/apps/cowswap-frontend/src/modules/permit/hooks/useAccountAgnosticPermitHookData.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/useAccountAgnosticPermitHookData.ts
@@ -26,7 +26,11 @@ export function useAccountAgnosticPermitHookData(): PermitHookData | undefined {
   const [data, setData] = useState<PermitHookData | undefined>(undefined)
 
   useEffect(() => {
-    if (!params) return
+    if (!params) {
+      setData(undefined)
+
+      return
+    }
 
     generatePermitHook(params).then(setData)
   }, [params])

--- a/apps/cowswap-frontend/src/modules/permit/hooks/useIsTokenPermittable.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/useIsTokenPermittable.ts
@@ -8,8 +8,11 @@ import { useWeb3React } from '@web3-react/core'
 
 import { Nullish } from 'types'
 
+import { TradeType } from 'modules/trade'
+
 import { useIsPermitEnabled } from 'common/hooks/featureFlags/useIsPermitEnabled'
 
+import { ORDER_TYPE_SUPPORTS_PERMIT } from '../const'
 import { addPermitInfoForTokenAtom, permittableTokensAtom } from '../state/atoms'
 import { IsTokenPermittableResult } from '../types'
 import { checkIsTokenPermittable } from '../utils/checkIsTokenPermittable'
@@ -21,9 +24,11 @@ import { checkIsTokenPermittable } from '../utils/checkIsTokenPermittable'
  * When it is not, returned type is `false`
  * When it is unknown, returned type is `undefined`
  *
- * @param token
  */
-export function useIsTokenPermittable(token: Nullish<Currency>): IsTokenPermittableResult {
+export function useIsTokenPermittable(
+  token: Nullish<Currency>,
+  tradeType: Nullish<TradeType>
+): IsTokenPermittableResult {
   const { chainId } = useWalletInfo()
   const { provider } = useWeb3React()
 
@@ -31,7 +36,10 @@ export function useIsTokenPermittable(token: Nullish<Currency>): IsTokenPermitta
   const isNative = token?.isNative
   const tokenName = token?.name || lowerCaseAddress || ''
 
-  const isPermitEnabled = useIsPermitEnabled(chainId)
+  // Avoid building permit info in the first place if order type is not supported
+  const isPermitSupported = !!tradeType && ORDER_TYPE_SUPPORTS_PERMIT[tradeType]
+
+  const isPermitEnabled = useIsPermitEnabled(chainId) && isPermitSupported
 
   const addPermitInfo = useAddPermitInfo()
   const permitInfo = usePermitInfo(chainId, isPermitEnabled ? lowerCaseAddress : undefined)

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useSwapButtonContext.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useSwapButtonContext.ts
@@ -1,9 +1,9 @@
 import {
-  useIsSmartContractWallet,
   useGnosisSafeInfo,
+  useIsBundlingSupported,
+  useIsSmartContractWallet,
   useWalletDetails,
   useWalletInfo,
-  useIsBundlingSupported,
 } from '@cowprotocol/wallet'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
@@ -23,7 +23,7 @@ import { useSwapConfirmManager } from 'modules/swap/hooks/useSwapConfirmManager'
 import { useSwapFlowContext } from 'modules/swap/hooks/useSwapFlowContext'
 import { SwapButtonsContext } from 'modules/swap/pure/SwapButtons'
 import useCurrencyBalance from 'modules/tokens/hooks/useCurrencyBalance'
-import { useWrapNativeFlow } from 'modules/trade'
+import { TradeType, useWrapNativeFlow } from 'modules/trade'
 import { useIsNativeIn } from 'modules/trade/hooks/useIsNativeInOrOut'
 import { useIsWrappedOut } from 'modules/trade/hooks/useIsWrappedInOrOut'
 import { useWrappedToken } from 'modules/trade/hooks/useWrappedToken'
@@ -92,7 +92,7 @@ export function useSwapButtonContext(input: SwapButtonInput): SwapButtonsContext
   const isSwapUnsupported = useIsTradeUnsupported(currencyIn, currencyOut)
   const isSmartContractWallet = useIsSmartContractWallet()
   const isBundlingSupported = useIsBundlingSupported()
-  const isPermitSupported = !!useIsTokenPermittable(currencyIn)
+  const isPermitSupported = !!useIsTokenPermittable(currencyIn, TradeType.SWAP)
 
   const swapButtonState = getSwapButtonState({
     account,

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useSwapFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useSwapFlowContext.ts
@@ -1,18 +1,19 @@
 import { GP_VAULT_RELAYER } from '@cowprotocol/common-const'
 import { useGP2SettlementContract } from '@cowprotocol/common-hooks'
 import { OrderKind, SupportedChainId } from '@cowprotocol/cow-sdk'
-import { TradeType } from '@uniswap/sdk-core'
+import { TradeType as UniTradeType } from '@uniswap/sdk-core'
 
 import { useIsTokenPermittable } from 'modules/permit'
 import { FlowType, getFlowContext, useBaseFlowContextSetup } from 'modules/swap/hooks/useFlowContext'
 import { SwapFlowContext } from 'modules/swap/services/types'
 import { useEnoughBalanceAndAllowance } from 'modules/tokens'
+import { TradeType } from 'modules/trade'
 
 export function useSwapFlowContext(): SwapFlowContext | null {
   const contract = useGP2SettlementContract()
   const baseProps = useBaseFlowContextSetup()
   const sellCurrency = baseProps.trade?.inputAmount?.currency
-  const permitInfo = useIsTokenPermittable(sellCurrency)
+  const permitInfo = useIsTokenPermittable(sellCurrency, TradeType.SWAP)
 
   const checkAllowanceAddress = GP_VAULT_RELAYER[baseProps.chainId || SupportedChainId.MAINNET]
   const { enoughAllowance: hasEnoughAllowance } = useEnoughBalanceAndAllowance({
@@ -26,7 +27,7 @@ export function useSwapFlowContext(): SwapFlowContext | null {
   const baseContext = getFlowContext({
     baseProps,
     sellToken: baseProps.trade.inputAmount.currency.wrapped,
-    kind: baseProps.trade.tradeType === TradeType.EXACT_INPUT ? OrderKind.SELL : OrderKind.BUY,
+    kind: baseProps.trade.tradeType === UniTradeType.EXACT_INPUT ? OrderKind.SELL : OrderKind.BUY,
   })
 
   if (!contract || !baseContext || baseProps.flowType !== FlowType.REGULAR) return null

--- a/apps/cowswap-frontend/src/modules/swap/state/useSwapDerivedState.ts
+++ b/apps/cowswap-frontend/src/modules/swap/state/useSwapDerivedState.ts
@@ -5,6 +5,7 @@ import { OrderKind } from '@cowprotocol/cow-sdk'
 
 import { Field } from 'legacy/state/types'
 
+import { TradeType } from 'modules/trade'
 import { useTradeUsdAmounts } from 'modules/usdAmount'
 
 import { useSafeMemoObject } from 'common/hooks/useSafeMemo'
@@ -49,6 +50,7 @@ export function useFillSwapDerivedState() {
     recipient,
     recipientAddress,
     orderKind: isSellTrade ? OrderKind.SELL : OrderKind.BUY,
+    tradeType: TradeType.SWAP,
   })
 
   useEffect(() => {

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useDerivedTradeState.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useDerivedTradeState.ts
@@ -18,19 +18,13 @@ export function useDerivedTradeState(): { state?: TradeDerivedState } {
     if (!tradeTypeInfo) return {}
 
     if (tradeTypeInfo.tradeType === TradeType.SWAP) {
-      return {
-        state: swapDerivedState,
-      }
+      return { state: swapDerivedState }
     }
 
     if (tradeTypeInfo.tradeType === TradeType.ADVANCED_ORDERS) {
-      return {
-        state: advancedOrdersDerivedState,
-      }
+      return { state: advancedOrdersDerivedState }
     }
 
-    return {
-      state: limitOrdersDerivedState,
-    }
+    return { state: limitOrdersDerivedState }
   }, [tradeTypeInfo, swapDerivedState, limitOrdersDerivedState, advancedOrdersDerivedState])
 }

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useTradeTypeInfo.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useTradeTypeInfo.ts
@@ -6,9 +6,9 @@ import { useMatch } from 'react-router-dom'
 import { Routes, RoutesValues, TRADE_WIDGET_PREFIX } from 'common/constants/routes'
 
 export enum TradeType {
-  SWAP,
-  LIMIT_ORDER,
-  ADVANCED_ORDERS,
+  SWAP = 'SWAP',
+  LIMIT_ORDER = 'LIMIT_ORDER',
+  ADVANCED_ORDERS = 'ADVANCED_ORDERS',
 }
 
 export interface TradeTypeInfo {

--- a/apps/cowswap-frontend/src/modules/trade/types/TradeDerivedState.ts
+++ b/apps/cowswap-frontend/src/modules/trade/types/TradeDerivedState.ts
@@ -1,6 +1,8 @@
 import { OrderKind } from '@cowprotocol/cow-sdk'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
+import { TradeType } from '../hooks/useTradeTypeInfo'
+
 export interface TradeDerivedState {
   readonly inputCurrency: Currency | null
   readonly outputCurrency: Currency | null
@@ -25,6 +27,7 @@ export interface TradeDerivedState {
   readonly recipient: string | null
   readonly recipientAddress: string | null
   readonly orderKind: OrderKind
+  readonly tradeType: TradeType | null
 }
 
 export const DEFAULT_TRADE_DERIVED_STATE: TradeDerivedState = {
@@ -40,4 +43,5 @@ export const DEFAULT_TRADE_DERIVED_STATE: TradeDerivedState = {
   recipient: null,
   recipientAddress: null,
   orderKind: OrderKind.SELL,
+  tradeType: null,
 }

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormValidationContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormValidationContext.ts
@@ -20,7 +20,7 @@ export function useTradeFormValidationContext(): TradeFormValidationCommonContex
   const { state: derivedTradeState } = useDerivedTradeState()
   const tradeQuote = useTradeQuote()
 
-  const { inputCurrency, outputCurrency, slippageAdjustedSellAmount, recipient } = derivedTradeState || {}
+  const { inputCurrency, outputCurrency, slippageAdjustedSellAmount, recipient, tradeType } = derivedTradeState || {}
   const approvalState = useTradeApproveState(slippageAdjustedSellAmount)
   const { address: recipientEnsAddress } = useENSAddress(recipient)
   const isSwapUnsupported =
@@ -33,7 +33,7 @@ export function useTradeFormValidationContext(): TradeFormValidationCommonContex
 
   const isSafeReadonlyUser = gnosisSafeInfo?.isReadOnly || false
 
-  const isPermitSupported = !!useIsTokenPermittable(inputCurrency)
+  const isPermitSupported = !!useIsTokenPermittable(inputCurrency, tradeType)
 
   const commonContext = {
     account,

--- a/apps/cowswap-frontend/src/modules/twap/services/createTwapOrderTxs.test.ts
+++ b/apps/cowswap-frontend/src/modules/twap/services/createTwapOrderTxs.test.ts
@@ -1,5 +1,4 @@
-import { COW } from '@cowprotocol/common-const'
-import { WETH_GOERLI } from '@cowprotocol/common-const'
+import { COW, WETH_GOERLI } from '@cowprotocol/common-const'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { CurrencyAmount } from '@uniswap/sdk-core'
 
@@ -11,6 +10,8 @@ import { createTwapOrderTxs } from './createTwapOrderTxs'
 import { TwapOrderCreationContext } from '../hooks/useTwapOrderCreationContext'
 import { TWAPOrder } from '../types'
 import { buildTwapOrderParamsStruct } from '../utils/buildTwapOrderParamsStruct'
+
+jest.mock('modules/permit')
 
 const APP_DATA_HASH = getAppData().appDataKeccak256
 


### PR DESCRIPTION
# Summary

Closes #3153

Disabling permit/quote based on order type

⚠️ This PR disables PERMIT for LIMIT (until backend is sorted) ⚠️ 

# To Test

1. On SWAP, pick a token that is permittable (COW or UNI on Goerli for example)
2. Make sure you have no allowance for it (revoke.cash)
3. Fill the form with the buy token and the amount
* Should not show allowance button
4. Switch to LIMIT, with the same parameters
* Should show allowance button
5. Go back to SWAP and place the order
* Should prompt for permit signature
* Placed order should contain permit hooks data
6. Once traded, head to LIMIT with the same sell token
* Now that the token has been approved on SWAP, there should not be a allowance button
7. Place the LIMIT order
* Placed order should NOT contain permit hooks data

* TWAP should behave the same as LIMIT