### PR TITLE
fix(twap): get rid of race condition while unknown tokens fetching

### DIFF
--- a/apps/cowswap-frontend/src/modules/orders/hooks/useTokensForOrdersList.ts
+++ b/apps/cowswap-frontend/src/modules/orders/hooks/useTokensForOrdersList.ts
@@ -1,7 +1,7 @@
 import { useCallback, useRef } from 'react'
 
 import { TokenWithLogo } from '@cowprotocol/common-const'
-import { fetchTokenFromBlockchain, TokensByAddress, useTokensByAddressMap } from '@cowprotocol/tokens'
+import { fetchTokenFromBlockchain, TokensByAddress, useAddUserToken, useTokensByAddressMap } from '@cowprotocol/tokens'
 import { useWalletInfo } from '@cowprotocol/wallet'
 import { Token } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
@@ -12,6 +12,7 @@ export function useTokensForOrdersList(): (tokensToFetch: string[]) => Promise<T
   const { chainId } = useWalletInfo()
   const { provider } = useWeb3React()
   const allTokens = useTokensByAddressMap()
+  const addUserTokens = useAddUserToken()
 
   const getToken = useCallback(
     async (address: string) => {
@@ -42,10 +43,13 @@ export function useTokensForOrdersList(): (tokensToFetch: string[]) => Promise<T
 
       const fetchedTokens = await _fetchTokens(tokensToFetch, getToken)
 
+      // Add fetched tokens to the user-added tokens store to avoid re-fetching them
+      addUserTokens(Object.values(fetchedTokens))
+
       // Merge fetched tokens with what's currently loaded
       return { ...tokens, ...fetchedTokens }
     },
-    [chainId, getToken]
+    [chainId, getToken, addUserTokens]
   )
 }
 

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useEmulatedPartOrders.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useEmulatedPartOrders.ts
@@ -46,9 +46,7 @@ function emulatePartOrders(
     const enrichedOrder = emulatePartAsOrder(item, parent)
     const order = mapPartOrderToStoreOrder(item, enrichedOrder, isVirtualPart, parent, tokensByAddress)
 
-    if (order) {
-      acc.push(order)
-    }
+    acc.push(order)
 
     return acc
   }, [])

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useEmulatedTwapOrders.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useEmulatedTwapOrders.ts
@@ -14,6 +14,14 @@ import { mapTwapOrderToStoreOrder } from '../utils/mapTwapOrderToStoreOrder'
 
 const EMULATED_ORDERS_REFRESH_MS = ms`5s`
 
+/**
+ * Returns a list of emulated twap orders
+ *
+ * `tokenByAddress` is a map of all known tokens, it comes from `useTwapOrdersTokens()` hook
+ * `useTwapOrdersTokens()` fetches unkown tokens from blockchain and stores them in the store
+ * So, there might be a race condition when we have an order but haven't fetched its token yet
+ * Because of it, we wrap mapTwapOrderToStoreOrder() in try/catch and just don't add an order to the list
+ */
 export function useEmulatedTwapOrders(tokensByAddress: TokensByAddress | undefined): Order[] {
   const { account, chainId } = useWalletInfo()
   const allTwapOrders = useAtomValue(twapOrdersListAtom)
@@ -32,7 +40,12 @@ export function useEmulatedTwapOrders(tokensByAddress: TokensByAddress | undefin
         return acc
       }
 
-      acc.push(mapTwapOrderToStoreOrder(order, tokensByAddress))
+      try {
+        acc.push(mapTwapOrderToStoreOrder(order, tokensByAddress))
+      } catch (e) {
+        console.error(e, order)
+      }
+
       return acc
     }, [])
   }, [allTwapOrders, accountLowerCase, chainId, tokensByAddress, refresher])

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useEmulatedTwapOrders.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useEmulatedTwapOrders.ts
@@ -32,10 +32,7 @@ export function useEmulatedTwapOrders(tokensByAddress: TokensByAddress | undefin
         return acc
       }
 
