### PR TITLE
Misc. style fixes

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/ConfirmationPendingContent/styled.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ConfirmationPendingContent/styled.tsx
@@ -73,10 +73,6 @@ export const UpperSection = styled.div`
   color: inherit;
   position: relative;
 
-  ${({ theme }) => theme.mediaWidth.upToSmall`
-    border-radius: 0;
-  `};
-
   > span {
     font-size: 18px;
     font-weight: 300;

--- a/apps/cowswap-frontend/src/common/pure/CurrencyAmountPreview/styled.tsx
+++ b/apps/cowswap-frontend/src/common/pure/CurrencyAmountPreview/styled.tsx
@@ -13,6 +13,11 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: 20px;
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    font-size: 13px;
+    letter-spacing: -0.1px;
+  `}
 `
 
 export const Amount = styled.div`

--- a/apps/cowswap-frontend/src/common/pure/TransactionErrorContent/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/TransactionErrorContent/index.tsx
@@ -25,7 +25,7 @@ const Header = styled.div`
 const Body = styled.div`
   width: 100%;
   text-align: center;
-  margin: 40px 0;
+  margin: 80px 0;
 `
 
 const Text = styled.div`

--- a/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/index.tsx
@@ -6,7 +6,6 @@ import { SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
 import { BackButton } from '@cowprotocol/ui'
 import { Currency } from '@uniswap/sdk-core'
 
-import { Link } from 'react-router-dom'
 import { Text } from 'rebass'
 import { Nullish } from 'types'
 
@@ -91,12 +90,16 @@ export function TransactionSubmittedContent({
               <AddToMetamask shortLabel currency={currencyToAdd} />
 
               {!isInjectedWidgetMode && (
-                <styledEl.ButtonCustom>
-                  <Link to={Routes.PLAY_COWRUNNER} onClick={onDismiss}>
+                <a href={`#${Routes.PLAY_COWRUNNER}`} target="_blank" rel="noreferrer noopener">
+                  <styledEl.ButtonCustom cowGame>
                     <styledEl.StyledIcon src={GameIcon} alt="Play CowGame" />
                     Play the CoW Runner Game!
-                  </Link>
-                </styledEl.ButtonCustom>
+                  </styledEl.ButtonCustom>
+                </a>
+              )}
+
+              {activityDerivedState?.status === ActivityStatus.CONFIRMED && (
+                <styledEl.ButtonCustom onClick={onDismiss}>Close</styledEl.ButtonCustom>
               )}
             </styledEl.ButtonGroup>
           </>

--- a/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/index.tsx
@@ -98,7 +98,7 @@ export function TransactionSubmittedContent({
                 </a>
               )}
 
-              {activityDerivedState?.status === ActivityStatus.CONFIRMED && (
+              {activityDerivedState?.status === ActivityStatus.PENDING && (
                 <styledEl.ButtonCustom onClick={onDismiss}>Close</styledEl.ButtonCustom>
               )}
             </styledEl.ButtonGroup>

--- a/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/styled.tsx
+++ b/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/styled.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/macro'
 
 import { CloseIcon } from 'legacy/theme'
 
-export const ButtonCustom = styled.button`
+export const ButtonCustom = styled.button<{ cowGame?: boolean }>`
   display: flex;
   flex: 1 1 auto;
   align-self: center;
@@ -13,19 +13,20 @@ export const ButtonCustom = styled.button`
   border-radius: 16px;
   min-height: 52px;
   border: 0;
-  color: var(${UI.COLOR_BUTTON_TEXT});
-  background: var(${UI.COLOR_PRIMARY});
+  color: ${({ cowGame }) => (cowGame ? `var(${UI.COLOR_INFO_TEXT})` : `var(${UI.COLOR_BUTTON_TEXT})`)};
+  background: ${({ cowGame }) => (cowGame ? `var(${UI.COLOR_INFO_BG})` : `var(${UI.COLOR_PRIMARY})`)};
   outline: 0;
   padding: 8px 16px;
-  margin: 16px 0 0;
-  font-size: 14px;
-  line-height: 1;
-  font-weight: 500;
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
   transition: background var(${UI.ANIMATION_DURATION}) ease-in-out;
   cursor: pointer;
+  width: 100%;
 
   &:hover {
-    background: var(${UI.COLOR_PRIMARY_DARKER});
+    color: ${({ cowGame }) => (cowGame ? `var(${UI.COLOR_PAPER})` : `var(${UI.COLOR_BUTTON_TEXT})`)};
+    background: ${({ cowGame }) => (cowGame ? `var(${UI.COLOR_INFO_TEXT})` : `var(${UI.COLOR_PRIMARY_DARKER})`)};
   }
 
   > a {
@@ -40,9 +41,16 @@ export const ButtonGroup = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 12px;
-  margin: 12px 0 0;
+  flex-flow: column wrap;
+  gap: 14px;
+  padding: 0;
+  margin: 16px auto 0;
   width: 100%;
+
+  > a {
+    width: 100%;
+    text-decoration: none;
+  }
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
     flex-direction: column;

--- a/apps/cowswap-frontend/src/legacy/components/OrderProgressBar/styled.ts
+++ b/apps/cowswap-frontend/src/legacy/components/OrderProgressBar/styled.ts
@@ -16,7 +16,7 @@ export const ProgressBarWrapper = animated(styled.div`
   display: flex;
   flex-flow: column wrap;
   border-radius: 12px;
-  padding: 20px 20px 0;
+  padding: 20px;
   color: inherit;
   background-color: var(${UI.COLOR_PAPER_DARKER});
   transition: height 0.2s ease;
@@ -150,7 +150,7 @@ export const StatusMsgContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  margin: 1rem 0;
+  margin: 20px auto 0;
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
     gap: 0.2rem;

--- a/apps/cowswap-frontend/src/legacy/components/OrderProgressBar/styled.ts
+++ b/apps/cowswap-frontend/src/legacy/components/OrderProgressBar/styled.ts
@@ -22,13 +22,11 @@ export const ProgressBarWrapper = animated(styled.div`
   transition: height 0.2s ease;
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
+    padding: 18px;
     margin: 24px auto 12px;
     width: 100%;
     max-width: 100%;
     grid-column: 1 / -1;
-  `};
-  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
-    padding: 24px 10px 0;
   `};
 `)
 

--- a/apps/cowswap-frontend/src/legacy/components/Popups/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Popups/index.tsx
@@ -30,7 +30,7 @@ export const MobilePopupWrapper = styled.div<{ show: boolean }>`
   width: 100%;
   height: 100%;
   margin: 0;
-  background: var(${UI.COLOR_PAPER_DARKER});
+  background: var(${UI.COLOR_PAPER_DARKEST});
   display: none;
 
   ${({ theme, show }) => theme.mediaWidth.upToSmall`

--- a/apps/cowswap-frontend/src/legacy/components/Popups/styled.ts
+++ b/apps/cowswap-frontend/src/legacy/components/Popups/styled.ts
@@ -56,14 +56,11 @@ export const StyledClose = styled(X)`
 
   &:hover {
     opacity: 1;
+    cursor: pointer;
   }
 
   svg {
     stroke: currentColor;
-  }
-
-  :hover {
-    cursor: pointer;
   }
 `
 

--- a/apps/cowswap-frontend/src/legacy/components/TransactionExecutedContent/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/TransactionExecutedContent/index.tsx
@@ -28,15 +28,15 @@ export function TransactionExecutedContent({
       <img src={cowMeditatingSmooth} alt="Cow Smoooth ..." />
 
       <div>
-        <div>
+        <span>
           Traded{' '}
           <styledEl.StyledTokenAmount amount={formattedFilledAmount} tokenSymbol={formattedFilledAmount.currency} /> for
           a total of{' '}
           <styledEl.StyledTokenAmount amount={formattedSwappedAmount} tokenSymbol={formattedSwappedAmount.currency} />
-        </div>
+        </span>
 
         {!!surplusAmount && (
-          <div>
+          <span>
             You received a surplus of <styledEl.StyledTokenAmount amount={surplusAmount} tokenSymbol={surplusToken} />{' '}
             {showFiatValue && (
               <span>
@@ -44,7 +44,7 @@ export function TransactionExecutedContent({
               </span>
             )}{' '}
             on this trade!
-          </div>
+          </span>
         )}
 
         <DisplayLink id={hash} chainId={chainId} />

--- a/apps/cowswap-frontend/src/legacy/components/TransactionExecutedContent/styled.ts
+++ b/apps/cowswap-frontend/src/legacy/components/TransactionExecutedContent/styled.ts
@@ -21,6 +21,7 @@ export const ExecutedWrapper = styled.div`
     > a {
       text-decoration: underline;
       display: block;
+      margin: 0;
     }
   }
 `

--- a/apps/cowswap-frontend/src/legacy/components/TransactionExecutedContent/styled.ts
+++ b/apps/cowswap-frontend/src/legacy/components/TransactionExecutedContent/styled.ts
@@ -4,31 +4,24 @@ import styled from 'styled-components/macro'
 
 export const ExecutedWrapper = styled.div`
   display: flex;
+  gap: 20px;
   align-items: center;
-  padding-bottom: 1rem;
 
-  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
-    font-size: 0.8rem;
-  `};
-
-  img {
-    padding: 1rem;
-    margin-right: 10px;
-
-    ${({ theme }) => theme.mediaWidth.upToExtraSmall`
-      padding: 0;
-      max-width: 60px;
-    `};
+  > img {
+    max-width: 100%;
   }
 
-  a {
-    margin: 0;
-    margin-top: 15px;
-    display: block;
-  }
+  > div {
+    display: flex;
+    flex-flow: column wrap;
+    align-items: flex-start;
+    gap: 16px;
+    font-size: 15px;
 
-  > div > div {
-    margin-bottom: 5px;
+    > a {
+      text-decoration: underline;
+      display: block;
+    }
   }
 `
 

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/styled.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/styled.tsx
@@ -186,7 +186,7 @@ export const ProgressBarWrapper = styled.div`
   flex-flow: row nowrap;
   gap: 8px;
   flex-direction: row-reverse;
-  padding: 0 0;
+  padding: 0;
   font-size: 12px;
   font-weight: 500;
   height: 100%;

--- a/apps/cowswap-frontend/src/modules/swap/pure/EthFlow/EthFlowStepper/Step.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/EthFlow/EthFlowStepper/Step.tsx
@@ -12,7 +12,7 @@ export const ExplorerLinkStyled = styled(ExplorerLink)``
 
 const StepWrapper = styled.div`
   height: auto;
-  width: auto;
+  width: max-content;
   text-align: center;
   display: flex;
   flex-direction: column;
@@ -37,6 +37,12 @@ const StepWrapper = styled.div`
     color: var(${UI.COLOR_TEXT});
     opacity: 1;
     font-size: 13px;
+    width: 100%;
+    max-width: 90px;
+    word-break: break-word;
+    white-space: pre-line;
+    line-height: 1.3;
+    margin: 4px auto 0;
   }
 `
 

--- a/apps/cowswap-frontend/src/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
@@ -101,7 +101,7 @@ export const Progress = styled.div<ProgressProps>`
   border-radius: var(--height);
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
-    --height: 50px;
+    --height: 30px;
     --width: 3px;
     border-radius: var(--width);
     margin: 24px auto;

--- a/apps/cowswap-frontend/src/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/EthFlow/EthFlowStepper/index.tsx
@@ -72,8 +72,8 @@ const Wrapper = styled.div`
   grid-template-rows: max-content;
   align-items: flex-start;
   width: 100%;
-  padding: 22px;
-  border-radius: 0 0 12px 12px;
+  padding: 20px;
+  border-radius: 12px;
   background: var(${UI.COLOR_PAPER_DARKER});
   font-size: 15px;
   line-height: 1;

--- a/apps/cowswap-frontend/src/modules/trade/pure/Row/styled.ts
+++ b/apps/cowswap-frontend/src/modules/trade/pure/Row/styled.ts
@@ -7,7 +7,7 @@ export const DividerHorizontal = styled.hr`
   border-bottom: 1px solid var(${UI.COLOR_TEXT});
   display: flex;
   width: 100%;
-  margin: 0;
+  margin: 10px auto;
   opacity: 0.1;
 `
 

--- a/libs/snackbars/src/containers/SnackbarsWidget/index.tsx
+++ b/libs/snackbars/src/containers/SnackbarsWidget/index.tsx
@@ -6,7 +6,7 @@ import ms from 'ms.macro'
 import { AlertCircle, CheckCircle } from 'react-feather'
 import { ReactElement, useCallback, useMemo } from 'react'
 import { useResetAtom } from 'jotai/utils'
-import { darken } from 'color2k'
+import { UI } from '@cowprotocol/ui'
 
 const Overlay = styled.div`
   display: none;
@@ -16,7 +16,7 @@ const Overlay = styled.div`
   width: 100%;
   height: 100%;
   z-index: 4;
-  background: ${({ theme }) => darken(theme.bg1, 0.2)};
+  background: var(${UI.COLOR_PAPER_DARKEST});
 `
 
 const List = styled.div`
@@ -33,7 +33,11 @@ const Host = styled.div`
   max-width: 800px;
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
-    width: 100%;
+    width: 90%;
+    left: 0;
+    right: 0;
+    margin: auto;
+    top: 20px;
 
     ${Overlay} {
       display: block;

--- a/libs/snackbars/src/pure/SnackbarPopup/index.tsx
+++ b/libs/snackbars/src/pure/SnackbarPopup/index.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useCallback, useEffect } from 'react'
+import { UI } from '@cowprotocol/ui'
 
 import styled from 'styled-components/macro'
 import { X } from 'react-feather'
@@ -7,17 +8,12 @@ import { animated, useSpring } from '@react-spring/web'
 const Wrapper = styled.div`
   display: inline-block;
   width: 100%;
-  background-color: ${({ theme }) => theme.bg1};
+  background-color: var(${UI.COLOR_PAPER});
   position: relative;
   border-radius: 10px;
-  padding: 20px 40px 20px 20px;
-  margin-bottom: 20px;
+  padding: 20px 35px 20px 20px;
   overflow: hidden;
-  border: 2px solid ${({ theme }) => theme.black};
-  box-shadow: 2px 2px 0 ${({ theme }) => theme.black};
-  font-weight: 500;
-  font-size: 16px;
-  color: ${({ theme }) => theme.text1};
+  border: 2px solid var(${UI.COLOR_TEXT_OPACITY_50});
 `
 
 const ContentWrapper = styled.div`
@@ -31,11 +27,17 @@ const StyledClose = styled(X)`
   position: absolute;
   right: 10px;
   top: 10px;
-  stroke: currentColor;
-  color: currentColor;
+  color: inherit;
+  opacity: 0.7;
+  transition: opacity ${UI.ANIMATION_DURATION} ease-in-out;
 
   &:hover {
+    opacity: 1;
     cursor: pointer;
+  }
+
+  svg {
+    stroke: currentColor;
   }
 `
 
@@ -44,8 +46,8 @@ const Fader = styled.div`
   bottom: 0;
   left: 0;
   width: 100%;
-  background-color: ${({ theme }) => theme.disabled};
-  height: 4px;
+  height: 2px;
+  background-color: var(${UI.COLOR_PAPER_DARKER});
 `
 
 const AnimatedFader = animated(Fader)


### PR DESCRIPTION
# Summary
- Addresses: 
  - https://github.com/cowprotocol/cowswap/issues/3858
  - https://github.com/cowprotocol/cowswap/issues/3788
  - And others
- On order progress show the Cow Runner Game button in less prominent colors (secondary button). When finished show the CLOSE button in addition.
- Made sure the Toast/Popup components (they are different components doing the same...) use the same styles. In the future this should be re-factored to use a single component.

<img width="373" alt="Screenshot 2024-02-16 at 13 56 41" src="https://github.com/cowprotocol/cowswap/assets/31534717/a619b08c-1135-44f1-962f-c53896fb9454">

 
<img width="375" alt="Screenshot 2024-02-16 at 13 46 15" src="https://github.com/cowprotocol/cowswap/assets/31534717/bfb2a9e7-a3e1-497d-976c-e4efc18d66b6">
<img width="556" alt="Screenshot 2024-02-16 at 12 26 21" src="https://github.com/cowprotocol/cowswap/assets/31534717/ecd3cd76-9d00-403f-a70c-6b236ac9f805">
<img width="539" alt="Screenshot 2024-02-16 at 12 26 13" src="https://github.com/cowprotocol/cowswap/assets/31534717/423cede4-f82c-4adb-8fb0-342186d6c7a7">

<img width="612" alt="Screenshot 2024-02-15 at 18 03 54" src="https://github.com/cowprotocol/cowswap/assets/31534717/27cd3513-b857-4623-92b3-c7a63ee524a6">
