### PR TITLE
feat: increase AB testing for fee 0 to 30% of users

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/featureFlags/useSwapZeroFee.ts
+++ b/apps/cowswap-frontend/src/common/hooks/featureFlags/useSwapZeroFee.ts
@@ -3,7 +3,7 @@ import { useWalletInfo } from '@cowprotocol/wallet'
 import { useFeatureFlags } from './useFeatureFlags'
 
 // Expose the feature to XX% of users
-const PERCENTAGE_OF_USERS_WITH_FLAG = 10 // XX% of users
+const PERCENTAGE_OF_USERS_WITH_FLAG = 30 // XX% of users
 
 export function useSwapZeroFee(): boolean {
   const { account } = useWalletInfo()


### PR DESCRIPTION
# Summary
continuation on #3614
Increase AB testing to 30%

## Test
to test it we need to find a wallet that its "selected" to receive the feature.

You can check which of your wallets fits the criteria by running this in the console:

```js
parseInt('add-here-your-address', 16) % 100 < 30
```

If you have a wallet that matches the criteria, you can verify that once connected, you will have the feature on.


If you struggle to find one, I can help to make a script so you get an account that fits the criteria. 