### PR TITLE
fix: don't display Sepolia in supported list when it is off

### DIFF
--- a/apps/cowswap-frontend/src/common/containers/WalletUnsupportedNetworkBanner/index.tsx
+++ b/apps/cowswap-frontend/src/common/containers/WalletUnsupportedNetworkBanner/index.tsx
@@ -1,22 +1,11 @@
-import { getChainInfo } from '@cowprotocol/common-const'
-import { ALL_SUPPORTED_CHAIN_IDS } from '@cowprotocol/cow-sdk'
 import { UI } from '@cowprotocol/ui'
 
-import { Trans } from '@lingui/macro'
 import { AlertCircle } from 'react-feather'
 import styled from 'styled-components/macro'
 
 import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetworkUnsupported'
 
-export const UNSUPPORTED_WALLET_TEXT = (
-  <Trans>
-    Please connect your wallet to one of our supported networks:
-    <br />
-    {ALL_SUPPORTED_CHAIN_IDS.map((chainId) => getChainInfo(chainId)?.label)
-      .filter(Boolean)
-      .join(', ')}
-  </Trans>
-)
+import { useUnsupportedNetworksText } from '../../hooks/useUnsupportedNetworksText'
 
 const Wrapper = styled.div`
   position: fixed;
@@ -43,6 +32,7 @@ const StyledAlertCircle = styled(AlertCircle)`
 
 export function WalletUnsupportedNetworkBanner() {
   const isChainIdUnsupported = useIsProviderNetworkUnsupported()
+  const unsupportedNetworksText = useUnsupportedNetworksText()
 
   return (
     <>
@@ -51,7 +41,7 @@ export function WalletUnsupportedNetworkBanner() {
           <div>
             <StyledAlertCircle size={24} />
           </div>
-          <div>{UNSUPPORTED_WALLET_TEXT}</div>
+          <div>{unsupportedNetworksText}</div>
         </Wrapper>
       )}
     </>

--- a/apps/cowswap-frontend/src/common/hooks/useUnsupportedNetworksText.tsx
+++ b/apps/cowswap-frontend/src/common/hooks/useUnsupportedNetworksText.tsx
@@ -1,0 +1,25 @@
+import { getChainInfo } from '@cowprotocol/common-const'
+import { ALL_SUPPORTED_CHAIN_IDS, SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import { Trans } from '@lingui/macro'
+
+import { useFeatureFlags } from './featureFlags/useFeatureFlags'
+
+export function useUnsupportedNetworksText(): JSX.Element {
+  const { isSepoliaEnabled } = useFeatureFlags()
+
+  const allNetworks = isSepoliaEnabled
+    ? ALL_SUPPORTED_CHAIN_IDS
+    : ALL_SUPPORTED_CHAIN_IDS.filter((id) => id !== SupportedChainId.SEPOLIA)
+
+  return (
+    <Trans>
+      Please connect your wallet to one of our supported networks:
+      <br />
+      {allNetworks
+        .map((chainId) => getChainInfo(chainId)?.label)
+        .filter(Boolean)
+        .join(', ')}
+    </Trans>
+  )
+}

--- a/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/index.tsx
@@ -38,7 +38,6 @@ import {
 
 import Activity from 'modules/account/containers/Transaction'
 
-import { UNSUPPORTED_WALLET_TEXT } from 'common/containers/WalletUnsupportedNetworkBanner'
 import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetworkUnsupported'
 
 import {
@@ -63,6 +62,7 @@ import {
 } from './styled'
 import { SurplusCard } from './SurplusCard'
 
+import { useUnsupportedNetworksText } from '../../../../common/hooks/useUnsupportedNetworksText'
 import { useDisconnectWallet } from '../../hooks/useDisconnectWallet'
 import { CreationDateText } from '../Transaction/styled'
 
@@ -158,6 +158,8 @@ export function AccountDetails({
   const connection = useMemo(() => getWeb3ReactConnection(connector), [connector])
   const isInjectedMobileBrowser = (isMetaMask || isCoinbaseWallet) && isMobile
 
+  const unsupportedNetworksText = useUnsupportedNetworksText()
+
   function formatConnectorName() {
     const name = walletDetails?.walletName || getConnectionName(connection.type, getIsMetaMask())
     // In case the wallet is connected via WalletConnect and has wallet name set, add the suffix to be clear
@@ -246,7 +248,7 @@ export function AccountDetails({
       </InfoCard>
 
       {isChainIdUnsupported ? (
-        <UnsupportedWalletBox>{UNSUPPORTED_WALLET_TEXT}</UnsupportedWalletBox>
+        <UnsupportedWalletBox>{unsupportedNetworksText}</UnsupportedWalletBox>
       ) : (
         <>
           <SurplusCard />


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C0361CDG8GP/p1705320722004659

![image](https://github.com/cowprotocol/cowswap/assets/7122625/53710d99-a4a1-49f1-9a3c-b47ca56a5714)

  # To Test

1. Open Cowswap when Sepolia feature flag is off
2. Connect wallet and switch network to Sepolia
- [ ] AR: the warning contains Sepolia
- [ ] ER: the warning doesn't contain Sepolia