### PR TITLE
fix: fix race condition with widget

### DIFF
--- a/apps/cowswap-frontend/src/modules/appData/updater/AppDataInfoUpdater.ts
+++ b/apps/cowswap-frontend/src/modules/appData/updater/AppDataInfoUpdater.ts
@@ -1,5 +1,5 @@
 import { useSetAtom } from 'jotai'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { CowEnv, SupportedChainId } from '@cowprotocol/cow-sdk'
 
@@ -30,6 +30,8 @@ export function AppDataInfoUpdater({ chainId, slippageBips, orderClass, utm, hoo
   // AppCode is dynamic and based on how it's loaded (if used as a Gnosis Safe app)
   const appCode = useAppCode()
 
+  const updateAppDataPromiseRef = useRef(Promise.resolve())
+
   useEffect(() => {
     if (!appCode) {
       // reset values when there is no price estimation or network changes
@@ -51,7 +53,8 @@ export function AppDataInfoUpdater({ chainId, slippageBips, orderClass, utm, hoo
       }
     }
 
-    updateAppData()
+    // Chain the next update to avoid race conditions
+    updateAppDataPromiseRef.current = updateAppDataPromiseRef.current.finally(updateAppData)
   }, [appCode, chainId, setAppDataInfo, slippageBips, orderClass, utm, hooks])
 }
 function getEnvByClass(orderClass: string): CowEnv | undefined {


### PR DESCRIPTION
# Summary

There's currently a race condition that makes us to loose the `appData` passed by the host app.

The reason is, that a hook is re-rendering. Each re-render triggers an update. The update is a promise. There's no guarantee on the order in which the updates are performed.


the solution is to chain the tasks using a mutable reference to the latest promise.

# Test
One way is to try before this change (check 1 commit before). 

Load the configurator. Enable debug logs in your browser. 
Then filter for `useAppData`. you should see this:


<img width="1403" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/70d361d0-da6b-4738-afa5-09c71163441e">


In this PR shouldn't happen