-      const orderDetails = mapTwapOrderToStoreOrder(order, tokensByAddress)
-      if (orderDetails) {
-        acc.push(orderDetails)
-      }
+      acc.push(mapTwapOrderToStoreOrder(order, tokensByAddress))
       return acc
     }, [])
   }, [allTwapOrders, accountLowerCase, chainId, tokensByAddress, refresher])

--- a/apps/cowswap-frontend/src/modules/twap/updaters/CreatedInOrderBookOrdersUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/updaters/CreatedInOrderBookOrdersUpdater.tsx
@@ -14,7 +14,7 @@ import { useTokensForOrdersList, getTokensListFromOrders, useSWRProdOrders } fro
 import { twapOrdersAtom } from '../state/twapOrdersListAtom'
 import { TwapPartOrderItem, twapPartOrdersListAtom, updatePartOrdersAtom } from '../state/twapPartOrdersAtom'
 import { TwapOrderItem } from '../types'
-import { isOrder, mapPartOrderToStoreOrder } from '../utils/mapPartOrderToStoreOrder'
+import { mapPartOrderToStoreOrder } from '../utils/mapPartOrderToStoreOrder'
 
 interface TwapOrderInfo {
   item: TwapPartOrderItem
@@ -65,11 +65,9 @@ export function CreatedInOrderBookOrdersUpdater() {
 
       const allTokens = await getTokensForOrdersList(getTokensListFromOrders(ordersInfo))
 
-      return ordersInfo
-        .map(({ item, parent, order }) => {
-          return mapPartOrderToStoreOrder(item, order, isVirtualPart, parent, allTokens)
-        })
-        .filter(isOrder)
+      return ordersInfo.map(({ item, parent, order }) => {
+        return mapPartOrderToStoreOrder(item, order, isVirtualPart, parent, allTokens)
+      })
     },
     [prodOrders, twapPartOrdersMap, getTokensForOrdersList, twapOrders],
     []

--- a/apps/cowswap-frontend/src/modules/twap/utils/mapPartOrderToStoreOrder.ts
+++ b/apps/cowswap-frontend/src/modules/twap/utils/mapPartOrderToStoreOrder.ts
@@ -17,18 +17,9 @@ export function mapPartOrderToStoreOrder(
   isVirtualPart: boolean,
   parent: TwapOrderItem,
   tokensByAddress: TokensByAddress
-): Order | undefined {
+): Order {
   const isCancelling = item.isCancelling || parent.status === TwapOrderStatus.Cancelling
   const status = getPartOrderStatus(enrichedOrder, parent, isVirtualPart)
-
-  const inputToken = tokensByAddress[enrichedOrder.sellToken.toLowerCase()]
-  const outputToken = tokensByAddress[enrichedOrder.buyToken.toLowerCase()]
-
-  if (!inputToken || !outputToken) {
-    // FIXME: this is a hack to prevent errors, we should ensure this doesn't happen
-    console.error('mapTwapOrderToStoreOrder: inputToken or outputToken not found', { inputToken, outputToken })
-    return undefined
-  }
 
   const storeOrder: Order = {
     ...enrichedOrder,
@@ -39,8 +30,8 @@ export function mapPartOrderToStoreOrder(
       parentId: parent.id,
     },
     sellAmountBeforeFee: enrichedOrder.sellAmount,
-    inputToken,
-    outputToken,
+    inputToken: tokensByAddress[enrichedOrder.sellToken.toLowerCase()],
+    outputToken: tokensByAddress[enrichedOrder.buyToken.toLowerCase()],
     creationTime: enrichedOrder.creationDate,
     summary: '',
     status,

--- a/apps/cowswap-frontend/src/modules/twap/utils/mapTwapOrderToStoreOrder.ts
+++ b/apps/cowswap-frontend/src/modules/twap/utils/mapTwapOrderToStoreOrder.ts
@@ -20,6 +20,10 @@ const statusesMap: Record<TwapOrderStatus, OrderStatus> = {
 export function mapTwapOrderToStoreOrder(order: TwapOrderItem, tokensByAddress: TokensByAddress): Order {
   const enrichedOrder = emulateTwapAsOrder(order)
   const status = statusesMap[order.status]
+  const inputToken = tokensByAddress[enrichedOrder.sellToken.toLowerCase()]
+  const outputToken = tokensByAddress[enrichedOrder.buyToken.toLowerCase()]
+
+  if (!inputToken || !outputToken) throw new Error('Token not found')
 
   const storeOrder: Order = {
     ...enrichedOrder,
@@ -28,8 +32,8 @@ export function mapTwapOrderToStoreOrder(order: TwapOrderItem, tokensByAddress: 
       id: order.id,
     },
     sellAmountBeforeFee: enrichedOrder.sellAmount,
-    inputToken: tokensByAddress[enrichedOrder.sellToken.toLowerCase()],
-    outputToken: tokensByAddress[enrichedOrder.buyToken.toLowerCase()],
+    inputToken,
+    outputToken,
     creationTime: enrichedOrder.creationDate,
     summary: '',
     status,

--- a/apps/cowswap-frontend/src/modules/twap/utils/mapTwapOrderToStoreOrder.ts
+++ b/apps/cowswap-frontend/src/modules/twap/utils/mapTwapOrderToStoreOrder.ts
@@ -17,18 +17,9 @@ const statusesMap: Record<TwapOrderStatus, OrderStatus> = {
   [TwapOrderStatus.Cancelling]: OrderStatus.PENDING,
 }
 
-export function mapTwapOrderToStoreOrder(order: TwapOrderItem, tokensByAddress: TokensByAddress): Order | undefined {
+export function mapTwapOrderToStoreOrder(order: TwapOrderItem, tokensByAddress: TokensByAddress): Order {
   const enrichedOrder = emulateTwapAsOrder(order)
   const status = statusesMap[order.status]
-
-  const inputToken = tokensByAddress[enrichedOrder.sellToken.toLowerCase()]
-  const outputToken = tokensByAddress[enrichedOrder.buyToken.toLowerCase()]
-
-  if (!inputToken || !outputToken) {
-    // FIXME: this is a hack to prevent errors, we should ensure this doesn't happen
-    console.error('mapTwapOrderToStoreOrder: inputToken or outputToken not found', { inputToken, outputToken })
-    return undefined
-  }
 
   const storeOrder: Order = {
     ...enrichedOrder,
@@ -37,8 +28,8 @@ export function mapTwapOrderToStoreOrder(order: TwapOrderItem, tokensByAddress: 
       id: order.id,
     },
     sellAmountBeforeFee: enrichedOrder.sellAmount,
-    inputToken,
-    outputToken,
+    inputToken: tokensByAddress[enrichedOrder.sellToken.toLowerCase()],
+    outputToken: tokensByAddress[enrichedOrder.buyToken.toLowerCase()],
     creationTime: enrichedOrder.creationDate,
     summary: '',
     status,


### PR DESCRIPTION
# Summary

Fixes https://github.com/cowprotocol/cowswap/issues/3442 and https://github.com/cowprotocol/cowswap/issues/3441

This is a follow up of https://github.com/cowprotocol/cowswap/pull/3451

### The cause of the problem
A TWAP order might contain an unknown token that is not included in any active token list.
In this case, we dynamically fetch tokens like that from blockchain, see `useTwapOrdersTokens()` and `useTokensForOrdersList()`.

`useEmulatedTwapOrders()` depends on the result of `useTwapOrdersTokens()` and uses it to create emulate a TWAP order. Since `useTwapOrdersTokens()` works asynchronously, we can meet a race condition, when we haven't loaded tokens yet and trying to emulate a TWAP order.

To avoid it, we wrap `mapTwapOrderToStoreOrder()` in try/catch and just don't add an order to the list.

  # To Test

1. Open TWAP page
2. Place an order: WETH/WBTC in Goerli
3. Sigh and execute the order
- [ ] AR: the app is crashed
- [ ] ER: the app doesn't crash, the order is displayed in the orders table