### PR TITLE
fix(tokens): display favourite tokens as list

### DIFF
--- a/apps/cowswap-frontend/src/modules/tokensList/pure/FavouriteTokensList/styled.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/FavouriteTokensList/styled.ts
@@ -16,11 +16,9 @@ export const Header = styled.div`
 `
 
 export const List = styled.div`
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  display: block;
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
-    display: block;
     white-space: nowrap;
     overflow-x: scroll;
     ${theme.colorScrollbar};
@@ -33,7 +31,7 @@ export const TokensItem = styled.button`
   align-items: center;
   gap: 6px;
   justify-content: center;
-  margin: 5px 5px 5px 0;
+  margin: 5px 10px 5px 0;
   background: none;
   outline: none;
   padding: 6px 10px;


### PR DESCRIPTION
# Summary

After merging the tokens refactoring, one of Michel's changes related to Widget is lost.
The list of favourite tokens should be displayed as list instead of grid.

<img width="580" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/60e02123-319b-4148-a138-507871668d8d">
