### PR TITLE
fix(permit): disable permit for sc wallets

### DIFF
--- a/apps/cowswap-frontend/src/modules/permit/hooks/useIsTokenPermittable.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/useIsTokenPermittable.ts
@@ -47,7 +47,9 @@ export function useIsTokenPermittable(
 
   const addPermitInfo = useAddPermitInfo()
   const permitInfo = usePermitInfo(chainId, isPermitEnabled ? lowerCaseAddress : undefined)
-  const { permitInfo: preGeneratedInfo, isLoading: preGeneratedIsLoading } = usePreGeneratedPermitInfoForToken(token)
+  const { permitInfo: preGeneratedInfo, isLoading: preGeneratedIsLoading } = usePreGeneratedPermitInfoForToken(
+    isPermitEnabled ? token : undefined
+  )
 
   const spender = GP_VAULT_RELAYER[chainId]
 

--- a/apps/cowswap-frontend/src/modules/permit/state/permitCacheAtom.ts
+++ b/apps/cowswap-frontend/src/modules/permit/state/permitCacheAtom.ts
@@ -14,7 +14,7 @@ import {
  * Should never change once it has been created.
  * Used exclusively for quote requests
  */
-export const staticPermitCacheAtom = atomWithStorage<PermitCache>('staticPermitCache:v0', {})
+export const staticPermitCacheAtom = atomWithStorage<PermitCache>('staticPermitCache:v1', {})
 
 /**
  * Atom that stores permit data for user permit requests.

--- a/libs/permit-utils/src/const.ts
+++ b/libs/permit-utils/src/const.ts
@@ -4,7 +4,7 @@ import ms from 'ms.macro'
 
 // PK used only for signing permit requests for quoting and identifying token 'permittability'
 // Do not use or try to send funds to it. Or do. It'll be your funds 🤷
-const PERMIT_PK = '0xc58a2a421ca71ca57ae698f1c32feeb0b0ccb434da0b8089d88d80fb918f3f9d' // address: 0xFf65D1DfCF256cf4A8D5F2fb8e70F936606B7474
+const PERMIT_PK = '0xec10458cfaafb32533a4a27e18d9da345758094dde7052521b939a41c55dd1b0' // address: 0x9eF31A6BB1A80e58cb73A906bddFaE308978095C
 
 export const PERMIT_SIGNER = new Wallet(PERMIT_PK)
 

--- a/libs/wallet/src/web3-react/hooks/useIsSmartContractWallet.ts
+++ b/libs/wallet/src/web3-react/hooks/useIsSmartContractWallet.ts
@@ -45,11 +45,8 @@ export function useIsSmartContractWallet(): boolean {
   useEffect(() => {
     if (!account) {
       setIsSmartContractWallet(false)
-      return
-    }
-
-    if (isAmbireWallet || isArgentWallet || isSmartContract) {
-      setIsSmartContractWallet(true)
+    } else {
+      setIsSmartContractWallet(Boolean(isAmbireWallet || isArgentWallet || isSmartContract))
     }
   }, [account, isAmbireWallet, isArgentWallet, isSmartContract])
 


### PR DESCRIPTION
# Summary

Multiple users reported permits failing due to low insufficient fees
Also, Waymont wallet (Safe based) reported users getting permit related issues, although permit should be disabled for SC wallets

See the full investigation on https://github.com/cowprotocol/cowswap/issues/3400

Turns out a bug was introduced on 1.49.0 where pre-generated permits were added.
It did not check whether permit is enabled before returning the pre-generated info.

Thus, SC wallets were having permit hook data added to their orders.
Because of that, permits for the quote account were being executed, making the permits cheaper gas wise while quoting.
That results in real users having the insufficient fee error, given that their real order permit cost more than what was quoted.

This is in no way a 100% fix for some of the edge cases still possible, but should definitely fix the bulk of the issues.

# To Test

1. Connect app with a SC wallet
2. Pick gas-less token as sell
* First, tokens should not be marked as gas-less
* Second, orders placed should NOT include any permit hook data (not the case with latest PROD)
3. Repeat steps with non gas-less token
* Should have the same result
4. Connect with EOA wallet
5. Pick gas-less token as sell for which you have no approvals
* Should show in the selector which tokens are gas-less
* Orders placed should contain the permit hook info
6. Repeat with non gas-less token
* Orders placed should NOT contain the permit hook info