### PR TITLE
feat(feeZero): deliver fee zero only to 10% of users

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/featureFlags/useSwapZeroFee.ts
+++ b/apps/cowswap-frontend/src/common/hooks/featureFlags/useSwapZeroFee.ts
@@ -1,0 +1,21 @@
+import { useWalletInfo } from '@cowprotocol/wallet'
+
+import { useFeatureFlags } from './useFeatureFlags'
+
+// Expose the feature to XX% of users
+const PERCENTAGE_OF_USERS_WITH_FLAG = 10 // XX% of users
+
+export function useSwapZeroFee(): boolean {
+  const { account } = useWalletInfo()
+  const { swapZeroFee } = useFeatureFlags()
+
+  return enabledForUser(account) && swapZeroFee
+}
+
+function enabledForUser(account: string | undefined): boolean {
+  if (!account) {
+    return false
+  }
+
+  return parseInt(account.toLowerCase(), 0) % 100 < PERCENTAGE_OF_USERS_WITH_FLAG
+}

--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useTradeFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useTradeFlowContext.ts
@@ -20,7 +20,7 @@ import { useEnoughBalanceAndAllowance } from 'modules/tokens'
 import { TradeType } from 'modules/trade'
 import { useTradeQuote } from 'modules/tradeQuote'
 
-import { useFeatureFlags } from 'common/hooks/featureFlags/useFeatureFlags'
+import { useSwapZeroFee } from 'common/hooks/featureFlags/useSwapZeroFee'
 
 import { useLimitOrdersDerivedState } from './useLimitOrdersDerivedState'
 
@@ -37,7 +37,7 @@ export function useTradeFlowContext(): TradeFlowContext | null {
   const rateImpact = useRateImpact()
   const settingsState = useAtomValue(limitOrdersSettingsAtom)
   const permitInfo = usePermitInfo(state.inputCurrency, TradeType.LIMIT_ORDER)
-  const { swapZeroFee } = useFeatureFlags()
+  const swapZeroFee = useSwapZeroFee()
 
   const checkAllowanceAddress = GP_VAULT_RELAYER[chainId]
   const { enoughAllowance } = useEnoughBalanceAndAllowance({

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useFlowContext.ts
@@ -28,7 +28,7 @@ import { SwapConfirmManager, useSwapConfirmManager } from 'modules/swap/hooks/us
 import { BaseFlowContext } from 'modules/swap/services/types'
 import { SwapFlowAnalyticsContext } from 'modules/trade/utils/analytics'
 
-import { useFeatureFlags } from 'common/hooks/featureFlags/useFeatureFlags'
+import { useSwapZeroFee } from 'common/hooks/featureFlags/useSwapZeroFee'
 
 import { useIsSafeEthFlow } from './useIsSafeEthFlow'
 import { useDerivedSwapInfo, useSwapState } from './useSwapState'
@@ -88,7 +88,7 @@ export function useBaseFlowContextSetup(): BaseFlowContextSetup {
   const gnosisSafeInfo = useGnosisSafeInfo()
   const { recipient } = useSwapState()
   const { v2Trade: trade } = useDerivedSwapInfo()
-  const { swapZeroFee } = useFeatureFlags()
+  const swapZeroFee = useSwapZeroFee()
 
   const appData = useAppData()
   const closeModals = useCloseModals()


### PR DESCRIPTION
# Summary

To launch the fee=0 feature, we already have a feature flag, but we want to delivery it progressively to be able to monitor it

This PR adds a const that allows us to select the % of users we want to see affected by the feature. 
It just decides based on the wallet address

## Note
This have a effect which is, unless the user is connected, we won't show if the fee=zero is activated

We have to try it out. In principle, i don't think is a big problem, but we have to see if this becomes a bit weird UX

## Test
to test it we need to find a wallet that its "selected" to receive the feature.

You can check which of your wallets fits the criteria by running this in the console:

```js
parseInt('add-here-your-address', 16) % 100 < 10
```

If you have a wallet that matches the criteria, you can verify that once connected, you will have the feature on.


If you struggle to find one, I can help to make a script so you get an account that fits the criteria. 