### PR TITLE
fix(widget): add a threshold for the widget height

### DIFF
--- a/libs/widget-lib/src/cowSwapWidget.ts
+++ b/libs/widget-lib/src/cowSwapWidget.ts
@@ -11,6 +11,14 @@ const DEFAULT_HEIGHT = '640px'
 const DEFAULT_WIDTH = '450px'
 
 /**
+ * Reference: IframeResizer (apps/cowswap-frontend/src/modules/injectedWidget/updaters/IframeResizer.ts)
+ * Sometimes MutationObserver doesn't trigger when the height of the widget changes and the widget displays with a scrollbar.
+ * To avoid this we add a threshold to the height.
+ * 20px
+ */
+const HEIGHT_THRESHOLD = 20
+
+/**
  * Callback function signature for updating the CoW Swap Widget.
  */
 export type UpdateWidgetCallback = (params: CowSwapWidgetParams) => void
@@ -126,6 +134,6 @@ function applyDynamicHeight(iframe: HTMLIFrameElement, defaultHeight = DEFAULT_H
       return
     }
 
-    iframe.style.height = event.data.height ? `${event.data.height}px` : defaultHeight
+    iframe.style.height = event.data.height ? `${event.data.height + HEIGHT_THRESHOLD}px` : defaultHeight
   })
 }


### PR DESCRIPTION
# Summary

Reference: https://cowservices.slack.com/archives/C0361CDG8GP/p1699558059623669

In some cases `IframeResizer` sends a hight value that a little less than real height and it cause displaying a scrollbar for the widget. To avoid this I added a small threshold (20px) to the widget height.

![image](https://github.com/cowprotocol/cowswap/assets/7122625/2e10b1a0-914b-4d70-933b-bc9193c95253)


  # To Test

1. Open widget configurator
2. Navigate between different pages in the widget (swap, limit, advanced, account modal, etc)
- [ ] ER: the widget shouldn't have a scrollbar