### PR TITLE
fix(permit): invalidate static and user permit cache

### DIFF
--- a/apps/cowswap-frontend/src/modules/permit/state/permitCacheAtom.ts
+++ b/apps/cowswap-frontend/src/modules/permit/state/permitCacheAtom.ts
@@ -14,14 +14,14 @@ import {
  * Should never change once it has been created.
  * Used exclusively for quote requests
  */
-export const staticPermitCacheAtom = atomWithStorage<PermitCache>('staticPermitCache:v1', {})
+export const staticPermitCacheAtom = atomWithStorage<PermitCache>('staticPermitCache:v2', {})
 
 /**
  * Atom that stores permit data for user permit requests.
  * Should be updated whenever the permit nonce is updated.
  * Used exclusively for order requests
  */
-export const userPermitCacheAtom = atomWithStorage<PermitCache>('userPermitCache:v0', {})
+export const userPermitCacheAtom = atomWithStorage<PermitCache>('userPermitCache:v1', {})
 
 /**
  * Atom to add/update permit cache data


### PR DESCRIPTION
# Summary

We saw an issue with USDC quote permit approvals being too cheap, causing user permit being too expensive and prevent users from placing orders.

The puzzling part was that, the permit signer account had no USDC approvals, and it was still cheap to approve it again.

Check [the simulation](https://www.tdly.co/shared/simulation/aa95f665-2e2e-4d75-9eb9-b25c0de760cc) of one of the quote permit approvals.

Turns out, the permit was using the first account used for permit, which [had indeed USDC approvals](https://revoke.cash/address/0x9eF31A6BB1A80e58cb73A906bddFaE308978095C?chainId=1).

Reason being, even though the account was replaced because of that very problem, the localStorage cache was not cleared.
Thus anyone who used CoW Swap when that key was used can still face this issue today.

# To Test

Not really testable in this PR as the localStorage will be empty.
Unless you copy the localStorage from swap.cow.fi and paste it here.

1. Select a permittable token as sell, pick a buy token and fill in the amounts
2. Check the localStorage
* There should be a key `staticPermitCache:v2`
* There should be a key `userPermitCache:v1`

3. Try to sell USDC on mainnet.
4. It should not fail

  # Background

For full context and investigation see [the internal thread](https://cowservices.slack.com/archives/C0361CDD1FZ/p1706204681201939?thread_ts=1706092507.043629&cid=C0361CDD1FZ)
