### PR TITLE
fix(swap): don't add/sub fee for swap orders

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/featureFlags/useFeatureFlags.ts
+++ b/apps/cowswap-frontend/src/common/hooks/featureFlags/useFeatureFlags.ts
@@ -1,4 +1,5 @@
-// TODO: revert this change, this is just for testing
+import { useFlags } from 'launchdarkly-react-client-sdk'
+
 export function useFeatureFlags() {
-  return { swapZeroFee: true } as any
+  return useFlags()
 }

--- a/apps/cowswap-frontend/src/common/hooks/featureFlags/useFeatureFlags.ts
+++ b/apps/cowswap-frontend/src/common/hooks/featureFlags/useFeatureFlags.ts
@@ -1,5 +1,4 @@
-import { useFlags } from 'launchdarkly-react-client-sdk'
-
+// TODO: revert this change, this is just for testing
 export function useFeatureFlags() {
-  return useFlags()
+  return { swapZeroFee: true } as any
 }

--- a/apps/cowswap-frontend/src/legacy/hooks/useRefetchPriceCallback.tsx
+++ b/apps/cowswap-frontend/src/legacy/hooks/useRefetchPriceCallback.tsx
@@ -9,7 +9,7 @@ import {
   calculateValidTo,
   getQuoteUnsupportedToken,
 } from '@cowprotocol/common-utils'
-import { PriceQuality } from '@cowprotocol/cow-sdk'
+import { PriceQuality, OrderKind } from '@cowprotocol/cow-sdk'
 import { useAddUnsupportedToken, useIsUnsupportedToken, useRemoveUnsupportedToken } from '@cowprotocol/tokens'
 
 import { useGetGpPriceStrategy } from 'legacy/hooks/useGetGpPriceStrategy'
@@ -28,6 +28,8 @@ import GpQuoteError, {
   GpQuoteErrorDetails,
   isValidQuoteError,
 } from 'api/gnosisProtocol/errors/QuoteError'
+
+import { logSwapParams } from '../../modules/swap/helpers/logSwapParams'
 
 interface HandleQuoteErrorParams {
   quoteData: QuoteInformationObject | LegacyFeeQuoteParams
@@ -184,6 +186,13 @@ export function useRefetchQuoteCallback() {
           removeGpUnsupportedToken(previouslyUnsupportedToken)
         }
 
+        logSwapParams('quote', {
+          sellAmount: quoteData.kind === OrderKind.SELL ? quoteData.amount : price.value.amount,
+          buyAmount: quoteData.kind === OrderKind.BUY ? quoteData.amount : price.value.amount,
+          feeAmount: fee.value.amount,
+          sellDecimals: quoteData.fromDecimals,
+          buyDecimals: quoteData.toDecimals,
+        })
         // Update quote
         updateQuote({ ...quoteData, isBestQuote })
       }

