### PR TITLE
chore: change fee label

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/pure/Row/RowFeeContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/Row/RowFeeContent/index.tsx
@@ -31,7 +31,7 @@ export function RowFeeContent(props: RowFeeContentProps) {
   return (
     <StyledRowBetween {...styleProps}>
       <RowFixed>
-        <TextWrapper>Fees {includeGasMessage}</TextWrapper>
+        <TextWrapper>Est. fees {includeGasMessage}</TextWrapper>
         {showHelpers && (
           <MouseoverTooltipContent content={tooltip} wrap>
             <StyledInfoIcon size={16} />


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C036G0J90BU/p1701858407051049

Just changed `Fees` to `Est. fees` in swap form and swap confirmation modal.

<img width="540" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/ec0946e6-01b4-494c-9ccb-d0b1a160ebf3">
