### PR TITLE
fix(trade): don't display fiat value when there is no amount

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
+++ b/apps/cowswap-frontend/src/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
@@ -161,9 +161,11 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
             )}
           </div>
           <div>
-            <styledEl.FiatAmountText>
-              <FiatValue priceImpactParams={priceImpactParams} fiatValue={fiatAmount} />
-            </styledEl.FiatAmountText>
+            {amount && (
+              <styledEl.FiatAmountText>
+                <FiatValue priceImpactParams={priceImpactParams} fiatValue={fiatAmount} />
+              </styledEl.FiatAmountText>
+            )}
           </div>
         </styledEl.CurrencyInputBox>
       </styledEl.Wrapper>


### PR DESCRIPTION
# Summary

Fixes #3486

 Fiat amount loader is displayed when no tokens selected in the form.
We should not display it when there is no amount.

<img width="525" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/984570c5-c156-4f46-86f6-d4edc7c59c79">


  # To Test

See #3486
