### PR TITLE
fix: pass env to vercel

### DIFF
--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -45,6 +45,7 @@ jobs:
           REACT_APP_NETWORK_URL_1=${{ secrets.REACT_APP_NETWORK_URL_1 }}
           REACT_APP_NETWORK_URL_100=${{ secrets.REACT_APP_NETWORK_URL_100 }}
           REACT_APP_NETWORK_URL_5=${{ secrets.REACT_APP_NETWORK_URL_5 }}
+          REACT_APP_WC_PROJECT_ID=${{ env.REACT_APP_WC_PROJECT_ID }}
           vercel build -t ${{ secrets.VERCEL_TOKEN }} --prod
 
       - name: Get the version


### PR DESCRIPTION
# Summary

I set the ENV in the project, but is not reaching to vercel. 
I don't think this will change anything, since its already an env, but let me try just in case

# To Test
i need to test in staging so i will just merge