### PR TITLE
fix: always open hash links in new tab

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/CancellationModal/RequestCancellationModal.tsx
+++ b/apps/cowswap-frontend/src/common/pure/CancellationModal/RequestCancellationModal.tsx
@@ -8,7 +8,7 @@ import type { BigNumber } from '@ethersproject/bignumber'
 import { CurrencyAmount } from '@uniswap/sdk-core'
 
 import { ArrowRight, ArrowLeft } from 'react-feather'
-import { NavHashLink } from 'react-router-hash-link'
+import { HashLink } from 'react-router-hash-link'
 import styled from 'styled-components/macro'
 
 import NotificationBanner from 'legacy/components/NotificationBanner'
@@ -141,9 +141,9 @@ export function RequestCancellationModal(props: RequestCancellationModalProps): 
               <p>
                 Keep in mind a solver might already have included the order in a solution even if this cancellation is
                 successful. Read more in the{' '}
-                <NavHashLink target="_blank" rel="noreferrer" to={`${Routes.FAQ_TRADING}#can-i-cancel-an-order`}>
+                <HashLink target="_blank" rel="noreferrer" to={`${Routes.FAQ_TRADING}#can-i-cancel-an-order`}>
                   FAQ
-                </NavHashLink>
+                </HashLink>
                 .
                 {isOnChainType && (
                   <StyledNotificationBanner isVisible={true} canClose={false} level="INFO">

--- a/apps/cowswap-frontend/src/common/pure/ZeroApprovalWarning/ZeroApprovalWarning.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ZeroApprovalWarning/ZeroApprovalWarning.tsx
@@ -28,7 +28,12 @@ export function ZeroApprovalWarning({ currency }: ZeroApprovalWarningProps) {
     <WarningCard>
       <strong>Note:</strong> {symbol} specifically requires 2 approval transactions. The first resets your spending cap
       to 0, and the second sets your desired spending cap. To avoid this in the future, set your spending cap to CoW
-      Swap's recommended default amount. {faqLink && <Link to={faqLink}>Learn more</Link>}
+      Swap's recommended default amount.{' '}
+      {faqLink && (
+        <Link target="_blank" to={faqLink}>
+          Learn more
+        </Link>
+      )}
     </WarningCard>
   )
 }

--- a/apps/cowswap-frontend/src/legacy/components/HashLink/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/HashLink/index.tsx
@@ -1,3 +1,0 @@
-import { HashLink } from 'react-router-hash-link'
-
-export default HashLink

--- a/apps/cowswap-frontend/src/legacy/components/Link/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Link/index.tsx
@@ -1,6 +1,6 @@
 import { ExternalLink } from '@cowprotocol/ui'
 
-import HashLink from 'legacy/components/HashLink'
+import { HashLink } from 'react-router-hash-link'
 
 const SCROLL_OFFSET = 24
 

--- a/apps/cowswap-frontend/src/legacy/components/swap/UnsupportedCurrencyFooter/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/swap/UnsupportedCurrencyFooter/index.tsx
@@ -14,7 +14,11 @@ const DEFAULT_DETAILS_TEXT = (
     CoW Swap does not support all tokens. Some tokens implement similar, but logically different ERC20 contract methods
     which do not operate optimally with CoW Protocol.
     <p>
-      For more information, please refer to the <HashLink to={UNSUPPORTED_TOKENS_FAQ_URL}>FAQ</HashLink>.
+      For more information, please refer to the{' '}
+      <HashLink target="_blank" to={UNSUPPORTED_TOKENS_FAQ_URL}>
+        FAQ
+      </HashLink>
+      .
     </p>
   </div>
 )

--- a/apps/cowswap-frontend/src/modules/limitOrders/pure/InfoBanner/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/pure/InfoBanner/index.tsx
@@ -34,7 +34,9 @@ export function InfoBanner() {
       </div>
       <div className="content">
         Your order may not fill exactly when the market price reaches your limit price.{' '}
-        <HashLink to="/faq/limit-order#how-do-fees-work">Learn more</HashLink>
+        <HashLink target="_blank" to="/faq/limit-order#how-do-fees-work">
+          Learn more
+        </HashLink>
       </div>
 
       <styledEl.CloseIcon onClick={() => closeBanner()} />

--- a/apps/cowswap-frontend/src/modules/trade/pure/CompatibilityIssuesWarning/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/CompatibilityIssuesWarning/index.tsx
@@ -27,7 +27,11 @@ export const CompatibilityIssuesWarning = React.memo((props: CompatibilityIssues
           <>
             <p>CoW Swap requires offline signatures, which is currently not supported by some wallets.</p>
             <p>
-              Read more in the <HashLink to="/faq/protocol#wallet-not-supported">FAQ</HashLink>.
+              Read more in the{' '}
+              <HashLink target="_blank" to="/faq/protocol#wallet-not-supported">
+                FAQ
+              </HashLink>
+              .
             </p>
           </>
         }


### PR DESCRIPTION
# Summary

Fixes #3886, #3458

Since some of links already have `target="_blank"` I decided to add it everywhere to be consistent.

  # To Test

See  #3886, #3458

