### PR TITLE
fix(explorer): change link to explorer version

### DIFF
--- a/apps/explorer/src/components/layout/GenericLayout/Footer/config.ts
+++ b/apps/explorer/src/components/layout/GenericLayout/Footer/config.ts
@@ -1,7 +1,7 @@
 export const footerConfig = {
   isBeta: false,
   url: {
-    web: 'https://github.com/cowprotocol/explorer/tree/v',
+    web: 'https://github.com/cowprotocol/cowswap/releases/tag/explorer-v',
     // TODO: Pending to move and adapt the wiki
     appId: null,
     // appId: 'https://github.com/gnosis/gp-v1-ui/wiki/App-Ids-for-Forks',


### PR DESCRIPTION
# Summary

Context: https://github.com/cowprotocol/cowswap/pull/3580#issuecomment-1884382996

Since Explorer migrated to monorepo we should update the link

<img width="232" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/d3c39eac-ae15-498f-a500-60da4247f5b9">

  # To Test

The link should open a release page of the latest version
