### PR TITLE
fix: update chainId in trade state

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
@@ -105,6 +105,8 @@ export function useSetupTradeState(): void {
       } else if (tokensAreEmpty) {
         console.debug('[TRADE STATE]', 'Url does not contain both tokens, resetting')
       } else if (onlyChainIdIsChanged) {
+        // In this case we should update only chainId in the trade state
+        updateState?.({ ...state, chainId: currentChainId })
         console.debug('[TRADE STATE]', 'Only chainId was changed in URL, resetting')
       }
 


### PR DESCRIPTION
# Summary

This is very annoying bug. See the scenario bellow.

<img width="274" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/0fcbdb4a-1934-48e6-a3e8-2c414f89bdee">

  # To Test

1. Open cowswap and connect to a wallet (I tested with Metamask)
2. Change network in Metamask to Mainnet
3. Copy the tab URL and close the tab
4. Open a new tab with the copied URL but replace chainId  from 1 to 100 (Gnosis chain)
- [ ] AR: No one of Swap / Limit / TWAP is active (see the image above)
- [ ] ER: the current widget menu item is active
5. Click to other widget menu item (Limit orders for example)
- [ ] AR: along with opening another trade widget you receive a request to the wallet to switch network to Gnosis chain
- [ ] ER: there are not requests to switch network
