### PR TITLE
feat(appzi): add appzi triggers for limit orders

### DIFF
--- a/apps/cowswap-frontend/src/common/updaters/orders/PendingOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/PendingOrdersUpdater.ts
@@ -267,6 +267,7 @@ function _triggerNps(pending: Order[], chainId: ChainId) {
         secondsSinceOpen: timeSinceInSeconds(openSince),
         explorerUrl,
         chainId,
+        orderType: getUiOrderType(order),
       })
       // Break the loop, don't need to show more than once
       break

--- a/apps/cowswap-frontend/src/legacy/state/orders/middleware/appziMiddleware.test.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/middleware/appziMiddleware.test.ts
@@ -1,8 +1,9 @@
 import { isOrderInPendingTooLong, openNpsAppziSometimes } from '@cowprotocol/common-utils'
-import { OrderClass } from '@cowprotocol/cow-sdk'
 
 import { AnyAction, Dispatch, MiddlewareAPI } from 'redux'
 import { instance, mock, resetCalls, when } from 'ts-mockito'
+
+import { getUiOrderType, UiOrderType } from 'utils/orderUtils/getUiOrderType'
 
 import { appziMiddleware } from './appziMiddleware'
 
@@ -16,26 +17,25 @@ jest.mock('../helpers', () => {
     getOrderByIdFromState: jest.fn(),
   }
 })
+jest.mock('utils/orderUtils/getUiOrderType', () => {
+  return {
+    ...jest.requireActual('utils/orderUtils/getUiOrderType'),
+    getUiOrderType: jest.fn(),
+  }
+})
 
 const isOrderInPendingTooLongMock = jest.mocked(isOrderInPendingTooLong)
 const openNpsAppziSometimesMock = jest.mocked(openNpsAppziSometimes)
 const getOrderByOrderIdFromStateMock = jest.mocked(getOrderByIdFromState)
+const getUiOrderTypeMock = jest.mocked(getUiOrderType)
 
 const mockStore = mock<MiddlewareAPI<Dispatch, AppState>>()
 const nextMock = jest.fn()
 const actionMock = mock<AnyAction>()
 
