### PR TITLE
fix: don't crash when permittable tokens atom doesn't contain new network

### DIFF
--- a/apps/cowswap-frontend/src/modules/permit/hooks/useGetPermitInfo.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/useGetPermitInfo.ts
@@ -15,7 +15,7 @@ export function useGetPermitInfo(chainId: SupportedChainId): (tokenAddress: stri
   const permittableTokens = useAtomValue(permittableTokensAtom)
 
   return useCallback(
-    (tokenAddress: string) => permittableTokens[chainId][tokenAddress.toLowerCase()],
+    (tokenAddress: string) => permittableTokens[chainId]?.[tokenAddress.toLowerCase()],
     [chainId, permittableTokens]
   )
 }

--- a/apps/cowswap-frontend/src/modules/permit/hooks/usePermitInfo.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/usePermitInfo.ts
@@ -117,6 +117,6 @@ function _usePermitInfo(chainId: SupportedChainId, tokenAddress: string | undefi
   return useMemo(() => {
     if (!tokenAddress) return undefined
 
-    return permittableTokens[chainId][tokenAddress.toLowerCase()]
+    return permittableTokens[chainId]?.[tokenAddress.toLowerCase()]
   }, [chainId, permittableTokens, tokenAddress])
 }

--- a/apps/cowswap-frontend/src/modules/permit/state/permittableTokensAtom.ts
+++ b/apps/cowswap-frontend/src/modules/permit/state/permittableTokensAtom.ts
@@ -15,7 +15,7 @@ type PermittableTokens = Record<string, PermitInfo>
  * Contains either the permit info for every token checked locally
  */
 
-export const permittableTokensAtom = atomWithStorage<Record<SupportedChainId, PermittableTokens>>(
+export const permittableTokensAtom = atomWithStorage<Record<SupportedChainId, PermittableTokens | undefined>>(
   'permittableTokens:v2',
   mapSupportedNetworks({})
 )
@@ -28,7 +28,10 @@ export const addPermitInfoForTokenAtom = atom(
   (get, set, { chainId, tokenAddress, permitInfo }: AddPermitTokenParams) => {
     const permittableTokens = { ...get(permittableTokensAtom) }
 
-    permittableTokens[chainId][tokenAddress.toLowerCase()] = permitInfo
+    permittableTokens[chainId] = {
+      ...permittableTokens[chainId],
+      [tokenAddress.toLowerCase()]: permitInfo,
+    }
 
     set(permittableTokensAtom, permittableTokens)
   }


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C0361CDG8GP/p1704892417024459?thread_ts=1704724619.995319&cid=C0361CDG8GP

1. Changed type to `PermittableTokens | undefined` to be safe from undefined values
2. Added optional operators for atom

