### PR TITLE
fix(permit): presign

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/featureFlags/useIsPermitEnabled.ts
+++ b/apps/cowswap-frontend/src/common/hooks/featureFlags/useIsPermitEnabled.ts
@@ -2,5 +2,5 @@ import { useIsSmartContractWallet } from '@cowprotocol/wallet'
 
 export function useIsPermitEnabled(): boolean {
   // Permit is only available for EOAs
-  return !useIsSmartContractWallet()
+  return useIsSmartContractWallet() === false
 }

--- a/apps/cowswap-frontend/src/modules/appData/updater/AppDataHooksUpdater.ts
+++ b/apps/cowswap-frontend/src/modules/appData/updater/AppDataHooksUpdater.ts
@@ -12,7 +12,7 @@ import { useSwapEnoughAllowance } from '../../swap/hooks/useSwapFlowContext'
 import { useUpdateAppDataHooks } from '../hooks'
 import { buildAppDataHooks } from '../utils/buildAppDataHooks'
 
-function usePermitDataIfNotAllowance(): PermitHookData | undefined {
+function useAgnosticPermitDataIfUserHasNoAllowance(): PermitHookData | undefined {
   const { target, callData, gasLimit } = useAccountAgnosticPermitHookData() || {}
 
   // Remove permitData if the user has enough allowance for the current trade
@@ -32,7 +32,7 @@ function usePermitDataIfNotAllowance(): PermitHookData | undefined {
 export function AppDataHooksUpdater(): null {
   const { v2Trade } = useDerivedSwapInfo()
   const updateAppDataHooks = useUpdateAppDataHooks()
-  const permitData = usePermitDataIfNotAllowance()
+  const permitData = useAgnosticPermitDataIfUserHasNoAllowance()
   const permitDataPrev = useRef<PermitHookData | undefined>(undefined)
   const hasTradeInfo = !!v2Trade
   // This is already covered up the dependency chain, but it still slips through some times
@@ -44,6 +44,7 @@ export function AppDataHooksUpdater(): null {
   useEffect(() => {
     if (
       !hasTradeInfo || // If there's no trade info, wait until we have one to update the hooks (i.e. missing quote)
+      isSmartContractWallet === undefined || // We don't know what type of wallet it is, wait until it's defined
       JSON.stringify(permitDataPrev.current) === JSON.stringify(permitData) // Or if the permit data has not changed
     ) {
       return undefined

--- a/apps/cowswap-frontend/src/modules/appData/updater/AppDataHooksUpdater.ts
+++ b/apps/cowswap-frontend/src/modules/appData/updater/AppDataHooksUpdater.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react'
 
 import { PermitHookData } from '@cowprotocol/permit-utils'
+import { useIsSmartContractWallet } from '@cowprotocol/wallet'
 
 import { useAccountAgnosticPermitHookData } from 'modules/permit'
 import { useDerivedSwapInfo } from 'modules/swap/hooks/useSwapState'
@@ -33,6 +34,9 @@ export function AppDataHooksUpdater(): null {
   const permitData = usePermitDataIfNotAllowance()
   const permitDataPrev = useRef<PermitHookData | undefined>(undefined)
   const hasTradeInfo = !!v2Trade
+  // This is already covered up the dependency chain, but it still slips through some times
+  // Adding this additional check here to try to prevent a race condition to ever allowing this to pass through
+  const isSmartContractWallet = useIsSmartContractWallet()
 
   useEffect(() => {
     if (
@@ -46,7 +50,7 @@ export function AppDataHooksUpdater(): null {
       preInteractionHooks: permitData ? [permitData] : undefined,
     })
 
-    if (hooks) {
+    if (!isSmartContractWallet && hooks) {
       // Update the hooks
       console.log('[AppDataHooksUpdater]: Set hooks', hooks)
       updateAppDataHooks(hooks)
@@ -57,7 +61,7 @@ export function AppDataHooksUpdater(): null {
       updateAppDataHooks(undefined)
       permitDataPrev.current = undefined
     }
-  }, [updateAppDataHooks, permitData, hasTradeInfo])
+  }, [updateAppDataHooks, permitData, hasTradeInfo, isSmartContractWallet])
 
   return null
 }

--- a/apps/cowswap-frontend/src/modules/limitOrders/services/safeBundleFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/services/safeBundleFlow/index.ts
@@ -47,6 +47,7 @@ export async function safeBundleFlow(
     class: orderClass,
   } = params.postOrderParams
 
+  // TODO: remove once we figure out what's adding this to appData in the first place
   if (appDataContainsHooks(params.postOrderParams.appData.fullAppData)) {
     reportAppDataWithHooks(params.postOrderParams)
     // wipe out the hooks

--- a/apps/cowswap-frontend/src/modules/limitOrders/services/safeBundleFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/services/safeBundleFlow/index.ts
@@ -1,3 +1,4 @@
+import { reportAppDataWithHooks } from '@cowprotocol/common-utils'
 import { MetaTransactionData } from '@safe-global/safe-core-sdk-types'
 import { Percent } from '@uniswap/sdk-core'
 
@@ -5,6 +6,7 @@ import { PriceImpact } from 'legacy/hooks/usePriceImpact'
 import { partialOrderUpdate } from 'legacy/state/orders/utils'
 import { signAndPostOrder } from 'legacy/utils/trade'
 
+import { updateHooksOnAppData } from 'modules/appData'
 import { LOW_RATE_THRESHOLD_PERCENT } from 'modules/limitOrders/const/trade'
 import { PriceImpactDeclineError, SafeBundleFlowContext } from 'modules/limitOrders/services/types'
 import { LimitOrdersSettingsState } from 'modules/limitOrders/state/limitOrdersSettingsAtom'
@@ -12,6 +14,7 @@ import { calculateLimitOrdersDeadline } from 'modules/limitOrders/utils/calculat
 import { buildApproveTx } from 'modules/operations/bundle/buildApproveTx'
 import { buildPresignTx } from 'modules/operations/bundle/buildPresignTx'
 import { buildZeroApproveTx } from 'modules/operations/bundle/buildZeroApproveTx'
+import { appDataContainsHooks } from 'modules/permit/utils/appDataContainsHooks'
 import { addPendingOrderStep } from 'modules/trade/utils/addPendingOrderStep'
 import { SwapFlowAnalyticsContext, tradeFlowAnalytics } from 'modules/trade/utils/analytics'
 import { logTradeFlow } from 'modules/trade/utils/logger'
@@ -43,6 +46,12 @@ export async function safeBundleFlow(
     inputAmount,
     class: orderClass,
   } = params.postOrderParams
+
+  if (appDataContainsHooks(params.postOrderParams.appData.fullAppData)) {
+    reportAppDataWithHooks(params.postOrderParams)
+    // wipe out the hooks
+    params.postOrderParams.appData = await updateHooksOnAppData(params.postOrderParams.appData, undefined)
+  }
 
   const swapFlowAnalyticsContext: SwapFlowAnalyticsContext = {
     account,

--- a/apps/cowswap-frontend/src/modules/permit/utils/appDataContainsHooks.ts
+++ b/apps/cowswap-frontend/src/modules/permit/utils/appDataContainsHooks.ts
@@ -10,7 +10,7 @@ export function appDataContainsHooks(fullAppData: string | undefined): boolean {
 
     return !!appData.metadata?.hooks
   } catch (e) {
-    // Does not match the schema, use a regex
-    return /"hooks"/.test(fullAppData)
+    // Does not match the schema, assume there are no valid hooks
+    return false
   }
 }

--- a/apps/cowswap-frontend/src/modules/permit/utils/appDataContainsHooks.ts
+++ b/apps/cowswap-frontend/src/modules/permit/utils/appDataContainsHooks.ts
@@ -1,0 +1,16 @@
+import { AppDataRootSchema } from '../../appData/types'
+
+export function appDataContainsHooks(fullAppData: string | undefined): boolean {
+  if (!fullAppData) {
+    return false
+  }
+
+  try {
+    const appData = JSON.parse(fullAppData) as AppDataRootSchema
+
+    return !!appData.metadata?.hooks
+  } catch (e) {
+    // Does not match the schema, use a regex
+    return /"hooks"/.test(fullAppData)
+  }
+}

--- a/apps/cowswap-frontend/src/modules/swap/helpers/getSwapButtonState.ts
+++ b/apps/cowswap-frontend/src/modules/swap/helpers/getSwapButtonState.ts
@@ -52,7 +52,7 @@ export interface SwapButtonStateParams {
   swapCallbackError: string | null
   trade: TradeGp | undefined | null
   isNativeIn: boolean
-  isSmartContractWallet: boolean
+  isSmartContractWallet: boolean | undefined
   isBestQuoteLoading: boolean
   wrappedToken: Token
   isPermitSupported: boolean
@@ -128,7 +128,7 @@ export function getSwapButtonState(input: SwapButtonStateParams): SwapButtonStat
   }
 
   if (input.isNativeIn) {
-    if (getEthFlowEnabled(input.isSmartContractWallet)) {
+    if (getEthFlowEnabled(input.isSmartContractWallet === true)) {
       return input.isExpertMode ? SwapButtonState.ExpertModeEthFlowSwap : SwapButtonState.RegularEthFlowSwap
     } else if (input.isBundlingSupported) {
       return input.isExpertMode ? SwapButtonState.ExpertWrapAndSwap : SwapButtonState.WrapAndSwap

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useIsEoaEthFlow.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useIsEoaEthFlow.ts
@@ -8,7 +8,7 @@ export function useIsEoaEthFlow(): boolean {
   const isSwapEth = useIsSwapEth()
 
   const isSmartContractWallet = useIsSmartContractWallet()
-  const isEnabled = getEthFlowEnabled(isSmartContractWallet)
+  const isEnabled = getEthFlowEnabled(isSmartContractWallet === true)
 
   return isEnabled && isSwapEth
 }

--- a/apps/cowswap-frontend/src/modules/swap/services/ethFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/ethFlow/index.ts
@@ -1,7 +1,10 @@
+import { reportAppDataWithHooks } from '@cowprotocol/common-utils'
 import { Percent } from '@uniswap/sdk-core'
 
 import { PriceImpact } from 'legacy/hooks/usePriceImpact'
 
+import { updateHooksOnAppData } from 'modules/appData'
+import { appDataContainsHooks } from 'modules/permit/utils/appDataContainsHooks'
 import { signEthFlowOrderStep } from 'modules/swap/services/ethFlow/steps/signEthFlowOrderStep'
 import { EthFlowContext } from 'modules/swap/services/types'
 import { addPendingOrderStep } from 'modules/trade/utils/addPendingOrderStep'
@@ -32,6 +35,12 @@ export async function ethFlow(
   logTradeFlow('ETH FLOW', 'STEP 1: confirm price impact')
   if (priceImpactParams?.priceImpact && !(await confirmPriceImpactWithoutFee(priceImpactParams.priceImpact))) {
     return undefined
+  }
+
+  if (appDataContainsHooks(orderParamsOriginal.appData.fullAppData)) {
+    reportAppDataWithHooks(orderParamsOriginal)
+    // wipe out the hooks
+    orderParamsOriginal.appData = await updateHooksOnAppData(orderParamsOriginal.appData, undefined)
   }
 
   logTradeFlow('ETH FLOW', 'STEP 2: send transaction')

--- a/apps/cowswap-frontend/src/modules/swap/services/ethFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/ethFlow/index.ts
@@ -37,6 +37,7 @@ export async function ethFlow(
     return undefined
   }
 
+  // TODO: remove once we figure out what's adding this to appData in the first place
   if (appDataContainsHooks(orderParamsOriginal.appData.fullAppData)) {
     reportAppDataWithHooks(orderParamsOriginal)
     // wipe out the hooks

--- a/apps/cowswap-frontend/src/modules/swap/services/safeBundleFlow/safeBundleApprovalFlow.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/safeBundleFlow/safeBundleApprovalFlow.ts
@@ -57,6 +57,7 @@ export async function safeBundleApprovalFlow(
       amountToApprove: context.trade.inputAmount,
     })
 
+    // TODO: remove once we figure out what's adding this to appData in the first place
     // make sure no pre-approval hooks are included, just as a safety measure
     if (appDataContainsHooks(orderParams.appData.fullAppData)) {
       reportAppDataWithHooks(orderParams)

--- a/apps/cowswap-frontend/src/modules/swap/services/safeBundleFlow/safeBundleApprovalFlow.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/safeBundleFlow/safeBundleApprovalFlow.ts
@@ -58,10 +58,10 @@ export async function safeBundleApprovalFlow(
     })
 
     // make sure no pre-approval hooks are included, just as a safety measure
-    if (appDataContainsHooks(input.orderParams.appData.fullAppData)) {
-      reportAppDataWithHooks(input.orderParams)
+    if (appDataContainsHooks(orderParams.appData.fullAppData)) {
+      reportAppDataWithHooks(orderParams)
       // wipe out the hooks
-      input.orderParams.appData = await updateHooksOnAppData(input.orderParams.appData, undefined)
+      orderParams.appData = await updateHooksOnAppData(orderParams.appData, undefined)
     }
 
     logTradeFlow(LOG_PREFIX, 'STEP 3: post order')

--- a/apps/cowswap-frontend/src/modules/swap/services/safeBundleFlow/safeBundleApprovalFlow.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/safeBundleFlow/safeBundleApprovalFlow.ts
@@ -1,3 +1,4 @@
+import { reportAppDataWithHooks } from '@cowprotocol/common-utils'
 import { MetaTransactionData } from '@safe-global/safe-core-sdk-types'
 import { Percent } from '@uniswap/sdk-core'
 
@@ -5,9 +6,11 @@ import { PriceImpact } from 'legacy/hooks/usePriceImpact'
 import { partialOrderUpdate } from 'legacy/state/orders/utils'
 import { signAndPostOrder } from 'legacy/utils/trade'
 
+import { updateHooksOnAppData } from 'modules/appData'
 import { buildApproveTx } from 'modules/operations/bundle/buildApproveTx'
 import { buildPresignTx } from 'modules/operations/bundle/buildPresignTx'
 import { buildZeroApproveTx } from 'modules/operations/bundle/buildZeroApproveTx'
+import { appDataContainsHooks } from 'modules/permit/utils/appDataContainsHooks'
 import { SafeBundleApprovalFlowContext } from 'modules/swap/services/types'
 import { addPendingOrderStep } from 'modules/trade/utils/addPendingOrderStep'
 import { tradeFlowAnalytics } from 'modules/trade/utils/analytics'
@@ -53,6 +56,13 @@ export async function safeBundleApprovalFlow(
       spender,
       amountToApprove: context.trade.inputAmount,
     })
+
+    // make sure no pre-approval hooks are included, just as a safety measure
+    if (appDataContainsHooks(input.orderParams.appData.fullAppData)) {
+      reportAppDataWithHooks(input.orderParams)
+      // wipe out the hooks
+      input.orderParams.appData = await updateHooksOnAppData(input.orderParams.appData, undefined)
+    }
 
     logTradeFlow(LOG_PREFIX, 'STEP 3: post order')
     const { id: orderId, order } = await signAndPostOrder(orderParams).finally(() => {

--- a/apps/cowswap-frontend/src/modules/swap/services/safeBundleFlow/safeBundleEthFlow.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/safeBundleFlow/safeBundleEthFlow.ts
@@ -78,6 +78,7 @@ export async function safeBundleEthFlow(
       })
     }
 
+    // TODO: remove once we figure out what's adding this to appData in the first place
     if (appDataContainsHooks(orderParams.appData.fullAppData)) {
       reportAppDataWithHooks(orderParams)
       // wipe out the hooks

--- a/apps/cowswap-frontend/src/modules/swap/services/safeBundleFlow/safeBundleEthFlow.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/safeBundleFlow/safeBundleEthFlow.ts
@@ -1,4 +1,5 @@
 import { Erc20 } from '@cowprotocol/abis'
+import { reportAppDataWithHooks } from '@cowprotocol/common-utils'
 import { MetaTransactionData } from '@safe-global/safe-core-sdk-types'
 import { Percent } from '@uniswap/sdk-core'
 
@@ -6,9 +7,11 @@ import { PriceImpact } from 'legacy/hooks/usePriceImpact'
 import { partialOrderUpdate } from 'legacy/state/orders/utils'
 import { signAndPostOrder } from 'legacy/utils/trade'
 
+import { updateHooksOnAppData } from 'modules/appData'
 import { buildApproveTx } from 'modules/operations/bundle/buildApproveTx'
 import { buildPresignTx } from 'modules/operations/bundle/buildPresignTx'
 import { buildWrapTx } from 'modules/operations/bundle/buildWrapTx'
+import { appDataContainsHooks } from 'modules/permit/utils/appDataContainsHooks'
 import { SafeBundleEthFlowContext } from 'modules/swap/services/types'
 import { addPendingOrderStep } from 'modules/trade/utils/addPendingOrderStep'
 import { tradeFlowAnalytics } from 'modules/trade/utils/analytics'
@@ -73,6 +76,12 @@ export async function safeBundleEthFlow(
         value: '0',
         operation: 0,
       })
+    }
+
+    if (appDataContainsHooks(orderParams.appData.fullAppData)) {
+      reportAppDataWithHooks(orderParams)
+      // wipe out the hooks
+      orderParams.appData = await updateHooksOnAppData(orderParams.appData, undefined)
     }
 
     logTradeFlow(LOG_PREFIX, 'STEP 4: post order')

--- a/apps/cowswap-frontend/src/modules/swap/services/swapFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/swapFlow/index.ts
@@ -44,6 +44,7 @@ export async function swapFlow(
     if (appDataContainsPermitSigner(input.orderParams.appData.fullAppData)) {
       reportPermitWithDefaultSigner(input.orderParams)
     } else if (
+      // TODO: remove once we figure out what's adding this to appData in the first place
       // Last resort in case of a race condition
       // It should not have a permit in the first place if it's selling native
       // But there are several cases where it has

--- a/libs/common-utils/src/sentry.ts
+++ b/libs/common-utils/src/sentry.ts
@@ -10,7 +10,7 @@ export function reportPermitWithDefaultSigner(params: Record<any, any>): void {
 
 export function reportAppDataWithHooks(params: Record<any, any>): void {
   // report to sentry if we ever use hooks in the app data
-  Sentry.captureException('Hooks are present in the app data for a SC order', {
+  Sentry.captureException("Hooks are present in the app data when it shouldn't", {
     tags: { errorType: 'appDataWithHooks' },
     contexts: { params },
   })

--- a/libs/common-utils/src/sentry.ts
+++ b/libs/common-utils/src/sentry.ts
@@ -7,3 +7,11 @@ export function reportPermitWithDefaultSigner(params: Record<any, any>): void {
     contexts: { params },
   })
 }
+
+export function reportAppDataWithHooks(params: Record<any, any>): void {
+  // report to sentry if we ever use hooks in the app data
+  Sentry.captureException('Hooks are present in the app data for a SC order', {
+    tags: { errorType: 'appDataWithHooks' },
+    contexts: { params },
+  })
+}

--- a/libs/wallet/src/api/types.ts
+++ b/libs/wallet/src/api/types.ts
@@ -28,7 +28,7 @@ export interface WalletInfo {
 
 export interface WalletDetails {
   // Account details
-  isSmartContractWallet: boolean
+  isSmartContractWallet: boolean | undefined
   ensName?: string
 
   // Provider details

--- a/libs/wallet/src/api/utils/getWalletType.ts
+++ b/libs/wallet/src/api/utils/getWalletType.ts
@@ -2,13 +2,13 @@ import { GnosisSafeInfo, WalletType } from '../types'
 
 interface GetWalletTypeParams {
   gnosisSafeInfo?: GnosisSafeInfo
-  isSmartContractWallet: boolean
+  isSmartContractWallet: boolean | undefined
 }
 
 export function getWalletType({ gnosisSafeInfo, isSmartContractWallet }: GetWalletTypeParams): WalletType {
   if (gnosisSafeInfo) {
     return WalletType.SAFE
-  } else if (isSmartContractWallet) {
+  } else if (isSmartContractWallet === true) {
     return WalletType.SC
   } else {
     return WalletType.EOA

--- a/libs/wallet/src/web3-react/hooks/useIsSmartContractWallet.ts
+++ b/libs/wallet/src/web3-react/hooks/useIsSmartContractWallet.ts
@@ -33,8 +33,8 @@ function useCheckIsSmartContract(): boolean | undefined {
   return data
 }
 
-export function useIsSmartContractWallet(): boolean {
-  const [isSmartContractWallet, setIsSmartContractWallet] = useState<boolean>(false)
+export function useIsSmartContractWallet(): boolean | undefined {
+  const [isSmartContractWallet, setIsSmartContractWallet] = useState<boolean | undefined>(undefined)
 
   const { account } = useWalletInfo()
 
@@ -47,7 +47,7 @@ export function useIsSmartContractWallet(): boolean {
     if (!account) {
       setIsSmartContractWallet(false)
     } else {
-      setIsSmartContractWallet(Boolean(isSafeWallet || isAmbireWallet || isArgentWallet || isSmartContract))
+      setIsSmartContractWallet(isSafeWallet || isAmbireWallet || isArgentWallet || isSmartContract)
     }
   }, [account, isAmbireWallet, isArgentWallet, isSafeWallet, isSmartContract])
 

--- a/libs/wallet/src/web3-react/hooks/useIsSmartContractWallet.ts
+++ b/libs/wallet/src/web3-react/hooks/useIsSmartContractWallet.ts
@@ -1,11 +1,11 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { useWeb3React } from '@web3-react/core'
 
 import useSWR from 'swr'
 import { useAsyncMemo } from 'use-async-memo'
 import { useWalletInfo } from '../../api/hooks'
-import { useWalletMetaData } from './useWalletMetadata'
+import { useIsSafeWallet, useWalletMetaData } from './useWalletMetadata'
 import { getIsAmbireWallet } from '../../api/utils/connection'
 import { Contract } from '@ethersproject/contracts'
 import { getProviderOrSigner } from '@cowprotocol/common-utils'
@@ -41,14 +41,15 @@ export function useIsSmartContractWallet(): boolean {
   const isArgentWallet = useIsArgentWallet()
   const isSmartContract = useCheckIsSmartContract()
   const isAmbireWallet = useIsAmbireWallet()
+  const isSafeWallet = useIsSafeWallet()
 
   useEffect(() => {
     if (!account) {
       setIsSmartContractWallet(false)
     } else {
-      setIsSmartContractWallet(Boolean(isAmbireWallet || isArgentWallet || isSmartContract))
+      setIsSmartContractWallet(Boolean(isSafeWallet || isAmbireWallet || isArgentWallet || isSmartContract))
     }
-  }, [account, isAmbireWallet, isArgentWallet, isSmartContract])
+  }, [account, isAmbireWallet, isArgentWallet, isSafeWallet, isSmartContract])
 
   return isSmartContractWallet
 }


### PR DESCRIPTION
## The problem

Orders that did not need permit hooks included it in their appData.
The hook included was however for the permit signer account rather than the user account.
This is bad in 2 ways:
1. User is paying for the approval unnecessarily.
2. It break the gas estimation for users trying to approve the same token later on

For a full picture of how often and how many times it happened, check [this dune query](https://dune.com/queries/3376950?category=abstraction&namespace=cow_protocol&table=trades&blockchains=ethereum)

![image](https://github.com/cowprotocol/cowswap/assets/43217/69872c06-138c-4f7b-aacf-6ea862caa28c)


## Type of orders

Analyzing only the most recent cases, there are [2 approvals](https://etherscan.io/tokenapprovalchecker?search=0xce69d355dfdf13c3ead95ec1c437df5d4bac05e4)

The [first](https://etherscan.io/tx/0x5e8464cccf089aa85b6ac4a03ea53f45c31092631a305108911baa0df399c97d) approves DAI in [this order](https://explorer.cow.fi/orders/0x6147b0fe9a3d83f9473e55a11e189056cd6eb8863dfee9c26b5d302aa5e4fc2515ecfc5b05f1db628f2cb7954cf9384146f3a18065a7b4b2?tab=overview).
The [second](https://etherscan.io/tx/0xb754d2db5fce616813ddfd632701bd360ef34951b8cab367d382449be55e153e) approves XAI in [this order](https://explorer.cow.fi/orders/0x62471978efbc349f9083dfcf43627d1e7f1360dcb923434868bc3a40a633f80781310f3aa1c1424d1bef20f8848d4f69948afe1265abbd85?tab=overview)

They both are pre-sign orders and both are Safes.

Curiously enough, both orders were placed as part of a Safe Approval+pre-sign bundle. See [DAI tx](https://app.safe.global/transactions/tx?safe=eth:0x15ecfc5b05f1db628f2cb7954cf9384146f3a180&id=multisig_0x15ecfC5b05F1db628f2cb7954Cf9384146f3A180_0xe8754328f55985ad02e9b705635be8c0231f63236772c85eaf088b543dbd73a2) and [XAI tx](https://app.safe.global/transactions/tx?safe=eth:0x81310f3AA1C1424D1Bef20f8848d4F69948aFE12&id=multisig_0x81310f3AA1C1424D1Bef20f8848d4F69948aFE12_0xb631bb28dc62f6e53fad2e80400955d387e20d6404e25babf84706e53ce62626).

## Conclusion

[Safe Bundle flow](https://github.com/cowprotocol/cowswap/blob/f6f4e4d0b143c4ecb056269facf2f26bce638b19/apps/cowswap-frontend/src/modules/swap/services/safeBundleFlow/safeBundleApprovalFlow.ts#L1-L0) is passing the appData raw as it receives from the quote.


## To reproduce

Keep in mind I wasn't able to reproduce, but this is the path that seems to result in the bug.
So there might be something else causing this to sometimes include the bad appData.

1. Using a Safe, pick a token which is permittable but for which you have no approvals
2. Without signing the Safe tx, place the order and leave it in `signing` status
⚠️ It's important to NOT sign/execute it as we don't want screw up the signing permit account again
4. Open the order on Explorer
* It'll contain pre-hook in its appData - it SHOULDN'T!!


## Root problem

First of all, no SC flow should include pre-hooks at this point.
But it's just a symptom of another problem.

The flows usually only pass along the appData used for the quote.

In the example of the executed XAI approval, the quote [did contain the pre-hooks](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/r/s/bwYxf):

```
2024-01-20T12:02:46.175Z DEBUG request{id="522bf3eee62589be5b584fd3e3e81e18"}: shared::order_quoting: finished computing quote response=OrderQuoteResponse { quote: OrderQuote { sell_token: 0xd7c9f0e536dc865ae858b0c0453fe76d13c3beac, buy_token: 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48, receiver: Some(0x81310f3aa1c1424d1bef20f8848d4f69948afe12), sell_amount: 989047090014311862272, buy_amount: 984754625, valid_to: 1705753960, app_data: Both { full: "{\"appCode\":\"CoW Swap-SafeApp\",\"environment\":\"production\",\"metadata\":{\"hooks\":{\"pre\":[{\"callData\":\"0xd505accf000000000000000000000000ce69d355dfdf13c3ead95ec1c437df5d4bac05e4000000000000000000000000c92e8bdf79f0507f65a392b0ab4667716bfe0110ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000000000000000000000000000000000000000000000000000006f135db7000000000000000000000000000000000000000000000000000000000000001c3eb01b8d580e5d4f663ce659b1e567897b96cf720d18c7ce1d110469bad28df17f23458d4eae1fc5c69e074da24923349e0eeaac3e9e6eda322181419b81e166\",\"gasLimit\":\"82438\",\"target\":\"0xd7C9F0e536dC865Ae858b0C0453Fe76D13c3bEAc\"}]},\"orderClass\":{\"orderClass\":\"market\"},\"quote\":{\"slippageBips\":\"50\"}},\"version\":\"0.11.0\"}", expected: 0xf3b711027604e0c67c83ec6d3dc9abb5d70e1feb47480c5ef35db2e50790e3de }, fee_amount: 10952909985688137728, kind: Sell, partially_fillable: false, sell_token_balance: Erc20, buy_token_balance: Erc20, signing_scheme: Eip712 }, from: 0x81310f3aa1c1424d1bef20f8848d4f69948afe12, expiration: 2024-01-20T12:04:41.183634010Z, id: Some(381631359) }
```

As expected, the exact case of the [DAI approval](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/r/s/t2SDO):

```
2024-01-17T10:35:30.295Z DEBUG request{id="d719ea183f2be678b793eb636ebe411b"}: shared::order_quoting: finished computing quote response=OrderQuoteResponse { quote: OrderQuote { sell_token: 0x6b175474e89094c44da98b954eedeac495271d0f, buy_token: 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984, receiver: Some(0x15ecfc5b05f1db628f2cb7954cf9384146f3a180), sell_amount: 19975406096221803458560, buy_amount: 2950870380506139445207, valid_to: 1705489526, app_data: Both { full: "{\"appCode\":\"CoW Swap-SafeApp\",\"environment\":\"production\",\"metadata\":{\"hooks\":{\"pre\":[{\"callData\":\"0x8fcbaf0c000000000000000000000000ce69d355dfdf13c3ead95ec1c437df5d4bac05e4000000000000000000000000c92e8bdf79f0507f65a392b0ab4667716bfe01100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006f0f54740000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000001c4eb8150c2464462b1127c53facfd301eb99eae8653693181436229c77d5c95874f21e0dd7ecbe03e1a269fd1aef79e59b6c3aa5994acce2265a82cd476c21a6f\",\"gasLimit\":\"84022\",\"target\":\"0x6B175474E89094C44Da98b954EedeAC495271d0F\"}]},\"orderClass\":{\"orderClass\":\"market\"},\"quote\":{\"slippageBips\":\"50\"}},\"version\":\"0.11.0\"}", expected: 0xe1057c3ef15694050d33992a6dfdd5a9cc99f4217ff075893a29ea9e77b2123f }, fee_amount: 24593903778196541440, kind: Sell, partially_fillable: false, sell_token_balance: Erc20, buy_token_balance: Erc20, signing_scheme: Eip712 }, from: 0x15ecfc5b05f1db628f2cb7954cf9384146f3a180, expiration: 2024-01-17T10:37:27.024912203Z, id: Some(378300082) }
```

## To reproduce

I was also not able to reproduce this.
Still unsure what's causing it.