### PR TITLE
feat: ensure appData is always correct

### DIFF
--- a/apps/cowswap-frontend/.env
+++ b/apps/cowswap-frontend/.env
@@ -56,13 +56,13 @@
 # To set your own `AppData`, change `REACT_APP_FULL_APP_DATA_<environment>`
 
 # AppData, build yours at https://explorer.cow.fi/appdata
-REACT_APP_FULL_APP_DATA_PRODUCTION='{"version":"0.7.0","appCode":"CoW Swap","environment":"production","metadata":{}}'
-REACT_APP_FULL_APP_DATA_ENS='{"version":"0.7.0","appCode":"CoW Swap","environment":"ens","metadata":{}}'
-REACT_APP_FULL_APP_DATA_BARN='{"version":"0.7.0","appCode":"CoW Swap","environment":"barn","metadata":{}}'
-REACT_APP_FULL_APP_DATA_STAGING='{"version":"0.7.0","appCode":"CoW Swap","environment":"staging","metadata":{}}'
-REACT_APP_FULL_APP_DATA_PR='{"version":"0.7.0","appCode":"CoW Swap","environment":"pr","metadata":{}}'
-REACT_APP_FULL_APP_DATA_DEVELOPMENT='{"version":"0.7.0","appCode":"CoW Swap","environment":"development","metadata":{}}'
-REACT_APP_FULL_APP_DATA_LOCAL='{"version":"0.7.0","appCode":"CoW Swap","environment":"local","metadata":{}}'
+REACT_APP_FULL_APP_DATA_PRODUCTION='{"version":"0.10.0","appCode":"CoW Swap","environment":"production","metadata":{}}'
+REACT_APP_FULL_APP_DATA_ENS='{"version":"0.10.0","appCode":"CoW Swap","environment":"ens","metadata":{}}'
+REACT_APP_FULL_APP_DATA_BARN='{"version":"0.10.0","appCode":"CoW Swap","environment":"barn","metadata":{}}'
+REACT_APP_FULL_APP_DATA_STAGING='{"version":"0.10.0","appCode":"CoW Swap","environment":"staging","metadata":{}}'
+REACT_APP_FULL_APP_DATA_PR='{"version":"0.10.0","appCode":"CoW Swap","environment":"pr","metadata":{}}'
+REACT_APP_FULL_APP_DATA_DEVELOPMENT='{"version":"0.10.0","appCode":"CoW Swap","environment":"development","metadata":{}}'
+REACT_APP_FULL_APP_DATA_LOCAL='{"version":"0.10.0","appCode":"CoW Swap","environment":"local","metadata":{}}'
 
 
 

--- a/apps/cowswap-frontend/src/modules/appData/utils/fullAppData.spec.ts
+++ b/apps/cowswap-frontend/src/modules/appData/utils/fullAppData.spec.ts
@@ -1,0 +1,41 @@
+import { LATEST_APP_DATA_VERSION } from '@cowprotocol/app-data'
+import { MetadataApi } from '@cowprotocol/app-data'
+import { DEFAULT_APP_CODE } from '@cowprotocol/common-const'
+import { ALL_ENVIRONMENTS, EnvironmentName } from '@cowprotocol/common-utils'
+
+import { getFullAppDataByEnv } from './fullAppData'
+
+const getAppData = (env: EnvironmentName | undefined) => JSON.parse(getFullAppDataByEnv(env))
+const metadataApi = new MetadataApi()
+
+describe('getFullAppDataByEnv', () => {
+  ALL_ENVIRONMENTS.forEach((env) => {
+    it(`[${env}] AppData is on its last version and has the right content`, () => {
+      const appData = getAppData(env)
+      expect(appData).toEqual({
+        version: LATEST_APP_DATA_VERSION,
+        appCode: DEFAULT_APP_CODE,
+        environment: env,
+        metadata: {},
+      })
+    })
+
+    it(`[${env}] AppData is valid`, async () => {
+      const appData = getAppData(env)
+      const result = await metadataApi.validateAppDataDoc(appData)
+      expect(result).toEqual({ success: true, errors: undefined })
+    })
+  })
+
+  it(`[DEFAULT_FULL_APP_DATA] AppData is on its last version and has the right content`, () => {
+    const appData = getAppData(undefined)
+    expect(appData).toEqual({ version: LATEST_APP_DATA_VERSION, appCode: DEFAULT_APP_CODE, metadata: {} })
+  })
+
+  it(`[DEFAULT_FULL_APP_DATA] AppData is valid`, async () => {
+    const appData = getAppData(undefined)
+
+    const result = await metadataApi.validateAppDataDoc(appData)
+    expect(result).toEqual({ success: true, errors: undefined })
+  })
+})

