### PR TITLE
feat(permit): remove permit related feature flags

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/featureFlags/useIsPermitEnabled.ts
+++ b/apps/cowswap-frontend/src/common/hooks/featureFlags/useIsPermitEnabled.ts
@@ -1,25 +1,8 @@
-import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { useIsSmartContractWallet } from '@cowprotocol/wallet'
 
-import { useFeatureFlags } from './useFeatureFlags'
-
-export function useIsPermitEnabled(chainId: SupportedChainId | undefined): boolean {
+export function useIsPermitEnabled(): boolean {
   const isSmartContractWallet = useIsSmartContractWallet()
-  const { permitEnabledMainnet, permitEnabledGoerli, permitEnabledGnosis } = useFeatureFlags()
 
   // Permit is only available for EOAs
-  if (isSmartContractWallet) {
-    return false
-  }
-
-  switch (chainId) {
-    case SupportedChainId.MAINNET:
-      return !!permitEnabledMainnet
-    case SupportedChainId.GNOSIS_CHAIN:
-      return !!permitEnabledGnosis
-    case SupportedChainId.GOERLI:
-      return !!permitEnabledGoerli
-    default:
-      return false
-  }
+  return !isSmartContractWallet
 }

--- a/apps/cowswap-frontend/src/common/hooks/featureFlags/useIsPermitEnabled.ts
+++ b/apps/cowswap-frontend/src/common/hooks/featureFlags/useIsPermitEnabled.ts
@@ -1,8 +1,6 @@
 import { useIsSmartContractWallet } from '@cowprotocol/wallet'
 
 export function useIsPermitEnabled(): boolean {
-  const isSmartContractWallet = useIsSmartContractWallet()
-
   // Permit is only available for EOAs
-  return !isSmartContractWallet
+  return !useIsSmartContractWallet()
 }

--- a/apps/cowswap-frontend/src/modules/permit/hooks/useIsTokenPermittable.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/useIsTokenPermittable.ts
@@ -43,7 +43,7 @@ export function useIsTokenPermittable(
   // Avoid building permit info in the first place if order type is not supported
   const isPermitSupported = !!tradeType && ORDER_TYPE_SUPPORTS_PERMIT[tradeType]
 
-  const isPermitEnabled = useIsPermitEnabled(chainId) && isPermitSupported
+  const isPermitEnabled = useIsPermitEnabled() && isPermitSupported
 
   const addPermitInfo = useAddPermitInfo()
   const permitInfo = usePermitInfo(chainId, isPermitEnabled ? lowerCaseAddress : undefined)


### PR DESCRIPTION
# Summary

Remove permit related feature flags

Permit is already enabled in prod, no longer need the feature flags.
Even for gnosis chain - which is currently not enabled - there's [at least one token identified as permittable](https://github.com/cowprotocol/token-lists/blob/eb1454efa1f26eecbe7d35aa1d075901c276463a/src/public/PermitInfo.100.json)
So it should be safe to enable it there as well.
Further work is still needed to fix it for other tokens, but it should be fine.

# To Test

1. Permit should work as usual