--- a/apps/cowswap-frontend/src/modules/swap/helpers/getAmountsForSignature.test.ts
+++ b/apps/cowswap-frontend/src/modules/swap/helpers/getAmountsForSignature.test.ts
@@ -99,7 +99,7 @@ describe('getAmountsForSignature()', () => {
 
     /**
      * Sell amount is just what user entered
-     * Output amount calculated as: (outputAmount - slippage) - fee
+     * Output amount calculated as: outputAmount - slippage
      */
     it('Sell order', () => {
       const trade = getTrade({ tradeType: TradeType.EXACT_INPUT, inputAmount, outputAmount, feeAmount })
@@ -114,13 +114,12 @@ describe('getAmountsForSignature()', () => {
       // Input amount the same, because we don't subtract fee
       expect(result.inputAmount.toFixed()).toEqual('3012.000000')
 
-      // Fee in WETH = 0.005312084993359893
-      // outputAmount = (2 - 5%) - 0.005312 = 1.89468
-      expect(result.outputAmount.toFixed()).toEqual('1.894687915006640106')
+      // outputAmount = 2 - 5% = 1.894953
+      expect(result.outputAmount.toFixed()).toEqual('1.894953519256308100')
     })
 
     /**
-     * Sell amount calculated as: (inputAmount + slippage) + fee
+     * Sell amount calculated as: inputAmount + slippage
      * Output amount is just what user entered
      */
     it('Buy order', () => {
@@ -133,8 +132,8 @@ describe('getAmountsForSignature()', () => {
         kind: OrderKind.BUY,
       })
 
-      // inputAmount = (3012 + 5%) + 8 = 3170
-      expect(result.inputAmount.toFixed()).toEqual('3170.600000')
+      // inputAmount = 3012 + 5% = 3162.600000
+      expect(result.inputAmount.toFixed()).toEqual('3162.600000')
 
       // Output amount the same, because this is buy order
       expect(result.outputAmount.toFixed()).toEqual('2.000000000000000000')

--- a/apps/cowswap-frontend/src/modules/swap/helpers/getAmountsForSignature.ts
+++ b/apps/cowswap-frontend/src/modules/swap/helpers/getAmountsForSignature.ts
@@ -15,16 +15,13 @@ interface AmountForSignatureParams {
 
 function inputAmountForSignature(params: AmountForSignatureParams): CurrencyAmount<Currency> {
   const { trade, allowedSlippage, kind, featureFlags } = params
-  const fee = trade.fee.feeAsCurrency
   const slippageCoeff = ONE_FRACTION.add(allowedSlippage)
 
   if (featureFlags.swapZeroFee) {
     if (kind === OrderKind.SELL) {
       return trade.inputAmount
     } else {
-      return trade.inputAmountWithoutFee
-        .multiply(slippageCoeff) // add slippage
-        .add(fee) // add fee
+      return trade.inputAmountWithoutFee.multiply(slippageCoeff) // add slippage
     }
   }
 
@@ -41,13 +38,7 @@ function outputAmountForSignature(params: AmountForSignatureParams): CurrencyAmo
 
   if (featureFlags.swapZeroFee) {
     if (kind === OrderKind.SELL) {
-      const shouldRevertPrice = trade.executionPrice.quoteCurrency.equals(trade.fee.feeAsCurrency.currency)
-      const price = shouldRevertPrice ? trade.executionPrice.invert() : trade.executionPrice
-      const feeInOutputCurrency = price.quote(trade.fee.feeAsCurrency)
-
-      return trade.outputAmountWithoutFee
-        .multiply(slippageCoeff) // subtract slippage
-        .subtract(feeInOutputCurrency) // subtract fee
+      return trade.outputAmount.multiply(slippageCoeff) // subtract slippage
     } else {
       return trade.outputAmountWithoutFee
     }

--- a/apps/cowswap-frontend/src/modules/swap/helpers/logSwapParams.ts
+++ b/apps/cowswap-frontend/src/modules/swap/helpers/logSwapParams.ts
@@ -1,0 +1,12 @@
+type SwapParamsData = Record<string, string | number | null | undefined>
+
+const CACHE: Record<string, SwapParamsData> = {}
+
+export function logSwapParams(key: string, data: SwapParamsData) {
+  const cached = CACHE[key]
+
+  if (cached && JSON.stringify(cached) === JSON.stringify(data)) return
+
+  CACHE[key] = data
+  console.debug(`[SWAP PARAMS] ${key}`, data)
+}

--- a/apps/cowswap-frontend/src/modules/swap/helpers/logSwapParams.ts
+++ b/apps/cowswap-frontend/src/modules/swap/helpers/logSwapParams.ts
@@ -8,5 +8,5 @@ export function logSwapParams(key: string, data: SwapParamsData) {
   if (cached && JSON.stringify(cached) === JSON.stringify(data)) return
 
   CACHE[key] = data
-  console.debug(`[SWAP PARAMS] ${key}`, data)
+  console.log(`[SWAP PARAMS] ${key}`, data)
 }


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C036G0J90BU/p1703156515196189

This is a follow up of fee=zero feature.
The amount from Quote API already took into account the fee amount, so we don't need to substract it again.
The only this we should do is adding/substracting slippage.

![image](https://github.com/cowprotocol/cowswap/assets/7122625/2d9590d9-f546-4b63-b8a2-420cd33a3144)


  # To Test

In console you can find logs with prefix '[SWAP PARAMS]'.
`[SWAP PARAMS] quote` - displays what we got from quote
`[SWAP PARAMS] amounts to sign` - displays what we are going to sign


The simpliest way how to test:
1. Set slippage to 0
2. What you sign in your wallet must be the same what you got from Quote API
3. Set slippage to 50%
4. What you sign in your wallet must be 50% from what you got from Quote API