### PR TITLE
chore: bump @cowprotocol/permit-utils version

### DIFF
--- a/libs/permit-utils/package.json
+++ b/libs/permit-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/permit-utils",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "dependencies": {
     "ethers": "^5.7.2",


### PR DESCRIPTION
# Summary

The package must be published with Sepolia updates