### PR TITLE
feat: allow to change rpc nodes

### DIFF
--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -42,6 +42,9 @@ jobs:
           REACT_APP_AMPLITUDE_KEY=${{ secrets.REACT_APP_AMPLITUDE_KEY }}
           REACT_APP_LAUNCH_DARKLY_KEY=${{ secrets.REACT_APP_LAUNCH_DARKLY_KEY }}
           REACT_APP_WALLET_CONNECT_V1_BRIDGE=${{ secrets.REACT_APP_WALLET_CONNECT_V1_BRIDGE }}
+          REACT_APP_NETWORK_URL_1=${{ secrets.REACT_APP_NETWORK_URL_1 }}
+          REACT_APP_NETWORK_URL_100=${{ secrets.REACT_APP_NETWORK_URL_100 }}
+          REACT_APP_NETWORK_URL_5=${{ secrets.REACT_APP_NETWORK_URL_5 }}
           vercel build -t ${{ secrets.VERCEL_TOKEN }} --prod
 
       - name: Get the version

--- a/README.md
+++ b/README.md
@@ -144,19 +144,23 @@ To set your own `AppData`, change `REACT_APP_FULL_APP_DATA_<environment>` enviro
 
 ### Supported networks
 
-You can change the supported networks and their RPC endpoint.
-
-To have the interface default to a different network when a wallet is not connected:
-
-1. Change `REACT_APP_NETWORK_ID` to `"{YOUR_NETWORK_ID}"`. This will be your default network id
-2. Define your own list of supported networks:
+You should set your own RPC endpoints by defining the following environment variables:
 
 ```ini
-REACT_APP_SUPPORTED_CHAIN_IDS="1,100,5"
+# Define your own RPC endpoints
 REACT_APP_NETWORK_URL_1=https://mainnet.infura.io/v3/{YOUR_INFURA_KEY}
 REACT_APP_NETWORK_URL_5=https://goerli.infura.io/v3/{YOUR_INFURA_KEY}
 REACT_APP_NETWORK_URL_100=https://rpc.gnosischain.com
 ```
+
+If you plan to use Infura, you can omit defining the RPC endpoints, and just define the `REACT_APP_INFURA_KEY` environment variable.
+
+```ini
+# Alternatively you can just define your Infura key (instead of defining the RPC endpoints)
+REACT_APP_INFURA_KEY={YOUR_INFURA_KEY}
+```
+
+````
 
 ### API endpoints
 
@@ -201,7 +205,7 @@ You can define your own bridge by setting the following environment variable:
 
 ```ini
 REACT_APP_WALLET_CONNECT_V1_BRIDGE='https://bridge.walletconnect.org'
-```
+````
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -205,10 +205,11 @@ You can define your own bridge by setting the following environment variable:
 
 ```ini
 REACT_APP_WALLET_CONNECT_V1_BRIDGE='https://bridge.walletconnect.org'
-````
+```
 
 ## Documentation
 
 1. [Oveall Architecture](docs/architecture-overview.md)
 2. [Amounts formatting](apps/cowswap-frontend/src/utils/amountFormat/README.md)
 3. [ABIs](libs/abis/README.md)
+````

--- a/apps/cowswap-frontend/.env
+++ b/apps/cowswap-frontend/.env
@@ -28,9 +28,7 @@ INTEGRATION_TESTS_INFURA_KEY=
 # if you need that locally, get the key from blocknative. Access details in shared team vault
 #REACT_APP_BLOCKNATIVE_API_KEY=
 
-# Node
-REACT_APP_CHAIN_ID="1"
-REACT_APP_SUPPORTED_CHAIN_IDS="1,100,5"
+# RPC Nodes
 REACT_APP_NETWORK_URL_1=https://mainnet.infura.io/v3/586e7e6b7c7e437aa41f5da496a749f5
 REACT_APP_NETWORK_URL_5=https://goerli.infura.io/v3/586e7e6b7c7e437aa41f5da496a749f5
 REACT_APP_NETWORK_URL_100=https://rpc.gnosischain.com

