### PR TITLE
fix(widget): don't use official app code for widget meta data

### DIFF
--- a/apps/cowswap-frontend/src/modules/injectedWidget/hooks/useAppCodeWidgetAware.ts
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/hooks/useAppCodeWidgetAware.ts
@@ -39,10 +39,10 @@ export function useAppCodeWidgetAware(appCodeOfficial: string | null): AppCodeWi
     if (appCodeInjectedHostApp) {
       return {
         // The main appCode will be the one of the host app that uses the widget
-        appCode: appCodeInjectedHostApp,
+        appCode: appCodeOfficial,
         widget: {
           // In the widget appCode we include the official appCode and environment (this way we report which app is backing the widget iframe)
-          appCode: appCodeOfficial,
+          appCode: appCodeInjectedHostApp,
           environment: environmentName,
         },
       }


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C0361CCTFD5/p1701771334502269?thread_ts=1699976369.079659&cid=C0361CCTFD5

Mainly, we just swapped `appCodeOfficial` and `appCodeInjectedHostApp` places

  # To Test

1. Create an order from Widget configurator
2. Check app-data in Explorer
- [ ] AR: 
```
{
  "appCode": "CoW Widget: Configurator",
  "metadata": {
    "orderClass": {
      "orderClass": "market"
    },
    "quote": {
      "slippageBips": "50"
    },
    "widget": {
      "appCode": "CoW Swap",
      "environment": "local"
    }
  },
  "version": "0.11.0"
}
```

- [ ] ER: 
```
{
  "appCode": "CoW Swap",
  "metadata": {
    "orderClass": {
      "orderClass": "market"
    },
    "quote": {
      "slippageBips": "50"
    },
    "widget": {
      "appCode": "CoW Widget: Configurator",
      "environment": "local"
    }
  },
  "version": "0.11.0"
}
```
