### PR TITLE
fix: typo on classic eth flow banner

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/pure/EthFlow/EthFlowBanner/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/EthFlow/EthFlowBanner/index.tsx
@@ -55,7 +55,7 @@ export function EthFlowBannerContent(props: EthFlowBannerContentProps) {
                   before placing your order.
                 </>
               ) : null}{' '}
-              This way, you&apos;ll take of advantage of:
+              This way, you&apos;ll take advantage of:
             </p>
             <ul>
               <li>Lower overall fees</li>


### PR DESCRIPTION
# Summary

Reported on Discord

Before
![Screenshot 2023-11-17 at 07 46 16](https://github.com/cowprotocol/cowswap/assets/43217/21a187b4-7996-4f89-9f14-7f9e501f374f)

After
![Screenshot 2023-11-17 at 07 45 44](https://github.com/cowprotocol/cowswap/assets/43217/694dbafe-7170-4e64-a3bd-cff70a289dc0)


# To Test

1. Connect wallet
2. Select native token as sell, anything other than wrapped native as buy tokens
3. Click on the `wrap` banner at the bottom
* It should not have the typo