### PR TITLE
fix: fix label for fee0

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/pure/Row/RowFeeContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/Row/RowFeeContent/index.tsx
@@ -5,7 +5,7 @@ import { StyledRowBetween, TextWrapper } from 'modules/swap/pure/Row/styled'
 import { RowStyleProps, RowWithShowHelpersProps } from 'modules/swap/pure/Row/types'
 import { StyledInfoIcon } from 'modules/swap/pure/styled'
 
-import { FeatureGuard } from 'common/containers/FeatureGuard'
+import { useSwapZeroFee } from 'common/hooks/featureFlags/useSwapZeroFee'
 import { FiatRate } from 'common/pure/RateInfo'
 
 export interface RowFeeContentProps extends RowWithShowHelpersProps {
@@ -19,6 +19,7 @@ export interface RowFeeContentProps extends RowWithShowHelpersProps {
 }
 
 export function RowFeeContent(props: RowFeeContentProps) {
+  const swapZeroFee = useSwapZeroFee()
   const {
     showHelpers,
     includeGasMessage,
@@ -33,9 +34,7 @@ export function RowFeeContent(props: RowFeeContentProps) {
     <StyledRowBetween {...styleProps}>
       <RowFixed>
         <TextWrapper>
-          <FeatureGuard featureFlag="swapZeroFee" defaultContent="Fees">
-            Est. fees
-          </FeatureGuard>
+          {swapZeroFee ? 'Est. fees' : 'Fees'}
           {includeGasMessage}
         </TextWrapper>
         {showHelpers && (


### PR DESCRIPTION
# Summary

This issue solves the issue with fee=0 in the AB testing.

When the flag is enabled, it enables fee=0 only for 10% of users.
More concretely to users whose address return true to:
`parseInt('add-here-your-address', 16) % 100 < 10`

The AB selection works, it only delivers the feature  to 10%, however for the users that it doesn't deliver the feature, they still will see some change in the UI: the will see the `Est. fee` instead of just `Fee`
<img width="740" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/682313b3-0c5e-4ffa-8eb6-b0897233f6e4">

This PR fixes it.

# To Test
- Enable flag
- Use a wallet that returns `true` to `parseInt('add-here-your-address', 16) % 100 < 10`, make sure the label is correct (`Est. fee`), and the fee is zero when you sign the order
- Use a wallet that returns `false` to `parseInt('add-here-your-address', 16) % 100 < 10`, make sure the label is correct (`Est. fee`), and the fee is set to a non-zero amount when you sign the order