### PR TITLE
fix(twap): fix infinite loop in orders hook

### DIFF
--- a/apps/cowswap-frontend/src/modules/orders/hooks/useSWRProdOrders.ts
+++ b/apps/cowswap-frontend/src/modules/orders/hooks/useSWRProdOrders.ts
@@ -12,6 +12,8 @@ import { getOrders } from 'api/gnosisProtocol'
 import { useApiOrders } from './useApiOrders'
 import { useSWROrdersRequest } from './useSWROrdersRequest'
 
+const EMPTY_ORDERS: EnrichedOrder[] = []
+
 // Fetch PROD orders only when current env is not prod
 // We need them for TWAP, because WatchTower creates orders only on Prod
 export function useSWRProdOrders(): EnrichedOrder[] {
@@ -19,11 +21,10 @@ export function useSWRProdOrders(): EnrichedOrder[] {
   const requestParams = useSWROrdersRequest()
   const apiOrders = useApiOrders()
 
-  const { data: loadedProdOrders = [] } = useSWR<EnrichedOrder[]>(
+  const { data: loadedProdOrders = EMPTY_ORDERS } = useSWR<EnrichedOrder[]>(
     ['prod-orders', requestParams, chainId],
     () => {
-      if (!chainId || !requestParams) return []
-      if (!isBarnBackendEnv) return []
+      if (!chainId || !requestParams || !isBarnBackendEnv) return EMPTY_ORDERS
 
       return getOrders(requestParams, { chainId, env: 'prod' })
     },


### PR DESCRIPTION
# Summary

While testing I noticed that my M2 Max processor sometimes freezes.
By stopping the main thread periodically I noticed that I almost always get into `CreatedInOrderBookOrdersUpdater`.
After adding a `console.log` here I saw that it gets tons of recalculations for `partOrdersFromProd`.
After some bisection on `useAsyncMemo` deps I got into `useSWRProdOrders` and here I found the cause of the problem.
So, the main problem in the fact that we always return a new array and it makes `useAsyncMemo()` recalculate everything many times.


https://github.com/cowprotocol/cowswap/assets/7122625/419e2e7f-0b7b-4372-9670-861ffdfb6624


  # To Test

1. I just add a `console.log` like:

```
  const partOrdersFromProd = useAsyncMemo(
    async () => {
      console.log('TRIGGER')
...
```

Before the fix I got tons of console logs. After only few
