### PR TITLE
fix(trade): restore state from URL after provider network changes

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/hooks/useSetupSwapAmountsFromUrl.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useSetupSwapAmountsFromUrl.ts
@@ -43,6 +43,9 @@ export function useSetupSwapAmountsFromUrl() {
       onUserInput(Field.OUTPUT, buyAmount)
     }
 
-    cleanParams()
+    // Clean params only at least one of them is set
+    if (sellAmount || buyAmount) {
+      cleanParams()
+    }
   }, [params, onUserInput, cleanParams])
 }


### PR DESCRIPTION
# Summary

Fixes #3768

1. `useSetupSwapAmountsFromUrl()` was overriding URL when it's not needed
2. In the previous refactoring (#3848) I was moved provider network processing to the callback `onProviderNetworkChanges` which also contains `rememberedUrlState` processing. Along with it I should have removed the remembered state resetting from "On URL parameter changes" hook.
3. As a part of refactoring changed `rememberedUrlState` from `useState()` to `useRef()` to avoid confusion. In the future we should change other parts of the logic to avoid using `react-hooks/exhaustive-deps`.

  # To Test

1. Connect the app to the Mainnet
2. Modify the link swap.cow.fi/#/100/swap/dai/cow?recipient=vitalik.eth&sellAmount=100
3. Paste the link to the browser's tab
- [ ] AR: tokens are resent
- [ ] ER: tokens are displayed in the fields after switching to the 100 network.
