### PR TITLE
[Widget enhancement] 10 - Optimise widget updates

### DIFF
--- a/apps/widget-configurator/src/app/configurator/index.tsx
+++ b/apps/widget-configurator/src/app/configurator/index.tsx
@@ -52,41 +52,41 @@ const COW_LISTENERS: CowEventListeners = [
   {
     event: CowEvents.ON_TOAST_MESSAGE,
     handler: (event) => {
-      console.log('[configurator] 🍞 Toast message', event.message, event.data)
+      console.log('[TODO:remove] 🍞 Toast message', event.message, event.data)
 
       // You can provide a simplistic way to handle toast messages (use the "message" to show it in your app)
       if (event.messageType === ToastMessageType.SWAP_ETH_FLOW_SENT_TX) {
-        console.error('[configurator] 🍞 Toast message: New eth flow order', event.data.tx)
+        console.error('[TODO:remove] 🍞 Toast message: New eth flow order', event.data.tx)
       }
 
       // ...or you can do handle them your way using the data:
       switch (event.messageType) {
         case ToastMessageType.SWAP_ETH_FLOW_SENT_TX:
-          console.error('[configurator] 🍞 Toast message: New eth flow order. Tx: ', event.data.tx)
+          console.error('[TODO:remove] 🍞 Toast message: New eth flow order. Tx: ', event.data.tx)
           break
         case ToastMessageType.SWAP_POSTED_API:
-          console.warn('[configurator] 🍞 Toast message: Posted order', event.data.orderUid)
+          console.warn('[TODO:remove] 🍞 Toast message: Posted order', event.data.orderUid)
           break
         // ... and so on
         default:
-          console.error('[configurator] 🍞 Toast message: Default', event.message)
+          console.error('[TODO:remove] 🍞 Toast message: Default', event.message)
       }
     },
   },
 
   {
     event: CowEvents.ON_POSTED_ORDER,
-    handler: (event) => console.log('[configurator] ✉️ Posted order: ', event.orderUid),
+    handler: (event) => console.log('[TODO:remove] 💌 Posted order: ', event.orderUid),
   },
 
   {
-    event: CowEvents.ON_REJECTED_ORDER,
-    handler: (event) => console.log(`[configurator] ❌ Posted order ${event.orderUid}. Reason: ${event.reason}`),
+    event: CowEvents.ON_CANCELLED_ORDER,
+    handler: (event) => console.log(`[TODO:remove] ❌ Cancelled order ${event.orderUid}. Reason: ${event.reason}`),
   },
 
   {
     event: CowEvents.ON_EXECUTED_ORDER,
-    handler: (event) => console.log(`[configurator] ✅ Executed order ${event.orderUid}`),
+    handler: (event) => console.log(`[TODO:remove] ✅ Executed order ${event.orderUid}`),
   },
 ]
 
@@ -255,7 +255,7 @@ export function Configurator({ title }: { title: string }) {
       </Drawer>
 
       <Box sx={ContentStyled}>
-        {params && (
+        {params && provider && (
           <>
             <EmbedDialog
               params={params}

--- a/libs/events/src/CowEventEmitter.ts
+++ b/libs/events/src/CowEventEmitter.ts
@@ -9,8 +9,8 @@ export type CowEventListener<T extends CowEvents> = T extends keyof CowEventPayl
 export type CowEventListeners = CowEventListener<CowEvents>[]
 
 export interface CowEventEmitter {
-  on<T extends CowEvents>(listener: CowEventListener<T>): void
-  off<T extends CowEvents>(listener: CowEventListener<T>): void
+  on(listener: CowEventListener<CowEvents>): void
+  off(listener: CowEventListener<CowEvents>): void
   emit<T extends CowEvents>(event: T, payload: CowEventPayloads[T]): void
 }
 
@@ -23,7 +23,7 @@ export class CowEventEmitterImpl implements CowEventEmitter {
     this.events = {}
   }
 
-  on<T extends CowEvents>(listener: CowEventListener<T>): void {
+  on(listener: CowEventListener<CowEvents>): void {
     const { event, handler } = listener
     if (!this.events[event]) {
       this.events[event] = []
@@ -31,7 +31,7 @@ export class CowEventEmitterImpl implements CowEventEmitter {
     this.events[event].push(handler)
   }
 
-  off<T extends CowEvents>(listener: CowEventListener<T>): void {
+  off(listener: CowEventListener<CowEvents>): void {
     const { event, handler } = listener
     if (this.events[event]) {
       this.events[event] = this.events[event].filter((listener) => listener !== handler)
@@ -40,9 +40,7 @@ export class CowEventEmitterImpl implements CowEventEmitter {
 
   emit<T extends keyof CowEventPayloads>(event: T, payload: CowEventPayloads[T]): void {
     if (this.events[event]) {
-      this.events[event].forEach((handler) => {
-        handler(payload)
-      })
+      this.events[event].forEach((handler) => handler(payload))
     }
   }
 }

--- a/libs/events/src/types/toastMessages.ts
+++ b/libs/events/src/types/toastMessages.ts
@@ -12,7 +12,7 @@ export interface ToastMessagePayloads {
   }
 
   [ToastMessageType.SWAP_POSTED_API]: {
-    orderId: string
+    orderUid: string
     // TODO: Potentially add all order info here, but lets keep it minimal for now
   }
 

--- a/libs/widget-lib/src/index.ts
+++ b/libs/widget-lib/src/index.ts
@@ -1,4 +1,4 @@
-export { cowSwapWidget } from './cowSwapWidget'
-export type { UpdateWidgetCallback } from './cowSwapWidget'
+export { createCowSwapWidget } from './cowSwapWidget'
+export type { CowSwapWidgetHandler } from './cowSwapWidget'
 export { COWSWAP_URLS } from './consts'
 export * from './types'


### PR DESCRIPTION
# Summary

Part of the series https://github.com/cowprotocol/cowswap/pull/3812

So this PR is the first one I could test if all this inter-iFrame event communication was working. 
And it did!! it did too well! I was receiving every message TWICE! 👯

I saw that the cause is because the widget is redrawn at least TWICE.

One reason is because, it depends on the `provider` and the `params`. A react hook will update first with the params, and then again once the provider is ready.

As the method to create a widget (`cowSwapWidget`) returns only one `update` function which:
- deletes all content in the iFrame parent container
- creates the iFrame again
- Create all listeners and bridging logics  👈 here is where I was registering twice, once per re-draw of the widget


This is when I decided to:
- Make the `cowSwapWidget` to not return only one `update` method, so now it will return `CowSwapWidgetHandler`
- The `CowSwapWidgetHandler` contains now 3 methods that provide a more efficient control 
   - `updateWidget`: post a message to cowswap to update some params
   - `updateListeners`: re-register all listeners for events 
   - `updateProvider`: re-register the provider

With this handlers we have finer control, and we can update the widget part that changes (now there's 3 useEffects controlling the changes of the 3 things: params, listener, provider)
https://github.com/cowprotocol/cowswap/pull/3822/files#diff-95bce0f32b886f9e630b2565e9f47a3636b66db3255db831562fdc1bf5e77b8bL30

