### PR TITLE
[Widget enhancement] 03 - Param enhancement: sounds, images, and mooooore

### DIFF
--- a/libs/widget-lib/src/types.ts
+++ b/libs/widget-lib/src/types.ts
@@ -1,4 +1,5 @@
 import type { SupportedChainId } from '@cowprotocol/cow-sdk'
+export type { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 export interface JsonRpcRequest {
   id: number
@@ -150,6 +151,58 @@ interface CowSwapWidgetConfig {
    * Please contact https://cowprotocol.typeform.com/to/rONXaxHV
    */
   interfaceFeeBips: string
+
+  /**
+   * Sounds configuration for the app.
+   */
+  sounds?: {
+    /**
+     * The sound to play when the order is executed. Defaults to world wide famous CoW Swap moooooooooo!
+     * Alternatively, you can use a URL to a custom sound file, or set to null to disable the sound.
+     */
+    postOrder?: string | null
+
+    /**
+     * The sound to play when the order is executed. Defaults to world wide famous CoW Swap happy moooooooooo!
+     * Alternatively, you can use a URL to a custom sound file, or set to null to disable the sound.
+     */
+    orderExecuted?: string | null
+
+    /**
+     * The sound to play when the order is executed. Defaults to world wide famous CoW Swap unhappy moooooooooo!
+     * Alternatively, you can use a URL to a custom sound file, or set to null to disable the sound.
+     */
+    orderError?: string | null
+  }
+
+  /**
+   * Customizable images for the widget.
+   */
+  images: {
+    /**
+     * The image to display when the orders table is empty (no orders yet). It defaults to "Yoga CoW" image.
+     * Alternatively, you can use a URL to a custom image file, or set to null to disable the image.
+     */
+    emptyOrders?: string | null
+  }
+
+  /**
+   * Disables showing the confirmation modal you get after posting an order.
+   * Defaults to false.
+   */
+  disablePostedOrderConfirmationModal?: boolean
+
+  /**
+   * Disables showing the toast messages.
+   * Some UI might want to disable it and subscribe to 'onToastMessage' event to handle the toast messages itself.
+   * Defaults to false.
+   */
+  disableToastMessages?: boolean
+
+  /**
+   * Disables showing the recent history in the widget. Defaults to false.
+   */
+  hideAccountButton?: boolean
 }
 
 export type CowSwapWidgetParams = Partial<CowSwapWidgetConfig>


### PR DESCRIPTION
Part of the series https://github.com/cowprotocol/cowswap/pull/3812

This PR adds a bunch of parametrization in the widget param.

They are all optional fields, and they will default to our current behaviour if not specified.

Note all settings are optional and nullable! this is to model:
- `undefined`: We use the default we had until now
- `null`: We disable it. For example, for images and sounds, would mean we need to remove the image or sound
- `actual value`: We override our default

They include:
- Define your own sounds! silly someone might want to remove or change the moooo. I would think this will only be used to make the mooooooo even louder
- Define your own images! You don't like yoga cow, you can replace it, we welcome people with no-taste for images.
- A bunch of disable or hide flags

## Not included
This PR doesn't include any implementation for handling this param. This will come in a future PR. 
