### PR TITLE
fix: terms and conditions link hover color

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/Card/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Card/index.tsx
@@ -24,7 +24,7 @@ export const LightCard = styled(Card)`
     width: 100%;
     border-radius: 16px;
     height: 100%;
-    border: 1px solid var(${UI.COLOR_PAPER_DARKER});
+    border: 1px solid var(${UI.COLOR_TEXT_PAPER});
     opacity: 0.2;
     user-select: none;
     pointer-events: none;

--- a/apps/cowswap-frontend/src/legacy/theme/components.tsx
+++ b/apps/cowswap-frontend/src/legacy/theme/components.tsx
@@ -81,7 +81,7 @@ export const StyledInternalLink = styled(Link)`
 
   :hover {
     text-decoration: underline;
-    color: var(${UI.COLOR_PRIMARY_DARKER});
+    color: var(${UI.COLOR_PRIMARY});
   }
 
   :focus {


### PR DESCRIPTION
# Summary

Before
![image](https://github.com/cowprotocol/cowswap/assets/43217/6301a3be-b4cb-47a8-a359-a83785282ef4)

After
![image](https://github.com/cowprotocol/cowswap/assets/43217/557b008b-6a2c-4a51-bc09-ec21ff4e1911)
![image](https://github.com/cowprotocol/cowswap/assets/43217/a256dd90-a4d9-4c8a-8b4e-9c69bc9bbece)


  # To Test

1. Change wallet
2. Hover over t&c
* Link is visible