### PR TITLE
fix(classic-eth-flow): wrap no longer clears input amounts

### DIFF
--- a/apps/cowswap-frontend/src/legacy/hooks/useWrapCallback.ts
+++ b/apps/cowswap-frontend/src/legacy/hooks/useWrapCallback.ts
@@ -1,6 +1,5 @@
 import { wrapAnalytics } from '@cowprotocol/analytics'
-import { RADIX_HEX } from '@cowprotocol/common-const'
-import { getChainCurrencySymbols } from '@cowprotocol/common-const'
+import { getChainCurrencySymbols, RADIX_HEX } from '@cowprotocol/common-const'
 import {
   calculateGasMargin,
   formatTokenAmount,
@@ -14,8 +13,6 @@ import { TransactionResponse } from '@ethersproject/providers'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
 import { useTransactionAdder } from 'legacy/state/enhancedTransactions/hooks'
-
-import { ExtendedTradeRawState, TradeRawState } from 'modules/trade/types/TradeRawState'
 
 import { getOperationMessage } from '../components/TransactionConfirmationModal/LegacyConfirmationPendingContent'
 import { ConfirmOperationType } from '../state/types'
@@ -44,8 +41,6 @@ export interface WrapUnwrapContext {
   wethContract: Contract
   amount: CurrencyAmount<Currency>
   addTransaction: TransactionAdder
-  tradeState: TradeRawState
-  updateTradeState: (update: Partial<ExtendedTradeRawState>) => void
   closeModals: () => void
   openTransactionConfirmationModal: OpenSwapConfirmModalCallback
 }
@@ -54,16 +49,7 @@ export async function wrapUnwrapCallback(
   context: WrapUnwrapContext,
   params: WrapUnwrapCallbackParams = { useModals: true }
 ): Promise<TransactionResponse | null> {
-  const {
-    chainId,
-    amount,
-    wethContract,
-    addTransaction,
-    openTransactionConfirmationModal,
-    closeModals,
-    updateTradeState,
-    tradeState,
-  } = context
+  const { chainId, amount, wethContract, addTransaction, openTransactionConfirmationModal, closeModals } = context
   const isNativeIn = getIsNativeToken(amount.currency)
   const amountHex = `0x${amount.quotient.toString(RADIX_HEX)}`
   const operationType = isNativeIn ? ConfirmOperationType.WRAP_ETHER : ConfirmOperationType.UNWRAP_WETH
@@ -84,9 +70,6 @@ export async function wrapUnwrapCallback(
       summary,
     })
     useModals && closeModals()
-
-    // Clean up form fields after successful wrap/unwrap
-    updateTradeState({ ...tradeState, inputCurrencyAmount: '', outputCurrencyAmount: '' })
 
     return txReceipt
   } catch (error: any) {

--- a/apps/cowswap-frontend/src/modules/swap/pure/EthFlow/WrappingPreview/WrapCard.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/EthFlow/WrappingPreview/WrapCard.tsx
@@ -1,6 +1,6 @@
 import { TokenLogo } from '@cowprotocol/tokens'
 import { TokenAmount } from '@cowprotocol/ui'
-import { CurrencyAmount, Currency } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
 import * as styledEl from 'modules/swap/pure/EthFlow/WrappingPreview/styled'
 
@@ -25,7 +25,8 @@ export function WrapCard(props: WrapCardProps) {
       </styledEl.BalanceLabel>
       {/* user balance */}
       <styledEl.BalanceLabel>
-        Balance: <TokenAmount amount={balance} />
+        Balance:&nbsp;
+        <TokenAmount amount={balance} />
       </styledEl.BalanceLabel>
     </styledEl.WrapCardWrapper>
   )

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useWrapNativeFlow.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useWrapNativeFlow.ts
@@ -16,7 +16,6 @@ import {
 import { useTransactionAdder } from 'legacy/state/enhancedTransactions/hooks'
 
 import { useDerivedTradeState } from './useDerivedTradeState'
-import { useTradeState } from './useTradeState'
 
 import { wrapNativeStateAtom } from '../state/wrapNativeStateAtom'
 
@@ -38,10 +37,9 @@ function useWrapNativeContext(amount: Nullish<CurrencyAmount<Currency>>): WrapUn
   const { chainId } = useWalletInfo()
   const wethContract = useWETHContract()
   const addTransaction = useTransactionAdder()
-  const { updateState, state: tradeState } = useTradeState()
   const setWrapNativeState = useSetAtom(wrapNativeStateAtom)
 
-  if (!wethContract || !chainId || !amount || !updateState || !tradeState) {
+  if (!wethContract || !chainId || !amount) {
     return null
   }
 
@@ -50,8 +48,6 @@ function useWrapNativeContext(amount: Nullish<CurrencyAmount<Currency>>): WrapUn
     wethContract,
     amount,
     addTransaction,
-    tradeState,
-    updateTradeState: updateState,
     closeModals() {
       setWrapNativeState({ isOpen: false })
     },


### PR DESCRIPTION
# Summary

Fix #3421

Classic eth flow works again!

  # To Test

1. Select native as sell and another token as buy
2. Input the sell amount less than what you have in wrapped native
3. Click on `wrap` button at the bottom of the SWAP form 
![image](https://github.com/cowprotocol/cowswap/assets/43217/180d6356-da63-4440-9a7d-89ac8027b45f)
4. Click on `wrap and swap` button at the bottom 
![image](https://github.com/cowprotocol/cowswap/assets/43217/c0d9b481-45b6-4bd3-83f9-c4312f359efe)
5. Wrap
* Should wrap
6. After wrapped, approve (if needed)
* Should approve if needed
7. Swap
* Should swap with wrapped native