### PR TITLE
fix(token-search): fix token search results

### DIFF
--- a/apps/cowswap-frontend/src/modules/tokensList/pure/FavouriteTokensList/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/FavouriteTokensList/index.tsx
@@ -18,8 +18,8 @@ export function FavouriteTokensList(props: FavouriteTokensListProps) {
   return (
     <div>
       <styledEl.Header>
-        <h4>Favourite tokens</h4>
-        <InfoIcon iconType="help" content="Your favourite saved tokens. Edit this list in your account page." />
+        <h4>Favorite tokens</h4>
+        <InfoIcon iconType="help" content="Your favorite saved tokens. Edit this list in your account page." />
       </styledEl.Header>
       <styledEl.List>
         {tokens.map((token) => {

--- a/libs/tokens/src/utils/tokenMapToListWithLogo.ts
+++ b/libs/tokens/src/utils/tokenMapToListWithLogo.ts
@@ -7,6 +7,6 @@ import { TokensMap } from '../types'
  */
 export function tokenMapToListWithLogo(tokenMap: TokensMap): TokenWithLogo[] {
   return Object.values(tokenMap)
-    .sort((a, b) => (a.symbol > b.symbol ? 1 : -1))
+    .sort((a, b) => (a.symbol === b.symbol ? 0 : a.symbol > b.symbol ? 1 : -1))
     .map((token) => TokenWithLogo.fromToken(token, token.logoURI))
 }

--- a/libs/tokens/src/utils/tokenMapToListWithLogo.ts
+++ b/libs/tokens/src/utils/tokenMapToListWithLogo.ts
@@ -7,6 +7,6 @@ import { TokensMap } from '../types'
  */
 export function tokenMapToListWithLogo(tokenMap: TokensMap): TokenWithLogo[] {
   return Object.values(tokenMap)
-    .sort((a, b) => (a.symbol === b.symbol ? 0 : a.symbol > b.symbol ? 1 : -1))
+    .sort((a, b) => a.symbol.localeCompare(b.symbol))
     .map((token) => TokenWithLogo.fromToken(token, token.logoURI))
 }


### PR DESCRIPTION
# Summary

Fixes #3599 

There were 2 issues with token search

1. Sorting inconsistency

Due to default browsers' sorting behaviour, the results were different when the symbols were identical.
This is the case for [StaFi](https://etherscan.io/token/0x9559Aaa82d9649C7A7b220E7c461d2E74c9a3593) and [Rocket Poll Eth](https://etherscan.io/token/0xae78736Cd615f374D3085123A210448E74Fc6393).

2. Only last match was picked

In the displayed list of matches, we picked the one matching exactly the search terms, by address or symbol.
Turns out symbol is not unique, so we were silently dropping everything but the last match.
This is the case for both tokens above, as well as [COW Protocol Token](https://etherscan.io/token/0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB) and [cowfarm.finance](https://etherscan.io/token/0x0CC4F8735DAE4b1aB7682cb05AEb19115e693E98)

# To Test

1. Using firefox, on mainnet, search for `reth`
* Should show 3 active token matches plus other inactive/additional matches
![image](https://github.com/cowprotocol/cowswap/assets/43217/3fdc376c-96e3-4973-877a-c1246318f8e5)
2. Search for `cow`
* Should show 1 active token match plus other inactive/additional matches
![image](https://github.com/cowprotocol/cowswap/assets/43217/bfd914cc-8261-438f-8c85-79faa97d5c90)
3. Repeat 1 and 2 using chrome/brave/safari


