### PR TITLE
chore: bump ethflowcontract to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@cowprotocol/contracts": "^1.3.1",
     "@cowprotocol/cow-runner-game": "^0.2.9",
     "@cowprotocol/cow-sdk": "^4.0.5",
-    "@cowprotocol/ethflowcontract": "cowprotocol/ethflowcontract.git#v1.1.0-artifacts",
+    "@cowprotocol/ethflowcontract": "cowprotocol/ethflowcontract.git#v1.1.1-artifacts",
     "@davatar/react": "1.8.1",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2302,9 +2302,9 @@
     graphql-request "^4.3.0"
     limiter "^2.1.0"
 
-"@cowprotocol/ethflowcontract@cowprotocol/ethflowcontract.git#v1.1.0-artifacts":
-  version "1.0.0"
-  resolved "https://codeload.github.com/cowprotocol/ethflowcontract/tar.gz/58dd33fa5250f31ff99008c1bf3c626ffe63bee0"
+"@cowprotocol/ethflowcontract@cowprotocol/ethflowcontract.git#v1.1.1-artifacts":
+  version "1.1.1"
+  resolved "https://codeload.github.com/cowprotocol/ethflowcontract/tar.gz/70e5ac842c10f82aff098f29abfcd2d14f083134"
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"


### PR DESCRIPTION
# Summary

New version https://github.com/cowprotocol/ethflowcontract/releases/tag/v1.1.1-artifacts

Only change from 1.1.0 is the package.json version bump from 1.0.0 to 1.1.1

# To Test

1. Ethflow should work on all networks, including sepolia