### PR TITLE
feat(limit): recreate orders

### DIFF
--- a/apps/cowswap-frontend/src/modules/account/hooks/useCopyToNewSwap.ts
+++ b/apps/cowswap-frontend/src/modules/account/hooks/useCopyToNewSwap.ts
@@ -1,68 +1,19 @@
 import { useCallback } from 'react'
 
-import { OrderKind } from '@cowprotocol/cow-sdk'
-import { useWalletInfo } from '@cowprotocol/wallet'
-import { CurrencyAmount } from '@uniswap/sdk-core'
-
-import { CONFIRMED_STATES, Order } from 'legacy/state/orders/actions'
-
-import { Routes } from 'common/constants/routes'
+import { Order } from 'legacy/state/orders/actions'
 
 import { useToggleAccountModal } from './useToggleAccountModal'
 
-import { useTradeNavigate } from '../../trade/hooks/useTradeNavigate'
+import { useCopyToNew } from '../../trade/hooks/useCopyToNew'
 
 export function useCopyToNewSwap(order: Order | undefined): undefined | (() => void) {
-  const navigate = useTradeNavigate()
-  const { chainId } = useWalletInfo()
+  const copyToNew = useCopyToNew(order)
   const handleCloseOrdersPanel = useToggleAccountModal()
 
-  const {
-    sellToken: inputCurrencyId,
-    buyToken: outputCurrencyId,
-    kind,
-    inputToken,
-    outputToken,
-    sellAmount,
-    buyAmount,
-    feeAmount,
-    status,
-  } = order || {}
-
-  // Only return callback if order is in a final state
-  const canRecreateOrder = status && CONFIRMED_STATES.includes(status)
-
-  // Load CurrencyAmount instances for parsing the amounts in units rather than atoms
-  const inputAmount = inputToken && sellAmount && CurrencyAmount.fromRawAmount(inputToken, sellAmount.toString())
-  const outputAmount = outputToken && buyAmount && CurrencyAmount.fromRawAmount(outputToken, buyAmount.toString())
-  const fee = inputToken && feeAmount && CurrencyAmount.fromRawAmount(inputToken, feeAmount.toString())
-
-  // Get the currencyAmount according to order kind
-  const currencyAmount = kind === OrderKind.SELL && inputAmount && fee ? inputAmount?.add(fee) : outputAmount
-  // Get the amount units
-  const amount =
-    currencyAmount && currencyAmount.toFixed(kind === OrderKind.SELL ? inputToken?.decimals : outputToken?.decimals)
-
-  const recreateOrder = useCallback(() => {
-    if (!chainId || !canRecreateOrder || !inputCurrencyId || !outputCurrencyId || !amount || !kind) {
-      return
-    }
-
-    // Move to SWAP with same order details filled in
-    navigate(
-      chainId,
-      {
-        inputCurrencyId,
-        outputCurrencyId,
-      },
-      { kind, amount },
-      Routes.SWAP
-    )
-
-    // TODO: should this be somewhere else?
-    // Close account modal
+  const copyToNewSwap = useCallback(() => {
+    copyToNew?.()
     handleCloseOrdersPanel()
-  }, [amount, canRecreateOrder, chainId, handleCloseOrdersPanel, inputCurrencyId, kind, navigate, outputCurrencyId])
+  }, [copyToNew, handleCloseOrdersPanel])
 
-  return canRecreateOrder ? recreateOrder : undefined
+  return copyToNew ? copyToNewSwap : undefined
 }

--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useSetupLimitOrderAmountsFromUrl.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useSetupLimitOrderAmountsFromUrl.ts
@@ -1,9 +1,7 @@
 import { useSetAtom } from 'jotai'
 import { useCallback, useLayoutEffect, useMemo } from 'react'
 
-import { tryParseCurrencyAmount } from '@cowprotocol/common-utils'
-import { FractionUtils } from '@cowprotocol/common-utils'
-import { getIntOrFloat } from '@cowprotocol/common-utils'
+import { FractionUtils, getIntOrFloat, tryParseCurrencyAmount } from '@cowprotocol/common-utils'
 import { OrderKind } from '@cowprotocol/cow-sdk'
 import { Price } from '@uniswap/sdk-core'
 
