### PR TITLE
fix(orders-table): show not enough allowance warning only when needed

### DIFF
--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
@@ -175,12 +175,7 @@ export function OrderRow({
 
   const showCancellationModal = orderActions.getShowCancellationModal(order)
 
-  /**
-   * TODO: I'm not sure about !hasValidPendingPermit
-   * Before the fix it was: hasValidPendingPermit === false
-   * In useCheckHasValidPendingPermit() we intentionally return undefined in cases when we don't know the permit status
-   */
-  const withAllowanceWarning = hasEnoughAllowance === false && !hasValidPendingPermit
+  const withAllowanceWarning = hasEnoughAllowance === false && hasValidPendingPermit === false
   const withWarning =
     (hasEnoughBalance === false || withAllowanceWarning) &&
     // show the warning only for pending and scheduled orders

--- a/apps/cowswap-frontend/src/modules/permit/hooks/usePermitCompatibleTokens.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/usePermitCompatibleTokens.ts
@@ -34,11 +34,17 @@ export function usePermitCompatibleTokens(): PermitCompatibleTokens {
     const permitCompatibleTokens: PermitCompatibleTokens = {}
 
     for (const address of Object.keys(preGeneratedPermitInfoRef.current)) {
-      permitCompatibleTokens[address.toLowerCase()] = isSupportedPermitInfo(preGeneratedPermitInfoRef.current[address])
+      const addressLowerCased = address.toLowerCase()
+
+      permitCompatibleTokens[addressLowerCased] = isSupportedPermitInfo(
+        preGeneratedPermitInfoRef.current[addressLowerCased]
+      )
     }
 
     for (const address of Object.keys(localPermitInfoRef.current)) {
-      permitCompatibleTokens[address.toLowerCase()] = isSupportedPermitInfo(localPermitInfoRef.current[address])
+      const addressLowerCased = address.toLowerCase()
+
+      permitCompatibleTokens[addressLowerCased] = isSupportedPermitInfo(localPermitInfoRef.current[addressLowerCased])
     }
 
     return permitCompatibleTokens

--- a/apps/cowswap-frontend/src/modules/permit/hooks/usePermitInfo.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/usePermitInfo.ts
@@ -77,6 +77,8 @@ export function usePermitInfo(token: Nullish<Currency>, tradeType: Nullish<Trade
           `useIsTokenPermittable: failed to check whether token ${lowerCaseAddress} is permittable: ${result.error}`
         )
       } else {
+        // TODO: there is a Single Responsibility Principle breach here. This hook should not be responsible for caching.
+        // TODO: better to create a separate updater for caching.
         // Otherwise, we know it is permittable or not. Cache it.
         addPermitInfo({ chainId, tokenAddress: lowerCaseAddress, permitInfo: result })
       }

--- a/apps/cowswap-frontend/src/modules/permit/hooks/usePreGeneratedPermitInfo.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/usePreGeneratedPermitInfo.ts
@@ -12,7 +12,7 @@ import { PRE_GENERATED_PERMIT_URL } from '../const'
  * Caches result with SWR until a page refresh
  */
 export function usePreGeneratedPermitInfo(): {
-  allPermitInfo: Record<string, PermitInfo>
+  allPermitInfo: Record<string, PermitInfo | undefined>
   isLoading: boolean
 } {
   const { chainId } = useWalletInfo()
@@ -21,7 +21,7 @@ export function usePreGeneratedPermitInfo(): {
 
   const { data, isLoading } = useSWR(
     url,
-    (url: string): Promise<Record<string, PermitInfo>> =>
+    (url: string): Promise<Record<string, PermitInfo | undefined>> =>
       fetch(url)
         .then((r) => r.json())
         .then(migrateData),


### PR DESCRIPTION
# Summary

Fixes #3480

Was introduced here: https://github.com/cowprotocol/cowswap/pull/3374

The key of the problem was in `useCheckHasValidPendingPermit()`, the hook didn't consider pre-generated permit info.
I've left a couple of TODOs for the future.

<img width="1030" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/4ebe9070-e343-49a4-8966-eb21c9cc5f17">

  # To Test

See #3480