### PR TITLE
fix: display snackbars in mobile correctly

### DIFF
--- a/apps/cowswap-frontend/src/legacy/state/orders/middleware/showPendingOrderNotification.tsx
+++ b/apps/cowswap-frontend/src/legacy/state/orders/middleware/showPendingOrderNotification.tsx
@@ -5,6 +5,7 @@ import { addSnackbarAtom } from '@cowprotocol/snackbars'
 import { CurrencyAmount, Token } from '@uniswap/sdk-core'
 
 import { EVENT_EMITTER } from 'eventEmitter'
+import ms from 'ms.macro'
 import { Nullish } from 'types'
 
 import {
@@ -13,6 +14,8 @@ import {
   getPendingOrderNotificationToast,
 } from 'common/pure/PendingOrderNotification'
 import { UiOrderType } from 'utils/orderUtils/getUiOrderType'
+
+const PENDING_ORDER_DURATION = ms`10s`
 
 interface PendingOrderNotificationParams {
   chainId: SupportedChainId
@@ -62,6 +65,7 @@ export function showPendingOrderNotification(params: PendingOrderNotificationPar
       id: 'pending-order',
       icon: 'success',
       content,
+      duration: PENDING_ORDER_DURATION,
     })
 
     const toastMessage = getPendingOrderNotificationToast(pendingOrderNotificationMessage)

--- a/libs/snackbars/src/containers/SnackbarsWidget/index.tsx
+++ b/libs/snackbars/src/containers/SnackbarsWidget/index.tsx
@@ -34,6 +34,8 @@ const Host = styled.div`
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
     width: 100%;
+    right: 0;
+    top: 0;
 
     ${Overlay} {
       display: block;


### PR DESCRIPTION
# Summary

Fixes #3858

<img width="553" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/b03775ba-fd2b-44c6-8bb5-5d9715cd6029">

1. Removed margins from snackbars on mobile view
2. A bit increased the "Submitted order" snackbar duration (from 8 to 10 sec)

  # To Test

See #3858
