### PR TITLE
fix: connect wallet not working in widget mode

### DIFF
--- a/libs/widget-react/src/lib/CowSwapWidget.tsx
+++ b/libs/widget-react/src/lib/CowSwapWidget.tsx
@@ -70,6 +70,9 @@ export function CowSwapWidget({ params, provider, listeners }: CowSwapWidgetProp
       return
     }
 
+    // Update provider
+    providerRef.current = provider || null
+
     // TODO: Fix this https://github.com/cowprotocol/cowswap/issues/3810#issue-2127257473 (in meantime forcing full refresh as before)
     // const handler = widgetHandlerRef.current
     // tryOrHandleError('Updating the provider', () => handler.updateProvider(provider))


### PR DESCRIPTION
# Summary

The widget connection became broken. When connecting, it was not showing 


## The problem
Currently in https://dev.widget.cow.fi if you disconnect from the widget:

<img width="1307" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/b671e692-890f-4275-90a5-f2b3b5f41c3e">

And then connect:
<img width="1452" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/75774b26-62b7-426e-ad6d-80beb8366350">

It will connect for the host app, but not the widget:
<img width="1378" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/f68d3722-8373-48c3-965c-e8453b5dfeed">



# To Test
- Open configurator
- Connect, 