### PR TITLE
feat: replace time column labels with nouns

### DIFF
--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrdersTable.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrdersTable.tsx
@@ -365,9 +365,9 @@ export function OrdersTable({
 
             {isOpenOrdersTab && (
               <HeaderElement doubleRow>
-                <Trans>Expires</Trans>
+                <Trans>Expiration</Trans>
                 <i>
-                  <Trans>Created</Trans>
+                  <Trans>Creation</Trans>
                 </i>
               </HeaderElement>
             )}


### PR DESCRIPTION
# Summary

Tiny change, fixing the labels that have been bothering me forever

The label for this column used 2 verbs in different tenses.
Not that of a big deal when creation date is always in the past (limit orders), but it doesn't make sense when it can be in the future (TWAP orders)

| Before | Now |
|-|-|
| ![image](https://github.com/cowprotocol/cowswap/assets/43217/93e1eaf4-3b8b-4b7e-a76b-ed98f658d3b1) | ![image](https://github.com/cowprotocol/cowswap/assets/43217/e11b3c86-3cb3-4f0e-8402-1cf8d00fa010) |


  # To Test

1. Open an active Limit or TWAP order
2. Label should be updated

No other changes, that's all