### PR TITLE
Fix custom recipient style

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/AddressInputPanel/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/AddressInputPanel/index.tsx
@@ -46,7 +46,7 @@ const Input = styled.input<{ error?: boolean }>`
   flex: 1 1 auto;
   background: none;
   transition: color 0.2s ${({ error }) => (error ? 'step-end' : 'step-start')};
-  color: ${({ error }) => (error ? `var(${UI.COLOR_DANGER}` : 'inherit')};
+  color: ${({ error }) => (error ? `var(${UI.COLOR_DANGER})` : 'inherit')};
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 500;


### PR DESCRIPTION
# Summary

- Fixes the custom recipient input field (part of issue https://github.com/cowprotocol/cowswap/issues/3522)
- It also crashed the app with broken CSS styles

<img width="611" alt="Screenshot 2024-02-01 at 18 23 51" src="https://github.com/cowprotocol/cowswap/assets/31534717/413c079b-e3a1-45b2-a5b5-13e1e44d0aab">
