### PR TITLE
fix(twap): orders auth updating and rerending issues

### DIFF
--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWidget/index.tsx
@@ -1,5 +1,5 @@
 import { useAtomValue, useSetAtom } from 'jotai'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import { openAdvancedOrdersTabAnalytics, twapWalletCompatibilityAnalytics } from '@cowprotocol/analytics'
 import { renderTooltip } from '@cowprotocol/ui'
@@ -102,6 +102,17 @@ export function TwapFormWidget() {
   const isInvertedState = useState(false)
   const [isInverted] = isInvertedState
 
+  const onSlippageInput = useCallback(
+    (value: number | null) => updateSettingsState({ slippageValue: value }),
+    [updateSettingsState]
+  )
+  const onNumOfPartsInput = useCallback(
+    (value: number | null) => {
+      updateSettingsState({ numberOfPartsValue: value || DEFAULT_NUM_OF_PARTS })
+    },
+    [updateSettingsState]
+  )
+
   return (
     <>
       <TwapConfirmModal fallbackHandlerIsNotSet={isFallbackHandlerRequired} />
@@ -117,7 +128,7 @@ export function TwapFormWidget() {
       )}
       <TradeNumberInput
         value={+twapOrderSlippage.toFixed(2)}
-        onUserInput={(value: number | null) => updateSettingsState({ slippageValue: value })}
+        onUserInput={onSlippageInput}
         decimalsPlaces={2}
         placeholder={DEFAULT_TWAP_SLIPPAGE.toFixed(1)}
         min={0}
@@ -141,9 +152,7 @@ export function TwapFormWidget() {
       <styledEl.Row>
         <TradeNumberInput
           value={numberOfPartsValue}
-          onUserInput={(value: number | null) => {
-            updateSettingsState({ numberOfPartsValue: value || DEFAULT_NUM_OF_PARTS })
-          }}
+          onUserInput={onNumOfPartsInput}
           min={DEFAULT_NUM_OF_PARTS}
           label={LABELS_TOOLTIPS.numberOfParts.label}
           tooltip={renderTooltip(LABELS_TOOLTIPS.numberOfParts.tooltip)}

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useTwapOrdersAuthMulticall.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useTwapOrdersAuthMulticall.ts
@@ -20,7 +20,7 @@ export function useTwapOrdersAuthMulticall(
     return ordersInfo.map(({ id }) => [safeAddress, id])
   }, [safeAddress, ordersInfo])
 
-  const results = useSingleContractMultipleData<boolean>(
+  const { data: loadedResults, isLoading } = useSingleContractMultipleData<[boolean]>(
     composableCowContract,
     'singleOrders',
     input,
@@ -29,15 +29,13 @@ export function useTwapOrdersAuthMulticall(
   )
 
   return useMemo(() => {
-    const loadedResults = results.data
-
     if (ordersInfo.length === 0) return EMPTY_AUTH_RESULT
 
-    if (results.isLoading || !loadedResults || loadedResults.length !== ordersInfo.length) return null
+    if (isLoading || !loadedResults || loadedResults.length !== ordersInfo.length) return null
 
     return ordersInfo.reduce((acc, val, index) => {
-      acc[val.id] = loadedResults[index]
+      acc[val.id] = loadedResults[index]?.[0]
       return acc
     }, {} as TwapOrdersAuthResult)
-  }, [ordersInfo, results])
+  }, [ordersInfo, loadedResults, isLoading])
 }


### PR DESCRIPTION
# Summary

Fixes #3530 #3809

#3530 issue was introduced since the last multicall refactoring (#3416), the multicall in `useTwapOrdersAuthMulticall` returns a tuple of boolean, not just boolean.

#3809 issue also came from the multicall refactoring, the `useSWR` result shouldn't be used in hook dependencies, because it causes re-rendering issues.

I also found another rerendering issue in `TwapFormWidget`, there were two callbacks not wrapped in `useCallback`.

  # To Test

1. See #3530
2. For developers: add a console log into `TwapOrdersUpdater` body and check that there is no tons of calls