### PR TITLE
fix(swap): fix swap out of market

### DIFF
--- a/apps/cowswap-frontend/src/common/updaters/orders/UnfillableOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/UnfillableOrdersUpdater.ts
@@ -1,5 +1,5 @@
 import { useSetAtom } from 'jotai'
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 
 import { priceOutOfRangeAnalytics } from '@cowprotocol/analytics'
 import { useTokensBalances } from '@cowprotocol/balances-and-allowances'
@@ -44,9 +44,7 @@ export function UnfillableOrdersUpdater(): null {
   const updatePendingOrderPrices = useSetAtom(updatePendingOrderPricesAtom)
   const isWindowVisible = useIsWindowVisible()
 
-  const pendingLimit = useOnlyPendingOrders(chainId, UiOrderType.LIMIT)
-  const pendingTwap = useOnlyPendingOrders(chainId, UiOrderType.TWAP)
-  const pending = useMemo(() => pendingLimit.concat(pendingTwap), [pendingLimit, pendingTwap])
+  const pending = useOnlyPendingOrders(chainId)
 
   const setIsOrderUnfillable = useSetIsOrderUnfillable()
   const strategy = useGetGpPriceStrategy()

--- a/apps/cowswap-frontend/src/common/updaters/orders/UnfillableOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/UnfillableOrdersUpdater.ts
@@ -263,6 +263,8 @@ async function _getOrderPrice(
     receiver: order.receiver,
     isEthFlow,
     priceQuality: getPriceQuality({ verifyQuote }),
+    appData: order.appData ?? undefined,
+    appDataHash: order.appDataHash ?? undefined,
   }
   try {
     return getBestQuote({ strategy, quoteParams, fetchFee: false, isPriceRefresh: false })

--- a/apps/cowswap-frontend/src/common/updaters/orders/UnfillableOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/UnfillableOrdersUpdater.ts
@@ -223,6 +223,9 @@ async function _getOrderPrice(
 
   const amount = getRemainderAmount(order.kind, order)
 
+  // Don't quote if there's nothing left to match in this order
+  if (amount === '0') return null
+
   if (order.kind === 'sell') {
     // this order sell amount is sellAmountAfterFees
     // this is an issue as it will be adjusted again in the backend

--- a/apps/cowswap-frontend/src/legacy/state/orders/hooks.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/hooks.ts
@@ -294,7 +294,7 @@ export const useCombinedPendingOrders = ({
  * The difference is that this hook returns only orders that have the status PENDING
  * while usePendingOrders aggregates all pending states
  */
-export const useOnlyPendingOrders = (chainId: SupportedChainId, uiOrderType: UiOrderType): Order[] => {
+export const useOnlyPendingOrders = (chainId: SupportedChainId): Order[] => {
   const state = useSelector<AppState, PartialOrdersMap | undefined>(
     (state) => chainId && state.orders?.[chainId]?.pending
   )
@@ -302,11 +302,8 @@ export const useOnlyPendingOrders = (chainId: SupportedChainId, uiOrderType: UiO
   return useMemo(() => {
     if (!state) return []
 
-    return Object.values(state)
-      .filter((order) => order && getUiOrderType(order.order) === uiOrderType)
-      .map(_deserializeOrder)
-      .filter(isTruthy)
-  }, [state, uiOrderType])
+    return Object.values(state).map(_deserializeOrder).filter(isTruthy)
+  }, [state])
 }
 
 export const useCancelledOrders = ({ chainId }: GetOrdersParams): Order[] => {


### PR DESCRIPTION
# Summary

Fixes #3561 

Swap orders should show out of the market again.

![Screenshot 2024-01-05 at 16 28 04](https://github.com/cowprotocol/cowswap/assets/43217/8ad5822c-f1cd-47bd-a961-c0e1ed770e79)

![Screenshot 2024-01-05 at 16 28 18](https://github.com/cowprotocol/cowswap/assets/43217/8e2c999b-e41d-4fdb-a5a3-52360b51b77d)

# To Test

Check the instructions on #3561 