### PR TITLE
fix(widget-configurator): switch network only when user changed in the configurator

### DIFF
--- a/apps/widget-configurator/src/app/configurator/hooks/useSyncWidgetNetwork.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useSyncWidgetNetwork.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 import type { SupportedChainId } from '@cowprotocol/cow-sdk'
 
@@ -14,6 +14,8 @@ export function useSyncWidgetNetwork(
   const network = useNetwork()
   const { switchNetwork } = useSwitchNetwork()
   const walletChainId = network.chain?.id
+  const walletChainIdRef = useRef(walletChainId)
+  walletChainIdRef.current = walletChainId
 
   // Bind network control to wallet network
   useEffect(() => {
@@ -26,10 +28,10 @@ export function useSyncWidgetNetwork(
     }
   }, [isDisconnected, walletChainId, setNetworkControlState])
 
-  // Send a request to switch network if wallet network is different from widget network
+  // Send a request to switch network when user changes network in the configurator
   useEffect(() => {
-    if (!switchNetwork || isDisconnected || walletChainId === chainId) return
+    if (!switchNetwork || isDisconnected || walletChainIdRef.current === chainId) return
 
     switchNetwork(chainId)
-  }, [chainId, isDisconnected, switchNetwork, walletChainId, setNetworkControlState])
+  }, [chainId, isDisconnected, switchNetwork, setNetworkControlState])
 }


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C0361CDG8GP/p1699458252970569

  # To Test

1. Open widget configurator
2. Connect a wallet
3. Changed network on the wallet side
- [ ] AR: configurator start changing wallet forward and back in a loop
- [ ] ER: the network changes only once
4. Change network in the configurator UI
- [ ] wallet receives a requests to switch network
5. Accept network switching in the wallet
- [ ] network changed only once
