### PR TITLE
fix(fee=0): buy order amounts again

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/swap/ConfirmSwapModal/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/swap/ConfirmSwapModal/index.tsx
@@ -11,7 +11,6 @@ import TradeGp from 'legacy/state/swap/TradeGp'
 
 import { SwapConfirmState } from 'modules/swap/state/swapConfirmAtom'
 
-import { useFeatureFlags } from 'common/hooks/featureFlags/useFeatureFlags'
 import { RateInfoParams } from 'common/pure/RateInfo'
 import { TransactionErrorContent } from 'common/pure/TransactionErrorContent'
 import { TradeAmounts } from 'common/types'
@@ -77,9 +76,7 @@ export function ConfirmSwapModal({
     rateInfoParams,
   ])
 
-  const { swapZeroFee } = useFeatureFlags()
-
-  const slippageAdjustedSellAmount = trade?.maximumAmountIn(allowedSlippage, swapZeroFee)
+  const slippageAdjustedSellAmount = trade?.maximumAmountIn(allowedSlippage)
   const buttonText = useButtonText(slippageAdjustedSellAmount)
 
   const modalBottom = useCallback(() => {

--- a/apps/cowswap-frontend/src/legacy/components/swap/SwapModalHeader/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/swap/SwapModalHeader/index.tsx
@@ -23,7 +23,6 @@ import { NoImpactWarning } from 'modules/trade/pure/NoImpactWarning'
 import { PriceUpdatedBanner } from 'modules/trade/pure/PriceUpdatedBanner'
 import { useTradeUsdAmounts } from 'modules/usdAmount'
 
-import { useFeatureFlags } from 'common/hooks/featureFlags/useFeatureFlags'
 import { FiatValue } from 'common/pure/FiatValue'
 import { BannerOrientation, CustomRecipientWarningBanner } from 'common/pure/InlineBanner/banners'
 import { RateInfoParams } from 'common/pure/RateInfo'
@@ -78,11 +77,9 @@ function SwapModalHeaderComponent({
   allowsOffchainSigning,
   rateInfoParams,
 }: SwapModalHeaderProps) {
-  const { swapZeroFee } = useFeatureFlags()
-
   const slippageAdjustedAmounts = useMemo(
-    () => computeSlippageAdjustedAmounts(trade, allowedSlippage, swapZeroFee),
-    [trade, allowedSlippage, swapZeroFee]
+    () => computeSlippageAdjustedAmounts(trade, allowedSlippage),
+    [trade, allowedSlippage]
   )
 
   const {

--- a/apps/cowswap-frontend/src/legacy/state/swap/TradeGp.ts
+++ b/apps/cowswap-frontend/src/legacy/state/swap/TradeGp.ts
@@ -55,12 +55,12 @@ export function _minimumAmountOut(pct: Percent, trade: TradeGp) {
   return trade.outputAmount.multiply(ONE_FRACTION.subtract(pct))
 }
 
-export function _maximumAmountIn(pct: Percent, trade: TradeGp, withoutFee?: boolean) {
+export function _maximumAmountIn(pct: Percent, trade: TradeGp) {
   if (trade.tradeType === TradeType.EXACT_INPUT) {
     return trade.inputAmount
   }
 
-  return (withoutFee ? trade.inputAmountWithoutFee : trade.inputAmountWithFee).multiply(ONE_FRACTION.add(pct))
+  return trade.inputAmount.multiply(ONE_FRACTION.add(pct))
 }
 
 interface TradeGpConstructor {
@@ -143,7 +143,7 @@ export default class TradeGp {
    * Get the maximum amount in that can be spent via this trade for the given slippage tolerance
    * @param slippageTolerance tolerance of unfavorable slippage from the execution price of this trade
    */
-  public maximumAmountIn(slippageTolerance: Percent, withoutFee?: boolean): CurrencyAmount<Currency> {
-    return _maximumAmountIn(slippageTolerance, this, withoutFee)
+  public maximumAmountIn(slippageTolerance: Percent): CurrencyAmount<Currency> {
+    return _maximumAmountIn(slippageTolerance, this)
   }
 }

--- a/apps/cowswap-frontend/src/legacy/state/swap/TradeGp.ts
+++ b/apps/cowswap-frontend/src/legacy/state/swap/TradeGp.ts
@@ -60,7 +60,7 @@ export function _maximumAmountIn(pct: Percent, trade: TradeGp) {
     return trade.inputAmount
   }
 
-  return trade.inputAmount.multiply(ONE_FRACTION.add(pct))
+  return trade.inputAmountWithFee.multiply(ONE_FRACTION.add(pct))
 }
 
 interface TradeGpConstructor {

--- a/apps/cowswap-frontend/src/legacy/utils/prices.ts
+++ b/apps/cowswap-frontend/src/legacy/utils/prices.ts
@@ -34,11 +34,10 @@ export function warningSeverity(priceImpact: Percent | undefined): WarningSeveri
 export function computeSlippageAdjustedAmounts(
   //   trade: Trade | undefined,
   trade: TradeGp | undefined,
-  allowedSlippage: Percent,
-  withoutFee?: boolean
+  allowedSlippage: Percent
 ): { [field in Field]?: CurrencyAmount<Currency> } {
   return {
-    [Field.INPUT]: trade?.maximumAmountIn(allowedSlippage, withoutFee),
+    [Field.INPUT]: trade?.maximumAmountIn(allowedSlippage),
     [Field.OUTPUT]: trade?.minimumAmountOut(allowedSlippage),
   }
 }

--- a/apps/cowswap-frontend/src/legacy/utils/trade.ts
+++ b/apps/cowswap-frontend/src/legacy/utils/trade.ts
@@ -1,5 +1,5 @@
-import { RADIX_DECIMAL, NATIVE_CURRENCY_ADDRESS } from '@cowprotocol/common-const'
-import { isAddress, shortenAddress, formatTokenAmount, formatSymbol, getIsNativeToken } from '@cowprotocol/common-utils'
+import { NATIVE_CURRENCY_ADDRESS, RADIX_DECIMAL } from '@cowprotocol/common-const'
+import { formatSymbol, formatTokenAmount, getIsNativeToken, isAddress, shortenAddress } from '@cowprotocol/common-utils'
 import {
   EcdsaSigningScheme,
   OrderClass,
@@ -57,10 +57,26 @@ export type UnsignedOrderAdditionalParams = PostOrderParams & {
 export function getOrderSubmitSummary(
   params: Pick<
     PostOrderParams,
-    'kind' | 'account' | 'inputAmount' | 'outputAmount' | 'recipient' | 'recipientAddressOrName' | 'feeAmount'
+    | 'kind'
+    | 'account'
+    | 'inputAmount'
+    | 'outputAmount'
+    | 'recipient'
+    | 'recipientAddressOrName'
+    | 'feeAmount'
+    | 'featureFlags'
   >
 ): string {
-  const { kind, account, inputAmount, outputAmount, recipient, recipientAddressOrName, feeAmount } = params
+  const {
+    kind,
+    account,
+    inputAmount,
+    outputAmount,
+    recipient,
+    recipientAddressOrName,
+    feeAmount,
+    featureFlags: { swapZeroFee },
+  } = params
 
   const sellToken = inputAmount.currency
   const buyToken = outputAmount.currency
@@ -71,7 +87,8 @@ export function getOrderSubmitSummary(
   ]
   const inputSymbol = formatSymbol(sellToken.symbol)
   const outputSymbol = formatSymbol(buyToken.symbol)
-  const inputAmountValue = formatTokenAmount(feeAmount ? inputAmount.add(feeAmount) : inputAmount)
+  // this already contains the fee in the fee amount when fee=0
+  const inputAmountValue = formatTokenAmount(feeAmount && !swapZeroFee ? inputAmount.add(feeAmount) : inputAmount)
   const outputAmountValue = formatTokenAmount(outputAmount)
 
   const base = `Swap ${inputQuantifier}${inputAmountValue} ${inputSymbol} for ${outputQuantifier}${outputAmountValue} ${outputSymbol}`

--- a/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/index.tsx
@@ -3,25 +3,26 @@ import { Fragment, useMemo } from 'react'
 import { CHAIN_INFO } from '@cowprotocol/common-const'
 import {
   getEtherscanLink,
-  getExplorerAddressLink,
   getExplorerLabel,
-  isMobile,
   shortenAddress,
+  getExplorerAddressLink,
+  isMobile,
 } from '@cowprotocol/common-utils'
-import { ExternalLink, MouseoverTooltip } from '@cowprotocol/ui'
+import { MouseoverTooltip } from '@cowprotocol/ui'
+import { ExternalLink } from '@cowprotocol/ui'
 import {
   ConnectionType,
+  useWalletInfo,
+  WalletDetails,
   getConnectionIcon,
   getConnectionName,
   getIsCoinbaseWallet,
-  getIsHardWareWallet,
   getIsMetaMask,
-  getWeb3ReactConnection,
   Identicon,
-  useIsWalletConnect,
   useWalletDetails,
-  useWalletInfo,
-  WalletDetails,
+  useIsWalletConnect,
+  getWeb3ReactConnection,
+  getIsHardWareWallet,
 } from '@cowprotocol/wallet'
 import { useWeb3React } from '@web3-react/core'
 import { Connector } from '@web3-react/types'
@@ -38,7 +39,6 @@ import {
 import Activity from 'modules/account/containers/Transaction'
 
 import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetworkUnsupported'
-import { useUnsupportedNetworksText } from 'common/hooks/useUnsupportedNetworksText'
 
 import {
   AccountControl,
@@ -55,13 +55,14 @@ import {
   WalletActions,
   WalletName,
   WalletNameAddress,
-  WalletSecondaryActions,
   WalletSelector,
+  WalletSecondaryActions,
   WalletWrapper,
   Wrapper,
 } from './styled'
 import { SurplusCard } from './SurplusCard'
 
+import { useUnsupportedNetworksText } from '../../../../common/hooks/useUnsupportedNetworksText'
 import { useDisconnectWallet } from '../../hooks/useDisconnectWallet'
 import { CreationDateText } from '../Transaction/styled'
 

--- a/apps/cowswap-frontend/src/modules/swap/containers/Row/RowReceivedAfterSlippage/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/Row/RowReceivedAfterSlippage/index.tsx
@@ -12,16 +12,10 @@ import { RowWithShowHelpersProps } from 'modules/swap/pure/Row/typings'
 export interface RowReceivedAfterSlippageProps extends RowWithShowHelpersProps {
   trade: TradeGp
   allowedSlippage: Percent
-  withoutFee?: boolean
 }
 
-export function RowReceivedAfterSlippage({
-  trade,
-  allowedSlippage,
-  showHelpers,
-  withoutFee,
-}: RowReceivedAfterSlippageProps) {
-  const slippageAdjustedAmounts = computeSlippageAdjustedAmounts(trade, allowedSlippage, withoutFee)
+export function RowReceivedAfterSlippage({ trade, allowedSlippage, showHelpers }: RowReceivedAfterSlippageProps) {
+  const slippageAdjustedAmounts = computeSlippageAdjustedAmounts(trade, allowedSlippage)
 
   const props = useMemo(
     () => ({

--- a/apps/cowswap-frontend/src/modules/swap/containers/TradeBasicDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/TradeBasicDetails/index.tsx
@@ -13,8 +13,6 @@ import { LowerSectionWrapper } from 'modules/swap/pure/styled'
 import { useIsWrapOrUnwrap } from 'modules/trade/hooks/useIsWrapOrUnwrap'
 import { useUsdAmount } from 'modules/usdAmount'
 
-import { useFeatureFlags } from 'common/hooks/featureFlags/useFeatureFlags'
-
 interface TradeBasicDetailsProp extends BoxProps {
   allowedSlippage: Percent | string
   isExpertMode: boolean
@@ -35,8 +33,6 @@ export function TradeBasicDetails(props: TradeBasicDetailsProp) {
   const isEoaEthFlow = useIsEoaEthFlow()
   const isWrapOrUnwrap = useIsWrapOrUnwrap()
 
-  const { swapZeroFee } = useFeatureFlags()
-
   const showRowSlippage =
     (isEoaEthFlow || isExpertMode || !allowedSlippagePercent.equalTo(INITIAL_ALLOWED_SLIPPAGE_PERCENT)) &&
     !isWrapOrUnwrap
@@ -55,12 +51,7 @@ export function TradeBasicDetails(props: TradeBasicDetailsProp) {
       {/* Slippage */}
       {showRowSlippage && <RowSlippage allowedSlippage={allowedSlippagePercent} />}
       {showRowReceivedAfterSlippage && (
-        <RowReceivedAfterSlippage
-          trade={trade}
-          allowedSlippage={allowedSlippagePercent}
-          showHelpers={true}
-          withoutFee={swapZeroFee}
-        />
+        <RowReceivedAfterSlippage trade={trade} allowedSlippage={allowedSlippagePercent} showHelpers={true} />
       )}
     </LowerSectionWrapper>
   )

--- a/apps/cowswap-frontend/src/modules/swap/containers/TradeSummary/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/TradeSummary/index.tsx
@@ -6,8 +6,6 @@ import TradeGp from 'legacy/state/swap/TradeGp'
 import { TradeSummaryContent } from 'modules/swap/pure/TradeSummary'
 import { useUsdAmount } from 'modules/usdAmount'
 
-import { useFeatureFlags } from 'common/hooks/featureFlags/useFeatureFlags'
-
 // Sub-components
 
 export type TradeSummaryProps = {
@@ -20,7 +18,6 @@ export type TradeSummaryProps = {
 export function TradeSummary({ trade, ...restProps }: TradeSummaryProps) {
   const { allowsOffchainSigning } = useWalletDetails()
   const feeFiatValue = useUsdAmount(trade.fee.feeAsCurrency).value
-  const { swapZeroFee } = useFeatureFlags()
 
   return (
     <TradeSummaryContent
@@ -28,7 +25,6 @@ export function TradeSummary({ trade, ...restProps }: TradeSummaryProps) {
       trade={trade}
       fee={feeFiatValue}
       allowsOffchainSigning={allowsOffchainSigning}
-      withoutFee={swapZeroFee}
     />
   )
 }

--- a/apps/cowswap-frontend/src/modules/swap/helpers/getAmountsForSignature.test.ts
+++ b/apps/cowswap-frontend/src/modules/swap/helpers/getAmountsForSignature.test.ts
@@ -73,7 +73,7 @@ describe('getAmountsForSignature()', () => {
     })
 
     /**
-     * Sell amount calculated as: (inputAmount + fee) + slippage
+     * Sell amount calculated as: (inputAmount) + slippage
      * Output amount is just what user entered
      */
     it('Buy order', () => {
@@ -86,8 +86,8 @@ describe('getAmountsForSignature()', () => {
         kind: OrderKind.BUY,
       })
 
-      // inputAmount = (3012 + 8) + 5% = 3171.000000
-      expect(result.inputAmount.toFixed()).toEqual('3171.000000')
+      // inputAmount = (3012) + 5% = 3,162.6
+      expect(result.inputAmount.toFixed()).toEqual('3162.600000')
       // Output amount the same, because this is buy order
       expect(result.outputAmount.toFixed()).toEqual('2.000000000000000000')
     })
@@ -119,7 +119,7 @@ describe('getAmountsForSignature()', () => {
     })
 
     /**
-     * Sell amount calculated as: inputAmount + slippage
+     * Sell amount calculated as: (inputAmount + fee) + slippage
      * Output amount is just what user entered
      */
     it('Buy order', () => {
@@ -132,8 +132,8 @@ describe('getAmountsForSignature()', () => {
         kind: OrderKind.BUY,
       })
 
-      // inputAmount = 3012 + 5% = 3162.600000
-      expect(result.inputAmount.toFixed()).toEqual('3162.600000')
+      // inputAmount = (3012 + 8) + 5% = 3,171
+      expect(result.inputAmount.toFixed()).toEqual('3171.000000')
 
       // Output amount the same, because this is buy order
       expect(result.outputAmount.toFixed()).toEqual('2.000000000000000000')

--- a/apps/cowswap-frontend/src/modules/swap/helpers/getAmountsForSignature.ts
+++ b/apps/cowswap-frontend/src/modules/swap/helpers/getAmountsForSignature.ts
@@ -21,7 +21,7 @@ function inputAmountForSignature(params: AmountForSignatureParams): CurrencyAmou
     if (kind === OrderKind.SELL) {
       return trade.inputAmount
     } else {
-      return trade.inputAmountWithoutFee.multiply(slippageCoeff) // add slippage
+      return trade.inputAmountWithFee.multiply(slippageCoeff) // add slippage
     }
   }
 

--- a/apps/cowswap-frontend/src/modules/swap/helpers/getAmountsForSignature.ts
+++ b/apps/cowswap-frontend/src/modules/swap/helpers/getAmountsForSignature.ts
@@ -28,7 +28,7 @@ function inputAmountForSignature(params: AmountForSignatureParams): CurrencyAmou
   if (kind === OrderKind.SELL) {
     return trade.inputAmountWithFee
   } else {
-    return trade.inputAmountWithFee.multiply(slippageCoeff) // add slippage
+    return trade.inputAmountWithoutFee.multiply(slippageCoeff) // add slippage
   }
 }
 

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useFlowContext.ts
@@ -75,9 +75,8 @@ export function useSwapAmountsWithSlippage(): [
   CurrencyAmount<Currency> | undefined
 ] {
   const { v2Trade: trade, allowedSlippage } = useDerivedSwapInfo()
-  const { swapZeroFee } = useFeatureFlags()
 
-  const { INPUT, OUTPUT } = computeSlippageAdjustedAmounts(trade, allowedSlippage, swapZeroFee)
+  const { INPUT, OUTPUT } = computeSlippageAdjustedAmounts(trade, allowedSlippage)
 
   return [INPUT, OUTPUT]
 }

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useSwapButtonContext.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useSwapButtonContext.ts
@@ -32,11 +32,11 @@ import { useWrappedToken } from 'modules/trade/hooks/useWrappedToken'
 
 import { useFeatureFlags } from 'common/hooks/featureFlags/useFeatureFlags'
 import { useApproveState } from 'common/hooks/useApproveState'
-import { useSafeMemo } from 'common/hooks/useSafeMemo'
 
 import { useSafeBundleEthFlowContext } from './useSafeBundleEthFlowContext'
 import { useDerivedSwapInfo, useSwapActionHandlers } from './useSwapState'
 
+import { useSafeMemo } from '../../../common/hooks/useSafeMemo'
 import { getAmountsForSignature } from '../helpers/getAmountsForSignature'
 import { logSwapParams } from '../helpers/logSwapParams'
 

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useSwapState.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useSwapState.tsx
@@ -6,7 +6,8 @@ import { FEE_SIZE_THRESHOLD } from '@cowprotocol/common-const'
 import { formatSymbol, getIsNativeToken, isAddress, tryParseCurrencyAmount } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { useENS } from '@cowprotocol/ens'
-import { useAreThereTokensWithSameSymbol, useTokenBySymbolOrAddress } from '@cowprotocol/tokens'
+import { useTokenBySymbolOrAddress } from '@cowprotocol/tokens'
+import { useAreThereTokensWithSameSymbol } from '@cowprotocol/tokens'
 import { useWalletInfo } from '@cowprotocol/wallet'
 import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
 
@@ -25,7 +26,6 @@ import { useIsExpertMode } from 'legacy/state/user/hooks'
 import { useNavigateOnCurrencySelection } from 'modules/trade/hooks/useNavigateOnCurrencySelection'
 import { useTradeNavigate } from 'modules/trade/hooks/useTradeNavigate'
 
-import { useFeatureFlags } from 'common/hooks/featureFlags/useFeatureFlags'
 import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetworkUnsupported'
 
 import { useSwapSlippage } from './useSwapSlippage'
@@ -272,14 +272,12 @@ export function useDerivedSwapInfo(): DerivedSwapInfo {
     [inputCurrencyBalance, outputCurrencyBalance]
   )
 
-  const { swapZeroFee } = useFeatureFlags()
-
   // allowed slippage is either auto slippage, or custom user defined slippage if auto slippage disabled
   // TODO: check whether we want to enable auto slippage tolerance
   // const autoSlippageTolerance = useAutoSlippageTolerance(trade.trade)  // mod
   // const allowedSlippage = useUserSlippageToleranceWithDefault(autoSlippageTolerance) // mod
   const allowedSlippage = useSwapSlippage()
-  const slippageAdjustedSellAmount = v2Trade?.maximumAmountIn(allowedSlippage, swapZeroFee) || null
+  const slippageAdjustedSellAmount = v2Trade?.maximumAmountIn(allowedSlippage) || null
 
   const inputError = useMemo(() => {
     let inputError: string | undefined

--- a/apps/cowswap-frontend/src/modules/swap/pure/TradeSummary/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/TradeSummary/index.tsx
@@ -17,11 +17,10 @@ const Wrapper = styled.div``
 export interface TradeSummaryContentProps extends TradeSummaryProps {
   fee: CurrencyAmount<Token> | null
   allowsOffchainSigning: boolean
-  withoutFee?: boolean
 }
 
 export function TradeSummaryContent(props: TradeSummaryContentProps) {
-  const { showFee, trade, fee: feeFiatValue, allowsOffchainSigning, showHelpers, allowedSlippage, withoutFee } = props
+  const { showFee, trade, fee: feeFiatValue, allowsOffchainSigning, showHelpers, allowedSlippage } = props
   return (
     <Wrapper>
       <AutoColumn gap="2px">
@@ -42,12 +41,7 @@ export function TradeSummaryContent(props: TradeSummaryContentProps) {
         <RowDeadline />
 
         {/* Min/Max received */}
-        <RowReceivedAfterSlippage
-          trade={trade}
-          showHelpers={showHelpers}
-          allowedSlippage={allowedSlippage}
-          withoutFee={withoutFee}
-        />
+        <RowReceivedAfterSlippage trade={trade} showHelpers={showHelpers} allowedSlippage={allowedSlippage} />
       </AutoColumn>
     </Wrapper>
   )

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useCreateTwapOrder.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useCreateTwapOrder.ts
@@ -1,11 +1,10 @@
-import { useAtomValue } from 'jotai'
-import { useSetAtom } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 import { useCallback } from 'react'
 
 import { twapConversionAnalytics } from '@cowprotocol/analytics'
 import { getCowSoundSend } from '@cowprotocol/common-utils'
 import { OrderClass, OrderKind } from '@cowprotocol/cow-sdk'
-import { useWalletInfo, useSafeAppsSdk } from '@cowprotocol/wallet'
+import { useSafeAppsSdk, useWalletInfo } from '@cowprotocol/wallet'
 import { CurrencyAmount, Token } from '@uniswap/sdk-core'
 
 import { Nullish } from 'types'
@@ -19,6 +18,7 @@ import { useAppData, useUploadAppData } from 'modules/appData'
 import { useTradeConfirmActions, useTradePriceImpact } from 'modules/trade'
 import { SwapFlowAnalyticsContext, tradeFlowAnalytics } from 'modules/trade/utils/analytics'
 
+import { useFeatureFlags } from 'common/hooks/featureFlags/useFeatureFlags'
 import { useConfirmPriceImpactWithoutFee } from 'common/hooks/useConfirmPriceImpactWithoutFee'
 
 import { useExtensibleFallbackContext } from './useExtensibleFallbackContext'
@@ -54,6 +54,7 @@ export function useCreateTwapOrder() {
 
   const { priceImpact } = useTradePriceImpact()
   const { confirmPriceImpactWithoutFee } = useConfirmPriceImpactWithoutFee()
+  const { swapZeroFee } = useFeatureFlags()
 
   return useCallback(
     async (fallbackHandlerIsNotSet: boolean) => {
@@ -122,6 +123,7 @@ export function useCreateTwapOrder() {
           inputAmount: twapOrder.sellAmount,
           outputAmount: twapOrder.buyAmount,
           feeAmount: undefined,
+          featureFlags: { swapZeroFee },
         })
         getCowSoundSend().play()
         dispatchPresignedOrderPosted(cowSwapStore, safeTxHash, summary, OrderClass.LIMIT, 'composable-order')
@@ -151,10 +153,11 @@ export function useCreateTwapOrder() {
       twapOrder,
       confirmPriceImpactWithoutFee,
       priceImpact,
-      uploadAppData,
       tradeConfirmActions,
       addTwapOrderToList,
       recipient,
+      swapZeroFee,
+      uploadAppData,
       updateAdvancedOrdersState,
     ]
   )


### PR DESCRIPTION
# Summary

While testing fee=0 on staging, we realized buy order amounts were being sent without the estimated fee in the sell amount, leading to un-matchable orders due to unrealistic limit prices.

This PR addresses that and somewhat reverts https://github.com/cowprotocol/cowswap/pull/3657, as the calculation is done at another level.

I believe this was not caught as I tested it:
1. On chains where the fee is very small (gchain and goerli)
2. With high slippage to help visualize the amounts (10%)

The combination of high slippage and low fees compensated for the lack of fee in the sell amounts.

# To Test

1. On mainnet, place a buy order with fee=0
* Check the max sell amount in the modal matches the signing
![Screenshot 2024-01-18 at 10 47 16](https://github.com/cowprotocol/cowswap/assets/43217/f5886de4-8420-4665-a0d1-58ead8124b48)
![Screenshot 2024-01-18 at 10 47 27](https://github.com/cowprotocol/cowswap/assets/43217/a3d9e0a8-c220-47d3-ad9e-a31a9adab180)

* Should include the fee and slippage in the sell amount
* Should show that value in the tooltip notification as well
![Screenshot 2024-01-18 at 10 47 38](https://github.com/cowprotocol/cowswap/assets/43217/3be5d74b-48ed-4c51-81c7-7cc6c3f17aa2)

2. Repeat for sell order
* Amounts should match too (min receive in this case)

3. Repeat with fee=0 flag off
* Should work as usual
![Screenshot 2024-01-18 at 11 22 12](https://github.com/cowprotocol/cowswap/assets/43217/9822753c-156e-4573-a6c8-9f2d82d38a95)
![Screenshot 2024-01-18 at 11 22 22](https://github.com/cowprotocol/cowswap/assets/43217/1a627731-a1e4-4d85-a65c-fc781717e73a)
![Screenshot 2024-01-18 at 11 22 32](https://github.com/cowprotocol/cowswap/assets/43217/34c556a8-e819-4c8c-95c1-c8b82c288edd)


4. Check the activity modal
* Values should be displayed properly too