### PR TITLE
feat(permit): disable permit for SC wallets

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/featureFlags/useIsPermitEnabled.ts
+++ b/apps/cowswap-frontend/src/common/hooks/featureFlags/useIsPermitEnabled.ts
@@ -1,9 +1,16 @@
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { useIsSmartContractWallet } from '@cowprotocol/wallet'
 
 import { useFeatureFlags } from './useFeatureFlags'
 
 export function useIsPermitEnabled(chainId: SupportedChainId | undefined): boolean {
+  const isSmartContractWallet = useIsSmartContractWallet()
   const { permitEnabledMainnet, permitEnabledGoerli, permitEnabledGnosis } = useFeatureFlags()
+
+  // Permit is only available for EOAs
+  if (isSmartContractWallet) {
+    return false
+  }
 
   switch (chainId) {
     case SupportedChainId.MAINNET:


### PR DESCRIPTION
# Summary

Fixes #3207 

Disable permit for SC wallets

# To Test

1. With a SC wallet, pick as sell a permittable token on Goerli or Mainnet
2. Make sure there's no allowance for it
3. Place a sell order
* If it's a Safe wallet, you'll be able to bundle the approval in one go
* Otherwise, you'll have to send an approval tx, then place the order
4. Open the placed order in the explorer
* It should not contain hook data in the appData field
![image](https://github.com/cowprotocol/cowswap/assets/43217/2504436b-8522-42d5-9958-0a871f090a18)
5. Now with an EOA wallet, repeat the process (sell permittable token, no allowance etc, etc)
* Permit flow should work as usual