### PR TITLE
fix: disable ab-testing for fee-zero. Enable flag for all users

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/featureFlags/useSwapZeroFee.ts
+++ b/apps/cowswap-frontend/src/common/hooks/featureFlags/useSwapZeroFee.ts
@@ -1,21 +1,8 @@
-import { useWalletInfo } from '@cowprotocol/wallet'
-
 import { useFeatureFlags } from './useFeatureFlags'
 
-// Expose the feature to XX% of users
-const PERCENTAGE_OF_USERS_WITH_FLAG = 30 // XX% of users
 
 export function useSwapZeroFee(): boolean {
-  const { account } = useWalletInfo()
   const { swapZeroFee } = useFeatureFlags()
 
-  return enabledForUser(account) && swapZeroFee
-}
-
-function enabledForUser(account: string | undefined): boolean {
-  if (!account) {
-    return false
-  }
-
-  return parseInt(account.toLowerCase(), 0) % 100 < PERCENTAGE_OF_USERS_WITH_FLAG
+  return swapZeroFee
 }


### PR DESCRIPTION
# Summary

Deletes the fee-zero AB testing.

It will leave the activation decision to the feature flag, so no more checking if the wallet has it or not activated.