### PR TITLE
fix(permit): add support for usdc mainnet

### DIFF
--- a/apps/cowswap-frontend/src/modules/permit/const.ts
+++ b/apps/cowswap-frontend/src/modules/permit/const.ts
@@ -1,3 +1,4 @@
+import { DAI } from '@cowprotocol/common-const'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { MaxUint256 } from '@ethersproject/constants'
 import { Wallet } from '@ethersproject/wallet'
@@ -31,3 +32,10 @@ export const ORDER_TYPE_SUPPORTS_PERMIT: Record<TradeType, boolean> = {
 }
 
 export const PENDING_ORDER_PERMIT_CHECK_INTERVAL = ms`1min`
+
+// DAI's mainnet contract (https://etherscan.io/address/0x6b175474e89094c44da98b954eedeac495271d0f#readContract) returns
+// `1` for the version, while when calling the contract method returns `2`.
+// Also, if we use the version returned by the contract, it simply doesn't work
+// Thus, do not call it for DAI.
+// TODO: figure out whether more tokens behave the same way
+export const TOKENS_TO_SKIP_VERSION = new Set([DAI.address.toLowerCase()])

--- a/apps/cowswap-frontend/src/modules/permit/state/permittableTokensAtom.ts
+++ b/apps/cowswap-frontend/src/modules/permit/state/permittableTokensAtom.ts
@@ -12,7 +12,7 @@ import { AddPermitTokenParams, PermittableTokens } from '../types'
  * Contains either the permit info with `type` and `gasLimit` when supported or
  * `false` when not supported
  */
