### PR TITLE
[Widget enhancement] 06 - Context for eventEmitter

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useCowEventEmitter.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useCowEventEmitter.ts
@@ -1,0 +1,13 @@
+import { useContext } from 'react'
+
+import { CowEventEmitter, CowEventEmitterContext } from '@cowprotocol/events'
+
+export function useCowEventEmitter(): CowEventEmitter {
+  const eventEmitter = useContext(CowEventEmitterContext)
+
+  if (!eventEmitter) {
+    throw new Error('useCowEventEmitter is not in the context. Please use CowEventEmitterProvider')
+  }
+
+  return eventEmitter
+}

--- a/apps/cowswap-frontend/src/cow-react/index.tsx
+++ b/apps/cowswap-frontend/src/cow-react/index.tsx
@@ -10,6 +10,7 @@ import { BlockNumberProvider } from '@cowprotocol/common-hooks'
 import { isInjectedWidget } from '@cowprotocol/common-utils'
 import { nodeRemoveChildFix } from '@cowprotocol/common-utils'
 import { jotaiStore } from '@cowprotocol/core'
+import { CowEventEmitterContext, CowEventEmitterImpl } from '@cowprotocol/events'
 import { SnackbarsWidget } from '@cowprotocol/snackbars'
 
 import { LanguageProvider } from 'i18n'
@@ -63,6 +64,9 @@ function Main() {
                   <ThemedGlobalStyle />
                   <BlockNumberProvider>
                     <WithLDProvider>
+                      <CowEventEmitterContext.Provider
+                        value={new CowEventEmitterImpl()}
+                      ></CowEventEmitterContext.Provider>
                       <WalletUnsupportedNetworkBanner />
                       <Updaters />
 

--- a/apps/cowswap-frontend/src/cow-react/index.tsx
+++ b/apps/cowswap-frontend/src/cow-react/index.tsx
@@ -64,24 +64,23 @@ function Main() {
                   <ThemedGlobalStyle />
                   <BlockNumberProvider>
                     <WithLDProvider>
-                      <CowEventEmitterContext.Provider
-                        value={new CowEventEmitterImpl()}
-                      ></CowEventEmitterContext.Provider>
-                      <WalletUnsupportedNetworkBanner />
-                      <Updaters />
+                      <CowEventEmitterContext.Provider value={new CowEventEmitterImpl()}>
+                        <WalletUnsupportedNetworkBanner />
+                        <Updaters />
 
-                      {!isInjectedWidgetMode && (
-                        <>
-                          <FeatureGuard featureFlag="cowFortuneEnabled">
-                            <FortuneWidget />
-                          </FeatureGuard>
-                          <AppziButton />
-                        </>
-                      )}
+                        {!isInjectedWidgetMode && (
+                          <>
+                            <FeatureGuard featureFlag="cowFortuneEnabled">
+                              <FortuneWidget />
+                            </FeatureGuard>
+                            <AppziButton />
+                          </>
+                        )}
 
-                      <Popups />
-                      <SnackbarsWidget />
-                      <App />
+                        <Popups />
+                        <SnackbarsWidget />
+                        <App />
+                      </CowEventEmitterContext.Provider>
                     </WithLDProvider>
                   </BlockNumberProvider>
                 </ThemeProvider>

--- a/libs/events/src/CowEventEmitter.ts
+++ b/libs/events/src/CowEventEmitter.ts
@@ -9,12 +9,12 @@ export type CowEventListener<T extends CowEvents> = T extends keyof CowEventPayl
 export type CowEventListeners = CowEventListener<CowEvents>[]
 
 export interface CowEventEmitter {
-  on<T extends CowEvents>(event: T, handler: CowEventHandler<T>): void
+  on<T extends CowEvents>(listener: CowEventListener<T>): void
   emit<T extends CowEvents>(event: T, payload: CowEventPayloads[T]): void
   off<T extends CowEvents>(event: T, listenerToRemove: CowEventHandler<T>): void
 }
 
-export class CowEventEmitterImpl {
+export class CowEventEmitterImpl implements CowEventEmitter {
   private events: {
     [key: string]: CowEventHandler<any>[] // Use generic parameter for listener type
   }

--- a/libs/events/src/CowEventEmitterProvider.ts
+++ b/libs/events/src/CowEventEmitterProvider.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'react'
+import { CowEventEmitter } from './CowEventEmitter'
+
+export const CowEventEmitterContext = createContext<CowEventEmitter | undefined>(undefined)

--- a/libs/events/src/index.ts
+++ b/libs/events/src/index.ts
@@ -1,2 +1,3 @@
 export * from './types'
 export * from './CowEventEmitter'
+export * from './CowEventEmitterProvider'


### PR DESCRIPTION
# Summary
Part of the series https://github.com/cowprotocol/cowswap/pull/3812

## How will CoW Swap emit events that reach to the widget users? 
Any component will be able to use a `CowEventEmitter` instance to send a message.

More particularly, they need to use `cowEventEmitterContext.emit(...)` function

## How do they get an instance of this emitter?
Good question! Glad you ask. As the emitter needs to be created only once, one good way to have an instance is to expose it using a provider.

This PR adds a provider `CowEventEmitterContext` and creates a convenient hook to get the instance `useCowEventEmitter()` 

this way code is as simple as:


```ts
const eventEmitter = useCowEventEmitter()

// somewhere in your component
eventEmitter.emit(youEvent, yourPayload)
```