### PR TITLE
docs: fix link to widget configurator

### DIFF
--- a/libs/widget-lib/README.md
+++ b/libs/widget-lib/README.md
@@ -6,7 +6,7 @@ look and much more!
 
 ## Live example
 
-See the widget in action in the [widget configurator](../../apps/widget-configurator/src/main.tsx)
+See the widget in action in the [widget configurator](https://widget.cow.fi)
 
 ## Docs
 


### PR DESCRIPTION
# Summary

Ref: https://cowservices.slack.com/archives/C05QVFJUX9R/p1707313932426889

Just updated the link
