### PR TITLE
feat(permit): modals LIMIT

### DIFF
--- a/apps/cowswap-frontend/src/common/constants/theme.ts
+++ b/apps/cowswap-frontend/src/common/constants/theme.ts
@@ -24,6 +24,7 @@ export enum UI {
   
   // Icons
   ICON_SIZE_NORMAL = '--cow-icon-size-normal',
+  ICON_SIZE_LARGE = '--cow-icon-size-large',
   ICON_COLOR_NORMAL = '--cow-icon-color-normal',
 
   // States

--- a/apps/cowswap-frontend/src/common/pure/Modal/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/Modal/index.tsx
@@ -105,6 +105,7 @@ export const CowModal = styled(Modal)<{
     transition: max-width 0.4s ease;
     background-color: var(${UI.COLOR_CONTAINER_BG_01});
     overflow: hidden;
+    border-radius: var(${UI.BORDER_RADIUS_NORMAL});
 
     ${({ theme }) => theme.mediaWidth.upToSmall`
       max-height: 100vh;
@@ -145,4 +146,9 @@ export const CowModal = styled(Modal)<{
       `}
     }
   }
+`
+
+export const NewCowModal = styled(Modal)`
+  width: 100vw;
+  height: 100vh;
 `

--- a/apps/cowswap-frontend/src/common/pure/Modal/styled.tsx
+++ b/apps/cowswap-frontend/src/common/pure/Modal/styled.tsx
@@ -59,6 +59,7 @@ export const StyledDialogOverlay = styled(AnimatedDialogOverlay)`
     justify-content: center;
 
     background-color: ${({ theme }) => theme.modalBG};
+    backdrop-filter: blur(5px);
   }
 `
 

--- a/apps/cowswap-frontend/src/common/pure/NewModal/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/NewModal/index.tsx
@@ -12,18 +12,9 @@ const ModalInner = styled.div`
   width: 100%;
   height: auto;
   margin: auto;
-  background: var(${UI.COLOR_CONTAINER_BG_01});
-  border-radius: var(${UI.BORDER_RADIUS_NORMAL});
-  box-shadow: var(${UI.BOX_SHADOW_NORMAL});
+  background: transparent;
   padding: 0;
-
-  ${({ theme }) => theme.mediaWidth.upToSmall`
-    margin: 8vh 0 0;
-    border-radius: 0;
-    border-top-left-radius: var(${UI.BORDER_RADIUS_NORMAL});
-    border-top-right-radius: var(${UI.BORDER_RADIUS_NORMAL});
-    box-shadow: none;
-  `}
+  position: relative;
 `
 
 const Wrapper = styled.div<{ maxWidth?: number | string; minHeight?: number | string }>`