--- a/apps/cowswap-frontend/src/modules/appData/utils/fullAppData.ts
+++ b/apps/cowswap-frontend/src/modules/appData/utils/fullAppData.ts
@@ -1,12 +1,12 @@
-import { environmentName } from '@cowprotocol/common-utils'
+import { EnvironmentName, environmentName } from '@cowprotocol/common-utils'
 
 import { AppDataInfo } from '../types'
 import { toKeccak256 } from '../utils/buildAppData'
 
-const DEFAULT_FULL_APP_DATA = '{"version":"0.7.0","appCode":"CoW Swap","metadata":{}}'
+const DEFAULT_FULL_APP_DATA = '{"version":"0.10.0","appCode":"CoW Swap","metadata":{}}'
 
 let appData: AppDataInfo = (() => {
-  const fullAppData = _getFullAppData()
+  const fullAppData = getFullAppDataByEnv(environmentName)
   return _fromFullAppData(fullAppData)
 })()
 
@@ -20,7 +20,7 @@ export function updateFullAppData(fullAppData: string | undefined) {
   }
 }
 
-function _getFullAppData(): string {
+export function getFullAppDataByEnv(environmentName: EnvironmentName | undefined): string {
   switch (environmentName) {
     case 'production':
       return process.env.REACT_APP_FULL_APP_DATA_PRODUCTION || DEFAULT_FULL_APP_DATA

--- a/libs/common-utils/src/environments.ts
+++ b/libs/common-utils/src/environments.ts
@@ -49,6 +49,15 @@ const { isLocal, isDev, isPr, isStaging, isProd, isEns, isBarn } = checkEnvironm
   window.location.pathname
 )
 
+export const ALL_ENVIRONMENTS: EnvironmentName[] = [
+  'local',
+  'development',
+  'pr',
+  'staging',
+  'production',
+  'barn',
+  'ens',
+]
 export type EnvironmentName = 'local' | 'development' | 'pr' | 'staging' | 'production' | 'barn' | 'ens'
 
 export const environmentName: EnvironmentName | undefined = (function () {


### PR DESCRIPTION
# Summary

Follow up on https://github.com/cowprotocol/cowswap/pull/3301#discussion_r1377406352


This PR adds some unit tests to enforce we don't forget to update the appData to the latest version, and we make sure the format is correct.

The tests will fail if its not in the right version (or they don't pass the validation)
<img width="1417" alt="Screenshot at Oct 31 19-47-17" src="https://github.com/cowprotocol/cowswap/assets/2352112/eb0c8ea9-0c7e-4f5f-a55a-86460fd8a9a1">


Its easy to spot when we have an issue with the appData:
<img width="895" alt="Screenshot at Oct 31 19-56-47" src="https://github.com/cowprotocol/cowswap/assets/2352112/849dba91-1d46-430b-ba32-467c0f202317">



All the test pass now:


<img width="1426" alt="Screenshot at Oct 31 20-11-56" src="https://github.com/cowprotocol/cowswap/assets/2352112/e89b2c00-092a-478f-9051-52915b054c39">

