### PR TITLE
fix: filter out twap orders from limit

### DIFF
--- a/apps/cowswap-frontend/src/cowSdk.ts
+++ b/apps/cowswap-frontend/src/cowSdk.ts
@@ -1,5 +1,4 @@
 import { MetadataApi } from '@cowprotocol/app-data'
-import { isBarnBackendEnv } from '@cowprotocol/common-utils'
 import { OrderBookApi } from '@cowprotocol/cow-sdk'
 
 const prodBaseUrls = process.env.REACT_APP_ORDER_BOOK_URLS
@@ -8,6 +7,6 @@ const prodBaseUrls = process.env.REACT_APP_ORDER_BOOK_URLS
 
 export const metadataApiSDK = new MetadataApi()
 export const orderBookApi = new OrderBookApi({
-  env: isBarnBackendEnv ? 'staging' : 'prod',
+  env: 'prod',
   ...(prodBaseUrls ? { baseUrls: prodBaseUrls } : undefined),
 })

--- a/apps/cowswap-frontend/src/cowSdk.ts
+++ b/apps/cowswap-frontend/src/cowSdk.ts
@@ -1,4 +1,5 @@
 import { MetadataApi } from '@cowprotocol/app-data'
+import { isBarnBackendEnv } from '@cowprotocol/common-utils'
 import { OrderBookApi } from '@cowprotocol/cow-sdk'
 
 const prodBaseUrls = process.env.REACT_APP_ORDER_BOOK_URLS
@@ -7,6 +8,6 @@ const prodBaseUrls = process.env.REACT_APP_ORDER_BOOK_URLS
 
 export const metadataApiSDK = new MetadataApi()
 export const orderBookApi = new OrderBookApi({
-  env: 'prod',
+  env: isBarnBackendEnv ? 'staging' : 'prod',
   ...(prodBaseUrls ? { baseUrls: prodBaseUrls } : undefined),
 })

--- a/apps/cowswap-frontend/src/modules/ordersTable/containers/OrdersTableWidget/hooks/useOrdersTableList.ts
+++ b/apps/cowswap-frontend/src/modules/ordersTable/containers/OrdersTableWidget/hooks/useOrdersTableList.ts
@@ -2,6 +2,10 @@ import { useMemo } from 'react'
 
 import { Order, PENDING_STATES } from 'legacy/state/orders/actions'
 
+import { getIsComposableCowOrder } from 'utils/orderUtils/getIsComposableCowOrder'
+import { getIsNotComposableCowOrder } from 'utils/orderUtils/getIsNotComposableCowOrder'
+
+import { TabOrderTypes } from '../../../pure/OrdersTableContainer'
 import { groupOrdersTable } from '../../../utils/groupOrdersTable'
 import { getParsedOrderFromTableItem, isParsedOrder, OrderTableItem } from '../../../utils/orderTableGroupUtils'
 
