### PR TITLE
fix(eth-flow): update refund info for expired orders

### DIFF
--- a/apps/cowswap-frontend/src/common/updaters/orders/ExpiredOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/ExpiredOrdersUpdater.ts
@@ -1,5 +1,6 @@
 import { useEffect, useCallback, useRef } from 'react'
 
+import { NATIVE_CURRENCY_BUY_ADDRESS } from '@cowprotocol/common-const'
 import { SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
 import { useWalletInfo } from '@cowprotocol/wallet'
 
@@ -32,10 +33,13 @@ export function ExpiredOrdersUpdater(): null {
         isUpdating.current = true
 
         // Filter orders:
+        // - Only eth-flow orders
         // - Owned by the current connected account
         // - Not yet refunded
-        const pending = expiredRef.current.filter(({ owner, refundHash }) => {
-          return owner.toLowerCase() === lowerCaseAccount && !refundHash
+        const pending = expiredRef.current.filter(({ owner, refundHash, sellToken }) => {
+          const isEthFlowOrder = sellToken === NATIVE_CURRENCY_BUY_ADDRESS
+
+          return isEthFlowOrder && owner.toLowerCase() === lowerCaseAccount && !refundHash
         })
 
         if (pending.length === 0) {

--- a/apps/cowswap-frontend/src/common/updaters/orders/ExpiredOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/ExpiredOrdersUpdater.ts
@@ -33,7 +33,6 @@ export function ExpiredOrdersUpdater(): null {
 
         // Filter orders:
         // - Owned by the current connected account
-        // - Created in the last 5 min, no further
         // - Not yet refunded
         const pending = expiredRef.current.filter(({ owner, refundHash }) => {
           return owner.toLowerCase() === lowerCaseAccount && !refundHash

--- a/apps/cowswap-frontend/src/common/updaters/orders/ExpiredOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/ExpiredOrdersUpdater.ts
@@ -32,24 +32,24 @@ export function ExpiredOrdersUpdater(): null {
       try {
         isUpdating.current = true
 
-        // Filter orders:
+        // Filter expired orders:
         // - Only eth-flow orders
         // - Owned by the current connected account
         // - Not yet refunded
-        const pending = expiredRef.current.filter(({ owner, refundHash, sellToken }) => {
+        const orderWithoutRefund = expiredRef.current.filter(({ owner, refundHash, sellToken }) => {
           const isEthFlowOrder = sellToken === NATIVE_CURRENCY_BUY_ADDRESS
 
           return isEthFlowOrder && owner.toLowerCase() === lowerCaseAccount && !refundHash
         })
 
-        if (pending.length === 0) {
+        if (orderWithoutRefund.length === 0) {
           // console.debug(`[CancelledOrdersUpdater] No orders are being expired`)
           return
         } else {
-          console.debug(`[ExpiredOrdersUpdater] Checking ${pending.length} recently expired orders...`)
+          console.debug(`[ExpiredOrdersUpdater] Checking ${orderWithoutRefund.length} recently expired orders...`)
         }
 
-        const ordersPromises = pending.map(({ id }) => getOrder(chainId, id))
+        const ordersPromises = orderWithoutRefund.map(({ id }) => getOrder(chainId, id))
 
         const resolvedPromises = await Promise.allSettled(ordersPromises)
 

--- a/apps/cowswap-frontend/src/common/updaters/orders/ExpiredOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/ExpiredOrdersUpdater.ts
@@ -1,6 +1,5 @@
 import { useEffect, useCallback, useRef } from 'react'
 
-import { EXPIRED_ORDERS_PENDING_TIME } from '@cowprotocol/common-const'
 import { SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
 import { useWalletInfo } from '@cowprotocol/wallet'
 
@@ -24,7 +23,6 @@ export function ExpiredOrdersUpdater(): null {
   const updateOrders = useCallback(
     async (chainId: ChainId, account: string) => {
       const lowerCaseAccount = account.toLowerCase()
-      const now = Date.now()
 
       if (isUpdating.current) {
         return
@@ -37,12 +35,8 @@ export function ExpiredOrdersUpdater(): null {
         // - Owned by the current connected account
         // - Created in the last 5 min, no further
         // - Not yet refunded
-        const pending = expiredRef.current.filter(({ owner, creationTime: creationTimeString, refundHash }) => {
-          const creationTime = new Date(creationTimeString).getTime()
-
-          return (
-            owner.toLowerCase() === lowerCaseAccount && now - creationTime < EXPIRED_ORDERS_PENDING_TIME && !refundHash
-          )
+        const pending = expiredRef.current.filter(({ owner, refundHash }) => {
+          return owner.toLowerCase() === lowerCaseAccount && !refundHash
         })
 
         if (pending.length === 0) {

--- a/apps/cowswap-frontend/src/modules/swap/pure/EthFlow/EthFlowStepper/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/EthFlow/EthFlowStepper/index.cosmos.tsx
@@ -1,6 +1,7 @@
 import 'inter-ui' // TODO: We need to do a cosmos wrapper with the global styles! Will reiterate to remove this line
 
 import { useSelect } from 'react-cosmos/client'
+import styled from 'styled-components/macro'
 
 import { EthFlowStepper, EthFlowStepperProps, SmartOrderStatus } from '.'
 
@@ -376,6 +377,11 @@ const STEPS_BY_DESCRIPTION = STEPS.reduce<{ [description: string]: EthFlowSteppe
   return acc
 }, {})
 
+const Wrapper = styled.div`
+  width: 80%;
+  margin: 20px auto;
+`
+
 function Fixture() {
   const [stepDescription] = useSelect('steps', {
     options: STEPS.map((step) => step.description),
@@ -383,13 +389,13 @@ function Fixture() {
   const props = STEPS_BY_DESCRIPTION[stepDescription]
 
   return (
-    <>
+    <Wrapper>
       <EthFlowStepper {...props} />
       <h3>Params</h3>
       <div>
         <pre>{JSON.stringify(props, null, 2)}</pre>
       </div>
-    </>
+    </Wrapper>
   )
 }
 

--- a/libs/common-const/src/common.ts
+++ b/libs/common-const/src/common.ts
@@ -99,7 +99,6 @@ export const NATIVE_CURRENCY_BUY_TOKEN: { [chainId in ChainId | number]: Token }
 export const INPUT_OUTPUT_EXPLANATION = 'Only executed swaps incur fees.'
 export const PENDING_ORDERS_BUFFER = ms`60s` // 60s
 export const CANCELLED_ORDERS_PENDING_TIME = ms`5min` // 5min
-export const EXPIRED_ORDERS_PENDING_TIME = ms`15min` // 15min
 export const PRICE_API_TIMEOUT_MS = ms`10s` // 10s
 export const GP_ORDER_UPDATE_INTERVAL = ms`30s` // 30s
 export const MINIMUM_ORDER_VALID_TO_TIME_SECONDS = 120


### PR DESCRIPTION
# Summary

Fixes #3218

The problem was in `ExpiredOrdersUpdater`, it was updating only orders created within the last 15 minutes, obviously, no one expired eth-flow order doesn't match this condition.

<img width="813" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/bf5e1fbd-c130-4380-9fe3-baa85e5673be">

  # To Test

1. Create an eth-flow order that won't be filled (I created sell 0,0009 ETH for USDC on Mainnet)
2. Wait until the order become expired
3. Open activities modal
- [ ] Within next ~1 min the state of the order should be changed from "Initiating ETH refund..." to "ETH refunded"
