### PR TITLE
feat: hide nose picker loader

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/CurrencyArrowSeparator/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/CurrencyArrowSeparator/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import loadingCowWebp from '@cowprotocol/assets/cow-swap/cow-load.webp'
+import { isInjectedWidget } from '@cowprotocol/common-utils'
 
 import * as styledEl from './styled'
 
@@ -15,11 +16,12 @@ export interface CurrencyArrowSeparatorProps {
 
 export function CurrencyArrowSeparator(props: CurrencyArrowSeparatorProps) {
   const { isLoading, onSwitchTokens, withRecipient, isCollapsed = true, hasSeparatorLine, border } = props
+  const isInjectedWidgetMode = isInjectedWidget()
 
   return (
     <styledEl.Box withRecipient={withRecipient} isCollapsed={isCollapsed} hasSeparatorLine={hasSeparatorLine}>
       <styledEl.LoadingWrapper isLoading={isLoading} border={border}>
-        {isLoading ? (
+        {!isInjectedWidgetMode && isLoading ? (
           <styledEl.CowImg src={loadingCowWebp} alt="loading" />
         ) : (
           <styledEl.ArrowDownIcon onClick={onSwitchTokens} />


### PR DESCRIPTION
# Summary

- Hides the cow nose picker loading image when in widget mode


https://github.com/cowprotocol/cowswap/assets/31534717/a45db1cb-1276-4890-b8ea-3be68811c27b

