### PR TITLE
fix: place order notification sell amount

### DIFF
--- a/apps/cowswap-frontend/src/legacy/state/orders/middleware/pendingOrderPopup.tsx
+++ b/apps/cowswap-frontend/src/legacy/state/orders/middleware/pendingOrderPopup.tsx
@@ -1,5 +1,6 @@
 import { orderAnalytics } from '@cowprotocol/analytics'
 import { TokenWithLogo } from '@cowprotocol/common-const'
+import { isSellOrder } from '@cowprotocol/common-utils'
 import { CurrencyAmount } from '@uniswap/sdk-core'
 
 import { MiddlewareAPI } from '@reduxjs/toolkit'
@@ -30,10 +31,23 @@ export function pendingOrderPopup(
 
   const order = orderObject.order
 
-  const { orderCreationHash, isHidden, class: orderClass, receiver } = order
+  const {
+    orderCreationHash,
+    isHidden,
+    class: orderClass,
+    receiver,
+    kind,
+    sellAmountBeforeFee,
+    sellAmount,
+    buyAmount,
+    inputToken,
+    outputToken,
+  } = order
 
-  const inputAmount = CurrencyAmount.fromRawAmount(TokenWithLogo.fromToken(order.inputToken), order.sellAmount)
-  const outputAmount = CurrencyAmount.fromRawAmount(TokenWithLogo.fromToken(order.outputToken), order.buyAmount)
+  const rawSellAmount = isSellOrder(kind) ? (sellAmountBeforeFee as string) : sellAmount
+
+  const inputAmount = CurrencyAmount.fromRawAmount(TokenWithLogo.fromToken(inputToken), rawSellAmount)
+  const outputAmount = CurrencyAmount.fromRawAmount(TokenWithLogo.fromToken(outputToken), buyAmount)
 
   showPendingOrderNotification({
     ...order,


### PR DESCRIPTION
# Summary

Fixes sell amount in the place order notification

# To Test

1. Place SELL SWAP with zeroFee flag on
* Notification sell amount should match what's signed
2. Repeat for BUY order
* Same result
3. Repeat 1 and 2 with zeroFee flag off
* Same result