### PR TITLE
fix(tokens): use default value for user-added tokens migration

### DIFF
--- a/libs/tokens/src/migrations/tokensLegacyStateMigration.ts
+++ b/libs/tokens/src/migrations/tokensLegacyStateMigration.ts
@@ -35,7 +35,15 @@ function migrateLegacyTokensInUserState() {
   const userState = JSON.parse(userStateRaw)
 
   if (userState?.tokens && Object.keys(userState.tokens).length > 0) {
-    localStorage.setItem('userAddedTokensAtom:v1', JSON.stringify(userState.tokens))
+    localStorage.setItem(
+      'userAddedTokensAtom:v1',
+      JSON.stringify({
+        [SupportedChainId.MAINNET]: {},
+        [SupportedChainId.GNOSIS_CHAIN]: {},
+        [SupportedChainId.GOERLI]: {},
+        ...userState.tokens,
+      })
+    )
   }
 
   // Cleanup legacy redux store (UserState)


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C0361CDG8GP/p1699355067687489

The old redux state of user-added tokens might be not full, so we need to add default values for all networks for it.

<img width="374" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/8676c67d-3084-4b06-880d-13fd0f7bfc82">

![image](https://github.com/cowprotocol/cowswap/assets/7122625/59d69e70-2daa-4422-842d-01ea1178e949)


  # To Test

1. locally checkout previous release (1.48.17)
2. Open localhost and clean localStorage
3. Reload the page
4. Add a custom token only to one network (for example Mainnet)
5. Close the tab
6. Switch to 1.49 release branch
7. Open localhost again
- [ ] AR: App crashes with the error above
- [ ] ER: App doesn't crash, you still have the token you added before
