### PR TITLE
feat(twap): unlimited twap deadline

### DIFF
--- a/apps/cowswap-frontend/src/common/constants/common.ts
+++ b/apps/cowswap-frontend/src/common/constants/common.ts
@@ -1,5 +1,9 @@
 import { Percent } from '@uniswap/sdk-core'
 
+import ms from 'ms.macro'
+
 export const HIGH_FEE_WARNING_PERCENTAGE = new Percent(1, 10)
 
 export const SAFE_COW_APP_LINK = 'https://app.safe.global/share/safe-app?appUrl=https%3A%2F%2Fswap.cow.fi&chain=eth'
+
+export const MAX_ORDER_DEADLINE = ms`182d` + ms`12h` // 6 months, matching backend's https://github.com/cowprotocol/infrastructure/blob/901ed8e2fe3ea57956585f107bdd7539c2e7d3d1/services/Pulumi.yaml#L15

--- a/apps/cowswap-frontend/src/modules/limitOrders/pure/DeadlineSelector/deadlines.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/pure/DeadlineSelector/deadlines.ts
@@ -1,12 +1,14 @@
 import ms from 'ms.macro'
 
+import { MAX_ORDER_DEADLINE } from 'common/constants/common'
+
 export interface LimitOrderDeadline {
   title: string
   value: number
 }
 
 export const MIN_CUSTOM_DEADLINE = ms`30min`
-export const MAX_CUSTOM_DEADLINE = ms`182d` + ms`12h` // 6 months, matching backend's https://github.com/cowprotocol/infrastructure/blob/901ed8e2fe3ea57956585f107bdd7539c2e7d3d1/services/Pulumi.yaml#L15
+export const MAX_CUSTOM_DEADLINE = MAX_ORDER_DEADLINE
 
 export const defaultLimitOrderDeadline: LimitOrderDeadline = { title: '7 Days', value: ms`7d` }
 

--- a/apps/cowswap-frontend/src/modules/twap/const.ts
+++ b/apps/cowswap-frontend/src/modules/twap/const.ts
@@ -4,9 +4,9 @@ import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
 
 import ms from 'ms.macro'
 
-import { TwapOrderExecutionInfo, TwapOrderStatus } from './types'
+import { MAX_ORDER_DEADLINE } from 'common/constants/common'
 
-import { MAX_CUSTOM_DEADLINE } from '../limitOrders/pure/DeadlineSelector/deadlines'
+import { TwapOrderExecutionInfo, TwapOrderStatus } from './types'
 
 export const DEFAULT_TWAP_SLIPPAGE = new Percent(10, 100) // 10%
 
@@ -46,7 +46,7 @@ export const MINIMUM_PART_SELL_AMOUNT_FIAT: Record<SupportedChainId, CurrencyAmo
 }
 
 export const MINIMUM_PART_TIME = ms`5min` / 1000 // in seconds
-export const MAX_PART_TIME = MAX_CUSTOM_DEADLINE / 1000 // in seconds
+export const MAX_PART_TIME = MAX_ORDER_DEADLINE / 1000 // in seconds
 
 export const DEFAULT_TWAP_EXECUTION_INFO: TwapOrderExecutionInfo = {
   executedSellAmount: '0',

--- a/apps/cowswap-frontend/src/modules/twap/const.ts
+++ b/apps/cowswap-frontend/src/modules/twap/const.ts
@@ -6,6 +6,8 @@ import ms from 'ms.macro'
 
 import { TwapOrderExecutionInfo, TwapOrderStatus } from './types'
 
+import { MAX_CUSTOM_DEADLINE } from '../limitOrders/pure/DeadlineSelector/deadlines'
+
 export const DEFAULT_TWAP_SLIPPAGE = new Percent(10, 100) // 10%
 
 export const MAX_TWAP_SLIPPAGE = 100 // 100%
@@ -44,6 +46,7 @@ export const MINIMUM_PART_SELL_AMOUNT_FIAT: Record<SupportedChainId, CurrencyAmo
 }
 
 export const MINIMUM_PART_TIME = ms`5min` / 1000 // in seconds
