### PR TITLE
Fix and style vanilla html

### DIFF
--- a/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
@@ -32,7 +32,7 @@ export function useWidgetParamsAndSettings(
 
     const params: CowSwapWidgetProps['params'] = {
       appKey: '<YOUR_APP_ID>',
-      width: '400px',
+      width: '450px',
       height: '640px',
       provider,
       theme,

--- a/apps/widget-configurator/src/app/embedDialog/utils/vanillaNoDepsExample.ts
+++ b/apps/widget-configurator/src/app/embedDialog/utils/vanillaNoDepsExample.ts
@@ -13,12 +13,16 @@ export function vanillaNoDepsExample(params: CowSwapWidgetParams): string {
   <title>CoWSwap Widget demo</title>
   <script src="https://cdn.jsdelivr.net/npm/@cowprotocol/widget-lib@latest/index.iife.js"></script>
 </head>
-<body>
+<body style="display: flex; align-items: center; justify-content: center; background-color: #06172e; padding: 10px;">
   <div id="app"></div>
   <script>
     const params = ${JSON.stringify(paramsSanitized, null, 4)}
 
-    cowSwapWidget.cowSwapWidget(document.getElementById("app"), params)
+    cowSwapWidget.cowSwapWidget({
+      container: document.getElementById("app"),
+      width: '450px',
+      height: '640px',
+    }, params)
   </script>
 </body>
 </html>

--- a/libs/widget-lib/docs/README.md
+++ b/libs/widget-lib/docs/README.md
@@ -21,7 +21,7 @@ npm install @cowprotocol/widget-lib
 ## Quick start
 
 ```typescript
-import {cowSwapWidget, CowSwapWidgetParams} from '@cowprotocol/widget-lib'
+import { cowSwapWidget, CowSwapWidgetParams } from '@cowprotocol/widget-lib'
 
 // HTML element where the widget will be rendered
 const widgetContainer = document.getElementById('cowswap-widget')
@@ -30,8 +30,8 @@ const params: CowSwapWidgetParams = {
   appKey: 'YOUR_APP_ID',
   width: 600,
   height: 640,
-  sell: {asset: 'DAI'},
-  buy: {asset: 'USDC', amount: '0.1'}
+  sell: { asset: 'DAI' },
+  buy: { asset: 'USDC', amount: '0.1' },
 }
 
 cowSwapWidget(widgetContainer, params)
@@ -50,12 +50,12 @@ the [CoW Protocol Docs](https://docs.cow.fi/front-end/creating-app-ids/create-th
 If your business model involves charging a fee for trading, you can easily do this by adding just one parameter:
 
 ```typescript
-import {cowSwapWidget, CowSwapWidgetParams} from '@cowprotocol/widget-lib'
+import { cowSwapWidget, CowSwapWidgetParams } from '@cowprotocol/widget-lib'
 
 const widgetContainer = document.getElementById('cowswap-widget')
 
 const params: CowSwapWidgetParams = {
-  partnerFeeBips: '50' // 0.5%
+  partnerFeeBips: '50', // 0.5%
 }
 
 cowSwapWidget(widgetContainer, params)
@@ -90,14 +90,11 @@ interface JsonRpcRequest {
 An example of connecting a widget to Rabby Wallet or Metamask:
 
 ```typescript
-import {cowSwapWidget, CowSwapWidgetParams} from '@cowprotocol/widget-lib'
+import { cowSwapWidget, CowSwapWidgetParams } from '@cowprotocol/widget-lib'
 
-cowSwapWidget(
-  document.getElementById('cowswap-widget'),
-  {
-    provider: window.ethereum // <-------
-  }
-)
+cowSwapWidget(document.getElementById('cowswap-widget'), {
+  provider: window.ethereum, // <-------
+})
 ```
 
 ## Configuration
@@ -107,12 +104,12 @@ cowSwapWidget(
 > All params are optional
 
 | Parameter             | Type                   | Default                   | Description                                                                                                                                                                                        |
-|-----------------------|------------------------|---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `width`               | `string`               | 400px                     | The width of the widget in css values (px, vh, etc.).                                                                                                                                              |
-| `height`              | `string`               | 600px                     | The height of the widget in css values (px, vh, etc.).                                                                                                                                             |
+| --------------------- | ---------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `width`               | `string`               | 450px                     | The width of the widget in css values (px, vh, etc.).                                                                                                                                              |
+| `height`              | `string`               | 640px                     | The height of the widget in css values (px, vh, etc.).                                                                                                                                             |
 | `appKey`              | `string`               | 'DEFAULT_INJECTED_WIDGET' | The unique identifier of the widget consumer. Please fill the for to let us know a little about you: TODO-TYPEFORM                                                                                 |
 | `provider`            | `EthereumProvider`     | ---                       | The Ethereum provider to be used for interacting with a wallet. To connect, for example, to Rabby Wallet or Metamask, just set `window.ethereum`. You also might like to use https://web3modal.com |
-| `chainId`             | `number`               | 1                         | The blockchain ID on which the trade will take place.  Currently supported: 1 (Mainnet), 5 (Goerli), 100 (Gnosis chain)                                                                            |
+| `chainId`             | `number`               | 1                         | The blockchain ID on which the trade will take place. Currently supported: 1 (Mainnet), 5 (Goerli), 100 (Gnosis chain)                                                                             |
 | `tradeType`           | `TradeType`            | 'swap'                    | The type of trade. Can be `swap` or `limit` or `advanced`.                                                                                                                                         |
 | `env`                 | `CowSwapWidgetEnv`     | 'prod'                    | The environment of the widget (`local` , `prod` , `dev` , `pr`). See [`COWSWAP_URLS`](https://github.com/cowprotocol/cowswap/blob/develop/libs/widget-lib/src/consts.ts) const value for urls.     |
 | `tradeAssets`         | `TradeAssets`          | Same as in swap.cow.fi    | An object containing information about the selling and buying assets. Example: `{ asset: 'WBTC', amount: 12 }` or `{ asset: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' }`                        |
@@ -129,13 +126,13 @@ cowSwapWidget(
 You can change all possible widget options on the fly:
 
 ```typescript
-import {cowSwapWidget, CowSwapWidgetParams} from '@cowprotocol/widget-lib'
+import { cowSwapWidget, CowSwapWidgetParams } from '@cowprotocol/widget-lib'
 
 const container = document.getElementById('cowswap-widget')
 
 const params: CowSwapWidgetParams = {
   appKey: 'YOUR_APP_ID',
-  logoUrl: 'YOUR_LOGO_URL'
+  logoUrl: 'YOUR_LOGO_URL',
 }
 
 const updateWidget = cowSwapWidget(container, params)
@@ -144,7 +141,7 @@ const updateWidget = cowSwapWidget(container, params)
 updateWidget({
   ...params,
   theme: 'dark', // <- Change theme to dark
-  hideNetworkSelector: true // <- Hide the network selector
+  hideNetworkSelector: true, // <- Hide the network selector
 })
 ```
 

--- a/libs/widget-lib/src/cowSwapWidget.ts
+++ b/libs/widget-lib/src/cowSwapWidget.ts
@@ -7,8 +7,8 @@ import { buildTradeAmountsQuery, buildWidgetPath, buildWidgetUrl } from './urlUt
  */
 const COW_SWAP_WIDGET_EVENT_KEY = 'cowSwapWidget'
 
-const DEFAULT_HEIGHT = '600px'
-const DEFAULT_WIDTH = '400px'
+const DEFAULT_HEIGHT = '640px'
+const DEFAULT_WIDTH = '450px'
 
 /**
  * Callback function signature for updating the CoW Swap Widget.


### PR DESCRIPTION
# Summary

Fixes a small issue in the HTML vanilla example:
![image](https://github.com/cowprotocol/cowswap/assets/2352112/577525c8-f8fe-4daf-9884-2343ba922bfb)


## Style
Also adds some style


Before:
<img width="894" alt="Screenshot at Nov 03 16-04-27" src="https://github.com/cowprotocol/cowswap/assets/2352112/ee6b3be2-def9-4329-8038-634f7844a444">


After:
<img width="893" alt="Screenshot at Nov 03 16-05-52" src="https://github.com/cowprotocol/cowswap/assets/2352112/ce6a6d3b-2b22-4055-831e-1cb94d9af0b9">


