### PR TITLE
fix(wallet): use new Safe wallet name via WC

### DIFF
--- a/libs/wallet/src/web3-react/hooks/useWalletMetadata.ts
+++ b/libs/wallet/src/web3-react/hooks/useWalletMetadata.ts
@@ -11,11 +11,13 @@ const WC_DESKTOP_GNOSIS_SAFE_APP_NAME = 'WalletConnect Safe App'
 const WC_MOBILE_GNOSIS_SAFE_APP_NAME = 'Safe'
 const SAFE_APP_NAME = 'Safe App'
 const GNOSIS_SAFE_APP_NAME = 'Gnosis Safe App'
+const SAFE_WALLET_NAME = 'Safe{Wallet}'
 const GNOSIS_APP_NAMES = [
   SAFE_APP_NAME,
   GNOSIS_SAFE_APP_NAME,
   WC_DESKTOP_GNOSIS_SAFE_APP_NAME,
   WC_MOBILE_GNOSIS_SAFE_APP_NAME,
+  SAFE_WALLET_NAME,
 ]
 
 const SAFE_ICON_URL = 'https://app.safe.global/favicon.ico'


### PR DESCRIPTION
# Summary

Fix https://github.com/cowprotocol/cowswap/issues/3465

Safe has a new name via WC.
And we rely on that to identify whether we are using a Safe wallet.

This is not a long term fix.

I started to refactor how this is done here 3488f07bbecc1dcf9831d51b1c9b6b6cd0ed65f8 and hopefully it'll be more reliable.

For now, it does fixes the issue at hand and correctly identifying Safe txs and showing Safe context info via WC 
<img width="417" alt="image" src="https://github.com/cowprotocol/cowswap/assets/43217/3bfa321f-1e47-4eac-b066-190884219264">

# To Test

1. Connect with a Safe wallet via WC
2. Do a wrapping/approval tx
* The Safe tx hash should be properly displayed
* It should correctly track the Safe tx status
* It should NOT remain pending forever
3. Place an order
* The Safe tx hash should be properly displayed
* It should correctly track the Safe tx status
* It should NOT remain pending forever