### PR TITLE
fix(explorer): cast string SupportedChainId to number

### DIFF
--- a/apps/explorer/src/state/network/NetworkUpdater.tsx
+++ b/apps/explorer/src/state/network/NetworkUpdater.tsx
@@ -10,7 +10,7 @@ import { CHAIN_ID_TO_URL_PREFIX, NETWORK_PREFIXES } from '../../consts/network'
 
 const MAINNET_PREFIX = CHAIN_ID_TO_URL_PREFIX[SupportedChainId.MAINNET]
 const NETWORK_PREFIXES_RAW: [SupportedChainId, string][] = Object.keys(CHAIN_ID_TO_URL_PREFIX).map((key) => [
-  key as unknown as SupportedChainId,
+  +key, // SupportedChainId is a number enum
   CHAIN_ID_TO_URL_PREFIX[key],
 ])
 const NETWORK_ID_BY_PREFIX: Map<string, SupportedChainId> = new Map(


### PR DESCRIPTION
# Summary

Fixes #3621 

Properly identify gchain network id and use the correct rpc provider (not infura).

# To Test

1. Open a gchain order such as `0xf8def1173a59451d5d2d5db2f57cfabe5cfa3ad0cd6d8d63e602dc66bb1e76d35b0abe214ab7875562adee331deff0fe1912fe4265aa8bdd`
* Should load
* Other networks should load too

# Background

The code was ignoring TS and casting the SupportedChainId enum value (number) to the type itself.
In the end, this check was failing because `'100' !== 100` 

https://github.com/cowprotocol/cowswap/blob/d744c4adc595b93b55310fd5d4e57594f45d9b26/apps/explorer/src/api/web3/index.ts#L93
