### PR TITLE
fix(trade): update allowance immediately after approval tx mined

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useApproveCallback.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useApproveCallback.ts
@@ -74,7 +74,7 @@ export function useApproveCallback(
         addTransaction({
           hash: response.hash,
           summary: amountToApprove.greaterThan('0') ? `Approve ${token.symbol}` : `Revoke ${token.symbol} approval`,
-          approval: { tokenAddress: token.address, spender },
+          approval: { tokenAddress: token.address, spender, amount: '0x' + amountToApprove.quotient.toString(16) },
         })
         return response
       })

--- a/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/index.tsx
@@ -21,7 +21,7 @@ interface AccountElementProps {
 export function AccountElement({ className, isWidgetMode, pendingActivities }: AccountElementProps) {
   const { account, chainId } = useWalletInfo()
   const isChainIdUnsupported = useIsProviderNetworkUnsupported()
-  const userEthBalance = useNativeCurrencyAmount()
+  const userEthBalance = useNativeCurrencyAmount(chainId, account)
   const toggleAccountModal = useToggleAccountModal()
   const nativeToken = NATIVE_CURRENCY_BUY_TOKEN[chainId].symbol
 

--- a/apps/cowswap-frontend/src/legacy/hooks/useApproveCallback/useApproveCallbackMod.ts
+++ b/apps/cowswap-frontend/src/legacy/hooks/useApproveCallback/useApproveCallbackMod.ts
@@ -147,7 +147,7 @@ export function useApproveCallback({
             addTransaction({
               hash: response.hash,
               summary: optionalParams?.transactionSummary || 'Approve ' + amountToApprove.currency.symbol,
-              approval: { tokenAddress: token.address, spender },
+              approval: { tokenAddress: token.address, spender, amount: '0x' + amountToApprove.quotient.toString(16) },
             })
             return response
           })
@@ -216,16 +216,19 @@ export function useApproveCallback({
           optionalParams?.modalMessage || `Revoke ${token.symbol} approval from ${spenderCurrency?.symbol || spender}`,
           ConfirmOperationType.REVOKE_APPROVE_TOKEN
         )
+
+      const amount = '0'
+
       return (
         tokenContract
-          .approve(spender, '0', {
+          .approve(spender, amount, {
             gasLimit: calculateGasMargin(estimatedGas),
           })
           .then((response: TransactionResponse) => {
             addTransaction({
               hash: response.hash,
               summary: optionalParams?.transactionSummary || `Revoke ${token.symbol} approval from ${spender}`,
-              approval: { tokenAddress: getWrappedToken(token).address, spender },
+              approval: { tokenAddress: getWrappedToken(token).address, spender, amount },
             })
           })
           // .catch((error: Error) => {

--- a/apps/cowswap-frontend/src/legacy/state/enhancedTransactions/reducer.test.ts
+++ b/apps/cowswap-frontend/src/legacy/state/enhancedTransactions/reducer.test.ts
@@ -13,13 +13,15 @@ describe('transaction reducer', () => {
   describe('addTransaction', () => {
     it('adds the transaction', () => {
       const beforeTime = new Date().getTime()
+      const approval = { tokenAddress: 'abc', spender: 'def', amount: '0x1' }
+
       store.dispatch(
         addTransaction({
           hash: '0x0',
           hashType: HashType.ETHEREUM_TX,
           chainId: 1,
           summary: 'hello world',
-          approval: { tokenAddress: 'abc', spender: 'def' },
+          approval,
           from: 'abc',
         })
       )
@@ -30,7 +32,7 @@ describe('transaction reducer', () => {
       expect(tx).toBeTruthy()
       expect(tx?.hash).toEqual('0x0')
       expect(tx?.summary).toEqual('hello world')
-      expect(tx?.approval).toEqual({ tokenAddress: 'abc', spender: 'def' })
+      expect(tx?.approval).toEqual(approval)
       expect(tx?.from).toEqual('abc')
       expect(tx?.addedTime).toBeGreaterThanOrEqual(beforeTime)
     })
@@ -62,7 +64,7 @@ describe('transaction reducer', () => {
           hash: '0x0',
           hashType: HashType.ETHEREUM_TX,
           chainId: 4,
-          approval: { spender: '0x0', tokenAddress: '0x0' },
+          approval: { spender: '0x0', tokenAddress: '0x0', amount: '0x1' },
           summary: 'hello world',
           from: '0x0',
         })
@@ -117,7 +119,7 @@ describe('transaction reducer', () => {
           hash: '0x0',
           hashType: HashType.ETHEREUM_TX,
           chainId: 4,
-          approval: { spender: '0x0', tokenAddress: '0x0' },
+          approval: { spender: '0x0', tokenAddress: '0x0', amount: '0x1' },
           summary: 'hello world',
           from: '0x0',
         })
@@ -138,7 +140,7 @@ describe('transaction reducer', () => {
           hash: '0x0',
           hashType: HashType.ETHEREUM_TX,
           chainId: 4,
-          approval: { spender: '0x0', tokenAddress: '0x0' },
+          approval: { spender: '0x0', tokenAddress: '0x0', amount: '0x1' },
           summary: 'hello world',
           from: '0x0',
         })
@@ -170,7 +172,7 @@ describe('transaction reducer', () => {
           hashType: HashType.ETHEREUM_TX,
           chainId: 1,
           summary: 'hello world',
-          approval: { tokenAddress: 'abc', spender: 'def' },
+          approval: { tokenAddress: 'abc', spender: 'def', amount: '0x1' },
           from: 'abc',
         })
       )
@@ -180,7 +182,7 @@ describe('transaction reducer', () => {
           hashType: HashType.ETHEREUM_TX,
           chainId: 4,
           summary: 'hello world',
-          approval: { tokenAddress: 'abc', spender: 'def' },
+          approval: { tokenAddress: 'abc', spender: 'def', amount: '0x1' },
           from: 'abc',
         })
       )

--- a/apps/cowswap-frontend/src/legacy/state/enhancedTransactions/reducer.ts
+++ b/apps/cowswap-frontend/src/legacy/state/enhancedTransactions/reducer.ts
@@ -36,7 +36,12 @@ export interface EnhancedTransactionDetails {
   data?: any // any attached data type
 
   // Operations
-  approval?: { tokenAddress: string; spender: string }
+  approval?: {
+    tokenAddress: string
+    spender: string
+    // Hex string
+    amount: string
+  }
   presign?: { orderId: string }
   claim?: { recipient: string; cowAmountRaw?: string; indices: number[] }
   swapVCow?: boolean

--- a/apps/cowswap-frontend/src/modules/swap/services/ethFlow/transactionsMocks.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/ethFlow/transactionsMocks.ts
@@ -84,6 +84,7 @@ export function mockEthFlowPendingTxs() {
       approval: {
         tokenAddress: '0x02ABBDbAaa7b1BB64B5c878f7ac17f8DDa169532',
         spender: '0xC92E8bdf79f0507f65a392b0ab4667716BFE0110',
+        amount: '0x1',
       },
       summary: 'Approve GNO',
     })
@@ -98,6 +99,7 @@ export function mockEthFlowPendingTxs() {
       approval: {
         tokenAddress: '0x02ABBDbAaa7b1BB64B5c878f7ac17f8DDa169532',
         spender: '0xC92E8bdf79f0507f65a392b0ab4667716BFE0110',
+        amount: '0x1',
       },
       summary: 'Approve GNO',
     })
@@ -128,6 +130,7 @@ export function mockEthFlowPendingTxs() {
       approval: {
         tokenAddress: '0x02ABBDbAaa7b1BB64B5c878f7ac17f8DDa169532',
         spender: '0xC92E8bdf79f0507f65a392b0ab4667716BFE0110',
+        amount: '0x1',
       },
       summary: 'Approve GNO',
     })

--- a/libs/balances-and-allowances/src/hooks/useAddPriorityAllowance.ts
+++ b/libs/balances-and-allowances/src/hooks/useAddPriorityAllowance.ts
@@ -22,12 +22,10 @@ export function useAddPriorityAllowance() {
 
   return useCallback(
     ({ chainId, account, tokenAddress, blockNumber }: PriorityAllowanceParams) => {
-      if (!provider || !account) return undefined
+      if (!provider || !account || !blockNumber) return undefined
 
       const spender = GP_VAULT_RELAYER[chainId]
       const tokenContract = new Contract(tokenAddress, ERC_20_INTERFACE, provider) as Erc20
-
-      if (!blockNumber) return
 
       tokenContract.callStatic.allowance(account, spender, { blockTag: blockNumber }).then((result) => {
         setAllowance((state) => ({

--- a/libs/balances-and-allowances/src/hooks/useAddPriorityAllowance.ts
+++ b/libs/balances-and-allowances/src/hooks/useAddPriorityAllowance.ts
@@ -1,0 +1,47 @@
+import { useSetAtom } from 'jotai/index'
+import { useCallback } from 'react'
+
+import { Erc20, ERC_20_INTERFACE } from '@cowprotocol/abis'
+import { GP_VAULT_RELAYER } from '@cowprotocol/common-const'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { Contract } from '@ethersproject/contracts'
+import { useWeb3React } from '@web3-react/core'
+
+import { allowancesFullState } from '../state/allowancesAtom'
+
+interface PriorityAllowanceParams {
+  account: string | undefined
+  chainId: SupportedChainId
+  tokenAddress: string
+  blockNumber: number
+}
+
+export function useAddPriorityAllowance() {
+  const { provider } = useWeb3React()
+  const setAllowance = useSetAtom(allowancesFullState)
+
+  return useCallback(
+    ({ chainId, account, tokenAddress, blockNumber }: PriorityAllowanceParams) => {
+      if (!provider || !account) return undefined
+
+      const spender = GP_VAULT_RELAYER[chainId]
+      const tokenContract = new Contract(tokenAddress, ERC_20_INTERFACE, provider) as Erc20
+
+      if (!blockNumber) return
+
+      tokenContract.callStatic.allowance(account, spender, { blockTag: blockNumber }).then((result) => {
+        setAllowance((state) => ({
+          ...state,
+          priorityValues: {
+            ...state.priorityValues,
+            [tokenAddress.toLowerCase()]: {
+              value: result,
+              timestamp: Date.now(),
+            },
+          },
+        }))
+      })
+    },
+    [provider, setAllowance]
+  )
+}

--- a/libs/balances-and-allowances/src/hooks/useNativeCurrencyAmount.ts
+++ b/libs/balances-and-allowances/src/hooks/useNativeCurrencyAmount.ts
@@ -1,14 +1,16 @@
 import { useMemo } from 'react'
 
 import { NATIVE_CURRENCY_BUY_TOKEN, TokenWithLogo } from '@cowprotocol/common-const'
-import { useWalletInfo } from '@cowprotocol/wallet'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { CurrencyAmount } from '@uniswap/sdk-core'
 
 import { useNativeTokenBalance } from './useNativeTokenBalance'
 
-export function useNativeCurrencyAmount(): CurrencyAmount<TokenWithLogo> | undefined {
-  const { chainId } = useWalletInfo()
-  const { data: nativeTokenBalance } = useNativeTokenBalance()
+export function useNativeCurrencyAmount(
+  chainId: SupportedChainId,
+  account: string | undefined
+): CurrencyAmount<TokenWithLogo> | undefined {
+  const { data: nativeTokenBalance } = useNativeTokenBalance(account)
 
   return useMemo(() => {
     if (!nativeTokenBalance) return undefined

--- a/libs/balances-and-allowances/src/hooks/useNativeTokenBalance.ts
+++ b/libs/balances-and-allowances/src/hooks/useNativeTokenBalance.ts
@@ -1,5 +1,4 @@
 import { getMulticallContract } from '@cowprotocol/multicall'
-import { useWalletInfo } from '@cowprotocol/wallet'
 import { BigNumber } from '@ethersproject/bignumber'
 import { useWeb3React } from '@web3-react/core'
 
@@ -8,20 +7,17 @@ import useSWR, { SWRResponse } from 'swr'
 
 const SWR_CONFIG = { refreshInterval: ms`11s` }
 
-export function useNativeTokenBalance(customAccount?: string): SWRResponse<BigNumber | undefined> {
+export function useNativeTokenBalance(account: string | undefined): SWRResponse<BigNumber | undefined> {
   const { provider } = useWeb3React()
-  const { account } = useWalletInfo()
-
-  const balanceAccount = customAccount || account
 
   return useSWR(
-    ['useNativeTokenBalance', balanceAccount, provider],
+    ['useNativeTokenBalance', account, provider],
     async () => {
-      if (!provider || !balanceAccount) return undefined
+      if (!provider || !account) return undefined
 
       const contract = getMulticallContract(provider)
 
-      return contract.callStatic.getEthBalance(balanceAccount)
+      return contract.callStatic.getEthBalance(account)
     },
     SWR_CONFIG
   )

--- a/libs/balances-and-allowances/src/hooks/usePersistBalancesAndAllowances.ts
+++ b/libs/balances-and-allowances/src/hooks/usePersistBalancesAndAllowances.ts
@@ -11,7 +11,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 
 import { SWRConfiguration } from 'swr'
 
-import { AllowancesState, allowancesState } from '../state/allowancesAtom'
+import { AllowancesState, allowancesFullState } from '../state/allowancesAtom'
 import { balancesAtom, BalancesState } from '../state/balancesAtom'
 
 const MULTICALL_OPTIONS = {}
@@ -29,10 +29,10 @@ export function usePersistBalancesAndAllowances(params: PersistBalancesAndAllowa
   const { account, chainId, tokenAddresses, setLoadingState, balancesSwrConfig, allowancesSwrConfig } = params
 
   const setBalances = useSetAtom(balancesAtom)
-  const setAllowances = useSetAtom(allowancesState)
+  const setAllowances = useSetAtom(allowancesFullState)
 
   const resetBalances = useResetAtom(balancesAtom)
-  const resetAllowances = useResetAtom(allowancesState)
+  const resetAllowances = useResetAtom(allowancesFullState)
 
   const spender = GP_VAULT_RELAYER[chainId]
 

--- a/libs/balances-and-allowances/src/hooks/useTokensAllowances.ts
+++ b/libs/balances-and-allowances/src/hooks/useTokensAllowances.ts
@@ -1,7 +1,8 @@
 import { useAtomValue } from 'jotai'
 
-import { AllowancesState, allowancesState } from '../state/allowancesAtom'
+import { allowancesReadState } from '../state/allowancesAtom'
+import { Erc20MulticallState } from '../types'
 
-export function useTokensAllowances(): AllowancesState {
-  return useAtomValue(allowancesState)
+export function useTokensAllowances(): Erc20MulticallState {
+  return useAtomValue(allowancesReadState)
 }

--- a/libs/balances-and-allowances/src/index.ts
+++ b/libs/balances-and-allowances/src/index.ts
@@ -10,6 +10,7 @@ export { useNativeTokensBalances } from './hooks/useNativeTokensBalances'
 export { useNativeCurrencyAmount } from './hooks/useNativeCurrencyAmount'
 export { useCurrencyAmountBalance } from './hooks/useCurrencyAmountBalance'
 export { useTokenBalanceForAccount } from './hooks/useTokenBalanceForAccount'
+export { useAddPriorityAllowance } from './hooks/useAddPriorityAllowance'
 
 // Types
 export type { BalancesState } from './state/balancesAtom'

--- a/libs/balances-and-allowances/src/state/allowancesAtom.ts
+++ b/libs/balances-and-allowances/src/state/allowancesAtom.ts
@@ -16,7 +16,7 @@ const PRIORITY_VALUE_TTL = ms`30s`
 export interface AllowancesState extends Erc20MulticallState {
   /**
    * Since we update allowances periodically, we have a lag between the current allowance (in atom) and the actual allowance (blockchain)
-   * To avid this, we have a priority value that is updated immediately after tx mined (see FinalizeTxUpdater)
+   * To avoid this, we have a priority value that is updated immediately after tx mined (see FinalizeTxUpdater)
    */
   priorityValues: {
     [address: string]: {

--- a/libs/balances-and-allowances/src/state/allowancesAtom.ts
+++ b/libs/balances-and-allowances/src/state/allowancesAtom.ts
@@ -1,7 +1,47 @@
+import { atom } from 'jotai'
 import { atomWithReset } from 'jotai/utils'
+
+import { BigNumber } from '@ethersproject/bignumber'
+
+import ms from 'ms.macro'
 
 import { Erc20MulticallState } from '../types'
 
-export interface AllowancesState extends Erc20MulticallState {}
+/**
+ * Priority value is valid for 30 seconds after tx mined
+ * After that, we use allowance from Updaters
+ */
+const PRIORITY_VALUE_TTL = ms`30s`
 
-export const allowancesState = atomWithReset<AllowancesState>({ isLoading: false, values: {} })
+export interface AllowancesState extends Erc20MulticallState {
+  /**
+   * Since we update allowances periodically, we have a lag between the current allowance (in atom) and the actual allowance (blockchain)
+   * To avid this, we have a priority value that is updated immediately after tx mined (see FinalizeTxUpdater)
+   */
+  priorityValues: {
+    [address: string]: {
+      value: BigNumber | undefined
+      timestamp: number
+    }
+  }
+}
+
+export const allowancesFullState = atomWithReset<AllowancesState>({ isLoading: false, values: {}, priorityValues: {} })
+
+export const allowancesReadState = atom<Erc20MulticallState>((get) => {
+  const { values, priorityValues, isLoading } = get(allowancesFullState)
+
+  const computedValues = Object.keys(values).reduce<Erc20MulticallState['values']>((acc, address) => {
+    const priorityValue = priorityValues[address]
+    const isPriorityValueValid = priorityValue && Date.now() - priorityValue.timestamp < PRIORITY_VALUE_TTL
+
+    acc[address] = isPriorityValueValid ? priorityValue.value : values[address]
+
+    return acc
+  }, {})
+
+  return {
+    isLoading,
+    values: computedValues,
+  }
+})

--- a/libs/balances-and-allowances/src/updaters/BalancesAndAllowancesUpdater.ts
+++ b/libs/balances-and-allowances/src/updaters/BalancesAndAllowancesUpdater.ts
@@ -23,7 +23,7 @@ export function BalancesAndAllowancesUpdater({ account, chainId }: BalancesAndAl
   const setBalances = useSetAtom(balancesAtom)
 
   const allTokens = useAllTokens()
-  const { data: nativeTokenBalance } = useNativeTokenBalance()
+  const { data: nativeTokenBalance } = useNativeTokenBalance(account)
 
   const tokenAddresses = useMemo(() => allTokens.map((token) => token.address), [allTokens])
 


### PR DESCRIPTION
# Summary

Fixes #3533

Once a notification with approval success appears, the trade form state should changes from "Allow CoW Swap to use your..." to "Swap/Place order"

<img width="275" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/424596a8-7816-423a-ad96-278f8e058dce">


  # To Test
  
Only for trade widgets (Swap/Limit/Twap)!
The improvement doesn't affect eth-flow.

1. Approve a token
2. Wait for green "Approve" notification
- [ ] along with the notification you should become able to place an order