### PR TITLE
fix: better detection of transaction rejection

### DIFF
--- a/libs/common-utils/src/misc.ts
+++ b/libs/common-utils/src/misc.ts
@@ -10,9 +10,7 @@ interface Market<T = string> {
 const PROVIDER_REJECT_REQUEST_CODES = [4001, -32000] // See https://eips.ethereum.org/EIPS/eip-1193
 const PROVIDER_REJECT_REQUEST_ERROR_MESSAGES = [
   'User denied message signature',
-  'User rejected the transaction',
-  'user rejected transaction',
-  'User rejected signing',
+  'User rejected',
   'Transaction was rejected',
 ]
 


### PR DESCRIPTION
# Summary

Fixes issue with order rejection from WC

# To Test

1. Connect via WC
2. Create order and send request to wallet
3. Reject on wallet
* Should show the nice error msg
4. Repeat with EOA and SC wallets
* Same result