### PR TITLE
feat: link to explorer for tokens on trade widget

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/CurrencySelectButton/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/CurrencySelectButton/index.tsx
@@ -1,9 +1,12 @@
+import { getAddress, getEtherscanLink, isMobile } from '@cowprotocol/common-utils'
 import { TokenLogo } from '@cowprotocol/tokens'
 import { TokenSymbol } from '@cowprotocol/ui'
 import { Currency } from '@uniswap/sdk-core'
 
 import { Trans } from '@lingui/macro'
 import { Nullish } from 'types'
+
+import { UI } from 'common/constants/theme'
 
 import * as styledEl from './styled'
 
@@ -18,6 +21,16 @@ export function CurrencySelectButton(props: CurrencySelectButtonProps) {
   const { currency, onClick, loading, readonlyMode = false } = props
   const $stubbed = !currency || false
 
+  const explorerLink = currency ? getEtherscanLink(currency.chainId, 'token', getAddress(currency) || '') : ''
+
+  const CurrencyName = (
+    <styledEl.TokenNameLink target="_blank" href={explorerLink} rel="noreferrer" onClick={(e) => e.stopPropagation()}>
+      {currency?.name || ''}
+    </styledEl.TokenNameLink>
+  )
+
+  const CurrencyLogo = currency ? <TokenLogo token={currency} size={24} /> : <div></div>
+
   return (
     <styledEl.CurrencySelectWrapper
       className="open-currency-select-button"
@@ -26,7 +39,16 @@ export function CurrencySelectButton(props: CurrencySelectButtonProps) {
       isLoading={loading}
       $stubbed={$stubbed}
     >
-      {currency ? <TokenLogo token={currency} size={24} /> : <div></div>}
+      {isMobile ? (
+        CurrencyLogo
+      ) : (
+        <styledEl.QuestionHelperStyled
+          bgColor={`var(${UI.COLOR_CONTAINER_BG_01})`}
+          placement="left"
+          text={CurrencyName}
+          Icon={CurrencyLogo}
+        />
+      )}
       <styledEl.CurrencySymbol className="token-symbol-container" $stubbed={$stubbed}>
         {currency ? <TokenSymbol token={currency} length={40} /> : <Trans>Select a token</Trans>}
       </styledEl.CurrencySymbol>

--- a/apps/cowswap-frontend/src/common/pure/CurrencySelectButton/styled.tsx
+++ b/apps/cowswap-frontend/src/common/pure/CurrencySelectButton/styled.tsx
@@ -3,6 +3,8 @@ import { ReactComponent as DropDown } from '@cowprotocol/assets/images/dropdown.
 import { lighten, transparentize } from 'polished'
 import styled from 'styled-components/macro'
 
+import QuestionHelper from 'legacy/components/QuestionHelper'
+
 import { UI } from 'common/constants/theme'
 
 export const CurrencySelectWrapper = styled.button<{ isLoading: boolean; $stubbed: boolean; readonlyMode: boolean }>`
@@ -62,4 +64,22 @@ export const CurrencySymbol = styled.div<{ $stubbed: boolean }>`
     white-space: normal;
     text-align: left;
   `};
+`
+
+export const QuestionHelperStyled = styled(QuestionHelper)`
+  margin-left: 0;
+
+  > div > div {
+    width: auto;
+    height: auto;
+  }
+`
+
+export const TokenNameLink = styled.a`
+  text-decoration: none;
+  color: var(${UI.COLOR_TEXT1});
+
+  &:hover {
+    text-decoration: underline;
+  }
 `

--- a/libs/tokens/src/pure/TokenLogo/index.tsx
+++ b/libs/tokens/src/pure/TokenLogo/index.tsx
@@ -18,11 +18,6 @@ const TokenLogoWrapper = styled.div`
   background: var(--cow-container-bg-01);
   border-radius: 50%;
   overflow: hidden;
-
-  img {
-    width: 100%;
-    height: 100%;
-  }
 `
 
 export interface TokenLogoProps {
@@ -56,9 +51,11 @@ export function TokenLogo({ logoURI, token, className, size = 36 }: TokenLogoPro
     setInvalidUrls((state) => ({ ...state, [currentUrl]: true }))
   }
 
+  const sizeStyle = { width: size, height: size }
+
   return (
-    <TokenLogoWrapper className={className} style={{ width: size, height: size }}>
-      {!currentUrl ? <Slash size={size} /> : <img alt="" src={currentUrl} onError={onError} />}
+    <TokenLogoWrapper className={className} style={sizeStyle}>
+      {!currentUrl ? <Slash size={size} /> : <img alt="" style={sizeStyle} src={currentUrl} onError={onError} />}
     </TokenLogoWrapper>
   )
 }


### PR DESCRIPTION
# Summary

Reference: https://cowservices.slack.com/archives/C036G0J90BU/p1698324613755209

https://github.com/cowprotocol/cowswap/assets/7122625/ce6d8cd9-c075-4787-b3b4-bb6e7ba52d61

  # To Test

1. Each trade widget (swap/limit/twap) should display token selector button with a tooltip on logo
2. Tooltip should contain a link to etherscan
3. Tolltip shouldn't be displayed in mobile
