### PR TITLE
fix(balances): always use network provider for multicalls

### DIFF
--- a/apps/cowswap-frontend/src/legacy/state/multicall.tsx
+++ b/apps/cowswap-frontend/src/legacy/state/multicall.tsx
@@ -1,13 +1,32 @@
+import { useEffect } from 'react'
+
 import { useInterfaceMulticall, useBlockNumber } from '@cowprotocol/common-hooks'
+import { networkConnection } from '@cowprotocol/wallet'
+import { Web3Provider } from '@ethersproject/providers'
 import { createMulticall } from '@uniswap/redux-multicall'
 import { useWeb3React } from '@web3-react/core'
+
+// TODO: enable only for MevBlocker
+const shouldUseNetworkProvider = true
 
 export const multicall = createMulticall()
 
 export function MulticallUpdater() {
-  const { chainId } = useWeb3React()
+  const { chainId: currentChainId, connector } = useWeb3React()
   const latestBlockNumber = useBlockNumber()
-  const contract = useInterfaceMulticall()
 
-  return <multicall.Updater chainId={chainId} latestBlockNumber={latestBlockNumber} contract={contract} />
+  const customProvider = networkConnection.connector.customProvider as Web3Provider | undefined
+  const contract = useInterfaceMulticall(shouldUseNetworkProvider ? customProvider : undefined)
+
+  // Multicall uses the network connector because of Mevblocker issue
+  // So, the networkConnection should be synced with the current provider
+  useEffect(() => {
+    if (!shouldUseNetworkProvider) return
+
+    if (currentChainId && connector !== networkConnection.connector) {
+      networkConnection.connector.activate(currentChainId)
+    }
+  }, [currentChainId, connector])
+
+  return <multicall.Updater chainId={currentChainId} latestBlockNumber={latestBlockNumber} contract={contract} />
 }

--- a/libs/common-hooks/src/useContract.ts
+++ b/libs/common-hooks/src/useContract.ts
@@ -35,6 +35,7 @@ import {
 import { getContract, isEns, isProd, isStaging } from '@cowprotocol/common-utils'
 
 import { useWalletInfo } from '@cowprotocol/wallet'
+import { Web3Provider } from '@ethersproject/providers'
 
 const { abi: MulticallABI } = UniswapInterfaceMulticallAbi
 
@@ -42,10 +43,12 @@ const { abi: MulticallABI } = UniswapInterfaceMulticallAbi
 export function useContract<T extends Contract = Contract>(
   addressOrAddressMap: string | { [chainId: number]: string } | undefined,
   ABI: any,
-  withSignerIfPossible = true
+  withSignerIfPossible = true,
+  customProvider?: Web3Provider
 ): T | null {
-  const { provider } = useWeb3React()
+  const { provider: defaultProvider } = useWeb3React()
   const { account, chainId } = useWalletInfo()
+  const provider = customProvider || defaultProvider
 
   return useMemo(() => {
     if (!addressOrAddressMap || !ABI || !provider || !chainId) return null
@@ -91,8 +94,13 @@ export function useEIP2612Contract(tokenAddress?: string): Contract | null {
   return useContract(tokenAddress, Eip2612Abi, false)
 }
 
-export function useInterfaceMulticall() {
-  return useContract<UniswapInterfaceMulticall>(MULTICALL_ADDRESS, MulticallABI, false) as UniswapInterfaceMulticall
+export function useInterfaceMulticall(customProvider?: Web3Provider) {
+  return useContract<UniswapInterfaceMulticall>(
+    MULTICALL_ADDRESS,
+    MulticallABI,
+    false,
+    customProvider
+  ) as UniswapInterfaceMulticall
 }
 
 export function useEthFlowContract(): CoWSwapEthFlow | null {


### PR DESCRIPTION
# Summary

Unfortunately, MevBlockers has issues with heavy multicalls. The most notable place where we see it - balances.

**TODO:** In this PR I switched all multicalls to `networkConnection` providers. It means that we don't use a wallet provider and make requests through `RPC_URLS`. Ideally, we should do it only when user is connected to MevBlocker. Otherwise, we will get significant load on RPC nodes we use.

  # To Test

1. Choose MevBlocker in your wallet
2. Open CowSwap and connect your wallet
3. Open token selector
- [ ] there are no loaders in the tokens list
- [ ] swap form doesn't display "Couldn't load balances error"
4. Switch to another network
5. Open token selector
- [ ] there are no loaders in the tokens list
- [ ] swap form doesn't display "Couldn't load balances error"
