### PR TITLE
feat(safe): rely on safeInfo and iframe detection to identify Safe wallets

### DIFF
--- a/libs/wallet/src/web3-react/hooks/useWalletMetadata.ts
+++ b/libs/wallet/src/web3-react/hooks/useWalletMetadata.ts
@@ -6,21 +6,9 @@ import { default as AlphaImage } from '../../api/assets/alpha.svg'
 import { ConnectionType } from '../../api/types'
 import { getIsAlphaWallet } from '../../api/utils/connection'
 import { getWeb3ReactConnection } from '../utils/getWeb3ReactConnection'
+import { useGnosisSafeInfo } from '../../api/hooks'
 
-const WC_DESKTOP_GNOSIS_SAFE_APP_NAME = 'WalletConnect Safe App'
-const WC_MOBILE_GNOSIS_SAFE_APP_NAME = 'Safe'
 const SAFE_APP_NAME = 'Safe App'
-const GNOSIS_SAFE_APP_NAME = 'Gnosis Safe App'
-const SAFE_WALLET_NAME = 'Safe{Wallet}'
-const SAFE_WALLET_IOS = 'Safe (iOS)'
-const GNOSIS_APP_NAMES = [
-  SAFE_APP_NAME,
-  GNOSIS_SAFE_APP_NAME,
-  WC_DESKTOP_GNOSIS_SAFE_APP_NAME,
-  WC_MOBILE_GNOSIS_SAFE_APP_NAME,
-  SAFE_WALLET_NAME,
-  SAFE_WALLET_IOS,
-]
 
 const SAFE_ICON_URL = 'https://app.safe.global/favicon.ico'
 
@@ -88,6 +76,7 @@ export function useWalletMetaData(): WalletMetaData {
     }
 
     if (connectionType === ConnectionType.GNOSIS_SAFE) {
+      // TODO: potentially here is where we'll need to work to show the multiple flavours of Safe wallets
       return METADATA_SAFE
     }
 
@@ -100,9 +89,15 @@ export function useWalletMetaData(): WalletMetaData {
  * It'll be false if connected to Safe wallet via WalletConnect
  */
 export function useIsSafeApp(): boolean {
-  const { walletName } = useWalletMetaData()
+  const isSafeWallet = useIsSafeWallet()
 
-  return walletName === SAFE_APP_NAME
+  if (!isSafeWallet) {
+    return false
+  }
+
+  // Will only be a SafeApp if within an iframe
+  // Which means, window.parent is different than window
+  return window?.parent !== window
 }
 
 /**
@@ -110,11 +105,7 @@ export function useIsSafeApp(): boolean {
  * regardless of the connection method (WalletConnect or inside Safe as an App)
  */
 export function useIsSafeWallet(): boolean {
-  const { walletName } = useWalletMetaData()
-
-  if (!walletName) return false
-
-  return GNOSIS_APP_NAMES.includes(walletName.trim())
+  return !!useGnosisSafeInfo()
 }
 
 /**

--- a/libs/wallet/src/web3-react/updater.ts
+++ b/libs/wallet/src/web3-react/updater.ts
@@ -7,7 +7,7 @@ import { getSafeInfo } from '@cowprotocol/core'
 import { getCurrentChainIdFromUrl } from '@cowprotocol/common-utils'
 
 import { useSafeAppsSdkInfo } from './hooks/useSafeAppsSdkInfo'
-import { useIsSafeWallet, useWalletMetaData } from './hooks/useWalletMetadata'
+import { useWalletMetaData } from './hooks/useWalletMetadata'
 
 import { gnosisSafeInfoAtom, walletDetailsAtom, walletInfoAtom } from '../api/state'
 import { GnosisSafeInfo, WalletDetails, WalletInfo } from '../api/types'
@@ -61,12 +61,11 @@ function _useWalletDetails(account?: string): WalletDetails {
 function _useSafeInfo(walletInfo: WalletInfo): GnosisSafeInfo | undefined {
   const { provider } = useWeb3React()
   const { account, chainId } = walletInfo
-  const isSafeConnected = useIsSafeWallet()
   const [safeInfo, setSafeInfo] = useState<GnosisSafeInfo>()
   const { isReadOnly } = useSafeAppsSdkInfo() || {}
 
   useEffect(() => {
-    if (chainId && account && isSafeConnected && provider) {
+    if (chainId && account && provider) {
       getSafeInfo(chainId, account, provider)
         .then((_safeInfo) =>
           setSafeInfo({
@@ -80,7 +79,7 @@ function _useSafeInfo(walletInfo: WalletInfo): GnosisSafeInfo | undefined {
     } else {
       setSafeInfo(undefined)
     }
-  }, [setSafeInfo, chainId, account, isSafeConnected, provider, isReadOnly])
+  }, [setSafeInfo, chainId, account, provider, isReadOnly])
 
   return safeInfo
 }


### PR DESCRIPTION
# Summary

Initially part of https://github.com/cowprotocol/cowswap/pull/3372

Extracted only the improved Safe wallet detection as it's valuable on its own.

With this change, we rely on the existence of Safe info to detect when the wallet is a Safe.
And we detect whether the app is loaded within an iframe to tell when it's loaded as Safe App.

In the previous way, we were detecting based on wallet names, which varies by platform and was easily broken.

# To Test

1. Load the app as Safe app
* Should be loaded and detected as usual
* TWAP should be enabled
2. Connect with a Safe via WC
* Should detect it's a Safe via WC
* TWAP should not be enabled
3. Do a wrap/unwrap
* Should detect the proper Safe signing phases (signers, execution, etc)
4. Repeat steps 2 and 3 with iOS app
* Should have the same result as via WC
5. Connect a non-safe wallet
* Should behave as usual