+export const MAX_PART_TIME = MAX_CUSTOM_DEADLINE / 1000 // in seconds
 
 export const DEFAULT_TWAP_EXECUTION_INFO: TwapOrderExecutionInfo = {
   executedSellAmount: '0',

--- a/apps/cowswap-frontend/src/modules/twap/const.ts
+++ b/apps/cowswap-frontend/src/modules/twap/const.ts
@@ -23,6 +23,8 @@ export const ORDER_DEADLINES: OrderDeadline[] = [
   { label: '6 Hours', value: ms`6 hour` },
   { label: '12 Hours', value: ms`12 hour` },
   { label: '24 Hours', value: ms`1d` },
+  { label: '1 Week', value: ms`1d` * 7 },
+  { label: '1 Month', value: ms`1d` * 30 },
 ]
 
 export const TWAP_ORDER_STRUCT =

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/index.tsx
@@ -22,6 +22,7 @@ import {
   SmallPartVolumeWarning,
   UnsupportedWalletWarning,
 } from './warnings'
+import { BigPartTimeWarning } from './warnings/BigPartTimeWarning'
 import { SmallPriceProtectionWarning } from './warnings/SmallPriceProtectionWarning'
 import { SwapPriceDifferenceWarning } from './warnings/SwapPriceDifferenceWarning'
 
@@ -123,6 +124,10 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
 
         if (localFormValidation === TwapFormState.PART_TIME_INTERVAL_TOO_SHORT) {
           return <SmallPartTimeWarning />
+        }
+
+        if (localFormValidation === TwapFormState.PART_TIME_INTERVAL_TOO_LONG) {
+          return <BigPartTimeWarning />
         }
 
         if (showFallbackHandlerWarning) {

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/warnings/BigPartTimeWarning.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/warnings/BigPartTimeWarning.tsx
@@ -8,7 +8,7 @@ export function BigPartTimeWarning() {
 
   return (
     <InlineBanner>
-      <strong>Insufficient time between parts</strong>
+      <strong>Too much time between parts</strong>
       <p>
         A maximum of <strong>{time}</strong> between parts is required. Increase the number of parts or decrease the
         total duration.

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/warnings/BigPartTimeWarning.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/warnings/BigPartTimeWarning.tsx
@@ -1,0 +1,18 @@
+import { InlineBanner } from 'common/pure/InlineBanner'
+
+import { MAX_PART_TIME } from '../../../const'
+import { deadlinePartsDisplay } from '../../../utils/deadlinePartsDisplay'
+
+export function BigPartTimeWarning() {
+  const time = deadlinePartsDisplay(MAX_PART_TIME, true)
+
+  return (
+    <InlineBanner>
+      <strong>Insufficient time between parts</strong>
+      <p>
+        A maximum of <strong>{time}</strong> between parts is required. Increase the number of parts or decrease the
+        total duration.
+      </p>
+    </InlineBanner>
+  )
+}

--- a/apps/cowswap-frontend/src/modules/twap/pure/CustomDeadlineSelector/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/pure/CustomDeadlineSelector/index.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useState } from 'react'
 import { ButtonPrimary } from '@cowprotocol/ui'
 
 import { Trans } from '@lingui/macro'
-import ms from 'ms'
 
 import { TradeNumberInput } from 'modules/trade/pure/TradeNumberInput'
 
@@ -20,9 +19,6 @@ interface CustomDeadlineSelectorProps {
   selectCustomDeadline(deadline: CustomDeadline): void
 }
 
-const MAX_TWAP_ORDER_DEADLINE = ms(`30d`) * 6 // ~ 6months
-const MAX_DEADLINE_ERROR = 'Twap order deadline cannot be longer then 6 months'
-
 export function CustomDeadlineSelector(props: CustomDeadlineSelectorProps) {
   const { isOpen, onDismiss, customDeadline, selectCustomDeadline } = props
   const { hours = 0, minutes = 0 } = customDeadline
@@ -33,7 +29,7 @@ export function CustomDeadlineSelector(props: CustomDeadlineSelectorProps) {
   useEffect(() => setHoursValue(hours), [hours, isOpen])
   useEffect(() => setMinutesValue(minutes), [minutes, isOpen])
 
-  const [error, setError] = useState<string | null>(null)
+  const [error] = useState<string | null>(null)
 
   const onHoursChange = useCallback((v: number | null) => setHoursValue(!v ? 0 : Math.round(v)), [])
   const onMinutesChange = useCallback((v: number | null) => setMinutesValue(!v ? 0 : Math.round(v)), [])
@@ -54,16 +50,6 @@ export function CustomDeadlineSelector(props: CustomDeadlineSelectorProps) {
     setMinutesValue(minutes || 0)
     onDismiss()
   }, [hours, minutes, onDismiss])
-
-  useEffect(() => {
-    const totalTime = ms(`${hoursValue}h`) + ms(`${minutesValue}m`)
-
-    if (totalTime > MAX_TWAP_ORDER_DEADLINE) {
-      setError(MAX_DEADLINE_ERROR)
-    } else {
-      setError(null)
-    }
-  }, [hoursValue, minutesValue])
 
   return (
     <Modal isOpen={isOpen} onDismiss={_onDismiss}>

--- a/apps/cowswap-frontend/src/modules/twap/pure/CustomDeadlineSelector/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/pure/CustomDeadlineSelector/index.tsx
@@ -29,13 +29,10 @@ export function CustomDeadlineSelector(props: CustomDeadlineSelectorProps) {
   useEffect(() => setHoursValue(hours), [hours, isOpen])
   useEffect(() => setMinutesValue(minutes), [minutes, isOpen])
 
-  const [error] = useState<string | null>(null)
-
   const onHoursChange = useCallback((v: number | null) => setHoursValue(!v ? 0 : Math.round(v)), [])
   const onMinutesChange = useCallback((v: number | null) => setMinutesValue(!v ? 0 : Math.round(v)), [])
 
-  const noValues = !hoursValue && !minutesValue
-  const isDisabled = !!error || noValues
+  const isDisabled = !hoursValue && !minutesValue
 
   const onApply = () => {
     onDismiss()
@@ -79,8 +76,6 @@ export function CustomDeadlineSelector(props: CustomDeadlineSelectorProps) {
             max={null}
           />
         </styledEl.ModalContent>
-
-        {error && <styledEl.ErrorText>{error}</styledEl.ErrorText>}
 
         <styledEl.ModalFooter>
           <styledEl.CancelButton onClick={_onDismiss}>

--- a/apps/cowswap-frontend/src/modules/twap/pure/PrimaryActionButton/getTwapFormState.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/pure/PrimaryActionButton/getTwapFormState.tsx
@@ -6,6 +6,7 @@ import { Nullish } from 'types'
 
 import { ExtensibleFallbackVerification } from '../../services/verifyExtensibleFallback'
 import { TWAPOrder } from '../../types'
+import { isPartTimeIntervalTooLong } from '../../utils/isPartTimeIntervalTooLong'
 import { isPartTimeIntervalTooShort } from '../../utils/isPartTimeIntervalTooShort'
 import { isSellAmountTooSmall } from '../../utils/isSellAmountTooSmall'
 
@@ -23,6 +24,7 @@ export enum TwapFormState {
   NOT_SAFE = 'NOT_SAFE',
   SELL_AMOUNT_TOO_SMALL = 'SELL_AMOUNT_TOO_SMALL',
   PART_TIME_INTERVAL_TOO_SHORT = 'PART_TIME_INTERVAL_TOO_SHORT',
+  PART_TIME_INTERVAL_TOO_LONG = 'PART_TIME_INTERVAL_TOO_LONG',
 }
 
 export function getTwapFormState(props: TwapFormStateParams): TwapFormState | null {
@@ -39,6 +41,9 @@ export function getTwapFormState(props: TwapFormStateParams): TwapFormState | nu
   // Not using `twapOrder.timeInterval` because it's not filled until the order is ready
   if (isPartTimeIntervalTooShort(partTime)) {
     return TwapFormState.PART_TIME_INTERVAL_TOO_SHORT
+  }
+  if (isPartTimeIntervalTooLong(partTime)) {
+    return TwapFormState.PART_TIME_INTERVAL_TOO_LONG
   }
 
   return null

--- a/apps/cowswap-frontend/src/modules/twap/pure/PrimaryActionButton/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/pure/PrimaryActionButton/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { ButtonSize, ButtonPrimary } from '@cowprotocol/ui'
+import { ButtonPrimary, ButtonSize } from '@cowprotocol/ui'
 
 import { TwapFormState } from './getTwapFormState'
 
@@ -27,6 +27,11 @@ const buttonsMap: Record<TwapFormState, (_context: PrimaryActionButtonContext) =
   [TwapFormState.PART_TIME_INTERVAL_TOO_SHORT]: () => (
     <ButtonPrimary disabled={true} buttonSize={ButtonSize.BIG}>
       Interval time too short
+    </ButtonPrimary>
+  ),
+  [TwapFormState.PART_TIME_INTERVAL_TOO_LONG]: () => (
+    <ButtonPrimary disabled={true} buttonSize={ButtonSize.BIG}>
+      Interval time too long
     </ButtonPrimary>
   ),
 }

--- a/apps/cowswap-frontend/src/modules/twap/utils/deadlinePartsDisplay.ts
+++ b/apps/cowswap-frontend/src/modules/twap/utils/deadlinePartsDisplay.ts
@@ -3,6 +3,8 @@ import ms from 'ms'
 import { TwapOrdersDeadline } from '../state/twapOrdersSettingsAtom'
 
 const [oneD, oneH, oneM, oneS] = [ms('1d'), ms('1h'), ms('1m'), ms('1s')]
+const oneYear = oneD * 365 // this is not very precise...
+const oneMonth = oneYear / 12 // this is much less precise...
 
 export function customDeadlineToSeconds(customDeadline: TwapOrdersDeadline['customDeadline']): number {
   const hoursToMinutes = customDeadline.hours * 60
@@ -13,12 +15,16 @@ export function customDeadlineToSeconds(customDeadline: TwapOrdersDeadline['cust
 export function deadlinePartsDisplay(timeInterval: number, longLabels = false): string {
   const timeMs = ms(`${timeInterval * 1000}ms`)
 
-  const days = Math.floor(timeMs / oneD)
+  const years = Math.floor(timeMs / oneYear)
+  const months = Math.floor((timeMs % oneYear) / oneMonth)
+  const days = Math.floor((timeMs % oneMonth) / oneD)
   const hours = Math.floor((timeMs % oneD) / oneH)
   const minutes = Math.floor((timeMs % oneH) / oneM)
   const seconds = Math.floor((timeMs % oneM) / oneS)
 
   return [
+    [years, longLabels ? ' years' : 'y'],
+    [months, longLabels ? ' months' : 'mo'],
     [days, longLabels ? ' days' : 'd'],
     [hours, longLabels ? ' hours' : 'h'],
     [minutes, longLabels ? ' minutes' : 'm'],

--- a/apps/cowswap-frontend/src/modules/twap/utils/deadlinePartsDisplay.ts
+++ b/apps/cowswap-frontend/src/modules/twap/utils/deadlinePartsDisplay.ts
@@ -6,9 +6,8 @@ const [oneD, oneH, oneM, oneS] = [ms('1d'), ms('1h'), ms('1m'), ms('1s')]
 
 export function customDeadlineToSeconds(customDeadline: TwapOrdersDeadline['customDeadline']): number {
   const hoursToMinutes = customDeadline.hours * 60
-  const minutesToSeconds = (hoursToMinutes + customDeadline.minutes) * 60
 
-  return minutesToSeconds
+  return (hoursToMinutes + customDeadline.minutes) * 60
 }
 
 export function deadlinePartsDisplay(timeInterval: number, longLabels = false): string {

--- a/apps/cowswap-frontend/src/modules/twap/utils/isPartTimeIntervalTooLong.ts
+++ b/apps/cowswap-frontend/src/modules/twap/utils/isPartTimeIntervalTooLong.ts
@@ -1,0 +1,5 @@
+import { MAX_PART_TIME } from '../const'
+
+export function isPartTimeIntervalTooLong(partTime: number | undefined): boolean {
+  return partTime !== undefined && partTime > MAX_PART_TIME
+}


### PR DESCRIPTION
# Summary

Follow up to and waterfalls into https://github.com/cowprotocol/cowswap/pull/3567

Another low hanging fruit from 2024 roadmap

TWAP orders in theory have no duration limit.
The only restriction is that each individual part can not be longer than 6 months.

This change:
1. Removes the 6 months limit for TWAP duration
2. Adds the limit for individual part duration
3. Also adds human friendly display for time in years and months (albeit not very precise...)

![Screenshot 2023-12-29 at 17 20 00](https://github.com/cowprotocol/cowswap/assets/43217/fb22a9c7-dd13-4ae1-8185-294feaef6d28)


# To Test

1. Open the app as a Safe App
2. Go to TWAP tab
3. Fill in the form and pick a custom order duration
4. Insert 9000 hours (rounding 1y up) and 2 parts
* You should be allowed to pick more than 4400 hours (rounding up 6 months)
* You should see a warning about the part time being too long
* You should not be able to place the TWAP
5. Increase the number of parts by 1
* Warnings should be gone
* You should be able to place the order

# Notes

- The new year and month calculation is not very precise.
Thus, you'll see the limit as `6 months and 12h`, when in fact it's `182d + 12h`
![image](https://github.com/cowprotocol/cowswap/assets/43217/28307fea-4fa8-4687-a03e-0a528979d301)

- The duration picker is still using hours and minutes
I'm aware it could use some updating, but it's out of the scope of this change.
