### PR TITLE
feat: update cow-sdk to 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@cowprotocol/app-data": "^1.2.0",
     "@cowprotocol/contracts": "^1.3.1",
     "@cowprotocol/cow-runner-game": "^0.2.9",
-    "@cowprotocol/cow-sdk": "^4.0.7",
+    "@cowprotocol/cow-sdk": "^4.1.0",
     "@cowprotocol/ethflowcontract": "cowprotocol/ethflowcontract.git#v1.1.1-artifacts",
     "@davatar/react": "1.8.1",
     "@emotion/react": "^11.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2288,10 +2288,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/cow-runner-game/-/cow-runner-game-0.2.9.tgz#3f94b3f370bd114f77db8b1d238cba3ef4e9d644"
   integrity sha512-rX7HnoV+HYEEkBaqVUsAkGGo0oBrExi+d6Io+8nQZYwZk+IYLmS9jdcIObsLviM2h4YX8+iin6NuKl35AaiHmg==
 
-"@cowprotocol/cow-sdk@^4.0.7":
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-4.0.7.tgz#9a97efcca08b7e7043a7e9e621131b1cffb25952"
-  integrity sha512-wfNy9yf0usYSNr+mF6Cj6ITQZsV3/TxSnTKHJ5hbnC4UZbqXEXssLBrRPRoDvaWT7Xx6k9GZ1V3gYexxOMlRLA==
+"@cowprotocol/cow-sdk@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-4.1.0.tgz#3707d53ac778470814e6395f0beefdad76dc8cc1"
+  integrity sha512-Ps5VmegGF3yi0u6midj1offs4MvtBX8u6SHrSNoCzQsuQ5re+41OfRswZsB1Xp+3kxe1JFtFtq6oa7fT6fE7sw==
   dependencies:
     "@cowprotocol/contracts" "^1.4.0"
     "@ethersproject/abstract-signer" "^5.7.0"


### PR DESCRIPTION
# Summary

Fixing issue reported internally [here](https://cowservices.slack.com/archives/C036G0J90BU/p1705083817684659)

Essentially, [this order](https://explorer.cow.fi/orders/0xdedb65b51a6f81493f8e6e1d811b56a57297dbb6fb11716d85e646a66a5d041f85cc3c8da85612013acabe9b5d954d578860b3c165a22c43?tab=overview) displays 0 fee although the value is filled.

It was fixed in https://github.com/cowprotocol/cow-sdk/pull/197

This change simply uses cow-sdk version released with that fix.

  # To Test

1. Open the order `0xdedb65b51a6f81493f8e6e1d811b56a57297dbb6fb11716d85e646a66a5d041f85cc3c8da85612013acabe9b5d954d578860b3c165a22c43` in the explorer
* Fee should not be `0`
2. Play around with different orders
* Fee should be displayed as usual