### PR TITLE
feat: fortune cookie position fix

### DIFF
--- a/apps/cowswap-frontend/src/modules/fortune/containers/FortuneWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/fortune/containers/FortuneWidget/index.tsx
@@ -68,7 +68,7 @@ const FortuneButton = styled.div<{ isDailyFortuneChecked: boolean }>`
     box-shadow: 0px 0px 50px 30px ${({ theme }) => (theme.darkMode ? theme.blueDark2 : theme.blueLight1)};
     z-index: -1;
 
-    ${({ theme }) => theme.mediaWidth.upToSmall`
+    ${({ theme }) => theme.mediaWidth.upToMedium`
       box-shadow: none;
     `}
   }

--- a/apps/cowswap-frontend/src/modules/fortune/containers/FortuneWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/fortune/containers/FortuneWidget/index.tsx
@@ -28,12 +28,12 @@ import {
 import { SuccessBanner } from 'pages/Claim/styled'
 
 const FortuneButton = styled.div<{ isDailyFortuneChecked: boolean }>`
-  --size: 75px;
+  --size: 64px;
   display: inline-block;
   position: fixed;
   z-index: 10;
-  right: 10px;
-  bottom: 94px;
+  right: 78px;
+  bottom: 30px;
   width: var(--size);
   height: var(--size);
   border-radius: var(--size);
@@ -46,7 +46,7 @@ const FortuneButton = styled.div<{ isDailyFortuneChecked: boolean }>`
   line-height: 0;
   color: ${({ theme }) => theme.blue1};
 
-  ${({ theme }) => theme.mediaWidth.upToSmall`
+  ${({ theme }) => theme.mediaWidth.upToMedium`
     --size: 52px;
     left: 65px;
     right: initial;

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/OrderContextMenu.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/OrderContextMenu.tsx
@@ -43,6 +43,7 @@ export const ContextMenuList = styled(MenuList)`
   min-width: 240px;
   margin: 10px 0;
   padding: 16px;
+  z-index: 100;
 `
 
 export const ContextMenuItem = styled(MenuItem)<{ $red?: boolean }>`
@@ -72,7 +73,7 @@ export interface OrderContextMenuProps {
 
 export function OrderContextMenu({ openReceipt, activityUrl, showCancellationModal }: OrderContextMenuProps) {
   return (
-    <Menu style={{ zIndex: 100 }}>
+    <Menu>
       <ContextMenuButton>
         <MoreVertical />
       </ContextMenuButton>

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/OrderContextMenu.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/OrderContextMenu.tsx
@@ -72,7 +72,7 @@ export interface OrderContextMenuProps {
 
 export function OrderContextMenu({ openReceipt, activityUrl, showCancellationModal }: OrderContextMenuProps) {
   return (
-    <Menu>
+    <Menu style={{ zIndex: 100 }}>
       <ContextMenuButton>
         <MoreVertical />
       </ContextMenuButton>

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/index.tsx
@@ -28,6 +28,7 @@ const OrdersBox = styled.div`
   padding: ${({ theme }) => (theme.isInjectedWidgetMode ? '16px' : '0')};
   min-height: 200px;
   width: 100%;
+  margin: 0 0 76px;
 `
 
 const Content = styled.div`
@@ -39,7 +40,7 @@ const Content = styled.div`
   border: 1px solid var(${UI.COLOR_TEXT_OPACITY_10});
   color: inherit;
   min-height: 490px;
-  padding: 0 0 24px;
+  padding: 0;
 
   > span {
     --size: 130px;

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/index.tsx
@@ -39,7 +39,7 @@ const Content = styled.div`
   border: 1px solid var(${UI.COLOR_TEXT_OPACITY_10});
   color: inherit;
   min-height: 490px;
-  padding: 0;
+  padding: 0 0 24px;
 
   > span {
     --size: 130px;


### PR DESCRIPTION
# Summary

- Solves for a scenario where the fortune cookie overlays the orders table. Preventing a user from clicking on the 3 dot ellipsis context menu. Current situation:
<img width="1241" alt="Screenshot 2024-01-29 at 14 41 51" src="https://github.com/cowprotocol/cowswap/assets/31534717/5dd4e228-123d-4635-9ab4-55f039cd0f2e">

---

- The solution provided in this PR:
  - Relocates the fortune cookie
  - Adds padding so that you always have space to scroll down and see the table unobstructed
  - Forces the fortune cookie to the mobile/table footer bar


<img width="1473" alt="Screenshot 2024-01-29 at 13 24 28" src="https://github.com/cowprotocol/cowswap/assets/31534717/bea1bfaf-0549-4a3f-b33e-5bf52560f136">

https://github.com/cowprotocol/cowswap/assets/31534717/38c0149e-6c27-475b-bbef-a5cc8655d7aa


https://github.com/cowprotocol/cowswap/assets/31534717/699e566e-91d2-4586-9de2-e408bbe0789b


Tablet (960px viewport width and lower):
<img width="951" alt="Screenshot 2024-01-29 at 14 43 43" src="https://github.com/cowprotocol/cowswap/assets/31534717/b75dd1dd-1274-41bc-a832-07c2f0a1744d">

Mobile:

https://github.com/cowprotocol/cowswap/assets/31534717/31444190-529c-4bb7-ad4c-78ed81ec5a45


