### PR TITLE
feat: sell eth warning for limit/twap

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/InlineBanner/banners.tsx
+++ b/apps/cowswap-frontend/src/common/pure/InlineBanner/banners.tsx
@@ -3,6 +3,8 @@ import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
 
 import { Nullish } from 'types'
 
+import { LinkStyledButton } from 'legacy/theme'
+
 import { ButtonSecondary } from '../ButtonSecondary'
 import { CowSwapSafeAppLink } from '../CowSwapSafeAppLink'
 
@@ -118,6 +120,34 @@ export function CustomRecipientWarningBanner({
           Dismiss
         </ButtonSecondary>
       )}
+    </InlineBanner>
+  )
+}
+
+export type SellNativeWarningBannerProps = {
+  sellWrapped: () => void
+  wrapNative: () => void
+  nativeSymbol: string | undefined
+  wrappedNativeSymbol: string | undefined
+}
+
+export function SellNativeWarningBanner({
+  sellWrapped,
+  wrapNative,
+  nativeSymbol = 'native',
+  wrappedNativeSymbol = 'wrapped native',
+}: SellNativeWarningBannerProps) {
+  return (
+    <InlineBanner bannerType="alert" iconSize={32}>
+      <strong>Cannot sell {nativeSymbol}</strong>
+      <p>Selling {nativeSymbol} is only supported on SWAP orders.</p>
+      <p>
+        <LinkStyledButton onClick={sellWrapped}>Switch to {wrappedNativeSymbol}</LinkStyledButton>or
+        <LinkStyledButton onClick={wrapNative}>
+          Wrap {nativeSymbol} to {wrappedNativeSymbol}
+        </LinkStyledButton>
+        first.
+      </p>
     </InlineBanner>
   )
 }

--- a/apps/cowswap-frontend/src/common/pure/InlineBanner/banners.tsx
+++ b/apps/cowswap-frontend/src/common/pure/InlineBanner/banners.tsx
@@ -1,6 +1,7 @@
 import { TokenAmount } from '@cowprotocol/ui'
 import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
 
+import styled from 'styled-components/macro'
 import { Nullish } from 'types'
 
 import { LinkStyledButton } from 'legacy/theme'
@@ -131,6 +132,10 @@ export type SellNativeWarningBannerProps = {
   wrappedNativeSymbol: string | undefined
 }
 
