### PR TITLE
fix(permit): usdc limit orders warning

### DIFF
--- a/apps/cowswap-frontend/src/modules/permit/hooks/useCheckHasValidPendingPermit.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/useCheckHasValidPendingPermit.ts
@@ -12,6 +12,7 @@ import { getAppDataHooks } from 'modules/appData'
 import { ParsedOrder } from 'utils/orderUtils/parseOrder'
 
 import { CheckHasValidPendingPermit } from '../types'
+import { fixTokenName } from '../utils/fixTokenName'
 import { getPermitUtilsInstance } from '../utils/getPermitUtilsInstance'
 
 export function useCheckHasValidPendingPermit(): CheckHasValidPendingPermit {
@@ -80,7 +81,7 @@ async function checkIsSingleCallDataAValidPermit(
   tokenName: string,
   callData: string
 ): Promise<boolean | undefined> {
-  const params = { chainId, tokenName, tokenAddress, callData }
+  const params = { chainId, tokenName: fixTokenName(tokenName), tokenAddress, callData }
 
   let recoverPermitOwnerPromise: Promise<string> | undefined = undefined
 

--- a/apps/cowswap-frontend/src/modules/permit/hooks/useCheckHasValidPendingPermit.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/useCheckHasValidPendingPermit.ts
@@ -11,13 +11,16 @@ import { getAppDataHooks } from 'modules/appData'
 
 import { ParsedOrder } from 'utils/orderUtils/parseOrder'
 
-import { CheckHasValidPendingPermit } from '../types'
+import { useGetPermitInfo } from './useGetPermitInfo'
+
+import { CheckHasValidPendingPermit, PermitInfo, SupportedPermitInfo } from '../types'
 import { fixTokenName } from '../utils/fixTokenName'
 import { getPermitUtilsInstance } from '../utils/getPermitUtilsInstance'
 
 export function useCheckHasValidPendingPermit(): CheckHasValidPendingPermit {
   const { chainId } = useWalletInfo()
   const { provider } = useWeb3React()
+  const getPermitInfo = useGetPermitInfo(chainId)
 
   return useCallback(
     async (order: ParsedOrder): Promise<boolean | undefined> => {
@@ -26,7 +29,14 @@ export function useCheckHasValidPendingPermit(): CheckHasValidPendingPermit {
         return undefined
       }
 
-      return checkHasValidPendingPermit(order, provider, chainId)
+      const permitInfo = getPermitInfo(order.inputToken.address)
+
+      if (permitInfo === undefined) {
+        // Missing permit info, we can't tell
+        return undefined
+      }
+
+      return checkHasValidPendingPermit(order, provider, chainId, permitInfo)
     },
     [chainId, provider]
   )
@@ -35,7 +45,8 @@ export function useCheckHasValidPendingPermit(): CheckHasValidPendingPermit {
 async function checkHasValidPendingPermit(
   order: ParsedOrder,
   provider: Web3Provider,
-  chainId: SupportedChainId
+  chainId: SupportedChainId,
+  permitInfo: PermitInfo
 ): Promise<boolean> {
   const { fullAppData, partiallyFillable, executionData } = order
   const preHooks = getAppDataHooks(fullAppData)?.pre
@@ -45,7 +56,9 @@ async function checkHasValidPendingPermit(
     !preHooks ||
     // Permit is only executed for partially fillable orders in the first execution
     // Thus, if there is any amount executed, partiallyFillable permit is no longer valid
-    (partiallyFillable && executionData.filledAmount.gt('0'))
+    (partiallyFillable && executionData.filledAmount.gt('0')) ||
+    // Permit not supported, shouldn't even get this far
+    !permitInfo
   ) {
     // These cases we know for sure permit isn't valid or there is no permit
     return false
@@ -58,7 +71,7 @@ async function checkHasValidPendingPermit(
 
   const checkedHooks = await Promise.all(
     preHooks.map(({ callData }) =>
-      checkIsSingleCallDataAValidPermit(order, chainId, eip2162Utils, tokenAddress, tokenName, callData)
+      checkIsSingleCallDataAValidPermit(order, chainId, eip2162Utils, tokenAddress, tokenName, callData, permitInfo)
     )
   )
 
@@ -79,9 +92,10 @@ async function checkIsSingleCallDataAValidPermit(
   eip2162Utils: Eip2612PermitUtils,
   tokenAddress: string,
   tokenName: string,
-  callData: string
+  callData: string,
+  { version }: SupportedPermitInfo
 ): Promise<boolean | undefined> {
-  const params = { chainId, tokenName: fixTokenName(tokenName), tokenAddress, callData }
+  const params = { chainId, tokenName: fixTokenName(tokenName), tokenAddress, callData, version }
 
   let recoverPermitOwnerPromise: Promise<string> | undefined = undefined
 

--- a/apps/cowswap-frontend/src/modules/permit/hooks/useGetPermitInfo.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/useGetPermitInfo.ts
@@ -1,0 +1,21 @@
+import { useAtomValue } from 'jotai'
+import { useCallback } from 'react'
+
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import { permittableTokensAtom } from '../state/permittableTokensAtom'
+import { IsTokenPermittableResult } from '../types'
+
+/**
+ * Returns a callback for getting PermitInfo for a given token
+ *
+ * Assumes permit info was already checked and cached.
+ */
+export function useGetPermitInfo(chainId: SupportedChainId): (tokenAddress: string) => IsTokenPermittableResult {
+  const permittableTokens = useAtomValue(permittableTokensAtom)
+
+  return useCallback(
+    (tokenAddress: string) => permittableTokens[chainId][tokenAddress.toLowerCase()],
+    [chainId, permittableTokens]
+  )
+}

--- a/apps/cowswap-frontend/src/modules/permit/utils/buildPermitCallData.ts
+++ b/apps/cowswap-frontend/src/modules/permit/utils/buildPermitCallData.ts
@@ -1,19 +1,16 @@
 import { DAI_PERMIT_SELECTOR, EIP_2612_PERMIT_SELECTOR } from '@1inch/permit-signed-approvals-utils'
 
+import { fixTokenName } from './fixTokenName'
+
 import { BuildDaiLikePermitCallDataParams, BuildEip2162PermitCallDataParams } from '../types'
 
 export async function buildEip2162PermitCallData({
   eip2162Utils,
   callDataParams,
 }: BuildEip2162PermitCallDataParams): Promise<string> {
-  // TODO: this is ugly and I'm not happy with it either
-  // It'll probably go away when the tokens overhaul is implemented
-  // For now, this is a problem for favourite tokens cached locally with the hardcoded name for USDC token
-  // Using the wrong name breaks the signature.
-  const [permitParams, chainId, _tokenName, ...rest] = callDataParams
-  const tokenName = _tokenName === 'USD//C' ? 'USD Coin' : _tokenName
+  const [permitParams, chainId, tokenName, ...rest] = callDataParams
 
-  const callData = await eip2162Utils.buildPermitCallData(permitParams, chainId, tokenName, ...rest)
+  const callData = await eip2162Utils.buildPermitCallData(permitParams, chainId, fixTokenName(tokenName), ...rest)
   // For some reason, the method above removes the permit selector prefix
   // https://github.com/1inch/permit-signed-approvals-utils/blob/master/src/eip-2612-permit.utils.ts#L92
   // Adding it back

--- a/apps/cowswap-frontend/src/modules/permit/utils/fixTokenName.ts
+++ b/apps/cowswap-frontend/src/modules/permit/utils/fixTokenName.ts
@@ -1,0 +1,7 @@
+export function fixTokenName(tokenName: string): string {
+  // TODO: this is ugly and I'm not happy with it either
+  // It'll probably go away when the tokens overhaul is implemented
+  // For now, this is a problem for favourite tokens cached locally with the hardcoded name for USDC token
+  // Using the wrong name breaks the signature.
+  return tokenName === 'USD//C' ? 'USD Coin' : tokenName
+}


### PR DESCRIPTION
# Summary

Fixes #3245

Apply the same logic used to check a token is permittable to check pending permits are still valid.

# To Test

1. Make sure there's no USDC approval on mainnet
2. Place a SELL LIMIT order of USDC with a higher price than market (just so the order is not instantly matched)
3. Wait ~1min until the updater kicks in
* There should NOT be a warning about missing approval