### PR TITLE
chore: replace rpc to rate-limited one

### DIFF
--- a/apps/cowswap-frontend/.env
+++ b/apps/cowswap-frontend/.env
@@ -17,7 +17,7 @@ REACT_APP_FULL_APP_DATA_DEVELOPMENT='{"version":"0.7.0","appCode":"CoW Swap","en
 REACT_APP_FULL_APP_DATA_LOCAL='{"version":"0.7.0","appCode":"CoW Swap","environment":"local","metadata":{}}'
 
 # INFURA KEY
-REACT_APP_INFURA_KEY=586e7e6b7c7e437aa41f5da496a749f5
+REACT_APP_INFURA_KEY=2af29cd5ac554ae3b8d991afe1ba4b7d
 
 # Cypress Integration Tests
 INTEGRATION_TEST_PRIVATE_KEY=
@@ -29,8 +29,8 @@ INTEGRATION_TESTS_INFURA_KEY=
 #REACT_APP_BLOCKNATIVE_API_KEY=
 
 # RPC Nodes
-REACT_APP_NETWORK_URL_1=https://mainnet.infura.io/v3/586e7e6b7c7e437aa41f5da496a749f5
-REACT_APP_NETWORK_URL_5=https://goerli.infura.io/v3/586e7e6b7c7e437aa41f5da496a749f5
+REACT_APP_NETWORK_URL_1=https://mainnet.infura.io/v3/2af29cd5ac554ae3b8d991afe1ba4b7d
+REACT_APP_NETWORK_URL_5=https://goerli.infura.io/v3/2af29cd5ac554ae3b8d991afe1ba4b7d
 REACT_APP_NETWORK_URL_100=https://rpc.gnosischain.com
 
 # Wallet Connect

--- a/apps/cowswap-frontend/.env.production
+++ b/apps/cowswap-frontend/.env.production
@@ -4,15 +4,15 @@ REACT_APP_PRICE_FEED_PARASWAP_ENABLED=true
 REACT_APP_PRICE_FEED_1INCH_ENABLED=true
 REACT_APP_PRICE_FEED_0X_ENABLED=true
 # INFURA KEY
-REACT_APP_INFURA_KEY=586e7e6b7c7e437aa41f5da496a749f5
+REACT_APP_INFURA_KEY=2af29cd5ac554ae3b8d991afe1ba4b7d
 
 # BLOCKNATIVE KEY
 # Loaded from GH secrets
 #REACT_APP_BLOCKNATIVE_API_KEY=
 
 # RPC Nodes
-REACT_APP_NETWORK_URL_1=https://mainnet.infura.io/v3/586e7e6b7c7e437aa41f5da496a749f5
-REACT_APP_NETWORK_URL_5=https://goerli.infura.io/v3/586e7e6b7c7e437aa41f5da496a749f5
+REACT_APP_NETWORK_URL_1=https://mainnet.infura.io/v3/2af29cd5ac554ae3b8d991afe1ba4b7d
+REACT_APP_NETWORK_URL_5=https://goerli.infura.io/v3/2af29cd5ac554ae3b8d991afe1ba4b7d
 #REACT_APP_NETWORK_URL_100=https://rpc.gnosischain.com/oe-only
 REACT_APP_NETWORK_URL_100=https://rpc.gnosischain.com
 

--- a/libs/common-utils/.env
+++ b/libs/common-utils/.env
@@ -17,7 +17,7 @@ REACT_APP_FULL_APP_DATA_DEVELOPMENT='{"version":"0.7.0","appCode":"CoW Swap","en
 REACT_APP_FULL_APP_DATA_LOCAL='{"version":"0.7.0","appCode":"CoW Swap","environment":"local","metadata":{}}'
 
 # INFURA KEY
-REACT_APP_INFURA_KEY=586e7e6b7c7e437aa41f5da496a749f5
+REACT_APP_INFURA_KEY=2af29cd5ac554ae3b8d991afe1ba4b7d
 
 # Cypress Integration Tests
 INTEGRATION_TEST_PRIVATE_KEY=
@@ -31,8 +31,8 @@ INTEGRATION_TESTS_INFURA_KEY=
 # Node
 REACT_APP_CHAIN_ID="1"
 REACT_APP_SUPPORTED_CHAIN_IDS="1,100,5"
-REACT_APP_NETWORK_URL_1=https://mainnet.infura.io/v3/586e7e6b7c7e437aa41f5da496a749f5
-REACT_APP_NETWORK_URL_5=https://goerli.infura.io/v3/586e7e6b7c7e437aa41f5da496a749f5
+REACT_APP_NETWORK_URL_1=https://mainnet.infura.io/v3/2af29cd5ac554ae3b8d991afe1ba4b7d
+REACT_APP_NETWORK_URL_5=https://goerli.infura.io/v3/2af29cd5ac554ae3b8d991afe1ba4b7d
 REACT_APP_NETWORK_URL_100=https://rpc.gnosischain.com
 
 # Wallet Connect


### PR DESCRIPTION
# Summary

Replaces an old default infura key we don't control anymore. I think is from Gnosis.

Adds our own, which has a max number of requests, and a ratelimit. 


# To Test
Just check its using the good one now (see infura key --> search for "public" one)