-export const permittableTokensAtom = atomWithStorage<PermittableTokens>('permittableTokens:v0', {
+export const permittableTokensAtom = atomWithStorage<PermittableTokens>('permittableTokens:v1', {
   [SupportedChainId.MAINNET]: {},
   [SupportedChainId.GOERLI]: {},
   [SupportedChainId.GNOSIS_CHAIN]: {},

--- a/apps/cowswap-frontend/src/modules/permit/types.ts
+++ b/apps/cowswap-frontend/src/modules/permit/types.ts
@@ -13,7 +13,6 @@ export type PermitType = 'dai-like' | 'eip-2612'
 
 export type SupportedPermitInfo = {
   type: PermitType
-  gasLimit: number
 }
 type UnsupportedPermitInfo = false
 export type PermitInfo = SupportedPermitInfo | UnsupportedPermitInfo

--- a/apps/cowswap-frontend/src/modules/permit/types.ts
+++ b/apps/cowswap-frontend/src/modules/permit/types.ts
@@ -13,6 +13,7 @@ export type PermitType = 'dai-like' | 'eip-2612'
 
 export type SupportedPermitInfo = {
   type: PermitType
+  version: string | undefined // Some tokens have it different than `1`, and won't work without it
 }
 type UnsupportedPermitInfo = false
 export type PermitInfo = SupportedPermitInfo | UnsupportedPermitInfo

--- a/apps/cowswap-frontend/src/modules/permit/utils/buildPermitCallData.ts
+++ b/apps/cowswap-frontend/src/modules/permit/utils/buildPermitCallData.ts
@@ -7,7 +7,7 @@ export async function buildEip2162PermitCallData({
   callDataParams,
 }: BuildEip2162PermitCallDataParams): Promise<string> {
   const callData = await eip2162Utils.buildPermitCallData(...callDataParams)
-
+  console.log(`[buildEip2162PermitCallData]`, callDataParams, callData)
   // For some reason, the method above removes the permit selector prefix
   // https://github.com/1inch/permit-signed-approvals-utils/blob/master/src/eip-2612-permit.utils.ts#L92
   // Adding it back
@@ -19,6 +19,7 @@ export async function buildDaiLikePermitCallData({
   callDataParams,
 }: BuildDaiLikePermitCallDataParams): Promise<string> {
   const callData = await eip2162Utils.buildDaiLikePermitCallData(...callDataParams)
+  console.log(`[buildDaiLikePermitCallData]`, callDataParams, callData)
 
   // Same as above, but for dai like
   // https://github.com/1inch/permit-signed-approvals-utils/blob/master/src/eip-2612-permit.utils.ts#L140

--- a/apps/cowswap-frontend/src/modules/permit/utils/buildPermitCallData.ts
+++ b/apps/cowswap-frontend/src/modules/permit/utils/buildPermitCallData.ts
@@ -14,7 +14,6 @@ export async function buildEip2162PermitCallData({
   const tokenName = _tokenName === 'USD//C' ? 'USD Coin' : _tokenName
 
   const callData = await eip2162Utils.buildPermitCallData(permitParams, chainId, tokenName, ...rest)
-  console.log(`[buildEip2162PermitCallData]`, callDataParams, callData)
   // For some reason, the method above removes the permit selector prefix
   // https://github.com/1inch/permit-signed-approvals-utils/blob/master/src/eip-2612-permit.utils.ts#L92
   // Adding it back
@@ -26,7 +25,6 @@ export async function buildDaiLikePermitCallData({
   callDataParams,
 }: BuildDaiLikePermitCallDataParams): Promise<string> {
   const callData = await eip2162Utils.buildDaiLikePermitCallData(...callDataParams)
-  console.log(`[buildDaiLikePermitCallData]`, callDataParams, callData)
 
   // Same as above, but for dai like
   // https://github.com/1inch/permit-signed-approvals-utils/blob/master/src/eip-2612-permit.utils.ts#L140

--- a/apps/cowswap-frontend/src/modules/permit/utils/buildPermitCallData.ts
+++ b/apps/cowswap-frontend/src/modules/permit/utils/buildPermitCallData.ts
@@ -6,7 +6,14 @@ export async function buildEip2162PermitCallData({
   eip2162Utils,
   callDataParams,
 }: BuildEip2162PermitCallDataParams): Promise<string> {
-  const callData = await eip2162Utils.buildPermitCallData(...callDataParams)
+  // TODO: this is ugly and I'm not happy with it either
+  // It'll probably go away when the tokens overhaul is implemented
+  // For now, this is a problem for favourite tokens cached locally with the hardcoded name for USDC token
+  // Using the wrong name breaks the signature.
+  const [permitParams, chainId, _tokenName, ...rest] = callDataParams
+  const tokenName = _tokenName === 'USD//C' ? 'USD Coin' : _tokenName
+
+  const callData = await eip2162Utils.buildPermitCallData(permitParams, chainId, tokenName, ...rest)
   console.log(`[buildEip2162PermitCallData]`, callDataParams, callData)
   // For some reason, the method above removes the permit selector prefix
   // https://github.com/1inch/permit-signed-approvals-utils/blob/master/src/eip-2612-permit.utils.ts#L92

--- a/apps/cowswap-frontend/src/modules/permit/utils/checkIsTokenPermittable.ts
+++ b/apps/cowswap-frontend/src/modules/permit/utils/checkIsTokenPermittable.ts
@@ -136,7 +136,6 @@ async function estimateTokenPermit(params: EstimateParams): Promise<EstimatePerm
 
   return gasLimit > PERMIT_GAS_LIMIT_MIN[chainId]
     ? {
-        gasLimit,
         type,
       }
     : false

--- a/apps/cowswap-frontend/src/modules/permit/utils/checkIsTokenPermittable.ts
+++ b/apps/cowswap-frontend/src/modules/permit/utils/checkIsTokenPermittable.ts
@@ -74,6 +74,17 @@ async function actuallyCheckTokenIsPermittable(params: CheckIsTokenPermittablePa
     return { error: e.message || e.toString() }
   }
 
+  let version: string | undefined = undefined
+
+  try {
+    // Required by USDC-mainnet as its version is `2`.
+    // There might be other tokens that need this as well.
+    version = await eip2612PermitUtils.getTokenVersion(tokenAddress)
+  } catch (e) {
+    // Not a problem, we can (try to) continue without it, and will default to `1` (part of the 1inch lib)
+    console.debug(`[checkTokenIsPermittable] Failed to get version for ${tokenAddress}`, e)
+  }
+
   const baseParams: BaseParams = {
     chainId,
     eip2612PermitUtils,
@@ -82,6 +93,7 @@ async function actuallyCheckTokenIsPermittable(params: CheckIsTokenPermittablePa
     tokenAddress,
     tokenName,
     walletAddress: owner,
+    version,
   }
 
   try {
@@ -108,6 +120,7 @@ type BaseParams = {
   spender: string
   eip2612PermitUtils: Eip2612PermitUtils
   nonce: number
+  version: string | undefined
 }
 
 type EstimateParams = BaseParams & {
@@ -116,7 +129,7 @@ type EstimateParams = BaseParams & {
 }
 
 async function estimateTokenPermit(params: EstimateParams): Promise<EstimatePermitResult> {
-  const { provider, chainId, walletAddress, tokenAddress, type } = params
+  const { provider, chainId, walletAddress, tokenAddress, type, version } = params
 
   const getCallDataFn = type === 'eip-2612' ? getEip2612CallData : getDaiLikeCallData
 
@@ -137,12 +150,13 @@ async function estimateTokenPermit(params: EstimateParams): Promise<EstimatePerm
   return gasLimit > PERMIT_GAS_LIMIT_MIN[chainId]
     ? {
         type,
+        version,
       }
     : false
 }
 
 async function getEip2612CallData(params: BaseParams): Promise<string> {
-  const { eip2612PermitUtils, walletAddress, spender, nonce, chainId, tokenName, tokenAddress } = params
+  const { eip2612PermitUtils, walletAddress, spender, nonce, chainId, tokenName, tokenAddress, version } = params
   return buildEip2162PermitCallData({
     eip2162Utils: eip2612PermitUtils,
     callDataParams: [
@@ -155,12 +169,13 @@ async function getEip2612CallData(params: BaseParams): Promise<string> {
       +chainId,
       tokenName,
       tokenAddress,
+      version,
     ],
   })
 }
 
 async function getDaiLikeCallData(params: BaseParams): Promise<string | false> {
-  const { eip2612PermitUtils, tokenAddress, walletAddress, spender, nonce, chainId, tokenName } = params
+  const { eip2612PermitUtils, tokenAddress, walletAddress, spender, nonce, chainId, tokenName, version } = params
 
   const permitTypeHash = await eip2612PermitUtils.getPermitTypeHash(tokenAddress)
 
@@ -177,6 +192,7 @@ async function getDaiLikeCallData(params: BaseParams): Promise<string | false> {
         chainId as number,
         tokenName,
         tokenAddress,
+        version,
       ],
     })
   }

--- a/apps/cowswap-frontend/src/modules/permit/utils/generatePermitHook.ts
+++ b/apps/cowswap-frontend/src/modules/permit/utils/generatePermitHook.ts
@@ -65,6 +65,7 @@ async function generatePermitHookRaw(params: PermitHookParams): Promise<PermitHo
             chainId as number,
             tokenName,
             tokenAddress,
+            permitInfo.version,
           ],
         })
       : await buildDaiLikePermitCallData({
@@ -81,6 +82,7 @@ async function generatePermitHookRaw(params: PermitHookParams): Promise<PermitHo
             chainId as number,
             tokenName,
             tokenAddress,
+            permitInfo.version,
           ],
         })
 

--- a/libs/common-const/src/tokens.ts
+++ b/libs/common-const/src/tokens.ts
@@ -23,14 +23,14 @@ export const USDC_MAINNET = new Token(
   '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
   6,
   'USDC',
-  'USD//C'
+  'USD Coin'
 )
 export const USDC_GOERLI = new Token(
   SupportedChainId.GOERLI,
   '0x07865c6e87b9f70255377e024ace6630c1eaa37f',
   6,
   'USDC',
-  'USD//C'
+  'USD Coin'
 )
 export const DAI = new Token(
   SupportedChainId.MAINNET,


### PR DESCRIPTION
# Summary

Fixes #3148

Make USDC on mainnet permittable \o/

(And any other token that has a different `version`)

## ~TODO~ DONE

There are 3 pending issues:

- [x] ~USDC not permittable when loading~ FIXED

1. Clear permit cache
2. Load the app with USDC already selected as sell token (https://swap-dev-git-permit-3148usdc-mainnet-cowswap.vercel.app/#/1/swap/USDC)
3. Whatever USDC token instance found, it comes with the token name as `USD//C`, different from contract's `USD Coin`
4. That leads to an invalid signature

- [x] ~DAI no longer permittable~ FIXED

1. Clear permit cache
2. Pick DAI as sell token
3. Not recognized as permittable

The `version` fetched  is `2` 
![image](https://github.com/cowprotocol/cowswap/assets/43217/1484f00a-9e3a-4e02-864b-d03f138003e0)

While the value when looking at [etherescan](https://etherscan.io/address/0x6b175474e89094c44da98b954eedeac495271d0f#readContract) is `1` 
![image](https://github.com/cowprotocol/cowswap/assets/43217/8b58bb07-b77f-4b99-bdb0-cde8a43e3514)

Not sure this issue is only for DAI or for any DAI like token

- [x] ~Not able to place order due to low fee~ FIXED

Estimated fee for the quote is much lower than what is calculated for the real user account.
This was an expected edge case which should have been addressed with increased defaults.
See [this thread](https://cowservices.slack.com/archives/C0361CDD1FZ/p1697475244724419) for more context

It was an issue with the local cache. Succeeded now: https://dev.explorer.cow.fi/orders/0xf087fab4df05bb0f6bb1e96d1915106312248cf900d410a2465d231b5d63ad2a5b0abe214ab7875562adee331deff0fe1912fe42652e9ae9?tab=overview

# To Test

1. On mainnet, select USDC as the sell token
2. Check the localStorage key `permittableTokens:v1`
* USDC (`0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48`) should contain:

```json
{"type":"eip-2612","version":"2"}
```
3. Make sure there's no allowance for USDC mainnet
4. Place a trade with USDC mainnet
* Should trade and set allowance to infinite

5. Do the same with DAI
* Should trade and set permit as usual

6. Do the same with other kind of permittable token such as COW
* Should trade and set permit as usual