### PR TITLE
fix(swap): don't crash app when token decimals eq 0

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/pure/warnings.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/warnings.tsx
@@ -101,7 +101,7 @@ export const SwapWarningsTop = React.memo(function (props: SwapWarningsTopProps)
         priceImpact={priceImpact}
         buyingFiatAmount={buyingFiatAmount}
         tradeUrlParams={tradeUrlParams}
-        sellAmount={trade?.inputAmount.toFixed(trade?.inputAmount?.currency?.decimals || 18)}
+        sellAmount={trade?.inputAmount.toExact()}
       />
     </>
   )


### PR DESCRIPTION
# Summary

<img width="1371" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/5fcb34bb-a28b-4f05-bf20-bdd463bf4d83">

  # To Test

1. Open https://dev.swap.cow.fi/#/1/swap/SLP/COW
- [ ] AR: the app crashes with the error above
- [ ] ER: the app doesn't crash
2. TWAP suggestion banner should contain a link with proper amounts
