### PR TITLE
Revert "fix: terms and conditions link hover color (#3538)"

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/Card/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Card/index.tsx
@@ -24,7 +24,7 @@ export const LightCard = styled(Card)`
     width: 100%;
     border-radius: 16px;
     height: 100%;
-    border: 1px solid var(${UI.COLOR_TEXT_PAPER});
+    border: 1px solid var(${UI.COLOR_PAPER_DARKER});
     opacity: 0.2;
     user-select: none;
     pointer-events: none;

--- a/apps/cowswap-frontend/src/legacy/theme/components.tsx
+++ b/apps/cowswap-frontend/src/legacy/theme/components.tsx
@@ -81,7 +81,7 @@ export const StyledInternalLink = styled(Link)`
 
   :hover {
     text-decoration: underline;
-    color: var(${UI.COLOR_PRIMARY});
+    color: var(${UI.COLOR_PRIMARY_DARKER});
   }
 
   :focus {


### PR DESCRIPTION
This reverts commit f91aabb1573c3e9fc514efe4bb28169a4febe922.

# Summary
Revert https://github.com/cowprotocol/cowswap/pull/3538

Before:
![image](https://github.com/cowprotocol/cowswap/assets/2352112/70b74b67-a590-4285-a0dd-459f04199d06)


After:
![image](https://github.com/cowprotocol/cowswap/assets/2352112/1a189b15-1367-44f2-801b-1d4946adcd11)
