### PR TITLE
fix: fix issue with RPC env

### DIFF
--- a/libs/common-const/src/networks.ts
+++ b/libs/common-const/src/networks.ts
@@ -3,6 +3,12 @@ import { JsonRpcProvider } from '@ethersproject/providers'
 
 const INFURA_KEY = process.env.REACT_APP_INFURA_KEY || '2af29cd5ac554ae3b8d991afe1ba4b7d' // Default rate-limited infura key (should be overridden, not reliable to use)
 
+const RPC_URL_ENVS: Record<SupportedChainId, string | undefined> = {
+  [SupportedChainId.MAINNET]: process.env.REACT_APP_NETWORK_URL_1 || undefined,
+  [SupportedChainId.GNOSIS_CHAIN]: process.env.REACT_APP_NETWORK_URL_100 || undefined,
+  [SupportedChainId.GOERLI]: process.env.REACT_APP_NETWORK_URL_5 || undefined,
+}
+
 const DEFAULT_RPC_URL: Record<SupportedChainId, { url: string; usesInfura: boolean }> = {
   [SupportedChainId.MAINNET]: { url: `https://mainnet.infura.io/v3/${INFURA_KEY}`, usesInfura: true },
   [SupportedChainId.GNOSIS_CHAIN]: { url: `https://rpc.gnosis.gateway.fm`, usesInfura: false },
@@ -22,7 +28,7 @@ export const MAINNET_PROVIDER = new JsonRpcProvider(RPC_URLS[SupportedChainId.MA
 
 function getRpcUrl(chainId: SupportedChainId): string {
   const envKey = `REACT_APP_NETWORK_URL_${chainId}`
-  const rpcUrl = process.env[envKey]
+  const rpcUrl = RPC_URL_ENVS[chainId]
 
   if (rpcUrl) {
     return rpcUrl


### PR DESCRIPTION
# Summary

DEV still uses infura despite us adding the RPC envs:

![image](https://github.com/cowprotocol/cowswap/assets/2352112/f816c889-77ab-4723-98e7-ad03500eb82d)

I believe the issue is related to Vite not knowing at compile time the envs that will be there because I used a dynamic env: `REACT_APP_NETWORK_URL_${chainId}`

The solution is to save the RPC values in a const:
```
const RPC_URL_ENVS: Record<SupportedChainId, string | undefined> = {
  [SupportedChainId.MAINNET]: process.env.REACT_APP_NETWORK_URL_1 || undefined,
  [SupportedChainId.GNOSIS_CHAIN]: process.env.REACT_APP_NETWORK_URL_100 || undefined,
  [SupportedChainId.GOERLI]: process.env.REACT_APP_NETWORK_URL_5 || undefined,
}
```

Now vite can tell if `process.env.REACT_APP_NETWORK_URL_1` is in the env or not, and will replace it in the bundle

<img width="1010" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/0c4a5576-2db0-45ee-a26c-e7f85378eeaa">




# To Test
The good test will be when I merge this into develop and see if it works