### PR TITLE
[Widget enhancement] 07 - Emit post order events

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.ts
@@ -15,6 +15,7 @@ import { getSwapErrorMessage } from 'modules/trade/utils/swapErrorHelper'
 
 import OperatorError from 'api/gnosisProtocol/errors/OperatorError'
 import { useConfirmPriceImpactWithoutFee } from 'common/hooks/useConfirmPriceImpactWithoutFee'
+import { useCowEventEmitter } from 'common/hooks/useCowEventEmitter'
 import { useIsSafeApprovalBundle } from 'common/hooks/useIsSafeApprovalBundle'
 import { TradeAmounts } from 'common/types'
 
@@ -24,6 +25,7 @@ export function useHandleOrderPlacement(
   settingsState: LimitOrdersSettingsState,
   tradeConfirmActions: TradeConfirmActions
 ): () => Promise<void> {
+  const cowEventEmitter = useCowEventEmitter()
   const { confirmPriceImpactWithoutFee } = useConfirmPriceImpactWithoutFee()
   const updateLimitOrdersState = useSetAtom(updateLimitOrdersRawStateAtom)
   const [partiallyFillableOverride, setPartiallyFillableOverride] = useAtom(partiallyFillableOverrideAtom)
@@ -54,6 +56,7 @@ export function useHandleOrderPlacement(
         safeBundleFlowContext,
         priceImpact,
         settingsState,
+        cowEventEmitter,
         confirmPriceImpactWithoutFee,
         beforeTrade
       )
@@ -64,7 +67,15 @@ export function useHandleOrderPlacement(
     tradeContext.postOrderParams.partiallyFillable =
       partiallyFillableOverride ?? tradeContext.postOrderParams.partiallyFillable
 
-    return tradeFlow(tradeContext, priceImpact, settingsState, confirmPriceImpactWithoutFee, beforePermit, beforeTrade)
+    return tradeFlow(
+      tradeContext,
+      cowEventEmitter,
+      priceImpact,
+      settingsState,
+      confirmPriceImpactWithoutFee,
+      beforePermit,
+      beforeTrade
+    )
   }, [
     beforePermit,
     beforeTrade,
@@ -75,6 +86,7 @@ export function useHandleOrderPlacement(
     safeBundleFlowContext,
     settingsState,
     tradeContext,
+    cowEventEmitter,
   ])
 
   return useCallback(() => {

--- a/apps/cowswap-frontend/src/modules/limitOrders/services/safeBundleFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/services/safeBundleFlow/index.ts
@@ -1,4 +1,5 @@
 import { reportAppDataWithHooks } from '@cowprotocol/common-utils'
+import { CowEventEmitter, CowEvents } from '@cowprotocol/events'
 import { MetaTransactionData } from '@safe-global/safe-core-sdk-types'
 import { Percent } from '@uniswap/sdk-core'
 
@@ -27,6 +28,7 @@ export async function safeBundleFlow(
   params: SafeBundleFlowContext,
   priceImpact: PriceImpact,
   settingsState: LimitOrdersSettingsState,
+  cowEventEmitter: CowEventEmitter,
   confirmPriceImpactWithoutFee: (priceImpact: Percent) => Promise<boolean>,
   beforeTrade?: () => void
 ): Promise<string> {
@@ -86,6 +88,7 @@ export async function safeBundleFlow(
       signer: provider.getSigner(),
       validTo,
     })
+
     logTradeFlow(LOG_PREFIX, 'STEP 4: add order, but hidden')
     addPendingOrderStep(
       {
@@ -130,6 +133,7 @@ export async function safeBundleFlow(
     }
 
     const safeTx = await safeAppsSdk.txs.send({ txs: safeTransactionData })
+    cowEventEmitter.emit(CowEvents.ON_POSTED_ORDER, { orderUid: orderId, chainId })
 
     logTradeFlow(LOG_PREFIX, 'STEP 7: add safe tx hash and unhide order')
     partialOrderUpdate(

--- a/apps/cowswap-frontend/src/modules/limitOrders/services/tradeFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/services/tradeFlow/index.ts
@@ -1,5 +1,6 @@
 import { reportPermitWithDefaultSigner } from '@cowprotocol/common-utils'
 import { OrderClass } from '@cowprotocol/cow-sdk'
+import { CowEvents } from '@cowprotocol/events'
 import { isSupportedPermitInfo } from '@cowprotocol/permit-utils'
 import { Percent } from '@uniswap/sdk-core'
 
@@ -21,6 +22,7 @@ import { getSwapErrorMessage } from 'modules/trade/utils/swapErrorHelper'
 
 export async function tradeFlow(
   params: TradeFlowContext,
+  cowEventEmitter,
   priceImpact: PriceImpact,
   settingsState: LimitOrdersSettingsState,
   confirmPriceImpactWithoutFee: (priceImpact: Percent) => Promise<boolean>,
@@ -85,6 +87,8 @@ export async function tradeFlow(
       signer: provider.getSigner(),
       validTo,
     })
+    cowEventEmitter.emit(CowEvents.ON_POSTED_ORDER, { orderUid: orderId, chainId })
+
     logTradeFlow('LIMIT ORDER FLOW', 'STEP 5: add pending order step')
     addPendingOrderStep(
       {

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useHandleSwap.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useHandleSwap.ts
@@ -10,6 +10,7 @@ import { swapFlow } from 'modules/swap/services/swapFlow'
 import { logTradeFlow } from 'modules/trade/utils/logger'
 
 import { useConfirmPriceImpactWithoutFee } from 'common/hooks/useConfirmPriceImpactWithoutFee'
+import { useCowEventEmitter } from 'common/hooks/useCowEventEmitter'
 
 import { useEthFlowContext } from './useEthFlowContext'
 import { useSafeBundleEthFlowContext } from './useSafeBundleEthFlowContext'
@@ -18,6 +19,7 @@ import { useSwapActionHandlers } from './useSwapState'
 
 export function useHandleSwap(priceImpactParams: PriceImpact): () => Promise<void> {
   const swapFlowContext = useSwapFlowContext()
+  const cowEventEmitter = useCowEventEmitter()
   const ethFlowContext = useEthFlowContext()
   const safeBundleApprovalFlowContext = useSafeBundleApprovalFlowContext()
   const safeBundleEthFlowContext = useSafeBundleEthFlowContext()
@@ -30,16 +32,26 @@ export function useHandleSwap(priceImpactParams: PriceImpact): () => Promise<voi
     const tradeResult = await (async () => {
       if (safeBundleApprovalFlowContext) {
         logTradeFlow('SAFE BUNDLE APPROVAL FLOW', 'Start safe bundle approval flow')
-        return safeBundleApprovalFlow(safeBundleApprovalFlowContext, priceImpactParams, confirmPriceImpactWithoutFee)
+        return safeBundleApprovalFlow(
+          safeBundleApprovalFlowContext,
+          cowEventEmitter,
+          priceImpactParams,
+          confirmPriceImpactWithoutFee
+        )
       } else if (safeBundleEthFlowContext) {
         logTradeFlow('SAFE BUNDLE ETH FLOW', 'Start safe bundle eth flow')
-        return safeBundleEthFlow(safeBundleEthFlowContext, priceImpactParams, confirmPriceImpactWithoutFee)
+        return safeBundleEthFlow(
+          safeBundleEthFlowContext,
+          cowEventEmitter,
+          priceImpactParams,
+          confirmPriceImpactWithoutFee
+        )
       } else if (swapFlowContext) {
         logTradeFlow('SWAP FLOW', 'Start swap flow')
-        return swapFlow(swapFlowContext, priceImpactParams, confirmPriceImpactWithoutFee)
+        return swapFlow(swapFlowContext, cowEventEmitter, priceImpactParams, confirmPriceImpactWithoutFee)
       } else if (ethFlowContext) {
         logTradeFlow('ETH FLOW', 'Start eth flow')
-        return ethFlow(ethFlowContext, priceImpactParams, confirmPriceImpactWithoutFee)
+        return ethFlow(ethFlowContext, cowEventEmitter, priceImpactParams, confirmPriceImpactWithoutFee)
       }
     })()
 
@@ -59,5 +71,6 @@ export function useHandleSwap(priceImpactParams: PriceImpact): () => Promise<voi
     onUserInput,
     priceImpactParams,
     confirmPriceImpactWithoutFee,
+    cowEventEmitter,
   ])
 }

--- a/apps/cowswap-frontend/src/modules/swap/services/ethFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/ethFlow/index.ts
@@ -1,4 +1,5 @@
 import { reportAppDataWithHooks } from '@cowprotocol/common-utils'
+import { CowEventEmitter, CowEvents } from '@cowprotocol/events'
 import { Percent } from '@uniswap/sdk-core'
 
 import { PriceImpact } from 'legacy/hooks/usePriceImpact'
@@ -16,6 +17,7 @@ import { calculateUniqueOrderId } from './steps/calculateUniqueOrderId'
 
 export async function ethFlow(
   ethFlowContext: EthFlowContext,
+  cowEventEmitter: CowEventEmitter,
   priceImpactParams: PriceImpact,
   confirmPriceImpactWithoutFee: (priceImpact: Percent) => Promise<boolean>
 ): Promise<void | false> {
@@ -69,6 +71,12 @@ export async function ethFlow(
         callbacks.closeModals()
       }
     )
+
+    cowEventEmitter.emit(CowEvents.ON_POSTED_ETH_FLOW_ORDER, {
+      txHash: txReceipt.hash,
+      orderUid: order.id,
+      chainId: context.chainId,
+    })
 
     logTradeFlow('ETH FLOW', 'STEP 5: add pending order step')
     addPendingOrderStep(

--- a/apps/cowswap-frontend/src/modules/swap/services/safeBundleFlow/safeBundleApprovalFlow.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/safeBundleFlow/safeBundleApprovalFlow.ts
@@ -1,4 +1,5 @@
 import { reportAppDataWithHooks } from '@cowprotocol/common-utils'
+import { CowEventEmitter, CowEvents } from '@cowprotocol/events'
 import { MetaTransactionData } from '@safe-global/safe-core-sdk-types'
 import { Percent } from '@uniswap/sdk-core'
 
@@ -22,6 +23,7 @@ const LOG_PREFIX = 'SAFE APPROVAL BUNDLE FLOW'
 
 export async function safeBundleApprovalFlow(
   input: SafeBundleApprovalFlowContext,
+  cowEventEmitter: CowEventEmitter,
   priceImpactParams: PriceImpact,
   confirmPriceImpactWithoutFee: (priceImpact: Percent) => Promise<boolean>
 ): Promise<void | false> {
@@ -112,6 +114,7 @@ export async function safeBundleApprovalFlow(
     }
 
     const safeTx = await safeAppsSdk.txs.send({ txs: safeTransactionData })
+    cowEventEmitter.emit(CowEvents.ON_POSTED_ORDER, { orderUid: orderId, chainId: context.chainId })
 
     logTradeFlow(LOG_PREFIX, 'STEP 6: add safe tx hash and unhide order')
     partialOrderUpdate(

--- a/apps/cowswap-frontend/src/modules/swap/services/safeBundleFlow/safeBundleEthFlow.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/safeBundleFlow/safeBundleEthFlow.ts
@@ -1,5 +1,6 @@
 import { Erc20 } from '@cowprotocol/abis'
 import { reportAppDataWithHooks } from '@cowprotocol/common-utils'
+import { CowEventEmitter, CowEvents } from '@cowprotocol/events'
 import { MetaTransactionData } from '@safe-global/safe-core-sdk-types'
 import { Percent } from '@uniswap/sdk-core'
 
@@ -22,6 +23,7 @@ const LOG_PREFIX = 'SAFE BUNDLE ETH FLOW'
 
 export async function safeBundleEthFlow(
   input: SafeBundleEthFlowContext,
+  cowEventEmitter: CowEventEmitter,
   priceImpactParams: PriceImpact,
   confirmPriceImpactWithoutFee: (priceImpact: Percent) => Promise<boolean>
 ): Promise<void | false> {
@@ -116,6 +118,7 @@ export async function safeBundleEthFlow(
     logTradeFlow(LOG_PREFIX, 'STEP 6: send safe tx')
 
     const safeTx = await safeAppsSdk.txs.send({ txs })
+    cowEventEmitter.emit(CowEvents.ON_POSTED_ORDER, { orderUid: orderId, chainId: context.chainId })
 
     logTradeFlow(LOG_PREFIX, 'STEP 7: add safe tx hash and unhide order')
     partialOrderUpdate(

--- a/apps/cowswap-frontend/src/modules/swap/services/swapFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/swapFlow/index.ts
@@ -1,4 +1,5 @@
 import { getIsNativeToken, reportAppDataWithHooks, reportPermitWithDefaultSigner } from '@cowprotocol/common-utils'
+import { CowEventEmitter, CowEvents } from '@cowprotocol/events'
 import { isSupportedPermitInfo } from '@cowprotocol/permit-utils'
 import { Percent } from '@uniswap/sdk-core'
 
@@ -21,6 +22,7 @@ import { SwapFlowContext } from '../types'
 
 export async function swapFlow(
   input: SwapFlowContext,
+  cowEventEmitter: CowEventEmitter,
   priceImpactParams: PriceImpact,
   confirmPriceImpactWithoutFee: (priceImpact: Percent) => Promise<boolean>
 ): Promise<void | false> {
@@ -93,6 +95,8 @@ export async function swapFlow(
     const presignTx = await (input.flags.allowsOffchainSigning
       ? Promise.resolve(null)
       : presignOrderStep(orderId, input.contract))
+
+    cowEventEmitter.emit(CowEvents.ON_POSTED_ORDER, { orderUid: orderId, chainId: input.context.chainId })
 
     logTradeFlow('SWAP FLOW', 'STEP 6: unhide SC order (optional)')
     if (presignTx) {

--- a/libs/events/src/types/events.ts
+++ b/libs/events/src/types/events.ts
@@ -1,18 +1,25 @@
-import { OnExecutedOrderPayload, OnPostedOrderPayload, OnRejectedOrderPayload } from './orders'
+import {
+  OnExecutedOrderPayload,
+  OnPostedOrderPayload,
+  OnRejectedOrderPayload as OnCancelledOrderPayload,
+  OnPostedEthFlowOrderPayload,
+} from './orders'
 import { OnToastMessagePayload } from './toastMessages'
 
 // export type CowEvents = 'updateWidgetConfig' | 'onToastMessage' | 'onPostedOrder' | 'onExecutedOrder'
 export enum CowEvents {
   ON_TOAST_MESSAGE = 'ON_TOAST_MESSAGE',
   ON_POSTED_ORDER = 'ON_POSTED_ORDER',
+  ON_POSTED_ETH_FLOW_ORDER = 'ON_POSTED_ETH_FLOW_ORDER',
   ON_EXECUTED_ORDER = 'ON_EXECUTED_ORDER',
-  ON_REJECTED_ORDER = 'ON_REJECTED_ORDER',
+  ON_CANCELLED_ORDER = 'ON_CANCELLED_ORDER',
 }
 
 // Define types for event payloads
 export interface CowEventPayloads {
   [CowEvents.ON_TOAST_MESSAGE]: OnToastMessagePayload
   [CowEvents.ON_POSTED_ORDER]: OnPostedOrderPayload
+  [CowEvents.ON_POSTED_ETH_FLOW_ORDER]: OnPostedEthFlowOrderPayload
   [CowEvents.ON_EXECUTED_ORDER]: OnExecutedOrderPayload
-  [CowEvents.ON_REJECTED_ORDER]: OnRejectedOrderPayload
+  [CowEvents.ON_CANCELLED_ORDER]: OnCancelledOrderPayload
 }

--- a/libs/events/src/types/orders.ts
+++ b/libs/events/src/types/orders.ts
@@ -1,15 +1,19 @@
-export interface OnPostedOrderPayload {
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
+export interface OrderUidInChain {
   orderUid: string
+  chainId: SupportedChainId
   // TODO: Potentially add all order info here, but lets keep it minimal for now
 }
 
-export interface OnExecutedOrderPayload {
-  orderUid: string
-  // TODO: Potentially add all order info here, but lets keep it minimal for now
+export type OnPostedOrderPayload = OrderUidInChain
+export type OnExecutedOrderPayload = OrderUidInChain
+
+export interface OnPostedEthFlowOrderPayload extends OrderUidInChain {
+  txHash: string
 }
 
-export interface OnRejectedOrderPayload {
-  orderUid: string
+export interface OnRejectedOrderPayload extends OrderUidInChain {
   reason: string
   errorCode?: number
   // TODO: Potentially add all order info here, but lets keep it minimal for now

--- a/libs/events/src/types/toastMessages.ts
+++ b/libs/events/src/types/toastMessages.ts
@@ -12,7 +12,7 @@ export interface ToastMessagePayloads {
   }
 
   [ToastMessageType.SWAP_POSTED_API]: {
-    orderUid: string
+    orderId: string
     // TODO: Potentially add all order info here, but lets keep it minimal for now
   }
 

--- a/libs/widget-lib/src/types.ts
+++ b/libs/widget-lib/src/types.ts
@@ -140,7 +140,7 @@ interface CowSwapWidgetConfig {
 
   /**
    * Disables showing the toast messages.
-   * Some UI might want to disable it and subscribe to 'onToastMessage' event to handle the toast messages itself.
+   * Some UI might want to disable it and subscribe to CowEvents.ON_TOAST_MESSAGE event to handle the toast messages itself.
    * Defaults to false.
    */
   disableToastMessages?: boolean


### PR DESCRIPTION
# Summary
Part of the series https://github.com/cowprotocol/cowswap/pull/3812

This PR start to use the `eventEmitter` in the app.

It triggers an event for when we post an order to the API.

Note that in the case of Safe flow, we want to make sure we get the transaction hash from the safe, before we post the event, just because for technical reasons we post the order to the API before the user signs/approve the order.