@@ -31,8 +22,18 @@ const Wrapper = styled.div<{ maxWidth?: number | string; minHeight?: number | st
   width: 100%;
   height: 100%;
   margin: auto;
-  background: var(${UI.MODAL_BACKDROP});
   overflow-y: auto;
+  background: var(${UI.COLOR_CONTAINER_BG_01});
+  border-radius: var(${UI.BORDER_RADIUS_NORMAL});
+  box-shadow: var(${UI.BOX_SHADOW_NORMAL});
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    margin: 0;
+    border-radius: 0;
+    border-top-left-radius: var(${UI.BORDER_RADIUS_NORMAL});
+    border-top-right-radius: var(${UI.BORDER_RADIUS_NORMAL});
+    box-shadow: none;
+  `}
 
   ${ModalInner} {
     max-width: ${({ maxWidth }) => (maxWidth ? `${maxWidth}px` : '100%')};
@@ -40,8 +41,7 @@ const Wrapper = styled.div<{ maxWidth?: number | string; minHeight?: number | st
 
     ${({ theme }) => theme.mediaWidth.upToSmall`
       max-width: 100%;
-      min-height: initial;
-      height: auto;
+      height: 100%;
     `}
   }
 `
@@ -62,18 +62,18 @@ const Heading = styled.h2`
 `
 
 const IconX = styled.div`
-  position: fixed;
-  top: 18px;
-  right: 18px;
+  position: absolute;
+  top: 16px;
+  right: 10px;
   cursor: pointer;
-  opacity: 0.6;
+  opacity: 0.7;
   transition: opacity 0.2s ease-in-out;
   margin: 0 0 0 auto;
 
   > svg {
     width: var(${UI.ICON_SIZE_NORMAL});
     height: var(${UI.ICON_SIZE_NORMAL});
-    fill: var(${UI.ICON_COLOR_NORMAL});
+    color: var(${UI.ICON_COLOR_NORMAL});
   }
 
   &:hover {
@@ -152,12 +152,12 @@ export function NewModal({ maxWidth = 450, minHeight = 450, title, children, onD
     <Wrapper maxWidth={maxWidth} minHeight={minHeight}>
       <ModalInner>
         {title && <Heading>{title}</Heading>}
+        <IconX onClick={() => onDismiss && onDismiss()}>
+          <SVG src={CLOSE_ICON} />
+        </IconX>
+
         <NewModalContent>{children}</NewModalContent>
       </ModalInner>
-
-      <IconX onClick={() => onDismiss && onDismiss()}>
-        <SVG src={CLOSE_ICON} />
-      </IconX>
     </Wrapper>
   )
 }

--- a/apps/cowswap-frontend/src/common/pure/PermitModal/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/common/pure/PermitModal/index.cosmos.tsx
@@ -23,25 +23,59 @@ const WALLET_ICON = (
 )
 
 const PermitModalFixtures = {
-  'Pending permit signature': (
+  'SWAP: Pending permit signature': (
     <Wrapper>
-      <PermitModal inputAmount={INPUT_AMOUNT} outputAmount={OUTPUT_AMOUNT} step="approve" icon={WALLET_ICON} />
+      <PermitModal
+        inputAmount={INPUT_AMOUNT}
+        outputAmount={OUTPUT_AMOUNT}
+        step="approve"
+        icon={WALLET_ICON}
+        orderType={'Swap'}
+      />
     </Wrapper>
   ),
-  'Pending order signature': (
+  'SWAP: Pending order signature': (
     <Wrapper>
-      <PermitModal inputAmount={INPUT_AMOUNT} outputAmount={OUTPUT_AMOUNT} step="submit" icon={WALLET_ICON} />
+      <PermitModal
+        inputAmount={INPUT_AMOUNT}
+        outputAmount={OUTPUT_AMOUNT}
+        step="submit"
+        icon={WALLET_ICON}
+        orderType={'Swap'}
+      />
+    </Wrapper>
+  ),
+  'LIMIT: Pending permit signature': (
+    <Wrapper>
+      <PermitModal
+        inputAmount={INPUT_AMOUNT}
+        outputAmount={OUTPUT_AMOUNT}
+        step="approve"
+        icon={WALLET_ICON}
+        orderType={'Limit Order'}
+      />
+    </Wrapper>
+  ),
+  'LIMIT: Pending order signature': (
+    <Wrapper>
+      <PermitModal
+        inputAmount={INPUT_AMOUNT}
+        outputAmount={OUTPUT_AMOUNT}
+        step="submit"
+        icon={WALLET_ICON}
+        orderType={'Limit Order'}
+      />
     </Wrapper>
   ),
   // These two cases should happen, but including for completeness as the parameters allow it
   'Missing amounts on approve': (
     <Wrapper>
-      <PermitModal inputAmount={undefined} outputAmount={undefined} step="approve" />
+      <PermitModal inputAmount={undefined} outputAmount={undefined} step="approve" orderType={'Swap'} />
     </Wrapper>
   ),
   'Missing amounts on submit': (
     <Wrapper>
-      <PermitModal inputAmount={undefined} outputAmount={undefined} step="submit" />
+      <PermitModal inputAmount={undefined} outputAmount={undefined} step="submit" orderType={'Swap'} />
     </Wrapper>
   ),
 }

--- a/apps/cowswap-frontend/src/common/pure/PermitModal/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/PermitModal/index.tsx
@@ -26,7 +26,7 @@ export type PermitModalProps = NewModalProps & {
  * This is the pure component for cosmos
  */
 export function PermitModal(props: PermitModalProps) {
-  const { inputAmount, outputAmount, step, icon: inputIcon, orderType } = props
+  const { inputAmount, outputAmount, step, icon: inputIcon, orderType, ...rest } = props
 
   const steps: StepProps[] = useMemo(
     () => [
@@ -74,7 +74,7 @@ export function PermitModal(props: PermitModalProps) {
   )
 
   return (
-    <NewModal>
+    <NewModal {...rest}>
       <NewModalContentTop paddingTop={90}>
         {icon}
         <span>

--- a/apps/cowswap-frontend/src/common/pure/PermitModal/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/PermitModal/index.tsx
@@ -17,6 +17,7 @@ export type PermitModalProps = NewModalProps & {
   inputAmount: Nullish<CurrencyAmount<Currency>>
   outputAmount: Nullish<CurrencyAmount<Currency>>
   step: 'approve' | 'submit'
+  orderType: 'Swap' | 'Limit Order'
   icon?: React.ReactNode
 }
 
@@ -25,7 +26,7 @@ export type PermitModalProps = NewModalProps & {
  * This is the pure component for cosmos
  */
 export function PermitModal(props: PermitModalProps) {
-  const { inputAmount, outputAmount, step, icon: inputIcon } = props
+  const { inputAmount, outputAmount, step, icon: inputIcon, orderType } = props
 
   const steps: StepProps[] = useMemo(
     () => [
@@ -56,9 +57,9 @@ export function PermitModal(props: PermitModalProps) {
           on CoW Swap
         </>
       ) : (
-        'Confirm Swap'
+        `Confirm ${orderType}`
       ),
-    [inputAmount?.currency, step]
+    [inputAmount?.currency, orderType, step]
   )
 
   const body = useMemo(

--- a/apps/cowswap-frontend/src/legacy/components/TransactionConfirmationModal/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/TransactionConfirmationModal/index.tsx
@@ -83,6 +83,7 @@ export function TransactionConfirmationModal({
           inputAmount={tradeAmounts?.inputAmount}
           outputAmount={tradeAmounts?.outputAmount}
           step={swapConfirmState?.permitSignatureState === 'signed' ? 'submit' : 'approve'}
+          orderType={'Swap'}
         />
       ) : attemptingTxn ? (
         <LegacyConfirmationPendingContent

--- a/apps/cowswap-frontend/src/legacy/theme/baseTheme.tsx
+++ b/apps/cowswap-frontend/src/legacy/theme/baseTheme.tsx
@@ -413,6 +413,7 @@ export const UniThemedGlobalStyle = css`
 
     // Icons
     ${UI.ICON_SIZE_NORMAL}: 24px;
+    ${UI.ICON_SIZE_LARGE}: 36px;
     ${UI.ICON_COLOR_NORMAL}: var(${UI.COLOR_TEXT1});
 
     // [STATE] Information (light blue)

--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.test.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.test.ts
@@ -73,6 +73,9 @@ const tradeConfirmActions: TradeConfirmActions = {
   onOpen() {
     console.log('onOpen')
   },
+  requestPermitSignature() {
+    console.log('requestPermitSignature')
+  },
 }
 
 describe('useHandleOrderPlacement', () => {

--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.ts
@@ -1,5 +1,4 @@
-import { useAtom } from 'jotai'
-import { useSetAtom } from 'jotai'
+import { useAtom, useSetAtom } from 'jotai'
 import { useCallback } from 'react'
 
 import { PriceImpact } from 'legacy/hooks/usePriceImpact'
@@ -34,12 +33,8 @@ export function useHandleOrderPlacement(
   const beforeTrade = useCallback(() => {
     if (!tradeContext) return
 
-    const tradeAmounts: TradeAmounts = {
-      inputAmount: tradeContext.postOrderParams.inputAmount,
-      outputAmount: tradeContext.postOrderParams.outputAmount,
-    }
 
-    tradeConfirmActions.onSign(tradeAmounts)
+    tradeConfirmActions.onSign(buildTradeAmounts(tradeContext))
   }, [tradeContext, tradeConfirmActions])
 
   const tradeFn = useCallback(async () => {
@@ -94,4 +89,11 @@ export function useHandleOrderPlacement(
         }
       })
   }, [tradeFn, tradeConfirmActions, updateLimitOrdersState, setPartiallyFillableOverride])
+}
+
+function buildTradeAmounts(tradeContext: TradeFlowContext): TradeAmounts {
+  return {
+    inputAmount: tradeContext.postOrderParams.inputAmount,
+    outputAmount: tradeContext.postOrderParams.outputAmount,
+  }
 }

--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.ts
@@ -30,9 +30,14 @@ export function useHandleOrderPlacement(
   const safeBundleFlowContext = useSafeBundleFlowContext(tradeContext)
   const isSafeBundle = useIsSafeApprovalBundle(tradeContext?.postOrderParams.inputAmount)
 
-  const beforeTrade = useCallback(() => {
+  const beforePermit = useCallback(() => {
     if (!tradeContext) return
 
+    tradeConfirmActions.requestPermitSignature(buildTradeAmounts(tradeContext))
+  }, [tradeConfirmActions, tradeContext])
+
+  const beforeTrade = useCallback(() => {
+    if (!tradeContext) return
 
     tradeConfirmActions.onSign(buildTradeAmounts(tradeContext))
   }, [tradeContext, tradeConfirmActions])
@@ -58,8 +63,9 @@ export function useHandleOrderPlacement(
     tradeContext.postOrderParams.partiallyFillable =
       partiallyFillableOverride ?? tradeContext.postOrderParams.partiallyFillable
 
-    return tradeFlow(tradeContext, priceImpact, settingsState, confirmPriceImpactWithoutFee, beforeTrade)
+    return tradeFlow(tradeContext, priceImpact, settingsState, confirmPriceImpactWithoutFee, beforePermit, beforeTrade)
   }, [
+    beforePermit,
     beforeTrade,
     confirmPriceImpactWithoutFee,
     isSafeBundle,

--- a/apps/cowswap-frontend/src/modules/limitOrders/services/tradeFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/services/tradeFlow/index.ts
@@ -21,7 +21,7 @@ export async function tradeFlow(
   priceImpact: PriceImpact,
   settingsState: LimitOrdersSettingsState,
   confirmPriceImpactWithoutFee: (priceImpact: Percent) => Promise<boolean>,
-  beforeTrade?: () => void
+  beforePermit: () => void,
   beforeTrade: () => void
 ): Promise<string> {
   const {
@@ -56,6 +56,8 @@ export async function tradeFlow(
 
   try {
     logTradeFlow('LIMIT ORDER FLOW', 'STEP 2: handle permit')
+    if (permitInfo) beforePermit()
+
     postOrderParams.appData = await handlePermit({
       permitInfo,
       inputToken: sellToken,

--- a/apps/cowswap-frontend/src/modules/limitOrders/services/tradeFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/services/tradeFlow/index.ts
@@ -22,6 +22,7 @@ export async function tradeFlow(
   settingsState: LimitOrdersSettingsState,
   confirmPriceImpactWithoutFee: (priceImpact: Percent) => Promise<boolean>,
   beforeTrade?: () => void
+  beforeTrade: () => void
 ): Promise<string> {
   const {
     postOrderParams,
@@ -66,7 +67,8 @@ export async function tradeFlow(
 
     logTradeFlow('LIMIT ORDER FLOW', 'STEP 3: send transaction')
     tradeFlowAnalytics.trade(swapFlowAnalyticsContext)
-    beforeTrade?.()
+
+    beforeTrade()
 
     logTradeFlow('LIMIT ORDER FLOW', 'STEP 4: sign and post order')
     const { id: orderId, order } = await signAndPostOrder({

--- a/apps/cowswap-frontend/src/modules/permit/const.ts
+++ b/apps/cowswap-frontend/src/modules/permit/const.ts
@@ -26,6 +26,6 @@ export const DEFAULT_PERMIT_DURATION = ms`5 years`
 
 export const ORDER_TYPE_SUPPORTS_PERMIT: Record<TradeType, boolean> = {
   [TradeType.SWAP]: true,
-  [TradeType.LIMIT_ORDER]: false,
+  [TradeType.LIMIT_ORDER]: true, // TODO: temporary, for the modals. Should be turn on for real only when this is deployed https://github.com/cowprotocol/services/pull/1892
   [TradeType.ADVANCED_ORDERS]: false,
 }

--- a/apps/cowswap-frontend/src/modules/permit/const.ts
+++ b/apps/cowswap-frontend/src/modules/permit/const.ts
@@ -26,6 +26,6 @@ export const DEFAULT_PERMIT_DURATION = ms`5 years`
 
 export const ORDER_TYPE_SUPPORTS_PERMIT: Record<TradeType, boolean> = {
   [TradeType.SWAP]: true,
-  [TradeType.LIMIT_ORDER]: true, // TODO: temporary, for the modals. Should be turn on for real only when this is deployed https://github.com/cowprotocol/services/pull/1892
+  [TradeType.LIMIT_ORDER]: true,
   [TradeType.ADVANCED_ORDERS]: false,
 }

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeConfirmModal/index.tsx
@@ -3,7 +3,7 @@ import { useAtomValue } from 'jotai'
 import { useIsSafeWallet, useWalletInfo } from '@cowprotocol/wallet'
 
 import { PermitModal } from 'common/containers/PermitModal'
-import { CowModal } from 'common/pure/Modal'
+import { CowModal, NewCowModal } from 'common/pure/Modal'
 import { OrderSubmittedContent } from 'common/pure/OrderSubmittedContent'
 import { TransactionErrorContent } from 'common/pure/TransactionErrorContent'
 
@@ -26,47 +26,58 @@ export function TradeConfirmModal(props: TradeConfirmModalProps) {
 
   if (!account) return null
 
-  return (
-    <CowModal isOpen={isOpen} onDismiss={onDismiss}>
-      {(() => {
-        if (error) {
-          return <TransactionErrorContent message={error} onDismiss={onDismiss} />
-        }
+  const renderModalContent = () => {
+    if (error) {
+      return <TransactionErrorContent message={error} onDismiss={onDismiss} />
+    }
 
-        if (pendingTrade && permitSignatureState) {
-          // TODO: potentially replace TradeConfirmPendingContent completely with PermitModal
-          // We could use this not just for permit, but for any token, even already approved
-          const step = permitSignatureState === 'signed' ? 'submit' : 'approve'
+    if (pendingTrade && permitSignatureState) {
+      // TODO: potentially replace TradeConfirmPendingContent completely with PermitModal
+      // We could use this not just for permit, but for any token, even already approved
+      const step = permitSignatureState === 'signed' ? 'submit' : 'approve'
+      return (
+        <PermitModal
+          inputAmount={pendingTrade.inputAmount}
+          outputAmount={pendingTrade.outputAmount}
+          step={step}
+          onDismiss={onDismiss}
+        />
+      )
+    }
 
-          return (
-            <PermitModal
-              inputAmount={pendingTrade.inputAmount}
-              outputAmount={pendingTrade.outputAmount}
-              step={step}
-              onDismiss={onDismiss}
-            />
-          )
-        }
+    if (pendingTrade) {
+      return <TradeConfirmPendingContent pendingTrade={pendingTrade} onDismiss={onDismiss} />
+    }
 
-        if (pendingTrade) {
-          return <TradeConfirmPendingContent pendingTrade={pendingTrade} onDismiss={onDismiss} />
-        }
+    if (transactionHash) {
+      return (
+        <OrderSubmittedContent
+          chainId={chainId}
+          account={account}
+          isSafeWallet={isSafeWallet}
+          onDismiss={onDismiss}
+          hash={transactionHash}
+        />
+      )
+    }
 
-        // TODO: use <TransactionSubmittedContent/> for Swap
-        if (transactionHash) {
-          return (
-            <OrderSubmittedContent
-              chainId={chainId}
-              account={account}
-              isSafeWallet={isSafeWallet}
-              onDismiss={onDismiss}
-              hash={transactionHash}
-            />
-          )
-        }
+    return children
+  }
 
-        return children
-      })()}
-    </CowModal>
-  )
+  const renderModal = () => {
+    if (permitSignatureState) {
+      return (
+        <NewCowModal isOpen={isOpen} onDismiss={onDismiss}>
+          {renderModalContent()}
+        </NewCowModal>
+      )
+    }
+    return (
+      <CowModal isOpen={isOpen} onDismiss={onDismiss}>
+        {renderModalContent()}
+      </CowModal>
+    )
+  }
+
+  return renderModal()
 }

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeConfirmModal/index.tsx
@@ -41,6 +41,7 @@ export function TradeConfirmModal(props: TradeConfirmModalProps) {
           outputAmount={pendingTrade.outputAmount}
           step={step}
           onDismiss={onDismiss}
+          orderType={'Limit Order'}
         />
       )
     }

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeConfirmModal/index.tsx
@@ -2,6 +2,7 @@ import { useAtomValue } from 'jotai'
 
 import { useIsSafeWallet, useWalletInfo } from '@cowprotocol/wallet'
 
+import { PermitModal } from 'common/containers/PermitModal'
 import { CowModal } from 'common/pure/Modal'
 import { OrderSubmittedContent } from 'common/pure/OrderSubmittedContent'
 import { TransactionErrorContent } from 'common/pure/TransactionErrorContent'
@@ -20,7 +21,7 @@ export function TradeConfirmModal(props: TradeConfirmModalProps) {
 
   const { chainId, account } = useWalletInfo()
   const isSafeWallet = useIsSafeWallet()
-  const { isOpen, pendingTrade, transactionHash, error } = useAtomValue(tradeConfirmStateAtom)
+  const { isOpen, permitSignatureState, pendingTrade, transactionHash, error } = useAtomValue(tradeConfirmStateAtom)
   const { onDismiss } = useTradeConfirmActions()
 
   if (!account) return null
@@ -30,6 +31,21 @@ export function TradeConfirmModal(props: TradeConfirmModalProps) {
       {(() => {
         if (error) {
           return <TransactionErrorContent message={error} onDismiss={onDismiss} />
+        }
+
+        if (pendingTrade && permitSignatureState) {
+          // TODO: potentially replace TradeConfirmPendingContent completely with PermitModal
+          // We could use this not just for permit, but for any token, even already approved
+          const step = permitSignatureState === 'signed' ? 'submit' : 'approve'
+
+          return (
+            <PermitModal
+              inputAmount={pendingTrade.inputAmount}
+              outputAmount={pendingTrade.outputAmount}
+              step={step}
+              onDismiss={onDismiss}
+            />
+          )
         }
 
         if (pendingTrade) {

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useTradeConfirmActions.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useTradeConfirmActions.ts
@@ -19,7 +19,7 @@ export interface TradeConfirmActions {
 }
 
 export function useTradeConfirmActions(): TradeConfirmActions {
-  const setOpenTradeConfim = useSetAtom(setOpenTradeConfirmAtom)
+  const setOpenTradeConfirm = useSetAtom(setOpenTradeConfirmAtom)
   const setCloseTradeConfirm = useSetAtom(setCloseTradeConfirmAtom)
   const setErrorTradeConfirm = useSetAtom(setErrorTradeConfirmAtom)
   const setPendingTradeConfirm = useSetAtom(setPendingTradeConfirmAtom)
@@ -36,7 +36,7 @@ export function useTradeConfirmActions(): TradeConfirmActions {
       setTxHashTradeConfirm(transactionHash)
     },
     onOpen() {
-      setOpenTradeConfim()
+      setOpenTradeConfirm()
     },
     onDismiss() {
       setCloseTradeConfirm()

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useTradeConfirmActions.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useTradeConfirmActions.ts
@@ -7,6 +7,7 @@ import {
   setErrorTradeConfirmAtom,
   setOpenTradeConfirmAtom,
   setPendingTradeConfirmAtom,
+  setPermitSignatureRequestedTradeConfirmAtom,
   setTxHashTradeConfirmAtom,
 } from '../state/tradeConfirmStateAtom'
 
@@ -15,6 +16,7 @@ export interface TradeConfirmActions {
   onError(error: string): void
   onSuccess(transactionHash: string): void
   onOpen(): void
+  requestPermitSignature(pendingTrade: TradeAmounts): void
   onDismiss(): void
 }
 
@@ -24,6 +26,7 @@ export function useTradeConfirmActions(): TradeConfirmActions {
   const setErrorTradeConfirm = useSetAtom(setErrorTradeConfirmAtom)
   const setPendingTradeConfirm = useSetAtom(setPendingTradeConfirmAtom)
   const setTxHashTradeConfirm = useSetAtom(setTxHashTradeConfirmAtom)
+  const setPermitSignatureRequested = useSetAtom(setPermitSignatureRequestedTradeConfirmAtom)
 
   return {
     onSign(pendingTrade: TradeAmounts) {
@@ -37,6 +40,9 @@ export function useTradeConfirmActions(): TradeConfirmActions {
     },
     onOpen() {
       setOpenTradeConfirm()
+    },
+    requestPermitSignature(pendingTrade: TradeAmounts) {
+      setPermitSignatureRequested(pendingTrade)
     },
     onDismiss() {
       setCloseTradeConfirm()

--- a/apps/cowswap-frontend/src/modules/trade/state/tradeConfirmStateAtom.ts
+++ b/apps/cowswap-frontend/src/modules/trade/state/tradeConfirmStateAtom.ts
@@ -7,6 +7,7 @@ interface TradeConfirmModalState {
   pendingTrade: TradeAmounts | null
   transactionHash: string | null
   error: string | null
+  permitSignatureState: undefined | 'requested' | 'signed'
 }
 
 export const tradeConfirmStateAtom = atom<TradeConfirmModalState>({
@@ -14,6 +15,7 @@ export const tradeConfirmStateAtom = atom<TradeConfirmModalState>({
   pendingTrade: null,
   transactionHash: null,
   error: null,
+  permitSignatureState: undefined,
 })
 
 export const setOpenTradeConfirmAtom = atom(null, (get, set) => {
@@ -22,6 +24,7 @@ export const setOpenTradeConfirmAtom = atom(null, (get, set) => {
     error: null,
     pendingTrade: null,
     transactionHash: null,
+    permitSignatureState: undefined,
   }))
 })
 
@@ -29,6 +32,7 @@ export const setCloseTradeConfirmAtom = atom(null, (get, set) => {
   set(tradeConfirmStateAtom, () => ({
     ...get(tradeConfirmStateAtom),
     isOpen: false,
+    permitSignatureState: undefined,
   }))
 })
 
@@ -38,9 +42,16 @@ export const setErrorTradeConfirmAtom = atom(null, (get, set, error: string) => 
     error,
     pendingTrade: null,
     transactionHash: null,
+    permitSignatureState: undefined,
   }))
 })
 
+export const setPermitSignatureRequestedTradeConfirmAtom = atom(null, (get, set, pendingTrade: TradeAmounts) => {
+  set(tradeConfirmStateAtom, () => ({
+    ...get(tradeConfirmStateAtom),
+    pendingTrade,
+    permitSignatureState: 'requested',
+  }))
 })
 
 export const setPendingTradeConfirmAtom = atom(null, (get, set, pendingTrade: TradeAmounts) => {
@@ -52,6 +63,9 @@ export const setPendingTradeConfirmAtom = atom(null, (get, set, pendingTrade: Tr
       error: null,
       pendingTrade,
       transactionHash: null,
+      // Only move to the next state if coming in the right sequence.
+      // Otherwise, reset it
+      permitSignatureState: currentState.permitSignatureState === 'requested' ? 'signed' : undefined,
     }
   })
 })

--- a/apps/cowswap-frontend/src/modules/trade/state/tradeConfirmStateAtom.ts
+++ b/apps/cowswap-frontend/src/modules/trade/state/tradeConfirmStateAtom.ts
@@ -17,44 +17,38 @@ export const tradeConfirmStateAtom = atom<TradeConfirmModalState>({
 })
 
 export const setOpenTradeConfirmAtom = atom(null, (get, set) => {
-  set(tradeConfirmStateAtom, () => {
-    return {
-      isOpen: true,
-      error: null,
-      pendingTrade: null,
-      transactionHash: null,
-    }
-  })
+  set(tradeConfirmStateAtom, () => ({
+    isOpen: true,
+    error: null,
+    pendingTrade: null,
+    transactionHash: null,
+  }))
 })
 
 export const setCloseTradeConfirmAtom = atom(null, (get, set) => {
-  set(tradeConfirmStateAtom, () => {
-    return {
-      ...get(tradeConfirmStateAtom),
-      isOpen: false,
-    }
-  })
+  set(tradeConfirmStateAtom, () => ({
+    ...get(tradeConfirmStateAtom),
+    isOpen: false,
+  }))
 })
 
 export const setErrorTradeConfirmAtom = atom(null, (get, set, error: string) => {
-  set(tradeConfirmStateAtom, () => {
-    const currentState = get(tradeConfirmStateAtom)
+  set(tradeConfirmStateAtom, () => ({
+    ...get(tradeConfirmStateAtom),
+    error,
+    pendingTrade: null,
+    transactionHash: null,
+  }))
+})
 
-    return {
-      isOpen: currentState.isOpen,
-      error,
-      pendingTrade: null,
-      transactionHash: null,
-    }
-  })
 })
 
 export const setPendingTradeConfirmAtom = atom(null, (get, set, pendingTrade: TradeAmounts) => {
-  set(tradeConfirmStateAtom, () => {
-    const currentState = get(tradeConfirmStateAtom)
+  const currentState = get(tradeConfirmStateAtom)
 
+  set(tradeConfirmStateAtom, () => {
     return {
-      isOpen: currentState.isOpen,
+      ...currentState,
       error: null,
       pendingTrade,
       transactionHash: null,
@@ -63,14 +57,10 @@ export const setPendingTradeConfirmAtom = atom(null, (get, set, pendingTrade: Tr
 })
 
 export const setTxHashTradeConfirmAtom = atom(null, (get, set, transactionHash: string) => {
-  set(tradeConfirmStateAtom, () => {
-    const currentState = get(tradeConfirmStateAtom)
-
-    return {
-      isOpen: currentState.isOpen,
-      error: null,
-      pendingTrade: null,
-      transactionHash,
-    }
-  })
+  set(tradeConfirmStateAtom, () => ({
+    ...get(tradeConfirmStateAtom),
+    error: null,
+    pendingTrade: null,
+    transactionHash,
+  }))
 })


### PR DESCRIPTION
# Summary

Fixes https://github.com/cowprotocol/cowswap/issues/3145

Follow up to https://github.com/cowprotocol/cowswap/pull/3158


https://github.com/cowprotocol/cowswap/assets/43217/0e13ba7e-61e5-49f2-b77a-de7b3bd4ab73

Permit for LIMIT turned on for testing.
Partial fills might not work.

# To Test

1. Pick a permittable token to sell, make sure there's no allowance
2. On LIMIT, using non-expert mode, confirm the order
* Should show the new modal in the step 1 while the permit signature is requested in the wallet
3. Sign the approval
* Should show the new modal in the step 2 while the order signature is requested in the wallet
4. Sign the order
* Should show the regular modal
5. Place an order without permit
* Should show the old modal
6. Use a non-permit token that needs approval
* Approval button should be visible
8. Start the approval
* Should show the old modal