-const BASE_MARKET_ORDER = {
+const BASE_ORDER = {
   order: {
     id: '0x1',
-    class: OrderClass.MARKET,
-  },
-}
-
-const BASE_LIMIT_ORDER = {
-  order: {
-    id: '0x1',
-    class: OrderClass.LIMIT,
   },
 }
 
@@ -54,13 +54,13 @@ describe('appziMiddleware', () => {
 
   describe('batch fulfill', () => {
     beforeEach(() => {
-      when(actionMock.payload).thenReturn({ chainId: 1, ordersData: [{ id: '0x1' }] })
+      when(actionMock.payload).thenReturn({ chainId: 1, ordersData: [BASE_ORDER.order] })
       when(actionMock.type).thenReturn('order/fullfillOrdersBatch')
+      getUiOrderTypeMock.mockReturnValue(UiOrderType.SWAP)
+      getOrderByOrderIdFromStateMock.mockReturnValue(BASE_ORDER as any)
     })
 
     it('should open appzi if market order', () => {
-      getOrderByOrderIdFromStateMock.mockReturnValue(BASE_MARKET_ORDER as any)
-
       appziMiddleware(instance(mockStore))(nextMock)(instance(actionMock))
 
       expect(openNpsAppziSometimesMock).toHaveBeenCalledTimes(1)
@@ -68,7 +68,7 @@ describe('appziMiddleware', () => {
 
     it('should not open appzi if limit order is pending too long', () => {
       isOrderInPendingTooLongMock.mockReturnValue(true)
-      getOrderByOrderIdFromStateMock.mockReturnValue(BASE_LIMIT_ORDER as any)
+      getUiOrderTypeMock.mockReturnValue(UiOrderType.LIMIT)
 
       appziMiddleware(instance(mockStore))(nextMock)(instance(actionMock))
 
@@ -76,39 +76,39 @@ describe('appziMiddleware', () => {
     })
     it('should open appzi if limit order is not pending too long', () => {
       isOrderInPendingTooLongMock.mockReturnValue(false)
-      getOrderByOrderIdFromStateMock.mockReturnValue(BASE_LIMIT_ORDER as any)
+      getUiOrderTypeMock.mockReturnValue(UiOrderType.LIMIT)
 
       appziMiddleware(instance(mockStore))(nextMock)(instance(actionMock))
 
       expect(openNpsAppziSometimesMock).toHaveBeenCalledTimes(1)
     })
 
-    it('should open appzi if order is hidden', () => {
+    it('should not open appzi if order is hidden', () => {
       getOrderByOrderIdFromStateMock.mockReturnValue({
-        order: { ...BASE_MARKET_ORDER.order, isHidden: true },
+        order: { ...BASE_ORDER.order, isHidden: true },
       } as any)
 
       appziMiddleware(instance(mockStore))(nextMock)(instance(actionMock))
 
-      expect(openNpsAppziSometimesMock).toHaveBeenCalledTimes(1)
+      expect(openNpsAppziSometimesMock).not.toHaveBeenCalled()
     })
   })
   describe('batch expire', () => {
     beforeEach(() => {
-      when(actionMock.payload).thenReturn({ chainId: 1, ids: ['0x1'] })
+      when(actionMock.payload).thenReturn({ chainId: 1, ids: [BASE_ORDER.order.id] })
       when(actionMock.type).thenReturn('order/expireOrdersBatch')
+      getOrderByOrderIdFromStateMock.mockReturnValue(BASE_ORDER as any)
+      getUiOrderTypeMock.mockReturnValue(UiOrderType.SWAP)
     })
 
     it('should open appzi if market order', () => {
-      getOrderByOrderIdFromStateMock.mockReturnValue(BASE_MARKET_ORDER as any)
-
       appziMiddleware(instance(mockStore))(nextMock)(instance(actionMock))
 
       expect(openNpsAppziSometimesMock).toHaveBeenCalledTimes(1)
     })
 
     it('should open appzi if limit order', () => {
-      getOrderByOrderIdFromStateMock.mockReturnValue(BASE_LIMIT_ORDER as any)
+      getUiOrderTypeMock.mockReturnValue(UiOrderType.LIMIT)
 
       appziMiddleware(instance(mockStore))(nextMock)(instance(actionMock))
 
@@ -117,7 +117,7 @@ describe('appziMiddleware', () => {
 
     it('should not open appzi if market order is hidden', () => {
       getOrderByOrderIdFromStateMock.mockReturnValue({
-        order: { ...BASE_MARKET_ORDER.order, isHidden: true },
+        order: { ...BASE_ORDER.order, isHidden: true },
       } as any)
 
       appziMiddleware(instance(mockStore))(nextMock)(instance(actionMock))
@@ -127,12 +127,88 @@ describe('appziMiddleware', () => {
 
     it('should not open appzi if limit order is hidden', () => {
       getOrderByOrderIdFromStateMock.mockReturnValue({
-        order: { ...BASE_LIMIT_ORDER.order, isHidden: true },
+        order: { ...BASE_ORDER.order, isHidden: true },
       } as any)
+      getUiOrderTypeMock.mockReturnValue(UiOrderType.LIMIT)
 
       appziMiddleware(instance(mockStore))(nextMock)(instance(actionMock))
 
       expect(openNpsAppziSometimesMock).not.toHaveBeenCalled()
+    })
+  })
+  describe('batch presign', () => {
+    beforeEach(() => {
+      when(actionMock.payload).thenReturn({ chainId: 1, ids: [BASE_ORDER.order.id] })
+      when(actionMock.type).thenReturn('order/presignOrders')
+
+      getOrderByOrderIdFromStateMock.mockReturnValue(BASE_ORDER as any)
+    })
+
+    it('should not open appzi when SWAP', () => {
+      getUiOrderTypeMock.mockReturnValue(UiOrderType.SWAP)
+
+      appziMiddleware(instance(mockStore))(nextMock)(instance(actionMock))
+
+      expect(openNpsAppziSometimesMock).not.toHaveBeenCalled()
+    })
+
+    it('should not open appzi when TWAP', () => {
+      getUiOrderTypeMock.mockReturnValue(UiOrderType.TWAP)
+
+      appziMiddleware(instance(mockStore))(nextMock)(instance(actionMock))
+
+      expect(openNpsAppziSometimesMock).not.toHaveBeenCalled()
+    })
+
+    it('should open appzi when LIMIT', () => {
+      getUiOrderTypeMock.mockReturnValue(UiOrderType.LIMIT)
+
+      appziMiddleware(instance(mockStore))(nextMock)(instance(actionMock))
+
+      expect(openNpsAppziSometimesMock).toHaveBeenCalledTimes(1)
+    })
+  })
+  describe('add pending order', () => {
+    beforeEach(() => {
+      when(actionMock.payload).thenReturn({ chainId: 1, ...BASE_ORDER })
+      when(actionMock.type).thenReturn('order/addPendingOrder')
+
+      getOrderByOrderIdFromStateMock.mockReturnValue(BASE_ORDER as any)
+    })
+
+    it('should not open appzi when SWAP', () => {
+      getUiOrderTypeMock.mockReturnValue(UiOrderType.SWAP)
+
+      appziMiddleware(instance(mockStore))(nextMock)(instance(actionMock))
+
+      expect(openNpsAppziSometimesMock).not.toHaveBeenCalled()
+    })
+
+    it('should not open appzi when TWAP', () => {
+      getUiOrderTypeMock.mockReturnValue(UiOrderType.TWAP)
+
+      appziMiddleware(instance(mockStore))(nextMock)(instance(actionMock))
+
+      expect(openNpsAppziSometimesMock).not.toHaveBeenCalled()
+    })
+
+    it('should open appzi when LIMIT', () => {
+      getUiOrderTypeMock.mockReturnValue(UiOrderType.LIMIT)
+
+      appziMiddleware(instance(mockStore))(nextMock)(instance(actionMock))
+
+      expect(openNpsAppziSometimesMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('should open appzi when LIMIT is hidden', () => {
+      getUiOrderTypeMock.mockReturnValue(UiOrderType.LIMIT)
+      getOrderByOrderIdFromStateMock.mockReturnValue({
+        order: { ...BASE_ORDER.order, isHidden: true },
+      } as any)
+
+      appziMiddleware(instance(mockStore))(nextMock)(instance(actionMock))
+
+      expect(openNpsAppziSometimesMock).toHaveBeenCalledTimes(0)
     })
   })
 })

--- a/apps/cowswap-frontend/src/legacy/state/orders/middleware/appziMiddleware.test.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/middleware/appziMiddleware.test.ts
@@ -200,11 +200,14 @@ describe('appziMiddleware', () => {
       expect(openNpsAppziSometimesMock).toHaveBeenCalledTimes(1)
     })
 
-    it('should open appzi when LIMIT is hidden', () => {
+    it('should not open appzi when LIMIT is hidden', () => {
       getUiOrderTypeMock.mockReturnValue(UiOrderType.LIMIT)
-      getOrderByOrderIdFromStateMock.mockReturnValue({
-        order: { ...BASE_ORDER.order, isHidden: true },
-      } as any)
+      when(actionMock.payload).thenReturn({
+        chainId: 1,
+        ...{
+          order: { ...BASE_ORDER.order, isHidden: true },
+        },
+      })
 
       appziMiddleware(instance(mockStore))(nextMock)(instance(actionMock))
 

--- a/apps/cowswap-frontend/src/legacy/state/orders/middleware/appziMiddleware.test.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/middleware/appziMiddleware.test.ts
@@ -214,4 +214,36 @@ describe('appziMiddleware', () => {
       expect(openNpsAppziSometimesMock).toHaveBeenCalledTimes(0)
     })
   })
+  describe('batch cancel orders', () => {
+    beforeEach(() => {
+      when(actionMock.payload).thenReturn({ chainId: 1, ids: [BASE_ORDER.order.id] })
+      when(actionMock.type).thenReturn('order/cancelOrdersBatch')
+
+      getOrderByOrderIdFromStateMock.mockReturnValue(BASE_ORDER as any)
+    })
+
+    it('should not open appzi when SWAP', () => {
+      getUiOrderTypeMock.mockReturnValue(UiOrderType.SWAP)
+
+      appziMiddleware(instance(mockStore))(nextMock)(instance(actionMock))
+
+      expect(openNpsAppziSometimesMock).not.toHaveBeenCalled()
+    })
+
+    it('should not open appzi when TWAP', () => {
+      getUiOrderTypeMock.mockReturnValue(UiOrderType.TWAP)
+
+      appziMiddleware(instance(mockStore))(nextMock)(instance(actionMock))
+
+      expect(openNpsAppziSometimesMock).not.toHaveBeenCalled()
+    })
+
+    it('should open appzi when LIMIT', () => {
+      getUiOrderTypeMock.mockReturnValue(UiOrderType.LIMIT)
+
+      appziMiddleware(instance(mockStore))(nextMock)(instance(actionMock))
+
+      expect(openNpsAppziSometimesMock).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/apps/cowswap-frontend/src/legacy/state/orders/middleware/appziMiddleware.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/middleware/appziMiddleware.ts
@@ -65,5 +65,11 @@ function _triggerNps(
     return
   }
 
-  openNpsAppziSometimes({ ...npsParams, secondsSinceOpen: timeSinceInSeconds(openSince), explorerUrl, chainId })
+  openNpsAppziSometimes({
+    ...npsParams,
+    secondsSinceOpen: timeSinceInSeconds(openSince),
+    explorerUrl,
+    chainId,
+    orderType: uiOrderType,
+  })
 }

--- a/apps/cowswap-frontend/src/legacy/state/orders/middleware/appziMiddleware.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/middleware/appziMiddleware.ts
@@ -19,6 +19,7 @@ const isBatchFulfillOrderAction = isAnyOf(OrderActions.fulfillOrdersBatch)
 const isBatchExpireOrderAction = isAnyOf(OrderActions.expireOrdersBatch)
 const isBatchPresignOrderAction = isAnyOf(OrderActions.preSignOrders)
 const isPendingOrderAction = isAnyOf(OrderActions.addPendingOrder)
+const isBatchCancelOrderAction = isAnyOf(OrderActions.cancelOrdersBatch)
 
 export const appziMiddleware: Middleware<Record<string, unknown>, AppState> = (store) => (next) => (action) => {
   if (isBatchFulfillOrderAction(action)) {
@@ -60,6 +61,18 @@ export const appziMiddleware: Middleware<Record<string, unknown>, AppState> = (s
     // Only for limit orders
     if (uiOrderType === UiOrderType.LIMIT) {
       _triggerNps(store, chainId, order.id, { created: true }, order)
+    }
+  } else if (isBatchCancelOrderAction(action)) {
+    const {
+      chainId,
+      ids: [id],
+    } = action.payload
+
+    const uiOrderType = getUiOrderTypeFromStore(store, chainId, id)
+
+    // Only for limit orders
+    if (uiOrderType === UiOrderType.LIMIT) {
+      _triggerNps(store, chainId, id, { cancelled: true })
     }
   }
 

--- a/libs/common-utils/src/appzi.ts
+++ b/libs/common-utils/src/appzi.ts
@@ -1,7 +1,5 @@
 import ms from 'ms.macro'
 import ReactAppzi from 'react-appzi'
-
-import EventEmitter from 'events'
 import { isImTokenBrowser, majorBrowserVersion, userAgent } from './userAgent'
 import { environmentName, isProdLike } from './environments'
 
@@ -24,11 +22,8 @@ export const FEEDBACK_KEY =
 export const NPS_KEY = process.env.REACT_APP_APPZI_NPS_KEY || isProdLike ? PROD_NPS_KEY : TEST_NPS_KEY
 
 const APPZI_TOKEN = process.env.REACT_APP_APPZI_TOKEN || '5ju0G'
-const EVENT = 'message'
 
 const PENDING_TOO_LONG_TIME = ms`5 min`
-
-type EventCallback = (event: any) => void
 
 declare global {
   interface Window {
@@ -38,7 +33,6 @@ declare global {
     appziSettings: {
       userId: string
       data: AppziCustomSettings
-      onEvent: EventCallback
     }
   }
 }
@@ -63,35 +57,15 @@ type AppziSettings = {
   data?: Partial<AppziCustomSettings>
 }
 
-const eventEmitter = new EventEmitter()
-
-export function onAppziEvent(callback: EventCallback) {
-  eventEmitter.on(EVENT, callback)
-}
-
-export function onceAppziEvent(callback: EventCallback) {
-  eventEmitter.once(EVENT, callback)
-}
-
-export function offAppziEvent(callback: EventCallback) {
-  eventEmitter.off(EVENT, callback)
-}
-
-function triggerAppziEvent(payload: any) {
-  // console.log('[appzi] Event', payload)
-  eventEmitter.emit(EVENT, payload)
-}
-
 function initialize() {
   if (isAppziEnabled) {
     ReactAppzi.initialize(APPZI_TOKEN)
 
     window.appziSettings = window.appziSettings || {}
-    window.appziSettings.onEvent = triggerAppziEvent
   }
 }
 
-export function updateAppziSettings({ data = {}, userId = '' }: AppziSettings) {
+function updateAppziSettings({ data = {}, userId = '' }: AppziSettings) {
   window.appziSettings = { ...(window.appziSettings || {}), data, userId }
 }
 
@@ -99,28 +73,7 @@ export function openFeedbackAppzi() {
   window.appzi?.openWidget(FEEDBACK_KEY)
 }
 
-let appziRestyleApplied = false
-function applyOnceRestyleAppziNps() {
-  if (!appziRestyleApplied) {
-    appziRestyleApplied = true
-    // Make sure we apply the re-style once the appzi NPS is loaded
-    onceAppziEvent(restyleAppziNps)
-  }
-}
-
-function restyleAppziNps(event: any) {
-  if (event && event.type === 'open-survey') {
-    // Add a unique class based on NPS_KEY
-    const appziRoot = document.querySelector("div[id^='appzi-wfo-']")
-    if (appziRoot) {
-      appziRoot.classList.add(`appzi-nps-${NPS_KEY}`)
-      appziRestyleApplied = true
-    }
-  }
-}
-
 export function openNpsAppzi() {
-  applyOnceRestyleAppziNps()
   window.appzi?.openWidget(NPS_KEY)
 }
 
@@ -141,10 +94,8 @@ const NPS_DATA = isProdLike ? PROD_NPS_DATA : TEST_NPS_DATA
 /**
  * Opening of the modal is delegated to Appzi
  * It'll display only if the trigger rules are met
- * Check https://portal.appzi.com/portals/5ju0G/configs/55872789-593b-4c6c-9e49-9b5c7693e90a/trigger
  */
 export function openNpsAppziSometimes(data?: Omit<AppziCustomSettings, 'userTradedOrWaitedForLong' | 'isTestNps'>) {
-  applyOnceRestyleAppziNps()
   updateAppziSettings({ data: { env: environmentName, ...data, ...NPS_DATA } })
 }
 

--- a/libs/common-utils/src/appzi.ts
+++ b/libs/common-utils/src/appzi.ts
@@ -50,6 +50,7 @@ type AppziCustomSettings = {
   explorerUrl?: string
   env?: string
   chainId?: number
+  orderType?: string
 }
 
 type AppziSettings = {

--- a/libs/common-utils/src/appzi.ts
+++ b/libs/common-utils/src/appzi.ts
@@ -46,6 +46,7 @@ type AppziCustomSettings = {
   waitedTooLong?: true
   expired?: true
   traded?: true
+  created?: true
   // extra contextual data for statistics/debugging
   explorerUrl?: string
   env?: string

--- a/libs/common-utils/src/appzi.ts
+++ b/libs/common-utils/src/appzi.ts
@@ -47,6 +47,7 @@ type AppziCustomSettings = {
   expired?: true
   traded?: true
   created?: true
+  cancelled?: true
   // extra contextual data for statistics/debugging
   explorerUrl?: string
   env?: string


### PR DESCRIPTION
# Summary

Triggering Appzi for limit orders when:
- Order is placed (EOA)
- Order is presigned (SC)
- Order is cancelled

No changes to existing behaviour

Plus a small clean up on Appzi code which was using deprecated stuff.

# To Test

Before each action, remember to remove the appzi localStorage key starting with `azat-` and refresh the page
![image](https://github.com/cowprotocol/cowswap/assets/43217/d525024b-27f2-4a16-9603-386840dffdbe)

1. Using EOA, place LIMIT order
* NPS pops up
2. Remove appzi localStorage key, refresh the page
3. Cancel order
* NPS pops up
4. Using SC wallet, place LIMIT order but don't sign it yet
* No NPS pops up
5. Sign the order
* NPS pops up
6. Remove appzi localStorage key, refresh the page
7. Cancel order
* NPS pops up

8. Existing behaviour should still work
* Placing SWAP/TWAP should not trigger NPS
* Trading SWAP (and LIMIT within 5min) should trigger NPS
* Having a SWAP order pending for > 5min should trigger NPS
* Having an order expire should trigger NPS
