### PR TITLE
fix(widget-lib): adjust code for server-side rendering

### DIFF
--- a/libs/widget-lib/package.json
+++ b/libs/widget-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/widget-lib",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "commonjs",
   "description": "CoW Swap Widget Library. Allows you to easily embed a CoW Swap widget on your website.",
   "main": "index.js",

--- a/libs/widget-lib/src/consts.ts
+++ b/libs/widget-lib/src/consts.ts
@@ -1,7 +1,9 @@
 import { CowSwapWidgetEnv } from './types'
 
 function getPrHostName(): string {
-  const prKey = location.hostname.replace('widget-configurator-git-', '').replace('-cowswap.vercel.app', '')
+  if (typeof window === 'undefined' || !window) return ''
+
+  const prKey = window.location.hostname.replace('widget-configurator-git-', '').replace('-cowswap.vercel.app', '')
 
   return `https://swap-dev-git-${prKey}-cowswap.vercel.app`
 }

--- a/libs/widget-react/package.json
+++ b/libs/widget-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/widget-react",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "./index.js",
   "types": "./index.d.ts",
   "exports": {


### PR DESCRIPTION
# Summary

While trying to integrate the widget in Next.js project (cow.fi) I got an error: `ReferenceError: window is not defined`.
It's because Next.js renders the code not in browser environment.
Hence, I changed code to not break when it is running on server side.
