### PR TITLE
fix(permit-utils): aave permit

### DIFF
--- a/apps/cowswap-frontend/src/modules/permit/hooks/usePermitInfo.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/usePermitInfo.ts
@@ -55,7 +55,7 @@ export function usePermitInfo(token: Nullish<Currency>, tradeType: Nullish<Trade
   const addPermitInfo = useAddPermitInfo()
   const permitInfo = _usePermitInfo(chainId, isPermitEnabled ? lowerCaseAddress : undefined)
   const { permitInfo: preGeneratedInfo, isLoading: preGeneratedIsLoading } = usePreGeneratedPermitInfoForToken(
-    isPermitEnabled ? token : undefined
+    isPermitEnabled && !isNative ? token : undefined
   )
 
   const spender = GP_VAULT_RELAYER[chainId]

--- a/apps/cowswap-frontend/src/modules/permit/hooks/usePreGeneratedPermitInfo.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/usePreGeneratedPermitInfo.ts
@@ -25,5 +25,5 @@ export function usePreGeneratedPermitInfo(): {
     { ...SWR_NO_REFRESH_OPTIONS, fallbackData: {} }
   )
 
-  return { allPermitInfo: {}, isLoading }
+  return { allPermitInfo: data, isLoading }
 }

--- a/apps/cowswap-frontend/src/modules/permit/hooks/usePreGeneratedPermitInfo.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/usePreGeneratedPermitInfo.ts
@@ -12,7 +12,7 @@ import { PRE_GENERATED_PERMIT_URL } from '../const'
  * Caches result with SWR until a page refresh
  */
 export function usePreGeneratedPermitInfo(): {
-  allPermitInfo: Record<string, PermitInfo | undefined>
+  allPermitInfo: Record<string, PermitInfo>
   isLoading: boolean
 } {
   const { chainId } = useWalletInfo()
@@ -21,33 +21,9 @@ export function usePreGeneratedPermitInfo(): {
 
   const { data, isLoading } = useSWR(
     url,
-    (url: string): Promise<Record<string, PermitInfo | undefined>> =>
-      fetch(url)
-        .then((r) => r.json())
-        .then(migrateData),
+    (url: string): Promise<Record<string, PermitInfo | undefined>> => fetch(url).then((r) => r.json()),
     { ...SWR_NO_REFRESH_OPTIONS, fallbackData: {} }
   )
 
   return { allPermitInfo: data, isLoading }
-}
-
-type OldPermitInfo = PermitInfo | false
-
-const UNSUPPORTED: PermitInfo = { type: 'unsupported' }
-
-/**
- * Handles data migration from former way of storing unsupported tokens to the new one
- */
-function migrateData(data: Record<string, OldPermitInfo>): Record<string, PermitInfo> {
-  const migrated: Record<string, PermitInfo> = {}
-
-  for (const [k, v] of Object.entries(data)) {
-    if (v === false) {
-      migrated[k] = UNSUPPORTED
-    } else {
-      migrated[k] = v
-    }
-  }
-
-  return migrated
 }

--- a/apps/cowswap-frontend/src/modules/permit/hooks/usePreGeneratedPermitInfo.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/usePreGeneratedPermitInfo.ts
@@ -25,5 +25,5 @@ export function usePreGeneratedPermitInfo(): {
     { ...SWR_NO_REFRESH_OPTIONS, fallbackData: {} }
   )
 
-  return { allPermitInfo: data, isLoading }
+  return { allPermitInfo: {}, isLoading }
 }

