### PR TITLE
fix: display token logos from CoW Protocol correctly

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/CurrencyLogo/hooks/useCurrencyLogoURIs.ts
+++ b/apps/cowswap-frontend/src/common/pure/CurrencyLogo/hooks/useCurrencyLogoURIs.ts
@@ -40,6 +40,21 @@ function getTokenLogoURI(address: string, chainId: SupportedChainId = SupportedC
 
 const currencyLogoCache = new Map<string, Array<string>>()
 
+const COW_PROTOCOL_REPO = 'cowprotocol/token-lists'
+function getLogoURI(currency: Currency | null): string | null {
+  if (!currency) return null
+
+  const logoURI = (currency as Currency & { logoURI: string }).logoURI
+
+  if (!logoURI) return null
+
+  // Always lowercase logo URI if it's from CoW Protocol repo
+  // Because CoW Protocol repo has all logos in lowercase
+  if (logoURI.includes(COW_PROTOCOL_REPO)) return logoURI.toLowerCase()
+
+  return logoURI
+}
+
 // TODO: must be refactored
 export default function useCurrencyLogoURIs(currency?: Currency | null): string[] {
   const currencyAddress = currency ? (currency.isNative ? NATIVE_CURRENCY_BUY_ADDRESS : currency.address) : null
@@ -47,7 +62,7 @@ export default function useCurrencyLogoURIs(currency?: Currency | null): string[
   const externalLogo = useProxyTokenLogo(currency?.chainId, currencyAddress)
   const cacheKey = `${currencyAddress}|${currency?.chainId}`
   const cached = currencyLogoCache.get(cacheKey)
-  const logoURI = currency ? (currency as Currency & { logoURI: string }).logoURI : null
+  const logoURI = getLogoURI(currency || null)
   const imageOverride = currency?.isToken ? ADDRESS_IMAGE_OVERRIDE[currency.address] : null
 
   if (cached) {


### PR DESCRIPTION
# Summary

Since [the recent refactoring](https://github.com/cowprotocol/token-lists/pull/287) to lowerCase all tokens addresses in logo URLs we got broken some token logos, for example `USDM` on Mainnet.
To fix this, I always lowerCase token logoURI if it's from CoW Protocol repo.

<img width="580" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/7e7b5312-ab7f-4625-b911-02bf601e0448">

  # To Test

1. Select USDM token on Mainnet
- [ ] token logo should be displayed
