### PR TITLE
fix(swap): don't reset swap form on recipient ens input

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/updaters/RecipientAddressUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/updaters/RecipientAddressUpdater.tsx
@@ -10,9 +10,9 @@ export function RecipientAddressUpdater() {
 
   useEffect(() => {
     if (state?.recipientAddress !== recipientAddress) {
-      updateState?.({ recipientAddress })
+      updateState?.({ ...state, recipientAddress })
     }
-  }, [recipientAddress, state?.recipientAddress, updateState])
+  }, [recipientAddress, state, updateState])
 
   return null
 }


### PR DESCRIPTION
# Summary

Swap page is reset when fill in the Recipient field on the Swap page with an ENS name

![image](https://github.com/cowprotocol/cowswap/assets/7122625/e4c29eb7-9baf-46d3-9fd0-b4dbd2f94e82)
