### PR TITLE
fix(widget): widget displaying and expanded colors panel

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/Header/URLWarning/URLWarningMod.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Header/URLWarning/URLWarningMod.tsx
@@ -10,6 +10,8 @@ export const PhishAlert = styled.div<{ isActive: any }>`
   justify-content: space-between;
   align-items: center;
   display: ${({ isActive }) => (isActive ? 'flex' : 'none')};
+  border-radius: ${({ theme }) => (theme.isInjectedWidgetMode ? '8px' : '')};
+  margin-bottom: ${({ theme }) => (theme.isInjectedWidgetMode ? '10px' : '')};
 
   p {
     padding: 0;

--- a/apps/cowswap-frontend/src/modules/tokensList/containers/SelectTokenWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/containers/SelectTokenWidget/index.tsx
@@ -29,8 +29,8 @@ const Wrapper = styled.div`
   width: 100%;
 
   > div {
-    //TODO: check the UI
     height: calc(100vh - 200px);
+    min-height: 600px;
   }
 `
 

--- a/apps/widget-configurator/src/app/configurator/controls/PaletteControl.tsx
+++ b/apps/widget-configurator/src/app/configurator/controls/PaletteControl.tsx
@@ -18,16 +18,16 @@ export function PaletteControl({ paletteManager }: { paletteManager: ColorPalett
   const [expanded, setExpanded] = React.useState(false)
 
   return (
-    <>
+    <div>
       {visibleColorKeys.map((key) => (
-        <FormControl sx={{ width: '100%', gap: '1.6rem' }} key={key}>
+        <FormControl sx={{ width: '100%', margin: '10px 0' }} key={key}>
           <ColorInput colorKey={key} paletteManager={paletteManager} />
         </FormControl>
       ))}
 
       <Collapse in={expanded}>
         {otherColorKeys.map((colorKey) => (
-          <FormControl sx={{ width: '100%', margin: '0 0 1.6rem' }} key={colorKey}>
+          <FormControl sx={{ width: '100%', margin: '10px 0' }} key={colorKey}>
             <ColorInput colorKey={colorKey} paletteManager={paletteManager} />
           </FormControl>
         ))}
@@ -35,7 +35,7 @@ export function PaletteControl({ paletteManager }: { paletteManager: ColorPalett
 
       <Button onClick={() => setExpanded(!expanded)}>{expanded ? 'Less' : 'More'} Options</Button>
       <Button onClick={resetColorPalette}>Reset to Default</Button>
-    </>
+    </div>
   )
 }
 

--- a/apps/widget-configurator/src/app/configurator/index.tsx
+++ b/apps/widget-configurator/src/app/configurator/index.tsx
@@ -257,7 +257,7 @@ export function Configurator({ title }: { title: string }) {
       </Drawer>
 
       <Box sx={ContentStyled}>
-        {params && provider && (
+        {params && (
           <>
             <EmbedDialog
               params={params}

--- a/libs/tokens/src/hooks/tokens/useAreThereTokensWithSameSymbol.ts
+++ b/libs/tokens/src/hooks/tokens/useAreThereTokensWithSameSymbol.ts
@@ -11,7 +11,14 @@ export function useAreThereTokensWithSameSymbol(): (tokenAddressOrSymbol: string
     (tokenAddressOrSymbol: string | null | undefined) => {
       if (!tokenAddressOrSymbol || isAddress(tokenAddressOrSymbol)) return false
 
-      return tokensBySymbol[tokenAddressOrSymbol.toLowerCase()]?.length > 1
+      const tokens = tokensBySymbol[tokenAddressOrSymbol.toLowerCase()]
+      const hasDuplications = tokens?.length > 1
+
+      if (hasDuplications) {
+        console.debug('There are tokens with the same symbol:', tokens)
+      }
+
+      return hasDuplications
     },
     [tokensBySymbol]
   )


### PR DESCRIPTION
# Summary

1. When wallet is not connected in the widget configurator, the widget itself is not displayed

<img width="600" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/e8a03c26-6fb8-455e-87fc-cfb6d3453d52">

2. By clicking on "More options" the panel looks broken

<img width="293" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/11bfa6e3-30bc-4699-9a57-2587b39b5e61">

3. Token selection widget looks broken

<img width="500" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/6b571a2b-8533-46b6-915f-fe733113e244">

4. The top header banner appearance improvement

| Header | Header |
|--------|--------|
| <img width="580" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/2062a404-b1ec-4bd2-bed4-de27a8d2d4ef"> | <img width="533" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/658829cf-e239-47ab-8027-8e7352ea74bd"> | 

Each fix has a separate commit