### PR TITLE
fix: use button text color for error button

### DIFF
--- a/libs/ui/src/pure/Button/index.tsx
+++ b/libs/ui/src/pure/Button/index.tsx
@@ -8,13 +8,11 @@ import { RowBetween } from '../Row'
 import { ButtonSize, UI } from '../../enum'
 
 import {
-  // Import only the basic buttons
-  ButtonPrimary as ButtonPrimaryMod,
+  ButtonConfirmedStyle as ButtonConfirmedStyleMod,
+  ButtonEmpty as ButtonEmptyMod,
   ButtonGray as ButtonGrayMod,
   ButtonOutlined as ButtonOutlinedMod,
-  ButtonEmpty as ButtonEmptyMod,
-  ButtonConfirmedStyle as ButtonConfirmedStyleMod,
-  // We don't import the "composite" buttons, they are just redefined (c&p actually)
+  ButtonPrimary as ButtonPrimaryMod,
 } from './ButtonMod'
 
 export * from './ButtonMod'
@@ -169,14 +167,14 @@ export const ButtonConfirmedStyle = styled(ButtonConfirmedStyleMod)`
 export const ButtonErrorStyle = styled(ButtonPrimary)`
   // CSS overrides
   background: var(${UI.COLOR_DANGER});
-  color: var(${UI.COLOR_DANGER_TEXT});
+  color: var(${UI.COLOR_BUTTON_TEXT});
   transition: background var(${UI.ANIMATION_DURATION}) ease-in-out;
 
   &:focus,
   &:hover,
   &:active {
-    background: var(${UI.COLOR_DANGER});
-    color: var(${UI.COLOR_DANGER_TEXT});
+    background: var(${UI.COLOR_WARNING});
+    color: var(${UI.COLOR_BUTTON_TEXT});
   }
 `
 


### PR DESCRIPTION
# Summary

Fix text color for error button

## Before
![image](https://github.com/cowprotocol/cowswap/assets/43217/52056078-81cd-4ff8-8b11-6421c6250cf2)

## Now
|light|dark|
|-|-|
| ![image](https://github.com/cowprotocol/cowswap/assets/43217/c39b0d10-d353-4aa7-ba7f-c0659dd8d6b3) | ![image](https://github.com/cowprotocol/cowswap/assets/43217/01c72fcc-d91e-49db-8d5f-c1e772a61e9f) |

  # To Test

1. Open the setting and click on expert mode
2. Fill in `confirm`
* The button text should be legible