--- a/apps/cowswap-frontend/src/legacy/constants/networks.ts
+++ b/apps/cowswap-frontend/src/legacy/constants/networks.ts
@@ -5,7 +5,7 @@ function initRpcUrls(): Record<SupportedChainId, string> {
   const { REACT_APP_INFURA_KEY, REACT_APP_NETWORK_URL_1, REACT_APP_NETWORK_URL_5, REACT_APP_NETWORK_URL_100 } =
     process.env
 
-  if (!REACT_APP_INFURA_KEY && !(REACT_APP_NETWORK_URL_1 && !REACT_APP_NETWORK_URL_5 && REACT_APP_NETWORK_URL_100)) {
+  if (!REACT_APP_INFURA_KEY && !(REACT_APP_NETWORK_URL_1 && REACT_APP_NETWORK_URL_5 && REACT_APP_NETWORK_URL_100)) {
     throw new Error(
       `Either REACT_APP_INFURA_KEY or REACT_APP_NETWORK_URL_{1,5,100} environment variables must be defined`
     )

--- a/apps/cowswap-frontend/src/legacy/constants/networks.ts
+++ b/apps/cowswap-frontend/src/legacy/constants/networks.ts
@@ -1,18 +1,40 @@
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { JsonRpcProvider } from '@ethersproject/providers'
 
+function initRpcUrls(): Record<SupportedChainId, string> {
+  const { REACT_APP_INFURA_KEY, REACT_APP_NETWORK_URL_1, REACT_APP_NETWORK_URL_5, REACT_APP_NETWORK_URL_100 } =
+    process.env
+
+  console.log('process.env', process.env)
+
+  if (REACT_APP_NETWORK_URL_1 && REACT_APP_NETWORK_URL_5 && REACT_APP_NETWORK_URL_100) {
+    return {
+      [SupportedChainId.MAINNET]: REACT_APP_NETWORK_URL_1,
+      [SupportedChainId.GOERLI]: REACT_APP_NETWORK_URL_5,
+      [SupportedChainId.GNOSIS_CHAIN]: REACT_APP_NETWORK_URL_100,
+    }
+  }
+
+  if (REACT_APP_INFURA_KEY) {
+    return {
+      [SupportedChainId.MAINNET]: `https://mainnet.infura.io/v3/${INFURA_KEY}`,
+      [SupportedChainId.GOERLI]: `https://goerli.infura.io/v3/${INFURA_KEY}`,
+      [SupportedChainId.GNOSIS_CHAIN]: `https://rpc.gnosis.gateway.fm`,
+    }
+  }
+
+  throw new Error(
+    `Either REACT_APP_NETWORK_URL_{1,5,100} or REACT_APP_INFURA_KEY environment variables must be defined`
+  )
+}
+
 const INFURA_KEY = process.env.REACT_APP_INFURA_KEY
 if (typeof INFURA_KEY === 'undefined') {
   throw new Error(`REACT_APP_INFURA_KEY must be a defined environment variable`)
 }
 
-export const MAINNET_PROVIDER = new JsonRpcProvider(`https://mainnet.infura.io/v3/${INFURA_KEY}`)
-
 /**
  * These are the network URLs used by the interface when there is not another available source of chain data
  */
-export const RPC_URLS: Record<SupportedChainId, string> = {
-  [SupportedChainId.MAINNET]: `https://mainnet.infura.io/v3/${INFURA_KEY}`,
-  [SupportedChainId.GOERLI]: `https://goerli.infura.io/v3/${INFURA_KEY}`,
-  [SupportedChainId.GNOSIS_CHAIN]: `https://rpc.gnosis.gateway.fm`,
-}
+export const RPC_URLS = initRpcUrls()
+export const MAINNET_PROVIDER = new JsonRpcProvider(RPC_URLS[SupportedChainId.MAINNET])

--- a/apps/cowswap-frontend/src/legacy/constants/networks.ts
+++ b/apps/cowswap-frontend/src/legacy/constants/networks.ts
@@ -2,8 +2,13 @@ import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { JsonRpcProvider } from '@ethersproject/providers'
 
 function initRpcUrls(): Record<SupportedChainId, string> {
-  const { REACT_APP_INFURA_KEY, REACT_APP_NETWORK_URL_1, REACT_APP_NETWORK_URL_5, REACT_APP_NETWORK_URL_100 } =
-    process.env
+  const REACT_APP_INFURA_KEY = process.env.REACT_APP_INFURA_KEY
+  const REACT_APP_NETWORK_URL_1 = process.env.REACT_APP_NETWORK_URL_1
+  const REACT_APP_NETWORK_URL_5 = process.env.REACT_APP_NETWORK_URL_5
+  const REACT_APP_NETWORK_URL_100 = process.env.REACT_APP_NETWORK_URL_100
+
+  // const { REACT_APP_INFURA_KEY, REACT_APP_NETWORK_URL_1, REACT_APP_NETWORK_URL_5, REACT_APP_NETWORK_URL_100 } =
+  //   process.env
 
   console.log('DEBUG NETWORKS', {
     REACT_APP_INFURA_KEY,

--- a/apps/cowswap-frontend/src/legacy/constants/networks.ts
+++ b/apps/cowswap-frontend/src/legacy/constants/networks.ts
@@ -7,16 +7,6 @@ function initRpcUrls(): Record<SupportedChainId, string> {
   const REACT_APP_NETWORK_URL_5 = process.env.REACT_APP_NETWORK_URL_5
   const REACT_APP_NETWORK_URL_100 = process.env.REACT_APP_NETWORK_URL_100
 
-  // const { REACT_APP_INFURA_KEY, REACT_APP_NETWORK_URL_1, REACT_APP_NETWORK_URL_5, REACT_APP_NETWORK_URL_100 } =
-  //   process.env
-
-  console.log('DEBUG NETWORKS', {
-    REACT_APP_INFURA_KEY,
-    REACT_APP_NETWORK_URL_1,
-    REACT_APP_NETWORK_URL_5,
-    REACT_APP_NETWORK_URL_100,
-  })
-
   if (!REACT_APP_INFURA_KEY && !(REACT_APP_NETWORK_URL_1 && REACT_APP_NETWORK_URL_5 && REACT_APP_NETWORK_URL_100)) {
     throw new Error(
       `Either REACT_APP_INFURA_KEY or REACT_APP_NETWORK_URL_{1,5,100} environment variables must be defined`

--- a/apps/cowswap-frontend/src/legacy/constants/networks.ts
+++ b/apps/cowswap-frontend/src/legacy/constants/networks.ts
@@ -5,27 +5,17 @@ function initRpcUrls(): Record<SupportedChainId, string> {
   const { REACT_APP_INFURA_KEY, REACT_APP_NETWORK_URL_1, REACT_APP_NETWORK_URL_5, REACT_APP_NETWORK_URL_100 } =
     process.env
 
-  console.log('process.env', process.env)
-
-  if (REACT_APP_NETWORK_URL_1 && REACT_APP_NETWORK_URL_5 && REACT_APP_NETWORK_URL_100) {
-    return {
-      [SupportedChainId.MAINNET]: REACT_APP_NETWORK_URL_1,
-      [SupportedChainId.GOERLI]: REACT_APP_NETWORK_URL_5,
-      [SupportedChainId.GNOSIS_CHAIN]: REACT_APP_NETWORK_URL_100,
-    }
+  if (!REACT_APP_INFURA_KEY && !(REACT_APP_NETWORK_URL_1 && !REACT_APP_NETWORK_URL_5 && REACT_APP_NETWORK_URL_100)) {
+    throw new Error(
+      `Either REACT_APP_INFURA_KEY or REACT_APP_NETWORK_URL_{1,5,100} environment variables must be defined`
+    )
   }
 
-  if (REACT_APP_INFURA_KEY) {
-    return {
-      [SupportedChainId.MAINNET]: `https://mainnet.infura.io/v3/${INFURA_KEY}`,
-      [SupportedChainId.GOERLI]: `https://goerli.infura.io/v3/${INFURA_KEY}`,
-      [SupportedChainId.GNOSIS_CHAIN]: `https://rpc.gnosis.gateway.fm`,
-    }
+  return {
+    [SupportedChainId.MAINNET]: REACT_APP_NETWORK_URL_1 || `https://mainnet.infura.io/v3/${INFURA_KEY}`,
+    [SupportedChainId.GNOSIS_CHAIN]: REACT_APP_NETWORK_URL_100 || `https://rpc.gnosis.gateway.fm`,
+    [SupportedChainId.GOERLI]: REACT_APP_NETWORK_URL_5 || `https://goerli.infura.io/v3/${INFURA_KEY}`,
   }
-
-  throw new Error(
-    `Either REACT_APP_NETWORK_URL_{1,5,100} or REACT_APP_INFURA_KEY environment variables must be defined`
-  )
 }
 
 const INFURA_KEY = process.env.REACT_APP_INFURA_KEY

--- a/apps/cowswap-frontend/src/legacy/constants/networks.ts
+++ b/apps/cowswap-frontend/src/legacy/constants/networks.ts
@@ -5,6 +5,13 @@ function initRpcUrls(): Record<SupportedChainId, string> {
   const { REACT_APP_INFURA_KEY, REACT_APP_NETWORK_URL_1, REACT_APP_NETWORK_URL_5, REACT_APP_NETWORK_URL_100 } =
     process.env
 
+  console.log('DEBUG NETWORKS', {
+    REACT_APP_INFURA_KEY,
+    REACT_APP_NETWORK_URL_1,
+    REACT_APP_NETWORK_URL_5,
+    REACT_APP_NETWORK_URL_100,
+  })
+
   if (!REACT_APP_INFURA_KEY && !(REACT_APP_NETWORK_URL_1 && REACT_APP_NETWORK_URL_5 && REACT_APP_NETWORK_URL_100)) {
     throw new Error(
       `Either REACT_APP_INFURA_KEY or REACT_APP_NETWORK_URL_{1,5,100} environment variables must be defined`


### PR DESCRIPTION
# Summary

Introduce the possibility to define your own RPC nodes.

Before, you could only define your own INFURA key. So it was assumed you need to use infura for the RPC nodes.

This PR gives as an alternative, the possibility to define the RPC nodes.

It adapts also the README (it was outdated with some old env vars), and add the new ones.



## Test

You can test locally. Review I didn't mess up with the setup, and lastly check it in the preview (should use NodeReal now)

DEMO: https://swap-dev-git-allow-to-change-rpc-nodes-cowswap.vercel.app/