### PR TITLE
fix: network setup and recipient resetting

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/index.tsx
@@ -29,6 +29,7 @@ import { PoweredFooter } from 'common/pure/PoweredFooter'
 import * as styledEl from './styled'
 import { TradeWidgetModals } from './TradeWidgetModals'
 
+import { useTradeStateFromUrl } from '../../hooks/setupTradeState/useTradeStateFromUrl'
 import { usePriorityTokenAddresses } from '../../hooks/usePriorityTokenAddresses'
 import { CommonTradeUpdater } from '../../updaters/CommonTradeUpdater'
 import { DisableNativeTokenSellingUpdater } from '../../updaters/DisableNativeTokenSellingUpdater'
@@ -101,6 +102,7 @@ export function TradeWidget(props: TradeWidgetProps) {
   const isSafeWallet = useIsSafeWallet()
   const openTokenSelectWidget = useOpenTokenSelectWidget()
   const priorityTokenAddresses = usePriorityTokenAddresses()
+  const tradeStateFromUrl = useTradeStateFromUrl()
 
   const areCurrenciesLoading = !inputCurrencyInfo.currency && !outputCurrencyInfo.currency
   const bothCurrenciesSet = !!inputCurrencyInfo.currency && !!outputCurrencyInfo.currency
@@ -124,10 +126,12 @@ export function TradeWidget(props: TradeWidgetProps) {
   }
 
   /**
-   * Reset recipient value only once at App start
+   * Reset recipient value only once at App start if it's not set in URL
    */
   useEffect(() => {
-    onChangeRecipient(null)
+    if (!tradeStateFromUrl.recipient) {
+      onChangeRecipient(null)
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/index.tsx
@@ -107,9 +107,10 @@ export function TradeWidget(props: TradeWidgetProps) {
   const areCurrenciesLoading = !inputCurrencyInfo.currency && !outputCurrencyInfo.currency
   const bothCurrenciesSet = !!inputCurrencyInfo.currency && !!outputCurrencyInfo.currency
 
-  const canSellAllNative = isSafeWallet
-  const maxBalance = maxAmountSpend(inputCurrencyInfo.balance || undefined, canSellAllNative)
+  const hasRecipientInUrl = !!tradeStateFromUrl.recipient
+  const maxBalance = maxAmountSpend(inputCurrencyInfo.balance || undefined, isSafeWallet)
   const showSetMax = maxBalance?.greaterThan(0) && !inputCurrencyInfo.amount?.equalTo(maxBalance)
+  const withRecipient = !isWrapOrUnwrap && (showRecipient || hasRecipientInUrl)
 
   // Disable too frequent tokens switching
   const throttledOnSwitchTokens = useThrottleFn(onSwitchTokens, 500)
@@ -129,7 +130,7 @@ export function TradeWidget(props: TradeWidgetProps) {
    * Reset recipient value only once at App start if it's not set in URL
    */
   useEffect(() => {
-    if (!tradeStateFromUrl.recipient) {
+    if (!hasRecipientInUrl) {
       onChangeRecipient(null)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -178,13 +179,13 @@ export function TradeWidget(props: TradeWidgetProps) {
                 />
               </div>
               {!isWrapOrUnwrap && middleContent}
-              <styledEl.CurrencySeparatorBox compactView={compactView} withRecipient={!isWrapOrUnwrap && showRecipient}>
+              <styledEl.CurrencySeparatorBox compactView={compactView} withRecipient={withRecipient}>
                 <CurrencyArrowSeparator
                   isCollapsed={compactView}
                   hasSeparatorLine={!compactView}
                   border={!compactView}
                   onSwitchTokens={isChainIdUnsupported ? () => void 0 : throttledOnSwitchTokens}
-                  withRecipient={!isWrapOrUnwrap && showRecipient}
+                  withRecipient={withRecipient}
                   isLoading={isTradePriceUpdating}
                 />
               </styledEl.CurrencySeparatorBox>
@@ -205,7 +206,7 @@ export function TradeWidget(props: TradeWidgetProps) {
                   {...currencyInputCommonProps}
                 />
               </div>
-              {!isWrapOrUnwrap && showRecipient && (
+              {withRecipient && (
                 <styledEl.StyledRemoveRecipient recipient={recipient || ''} onChangeRecipient={onChangeRecipient} />
               )}
 

--- a/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
@@ -176,10 +176,13 @@ export function useSetupTradeState(): void {
     } else {
       if (isFirstLoad && isWalletConnected) {
         setIsFirstLoad(false)
-        urlChainId && switchNetworkInWallet(urlChainId)
-      } else {
-        tradeNavigate(providerChainId, getDefaultTradeRawState(providerChainId))
+
+        if (urlChainId) {
+          switchNetworkInWallet(urlChainId)
+        }
       }
+
+      tradeNavigate(providerChainId, getDefaultTradeRawState(providerChainId))
     }
 
     console.debug('[TRADE STATE]', 'Provider changed chainId', { providerChainId, urlChanges: rememberedUrlState })

--- a/libs/ens/src/hooks/useENSResolver.ts
+++ b/libs/ens/src/hooks/useENSResolver.ts
@@ -4,7 +4,7 @@ import { useENSRegistrarContract } from './useENSRegistrarContract'
 export function useENSResolver(node: string | undefined): SWRResponse<string | undefined> {
   const registrarContract = useENSRegistrarContract()
 
-  return useSWR(['useENSResolver', node], async () => {
+  return useSWR(['useENSResolver', node, registrarContract], async () => {
     if (!registrarContract || !node) return undefined
 
     return registrarContract.callStatic.resolver(node)


### PR DESCRIPTION
# Summary

Fixes #3757

There are two fixes:
1. On the first app load, if wallet connected and wallet network doesn't match url network we should request network switching in the wallet
2. Before the fix we reset the recipient value always. But we should not do that when it set in the URL

  # To Test

1. All cases with network switching
 - wallet connected
 - wallet not connected
 - change network from UI
 - change network from URL
 - change network from Wallet
 - navigation between pages
2. Recipient value should be set if it presents in URL
3. Recipient value should be reset after page reload if it is not presented in URL