### PR TITLE
fix(limit): show price impact warning for Safe App when bundling

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
@@ -73,7 +73,9 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
   const tradeQuote = useTradeQuote()
   const priceImpactParams = useTradePriceImpact()
 
-  const canTrade = localFormValidation === null && primaryFormValidation === null && !tradeQuote.error
+  const isBundling = primaryFormValidation && FORM_STATES_TO_SHOW_BUNDLE_BANNER.includes(primaryFormValidation)
+
+  const canTrade = localFormValidation === null && (primaryFormValidation === null || isBundling) && !tradeQuote.error
   const showPriceImpactWarning =
     canTrade && !expertMode && !!account && !priceImpactParams.loading && !priceImpactParams.priceImpact
 
@@ -84,8 +86,7 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
 
   const showHighFeeWarning = feePercentage?.greaterThan(HIGH_FEE_WARNING_PERCENTAGE)
 
-  const showApprovalBundlingBanner =
-    !isConfirmScreen && primaryFormValidation && FORM_STATES_TO_SHOW_BUNDLE_BANNER.includes(primaryFormValidation)
+  const showApprovalBundlingBanner = !isConfirmScreen && isBundling
   const shouldZeroApprove = useShouldZeroApprove(slippageAdjustedSellAmount)
   const showZeroApprovalWarning = shouldZeroApprove && outputCurrency !== null // Show warning only when output currency is also present.
 


### PR DESCRIPTION
# Summary

Fix #3060 

Warning wasn't displayed when doing a Limit order with approval bundled.

# To Test

1. Open as Safe app
2. Go to limit order
3. Pick a token that needs approval as sell
4. Pick a pair, set price below market (> 5%)
* Warning should be displayed
![image](https://github.com/cowprotocol/cowswap/assets/43217/ffde67d0-9079-45ac-a407-6d0448fb3ed6)
5. Proceed to confirm screen
* Warning should require confirmation to proceed 
![image](https://github.com/cowprotocol/cowswap/assets/43217/d3b3c95d-103c-4210-bc21-889749007fcf)


6. Repeat steps with non-safe wallet
* Warnings should work as usual