### PR TITLE
feat: change from node v16 to v18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize]
 
 env:
-  NODE_VERSION: lts/gallium
+  NODE_VERSION: lts/hydrogen
   REACT_APP_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   REACT_APP_PINATA_API_KEY: ${{ secrets.REACT_APP_PINATA_API_KEY }}
   REACT_APP_PINATA_SECRET_API_KEY: ${{ secrets.REACT_APP_PINATA_SECRET_API_KEY }}

--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -13,7 +13,7 @@ env:
   # Duplicated keys as these are required by `ipfs-deploy`
   IPFS_DEPLOY_PINATA__API_KEY: ${{ secrets.REACT_APP_PINATA_API_KEY }}
   IPFS_DEPLOY_PINATA__SECRET_API_KEY: ${{ secrets.REACT_APP_PINATA_SECRET_API_KEY }}
-  NODE_VERSION: lts/gallium
+  NODE_VERSION: lts/hydrogen
 
 jobs:
   ipfs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,11 +21,9 @@ on:
           - next
         default: latest
 
-
 env:
-  NODE_VERSION: lts/gallium
+  NODE_VERSION: lts/hydrogen
   DESTINATION_PATH: dist/libs/${{ inputs.lib }}
-
 
 jobs:
   publish-npm:

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -56,4 +56,3 @@ jobs:
           -t ${{ secrets.VERCEL_TOKEN }}
           -m VERSION=${{ steps.get_version.outputs.VERSION }}
           -m COMMIT=${{ github.sha }}
-          https://github.com/cowprotocol/cowswap/actions/runs/6783985092/job/18439356002

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -56,3 +56,4 @@ jobs:
           -t ${{ secrets.VERCEL_TOKEN }}
           -m VERSION=${{ steps.get_version.outputs.VERSION }}
           -m COMMIT=${{ github.sha }}
+          https://github.com/cowprotocol/cowswap/actions/runs/6783985092/job/18439356002

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/gallium
+lts/hydrogen


### PR DESCRIPTION
# Summary

Just a quick test, since locally worked and v16 will be deprecated soon.

We want to get rid of this warning, and build using a more modern Node version:

<img width="869" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/214c6361-35b7-469b-ae4c-601d06b2c121">

It looks like it worked, the 3 apps were build correctly! 🎉

Actually, the widget and cosmos were already migrated.

## Test
Test this doesn't break anything


```bash
nvm install
nvm use
yarn 

yarn build

yarn start
```