### PR TITLE
fix: add space on approve & swap text for Safe

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/pure/SwapButtons/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/SwapButtons/index.tsx
@@ -150,14 +150,9 @@ const swapButtonStateMap: { [key in SwapButtonState]: (props: SwapButtonsContext
     <ButtonError buttonSize={ButtonSize.BIG} onClick={props.openSwapConfirm}>
       <styledEl.SwapButtonBox>
         <Trans>
-          Approve&nbsp;
-          {
-            <TokenSymbol
-              token={props.inputAmount?.currency && getWrappedToken(props.inputAmount.currency)}
-              length={6}
-            />
-          }
-          &nbsp;and Swap
+          Approve{' '}
+          <TokenSymbol token={props.inputAmount?.currency && getWrappedToken(props.inputAmount.currency)} length={6} />{' '}
+          and Swap
         </Trans>
       </styledEl.SwapButtonBox>
     </ButtonError>
@@ -166,14 +161,9 @@ const swapButtonStateMap: { [key in SwapButtonState]: (props: SwapButtonsContext
     <ButtonError buttonSize={ButtonSize.BIG} onClick={props.handleSwap}>
       <styledEl.SwapButtonBox>
         <Trans>
-          Confirm (Approve&nbsp;
-          {
-            <TokenSymbol
-              token={props.inputAmount?.currency && getWrappedToken(props.inputAmount.currency)}
-              length={6}
-            />
-          }
-          &nbsp;and Swap)
+          Confirm (Approve{' '}
+          <TokenSymbol token={props.inputAmount?.currency && getWrappedToken(props.inputAmount.currency)} length={6} />{' '}
+          and Swap)
         </Trans>
       </styledEl.SwapButtonBox>
     </ButtonError>


### PR DESCRIPTION
# Summary

Minor fix

Before
![Screenshot 2023-11-16 at 17 32 18](https://github.com/cowprotocol/cowswap/assets/43217/af9ee33b-fd7d-40e4-ad53-1aa2e0e19b48)

After
![Screenshot 2023-11-16 at 17 31 37](https://github.com/cowprotocol/cowswap/assets/43217/ae959dd5-b20b-4f8e-8cc9-82c8ef33b9d8)


  # To Test

1. Load the Safe app
2. Pick as sell token one that you have balance and has no approval
3. Pick a buy token
* SWAP text should have a space after the token name