### PR TITLE
feat: simplify theme config

### DIFF
--- a/apps/cowswap-frontend/src/modules/injectedWidget/hooks/useInjectedWidgetPalette.ts
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/hooks/useInjectedWidgetPalette.ts
@@ -6,5 +6,9 @@ import { useInjectedWidgetParams } from './useInjectedWidgetParams'
 export function useInjectedWidgetPalette(): CowSwapWidgetPalette | undefined {
   const state = useInjectedWidgetParams()
 
-  return state.palette
+  return isCowSwapWidgetPallet(state.theme) ? state.theme : undefined
+}
+
+function isCowSwapWidgetPallet(palette: any): palette is CowSwapWidgetPalette {
+  return palette && typeof palette === 'object'
 }

--- a/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
@@ -41,14 +41,14 @@ export function useWidgetParamsAndSettings(
       sell: { asset: sellToken, amount: sellTokenAmount ? sellTokenAmount.toString() : undefined },
       buy: { asset: buyToken, amount: buyTokenAmount?.toString() },
       enabledTradeTypes,
-      // theme,
-      theme: {
-        baseTheme: theme,
-        primaryColor: '#fff700', //'#d9258e',
-        screenBackground: '#ee9b00', // '#ee00cd',
-        widgetBackground: '#ff0037', // '#b900ff',
-        textColor: '#7a75ff', //'#b348cc',
-      },
+      theme,
+      // theme: {
+      //   baseTheme: theme,
+      //   primaryColor: '#d9258e',
+      //   screenBackground: '#ee00cd',
+      //   widgetBackground: '#b900ff',
+      //   textColor: '#b348cc',
+      // },
     }
 
     return params

--- a/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
@@ -35,19 +35,20 @@ export function useWidgetParamsAndSettings(
       width: '450px',
       height: '640px',
       provider,
-      theme,
       chainId,
       env: getEnv(),
       tradeType: currentTradeType,
       sell: { asset: sellToken, amount: sellTokenAmount ? sellTokenAmount.toString() : undefined },
       buy: { asset: buyToken, amount: buyTokenAmount?.toString() },
       enabledTradeTypes,
-      // palette: {
-      //   primaryColor: '#d9258e',
-      //   screenBackground: '#ee00cd',
-      //   widgetBackground: '#b900ff',
-      //   textColor: '#b348cc',
-      // },
+      // theme,
+      theme: {
+        baseTheme: theme,
+        primaryColor: '#fff700', //'#d9258e',
+        screenBackground: '#ee9b00', // '#ee00cd',
+        widgetBackground: '#ff0037', // '#b900ff',
+        textColor: '#7a75ff', //'#b348cc',
+      },
     }
 
     return params

--- a/apps/widget-configurator/src/app/embedDialog/const.ts
+++ b/apps/widget-configurator/src/app/embedDialog/const.ts
@@ -8,7 +8,7 @@ export const COMMENTS_BY_PARAM_NAME: Record<string, string> = {
   provider:
     'Ethereum EIP-1193 provider. For a quick test, you can pass `window.ethereum`, but consider using something like https://web3modal.com',
   chainId: '1 (Mainnet), 5 (Goerli), 100 (Gnosis)',
-  theme: 'light or dark',
+  theme: 'light/dark or provide your own color palette',
   tradeType: 'swap, limit or advanced',
   sell: 'Sell token. Optionally add amount for sell orders',
   buy: 'Buy token. Optionally add amount for buy orders',

--- a/libs/widget-lib/src/types.ts
+++ b/libs/widget-lib/src/types.ts
@@ -60,6 +60,7 @@ export enum TradeType {
 }
 
 export interface CowSwapWidgetPalette {
+  baseTheme: CowSwapTheme
   primaryColor: string
   screenBackground: string
   widgetBackground: string
@@ -111,7 +112,7 @@ interface CowSwapWidgetConfig {
   /**
    * The theme of the widget UI.
    */
-  theme: CowSwapTheme
+  theme: CowSwapTheme | CowSwapWidgetPalette
 
   /**
    * Allows to set a custom logo for the widget.
@@ -132,11 +133,6 @@ interface CowSwapWidgetConfig {
    * Enables the ability to switch between trade types in the widget.
    */
   enabledTradeTypes: TradeType[]
-
-  /**
-   * Colors palette to customize the widget UI.
-   */
-  palette: CowSwapWidgetPalette
 
   /**
    * The interface fee in basis points.

--- a/libs/widget-lib/src/urlUtils.ts
+++ b/libs/widget-lib/src/urlUtils.ts
@@ -39,7 +39,7 @@ export function buildTradeAmountsQuery(params: CowSwapWidgetParams): URLSearchPa
   }
 
   if (theme) {
-    query.append('theme', theme)
+    query.append('theme', typeof theme === 'string' ? theme : theme.baseTheme)
   }
 
   return query


### PR DESCRIPTION
# Summary

> This PR is just a proposal. I like it more, but I want to get the temperature of the squad.

I feel that in order to control the theme, is easier if we just have a single `theme` parameter.

In this PR I propose to:
- 🔪 kill `palette` parameter
- 🤩 Enhance `theme` to allow more control


Basically you would use it like this:

```ts
// Dark theme
{ theme: 'dark' }

// Light theme
{ theme: 'light' }

// Full control, based on a theme, you override some colors
{
theme: {
        baseTheme: 'light',
        primaryColor: '#d9258e',
        screenBackground: '#ee00cd',
        widgetBackground: '#b900ff',
        textColor: '#b348cc',
   }
}
```


# Test
it should work as before, its just, we don't have 2 properties. Just one theme
<img width="1420" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/b548f8e8-197e-480c-8577-75878cc9f7c3">

You can uncomment this to see the new colors: https://github.com/cowprotocol/cowswap/blob/simplify-theme/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts#L45