### PR TITLE
fix: don't crash when there is no fav tokens in new network

### DIFF
--- a/libs/tokens/src/state/tokens/favouriteTokensAtom.ts
+++ b/libs/tokens/src/state/tokens/favouriteTokensAtom.ts
@@ -6,10 +6,12 @@ import { TokensMap } from '../../types'
 import { environmentAtom } from '../environmentAtom'
 import { TokenWithLogo } from '@cowprotocol/common-const'
 import { DEFAULT_FAVOURITE_TOKENS } from '../../const/defaultFavouriteTokens'
+import { getJotaiMergerStorage } from '@cowprotocol/core'
 
 export const favouriteTokensAtom = atomWithStorage<Record<SupportedChainId, TokensMap>>(
   'favouriteTokensAtom:v1',
-  DEFAULT_FAVOURITE_TOKENS
+  DEFAULT_FAVOURITE_TOKENS,
+  getJotaiMergerStorage()
 )
 
 export const favouriteTokensListAtom = atom((get) => {


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C0361CDG8GP/p1705320476117909?thread_ts=1705320166.113969&cid=C0361CDG8GP

The actual fix: #3604

![image](https://github.com/cowprotocol/cowswap/assets/7122625/5393df11-25e1-4a28-8b8e-accb73d19500)

  # To Test

The app shouldn't crash on Sepolia