### PR TITLE
fix: merge localStorage state with initial state to prevent empty states

### DIFF
--- a/apps/cowswap-frontend/src/modules/permit/state/permittableTokensAtom.ts
+++ b/apps/cowswap-frontend/src/modules/permit/state/permittableTokensAtom.ts
@@ -1,12 +1,16 @@
 import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 
-import { SupportedChainId, mapSupportedNetworks } from '@cowprotocol/cow-sdk'
+import { getJotaiMergerStorage } from '@cowprotocol/core'
+import { mapSupportedNetworks, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { PermitInfo } from '@cowprotocol/permit-utils'
 
 import { AddPermitTokenParams } from '../types'
 
 type PermittableTokens = Record<string, PermitInfo>
+type PermittableTokensAtom = Record<SupportedChainId, PermittableTokens>
+
+const INITIAL_STATE: PermittableTokensAtom = mapSupportedNetworks({})
 
 /**
  * Atom that stores the permittable tokens info for each chain on localStorage.
@@ -15,9 +19,10 @@ type PermittableTokens = Record<string, PermitInfo>
  * Contains either the permit info for every token checked locally
  */
 
-export const permittableTokensAtom = atomWithStorage<Record<SupportedChainId, PermittableTokens | undefined>>(
+export const permittableTokensAtom = atomWithStorage<PermittableTokensAtom>(
   'permittableTokens:v2',
-  mapSupportedNetworks({})
+  INITIAL_STATE,
+  getJotaiMergerStorage(INITIAL_STATE)
 )
 
 /**
@@ -28,10 +33,7 @@ export const addPermitInfoForTokenAtom = atom(
   (get, set, { chainId, tokenAddress, permitInfo }: AddPermitTokenParams) => {
     const permittableTokens = { ...get(permittableTokensAtom) }
 
-    permittableTokens[chainId] = {
-      ...permittableTokens[chainId],
-      [tokenAddress.toLowerCase()]: permitInfo,
-    }
+    permittableTokens[chainId][tokenAddress.toLowerCase()] = permitInfo
 
     set(permittableTokensAtom, permittableTokens)
   }

--- a/apps/cowswap-frontend/src/modules/permit/state/permittableTokensAtom.ts
+++ b/apps/cowswap-frontend/src/modules/permit/state/permittableTokensAtom.ts
@@ -8,9 +8,6 @@ import { PermitInfo } from '@cowprotocol/permit-utils'
 import { AddPermitTokenParams } from '../types'
 
 type PermittableTokens = Record<string, PermitInfo>
-type PermittableTokensAtom = Record<SupportedChainId, PermittableTokens>
-
-const INITIAL_STATE: PermittableTokensAtom = mapSupportedNetworks({})
 
 /**
  * Atom that stores the permittable tokens info for each chain on localStorage.
@@ -19,10 +16,10 @@ const INITIAL_STATE: PermittableTokensAtom = mapSupportedNetworks({})
  * Contains either the permit info for every token checked locally
  */
 
-export const permittableTokensAtom = atomWithStorage<PermittableTokensAtom>(
+export const permittableTokensAtom = atomWithStorage<Record<SupportedChainId, PermittableTokens>>(
   'permittableTokens:v2',
-  INITIAL_STATE,
-  getJotaiMergerStorage(INITIAL_STATE)
+  mapSupportedNetworks({}),
+  getJotaiMergerStorage()
 )
 
 /**

--- a/libs/core/src/jotaiStore.ts
+++ b/libs/core/src/jotaiStore.ts
@@ -28,18 +28,22 @@ export const getJotaiIsolatedStorage = <T>() => {
  *
  * Based on https://github.com/pmndrs/jotai/discussions/1357
  *
- * @param initialState initial state to merge with localStorage info
  * @returns jotai json storage with merged localStorage info and initial state.
  *
  * @example
  * const storage = getJotaiMergerStorage({ foo: 'bar' })
  */
-export function getJotaiMergerStorage<T>(initialState: T) {
+export function getJotaiMergerStorage<T>() {
   const storage = createJSONStorage<T>(() => localStorage)
 
-  function getItem(key: string) {
-    const value = storage.getItem(key, initialState)
-    return { ...value, ...initialState }
+  function getItem(key: string, initial: T) {
+    const value = storage.getItem(key, initial)
+
+    const r = { ...initial, ...value }
+
+    console.log(`jotaiStore: ${key}`, value, initial, r)
+
+    return r
   }
 
   return { ...storage, getItem }

--- a/libs/core/src/jotaiStore.ts
+++ b/libs/core/src/jotaiStore.ts
@@ -9,7 +9,7 @@ export const jotaiStore = createStore()
  * https://github.com/pmndrs/jotai/pull/1004/files
  *
  * Important!
- * In jotai@2.x they changed the fix above and now we have to patch subscribe method
+ * In jotai@2.x they changed the fix above, and now we have to patch the subscribe method
  */
 export const getJotaiIsolatedStorage = <T>() => {
   const storage = createJSONStorage<T>(() => localStorage)
@@ -23,15 +23,12 @@ export const getJotaiIsolatedStorage = <T>() => {
  * Creates a new jotai json storage which merges the existing local storage with given state
  *
  * By default, jotai returns the initial state when localStorage is unset
- * When it's set, though, it takes precedence, even if doesn't contain info in the initial state.
+ * When it's set, though, it takes precedence, even if it doesn't contain info in the initial state.
  * This is why we merge the initial state with the localStorage info.
  *
  * Based on https://github.com/pmndrs/jotai/discussions/1357
  *
  * @returns jotai json storage with merged localStorage info and initial state.
- *
- * @example
- * const storage = getJotaiMergerStorage({ foo: 'bar' })
  */
 export function getJotaiMergerStorage<T>() {
   const storage = createJSONStorage<T>(() => localStorage)
@@ -39,11 +36,8 @@ export function getJotaiMergerStorage<T>() {
   function getItem(key: string, initial: T) {
     const value = storage.getItem(key, initial)
 
-    const r = { ...initial, ...value }
-
-    console.log(`jotaiStore: ${key}`, value, initial, r)
-
-    return r
+    // `initial` comes first, as existing `value` should take precedence
+    return { ...initial, ...value }
   }
 
   return { ...storage, getItem }

--- a/libs/core/src/jotaiStore.ts
+++ b/libs/core/src/jotaiStore.ts
@@ -18,3 +18,29 @@ export const getJotaiIsolatedStorage = <T>() => {
 
   return storage
 }
+
+/**
+ * Creates a new jotai json storage which merges the existing local storage with given state
+ *
+ * By default, jotai returns the initial state when localStorage is unset
+ * When it's set, though, it takes precedence, even if doesn't contain info in the initial state.
+ * This is why we merge the initial state with the localStorage info.
+ *
+ * Based on https://github.com/pmndrs/jotai/discussions/1357
+ *
+ * @param initialState initial state to merge with localStorage info
+ * @returns jotai json storage with merged localStorage info and initial state.
+ *
+ * @example
+ * const storage = getJotaiMergerStorage({ foo: 'bar' })
+ */
+export function getJotaiMergerStorage<T>(initialState: T) {
+  const storage = createJSONStorage<T>(() => localStorage)
+
+  function getItem(key: string) {
+    const value = storage.getItem(key, initialState)
+    return { ...value, ...initialState }
+  }
+
+  return { ...storage, getItem }
+}

--- a/libs/tokens/src/state/tokenLists/tokenListsStateAtom.ts
+++ b/libs/tokens/src/state/tokenLists/tokenListsStateAtom.ts
@@ -5,10 +5,14 @@ import { mapSupportedNetworks } from '@cowprotocol/cow-sdk'
 import { ListsSourcesByNetwork, ListState, TokenListsState } from '../../types'
 import { DEFAULT_TOKENS_LISTS } from '../../const/tokensLists'
 import { environmentAtom } from '../environmentAtom'
+import { getJotaiMergerStorage } from '@cowprotocol/core'
+
+const USER_ADDED_LISTS_INITIAL_STATE: ListsSourcesByNetwork = mapSupportedNetworks([])
 
 export const userAddedListsSourcesAtom = atomWithStorage<ListsSourcesByNetwork>(
   'userAddedTokenListsAtom:v2',
-  mapSupportedNetworks([])
+  USER_ADDED_LISTS_INITIAL_STATE,
+  getJotaiMergerStorage(USER_ADDED_LISTS_INITIAL_STATE)
 )
 
 export const allListsSourcesAtom = atom((get) => {
@@ -18,10 +22,13 @@ export const allListsSourcesAtom = atom((get) => {
   return [...DEFAULT_TOKENS_LISTS[chainId], ...(userAddedTokenLists[chainId] || [])]
 })
 
+const LIST_STATES_INITIAL_STATE: TokenListsState = mapSupportedNetworks({})
+
 // Lists states
 export const listsStatesByChainAtom = atomWithStorage<TokenListsState>(
   'allTokenListsInfoAtom:v2',
-  mapSupportedNetworks({})
+  LIST_STATES_INITIAL_STATE,
+  getJotaiMergerStorage(LIST_STATES_INITIAL_STATE)
 )
 
 export const tokenListsUpdatingAtom = atom<boolean>(false)

--- a/libs/tokens/src/state/tokenLists/tokenListsStateAtom.ts
+++ b/libs/tokens/src/state/tokenLists/tokenListsStateAtom.ts
@@ -7,12 +7,10 @@ import { DEFAULT_TOKENS_LISTS } from '../../const/tokensLists'
 import { environmentAtom } from '../environmentAtom'
 import { getJotaiMergerStorage } from '@cowprotocol/core'
 
-const USER_ADDED_LISTS_INITIAL_STATE: ListsSourcesByNetwork = mapSupportedNetworks([])
-
 export const userAddedListsSourcesAtom = atomWithStorage<ListsSourcesByNetwork>(
   'userAddedTokenListsAtom:v2',
-  USER_ADDED_LISTS_INITIAL_STATE,
-  getJotaiMergerStorage(USER_ADDED_LISTS_INITIAL_STATE)
+  mapSupportedNetworks([]),
+  getJotaiMergerStorage()
 )
 
 export const allListsSourcesAtom = atom((get) => {
@@ -22,13 +20,11 @@ export const allListsSourcesAtom = atom((get) => {
   return [...DEFAULT_TOKENS_LISTS[chainId], ...(userAddedTokenLists[chainId] || [])]
 })
 
-const LIST_STATES_INITIAL_STATE: TokenListsState = mapSupportedNetworks({})
-
 // Lists states
 export const listsStatesByChainAtom = atomWithStorage<TokenListsState>(
   'allTokenListsInfoAtom:v2',
-  LIST_STATES_INITIAL_STATE,
-  getJotaiMergerStorage(LIST_STATES_INITIAL_STATE)
+  mapSupportedNetworks({}),
+  getJotaiMergerStorage()
 )
 
 export const tokenListsUpdatingAtom = atom<boolean>(false)

--- a/libs/tokens/src/state/tokens/unsupportedTokensAtom.ts
+++ b/libs/tokens/src/state/tokens/unsupportedTokensAtom.ts
@@ -5,14 +5,10 @@ import { environmentAtom } from '../environmentAtom'
 import { UnsupportedTokensState } from '../../types'
 import { getJotaiMergerStorage } from '@cowprotocol/core'
 
-type UnsupportedTokensAtom = Record<SupportedChainId, UnsupportedTokensState>
-
-const INITIAL_STATE: UnsupportedTokensAtom = mapSupportedNetworks({})
-
-export const unsupportedTokensAtom = atomWithStorage<UnsupportedTokensAtom>(
+export const unsupportedTokensAtom = atomWithStorage<Record<SupportedChainId, UnsupportedTokensState>>(
   'unsupportedTokensAtom:v1',
-  INITIAL_STATE,
-  getJotaiMergerStorage(INITIAL_STATE)
+  mapSupportedNetworks({}),
+  getJotaiMergerStorage()
 )
 
 export const currentUnsupportedTokensAtom = atom((get) => {

--- a/libs/tokens/src/state/tokens/unsupportedTokensAtom.ts
+++ b/libs/tokens/src/state/tokens/unsupportedTokensAtom.ts
@@ -1,12 +1,18 @@
 import { atomWithStorage } from 'jotai/utils'
-import { SupportedChainId, mapSupportedNetworks } from '@cowprotocol/cow-sdk'
+import { mapSupportedNetworks, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { atom } from 'jotai'
 import { environmentAtom } from '../environmentAtom'
 import { UnsupportedTokensState } from '../../types'
+import { getJotaiMergerStorage } from '@cowprotocol/core'
 
-export const unsupportedTokensAtom = atomWithStorage<Record<SupportedChainId, UnsupportedTokensState>>(
+type UnsupportedTokensAtom = Record<SupportedChainId, UnsupportedTokensState>
+
+const INITIAL_STATE: UnsupportedTokensAtom = mapSupportedNetworks({})
+
+export const unsupportedTokensAtom = atomWithStorage<UnsupportedTokensAtom>(
   'unsupportedTokensAtom:v1',
-  mapSupportedNetworks({})
+  INITIAL_STATE,
+  getJotaiMergerStorage(INITIAL_STATE)
 )
 
 export const currentUnsupportedTokensAtom = atom((get) => {

--- a/libs/tokens/src/state/tokens/userAddedTokensAtom.ts
+++ b/libs/tokens/src/state/tokens/userAddedTokensAtom.ts
@@ -7,14 +7,10 @@ import { TokenWithLogo } from '@cowprotocol/common-const'
 import { Token } from '@uniswap/sdk-core'
 import { getJotaiMergerStorage } from '@cowprotocol/core'
 
-type UserAddedTokensAtom = Record<SupportedChainId, TokensMap>
-
-const INITIAL_STATE: UserAddedTokensAtom = mapSupportedNetworks({})
-
-export const userAddedTokensAtom = atomWithStorage<UserAddedTokensAtom>(
+export const userAddedTokensAtom = atomWithStorage<Record<SupportedChainId, TokensMap>>(
   'userAddedTokensAtom:v1',
-  INITIAL_STATE,
-  getJotaiMergerStorage(INITIAL_STATE)
+  mapSupportedNetworks({}),
+  getJotaiMergerStorage()
 )
 
 export const userAddedTokensListAtom = atom((get) => {

--- a/libs/tokens/src/state/tokens/userAddedTokensAtom.ts
+++ b/libs/tokens/src/state/tokens/userAddedTokensAtom.ts
@@ -1,14 +1,20 @@
 import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
-import { SupportedChainId, mapSupportedNetworks } from '@cowprotocol/cow-sdk'
+import { mapSupportedNetworks, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { TokensMap } from '../../types'
 import { environmentAtom } from '../environmentAtom'
 import { TokenWithLogo } from '@cowprotocol/common-const'
 import { Token } from '@uniswap/sdk-core'
+import { getJotaiMergerStorage } from '@cowprotocol/core'
 
-export const userAddedTokensAtom = atomWithStorage<Record<SupportedChainId, TokensMap>>(
+type UserAddedTokensAtom = Record<SupportedChainId, TokensMap>
+
+const INITIAL_STATE: UserAddedTokensAtom = mapSupportedNetworks({})
+
+export const userAddedTokensAtom = atomWithStorage<UserAddedTokensAtom>(
   'userAddedTokensAtom:v1',
-  mapSupportedNetworks({})
+  INITIAL_STATE,
+  getJotaiMergerStorage(INITIAL_STATE)
 )
 
 export const userAddedTokensListAtom = atom((get) => {

--- a/libs/tokens/src/updaters/TokensListsUpdater/index.ts
+++ b/libs/tokens/src/updaters/TokensListsUpdater/index.ts
@@ -14,15 +14,11 @@ import { atomWithStorage } from 'jotai/utils'
 import { atomWithPartialUpdate } from '@cowprotocol/common-utils'
 import { getJotaiMergerStorage } from '@cowprotocol/core'
 
-type LastUpdateTimeAtom = Record<SupportedChainId, number>
-
-const INITIAL_STATE: LastUpdateTimeAtom = mapSupportedNetworks(0)
-
 const { atom: lastUpdateTimeAtom, updateAtom: updateLastUpdateTimeAtom } = atomWithPartialUpdate(
-  atomWithStorage<LastUpdateTimeAtom>(
+  atomWithStorage<Record<SupportedChainId, number>>(
     'tokens:lastUpdateTimeAtom:v0',
-    INITIAL_STATE,
-    getJotaiMergerStorage(INITIAL_STATE)
+    mapSupportedNetworks(0),
+    getJotaiMergerStorage()
   )
 )
 

--- a/libs/tokens/src/updaters/TokensListsUpdater/index.ts
+++ b/libs/tokens/src/updaters/TokensListsUpdater/index.ts
@@ -2,7 +2,7 @@ import { useAtomValue, useSetAtom } from 'jotai'
 import useSWR, { SWRConfiguration } from 'swr'
 import { useEffect } from 'react'
 
-import { SupportedChainId, mapSupportedNetworks } from '@cowprotocol/cow-sdk'
+import { mapSupportedNetworks, SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import { allListsSourcesAtom, tokenListsUpdatingAtom } from '../../state/tokenLists/tokenListsStateAtom'
 import { fetchTokenList } from '../../services/fetchTokenList'
@@ -12,9 +12,18 @@ import { ListState } from '../../types'
 import { upsertListsAtom } from '../../state/tokenLists/tokenListsActionsAtom'
 import { atomWithStorage } from 'jotai/utils'
 import { atomWithPartialUpdate } from '@cowprotocol/common-utils'
+import { getJotaiMergerStorage } from '@cowprotocol/core'
+
+type LastUpdateTimeAtom = Record<SupportedChainId, number>
+
+const INITIAL_STATE: LastUpdateTimeAtom = mapSupportedNetworks(0)
 
 const { atom: lastUpdateTimeAtom, updateAtom: updateLastUpdateTimeAtom } = atomWithPartialUpdate(
-  atomWithStorage<Record<SupportedChainId, number>>('tokens:lastUpdateTimeAtom:v0', mapSupportedNetworks(0))
+  atomWithStorage<LastUpdateTimeAtom>(
+    'tokens:lastUpdateTimeAtom:v0',
+    INITIAL_STATE,
+    getJotaiMergerStorage(INITIAL_STATE)
+  )
 )
 
 const swrOptions: SWRConfiguration = {


### PR DESCRIPTION
# Summary

There has been a couple of app crashes since the refactor to add Sepolia, due to missing data coming from localStorage

- https://github.com/cowprotocol/cowswap/pull/3603
- https://github.com/cowprotocol/cowswap/pull/3594
- https://github.com/cowprotocol/cowswap/pull/3589

This is an attempt to prevent this from happening on any atom that depends on multiple networks and might face the same issue.

The fix is to use a new jotai storage as proposed on https://github.com/pmndrs/jotai/discussions/1357

# To Test

1. Load app
* Should work as usual, no crashes
3. Insert local storage from an env without Sepolia
4. Refresh
* Should work as usual, no crashes
* Stored state should remain

One more PR exclusive feature (should be removed) is a log entry starting with `jotaiStore`
1. Filter by `jotaiStore` in the console
2. It should log the key being accessed, the value stored on localStorage, the initialValue for the key and at the end the merged state combining both, where localStorage takes precedence
![image](https://github.com/cowprotocol/cowswap/assets/43217/a632dd56-bd10-4545-a853-9aaf19c388bd)
