### PR TITLE
chore: use cache when building library

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -41,8 +41,17 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: yarn
 
-      - name: Install Nx
-        run: yarn add nx
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules1-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules1-
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
       - name: Build
         run: yarn nx build ${{ inputs.lib }}


### PR DESCRIPTION
# Summary
This PR removes a `yarn add nx` which was adding it "again" into our dependencies (we have it in the devDependencies)

The problems are:
- This adds another version (latest, instead of the one we have)
- This command brings also all the other dependencies does a normal `yarn install` implicitly), however it doesn't use the node_modules cache

Lastly, i took this opportunity to rename the workflow to NPM since its easier to find it. `publish` is too generic, and can be confused with our `deploy` workflow which deploys CoW Swap

CTX:
https://cowservices.slack.com/archives/C0361CDG8GP/p1699624696566869?thread_ts=1699623116.624319&cid=C0361CDG8GP