### PR TITLE
Disable bundling for non safe apps

### DIFF
--- a/libs/wallet/src/web3-react/hooks/useWalletMetadata.ts
+++ b/libs/wallet/src/web3-react/hooks/useWalletMetadata.ts
@@ -7,6 +7,7 @@ import { ConnectionType } from '../../api/types'
 import { getIsAlphaWallet } from '../../api/utils/connection'
 import { getWeb3ReactConnection } from '../utils/getWeb3ReactConnection'
 import { useGnosisSafeInfo } from '../../api/hooks'
+import { isInjectedWidget } from '@cowprotocol/common-utils'
 
 const SAFE_APP_NAME = 'Safe App'
 
@@ -97,7 +98,14 @@ export function useIsSafeApp(): boolean {
 
   // Will only be a SafeApp if within an iframe
   // Which means, window.parent is different than window
-  return window?.parent !== window
+  const isIframe = window?.parent !== window
+  if (!isIframe) {
+    return false
+  }
+
+  // For now, let's consider that if we are in Widget mode, then is not a Safe App, this allows Gnosis Safe to use the Widget
+  // TODO: Support Safe Apps in Widget mode
+  return !isInjectedWidget()
 }
 
 /**

--- a/libs/wallet/src/web3-react/hooks/useWalletMetadata.ts
+++ b/libs/wallet/src/web3-react/hooks/useWalletMetadata.ts
@@ -7,7 +7,7 @@ import { ConnectionType } from '../../api/types'
 import { getIsAlphaWallet } from '../../api/utils/connection'
 import { getWeb3ReactConnection } from '../utils/getWeb3ReactConnection'
 import { useGnosisSafeInfo } from '../../api/hooks'
-import { isInjectedWidget } from '@cowprotocol/common-utils'
+import { useSafeAppsSdk } from './useSafeAppsSdk'
 
 const SAFE_APP_NAME = 'Safe App'
 
@@ -91,21 +91,16 @@ export function useWalletMetaData(): WalletMetaData {
  */
 export function useIsSafeApp(): boolean {
   const isSafeWallet = useIsSafeWallet()
+  const sdk = useSafeAppsSdk()
 
-  if (!isSafeWallet) {
+  // If the wallet is not a Safe, or we don't have access to the SafeAppsSDK, we know is not a Safe App
+  if (!isSafeWallet || !sdk) {
     return false
   }
 
   // Will only be a SafeApp if within an iframe
   // Which means, window.parent is different than window
-  const isIframe = window?.parent !== window
-  if (!isIframe) {
-    return false
-  }
-
-  // For now, let's consider that if we are in Widget mode, then is not a Safe App, this allows Gnosis Safe to use the Widget
-  // TODO: Support Safe Apps in Widget mode
-  return !isInjectedWidget()
+  return window?.parent !== window
 }
 
 /**


### PR DESCRIPTION
# Summary

Safe is integrating the Widget.

The button was not working, the reason is because we detect that the flow is `SAFE_BUNDLE_APPROVAL`, however we never get an instance of an SDK 

We don't get the SDK because the app is native! we don't have the safe provider injected.

This PR makes sure that, if we don't have the SDK, we don't enable bundling.



