### PR TITLE
fix(wallet): fix ledger live

### DIFF
--- a/libs/wallet/src/constants.ts
+++ b/libs/wallet/src/constants.ts
@@ -1,2 +1,4 @@
 export const WC_DISABLED_TEXT =
   'Wallet-connect based wallet is already in use. Please disconnect it to connect to this wallet.'
+
+export const WC_PROJECT_ID = process.env.REACT_APP_WC_PROJECT_ID || 'a6cc11517a10f6f12953fd67b1eb67e7'

--- a/libs/wallet/src/web3-react/connection/walletConnectV2.tsx
+++ b/libs/wallet/src/web3-react/connection/walletConnectV2.tsx
@@ -24,7 +24,7 @@ import {
   getIsTrustWallet,
   getIsZengoWallet,
 } from '../../api/utils/connection'
-import { WC_DISABLED_TEXT } from '../../constants'
+import { WC_DISABLED_TEXT, WC_PROJECT_ID } from '../../constants'
 import { ConnectWalletOption } from '../../api/pure/ConnectWalletOption'
 
 export const walletConnectV2Option = {
@@ -32,8 +32,6 @@ export const walletConnectV2Option = {
   icon: WalletConnectV2Image,
   id: 'wallet-connect-v2',
 }
-
-const WC_PROJECT_ID = process.env.REACT_APP_WC_PROJECT_ID || 'a6cc11517a10f6f12953fd67b1eb67e7'
 
 function createWalletConnectV2Connector(chainId: SupportedChainId): [AsyncConnector, Web3ReactHooks, Web3ReactStore] {
   return initializeConnector<AsyncConnector>(

--- a/libs/wallet/src/web3-react/connectors/LedgerConnector.tsx
+++ b/libs/wallet/src/web3-react/connectors/LedgerConnector.tsx
@@ -1,7 +1,8 @@
-import { Web3Provider, ExternalProvider } from '@ethersproject/providers'
+import { ExternalProvider, Web3Provider } from '@ethersproject/providers'
 import { Actions, Connector, Provider, RequestArguments } from '@web3-react/types'
 
 import { LedgerConnectKit, SupportedProviders } from '@ledgerhq/connect-kit-loader'
+import { WC_PROJECT_ID } from '../../constants'
 
 type LedgerProvider = Provider & {
   connected: () => boolean
@@ -81,9 +82,11 @@ export class Ledger extends Connector {
 
     connectKit.checkSupport({
       providerType: SupportedProviders.Ethereum,
+      walletConnectVersion: 2,
+      projectId: WC_PROJECT_ID,
       chainId: this.options.chainId,
       infuraId: this.options.infuraId,
-      rpc: this.options.rpc,
+      rpcMap: this.options.rpc,
     })
   }
 

--- a/libs/wallet/src/web3-react/connectors/LedgerConnector.tsx
+++ b/libs/wallet/src/web3-react/connectors/LedgerConnector.tsx
@@ -42,11 +42,9 @@ export class Ledger extends Connector {
 
   async getAccounts() {
     const provider = await this.getProvider()
-    const accounts = (await provider.request({
+    return (await provider.request({
       method: 'eth_requestAccounts',
     })) as string[]
-
-    return accounts
   }
 
   async getChainId() {

--- a/libs/wallet/src/web3-react/connectors/LedgerConnector.tsx
+++ b/libs/wallet/src/web3-react/connectors/LedgerConnector.tsx
@@ -1,7 +1,7 @@
 import { Web3Provider, ExternalProvider } from '@ethersproject/providers'
 import { Actions, Connector, Provider, RequestArguments } from '@web3-react/types'
 
-import type { LedgerConnectKit, SupportedProviders } from '@ledgerhq/connect-kit-loader'
+import { LedgerConnectKit, SupportedProviders } from '@ledgerhq/connect-kit-loader'
 
 type LedgerProvider = Provider & {
   connected: () => boolean
@@ -79,8 +79,8 @@ export class Ledger extends Connector {
 
     connectKit.enableDebugLogs()
 
-      providerType: 'Ethereum' as SupportedProviders,
     connectKit.checkSupport({
+      providerType: SupportedProviders.Ethereum,
       chainId: this.options.chainId,
       infuraId: this.options.infuraId,
       rpc: this.options.rpc,

--- a/libs/wallet/src/web3-react/connectors/LedgerConnector.tsx
+++ b/libs/wallet/src/web3-react/connectors/LedgerConnector.tsx
@@ -77,10 +77,10 @@ export class Ledger extends Connector {
   async activateLedgerKit() {
     const connectKit = this.kit
 
-    await connectKit.enableDebugLogs()
+    connectKit.enableDebugLogs()
 
-    await connectKit.checkSupport({
       providerType: 'Ethereum' as SupportedProviders,
+    connectKit.checkSupport({
       chainId: this.options.chainId,
       infuraId: this.options.infuraId,
       rpc: this.options.rpc,

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@ethvault/iframe-provider": "^0.1.10",
     "@fontsource/ibm-plex-mono": "^4.5.1",
     "@fontsource/inter": "^4.5.1",
-    "@ledgerhq/connect-kit-loader": "^1.0.2",
+    "@ledgerhq/connect-kit-loader": "^1.1.2",
     "@lingui/cli": "^4.3.0",
     "@lingui/core": "^4.3.0",
     "@lingui/macro": "^4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3103,12 +3103,7 @@
   resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.4.0.tgz#08d6c5e20cf7e4cc02fd181c4b0c225cd31dbb60"
   integrity sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==
 
-"@ledgerhq/connect-kit-loader@^1.0.2":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.1.0.tgz#10343b78ef13436818bf3453568a559c0eeb9d48"
-  integrity sha512-HUy12FEczoWY2FPubnsm1uOA8tkVWc0j90i47suThV3C9NL2xx69ZAIEU3Ytzs2bwLek9S1Q2S1VQJvA+3Ygkg==
-
-"@ledgerhq/connect-kit-loader@^1.1.0":
+"@ledgerhq/connect-kit-loader@^1.1.0", "@ledgerhq/connect-kit-loader@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.1.2.tgz#d550e3c1f046e4c796f32a75324b03606b7e226a"
   integrity sha512-mscwGroSJQrCTjtNGBu+18FQbZYA4+q6Tyx6K7CXHl6AwgZKbWfZYdgP2F+fyZcRUdGRsMX8QtvU61VcGGtO1A==


### PR DESCRIPTION
# Summary

Fixes #3464 

Upgrade ledger live support to WCv2 according to their migration guide https://developers.ledger.com/docs/connectivity/connect-kit/implementation#walletconnect-v2-migration-guide

# To Test

1. Open the app
2. Connect with ledger
3. Select Ledger Live
* Should connect
* Should be able to trade

**Note**: I was not able to test the order placement as I don't have a ledger with me right now