### PR TITLE
feat(fee=0): classify order types

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useCategorizeRecentActivity.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useCategorizeRecentActivity.ts
@@ -1,11 +1,10 @@
 import { useMemo } from 'react'
 
-import { OrderClass } from '@cowprotocol/cow-sdk'
-
 import { useRecentActivity } from 'legacy/hooks/useRecentActivity'
-import { OrderStatus, PENDING_STATES } from 'legacy/state/orders/actions'
+import { Order, OrderStatus, PENDING_STATES } from 'legacy/state/orders/actions'
 
 import { getIsFinalizedOrder } from 'utils/orderUtils/getIsFinalizedOrder'
+import { getUiOrderType, UiOrderType } from 'utils/orderUtils/getUiOrderType'
 
 export const isPending = ({ status }: { status: OrderStatus }) => PENDING_STATES.includes(status)
 
@@ -19,7 +18,7 @@ export function useCategorizeRecentActivity() {
       allRecentActivity.reduce<[string[], string[]]>(
         (acc, activity) => {
           // Only display regular on-chain transactions (wrap, approval, etc) OR MARKET orders
-          if (!activity.class || activity.class === OrderClass.MARKET) {
+          if (!activity.class || getUiOrderType(activity as Order) === UiOrderType.SWAP) {
             if (isPending(activity)) {
               acc[0].push(activity.id)
             } else if (getIsFinalizedOrder(activity)) {

--- a/apps/cowswap-frontend/src/common/updaters/orders/SpotPricesUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/SpotPricesUpdater.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef } from 'react'
 
 import { useIsWindowVisible } from '@cowprotocol/common-hooks'
 import { FractionUtils } from '@cowprotocol/common-utils'
-import { OrderClass, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { useWalletInfo } from '@cowprotocol/wallet'
 import { Token } from '@uniswap/sdk-core'
 
@@ -12,6 +12,8 @@ import { useCombinedPendingOrders } from 'legacy/state/orders/hooks'
 
 import { requestPrice } from 'modules/limitOrders/hooks/useGetInitialPrice'
 import { UpdateSpotPriceAtom, updateSpotPricesAtom } from 'modules/orders/state/spotPricesAtom'
+
+import { getUiOrderType, UiOrderType } from 'utils/orderUtils/getUiOrderType'
 
 import { useSafeMemo } from '../../hooks/useSafeMemo'
 import { getCanonicalMarketChainKey } from '../../utils/markets'
@@ -31,8 +33,8 @@ function useMarkets(chainId: SupportedChainId, account: string | undefined): Mar
   return useSafeMemo(() => {
     return pending.reduce<Record<string, { chainId: number; inputCurrency: Token; outputCurrency: Token }>>(
       (acc, order) => {
-        // Query spot prices only for Limit orders
-        if (order.class !== OrderClass.LIMIT) return acc
+        // Do not query spot prices for SWAP
+        if (getUiOrderType(order) === UiOrderType.SWAP) return acc
 
         // Aggregating pending orders per market. No need to query multiple times same market
         const { marketInverted, marketKey } = getCanonicalMarketChainKey(chainId, order.sellToken, order.buyToken)

--- a/apps/cowswap-frontend/src/common/updaters/orders/UnfillableOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/UnfillableOrdersUpdater.ts
@@ -1,5 +1,5 @@
 import { useSetAtom } from 'jotai'
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 
 import { priceOutOfRangeAnalytics } from '@cowprotocol/analytics'
 import { useTokensBalances } from '@cowprotocol/balances-and-allowances'
@@ -46,7 +46,7 @@ export function UnfillableOrdersUpdater(): null {
 
   const pendingLimit = useOnlyPendingOrders(chainId, UiOrderType.LIMIT)
   const pendingTwap = useOnlyPendingOrders(chainId, UiOrderType.TWAP)
-  const pending = pendingLimit.concat(pendingTwap)
+  const pending = useMemo(() => pendingLimit.concat(pendingTwap), [pendingLimit, pendingTwap])
 
   const setIsOrderUnfillable = useSetIsOrderUnfillable()
   const strategy = useGetGpPriceStrategy()

--- a/apps/cowswap-frontend/src/common/updaters/orders/UnfillableOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/UnfillableOrdersUpdater.ts
@@ -7,7 +7,7 @@ import { NATIVE_CURRENCY_BUY_ADDRESS, WRAPPED_NATIVE_CURRENCY } from '@cowprotoc
 import { useIsWindowVisible } from '@cowprotocol/common-hooks'
 import { getPromiseFulfilledValue } from '@cowprotocol/common-utils'
 import { timestamp } from '@cowprotocol/contracts'
-import { OrderClass, SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
+import { SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
 import { useWalletInfo } from '@cowprotocol/wallet'
 import { Currency, CurrencyAmount, Price } from '@uniswap/sdk-core'
 
@@ -30,6 +30,7 @@ import { updatePendingOrderPricesAtom } from 'modules/orders/state/pendingOrders
 import { hasEnoughBalanceAndAllowance } from 'modules/tokens'
 
 import { getPriceQuality } from 'api/gnosisProtocol/api'
+import { getUiOrderType, UiOrderType } from 'utils/orderUtils/getUiOrderType'
 
 import { PRICE_QUOTE_VALID_TO_TIME } from '../../constants/quote'
 import { useVerifiedQuotesEnabled } from '../../hooks/featureFlags/useVerifiedQuotesEnabled'
@@ -43,7 +44,10 @@ export function UnfillableOrdersUpdater(): null {
   const updatePendingOrderPrices = useSetAtom(updatePendingOrderPricesAtom)
   const isWindowVisible = useIsWindowVisible()
 
-  const pending = useOnlyPendingOrders(chainId, OrderClass.LIMIT)
+  const pendingLimit = useOnlyPendingOrders(chainId, UiOrderType.LIMIT)
+  const pendingTwap = useOnlyPendingOrders(chainId, UiOrderType.TWAP)
+  const pending = pendingLimit.concat(pendingTwap)
+
   const setIsOrderUnfillable = useSetIsOrderUnfillable()
   const strategy = useGetGpPriceStrategy()
 
@@ -94,10 +98,12 @@ export function UnfillableOrdersUpdater(): null {
 
       const marketPrice = getOrderMarketPrice(order, price.amount, fee.amount)
       const estimatedExecutionPrice = getEstimatedExecutionPrice(order, marketPrice, fee.amount)
-      const isUnfillable = order.class === OrderClass.MARKET && isOrderUnfillable(order, orderPrice, marketPrice)
+
+      const isSwap = getUiOrderType(order) === UiOrderType.SWAP
+      const isUnfillable = isSwap && isOrderUnfillable(order, orderPrice, marketPrice)
 
       // Only trigger state update if flag changed
-      if (order.isUnfillable !== isUnfillable && order.class === OrderClass.MARKET) {
+      if (order.isUnfillable !== isUnfillable && isSwap) {
         setIsOrderUnfillable({ chainId, id: order.id, isUnfillable })
 
         // order.isUnfillable by default is undefined, so we don't want to dispatch this in that case

--- a/apps/cowswap-frontend/src/legacy/hooks/useRecentActivity.ts
+++ b/apps/cowswap-frontend/src/legacy/hooks/useRecentActivity.ts
@@ -2,13 +2,15 @@ import { useMemo } from 'react'
 
 import { MAXIMUM_ORDERS_TO_DISPLAY } from '@cowprotocol/common-const'
 import { getDateTimestamp } from '@cowprotocol/common-utils'
-import { OrderClass, SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
+import { SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
 import { useWalletInfo } from '@cowprotocol/wallet'
 
 import { isTransactionRecent, useAllTransactions, useTransactionsByHash } from 'legacy/state/enhancedTransactions/hooks'
 import { EnhancedTransactionDetails } from 'legacy/state/enhancedTransactions/reducer'
 import { Order, OrderStatus } from 'legacy/state/orders/actions'
 import { useCombinedPendingOrders, useOrder, useOrders, useOrdersById } from 'legacy/state/orders/hooks'
+
+import { UiOrderType } from 'utils/orderUtils/getUiOrderType'
 
 export interface AddedOrder extends Order {
   addedTime: number
@@ -48,7 +50,7 @@ enum TxReceiptStatus {
 export function useRecentActivity(): TransactionAndOrder[] {
   const { chainId, account } = useWalletInfo()
   const allTransactions = useAllTransactions()
-  const allNonEmptyOrders = useOrders(chainId, account, OrderClass.MARKET)
+  const allNonEmptyOrders = useOrders(chainId, account, UiOrderType.SWAP)
 
   const recentOrdersAdjusted = useMemo<TransactionAndOrder[]>(() => {
     return (

--- a/apps/cowswap-frontend/src/legacy/state/orders/actions.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/actions.ts
@@ -113,6 +113,7 @@ export type OrderInfoApi = Pick<
   | 'ethflowData'
   | 'onchainOrderData'
   | 'class'
+  | 'fullAppData'
 >
 
 /**

--- a/apps/cowswap-frontend/src/legacy/state/orders/hooks.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/hooks.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react'
 
 import { TokenWithLogo } from '@cowprotocol/common-const'
 import { isTruthy } from '@cowprotocol/common-utils'
-import { OrderClass, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -294,7 +294,7 @@ export const useCombinedPendingOrders = ({
  * The difference is that this hook returns only orders that have the status PENDING
  * while usePendingOrders aggregates all pending states
  */
-export const useOnlyPendingOrders = (chainId: SupportedChainId, orderClass: OrderClass): Order[] => {
+export const useOnlyPendingOrders = (chainId: SupportedChainId, uiOrderType: UiOrderType): Order[] => {
   const state = useSelector<AppState, PartialOrdersMap | undefined>(
     (state) => chainId && state.orders?.[chainId]?.pending
   )
@@ -303,10 +303,10 @@ export const useOnlyPendingOrders = (chainId: SupportedChainId, orderClass: Orde
     if (!state) return []
 
     return Object.values(state)
-      .filter((order) => order?.order.class === orderClass)
+      .filter((order) => order && getUiOrderType(order.order) === uiOrderType)
       .map(_deserializeOrder)
       .filter(isTruthy)
-  }, [state, orderClass])
+  }, [state, uiOrderType])
 }
 
 export const useCancelledOrders = ({ chainId }: GetOrdersParams): Order[] => {

--- a/apps/cowswap-frontend/src/legacy/state/orders/hooks.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/hooks.ts
@@ -6,11 +6,14 @@ import { OrderClass, SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import { useDispatch, useSelector } from 'react-redux'
 
+import { getUiOrderType, UiOrderType } from 'utils/orderUtils/getUiOrderType'
+
 import {
   addOrUpdateOrders,
   AddOrUpdateOrdersParams,
   addPendingOrder,
   cancelOrdersBatch,
+  clearOrdersStorage,
   expireOrdersBatch,
   fulfillOrdersBatch,
   FulfillOrdersBatchParams,
@@ -26,7 +29,6 @@ import {
   setOrderCancellationHash,
   updatePresignGnosisSafeTx,
   UpdatePresignGnosisSafeTxParams,
-  clearOrdersStorage,
 } from './actions'
 import { flatOrdersStateNetwork } from './flatOrdersStateNetwork'
 import {
@@ -181,7 +183,11 @@ function useOrdersStateNetwork(chainId: SupportedChainId | undefined): OrdersSta
   }, [JSON.stringify(ordersState), chainId])
 }
 
-export const useOrders = (chainId: SupportedChainId, account: string | undefined, orderClass: OrderClass): Order[] => {
+export const useOrders = (
+  chainId: SupportedChainId,
+  account: string | undefined,
+  uiOrderType: UiOrderType
+): Order[] => {
   const state = useOrdersStateNetwork(chainId)
   const accountLowerCase = account?.toLowerCase()
 
@@ -192,7 +198,8 @@ export const useOrders = (chainId: SupportedChainId, account: string | undefined
       if (!order) return acc
 
       const doesBelongToAccount = order.order.owner.toLowerCase() === accountLowerCase
-      const doesMatchClass = order.order.class === orderClass
+      const orderType = getUiOrderType(order.order)
+      const doesMatchClass = orderType === uiOrderType
 
       if (doesBelongToAccount && doesMatchClass) {
         const mappedOrder = _deserializeOrder(order)
@@ -204,7 +211,7 @@ export const useOrders = (chainId: SupportedChainId, account: string | undefined
 
       return acc
     }, [])
-  }, [state, accountLowerCase, orderClass])
+  }, [state, accountLowerCase, uiOrderType])
 }
 
 const useAllOrdersMap = ({ chainId }: GetOrdersParams): PartialOrdersMap => {

--- a/apps/cowswap-frontend/src/legacy/state/orders/middleware/appziMiddleware.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/middleware/appziMiddleware.ts
@@ -4,10 +4,12 @@ import {
   openNpsAppziSometimes,
   timeSinceInSeconds,
 } from '@cowprotocol/common-utils'
-import { OrderClass, SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
+import { SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
 
 import { isAnyOf } from '@reduxjs/toolkit'
 import { AnyAction, Dispatch, Middleware, MiddlewareAPI } from 'redux'
+
+import { getUiOrderType, UiOrderType } from 'utils/orderUtils/getUiOrderType'
 
 import { AppState } from '../../index'
 import * as OrderActions from '../actions'
@@ -49,9 +51,12 @@ function _triggerNps(
   const openSince = order?.openSince
   const explorerUrl = getExplorerOrderLink(chainId, orderId)
 
+  const uiOrderType = order && getUiOrderType(order)
+
+  // TODO: should we show NPS for TWAP orders as well?
   // Open Appzi NPS for limit orders only if they were filled before `PENDING_TOO_LONG_TIME` since creating
   const isLimitOrderRecentlyTraded =
-    order?.class === OrderClass.LIMIT && npsParams?.traded && isOrderInPendingTooLong(openSince)
+    uiOrderType === UiOrderType.LIMIT && npsParams?.traded && isOrderInPendingTooLong(openSince)
 
   // Do not show NPS if the order is hidden and expired
   const isHiddenAndExpired = order?.isHidden && npsParams?.expired

--- a/apps/cowswap-frontend/src/legacy/state/orders/utils.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/utils.ts
@@ -1,12 +1,13 @@
 import { ONE_HUNDRED_PERCENT, PENDING_ORDERS_BUFFER, ZERO_FRACTION } from '@cowprotocol/common-const'
 import { buildPriceFromCurrencyAmounts } from '@cowprotocol/common-utils'
-import { EnrichedOrder, OrderClass, OrderKind, OrderStatus } from '@cowprotocol/cow-sdk'
+import { EnrichedOrder, OrderKind, OrderStatus } from '@cowprotocol/cow-sdk'
 import { Currency, CurrencyAmount, Percent, Price } from '@uniswap/sdk-core'
 
 import JSBI from 'jsbi'
 
 import { getIsComposableCowParentOrder } from 'utils/orderUtils/getIsComposableCowParentOrder'
 import { getOrderSurplus } from 'utils/orderUtils/getOrderSurplus'
+import { getUiOrderType, UiOrderType } from 'utils/orderUtils/getUiOrderType'
 
 import { Order, updateOrder, UpdateOrderParams as UpdateOrderParamsAction } from './actions'
 import { OUT_OF_MARKET_PRICE_DELTA_PERCENTAGE } from './consts'
@@ -238,7 +239,7 @@ export function getEstimatedExecutionPrice(
   const outputAmount = CurrencyAmount.fromRawAmount(order.outputToken, order.buyAmount.toString())
   const limitPrice = buildPriceFromCurrencyAmounts(inputAmount, outputAmount)
 
-  if (order.class === OrderClass.MARKET) {
+  if (getUiOrderType(order) === UiOrderType.SWAP) {
     return limitPrice
   }
 

--- a/apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
@@ -1,13 +1,11 @@
 import { ReactNode } from 'react'
 
-import { V_COW_CONTRACT_ADDRESS, V_COW, COW } from '@cowprotocol/common-const'
+import { COW, V_COW, V_COW_CONTRACT_ADDRESS } from '@cowprotocol/common-const'
 import { ExplorerDataType, getExplorerLink, shortenAddress } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { useENS } from '@cowprotocol/ens'
-import { useTokenBySymbolOrAddress } from '@cowprotocol/tokens'
-import { TokenLogo } from '@cowprotocol/tokens'
-import { ExternalLink, TokenAmount } from '@cowprotocol/ui'
-import { UI } from '@cowprotocol/ui'
+import { TokenLogo, useTokenBySymbolOrAddress } from '@cowprotocol/tokens'
+import { ExternalLink, TokenAmount, UI } from '@cowprotocol/ui'
 import { CurrencyAmount } from '@uniswap/sdk-core'
 
 import { OrderProgressBar } from 'legacy/components/OrderProgressBar'
@@ -22,7 +20,7 @@ import { isPending } from 'common/hooks/useCategorizeRecentActivity'
 import { useGetSurplusData } from 'common/hooks/useGetSurplusFiatValue'
 import { Icon } from 'common/pure/Icon'
 import { BannerOrientation, CustomRecipientWarningBanner } from 'common/pure/InlineBanner/banners'
-import { RateInfoParams, RateInfo } from 'common/pure/RateInfo'
+import { RateInfo, RateInfoParams } from 'common/pure/RateInfo'
 import { SafeWalletLink } from 'common/pure/SafeWalletLink'
 import {
   useHideReceiverWalletBanner,
@@ -178,7 +176,7 @@ export function ActivityDetails(props: {
   const getShowCancellationModal = useCancelOrder()
 
   const showProgressBar = (activityState === 'open' || activityState === 'filled') && order?.class !== 'limit'
-  const showCancellationModal = activityDerivedState.order ? getShowCancellationModal(activityDerivedState.order) : null
+  const showCancellationModal = order ? getShowCancellationModal(order) : null
 
   const { surplusFiatValue, showFiatValue, surplusToken, surplusAmount } = useGetSurplusData(order)
 

--- a/apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
@@ -26,6 +26,7 @@ import {
   useHideReceiverWalletBanner,
   useIsReceiverWalletBannerHidden,
 } from 'common/state/receiverWalletBannerVisibility'
+import { getUiOrderType, UiOrderType } from 'utils/orderUtils/getUiOrderType'
 
 import { StatusDetails } from './StatusDetails'
 import {
@@ -175,7 +176,9 @@ export function ActivityDetails(props: {
 
   const getShowCancellationModal = useCancelOrder()
 
-  const showProgressBar = (activityState === 'open' || activityState === 'filled') && order?.class !== 'limit'
+  const isSwap = order && getUiOrderType(order) === UiOrderType.SWAP
+
+  const showProgressBar = (activityState === 'open' || activityState === 'filled') && isSwap
   const showCancellationModal = order ? getShowCancellationModal(order) : null
 
   const { surplusFiatValue, showFiatValue, surplusToken, surplusAmount } = useGetSurplusData(order)

--- a/apps/cowswap-frontend/src/modules/appData/types.ts
+++ b/apps/cowswap-frontend/src/modules/appData/types.ts
@@ -21,6 +21,7 @@ export type AppDataKeyParams = {
 
 export type AppDataRecord = AppDataInfo & AppDataUploadStatus & AppDataKeyParams
 
+export type AppDataMetadataOrderClass = latest.OrderClass
 export type AppDataOrderClass = latest.OrderClass['orderClass']
 
 export type AppDataPendingToUpload = Array<AppDataRecord>

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
@@ -4,10 +4,9 @@ import AlertTriangle from '@cowprotocol/assets/cow-swap/alert.svg'
 import { ZERO_FRACTION } from '@cowprotocol/common-const'
 import { useTimeAgo } from '@cowprotocol/common-hooks'
 import { getAddress, getEtherscanLink } from '@cowprotocol/common-utils'
-import { OrderClass, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { TokenLogo } from '@cowprotocol/tokens'
-import { UI } from '@cowprotocol/ui'
-import { Loader, TokenAmount, TokenSymbol } from '@cowprotocol/ui'
+import { Loader, TokenAmount, TokenSymbol, UI } from '@cowprotocol/ui'
 import { Currency, CurrencyAmount, Percent, Price } from '@uniswap/sdk-core'
 
 import SVG from 'react-inlinesvg'
@@ -36,6 +35,7 @@ import { calculatePercentageInRelationToReference } from 'utils/orderUtils/calcu
 import { calculatePriceDifference, PriceDifference } from 'utils/orderUtils/calculatePriceDifference'
 import { getIsComposableCowParentOrder } from 'utils/orderUtils/getIsComposableCowParentOrder'
 import { getSellAmountWithFee } from 'utils/orderUtils/getSellAmountWithFee'
+import { getUiOrderType, UiOrderType } from 'utils/orderUtils/getUiOrderType'
 import { ParsedOrder } from 'utils/orderUtils/parseOrder'
 
 import * as styledEl from './styled'
@@ -307,7 +307,7 @@ export function OrderRow({
                 amountDifference={priceDiffs?.amount}
                 percentageFee={feeDifference}
                 amountFee={feeAmount}
-                canShowWarning={order.class !== OrderClass.MARKET && !isUnfillable}
+                canShowWarning={getUiOrderType(order) !== UiOrderType.SWAP && !isUnfillable}
                 isUnfillable={isUnfillable}
               />
             </styledEl.ExecuteCellWrapper>

--- a/apps/cowswap-frontend/src/modules/trade/hooks/usePriorityTokenAddresses.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/usePriorityTokenAddresses.ts
@@ -1,13 +1,14 @@
 import { useMemo } from 'react'
 
 import { getAddress, isTruthy } from '@cowprotocol/common-utils'
-import { OrderClass } from '@cowprotocol/cow-sdk'
 import { useWalletInfo } from '@cowprotocol/wallet'
 
 import { useSelector } from 'react-redux'
 
 import { AppState } from 'legacy/state'
 import { PartialOrdersMap } from 'legacy/state/orders/reducer'
+
+import { getUiOrderType, UiOrderType } from 'utils/orderUtils/getUiOrderType'
 
 import { useDerivedTradeState } from './useDerivedTradeState'
 
@@ -24,7 +25,7 @@ export function usePriorityTokenAddresses(): string[] {
 
     return Object.values(pending)
       .filter(isTruthy)
-      .filter(({ order }) => order.class === OrderClass.MARKET)
+      .filter(({ order }) => getUiOrderType(order) === UiOrderType.SWAP)
       .map(({ order }) => {
         return [order.inputToken.address, order.outputToken.address]
       })

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useAllEmulatedOrders.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useAllEmulatedOrders.ts
@@ -1,10 +1,11 @@
 import { useMemo } from 'react'
 
-import { OrderClass } from '@cowprotocol/cow-sdk'
 import { useIsSafeApp, useWalletInfo } from '@cowprotocol/wallet'
 
 import { Order } from 'legacy/state/orders/actions'
 import { useOrders } from 'legacy/state/orders/hooks'
+
+import { UiOrderType } from 'utils/orderUtils/getUiOrderType'
 
 import { useEmulatedPartOrders } from './useEmulatedPartOrders'
 import { useEmulatedTwapOrders } from './useEmulatedTwapOrders'
@@ -17,16 +18,14 @@ export function useAllEmulatedOrders(): Order[] {
   const emulatedPartOrders = useEmulatedPartOrders(twapOrdersTokens)
   const isSafeApp = useIsSafeApp()
 
-  const limitOrders = useOrders(chainId, account, OrderClass.LIMIT)
+  const limitOrders = useOrders(chainId, account, UiOrderType.TWAP)
   const discreteTwapOrders = useMemo(() => {
     return limitOrders.filter((order) => order.composableCowInfo?.isVirtualPart === false)
   }, [limitOrders])
 
-  const allEmulatedOrders = useMemo(() => {
+  return useMemo(() => {
     if (!isSafeApp) return []
 
     return emulatedTwapOrders.concat(emulatedPartOrders).concat(discreteTwapOrders)
   }, [emulatedTwapOrders, emulatedPartOrders, discreteTwapOrders, isSafeApp])
-
-  return allEmulatedOrders
 }

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useAllEmulatedOrders.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useAllEmulatedOrders.ts
@@ -18,10 +18,10 @@ export function useAllEmulatedOrders(): Order[] {
   const emulatedPartOrders = useEmulatedPartOrders(twapOrdersTokens)
   const isSafeApp = useIsSafeApp()
 
-  const limitOrders = useOrders(chainId, account, UiOrderType.TWAP)
+  const twapOrders = useOrders(chainId, account, UiOrderType.TWAP)
   const discreteTwapOrders = useMemo(() => {
-    return limitOrders.filter((order) => order.composableCowInfo?.isVirtualPart === false)
-  }, [limitOrders])
+    return twapOrders.filter((order) => order.composableCowInfo?.isVirtualPart === false)
+  }, [twapOrders])
 
   return useMemo(() => {
     if (!isSafeApp) return []

--- a/apps/cowswap-frontend/src/pages/LimitOrders/index.tsx
+++ b/apps/cowswap-frontend/src/pages/LimitOrders/index.tsx
@@ -1,18 +1,15 @@
-import { useMemo } from 'react'
-
-import { OrderClass } from '@cowprotocol/cow-sdk'
 import { useWalletInfo } from '@cowprotocol/wallet'
 
 import { useOrders } from 'legacy/state/orders/hooks'
 
 import { AppDataUpdater } from 'modules/appData'
 import {
-  LimitOrdersWidget,
-  QuoteObserverUpdater,
-  InitialPriceUpdater,
   ExecutionPriceUpdater,
   FillLimitOrdersDerivedStateUpdater,
+  InitialPriceUpdater,
   LIMIT_ORDER_SLIPPAGE,
+  LimitOrdersWidget,
+  QuoteObserverUpdater,
   SetupLimitOrderAmountsFromUrlUpdater,
   useIsWidgetUnlocked,
 } from 'modules/limitOrders'
@@ -20,12 +17,11 @@ import { OrdersTableWidget } from 'modules/ordersTable'
 import { TabOrderTypes } from 'modules/ordersTable/pure/OrdersTableContainer'
 import * as styledEl from 'modules/trade/pure/TradePageLayout'
 
-import { getIsNotComposableCowOrder } from 'utils/orderUtils/getIsNotComposableCowOrder'
+import { UiOrderType } from 'utils/orderUtils/getUiOrderType'
 
 export default function LimitOrderPage() {
   const { chainId, account } = useWalletInfo()
-  const allLimitOrders = useOrders(chainId, account, OrderClass.LIMIT)
-  const onlyPlainLimitOrders = useMemo(() => allLimitOrders.filter(getIsNotComposableCowOrder), [allLimitOrders])
+  const allLimitOrders = useOrders(chainId, account, UiOrderType.LIMIT)
 
   const isUnlocked = useIsWidgetUnlocked()
 
@@ -46,7 +42,7 @@ export default function LimitOrderPage() {
           <OrdersTableWidget
             displayOrdersOnlyForSafeApp={false}
             orderType={TabOrderTypes.LIMIT}
-            orders={onlyPlainLimitOrders}
+            orders={allLimitOrders}
           />
         </styledEl.SecondaryWrapper>
       </styledEl.PageWrapper>

--- a/apps/cowswap-frontend/src/utils/orderUtils/getUiOrderType.ts
+++ b/apps/cowswap-frontend/src/utils/orderUtils/getUiOrderType.ts
@@ -1,0 +1,56 @@
+import { OrderClass } from '@cowprotocol/cow-sdk'
+
+import { Order } from 'legacy/state/orders/actions'
+
+import { AppDataMetadataOrderClass } from 'modules/appData/types'
+import { decodeAppData } from 'modules/appData/utils/decodeAppData'
+
+/**
+ * UI order type that is different from existing types or classes
+ *
+ * This concept doesn't match what the API returns, as it has no notion of advanced/twap orders
+ * It uses order appData if available, otherwise fallback to less reliable ways
+ */
+export enum UiOrderType {
+  SWAP = 'SWAP',
+  LIMIT = 'LIMIT',
+  TWAP = 'TWAP',
+}
+
+const APPDATA_ORDER_CLASS_TO_UI_ORDER_TYPE_MAP: Record<string, UiOrderType> = {
+  market: UiOrderType.SWAP,
+  limit: UiOrderType.LIMIT,
+  liquidity: UiOrderType.LIMIT,
+  twap: UiOrderType.TWAP,
+}
+
+const API_ORDER_CLASS_TO_UI_ORDER_TYPE_MAP: Record<OrderClass, UiOrderType> = {
+  [OrderClass.MARKET]: UiOrderType.SWAP,
+  [OrderClass.LIMIT]: UiOrderType.LIMIT,
+  [OrderClass.LIQUIDITY]: UiOrderType.LIMIT,
+}
+
+export function getUiOrderType({
+  fullAppData,
+  composableCowInfo,
+  class: orderClass,
+}: Pick<Order, 'fullAppData' | 'apiAdditionalInfo' | 'composableCowInfo' | 'class'>): UiOrderType {
+  const parsedAppData = decodeAppData(fullAppData)
+
+  const appDataOrderClass = parsedAppData?.metadata?.orderClass as AppDataMetadataOrderClass | undefined
+  const typeFromAppData = APPDATA_ORDER_CLASS_TO_UI_ORDER_TYPE_MAP[appDataOrderClass?.orderClass || '']
+
+  // 1. AppData info has priority as it's what's more precise
+  if (typeFromAppData) {
+    return typeFromAppData
+  }
+
+  // 2. If composableCowInfo is available, we know it to be a twap
+  if (composableCowInfo) {
+    return UiOrderType.TWAP
+  }
+
+  // 3. As a last resort, map it to API classification.
+  // Least precise as it doesn't distinguish twap type and uses backend logic which doesn't match frontend's classification
+  return API_ORDER_CLASS_TO_UI_ORDER_TYPE_MAP[orderClass]
+}

--- a/apps/cowswap-frontend/src/utils/orderUtils/getUiOrderType.ts
+++ b/apps/cowswap-frontend/src/utils/orderUtils/getUiOrderType.ts
@@ -34,7 +34,7 @@ export function getUiOrderType({
   fullAppData,
   composableCowInfo,
   class: orderClass,
-}: Pick<Order, 'fullAppData' | 'apiAdditionalInfo' | 'composableCowInfo' | 'class'>): UiOrderType {
+}: Pick<Order, 'fullAppData' | 'composableCowInfo' | 'class'>): UiOrderType {
   const parsedAppData = decodeAppData(fullAppData)
 
   const appDataOrderClass = parsedAppData?.metadata?.orderClass as AppDataMetadataOrderClass | undefined

--- a/libs/analytics/src/types.ts
+++ b/libs/analytics/src/types.ts
@@ -37,4 +37,5 @@ export enum Dimensions {
   injectedWidgetAppId = 'injectedWidgetAppId',
 }
 
+// TODO: use UiOrderType instead
 export type AnalyticsOrderType = OrderClass | 'TWAP'


### PR DESCRIPTION
# Summary

Refactoring how we classify orders in the app

Introduced a new type: `UiOrderType` that's a combination of `order.orderClass` and `appData.metada.orderClass.orderClass`.

Added an utils fn that takes and order and returns the type.

Applied it to everywhere in the app where it makes sense to.

# To Test

Changed a lot of things, so rather than steps I'll list what needs to be tested

1. Fee=0 SWAP orders should be displayed in Activity details (even past orders)
2. LIMIT and TWAP should be displayed in their respective sections
3. Pending SWAP, LIMIT and TWAP should be updated in the background
4. Appzi should trigger for all order types as before (different rules for SWAP than LIMIT and TWAP)
5. Market price should NOT be fetched/updated for SWAPs
6. Unfillable SWAPs should still work as before