### PR TITLE
fix(tokens): lowercase tokens addresses in map to avoid duplicates

### DIFF
--- a/apps/cowswap-frontend/src/modules/tokensList/containers/ManageTokens/styled.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/containers/ManageTokens/styled.ts
@@ -26,6 +26,9 @@ export const Title = styled.div`
 
 export const TokensWrapper = styled.div`
   height: calc(100vh - 450px);
+  overflow: auto;
+
+  ${({ theme }) => theme.colorScrollbar};
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
     height: calc(100vh - 350px);

--- a/libs/tokens/src/state/tokens/allTokensAtom.ts
+++ b/libs/tokens/src/state/tokens/allTokensAtom.ts
@@ -6,6 +6,7 @@ import { tokenMapToListWithLogo } from '../../utils/tokenMapToListWithLogo'
 import { userAddedTokensAtom } from './userAddedTokensAtom'
 import { favouriteTokensAtom } from './favouriteTokensAtom'
 import { listsEnabledStateAtom, listsStatesListAtom } from '../tokenLists/tokenListsStateAtom'
+import { lowerCaseTokensMap } from '../../utils/lowerCaseTokensMap'
 
 export interface TokensByAddress {
   [address: string]: TokenWithLogo
@@ -66,8 +67,8 @@ export const activeTokensAtom = atom<TokenWithLogo[]>((get) => {
 
   const tokens = tokenMapToListWithLogo({
     ...tokensMap.activeTokens,
-    ...userAddedTokens[chainId],
-    ...favouriteTokensState[chainId],
+    ...lowerCaseTokensMap(userAddedTokens[chainId]),
+    ...lowerCaseTokensMap(favouriteTokensState[chainId]),
   })
 
   tokens.unshift(nativeToken)

--- a/libs/tokens/src/utils/lowerCaseTokensMap.ts
+++ b/libs/tokens/src/utils/lowerCaseTokensMap.ts
@@ -1,0 +1,13 @@
+import { TokensMap } from '../types'
+
+export function lowerCaseTokensMap(tokensMap: TokensMap): TokensMap {
+  return Object.entries(tokensMap).reduce<TokensMap>((acc, [address, token]) => {
+    const addressLowerCased = address.toLowerCase()
+
+    if (!acc[addressLowerCased]) {
+      acc[addressLowerCased] = token
+    }
+
+    return acc
+  }, {})
+}


### PR DESCRIPTION
# Summary

There are two fixes in this PR:

1. Used added tokens may contain tokens with mixedCased addresses and it causes token duplicates.

![image](https://github.com/cowprotocol/cowswap/assets/7122625/5961a2d1-61d4-4ee0-ab36-0185df40bc4b)

2. When the list of user-added tokens is too long, it goes out of the container.

<img width="529" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/a57a24e7-700a-468c-8e01-86a91785d9da">

The state file.

[todo-1 (1).json](https://github.com/cowprotocol/cowswap/files/13201421/todo-1.1.json)


  # To Test

1. Open Dapp from this PR
2. Clean all browser data for this URL: Console -> Application -> Storage -> "Clear site data"
3. Copy the content of the file above and run in the console: `var state = <PUT_THE_FILE_CONTENT>`, press Enter
4. Run the code in the console: `localStorage.clear(); var stateObj = JSON.parse(state); Object.keys(stateObj).forEach(key => localStorage.setItem(key, stateObj[key]))`
5. Reload the page
- [ ] There is no alert with text "There is more than one token..."
6. Open user-added tokens list
- [ ] The list should be scrollable when there is no enough space for all tokens