### PR TITLE
feat: add tag styling for tokenlist

### DIFF
--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokenInfo/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokenInfo/index.tsx
@@ -14,7 +14,7 @@ export function TokenInfo(props: TokenInfoProps) {
 
   return (
     <styledEl.Wrapper className={className}>
-      <TokenLogo token={token} />
+      <TokenLogo token={token} sizeMobile={32} />
       <div>
         <TokenSymbol token={token} />
         <styledEl.TokenName>

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokenInfo/styled.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokenInfo/styled.ts
@@ -6,6 +6,11 @@ export const Wrapper = styled.div`
   text-align: left;
   gap: 16px;
   font-weight: 500;
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    gap: 10px;
+    flex: 1 1 auto;
+  `}
 `
 
 export const TokenName = styled.div`

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokenListItem/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokenListItem/index.tsx
@@ -15,13 +15,23 @@ export interface TokenListItemProps {
   selectedToken?: string
   balance: BigNumber | undefined
   onSelectToken(token: TokenWithLogo): void
+  measureElement?: (node: Element | null) => void
   virtualRow?: VirtualItem
   isUnsupported: boolean
   isPermitCompatible: boolean
 }
 
 export function TokenListItem(props: TokenListItemProps) {
-  const { token, selectedToken, balance, onSelectToken, virtualRow, isUnsupported, isPermitCompatible } = props
+  const {
+    token,
+    selectedToken,
+    balance,
+    onSelectToken,
+    virtualRow,
+    isUnsupported,
+    isPermitCompatible,
+    measureElement,
+  } = props
 
   const isTokenSelected = token.address.toLowerCase() === selectedToken?.toLowerCase()
 
@@ -30,14 +40,11 @@ export function TokenListItem(props: TokenListItemProps) {
   return (
     <styledEl.TokenItem
       key={token.address}
+      data-index={virtualRow?.index}
+      ref={measureElement}
       data-address={token.address.toLowerCase()}
       disabled={isTokenSelected}
       onClick={() => onSelectToken(token)}
-      $isVirtual={!!virtualRow}
-      style={{
-        height: virtualRow ? `${virtualRow.size}px` : undefined,
-        transform: virtualRow ? `translateY(${virtualRow.start}px)` : undefined,
-      }}
     >
       <TokenInfo token={token} />
       <TokenTags isUnsupported={isUnsupported} isPermitCompatible={isPermitCompatible} />

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokenListItem/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokenListItem/index.tsx
@@ -41,7 +41,7 @@ export function TokenListItem(props: TokenListItemProps) {
     >
       <TokenInfo token={token} />
       <TokenTags isUnsupported={isUnsupported} isPermitCompatible={isPermitCompatible} />
-      <span>{balanceAmount && <TokenAmount amount={balanceAmount} />}</span>
+      <styledEl.TokenBalance>{balanceAmount && <TokenAmount amount={balanceAmount} />}</styledEl.TokenBalance>
     </styledEl.TokenItem>
   )
 }

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokenListItem/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokenListItem/index.tsx
@@ -47,8 +47,8 @@ export function TokenListItem(props: TokenListItemProps) {
       onClick={() => onSelectToken(token)}
     >
       <TokenInfo token={token} />
-      <TokenTags isUnsupported={isUnsupported} isPermitCompatible={isPermitCompatible} />
       <styledEl.TokenBalance>{balanceAmount && <TokenAmount amount={balanceAmount} />}</styledEl.TokenBalance>
+      <TokenTags isUnsupported={isUnsupported} isPermitCompatible={isPermitCompatible} />
     </styledEl.TokenItem>
   )
 }

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokenListItem/styled.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokenListItem/styled.ts
@@ -9,7 +9,7 @@ export const Wrapper = styled.div`
 
 export const TokenItem = styled.button`
   display: flex;
-  flex-direction: row;
+  flex-flow: row wrap;
   justify-content: space-between;
   gap: 8px;
   align-items: center;
@@ -28,7 +28,7 @@ export const TokenItem = styled.button`
   ${({ theme }) => theme.mediaWidth.upToSmall`
     font-size: 14px;
     padding: 10px 15px;
-    flex-flow: row wrap;
+    justify-content: flex-end;
   `}
 
   &:last-child {
@@ -42,7 +42,11 @@ export const TokenItem = styled.button`
 `
 
 export const TokenBalance = styled.span`
-  flex: 0 1 auto;
+  flex: 1 1 auto;
   display: flex;
   justify-content: flex-end;
+
+  > span {
+    text-align: right;
+  }
 `

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokenListItem/styled.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokenListItem/styled.ts
@@ -1,13 +1,13 @@
 import { UI } from '@cowprotocol/ui'
 
-import styled, { css } from 'styled-components/macro'
+import styled from 'styled-components/macro'
 
 export const Wrapper = styled.div`
   border-top: 1px solid var(${UI.COLOR_BORDER});
   border-bottom: 1px solid var(${UI.COLOR_BORDER});
 `
 
-export const TokenItem = styled.button<{ $isVirtual?: boolean }>`
+export const TokenItem = styled.button`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -39,15 +39,6 @@ export const TokenItem = styled.button<{ $isVirtual?: boolean }>`
     background: ${({ disabled }) => !disabled && `var(${UI.COLOR_PAPER_DARKER})`};
     color: inherit;
   }
-
-  ${({ $isVirtual }) =>
-    $isVirtual &&
-    css`
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-    `}
 `
 
 export const TokenBalance = styled.span`

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokenListItem/styled.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokenListItem/styled.ts
@@ -11,6 +11,7 @@ export const TokenItem = styled.button<{ $isVirtual?: boolean }>`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  gap: 8px;
   align-items: center;
   width: 100%;
   background: none;
@@ -23,6 +24,12 @@ export const TokenItem = styled.button<{ $isVirtual?: boolean }>`
   margin-bottom: 10px;
   opacity: ${({ disabled }) => (disabled ? 0.5 : 1)};
   transition: background var(${UI.ANIMATION_DURATION}) ease-in-out, color var(${UI.ANIMATION_DURATION}) ease-in-out;
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    font-size: 14px;
+    padding: 10px 15px;
+    flex-flow: row wrap;
+  `}
 
   &:last-child {
     margin-bottom: 0;
@@ -41,4 +48,10 @@ export const TokenItem = styled.button<{ $isVirtual?: boolean }>`
       left: 0;
       width: 100%;
     `}
+`
+
+export const TokenBalance = styled.span`
+  flex: 0 1 auto;
+  display: flex;
+  justify-content: flex-end;
 `

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokenTags/styled.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokenTags/styled.tsx
@@ -7,13 +7,9 @@ export const TagContainer = styled.div`
   justify-content: flex-end;
   flex-flow: row wrap;
   color: inherit;
-  flex: 1 1 auto;
-
-  ${({ theme }) => theme.mediaWidth.upToSmall`
-    order: 3;
-    flex: 1 1 100%;
-    gap: 4px;
-  `}
+  flex: 0 1 auto;
+  gap: 4px;
+  margin: 0 0 0 auto;
 `
 
 export const Tag = styled.div<{ tag?: { id: string } }>`

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokenTags/styled.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokenTags/styled.tsx
@@ -7,6 +7,13 @@ export const TagContainer = styled.div`
   justify-content: flex-end;
   flex-flow: row wrap;
   color: inherit;
+  flex: 1 1 auto;
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    order: 3;
+    flex: 1 1 100%;
+    gap: 4px;
+  `}
 `
 
 export const Tag = styled.div<{ tag?: { id: string } }>`
@@ -33,6 +40,10 @@ export const Tag = styled.div<{ tag?: { id: string } }>`
   white-space: nowrap;
   justify-self: flex-end;
   margin: 0 4px 0 0;
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    margin: 0;
+  `}
 
   > img,
   > svg {

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokensVirtualList/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokensVirtualList/index.tsx
@@ -71,9 +71,6 @@ export function TokensVirtualList(props: TokensVirtualListProps) {
             return <styledEl.LoadingRows key={virtualRow.key}>{threeDivs()}</styledEl.LoadingRows>
           }
 
-          console.log('virtualRow=========')
-          console.log(virtualRow)
-
           return (
             <TokenListItem
               key={virtualRow.key}

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokensVirtualList/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokensVirtualList/index.tsx
@@ -71,6 +71,9 @@ export function TokensVirtualList(props: TokensVirtualListProps) {
             return <styledEl.LoadingRows key={virtualRow.key}>{threeDivs()}</styledEl.LoadingRows>
           }
 
+          console.log('virtualRow=========')
+          console.log(virtualRow)
+
           return (
             <TokenListItem
               key={virtualRow.key}

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokensVirtualList/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokensVirtualList/index.tsx
@@ -57,33 +57,36 @@ export function TokensVirtualList(props: TokensVirtualListProps) {
     return balances ? allTokens.sort(tokensListSorter(balances)) : allTokens
   }, [allTokens, balances])
 
-  const { getVirtualItems } = virtualizer
+  const items = virtualizer.getVirtualItems()
 
   return (
     <CommonListContainer id="tokens-list" ref={parentRef} onScroll={onScroll}>
-      <styledEl.TokensInner ref={wrapperRef} style={{ height: `${virtualizer.getTotalSize()}px` }}>
-        {getVirtualItems().map((virtualRow) => {
-          const token = sortedTokens[virtualRow.index]
-          const addressLowerCase = token.address.toLowerCase()
-          const balance = balances ? balances[token.address.toLowerCase()] : undefined
+      <styledEl.TokensInner ref={wrapperRef} style={{ height: virtualizer.getTotalSize() }}>
+        <styledEl.TokensScroller style={{ transform: `translateY(${items[0]?.start ?? 0}px)` }}>
+          {items.map((virtualRow) => {
+            const token = sortedTokens[virtualRow.index]
+            const addressLowerCase = token.address.toLowerCase()
+            const balance = balances ? balances[token.address.toLowerCase()] : undefined
 
-          if (balancesLoading) {
-            return <styledEl.LoadingRows key={virtualRow.key}>{threeDivs()}</styledEl.LoadingRows>
-          }
+            if (balancesLoading) {
+              return <styledEl.LoadingRows key={virtualRow.key}>{threeDivs()}</styledEl.LoadingRows>
+            }
 
-          return (
-            <TokenListItem
-              key={virtualRow.key}
-              virtualRow={virtualRow}
-              token={token}
-              isUnsupported={!!unsupportedTokens[addressLowerCase]}
-              isPermitCompatible={permitCompatibleTokens[addressLowerCase]}
-              selectedToken={selectedToken}
-              balance={balance}
-              onSelectToken={onSelectToken}
-            />
-          )
-        })}
+            return (
+              <TokenListItem
+                key={virtualRow.key}
+                virtualRow={virtualRow}
+                measureElement={virtualizer.measureElement}
+                token={token}
+                isUnsupported={!!unsupportedTokens[addressLowerCase]}
+                isPermitCompatible={permitCompatibleTokens[addressLowerCase]}
+                selectedToken={selectedToken}
+                balance={balance}
+                onSelectToken={onSelectToken}
+              />
+            )
+          })}
+        </styledEl.TokensScroller>
       </styledEl.TokensInner>
     </CommonListContainer>
   )

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokensVirtualList/styled.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokensVirtualList/styled.ts
@@ -7,6 +7,13 @@ export const TokensInner = styled.div`
   position: relative;
 `
 
+export const TokensScroller = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+`
+
 export const LoadingRows = styled(BaseLoadingRows)`
   grid-column-gap: 0.5em;
   grid-template-columns: repeat(12, 1fr);

--- a/libs/tokens/src/pure/TokenLogo/index.tsx
+++ b/libs/tokens/src/pure/TokenLogo/index.tsx
@@ -7,7 +7,7 @@ import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { Currency, NativeCurrency } from '@uniswap/sdk-core'
 
 import { Slash } from 'react-feather'
-import styled from 'styled-components/macro'
+import styled, { css } from 'styled-components/macro'
 
 import { UI } from '@cowprotocol/ui'
 
@@ -15,7 +15,7 @@ import { getTokenLogoUrls } from '../../utils/getTokenLogoUrls'
 
 const invalidUrlsAtom = atom<{ [url: string]: boolean }>({})
 
-export const TokenLogoWrapper = styled.div<{ size?: number }>`
+export const TokenLogoWrapper = styled.div<{ size?: number; sizeMobile?: number }>`
   display: inline-block;
   background: var(${UI.COLOR_PAPER});
   border-radius: ${({ size }) => size}px;
@@ -30,6 +30,23 @@ export const TokenLogoWrapper = styled.div<{ size?: number }>`
     border-radius: ${({ size }) => size}px;
     object-fit: contain;
   }
