### PR TITLE
fix: do not set appDataHash unless appData is also set when quoting

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/__snapshots__/useTradeQuotePolling.test.tsx.snap
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/__snapshots__/useTradeQuotePolling.test.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`useTradeQuotePolling() When wallet is NOT connected Then the "useAddress" field in the quote request should be 0x000...0000 1`] = `
 {
-  "appData": "0x93782141af03a1e83fd03bd86bd8de09f12030aa078e49abe02ad0b15c565d1b",
-  "appDataHash": undefined,
+  "appData": "{"version":"0.11.0","appCode":"CoW Swap","metadata":{}}",
+  "appDataHash": "0x93782141af03a1e83fd03bd86bd8de09f12030aa078e49abe02ad0b15c565d1b",
   "buyToken": "0x0625aFB445C3B6B7B929342a04A22599fd5dBB59",
   "from": "0x0000000000000000000000000000000000000000",
   "kind": "sell",
@@ -18,8 +18,8 @@ exports[`useTradeQuotePolling() When wallet is NOT connected Then the "useAddres
 
 exports[`useTradeQuotePolling() When wallet is connected Then should put account address into "useAddress" field in the quote request 1`] = `
 {
-  "appData": "0x93782141af03a1e83fd03bd86bd8de09f12030aa078e49abe02ad0b15c565d1b",
-  "appDataHash": undefined,
+  "appData": "{"version":"0.11.0","appCode":"CoW Swap","metadata":{}}",
+  "appDataHash": "0x93782141af03a1e83fd03bd86bd8de09f12030aa078e49abe02ad0b15c565d1b",
   "buyToken": "0x0625aFB445C3B6B7B929342a04A22599fd5dBB59",
   "from": "0x333333f332a06ecb5d20d35da44ba07986d6e203",
   "kind": "sell",


### PR DESCRIPTION
# Summary

There is a race condition where the appDataHash can be set in a quote call without having the fullAppData.
That is a problem as backend doesn't can't tell what's the appData content unless we pass it as part of the request.

![Screenshot 2024-02-05 at 12 18 34](https://github.com/cowprotocol/cowswap/assets/43217/6d1c3d58-57ee-48b0-a989-a3ee6748fbea)
([Internal link to logs](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/r/s/YfMNN))

This PR makes sure that, if the fullAppData is not present, we ignore the appDataHash and use the fallback values instead.

  # To Test

1. Observe the quote requests in the network console
* All of them should have both `appData` with the JSON doc and `appDataHash` with its hash
![image](https://github.com/cowprotocol/cowswap/assets/43217/9bea62fd-c2a7-44f9-b125-597fdd849d8b)
