### PR TITLE
[Widget enhancement] 09 - Create an iframe event emitter

### DIFF
--- a/libs/widget-lib/src/IframeCowEventEmitter.ts
+++ b/libs/widget-lib/src/IframeCowEventEmitter.ts
@@ -1,0 +1,42 @@
+import { CowEventEmitterImpl, CowEventListener, CowEventListeners, CowEvents } from '@cowprotocol/events'
+const COW_SWAP_WIDGET_EVENT_KEY = 'cowSwapWidget'
+
+export class IframeCowEventEmitter {
+  private listeners: CowEventListeners
+  private eventEmitter: CowEventEmitterImpl
+
+  constructor(listeners?: CowEventListeners) {
+    this.eventEmitter = new CowEventEmitterImpl()
+    this.listeners = listeners ?? []
+
+    // Subscribe to events
+    this.updateListeners(listeners)
+
+    // Forward messages to the event emitter
+    window.addEventListener('message', this.forwardEvents)
+  }
+
+  public updateListeners(listeners?: CowEventListeners): void {
+    // Unsubscribe from previous listeners
+    for (const listener of this.listeners) {
+      this.eventEmitter.off(listener as CowEventListener<CowEvents>)
+    }
+
+    // Subscribe to events
+    this.listeners = listeners ?? []
+    for (const listener of this.listeners) {
+      this.eventEmitter.on(listener as CowEventListener<CowEvents>)
+    }
+  }
+
+  private forwardEvents = (event: MessageEvent): void => {
+    if (event.data.key !== COW_SWAP_WIDGET_EVENT_KEY || event.data.method !== 'event') {
+      return
+    }
+    console.debug(
+      `[TODO:remove] Received message client side - Forward to eventEmitter ${event.data.eventName}`,
+      event.data.payload
+    )
+    this.eventEmitter.emit(event.data.eventName, event.data.payload)
+  }
+}


### PR DESCRIPTION
# Summary

Part of the series https://github.com/cowprotocol/cowswap/pull/3812

This PR creates `IframeCowEventEmitter` in our widget library.

This component will facilitate the bridging of events on the widget side. 

It has a local instance of the event emitter. It will be used to register all the listeners. 
This way, this component can listen to the events arriving to the window, and forward them into the listeners (with the help of the event emitter)