+const Button = styled(LinkStyledButton)`
+  text-decoration: underline;
+`
+
 export function SellNativeWarningBanner({
   sellWrapped,
   wrapNative,
@@ -142,10 +147,10 @@ export function SellNativeWarningBanner({
       <strong>Cannot sell {nativeSymbol}</strong>
       <p>Selling {nativeSymbol} is only supported on SWAP orders.</p>
       <p>
-        <LinkStyledButton onClick={sellWrapped}>Switch to {wrappedNativeSymbol}</LinkStyledButton>or
-        <LinkStyledButton onClick={wrapNative}>
+        <Button onClick={sellWrapped}>Switch to {wrappedNativeSymbol}</Button>or
+        <Button onClick={wrapNative}>
           Wrap {nativeSymbol} to {wrappedNativeSymbol}
-        </LinkStyledButton>
+        </Button>
         first.
       </p>
     </InlineBanner>

--- a/apps/cowswap-frontend/src/modules/advancedOrders/containers/AdvancedOrdersWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/advancedOrders/containers/AdvancedOrdersWidget/index.tsx
@@ -107,7 +107,6 @@ export function AdvancedOrdersWidget({ children, updaters, params }: AdvancedOrd
   const tradeWidgetParams = {
     recipient,
     compactView: true,
-    disableNativeSelling: true,
     showRecipient,
     isTradePriceUpdating,
     priceImpact,

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
@@ -2,7 +2,7 @@ import { useAtomValue, useSetAtom } from 'jotai'
 import React, { useCallback, useEffect } from 'react'
 
 import { isFractionFalsy } from '@cowprotocol/common-utils'
-import { useIsSafeApp, useIsSafeViaWc, useWalletInfo } from '@cowprotocol/wallet'
+import { useIsSafeViaWc, useWalletInfo } from '@cowprotocol/wallet'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
 import styled from 'styled-components/macro'
@@ -98,7 +98,6 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
   const shouldZeroApprove = useShouldZeroApprove(slippageAdjustedSellAmount)
   const showZeroApprovalWarning = shouldZeroApprove && outputCurrency !== null // Show warning only when output currency is also present.
 
-  const isSafeApp = useIsSafeApp()
   const isSafeViaWc = useIsSafeViaWc()
   const showSafeWcBundlingBanner =
     !isConfirmScreen &&
@@ -114,7 +113,8 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
   const isNativeIn = useIsNativeIn()
   const isWrappedOut = useIsWrappedOut()
 
-  const showNativeSellWarning = isNativeIn && !isWrappedOut && native && wrapped && !isSafeApp
+  // TODO: implement Safe App EthFlow bundling for LIMIT and disable the warning in that case
+  const showNativeSellWarning = isNativeIn && !isWrappedOut && native && wrapped
 
   const navigateOnCurrencySelection = useNavigateOnCurrencySelection()
 

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
@@ -8,8 +8,6 @@ import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import styled from 'styled-components/macro'
 import { Nullish } from 'types'
 
-import { Field } from 'legacy/state/types'
-
 import { useLimitOrdersDerivedState } from 'modules/limitOrders/hooks/useLimitOrdersDerivedState'
 import { useLimitOrdersFormState } from 'modules/limitOrders/hooks/useLimitOrdersFormState'
 import { useRateImpact } from 'modules/limitOrders/hooks/useRateImpact'
@@ -19,11 +17,10 @@ import {
   updateLimitOrdersWarningsAtom,
 } from 'modules/limitOrders/state/limitOrdersWarningsAtom'
 import { useTradePriceImpact } from 'modules/trade'
+import { SellNativeWarningBanner } from 'modules/trade/containers/SellNativeWarningBanner'
 import { useDerivedTradeState } from 'modules/trade/hooks/useDerivedTradeState'
 import { useIsNativeIn } from 'modules/trade/hooks/useIsNativeInOrOut'
 import { useIsWrappedOut } from 'modules/trade/hooks/useIsWrappedInOrOut'
-import { useNavigateOnCurrencySelection } from 'modules/trade/hooks/useNavigateOnCurrencySelection'
-import { useWrappedToken } from 'modules/trade/hooks/useWrappedToken'
 import { NoImpactWarning } from 'modules/trade/pure/NoImpactWarning'
 import { TradeFormValidation, useGetTradeFormValidation } from 'modules/tradeFormValidation'
 import { useTradeQuote } from 'modules/tradeQuote'
@@ -35,11 +32,9 @@ import {
   BundleTxApprovalBanner,
   BundleTxSafeWcBanner,
   CustomRecipientWarningBanner,
-  SellNativeWarningBanner,
   SmallVolumeWarningBanner,
 } from 'common/pure/InlineBanner/banners'
 import { ZeroApprovalWarning } from 'common/pure/ZeroApprovalWarning'
-import useNativeCurrency from 'lib/hooks/useNativeCurrency'
 import { calculatePercentageInRelationToReference } from 'utils/orderUtils/calculatePercentageInRelationToReference'
 
 import { RateImpactWarning } from '../../pure/RateImpactWarning'
@@ -108,15 +103,11 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
   const { state } = useDerivedTradeState()
   const showRecipientWarning = isConfirmScreen && state?.recipient && account !== state.recipient
 
-  const native = useNativeCurrency()
-  const wrapped = useWrappedToken()
   const isNativeIn = useIsNativeIn()
   const isWrappedOut = useIsWrappedOut()
 
   // TODO: implement Safe App EthFlow bundling for LIMIT and disable the warning in that case
-  const showNativeSellWarning = isNativeIn && !isWrappedOut && native && wrapped
-
-  const navigateOnCurrencySelection = useNavigateOnCurrencySelection()
+  const showNativeSellWarning = isNativeIn && !isWrappedOut
 
   const isVisible =
     showPriceImpactWarning ||
@@ -175,14 +166,7 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
       {showHighFeeWarning && <SmallVolumeWarningBanner feeAmount={feeAmount} feePercentage={feePercentage} />}
       {showApprovalBundlingBanner && <BundleTxApprovalBanner />}
       {showSafeWcBundlingBanner && <BundleTxSafeWcBanner />}
-      {showNativeSellWarning && (
-        <SellNativeWarningBanner
-          nativeSymbol={native.symbol}
-          wrappedNativeSymbol={wrapped.symbol}
-          sellWrapped={() => navigateOnCurrencySelection(Field.INPUT, wrapped)}
-          wrapNative={() => navigateOnCurrencySelection(Field.OUTPUT, wrapped)}
-        />
-      )}
+      {showNativeSellWarning && <SellNativeWarningBanner />}
     </Wrapper>
   ) : null
 }

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
@@ -19,8 +19,6 @@ import {
 import { useTradePriceImpact } from 'modules/trade'
 import { SellNativeWarningBanner } from 'modules/trade/containers/SellNativeWarningBanner'
 import { useDerivedTradeState } from 'modules/trade/hooks/useDerivedTradeState'
-import { useIsNativeIn } from 'modules/trade/hooks/useIsNativeInOrOut'
-import { useIsWrappedOut } from 'modules/trade/hooks/useIsWrappedInOrOut'
 import { NoImpactWarning } from 'modules/trade/pure/NoImpactWarning'
 import { TradeFormValidation, useGetTradeFormValidation } from 'modules/tradeFormValidation'
 import { useTradeQuote } from 'modules/tradeQuote'
@@ -103,11 +101,8 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
   const { state } = useDerivedTradeState()
   const showRecipientWarning = isConfirmScreen && state?.recipient && account !== state.recipient
 
-  const isNativeIn = useIsNativeIn()
-  const isWrappedOut = useIsWrappedOut()
-
   // TODO: implement Safe App EthFlow bundling for LIMIT and disable the warning in that case
-  const showNativeSellWarning = isNativeIn && !isWrappedOut
+  const showNativeSellWarning = primaryFormValidation === TradeFormValidation.SellNativeToken
 
   const isVisible =
     showPriceImpactWarning ||

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
@@ -113,7 +113,8 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
   const wrapped = useWrappedToken()
   const isNativeIn = useIsNativeIn()
   const isWrappedOut = useIsWrappedOut()
-  const isNativeSell = isNativeIn && !isWrappedOut && native && wrapped && !isSafeApp
+
+  const showNativeSellWarning = isNativeIn && !isWrappedOut && native && wrapped && !isSafeApp
 
   const navigateOnCurrencySelection = useNavigateOnCurrencySelection()
 
@@ -125,7 +126,7 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
     showSafeWcBundlingBanner ||
     shouldZeroApprove ||
     showRecipientWarning ||
-    isNativeSell
+    showNativeSellWarning
 
   // Reset price impact flag when there is no price impact
   useEffect(() => {
@@ -174,7 +175,7 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
       {showHighFeeWarning && <SmallVolumeWarningBanner feeAmount={feeAmount} feePercentage={feePercentage} />}
       {showApprovalBundlingBanner && <BundleTxApprovalBanner />}
       {showSafeWcBundlingBanner && <BundleTxSafeWcBanner />}
-      {isNativeSell && (
+      {showNativeSellWarning && (
         <SellNativeWarningBanner
           nativeSymbol={native.symbol}
           wrappedNativeSymbol={wrapped.symbol}

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -237,7 +237,6 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
 
   const params = {
     compactView: false,
-    disableNativeSelling: true,
     isExpertMode,
     recipient,
     showRecipient,

--- a/apps/cowswap-frontend/src/modules/swap/pure/banners/TwapSuggestionBanner.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/banners/TwapSuggestionBanner.tsx
@@ -1,12 +1,12 @@
-import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { OrderKind, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
 
 import { NavLink } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
-import { TRADE_URL_SELL_AMOUNT_KEY } from 'modules/trade/const/tradeUrl'
 import { TradeUrlParams } from 'modules/trade/types/TradeRawState'
 import { parameterizeTradeRoute } from 'modules/trade/utils/parameterizeTradeRoute'
+import { parameterizeTradeSearch } from 'modules/trade/utils/parameterizeTradeSearch'
 
 import { Routes } from 'common/constants/routes'
 import { InlineBanner } from 'common/pure/InlineBanner'
@@ -52,7 +52,12 @@ export function TwapSuggestionBanner({
   if (!shouldSuggestTwap) return null
 
   const routePath =
-    parameterizeTradeRoute(tradeUrlParams, Routes.ADVANCED_ORDERS) + `?${TRADE_URL_SELL_AMOUNT_KEY}=${sellAmount}`
+    parameterizeTradeRoute(tradeUrlParams, Routes.ADVANCED_ORDERS) +
+    '?' +
+    parameterizeTradeSearch('', {
+      amount: sellAmount,
+      kind: OrderKind.SELL,
+    })
 
   return (
     <InlineBanner bannerType="alert" iconSize={32}>

--- a/apps/cowswap-frontend/src/modules/trade/containers/SellNativeWarningBanner/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/SellNativeWarningBanner/index.tsx
@@ -1,8 +1,11 @@
+import { OrderKind } from '@cowprotocol/cow-sdk'
+
 import { Field } from 'legacy/state/types'
 
 import { SellNativeWarningBanner as Pure } from 'common/pure/InlineBanner/banners'
 import useNativeCurrency from 'lib/hooks/useNativeCurrency'
 
+import { useDerivedTradeState } from '../../hooks/useDerivedTradeState'
 import { useNavigateOnCurrencySelection } from '../../hooks/useNavigateOnCurrencySelection'
 import { useWrappedToken } from '../../hooks/useWrappedToken'
 
@@ -11,12 +14,21 @@ export function SellNativeWarningBanner() {
   const wrapped = useWrappedToken()
   const navigateOnCurrencySelection = useNavigateOnCurrencySelection()
 
+  const { state } = useDerivedTradeState()
+
+  const queryParams = state?.inputCurrencyAmount
+    ? {
+        kind: OrderKind.SELL,
+        amount: state.inputCurrencyAmount.toFixed(state.inputCurrencyAmount.currency.decimals),
+      }
+    : undefined
+
   return (
     <Pure
       nativeSymbol={native.symbol}
       wrappedNativeSymbol={wrapped.symbol}
       sellWrapped={() => navigateOnCurrencySelection(Field.INPUT, wrapped)}
-      wrapNative={() => navigateOnCurrencySelection(Field.OUTPUT, wrapped)}
+      wrapNative={() => navigateOnCurrencySelection(Field.OUTPUT, wrapped, undefined, queryParams)}
     />
   )
 }

--- a/apps/cowswap-frontend/src/modules/trade/containers/SellNativeWarningBanner/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/SellNativeWarningBanner/index.tsx
@@ -1,0 +1,22 @@
+import { Field } from 'legacy/state/types'
+
+import { SellNativeWarningBanner as Pure } from 'common/pure/InlineBanner/banners'
+import useNativeCurrency from 'lib/hooks/useNativeCurrency'
+
+import { useNavigateOnCurrencySelection } from '../../hooks/useNavigateOnCurrencySelection'
+import { useWrappedToken } from '../../hooks/useWrappedToken'
+
+export function SellNativeWarningBanner() {
+  const native = useNativeCurrency()
+  const wrapped = useWrappedToken()
+  const navigateOnCurrencySelection = useNavigateOnCurrencySelection()
+
+  return (
+    <Pure
+      nativeSymbol={native.symbol}
+      wrappedNativeSymbol={wrapped.symbol}
+      sellWrapped={() => navigateOnCurrencySelection(Field.INPUT, wrapped)}
+      wrapNative={() => navigateOnCurrencySelection(Field.OUTPUT, wrapped)}
+    />
+  )
+}

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useNavigateOnCurrencySelection.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useNavigateOnCurrencySelection.ts
@@ -6,13 +6,16 @@ import { Currency, Token } from '@uniswap/sdk-core'
 
 import { Field } from 'legacy/state/types'
 
-import { useTradeNavigate } from 'modules/trade/hooks/useTradeNavigate'
-import { useTradeState } from 'modules/trade/hooks/useTradeState'
+import { useTradeNavigate } from './useTradeNavigate'
+import { useTradeState } from './useTradeState'
+
+import { TradeSearchParams } from '../utils/parameterizeTradeSearch'
 
 export type CurrencySelectionCallback = (
   field: Field,
   currency: Currency | null,
-  stateUpdateCallback?: () => void
+  stateUpdateCallback?: () => void,
+  searchParams?: TradeSearchParams
 ) => void
 
 function useResolveCurrencyAddressOrSymbol(): (currency: Currency | null) => string | null {
@@ -40,7 +43,7 @@ export function useNavigateOnCurrencySelection(): CurrencySelectionCallback {
   const resolveCurrencyAddressOrSymbol = useResolveCurrencyAddressOrSymbol()
 
   return useCallback(
-    (field: Field, currency: Currency | null, stateUpdateCallback?: () => void) => {
+    (field: Field, currency: Currency | null, stateUpdateCallback?: () => void, searchParams?: TradeSearchParams) => {
       if (!state) return
 
       const { inputCurrencyId, outputCurrencyId } = state
@@ -58,7 +61,8 @@ export function useNavigateOnCurrencySelection(): CurrencySelectionCallback {
           : {
               inputCurrencyId: targetInputCurrencyId,
               outputCurrencyId: targetOutputCurrencyId,
-            }
+            },
+        searchParams
       )
 
       stateUpdateCallback?.()

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useTradeNavigate.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useTradeNavigate.ts
@@ -4,12 +4,18 @@ import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import { useLocation, useNavigate } from 'react-router-dom'
 
-import { useTradeTypeInfo } from 'modules/trade/hooks/useTradeTypeInfo'
-import { TradeCurrenciesIds } from 'modules/trade/types/TradeRawState'
-import { parameterizeTradeRoute } from 'modules/trade/utils/parameterizeTradeRoute'
+import { useTradeTypeInfo } from './useTradeTypeInfo'
+
+import { TradeCurrenciesIds } from '../types/TradeRawState'
+import { parameterizeTradeRoute } from '../utils/parameterizeTradeRoute'
+import { parameterizeTradeSearch, TradeSearchParams } from '../utils/parameterizeTradeSearch'
 
 interface UseTradeNavigateCallback {
-  (chainId: SupportedChainId | null | undefined, { inputCurrencyId, outputCurrencyId }: TradeCurrenciesIds): void
+  (
+    chainId: SupportedChainId | null | undefined,
+    { inputCurrencyId, outputCurrencyId }: TradeCurrenciesIds,
+    searchParams?: TradeSearchParams
+  ): void
 }
 
 export function useTradeNavigate(): UseTradeNavigateCallback {
@@ -19,7 +25,11 @@ export function useTradeNavigate(): UseTradeNavigateCallback {
   const tradeRoute = tradeTypeInfo?.route
 
   return useCallback(
-    (chainId: SupportedChainId | null | undefined, { inputCurrencyId, outputCurrencyId }: TradeCurrenciesIds) => {
+    (
+      chainId: SupportedChainId | null | undefined,
+      { inputCurrencyId, outputCurrencyId }: TradeCurrenciesIds,
+      searchParams?: TradeSearchParams
+    ) => {
       if (!tradeRoute) return
 
       const route = parameterizeTradeRoute(
@@ -33,7 +43,9 @@ export function useTradeNavigate(): UseTradeNavigateCallback {
 
       if (location.pathname === route) return
 
-      navigate({ pathname: route, search: location.search })
+      const search = parameterizeTradeSearch(location.search, searchParams)
+
+      navigate({ pathname: route, search })
     },
     [tradeRoute, navigate, location.pathname, location.search]
   )

--- a/apps/cowswap-frontend/src/modules/trade/utils/parameterizeTradeSearch.ts
+++ b/apps/cowswap-frontend/src/modules/trade/utils/parameterizeTradeSearch.ts
@@ -1,0 +1,27 @@
+import { OrderKind } from '@cowprotocol/cow-sdk'
+
+import { TRADE_URL_BUY_AMOUNT_KEY, TRADE_URL_SELL_AMOUNT_KEY } from '../const/tradeUrl'
+
+export type TradeSearchParams = {
+  amount: string | undefined
+  kind: OrderKind
+}
+
+/**
+ * Add/replace searchParams to existing search string
+ * @param search Existing search params string
+ * @param searchParamsToAdd Stuff to add
+ */
+export function parameterizeTradeSearch(search: string, searchParamsToAdd?: TradeSearchParams): string {
+  const searchParams = new URLSearchParams(search)
+
+  const amountQueryKey = searchParamsToAdd
+    ? searchParamsToAdd.kind === OrderKind.SELL
+      ? TRADE_URL_SELL_AMOUNT_KEY
+      : TRADE_URL_BUY_AMOUNT_KEY
+    : undefined
+
+  searchParamsToAdd?.amount && amountQueryKey && searchParams.set(amountQueryKey, searchParamsToAdd.amount)
+
+  return searchParams.toString()
+}

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
@@ -69,6 +69,7 @@ export const tradeButtonsMap: Record<TradeFormValidation, ButtonErrorConfig | Bu
       </TradeFormBlankButton>
     )
   },
+
   [TradeFormValidation.CurrencyNotSet]: {
     text: 'Select a token',
   },
@@ -156,6 +157,18 @@ export const tradeButtonsMap: Record<TradeFormValidation, ButtonErrorConfig | Bu
           <Trans>{context.defaultText}</Trans>
         </TradeFormBlankButton>
       </TradeApproveButton>
+    )
+  },
+  [TradeFormValidation.SellNativeToken]: (context) => {
+    const currency = context.derivedState.inputCurrency
+    const isNativeIn = !!currency && getIsNativeToken(currency)
+
+    if (!isNativeIn) return null
+
+    return (
+      <TradeFormBlankButton disabled>
+        <Trans>Selling {currency.symbol} is not supported</Trans>
+      </TradeFormBlankButton>
     )
   },
 }

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
@@ -21,7 +21,7 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
   } = context
 
   const { inputCurrency, outputCurrency, inputCurrencyAmount, inputCurrencyBalance, recipient } = derivedTradeState
-  const isNativeIn = inputCurrency && getIsNativeToken(inputCurrency)
+  const isNativeIn = inputCurrency && getIsNativeToken(inputCurrency) && !isWrapUnwrap
 
   const approvalRequired =
     !isPermitSupported && (approvalState === ApprovalState.NOT_APPROVED || approvalState === ApprovalState.PENDING)
@@ -48,6 +48,10 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
     return TradeFormValidation.CurrencyNotSet
   }
 
+  if (isNativeIn) {
+    return TradeFormValidation.SellNativeToken
+  }
+
   if (inputAmountIsNotSet) {
     return TradeFormValidation.InputAmountNotSet
   }
@@ -59,10 +63,6 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
 
     if (isSwapUnsupported) {
       return TradeFormValidation.CurrencyNotSupported
-    }
-
-    if (isNativeIn) {
-      return TradeFormValidation.SellNativeToken
     }
 
     if (!tradeQuote.response) {

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
@@ -1,4 +1,4 @@
-import { isAddress, isFractionFalsy } from '@cowprotocol/common-utils'
+import { getIsNativeToken, isAddress, isFractionFalsy } from '@cowprotocol/common-utils'
 
 import { ApprovalState } from 'legacy/hooks/useApproveCallback/useApproveCallbackMod'
 
@@ -21,6 +21,7 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
   } = context
 
   const { inputCurrency, outputCurrency, inputCurrencyAmount, inputCurrencyBalance, recipient } = derivedTradeState
+  const isNativeIn = inputCurrency && getIsNativeToken(inputCurrency)
 
   const approvalRequired =
     !isPermitSupported && (approvalState === ApprovalState.NOT_APPROVED || approvalState === ApprovalState.PENDING)
@@ -58,6 +59,10 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
 
     if (isSwapUnsupported) {
       return TradeFormValidation.CurrencyNotSupported
+    }
+
+    if (isNativeIn) {
+      return TradeFormValidation.SellNativeToken
     }
 
     if (!tradeQuote.response) {

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/types.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/types.ts
@@ -32,6 +32,9 @@ export enum TradeFormValidation {
   ExpertApproveAndSwap,
   ApproveAndSwap,
   ApproveRequired,
+
+  // Native
+  SellNativeToken,
 }
 
 export interface TradeFormValidationLocalContext {

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/index.tsx
@@ -4,14 +4,13 @@ import { useCallback } from 'react'
 import { modifySafeHandlerAnalytics } from '@cowprotocol/analytics'
 import { useIsSafeViaWc, useWalletInfo } from '@cowprotocol/wallet'
 
-import { Field } from 'legacy/state/types'
-
+import { useAdvancedOrdersDerivedState } from 'modules/advancedOrders'
+import { SellNativeWarningBanner } from 'modules/trade/containers/SellNativeWarningBanner'
 import { useIsNativeIn } from 'modules/trade/hooks/useIsNativeInOrOut'
 import { useIsWrappedOut } from 'modules/trade/hooks/useIsWrappedInOrOut'
-import { useNavigateOnCurrencySelection } from 'modules/trade/hooks/useNavigateOnCurrencySelection'
 import { useTradeRouteContext } from 'modules/trade/hooks/useTradeRouteContext'
-import { useWrappedToken } from 'modules/trade/hooks/useWrappedToken'
 import { NoImpactWarning } from 'modules/trade/pure/NoImpactWarning'
+import { TradeFormValidation, useGetTradeFormValidation } from 'modules/tradeFormValidation'
 import { useTradeQuoteFeeFiatAmount } from 'modules/tradeQuote'
 
 import { useShouldZeroApprove } from 'common/hooks/useShouldZeroApprove'
@@ -19,10 +18,8 @@ import {
   BannerOrientation,
   BundleTxApprovalBanner,
   CustomRecipientWarningBanner,
-  SellNativeWarningBanner,
 } from 'common/pure/InlineBanner/banners'
 import { ZeroApprovalWarning } from 'common/pure/ZeroApprovalWarning'
-import useNativeCurrency from 'lib/hooks/useNativeCurrency'
 
 import {
   FallbackHandlerWarning,
@@ -34,8 +31,6 @@ import { BigPartTimeWarning } from './warnings/BigPartTimeWarning'
 import { SmallPriceProtectionWarning } from './warnings/SmallPriceProtectionWarning'
 import { SwapPriceDifferenceWarning } from './warnings/SwapPriceDifferenceWarning'
 
-import { useAdvancedOrdersDerivedState } from '../../../advancedOrders'
-import { TradeFormValidation, useGetTradeFormValidation } from '../../../tradeFormValidation'
 import { useIsFallbackHandlerRequired } from '../../hooks/useFallbackHandlerVerification'
 import { useTwapWarningsContext } from '../../hooks/useTwapWarningsContext'
 import { TwapFormState } from '../../pure/PrimaryActionButton/getTwapFormState'
@@ -95,16 +90,12 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
 
   const showRecipientWarning = isConfirmationModal && twapOrder?.receiver && twapOrder.receiver !== account
 
-  const navigateOnCurrencySelection = useNavigateOnCurrencySelection()
-
-  const native = useNativeCurrency()
-  const wrapped = useWrappedToken()
   const isNativeIn = useIsNativeIn()
   const isWrappedOut = useIsWrappedOut()
 
   // TODO: implement Safe App EthFlow bundling for TWAP and disable the warning in that case
   const showNativeSellWarning =
-    isNativeIn && !isWrappedOut && native && wrapped && primaryFormValidation === TradeFormValidation.SellNativeToken
+    isNativeIn && !isWrappedOut && primaryFormValidation === TradeFormValidation.SellNativeToken
 
   // Don't display any warnings while a wallet is not connected
   if (walletIsNotConnected) return null
@@ -138,14 +129,7 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
         }
 
         if (showNativeSellWarning) {
-          return (
-            <SellNativeWarningBanner
-              nativeSymbol={native.symbol}
-              wrappedNativeSymbol={wrapped.symbol}
-              sellWrapped={() => navigateOnCurrencySelection(Field.INPUT, wrapped)}
-              wrapNative={() => navigateOnCurrencySelection(Field.OUTPUT, wrapped)}
-            />
-          )
+          return <SellNativeWarningBanner />
         }
 
         if (localFormValidation === TwapFormState.SELL_AMOUNT_TOO_SMALL) {

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/index.tsx
@@ -6,8 +6,6 @@ import { useIsSafeViaWc, useWalletInfo } from '@cowprotocol/wallet'
 
 import { useAdvancedOrdersDerivedState } from 'modules/advancedOrders'
 import { SellNativeWarningBanner } from 'modules/trade/containers/SellNativeWarningBanner'
-import { useIsNativeIn } from 'modules/trade/hooks/useIsNativeInOrOut'
-import { useIsWrappedOut } from 'modules/trade/hooks/useIsWrappedInOrOut'
 import { useTradeRouteContext } from 'modules/trade/hooks/useTradeRouteContext'
 import { NoImpactWarning } from 'modules/trade/pure/NoImpactWarning'
 import { TradeFormValidation, useGetTradeFormValidation } from 'modules/tradeFormValidation'
@@ -90,13 +88,6 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
 
   const showRecipientWarning = isConfirmationModal && twapOrder?.receiver && twapOrder.receiver !== account
 
-  const isNativeIn = useIsNativeIn()
-  const isWrappedOut = useIsWrappedOut()
-
-  // TODO: implement Safe App EthFlow bundling for TWAP and disable the warning in that case
-  const showNativeSellWarning =
-    isNativeIn && !isWrappedOut && primaryFormValidation === TradeFormValidation.SellNativeToken
-
   // Don't display any warnings while a wallet is not connected
   if (walletIsNotConnected) return null
 
@@ -128,7 +119,7 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
           return <UnsupportedWalletWarning isSafeViaWc={isSafeViaWc} />
         }
 
-        if (showNativeSellWarning) {
+        if (primaryFormValidation === TradeFormValidation.SellNativeToken) {
           return <SellNativeWarningBanner />
         }
 


### PR DESCRIPTION
# Summary

Part of 2024 roadmap.

Improve sell ETH UX for limit orders.

While UX wise the ethflow contract is not usable IMO for Limit orders, the current UX is also not optimal.
When the user tries to sell ETH for anything other than WETH (a wrap), the UI silently switches it to WETH.

This PR makes it so:
1. ETH is selectable both on limit and twap
2. The trade button is disabled
3. A warning with a short explanation and the options available are displayed

![Screenshot 2024-01-04 at 14 34 06](https://github.com/cowprotocol/cowswap/assets/43217/031f70ac-3f91-4508-ac15-2c4b122fb489)

Think of it as a poor's man version of the classic eth flow.

## Notes

 **1:** While Safe Apps could in theory do the wrap + order placement as it's available now for SWAPs on LIMIT and TWAP, it's out of the scope of this PR, mainly for a similar reason as for the ethflow contract.
While on LIMIT and TWAP the funds are NOT locked in the ethflow contract, they will end up in a different token and might be wrapped needlessly, in case the trades don't happen.

**2:** Text is definitely not final. Open to suggestions.

# To Test

1. Open the limit orders with an EOA
2. Pick eth as sell token
* Should not be tradable
* Should show warning
3. Click on `Switch to WETH`
* Should select WETH as the sell token. The rest of the parameters should remain unchanged
4. Go back and click on `Wrap ETH to WETH`
* Should switch to wrapping ETH for ETH. The rest of the parameters should remain unchanged
5. Repeat 2-4 with a Safe App
* Should have the same results
6. Repeat 2-4 with a Safe App, on TWAP form
* Should have the same results