+
+  ${({ theme, sizeMobile }) => theme.mediaWidth.upToSmall`
+    ${
+      sizeMobile
+        ? css`
+            border-radius: ${sizeMobile}px;
+            width: ${sizeMobile}px;
+            height: ${sizeMobile}px;
+
+            > img,
+            > svg {
+              border-radius: ${sizeMobile}px;
+            }
+          `
+        : ''
+    }
+  `}
 `
 
 export interface TokenLogoProps {
@@ -37,9 +54,10 @@ export interface TokenLogoProps {
   logoURI?: string
   className?: string
   size?: number
+  sizeMobile?: number
 }
 
-export function TokenLogo({ logoURI, token, className, size = 36 }: TokenLogoProps) {
+export function TokenLogo({ logoURI, token, className, size = 36, sizeMobile }: TokenLogoProps) {
   const [invalidUrls, setInvalidUrls] = useAtom(invalidUrlsAtom)
 
   const urls = useMemo(() => {
@@ -64,7 +82,7 @@ export function TokenLogo({ logoURI, token, className, size = 36 }: TokenLogoPro
   }
 
   return (
-    <TokenLogoWrapper className={className} size={size}>
+    <TokenLogoWrapper className={className} size={size} sizeMobile={sizeMobile}>
       {!currentUrl ? <Slash size={size} /> : <img alt="token logo" src={currentUrl} onError={onError} />}
     </TokenLogoWrapper>
   )

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@sentry/tracing": "^7.80.0",
     "@sentry/webpack-plugin": "^2.10.0",
     "@swc/helpers": "~0.5.0",
-    "@tanstack/react-virtual": "^3.0.0-beta.65",
+    "@tanstack/react-virtual": "^3.0.2",
     "@trezor/connect-plugin-ethereum": "^9.0.1",
     "@trezor/connect-web": "^9.0.11",
     "@types/hdkey": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6952,17 +6952,17 @@
     "@tanstack/query-core" "4.36.1"
     use-sync-external-store "^1.2.0"
 
-"@tanstack/react-virtual@^3.0.0-beta.65":
-  version "3.0.0-beta.68"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.68.tgz#225532329d74d7c0f82564d36ad8bf461e320ab5"
-  integrity sha512-YEFNCf+N3ZlNou2r4qnh+GscMe24foYEjTL05RS0ZHvah2RoUDPGuhnuedTv0z66dO2vIq6+Bl4TXatht5T7GQ==
+"@tanstack/react-virtual@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.0.2.tgz#e5a979f2585d3f583944840319cddf2c2d1b0e51"
+  integrity sha512-9XbRLPKgnhMwwmuQMnJMv+5a9sitGNCSEtf/AZXzmJdesYk7XsjYHaEDny+IrJzvPNwZliIIDwCRiaUqR3zzCA==
   dependencies:
-    "@tanstack/virtual-core" "3.0.0-beta.68"
+    "@tanstack/virtual-core" "3.0.0"
 
-"@tanstack/virtual-core@3.0.0-beta.68":
-  version "3.0.0-beta.68"
-  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.68.tgz#e6c478b393df57861e0a98fd0fea9982b79b6e7d"
-  integrity sha512-CnvsEJWK7cugigckt13AeY80FMzH+OMdEP0j0bS3/zjs44NiRe49x8FZC6R9suRXGMVMXtUHet0zbTp/Ec9Wfg==
+"@tanstack/virtual-core@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.0.0.tgz#637bee36f0cabf96a1d436887c90f138a7e9378b"
+  integrity sha512-SYXOBTjJb05rXa2vl55TTwO40A6wKu0R5i1qQwhJYNDIqaIGF7D0HsLw+pJAyi2OvntlEIVusx3xtbbgSUi6zg==
 
 "@testing-library/dom@^9.0.0":
   version "9.3.1"


### PR DESCRIPTION
# Summary

- Addresses https://github.com/cowprotocol/cowswap/issues/3498 

# Todo

The current height of each Tokenitem is not re-calculated after the given estimated height (`const estimateSize = () => 56`)
for the Virtual list. @alfetopito @shoom3301 if possible review this PR and see if we can re-calculate the actual height of each token item container. Also on resize of the viewport (https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) would be good to detect if height changes.

## Desktop 
<img width="593" alt="Screenshot 2024-01-22 at 13 15 46" src="https://github.com/cowprotocol/cowswap/assets/31534717/0d9f31ed-ea9c-4a00-bfdc-ad12ca3a5c18">


## Mobile / small viewport
<img width="373" alt="Screenshot 2024-01-22 at 13 05 00" src="https://github.com/cowprotocol/cowswap/assets/31534717/2c94e25c-9dc3-4298-b16c-8dac9626b487">
<img width="377" alt="Screenshot 2024-01-22 at 13 04 45" src="https://github.com/cowprotocol/cowswap/assets/31534717/038416d0-44e2-444d-9efc-a51c317588e3">

As you see above the Token item for USDC stays at 56px height whereas it should be higher.

**This is what the expected result should have been:**

<img width="373" alt="Screenshot 2024-01-22 at 13 04 30" src="https://github.com/cowprotocol/cowswap/assets/31534717/1c73faed-1f4b-4293-8e71-3b405695c840"><img width="372" alt="Screenshot 2024-01-22 at 13 04 19" src="https://github.com/cowprotocol/cowswap/assets/31534717/d0654f00-3871-44ef-bcfd-083eb4f7e25d">