@@ -30,6 +28,7 @@ export function useSetupLimitOrderAmountsFromUrl() {
   const updateRate = useUpdateActiveRate()
   const { inputCurrency, outputCurrency } = useLimitOrdersDerivedState()
 
+  // TODO: how do we deal with buy orders?
   const cleanParams = useCallback(() => {
     const queryParams = new URLSearchParams(search)
 

--- a/apps/cowswap-frontend/src/modules/ordersTable/containers/OrdersTableWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/containers/OrdersTableWidget/index.tsx
@@ -31,6 +31,7 @@ import { useOrdersTableTokenApprove } from './hooks/useOrdersTableTokenApprove'
 import { useValidatePageUrlParams } from './hooks/useValidatePageUrlParams'
 
 import { BalancesAndAllowances } from '../../../tokens'
+import { useGetCopyToNewCallback } from '../../../trade/hooks/useCopyToNew'
 import { OrdersTableContainer, TabOrderTypes } from '../../pure/OrdersTableContainer'
 import { OrderTableItem, tableItemsToOrders } from '../../utils/orderTableGroupUtils'
 
@@ -76,6 +77,7 @@ export function OrdersTableWidget({
   const selectReceiptOrder = useSelectReceiptOrder()
   const isSafeViaWc = useIsSafeViaWc()
   const ordersPermitStatus = useGetOrdersPermitStatus()
+  const getCopyToNew = useGetCopyToNewCallback()
 
   const { currentTabId, currentPageNumber } = useMemo(() => {
     const params = parseOrdersTableUrl(location.search)
@@ -144,6 +146,7 @@ export function OrdersTableWidget({
     toggleOrderForCancellation,
     toggleOrdersForCancellation,
     approveOrderToken,
+    getCopyToNew,
   }
 
   // Set page params initially once

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/OrderContextMenu.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/OrderContextMenu.tsx
@@ -2,7 +2,7 @@ import { UI } from '@cowprotocol/ui'
 
 import { Menu, MenuButton, MenuItem, MenuList } from '@reach/menu-button'
 import { transparentize } from 'color2k'
-import { FileText, Link2, MoreVertical, Trash2 } from 'react-feather'
+import { FileText, Link2, MoreVertical, Repeat, Trash2 } from 'react-feather'
 import styled from 'styled-components/macro'
 
 export const ContextMenuButton = styled(MenuButton)`
@@ -69,9 +69,15 @@ export interface OrderContextMenuProps {
   openReceipt: () => void
   activityUrl: string | undefined
   showCancellationModal: (() => void) | null
+  copyToNew: (() => void) | undefined
 }
 
-export function OrderContextMenu({ openReceipt, activityUrl, showCancellationModal }: OrderContextMenuProps) {
+export function OrderContextMenu({
+  openReceipt,
+  activityUrl,
+  showCancellationModal,
+  copyToNew,
+}: OrderContextMenuProps) {
   return (
     <Menu>
       <ContextMenuButton>
@@ -92,6 +98,12 @@ export function OrderContextMenu({ openReceipt, activityUrl, showCancellationMod
           <ContextMenuItem $red onSelect={() => showCancellationModal()}>
             <Trash2 size={16} />
             <span>Cancel order</span>
+          </ContextMenuItem>
+        )}
+        {copyToNew && (
+          <ContextMenuItem onSelect={copyToNew}>
+            <Repeat size={16} />
+            <span>Copy to new</span>
           </ContextMenuItem>
         )}
       </ContextMenuList>

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
@@ -174,6 +174,7 @@ export function OrderRow({
   const { estimatedExecutionPrice, feeAmount } = prices || {}
 
   const showCancellationModal = orderActions.getShowCancellationModal(order)
+  const copyToNew = orderActions.getCopyToNew(order)
 
   const withAllowanceWarning = hasEnoughAllowance === false && hasValidPendingPermit === false
   const withWarning =
@@ -384,6 +385,7 @@ export function OrderRow({
           activityUrl={activityUrl}
           openReceipt={onClick}
           showCancellationModal={showCancellationModal}
+          copyToNew={copyToNew}
         />
       </styledEl.CellElement>
     </TableRow>

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/types.ts
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/types.ts
@@ -9,4 +9,5 @@ export interface OrderActions {
   toggleOrderForCancellation(order: ParsedOrder): void
   toggleOrdersForCancellation(orders: ParsedOrder[]): void
   approveOrderToken(token: Token): void
+  getCopyToNew(order: ParsedOrder): (() => void) | undefined
 }

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useCopyToNew.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useCopyToNew.ts
@@ -1,0 +1,95 @@
+import { useCallback } from 'react'
+
+import { OrderKind } from '@cowprotocol/cow-sdk'
+import { useWalletInfo } from '@cowprotocol/wallet'
+import { CurrencyAmount } from '@uniswap/sdk-core'
+
+import { CONFIRMED_STATES, Order } from 'legacy/state/orders/actions'
+
+import { Routes, RoutesValues } from 'common/constants/routes'
+import { getUiOrderType, UiOrderType } from 'utils/orderUtils/getUiOrderType'
+import { ParsedOrder } from 'utils/orderUtils/parseOrder'
+
+import { useTradeNavigate } from './useTradeNavigate'
+
+const ORDER_TYPE_TO_ROUTE: Record<UiOrderType, RoutesValues> = {
+  SWAP: Routes.SWAP,
+  LIMIT: Routes.LIMIT_ORDER,
+  TWAP: Routes.ADVANCED_ORDERS,
+}
+
+export function useGetCopyToNewCallback(): (order: Order | ParsedOrder | undefined) => undefined | (() => void) {
+  return useCopyToNew
+}
+
+export function useCopyToNew(order: Order | ParsedOrder | undefined): undefined | (() => void) {
+  const navigate = useTradeNavigate()
+  const { chainId } = useWalletInfo()
+
+  const orderType = order && getUiOrderType(order)
+  const route = orderType && ORDER_TYPE_TO_ROUTE[orderType]
+
+  const { kind, inputToken, outputToken, sellAmount, buyAmount, feeAmount, status } = order || {}
+
+  const inputCurrencyId = inputToken?.address
+  const outputCurrencyId = outputToken?.address
+
+  // Only return callback if order is in a final state
+  const canRecreateOrder = status && CONFIRMED_STATES.includes(status)
+
+  // Load CurrencyAmount instances for parsing the amounts in units rather than atoms
+  const inputAmount = inputToken && sellAmount && CurrencyAmount.fromRawAmount(inputToken, sellAmount.toString())
+  const outputAmount = outputToken && buyAmount && CurrencyAmount.fromRawAmount(outputToken, buyAmount.toString())
+  const fee = inputToken && feeAmount && CurrencyAmount.fromRawAmount(inputToken, feeAmount.toString())
+  const totalInputAmount = inputAmount && fee && inputAmount.add(fee)
+
+  // Get the currencyAmount according to order kind
+  const currencyAmount = kind === OrderKind.SELL ? totalInputAmount : outputAmount
+  // Get the amount units
+  const amount =
+    orderType !== UiOrderType.LIMIT && currencyAmount
+      ? currencyAmount.toFixed(kind === OrderKind.SELL ? inputToken?.decimals : outputToken?.decimals)
+      : undefined
+  const totalSellAmount = totalInputAmount && totalInputAmount.toFixed(inputToken?.decimals)
+  const totalBuyAmount = outputAmount && outputAmount.toFixed(outputToken?.decimals)
+
+  const recreateOrder = useCallback(() => {
+    if (
+      !chainId ||
+      !canRecreateOrder ||
+      !inputCurrencyId ||
+      !outputCurrencyId ||
+      !kind ||
+      !orderType ||
+      !route ||
+      (!amount && !totalSellAmount && !totalBuyAmount)
+    ) {
+      return
+    }
+
+    // Move to route with order details filled in
+    navigate(
+      chainId,
+      {
+        inputCurrencyId,
+        outputCurrencyId,
+      },
+      { kind, amount, sellAmount: totalSellAmount, buyAmount: totalBuyAmount },
+      route
+    )
+  }, [
+    amount,
+    canRecreateOrder,
+    chainId,
+    inputCurrencyId,
+    kind,
+    navigate,
+    orderType,
+    outputCurrencyId,
+    route,
+    totalBuyAmount,
+    totalSellAmount,
+  ])
+
+  return canRecreateOrder ? recreateOrder : undefined
+}

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useTradeNavigate.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useTradeNavigate.ts
@@ -56,9 +56,9 @@ export function useTradeNavigate(): UseTradeNavigateCallback {
         newTradeRoute || tradeRoute
       )
 
-      if (location.pathname === route) return
-
       const search = parameterizeTradeSearch(location.search, searchParams)
+
+      if (location.pathname === route && location.search === search) return
 
       navigate({ pathname: route, search })
     },

--- a/apps/cowswap-frontend/src/modules/trade/utils/parameterizeTradeSearch.ts
+++ b/apps/cowswap-frontend/src/modules/trade/utils/parameterizeTradeSearch.ts
@@ -3,8 +3,10 @@ import { OrderKind } from '@cowprotocol/cow-sdk'
 import { TRADE_URL_BUY_AMOUNT_KEY, TRADE_URL_SELL_AMOUNT_KEY } from '../const/tradeUrl'
 
 export type TradeSearchParams = {
-  amount: string | undefined
-  kind: OrderKind
+  amount?: string | undefined
+  kind?: OrderKind
+  sellAmount?: string | undefined
+  buyAmount?: string | undefined
 }
 
 /**
@@ -15,13 +17,20 @@ export type TradeSearchParams = {
 export function parameterizeTradeSearch(search: string, searchParamsToAdd?: TradeSearchParams): string {
   const searchParams = new URLSearchParams(search)
 
-  const amountQueryKey = searchParamsToAdd
-    ? searchParamsToAdd.kind === OrderKind.SELL
-      ? TRADE_URL_SELL_AMOUNT_KEY
-      : TRADE_URL_BUY_AMOUNT_KEY
-    : undefined
+  // TODO: think about how to deal with buy limit orders
 
-  searchParamsToAdd?.amount && amountQueryKey && searchParams.set(amountQueryKey, searchParamsToAdd.amount)
+  if (searchParamsToAdd?.amount) {
+    const amountQueryKey =
+      searchParamsToAdd.kind === OrderKind.SELL ? TRADE_URL_SELL_AMOUNT_KEY : TRADE_URL_BUY_AMOUNT_KEY
+    searchParams.set(amountQueryKey, searchParamsToAdd.amount)
+  } else {
+    if (searchParamsToAdd?.sellAmount) {
+      searchParams.set(TRADE_URL_SELL_AMOUNT_KEY, searchParamsToAdd.sellAmount)
+    }
+    if (searchParamsToAdd?.buyAmount) {
+      searchParams.set(TRADE_URL_BUY_AMOUNT_KEY, searchParamsToAdd.buyAmount)
+    }
+  }
 
   return searchParams.toString()
 }


### PR DESCRIPTION
# Summary

Fixes https://github.com/cowprotocol/cowswap/issues/3797

Builds on top of https://github.com/cowprotocol/cowswap/pull/3806

Copy to new, for LIMIT orders
<img width="292" alt="image" src="https://github.com/cowprotocol/cowswap/assets/43217/647a9123-bff9-439e-9fe8-bbeb42074936">

## Notes

- Settings are NOT copied
  - Duration
  - Partial fill/fill or kill
  - Custom recipient
- BUY orders cannot be created. Values are copied but it'll be a sell order

# To Test

1. Go to an existing limit order that's closed
2. Open the context menu
3. Click on `Copy to new`

