### PR TITLE
fix(permit): replace permit signer used for quoting

### DIFF
--- a/libs/permit-utils/src/const.ts
+++ b/libs/permit-utils/src/const.ts
@@ -4,7 +4,7 @@ import ms from 'ms.macro'
 
 // PK used only for signing permit requests for quoting and identifying token 'permittability'
 // Do not use or try to send funds to it. Or do. It'll be your funds 🤷
-const PERMIT_PK = '0xec10458cfaafb32533a4a27e18d9da345758094dde7052521b939a41c55dd1b0' // address: 0x9eF31A6BB1A80e58cb73A906bddFaE308978095C
+const PERMIT_PK = '0x4dae303b820e9878cafeb0f84edcc015e8a81b1bff510e824e4fc27544e458dd' // address: 0xCe69D355dfdf13C3eAd95eC1C437DF5d4bac05E4
 
 export const PERMIT_SIGNER = new Wallet(PERMIT_PK)
 


### PR DESCRIPTION
# Summary

HOTFIX!!

No functional changes.
Only replacing signer PK with one without approvals to prevent users from placing orders with permit.

# To Test

1. On mainnet, make sure you have no approvals for one of/all of: wstETH, USDC or DAI
2. Place a sell order of any/all of the above
* Should ask to sign the permit
* Should place successfully
* Should execute the permit once successfully traded (check the approval on revoke.cash for example)

# Background

See [this thread](https://cowservices.slack.com/archives/C036G0J90BU/p1703764369248749)

