### PR TITLE
chore: don't display scrollbar on side menu when it's short

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/SideMenu/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/SideMenu/index.tsx
@@ -40,7 +40,7 @@ const Wrapper = styled.div<{ longList?: boolean }>`
 
   > div {
     height: 90vh;
-    overflow-y: scroll;
+    overflow-y: auto;
     margin-right: 5px;
     ${({ theme }) => theme.colorScrollbar};
 


### PR DESCRIPTION
# Summary

![image](https://github.com/cowprotocol/cowswap/assets/7122625/ff81af7d-daa5-40e1-a16c-4ab435b62c6c)

  # To Test

1. Faq, policies, account page - the scrollbar should not be displayed
2. Terms and conditions - the scrollbar should be displayed
