### PR TITLE
fix(fee=0): do not touch fee=0 ethflow fees

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/hooks/useEthFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useEthFlowContext.ts
@@ -10,12 +10,15 @@ import { FlowType, getFlowContext, useBaseFlowContextSetup } from 'modules/swap/
 import { EthFlowContext } from 'modules/swap/services/types'
 import { addInFlightOrderIdAtom } from 'modules/swap/state/EthFlow/ethFlowInFlightOrderIdsAtom'
 
+import { useSwapZeroFee } from 'common/hooks/featureFlags/useSwapZeroFee'
+
 import { useCheckEthFlowOrderExists } from './useCheckEthFlowOrderExists'
 
 export function useEthFlowContext(): EthFlowContext | null {
   const contract = useEthFlowContract()
   const baseProps = useBaseFlowContextSetup()
   const addTransaction = useTransactionAdder()
+  const swapZeroFee = useSwapZeroFee()
 
   const addInFlightOrderId = useSetAtom(addInFlightOrderIdAtom)
 
@@ -35,5 +38,6 @@ export function useEthFlowContext(): EthFlowContext | null {
     addTransaction,
     checkEthFlowOrderExists,
     addInFlightOrderId,
+    swapZeroFee,
   }
 }

--- a/apps/cowswap-frontend/src/modules/swap/services/ethFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/ethFlow/index.ts
@@ -30,6 +30,7 @@ export async function ethFlow(
     orderParams: orderParamsOriginal,
     checkEthFlowOrderExists,
     addInFlightOrderId,
+    swapZeroFee,
   } = ethFlowContext
 
   logTradeFlow('ETH FLOW', 'STEP 1: confirm price impact')
@@ -50,7 +51,12 @@ export async function ethFlow(
   swapConfirmManager.sendTransaction(context.trade)
 
   logTradeFlow('ETH FLOW', 'STEP 3: Get Unique Order Id (prevent collisions)')
-  const { orderId, orderParams } = await calculateUniqueOrderId(orderParamsOriginal, contract, checkEthFlowOrderExists)
+  const { orderId, orderParams } = await calculateUniqueOrderId(
+    orderParamsOriginal,
+    contract,
+    checkEthFlowOrderExists,
+    swapZeroFee
+  )
 
   try {
     logTradeFlow('ETH FLOW', 'STEP 4: sign order')

--- a/apps/cowswap-frontend/src/modules/swap/services/ethFlow/steps/calculateUniqueOrderId.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/ethFlow/steps/calculateUniqueOrderId.ts
@@ -16,11 +16,22 @@ export interface UniqueOrderIdResult {
   orderParams: PostOrderParams // most cases, will be the same as the ones in the parameter, but it might be modified to make the order unique
 }
 
-function incrementFee(params: PostOrderParams): PostOrderParams {
+function adjustAmounts(params: PostOrderParams, swapZeroFee: boolean): PostOrderParams {
   const nativeCurrency = params.feeAmount?.currency
+  const buyCurrency = params.outputAmount?.currency
 
-  if (!nativeCurrency) {
+  if (!nativeCurrency || !buyCurrency) {
     throw new Error('Missing currency for Eth Flow Fee') // Not a realistic case, just to make TS happy
+  }
+
+  if (swapZeroFee) {
+    // On fee=0, fee is, well, 0. Thus, we cannot shift amounts around and remain with the exact same price.
+    // Also, we don't want to touch the sell amount.
+    // If we move it down, the price might become "too good", if we move it up, the user might not have enough funds!
+    // Thus, we make the buy amount a tad bit worse by 1 wei.
+    // We can only hope this doesn't happen for an order buying 0 a decimals token 🤞
+    const oneBuyWei = CurrencyAmount.fromRawAmount(buyCurrency, 1)
+    return { ...params, outputAmount: params.outputAmount?.subtract(oneBuyWei) }
   }
 
   const oneWei = CurrencyAmount.fromRawAmount(nativeCurrency, 1)
@@ -34,7 +45,8 @@ function incrementFee(params: PostOrderParams): PostOrderParams {
 export async function calculateUniqueOrderId(
   orderParams: PostOrderParams,
   ethFlowContract: CoWSwapEthFlow,
-  checkEthFlowOrderExists: EthFlowOrderExistsCallback
+  checkEthFlowOrderExists: EthFlowOrderExistsCallback,
+  swapZeroFee: boolean
 ): Promise<UniqueOrderIdResult> {
   logTradeFlow('ETH FLOW', '[EthFlow::calculateUniqueOrderId] - Calculate unique order Id', orderParams)
   const { chainId } = orderParams
@@ -64,7 +76,12 @@ export async function calculateUniqueOrderId(
     logTradeFlow('ETH FLOW', '[calculateUniqueOrderId] ❌ Collision detected: ' + orderId, logParams)
 
     // Recursive call, increment one fee until we get an unique order Id
-    return calculateUniqueOrderId(incrementFee(orderParams), ethFlowContract, checkEthFlowOrderExists)
+    return calculateUniqueOrderId(
+      adjustAmounts(orderParams, swapZeroFee),
+      ethFlowContract,
+      checkEthFlowOrderExists,
+      swapZeroFee
+    )
   }
 
   logTradeFlow('ETH FLOW', '[calculateUniqueOrderId] ✅ Order Id is Unique' + orderId, logParams)

--- a/apps/cowswap-frontend/src/modules/swap/services/types.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/types.ts
@@ -53,6 +53,7 @@ export type EthFlowContext = BaseFlowContext & {
   addTransaction: ReturnType<typeof useTransactionAdder>
   checkEthFlowOrderExists: EthFlowOrderExistsCallback
   addInFlightOrderId: (orderId: string) => void
+  swapZeroFee: boolean
 }
 
 export type BaseSafeFlowContext = BaseFlowContext & {


### PR DESCRIPTION
# Summary

HOTFIX!

Addresses (not very likely, but if it does might not be good) edge case for ethflow orders with order id collision.

# To Test

1. EthFlow orders should work the same with and without fee=0 enabled accounts