@@ -19,7 +23,7 @@ const ordersSorter = (a: OrderTableItem, b: OrderTableItem) => {
 
 const ORDERS_LIMIT = 100
 
-export function useOrdersTableList(allOrders: Order[]): OrdersTableList {
+export function useOrdersTableList(allOrders: Order[], orderType: TabOrderTypes): OrdersTableList {
   const allSortedOrders = useMemo(() => {
     return groupOrdersTable(allOrders).sort(ordersSorter)
   }, [allOrders])
@@ -28,6 +32,14 @@ export function useOrdersTableList(allOrders: Order[]): OrdersTableList {
     const { pending, history } = allSortedOrders.reduce(
       (acc, item) => {
         const order = isParsedOrder(item) ? item : item.parent
+
+        if (
+          (orderType === TabOrderTypes.ADVANCED && getIsNotComposableCowOrder(order)) ||
+          (orderType === TabOrderTypes.LIMIT && getIsComposableCowOrder(order))
+        ) {
+          // Skip if order type doesn't match
+          return acc
+        }
 
         if (PENDING_STATES.includes(order.status)) {
           acc.pending.push(item)
@@ -41,5 +53,5 @@ export function useOrdersTableList(allOrders: Order[]): OrdersTableList {
     )
 
     return { pending: pending.slice(0, ORDERS_LIMIT), history: history.slice(0, ORDERS_LIMIT) }
-  }, [allSortedOrders])
+  }, [allSortedOrders, orderType])
 }

--- a/apps/cowswap-frontend/src/modules/ordersTable/containers/OrdersTableWidget/hooks/useOrdersTableList.ts
+++ b/apps/cowswap-frontend/src/modules/ordersTable/containers/OrdersTableWidget/hooks/useOrdersTableList.ts
@@ -33,10 +33,10 @@ export function useOrdersTableList(allOrders: Order[], orderType: TabOrderTypes)
       (acc, item) => {
         const order = isParsedOrder(item) ? item : item.parent
 
-        if (
-          (orderType === TabOrderTypes.ADVANCED && getIsNotComposableCowOrder(order)) ||
-          (orderType === TabOrderTypes.LIMIT && getIsComposableCowOrder(order))
-        ) {
+        const advancedTabNonAdvancedOrder = orderType === TabOrderTypes.ADVANCED && getIsNotComposableCowOrder(order)
+        const limitTabNonLimitOrder = orderType === TabOrderTypes.LIMIT && getIsComposableCowOrder(order)
+
+        if (advancedTabNonAdvancedOrder || limitTabNonLimitOrder) {
           // Skip if order type doesn't match
           return acc
         }

--- a/apps/cowswap-frontend/src/modules/ordersTable/containers/OrdersTableWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/containers/OrdersTableWidget/index.tsx
@@ -67,7 +67,7 @@ export function OrdersTableWidget({
   const location = useLocation()
   const navigate = useNavigate()
   const cancelOrder = useCancelOrder()
-  const ordersList = useOrdersTableList(allOrders)
+  const ordersList = useOrdersTableList(allOrders, orderType)
   const { allowsOffchainSigning } = useWalletDetails()
   const pendingOrdersPrices = useAtomValue(pendingOrdersPricesAtom)
   const ordersToCancel = useAtomValue(ordersToCancelAtom)

--- a/apps/cowswap-frontend/src/utils/orderUtils/getIsComposableCowOrder.ts
+++ b/apps/cowswap-frontend/src/utils/orderUtils/getIsComposableCowOrder.ts
@@ -1,0 +1,15 @@
+import { getIsNotComposableCowOrder } from './getIsNotComposableCowOrder'
+
+import { ComposableCowInfo } from '../../common/types'
+
+const TWAP_ORDER_REGEX = /"orderClass":\s*"twap"/
+
+export function getIsComposableCowOrder(order?: {
+  composableCowInfo?: ComposableCowInfo
+  fullAppData?: string | null
+}): boolean {
+  return (
+    !getIsNotComposableCowOrder(order) || // this check only works for orders placed in the same device, thus orders loaded from the API will never have this
+    TWAP_ORDER_REGEX.test(order?.fullAppData || '') // this check assumes the appData is correctly filled
+  )
+}


### PR DESCRIPTION
# Summary

Fixes #3549 

Each order type on its own table.

Only load LIMIT on LIMIT table, only load TWAP on TWAP table.

It's tricky to identify TWAP orders not created on the same device, as the TWAP part order type is LIMIT.
This PR adds a work around relying on the appData `orderClass`.
Not 100% reliable as this is not guaranteed to be filled in.

# To Test

⚠️ This PR uses PROD backend so the behaviour can be tested ⚠️ 
⚠️ dd2bb3c7ef053a1a617c551c31dc86aed9cd4534 SHOULD BE REVERTED BEFORE MERGING ⚠️ 

1. Open [this safe](https://app.safe.global/apps/open?safe=gno:0x42cEDde51198D1773590311E2A340DC06B24cB37)
2. Add this PR's url as a custom Safe app: https://swap-dev-git-fix-3549filter-out-twap-orders-from-limit-cowswap.vercel.app/
3. Check the limit orders tab
* It should be empty 
![image](https://github.com/cowprotocol/cowswap/assets/43217/10bcc8e3-69a0-4fb0-83c0-c3b142dc6384)
4. For comparison, on the same Safe, open prod CoW Swap App (swap.cow.fi)
* There all TWAP part orders are loaded in the LIMIT orders table
![image](https://github.com/cowprotocol/cowswap/assets/43217/230a0432-ea60-4ec6-b075-f0e14499d77e)

5. With another Safe that you own, place a TWAP order
* Should display as usual in the TWAP table
6. Place a LIMIT order
* Should display as usual in the LIMIT table