### PR TITLE
fix(token-search): ignore search input case when triggering the search

### DIFF
--- a/libs/tokens/src/hooks/tokens/useSearchToken.ts
+++ b/libs/tokens/src/hooks/tokens/useSearchToken.ts
@@ -72,7 +72,7 @@ export function useSearchToken(input: string | null): TokenSearchResponse {
 
   useEffect(() => {
     setIsLoading(true)
-  }, [input])
+  }, [inputLowerCase])
 
   useEffect(() => {
     // When there are results from toke lists, then we don't need to wait for the rest


### PR DESCRIPTION
# Summary

Fixes #3613 

The loading state of the token search was not case insensitive


https://github.com/cowprotocol/cowswap/assets/43217/92302fba-3c95-4cae-92fc-ca0af60b9bef

# To Test

1. Open the token dropdown and enter a search string
2. Change the case of any letter
* Search should remain same as before