### PR TITLE
remove ledger for now

### DIFF
--- a/libs/wallet/src/web3-react/utils/getWeb3ReactConnection.ts
+++ b/libs/wallet/src/web3-react/utils/getWeb3ReactConnection.ts
@@ -25,7 +25,7 @@ const connectionTypeToConnection: Record<ConnectionType, Web3ReactConnection> = 
   [ConnectionType.ALPHA]: walletConnectConnectionV2,
   [ConnectionType.TALLY]: tallyWalletConnection,
   [ConnectionType.TRUST]: trustWalletConnection,
-  [ConnectionType.LEDGER]: ledgerConnection,
+  // [ConnectionType.LEDGER]: ledgerConnection,
   [ConnectionType.KEYSTONE]: keystoneConnection,
   [ConnectionType.INJECTED_WIDGET]: injectedWidgetConnection,
   [ConnectionType.TREZOR]: trezorConnection,


### PR DESCRIPTION
# Summary

there is a vulnerability in the ledger package. remove it from the connector options

  # To Test

1. <<Step one>> Open connect wallet modal
- [ ] Expect that ledger is not available

  # Background
Ledger npm package has a vulnerability that replaces connector with a drainer
https://github.com/harvestfi/harvest-front/pull/27/files

It is expected to be patched soon and at that time, you can bump the version of the package and uncomment the line that was commented here
