### PR TITLE
fix(wallets): send request to switch network

### DIFF
--- a/libs/wallet/src/web3-react/connection/injected.tsx
+++ b/libs/wallet/src/web3-react/connection/injected.tsx
@@ -11,15 +11,18 @@ import { ConnectionOptionProps, Web3ReactConnection } from '../types'
 
 import { onError } from './onError'
 import { useIsActiveConnection } from '../hooks/useIsActiveConnection'
+import { AddEthereumChainParameter } from '@web3-react/types'
 
 class MetaMaskEnhanced extends MetaMask {
   /**
    * The trick is to override the activate method in order to call it without parameters
    * Because if we call it as activate(chainId)
    * It will request network change if the wallet is connected to a different chain
+   *
+   * @param chain when number, it means the initial request to connect, otherwise it's a request to change network
    */
-  activate(): Promise<void> {
-    return super.activate()
+  activate(chain: number | AddEthereumChainParameter): Promise<void> {
+    return super.activate(typeof chain === 'number' ? undefined : chain)
   }
 }
 


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C0361CDG8GP/p1703180798915089?thread_ts=1703151865.359929&cid=C0361CDG8GP

After [the fix](https://github.com/cowprotocol/cowswap/pull/3544) we lost an ability to change network using Metamask.

  # To Test

1. Disconnect wallet
2. Select mainnet in CoW Swap UI
3. Select Gnosis chain in Metamask
4. Try to connect to Metamask
- [ ] CoW Swap should switch to Gnosis chain automatically
5. Switch network to Goerli in CoW Swap ui
- [ ] wallet should receive a request to switch network
- [ ] after accepting the request the network should be applied to the wallet and to CoW Swap