--- a/apps/cowswap-frontend/src/modules/permit/hooks/usePreGeneratedPermitInfo.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/usePreGeneratedPermitInfo.ts
@@ -21,7 +21,7 @@ export function usePreGeneratedPermitInfo(): {
 
   const { data, isLoading } = useSWR(
     url,
-    (url: string): Promise<Record<string, PermitInfo | undefined>> => fetch(url).then((r) => r.json()),
+    (url: string): Promise<Record<string, PermitInfo>> => fetch(url).then((r) => r.json()),
     { ...SWR_NO_REFRESH_OPTIONS, fallbackData: {} }
   )
 

--- a/apps/cowswap-frontend/src/modules/permit/hooks/usePreGeneratedPermitInfoForToken.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/usePreGeneratedPermitInfoForToken.ts
@@ -1,5 +1,3 @@
-import { Currency } from '@uniswap/sdk-core'
-
 import { Nullish } from 'types'
 
 import { usePreGeneratedPermitInfo } from './usePreGeneratedPermitInfo'
@@ -9,13 +7,13 @@ import { IsTokenPermittableResult } from '../types'
 /**
  * Fetch pre-generated permit info for a single token
  */
-export function usePreGeneratedPermitInfoForToken(token: Nullish<Currency>): {
+export function usePreGeneratedPermitInfoForToken(token: Nullish<{ address: string }>): {
   permitInfo: IsTokenPermittableResult
   isLoading: boolean
 } {
   const { allPermitInfo, isLoading } = usePreGeneratedPermitInfo()
 
-  const address = token && 'address' in token && token.address.toLowerCase()
+  const address = token?.address.toLowerCase()
 
   const permitInfo = address ? allPermitInfo[address] : undefined
 

--- a/libs/permit-utils/package.json
+++ b/libs/permit-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/permit-utils",
-  "version": "0.1.0",
+  "version": "0.1.1-RC.0",
   "type": "module",
   "dependencies": {
     "ethers": "^5.7.2",

--- a/libs/permit-utils/package.json
+++ b/libs/permit-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/permit-utils",
-  "version": "0.1.1-RC.1",
+  "version": "0.1.1-RC.2",
   "type": "module",
   "dependencies": {
     "ethers": "^5.7.2",

--- a/libs/permit-utils/package.json
+++ b/libs/permit-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/permit-utils",
-  "version": "0.1.1-RC.0",
+  "version": "0.1.1-RC.1",
   "type": "module",
   "dependencies": {
     "ethers": "^5.7.2",

--- a/libs/permit-utils/package.json
+++ b/libs/permit-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/permit-utils",
-  "version": "0.1.1-RC.2",
+  "version": "0.1.1",
   "type": "module",
   "dependencies": {
     "ethers": "^5.7.2",

--- a/libs/permit-utils/src/abi/erc20.json
+++ b/libs/permit-utils/src/abi/erc20.json
@@ -12,5 +12,48 @@
     "payable": false,
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "eip712Domain",
+    "outputs": [
+      {
+        "internalType": "bytes1",
+        "name": "fields",
+        "type": "bytes1"
+      },
+      {
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "version",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "verifyingContract",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "salt",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "extensions",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/libs/permit-utils/src/const.ts
+++ b/libs/permit-utils/src/const.ts
@@ -8,15 +8,7 @@ const PERMIT_PK = '0x4dae303b820e9878cafeb0f84edcc015e8a81b1bff510e824e4fc27544e
 
 export const PERMIT_SIGNER = new Wallet(PERMIT_PK)
 
-const DEFAULT_GAS_LIMIT = 55_000
-
-// NOTE: intentionally hard coding the chainIds as numbers to NOT depend on cow-sdk
-export const PERMIT_GAS_LIMIT_MIN: Record<number, number> = {
-  1: DEFAULT_GAS_LIMIT,
-  100: DEFAULT_GAS_LIMIT,
-  11155111: DEFAULT_GAS_LIMIT,
-  5: 36_000,
-}
+export const DEFAULT_MIN_GAS_LIMIT = 55_000
 
 export const DEFAULT_PERMIT_GAS_LIMIT = '80000'
 

--- a/libs/permit-utils/src/const.ts
+++ b/libs/permit-utils/src/const.ts
@@ -1,4 +1,3 @@
-import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { MaxUint256 } from '@ethersproject/constants'
 import { Wallet } from '@ethersproject/wallet'
 import ms from 'ms.macro'
@@ -11,11 +10,12 @@ export const PERMIT_SIGNER = new Wallet(PERMIT_PK)
 
 const DEFAULT_GAS_LIMIT = 55_000
 
-export const PERMIT_GAS_LIMIT_MIN: Record<SupportedChainId, number> = {
-  [SupportedChainId.MAINNET]: DEFAULT_GAS_LIMIT,
-  [SupportedChainId.GNOSIS_CHAIN]: DEFAULT_GAS_LIMIT,
-  [SupportedChainId.SEPOLIA]: DEFAULT_GAS_LIMIT,
-  [SupportedChainId.GOERLI]: 36_000,
+// NOTE: intentionally hard coding the chainIds as numbers to NOT depend on cow-sdk
+export const PERMIT_GAS_LIMIT_MIN: Record<number, number> = {
+  1: DEFAULT_GAS_LIMIT,
+  100: DEFAULT_GAS_LIMIT,
+  11155111: DEFAULT_GAS_LIMIT,
+  5: 36_000,
 }
 
 export const DEFAULT_PERMIT_GAS_LIMIT = '80000'

--- a/libs/permit-utils/src/index.ts
+++ b/libs/permit-utils/src/index.ts
@@ -1,4 +1,4 @@
-export { PERMIT_SIGNER } from './const'
+export { PERMIT_SIGNER, DEFAULT_MIN_GAS_LIMIT } from './const'
 
 export { checkIsCallDataAValidPermit } from './lib/checkIsCallDataAValidPermit'
 export { generatePermitHook } from './lib/generatePermitHook'

--- a/libs/permit-utils/src/lib/checkIsCallDataAValidPermit.ts
+++ b/libs/permit-utils/src/lib/checkIsCallDataAValidPermit.ts
@@ -1,7 +1,6 @@
 import { DAI_PERMIT_SELECTOR, Eip2612PermitUtils, EIP_2612_PERMIT_SELECTOR } from '@1inch/permit-signed-approvals-utils'
 
 import { PermitInfo } from '../types'
-import { fixTokenName } from '../utils/fixTokenName'
 
 export async function checkIsCallDataAValidPermit(
   owner: string,
@@ -23,7 +22,7 @@ export async function checkIsCallDataAValidPermit(
     throw new Error(`No token name for ${tokenAddress}`)
   }
 
-  const params = { chainId, tokenName: fixTokenName(tokenName), tokenAddress, callData, version }
+  const params = { chainId, tokenName, tokenAddress, callData, version }
 
   let recoverPermitOwnerPromise: Promise<string> | undefined = undefined
 

--- a/libs/permit-utils/src/lib/getTokenPermitInfo.ts
+++ b/libs/permit-utils/src/lib/getTokenPermitInfo.ts
@@ -57,7 +57,7 @@ async function actuallyCheckTokenIsPermittable(params: GetTokenPermitInfoParams)
   try {
     domain = await getEip712Domain(tokenAddress, chainId, provider)
   } catch (e) {
-    console.debug(`[checkTokenIsPermittable] Couldn't fetch eip712domain for token ${tokenAddress}`, e)
+    console.debug(`[checkTokenIsPermittable] Couldn't fetch eip712domain for token ${tokenAddress}`)
   }
 
   let tokenName = domain?.name

--- a/libs/permit-utils/src/lib/getTokenPermitInfo.ts
+++ b/libs/permit-utils/src/lib/getTokenPermitInfo.ts
@@ -1,7 +1,6 @@
 import type { JsonRpcProvider } from '@ethersproject/providers'
 
 import { DAI_LIKE_PERMIT_TYPEHASH, Eip2612PermitUtils } from '@1inch/permit-signed-approvals-utils'
-import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import { getPermitUtilsInstance } from './getPermitUtilsInstance'
 
@@ -171,7 +170,7 @@ async function actuallyCheckTokenIsPermittable(params: GetTokenPermitInfoParams)
 type BaseParams = {
   tokenAddress: string
   tokenName: string
-  chainId: SupportedChainId
+  chainId: number
   walletAddress: string
   spender: string
   eip2612PermitUtils: Eip2612PermitUtils

--- a/libs/permit-utils/src/types.ts
+++ b/libs/permit-utils/src/types.ts
@@ -54,4 +54,5 @@ export type GetTokenPermitInfoParams = {
   tokenAddress: string
   chainId: number
   provider: JsonRpcProvider
+  minGasLimit?: number | undefined
 }

--- a/libs/permit-utils/src/types.ts
+++ b/libs/permit-utils/src/types.ts
@@ -52,7 +52,6 @@ export type BuildDaiLikePermitCallDataParams = BasePermitCallDataParams & {
 export type GetTokenPermitInfoParams = {
   spender: string
   tokenAddress: string
-  tokenName?: string | undefined
   chainId: number
   provider: JsonRpcProvider
 }

--- a/libs/permit-utils/src/utils/buildPermitCallData.ts
+++ b/libs/permit-utils/src/utils/buildPermitCallData.ts
@@ -1,7 +1,5 @@
 import { DAI_PERMIT_SELECTOR, EIP_2612_PERMIT_SELECTOR } from '@1inch/permit-signed-approvals-utils'
 
-import { fixTokenName } from './fixTokenName'
-
 import { BuildDaiLikePermitCallDataParams, BuildEip2162PermitCallDataParams } from '../types'
 
 export async function buildEip2162PermitCallData({
@@ -10,7 +8,7 @@ export async function buildEip2162PermitCallData({
 }: BuildEip2162PermitCallDataParams): Promise<string> {
   const [permitParams, chainId, tokenName, ...rest] = callDataParams
 
-  const callData = await eip2162Utils.buildPermitCallData(permitParams, chainId, fixTokenName(tokenName), ...rest)
+  const callData = await eip2162Utils.buildPermitCallData(permitParams, chainId, tokenName, ...rest)
   // For some reason, the method above removes the permit selector prefix
   // https://github.com/1inch/permit-signed-approvals-utils/blob/master/src/eip-2612-permit.utils.ts#L92
   // Adding it back

--- a/libs/permit-utils/src/utils/fixTokenName.ts
+++ b/libs/permit-utils/src/utils/fixTokenName.ts
@@ -1,8 +1,0 @@
-// TODO: remove this once permitInfo contains token names
-export function fixTokenName(tokenName: string): string {
-  // TODO: this is ugly and I'm not happy with it either
-  // It'll probably go away when the tokens overhaul is implemented
-  // For now, this is a problem for favourite tokens cached locally with the hardcoded name for USDC token
-  // Using the wrong name breaks the signature.
-  return tokenName === 'USD//C' ? 'USD Coin' : tokenName
-}

--- a/libs/permit-utils/src/utils/getEip712Domain.ts
+++ b/libs/permit-utils/src/utils/getEip712Domain.ts
@@ -1,0 +1,81 @@
+import type { JsonRpcProvider } from '@ethersproject/providers'
+
+import { getAddress } from '@ethersproject/address'
+
+import { getContract } from './getContract'
+
+import Erc20Abi from '../abi/erc20.json'
+
+// See https://eips.ethereum.org/EIPS/eip-5267
+
+export async function getEip712Domain(
+  tokenAddress: string,
+  chainId: number,
+  provider: JsonRpcProvider
+): Promise<Eip712Domain> {
+  const formattedAddress = getAddress(tokenAddress)
+  const erc20Contract = getContract(formattedAddress, Erc20Abi, provider)
+
+  const eip5267Domain: Required<Eip5267Return> = await erc20Contract.callStatic['eip712Domain']()
+
+  return processDomain(eip5267Domain, chainId, tokenAddress)
+}
+
+type Eip5267Return = {
+  fields: string
+  name?: string
+  version?: string
+  chainId?: string
+  verifyingContract?: string
+  salt?: string
+  extensions?: string[]
+}
+
+export type Eip712Domain = Omit<Eip5267Return, 'fields' | 'extensions'>
+
+/** Retrieves the EIP-712 domain of a contract using EIP-5267 without extensions.
+ *
+ * Derived from https://eips.ethereum.org/EIPS/eip-5267 reference Javascript implementation
+ **/
+async function processDomain(domain: Required<Eip5267Return>, chainId: number, address: string): Promise<Eip712Domain> {
+  const { extensions, ...rest } = domain
+
+  if (extensions.length > 0) {
+    throw Error('Extensions not implemented')
+  }
+
+  if (rest.chainId && chainId !== parseInt(rest.chainId, 16)) {
+    throw Error(`ChainId mismatch. Received: '${rest.chainId}', expected: '${chainId}'`)
+  }
+
+  if (rest.verifyingContract && address.toLowerCase() !== rest.verifyingContract.toLowerCase()) {
+    throw Error(`Address mismatch. Received: '${rest.verifyingContract}', expected: '${address}'`)
+  }
+
+  return buildBasicDomain(rest)
+}
+
+const FIELD_NAMES = ['name', 'version', 'chainId', 'verifyingContract', 'salt']
+
+/** Builds a domain object without extensions based on the return values of `eip712Domain()`. */
+function buildBasicDomain(domain: Required<Omit<Eip5267Return, 'extensions'>>): Eip712Domain {
+  // Will be a 5bit number as a hex string
+  const fields = parseInt(domain.fields, 16)
+
+  return FIELD_NAMES.reduce<Eip712Domain>((acc, field, i) => {
+    if (fields & (1 << i)) {
+      acc[field as keyof Eip712Domain] = domain[field as keyof Omit<Eip5267Return, 'extensions'>]
+    }
+    return acc
+  }, {})
+
+  // const result: Eip712Domain = {}
+  //
+  // for (const [i, field] of FIELD_NAMES.entries()) {
+  //   if (fields & (1 << i)) {
+  //     result[field as keyof Eip712Domain] = domain[field as keyof Omit<Eip5267Return, 'extensions'>]
+  //   }
+  // }
+  //
+  // return result
+}

--- a/libs/permit-utils/src/utils/getEip712Domain.ts
+++ b/libs/permit-utils/src/utils/getEip712Domain.ts
@@ -68,14 +68,4 @@ function buildBasicDomain(domain: Required<Omit<Eip5267Return, 'extensions'>>): 
     }
     return acc
   }, {})
-
-  // const result: Eip712Domain = {}
-  //
-  // for (const [i, field] of FIELD_NAMES.entries()) {
-  //   if (fields & (1 << i)) {
-  //     result[field as keyof Eip712Domain] = domain[field as keyof Omit<Eip5267Return, 'extensions'>]
-  //   }
-  // }
-  //
-  // return result
 }


### PR DESCRIPTION
# Summary

Use [EIP-5267](https://eips.ethereum.org/EIPS/eip-5267) when available for fetching token permit info.

# WARNING
Revert https://github.com/cowprotocol/cowswap/commit/8f601ec5e318515337d728447b7000877199d2da before merging!!

# To Test

## Note
Pre-generated permit has been disabled for testing, just so AAVE can be calculated locally.
It'll later be updated in the pre-generated doc.

1. On mainnet, pick AAVE as sell and something else as buy token
2. Clear any cached approvals by removing the localStorage key `userPermitCache:v0`
3. Proceed with the order
* Should prompt to sign
* Should place order successfully
4. Open order on explorer
* AppData should contain the prehook data
![image](https://github.com/cowprotocol/cowswap/assets/43217/ea629a3a-aa7c-4ea0-9cbd-82ebe85dc0f8)
5. Sell another permittable token like DAI, USDC, COW etc
* Should work as usual