### PR TITLE
fix: remove issue with non-argent smart-contract wallet throwing too …

### DIFF
--- a/libs/wallet/src/web3-react/hooks/useIsSmartContractWallet.ts
+++ b/libs/wallet/src/web3-react/hooks/useIsSmartContractWallet.ts
@@ -70,7 +70,7 @@ function useIsArgentWallet(): boolean {
     () => {
       if (!argentWalletContract || !account) return Promise.resolve(false)
 
-      return argentWalletContract.callStatic.isArgentWallet(account)
+      return argentWalletContract.callStatic.isArgentWallet(account).catch(() => false)
     },
     [argentWalletContract],
     false


### PR DESCRIPTION
Our top issue in Sentry is something expected. This PR just removes the noise

This is the top issue (the second issue is 7K):
<img width="1485" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/36ed0d3f-2b72-4709-95ab-9a417b919551">

This PR assumes that an error calling this function just means it is not an argent wallet. 
It's not bulletproof, as it can fail for a network issue, however, I think it's a good compromise. This wallet detection is not too critical, and refreshing would re-attempt, so its not an issue to assume that if it fails is not an argent wallet.