### PR TITLE
[widget] improve updater and params

### DIFF
--- a/apps/cowswap-frontend/src/modules/injectedWidget/hooks/useInjectedWidgetParams.ts
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/hooks/useInjectedWidgetParams.ts
@@ -1,9 +1,9 @@
 import { useAtomValue } from 'jotai'
 
-import { CowSwapWidgetParams } from '@cowprotocol/widget-lib'
+import type { CowSwapWidgetParams } from '@cowprotocol/widget-lib'
 
 import { injectedWidgetParamsAtom } from '../state/injectedWidgetParamsAtom'
 
-export function useInjectedWidgetParams(): CowSwapWidgetParams {
+export function useInjectedWidgetParams(): Partial<CowSwapWidgetParams> {
   return useAtomValue(injectedWidgetParamsAtom)
 }

--- a/apps/cowswap-frontend/src/modules/injectedWidget/hooks/useInjectedWidgetParams.ts
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/hooks/useInjectedWidgetParams.ts
@@ -1,6 +1,6 @@
 import { useAtomValue } from 'jotai'
 
-import type { CowSwapWidgetParams } from '@cowprotocol/widget-lib'
+import { CowSwapWidgetParams } from '@cowprotocol/widget-lib'
 
 import { injectedWidgetParamsAtom } from '../state/injectedWidgetParamsAtom'
 

--- a/apps/cowswap-frontend/src/modules/injectedWidget/state/injectedWidgetParamsAtom.ts
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/state/injectedWidgetParamsAtom.ts
@@ -2,4 +2,4 @@ import { atom } from 'jotai'
 
 import type { CowSwapWidgetParams } from '@cowprotocol/widget-lib'
 
-export const injectedWidgetParamsAtom = atom<CowSwapWidgetParams>({})
+export const injectedWidgetParamsAtom = atom<Partial<CowSwapWidgetParams>>({})

--- a/apps/cowswap-frontend/src/modules/injectedWidget/updaters/InjectedWidgetUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/updaters/InjectedWidgetUpdater.tsx
@@ -1,6 +1,7 @@
 import { useSetAtom } from 'jotai'
 import { useEffect, useRef } from 'react'
 
+import { deepEqual } from '@cowprotocol/common-utils'
 import {
   UpdateParamsPayload,
   WidgetMethodsEmit,
@@ -57,7 +58,7 @@ export function InjectedWidgetUpdater() {
 
     // Start listening messages inside of React
     const updateParamsListener = listenToMessageFromWindow(window, WidgetMethodsListen.UPDATE_PARAMS, (data) => {
-      // if (prevData.current && deepEqual(prevData.current, data)) return
+      if (prevData.current && deepEqual(prevData.current, data)) return
 
       // Update params
       prevData.current = data

--- a/apps/cowswap-frontend/src/modules/injectedWidget/updaters/InjectedWidgetUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/updaters/InjectedWidgetUpdater.tsx
@@ -56,7 +56,7 @@ export function InjectedWidgetUpdater() {
     // Stop listening of message outside of React
     window.removeEventListener('message', cacheMessages)
 
-    // Start listening messages inside of React
+    // Start listening for messages inside of React
     const updateParamsListener = listenToMessageFromWindow(window, WidgetMethodsListen.UPDATE_PARAMS, (data) => {
       if (prevData.current && deepEqual(prevData.current, data)) return
 

--- a/apps/cowswap-frontend/src/modules/injectedWidget/updaters/InjectedWidgetUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/updaters/InjectedWidgetUpdater.tsx
@@ -1,8 +1,14 @@
 import { useSetAtom } from 'jotai'
-import { useCallback, useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 
-import { deepEqual } from '@cowprotocol/common-utils'
-import { WidgetMethodsEmit, WidgetMethodsListen, postMessageToWindow } from '@cowprotocol/widget-lib'
+import {
+  UpdateParamsPayload,
+  WidgetMethodsEmit,
+  WidgetMethodsListen,
+  listenToMessageFromWindow,
+  postMessageToWindow,
+  stopListeningWindowListener,
+} from '@cowprotocol/widget-lib'
 
 import { useNavigate } from 'react-router-dom'
 
@@ -41,52 +47,44 @@ const cacheMessages = (event: MessageEvent) => {
 export function InjectedWidgetUpdater() {
   const updateParams = useSetAtom(injectedWidgetParamsAtom)
   const updateMetaData = useSetAtom(injectedWidgetMetaDataAtom)
+
   const navigate = useNavigate()
-  const prevData = useRef(null)
+  const prevData = useRef<UpdateParamsPayload | null>(null)
 
-  const processEvent = useCallback(
-    (method: string, data: any) => {
-      switch (method) {
-        case WidgetMethodsListen.UPDATE_PARAMS:
-          if (prevData.current && deepEqual(prevData.current, data)) return
-
-          prevData.current = data
-          updateParams(data.appParams)
-          navigate(data.urlParams)
-          break
-
-        case WidgetMethodsListen.UPDATE_APP_DATA:
-          if (data.metaData) {
-            updateMetaData(data.metaData)
-          }
-          break
-      }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  )
-
-  // Once app is loaded
   useEffect(() => {
     // Stop listening of message outside of React
     window.removeEventListener('message', cacheMessages)
 
+    // Start listening messages inside of React
+    const updateParamsListener = listenToMessageFromWindow(window, WidgetMethodsListen.UPDATE_PARAMS, (data) => {
+      // if (prevData.current && deepEqual(prevData.current, data)) return
+
+      // Update params
+      prevData.current = data
+      updateParams(data.appParams)
+
+      // Navigate to the new path
+      navigate(data.urlParams)
+    })
+
+    const updateAppDataListener = listenToMessageFromWindow(window, WidgetMethodsListen.UPDATE_APP_DATA, (data) => {
+      if (data.metaData) {
+        updateMetaData(data.metaData)
+      }
+    })
+
     // Process all cached messages
     Object.keys(messagesCache).forEach((method) => {
-      processEvent(method, messagesCache[method])
+      postMessageToWindow(window, method as any, messagesCache[method])
 
       delete messagesCache[method]
     })
 
-    // Start listening messages inside of React
-    window.addEventListener('message', (event) => {
-      const method = getEventMethod(event)
-
-      if (!method) return
-
-      processEvent(method, event.data)
-    })
-  }, [processEvent])
+    return () => {
+      stopListeningWindowListener(window, updateParamsListener)
+      stopListeningWindowListener(window, updateAppDataListener)
+    }
+  }, [updateMetaData, navigate, updateParams])
 
   return <IframeResizer />
 }

--- a/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react'
 
-import type { CowSwapWidgetEnv, EthereumProvider } from '@cowprotocol/widget-lib'
-import { CowSwapWidgetProps } from '@cowprotocol/widget-react'
+import type { CowSwapWidgetEnv, CowSwapWidgetParams } from '@cowprotocol/widget-lib'
 
 import { isDev, isLocalHost, isVercel } from '../../../env'
 import { ConfiguratorState } from '../types'
@@ -14,10 +13,7 @@ const getEnv = (): CowSwapWidgetEnv => {
   return 'prod'
 }
 
-export function useWidgetParamsAndSettings(
-  provider: EthereumProvider | undefined,
-  configuratorState: ConfiguratorState
-) {
+export function useWidgetParams(configuratorState: ConfiguratorState): CowSwapWidgetParams {
   return useMemo(() => {
     const {
       chainId,
@@ -38,7 +34,7 @@ export function useWidgetParamsAndSettings(
       ...customColors,
     }
 
-    const params: CowSwapWidgetProps['params'] = {
+    const params: CowSwapWidgetParams = {
       appCode: 'CoW Widget: Configurator',
       width: '450px',
       height: '640px',

--- a/apps/widget-configurator/src/app/configurator/index.tsx
+++ b/apps/widget-configurator/src/app/configurator/index.tsx
@@ -32,7 +32,7 @@ import { useColorPaletteManager } from './hooks/useColorPaletteManager'
 import { useEmbedDialogState } from './hooks/useEmbedDialogState'
 import { useProvider } from './hooks/useProvider'
 import { useSyncWidgetNetwork } from './hooks/useSyncWidgetNetwork'
-import { useWidgetParamsAndSettings } from './hooks/useWidgetParamsAndSettings'
+import { useWidgetParams } from './hooks/useWidgetParamsAndSettings'
 import { ContentStyled, DrawerStyled, WalletConnectionWrapper, WrapperStyled } from './styled'
 import { ConfiguratorState, TokenListItem } from './types'
 
@@ -161,7 +161,7 @@ export function Configurator({ title }: { title: string }) {
     defaultColors: defaultPalette,
   }
 
-  const params = useWidgetParamsAndSettings(provider, state)
+  const params = useWidgetParams(state)
 
   useEffect(() => {
     web3Modal.setThemeMode(mode)

--- a/apps/widget-configurator/src/app/configurator/index.tsx
+++ b/apps/widget-configurator/src/app/configurator/index.tsx
@@ -266,7 +266,7 @@ export function Configurator({ title }: { title: string }) {
               handleClose={handleDialogClose}
             />
             <br />
-            <CowSwapWidget provider={provider} params={params} listeners={COW_LISTENERS} />
+            <CowSwapWidget params={params} provider={provider} listeners={COW_LISTENERS} />
           </>
         )}
       </Box>

--- a/libs/widget-lib/src/cowSwapWidget.ts
+++ b/libs/widget-lib/src/cowSwapWidget.ts
@@ -153,8 +153,6 @@ function updateParams(contentWindow: Window, params: CowSwapWidgetParams, provid
   const pathname = buildWidgetPath(params)
   const search = buildTradeAmountsQuery(params).toString()
 
-  console.log('[cowSwapWidget] updateWidgetParams', { pathname, search, params, hasProvider })
-
   postMessageToWindow(contentWindow, WidgetMethodsListen.UPDATE_PARAMS, {
     urlParams: {
       pathname,

--- a/libs/widget-lib/src/types.ts
+++ b/libs/widget-lib/src/types.ts
@@ -96,50 +96,51 @@ export interface CowSwapWidgetPalette {
 
 export interface CowSwapWidgetParams {
   /**
-   * The width of the widget in pixels. Default: 400px
-   */
-  width: string
-  /**
-   * The height of the widget in pixels. Default: 600px
-   */
-  height: string
-  /**
    * The unique identifier of the widget consumer.
    * Please fill the for to let us know a little about you: https://cowprotocol.typeform.com/to/rONXaxHV
    */
   appCode: string
 
   /**
+   * The width of the widget in pixels. Default: 400px
+   */
+  width?: string
+  /**
+   * The height of the widget in pixels. Default: 600px
+   */
+  height?: string
+
+  /**
    * Network ID.
    */
-  chainId: SupportedChainId
+  chainId?: SupportedChainId
   /**
    * The token lists urls to use in the widget
    */
-  tokenLists: string[]
+  tokenLists?: string[]
   /**
    * Swap, Limit or Advanced (Twap).
    */
-  tradeType: TradeType
+  tradeType?: TradeType
   /**
    * The environment of the widget. Default: prod
    */
-  env: CowSwapWidgetEnv
+  env?: CowSwapWidgetEnv
 
   /**
    * Sell token, and optionally the amount.
    */
-  sell: TradeAsset
+  sell?: TradeAsset
 
   /**
    * Buy token, and optionally the amount.
    */
-  buy: TradeAsset
+  buy?: TradeAsset
 
   /**
    * Enables the ability to switch between trade types in the widget.
    */
-  enabledTradeTypes: TradeType[]
+  enabledTradeTypes?: TradeType[]
 
   /**
    * The interface fee in basis points.
@@ -147,7 +148,7 @@ export interface CowSwapWidgetParams {
    *
    * Please contact https://cowprotocol.typeform.com/to/rONXaxHV
    */
-  interfaceFeeBips: string
+  interfaceFeeBips?: string
 
   /**
    * Disables showing the confirmation modal you get after posting an order.
@@ -165,12 +166,12 @@ export interface CowSwapWidgetParams {
   /**
    * Option to hide the logo in the widget.
    */
-  hideLogo: boolean
+  hideLogo?: boolean
 
   /**
    * Option to hide the network selector in the widget.
    */
-  hideNetworkSelector: boolean
+  hideNetworkSelector?: boolean
 
   /**
    * Hides the connect buttons, and the connected account button. Defaults to false.
@@ -180,17 +181,17 @@ export interface CowSwapWidgetParams {
   /**
    * The theme of the widget UI.
    */
-  theme: CowSwapTheme | CowSwapWidgetPalette
+  theme?: CowSwapTheme | CowSwapWidgetPalette
 
   /**
    * Allows to set a custom logo for the widget.
    */
-  logoUrl: string
+  logoUrl?: string
 
   /**
    * Customizable images for the widget.
    */
-  images: {
+  images?: {
     /**
      * The image to display when the orders table is empty (no orders yet). It defaults to "Yoga CoW" image.
      * Alternatively, you can use a URL to a custom image file, or set to null to disable the image.

--- a/libs/widget-lib/src/types.ts
+++ b/libs/widget-lib/src/types.ts
@@ -1,8 +1,6 @@
 import type { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { CowEventPayloadMap, CowEvents } from '@cowprotocol/events'
+import { CowEventListeners, CowEventPayloadMap, CowEvents } from '@cowprotocol/events'
 export type { SupportedChainId } from '@cowprotocol/cow-sdk'
-
-export type CowSwapWidgetParams = Partial<CowSwapWidgetConfig>
 
 export enum WidgetMethodsEmit {
   ACTIVATE = 'ACTIVATE',
@@ -16,6 +14,12 @@ export enum WidgetMethodsListen {
   UPDATE_APP_DATA = 'UPDATE_APP_DATA',
   PROVIDER_RPC_RESPONSE = 'PROVIDER_RPC_RESPONSE',
   PROVIDER_ON_EVENT = 'PROVIDER_ON_EVENT',
+}
+
+export interface CowSwapWidgetProps {
+  params: CowSwapWidgetParams
+  provider?: EthereumProvider
+  listeners?: CowEventListeners
 }
 
 export interface JsonRpcRequest {
@@ -90,7 +94,7 @@ export interface CowSwapWidgetPalette {
   success: string
 }
 
-interface CowSwapWidgetConfig {
+export interface CowSwapWidgetParams {
   /**
    * The width of the widget in pixels. Default: 400px
    */
@@ -104,10 +108,6 @@ interface CowSwapWidgetConfig {
    * Please fill the for to let us know a little about you: https://cowprotocol.typeform.com/to/rONXaxHV
    */
   appCode: string
-  /**
-   * The widget might be connected to a custom Ethereum provider.
-   */
-  provider: EthereumProvider
 
   /**
    * Network ID.
@@ -246,6 +246,7 @@ export interface UpdateParamsPayload {
     search: string
   }
   appParams: CowSwapWidgetParams
+  hasProvider: boolean
 }
 
 export interface UpdateAppDataPayload {

--- a/libs/widget-lib/src/urlUtils.ts
+++ b/libs/widget-lib/src/urlUtils.ts
@@ -3,7 +3,7 @@ import { CowSwapWidgetParams, TradeType } from './types'
 
 const EMPTY_TOKEN = '_'
 
-export function buildWidgetUrl(params: CowSwapWidgetParams): string {
+export function buildWidgetUrl(params: Partial<CowSwapWidgetParams>): string {
   const host = COWSWAP_URLS[params.env || 'prod']
   const path = buildWidgetPath(params)
   const query = buildTradeAmountsQuery(params)
@@ -11,7 +11,7 @@ export function buildWidgetUrl(params: CowSwapWidgetParams): string {
   return host + '/#' + path + '?' + query
 }
 
-export function buildWidgetPath(params: CowSwapWidgetParams): string {
+export function buildWidgetPath(params: Partial<CowSwapWidgetParams>): string {
   const { chainId = 1, sell, buy, tradeType = TradeType.SWAP } = params
 
   const assetsPath = [sell?.asset || EMPTY_TOKEN, buy?.asset || EMPTY_TOKEN].map(encodeURIComponent).join('/')
@@ -19,7 +19,7 @@ export function buildWidgetPath(params: CowSwapWidgetParams): string {
   return `/${chainId}/widget/${tradeType}/${assetsPath}`
 }
 
-export function buildTradeAmountsQuery(params: CowSwapWidgetParams): URLSearchParams {
+export function buildTradeAmountsQuery(params: Partial<CowSwapWidgetParams>): URLSearchParams {
   const { sell, buy, theme } = params
   const query = new URLSearchParams()
 


### PR DESCRIPTION
# Summary

Okay, i've been trying to fix #3899 and as a result I did a few improves in the widget while I was trying things out. 

So this changes don't improve the connect/disconnect, but improves a few things and prepares the ground to fix the issue in a future PR.

## InjectedWidgeUpdater
It was not really benefiting from the new typed messages from the improvements in the widget communication.

`processEvent` was receiving an `any` object instead of the well typed payloads. This PR improes that.
https://github.com/cowprotocol/cowswap/pull/3909/files#diff-7cc2f0fdbe38430b866ecaabc2d6994287cf16cbcf476d53a1d048b5c966edd1L47


Additionally, this updater had an issue with the hooks. It was not updating the `useCallback` even if their dependencies changed.

## Provider in the params
The provider was never part of the params that travel through the iframe message, but was part of the widget configuration. 

I changed the types to consolidate this, so `provider` is part of the props, but not a configuration parameter. Inside the widget we don't want to send the original provider, as the communication will be through iframe postMessages. However, I added a `hasProvider` in the payload of the messages. 

This will inform the widget, that the host app has specified a `provider`.


## Params
I simplified the widget params and made sure all fields except the `appCode`
Now we don't rely anymore in having the params, and a `Partial` version of it with all fields as optional. 


## connect
The wallet connection works pretty decent as you can see in the video below, but still has the original issue. I will need to review more on way to fix it. 

https://github.com/cowprotocol/cowswap/assets/2352112/615447e7-69e3-4edc-816a-342ab92cb30c


