### PR TITLE
feat: connect wallet rounded modal

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/Modal/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/Modal/index.tsx
@@ -94,6 +94,8 @@ export const CowModal = styled(Modal)<{
   border?: string
   padding?: string
 }>`
+  border-radius: var(${UI.BORDER_RADIUS_NORMAL});
+
   > [data-reach-dialog-content] {
     color: var(${UI.COLOR_TEXT1});
     width: 100%;


### PR DESCRIPTION
# Summary

- Adds rounded borders (border-radius) to the connect wallet modal. This prevents the modal from showing with hard edges.

<img width="1717" alt="Screenshot 2023-11-08 at 18 06 30" src="https://github.com/cowprotocol/cowswap/assets/31534717/5cd57681-f422-417c-961b-382995210d6e">
