### PR TITLE
fix: unsupported token button text color

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/swap/UnsupportedCurrencyFooter/UnsupportedCurrencyFooterMod.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/swap/UnsupportedCurrencyFooter/UnsupportedCurrencyFooterMod.tsx
@@ -1,11 +1,8 @@
 import { useState } from 'react'
 
 import { getEtherscanLink, getWrappedToken } from '@cowprotocol/common-utils'
-import { useIsUnsupportedToken } from '@cowprotocol/tokens'
-import { TokenLogo } from '@cowprotocol/tokens'
-import { ButtonEmpty } from '@cowprotocol/ui'
-import { AutoRow, RowBetween } from '@cowprotocol/ui'
-import { ExternalLink } from '@cowprotocol/ui'
+import { TokenLogo, useIsUnsupportedToken } from '@cowprotocol/tokens'
+import { AutoRow, ButtonEmpty, ExternalLink, RowBetween } from '@cowprotocol/ui'
 import { useWalletInfo } from '@cowprotocol/wallet'
 import { Currency } from '@uniswap/sdk-core'
 
@@ -117,7 +114,7 @@ export default function UnsupportedCurrencyFooter({
         </Card>
       </Modal>
       <StyledButtonEmpty padding={'0'} onClick={() => setShowDetails(true)}>
-        <ThemedText.Error error={!!showDetailsText}>
+        <ThemedText.Error error={!!showDetailsText} color={'danger'}>
           <Trans>{showDetailsText}</Trans>
         </ThemedText.Error>
       </StyledButtonEmpty>

--- a/apps/cowswap-frontend/src/legacy/theme/styled.d.ts
+++ b/apps/cowswap-frontend/src/legacy/theme/styled.d.ts
@@ -51,9 +51,7 @@ interface ColorsUniswap {
   primary3: Color
   primary4: Color
   primary5: Color
-
-  text1: Color
-
+  
   // pinks
   secondary1: Color
   secondary2: Color
@@ -71,9 +69,6 @@ interface ColorsUniswap {
   blue2: Color
   blue4: Color
 
-  error: Color
-  success: Color
-  warning: Color
 }
 
 // Override colors
@@ -103,7 +98,6 @@ export interface Colors extends ColorsUniswap {
   info: Color
   information: Color
   warning: Color
-  danger: Color
   alert: Color
   alert2: Color
   error: Color


### PR DESCRIPTION
# Summary

Before
![image](https://github.com/cowprotocol/cowswap/assets/43217/92a2b687-d43e-40e9-9dab-88711984b9ec)

After
![Screenshot 2023-12-20 at 17 22 00](https://github.com/cowprotocol/cowswap/assets/43217/8e2e24ff-2e21-4726-afb2-f0db444ca9ba)
![Screenshot 2023-12-20 at 17 22 11](https://github.com/cowprotocol/cowswap/assets/43217/475ff75b-1967-4e9f-a70c-f10ba81926d9)

# To Test

1. Select unsupported token (such as AST on gchain)
* Unsupported token button should be visible with the correct text color