### PR TITLE
ci: deploy single app per tag

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -39,7 +39,7 @@ jobs:
         env_name: [barn, staging] # deploys both in parallel
     with:
       env_name: ${{ matrix.env_name }}
-      app: ALL
+      app: ${{ startsWith(github.ref, 'refs/tags/explorer') && EXPLORER || COWSWAP }}
 
   vercel-prod:
     # Deploys to Vercel prod environment

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        project_suffix: ${{ inputs.app == 'ALL' && fromJSON('["COWSWAP", "EXPLORER"]') || (inputs.app) }}
+        project_suffix: ${{ inputs.app == 'ALL' && fromJSON('["COWSWAP", "EXPLORER"]') || [inputs.app] }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
# Summary

Currently, cannot deploy single app. 
Got this on last attempt: https://github.com/cowprotocol/cowswap/actions/runs/7641838388

Also, when both apps are published at the same time, there are race conditions causing unexpected deployment order and random failures:

The [cowswap version deployment](https://github.com/cowprotocol/cowswap/actions/runs/7742412931) deployed **barn explorer** and **staging cowswap**.
The [explorer version deployment](https://github.com/cowprotocol/cowswap/actions/runs/7742413236) deployed **barn** and **staging explorer**.

No one deployed **barn cowswap**

# To Test

1. Must merge to develop in order to test it.