### PR TITLE
fix: eth-flow stepper missing border

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/pure/EthFlow/EthFlowStepper/StatusIcon.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/EthFlow/EthFlowStepper/StatusIcon.tsx
@@ -34,7 +34,7 @@ const StepIcon = styled.div<{ status: StatusIconState }>`
       ? 'none'
       : status === 'success'
       ? 'none'
-      : `2px solid var(${UI.COLOR_PAPER_DARKER})`};
+      : `2px solid var(${UI.COLOR_PAPER})`};
   box-shadow: ${({ status, theme }) => (status === 'pending' ? theme.boxShadow3 : 'none')};
   background: ${({ status, theme }) =>
     status === 'pending'


### PR DESCRIPTION
# Summary

Eth flow stepper border colors were missing.

Before

![image](https://github.com/cowprotocol/cowswap/assets/43217/fe6439b7-63c5-4ea1-8f81-204e32262437)

Now

![Screenshot 2023-12-20 at 16 38 50](https://github.com/cowprotocol/cowswap/assets/43217/f3d82f06-bb60-4814-a380-2c02c7c7b28f)
![Screenshot 2023-12-20 at 16 39 21](https://github.com/cowprotocol/cowswap/assets/43217/1c169b23-5889-450f-b676-2f32972ce442)

  # To Test

1. Place and eth-flow order
* Pending steps border should be shown