### PR TITLE
fix(swap): disable eth flow selling on buy orders

### DIFF
--- a/apps/cowswap-frontend/src/legacy/state/swap/reducer.ts
+++ b/apps/cowswap-frontend/src/legacy/state/swap/reducer.ts
@@ -78,12 +78,12 @@ export default createReducer<SwapState>(initialState, (builder) =>
       const { chainId, recipient, inputCurrencyId, outputCurrencyId, inputCurrencyAmount, outputCurrencyAmount } =
         payload
 
-      const probableTypedValue = state.independentField === Field.INPUT ? inputCurrencyAmount : outputCurrencyAmount
+      const defaultTypedValue = state.independentField === Field.INPUT ? inputCurrencyAmount : outputCurrencyAmount
 
       const { independentField, typedValue } = getEthFlowOverridesOnSelect(
         inputCurrencyId,
         state.independentField,
-        probableTypedValue || state.typedValue,
+        defaultTypedValue || state.typedValue,
         state
       )
 

--- a/apps/cowswap-frontend/src/legacy/state/swap/reducer.ts
+++ b/apps/cowswap-frontend/src/legacy/state/swap/reducer.ts
@@ -78,11 +78,19 @@ export default createReducer<SwapState>(initialState, (builder) =>
       const { chainId, recipient, inputCurrencyId, outputCurrencyId, inputCurrencyAmount, outputCurrencyAmount } =
         payload
 
-      const typedValue = state.independentField === Field.INPUT ? inputCurrencyAmount : outputCurrencyAmount
+      const probableTypedValue = state.independentField === Field.INPUT ? inputCurrencyAmount : outputCurrencyAmount
+
+      const { independentField, typedValue } = getEthFlowOverridesOnSelect(
+        inputCurrencyId,
+        state.independentField,
+        probableTypedValue || state.typedValue,
+        state
+      )
 
       return {
         ...state,
-        typedValue: typedValue ?? state.typedValue,
+        typedValue,
+        independentField,
         chainId,
         [Field.INPUT]: {
           currencyId: inputCurrencyId ?? null,


### PR DESCRIPTION
# Summary

Fix #3523 

It was possible to create a buy order selling ETH, which is not supported at protocol level.

# To Test

1. Pick any pair
2. Create a buy order
3. Replace the sell token with ETH
* The amounts should be cleared
* The buy input should not be editable
4. Play around with different combinations of buy and sell orders, buying and selling ETH and regular tokens
* Everything should work as usual

# Context

Nenad [left a note about this](https://github.com/cowprotocol/cowswap/blob/1cdfa24c6448e3ebf2c6e3c986cb5d7bfd269aa4/apps/cowswap-frontend/src/modules/trade/hooks/useSwitchTokensPlaces.ts#L16C1-L17) :)