### PR TITLE
feat(permit): update gas-free flag tooltip

### DIFF
--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokenTags/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokenTags/index.tsx
@@ -28,7 +28,7 @@ const TOKEN_TAGS: Record<Tags, TagInfo> = {
   [Tags.GAS_FREE]: {
     name: 'Gas-free approval',
     icon: ICON_GAS_FREE,
-    description: 'This token can be approved without spending gas, using the token Permit.',
+    description: 'This token supports gas-free approvals. Enjoy! 🐮',
     id: '1',
   },
 }

--- a/libs/ui/src/pure/Tooltip/index.tsx
+++ b/libs/ui/src/pure/Tooltip/index.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import Popover, { PopoverProps } from '../Popover'
 
 export const TooltipContainer = styled.div`
-  max-width: 300px;
+  max-width: 320px;
   padding: 4px 6px;
   font-weight: 400;
   word-break: break-word;


### PR DESCRIPTION
# Summary

Based on suggestion from [here](https://cowservices.slack.com/archives/C0361CDG8GP/p1699018201722129?thread_ts=1699015859.603799&cid=C0361CDG8GP)

![image](https://github.com/cowprotocol/cowswap/assets/43217/48318cd1-d4dc-403a-b5e7-eea723d53558)

# To Test

1. Open token selector
2. Look for a token with `gas-free approval` flag
3. Hover the mouse over it