### PR TITLE
feat: add dapp mode to widget

### DIFF
--- a/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
@@ -13,7 +13,7 @@ const getEnv = (): CowSwapWidgetEnv => {
   return 'prod'
 }
 
-export function useWidgetParams(configuratorState: ConfiguratorState): CowSwapWidgetParams {
+export function useWidgetParams(configuratorState: ConfiguratorState, isDappMode: boolean): CowSwapWidgetParams {
   return useMemo(() => {
     const {
       chainId,
@@ -58,9 +58,9 @@ export function useWidgetParams(configuratorState: ConfiguratorState): CowSwapWi
         success: themeColors.success,
       },
 
-      hideConnectButton: true,
+      hideConnectButton: isDappMode,
     }
 
     return params
-  }, [configuratorState])
+  }, [configuratorState, isDappMode])
 }

--- a/apps/widget-configurator/src/app/configurator/index.tsx
+++ b/apps/widget-configurator/src/app/configurator/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react'
+import { ChangeEvent, useContext, useEffect, useState } from 'react'
 
 import { CowEventListeners, CowEvents, ToastMessageType } from '@cowprotocol/events'
 import { TradeType } from '@cowprotocol/widget-lib'
@@ -9,6 +9,7 @@ import CodeIcon from '@mui/icons-material/Code'
 import EditIcon from '@mui/icons-material/Edit'
 import KeyboardDoubleArrowLeftIcon from '@mui/icons-material/KeyboardDoubleArrowLeft'
 import LanguageIcon from '@mui/icons-material/Language'
+import { Radio, RadioGroup, FormControlLabel, FormControl, FormLabel } from '@mui/material'
 import Box from '@mui/material/Box'
 import Divider from '@mui/material/Divider'
 import Drawer from '@mui/material/Drawer'
@@ -94,8 +95,17 @@ const COW_LISTENERS: CowEventListeners = [
 
 const UTM_PARAMS = 'utm_content=cow-widget-configurator&utm_medium=web&utm_source=widget.cow.fi'
 
+export type WidgetMode = 'dapp' | 'standalone'
+
 export function Configurator({ title }: { title: string }) {
   const { mode } = useContext(ColorModeContext)
+
+  const [widgetMode, setWidgetMode] = useState<WidgetMode>('dapp')
+  const isDappMode = widgetMode === 'dapp'
+
+  const selectWidgetMode = (event: ChangeEvent<HTMLInputElement>) => {
+    setWidgetMode(event.target.value as WidgetMode)
+  }
 
   const [isDrawerOpen, setIsDrawerOpen] = useState(true)
 
@@ -161,7 +171,7 @@ export function Configurator({ title }: { title: string }) {
     defaultColors: defaultPalette,
   }
 
-  const params = useWidgetParams(state)
+  const params = useWidgetParams(state, isDappMode)
 
   useEffect(() => {
     web3Modal.setThemeMode(mode)
@@ -196,9 +206,18 @@ export function Configurator({ title }: { title: string }) {
           {title}
         </Typography>
 
-        <div style={WalletConnectionWrapper}>
-          <w3m-button />
-        </div>
+        <FormControl component="fieldset">
+          <FormLabel component="legend">Select Mode:</FormLabel>
+          <RadioGroup row aria-label="mode" name="mode" value={widgetMode} onChange={selectWidgetMode}>
+            <FormControlLabel value="dapp" control={<Radio />} label="Dapp mode" />
+            <FormControlLabel value="standalone" control={<Radio />} label="Standalone mode" />
+          </RadioGroup>
+        </FormControl>
+        {isDappMode && (
+          <div style={WalletConnectionWrapper}>
+            <w3m-button />
+          </div>
+        )}
 
         <ThemeControl />
 
@@ -266,7 +285,7 @@ export function Configurator({ title }: { title: string }) {
               handleClose={handleDialogClose}
             />
             <br />
-            <CowSwapWidget params={params} provider={provider} listeners={COW_LISTENERS} />
+            <CowSwapWidget params={params} provider={isDappMode ? provider : undefined} listeners={COW_LISTENERS} />
           </>
         )}
       </Box>


### PR DESCRIPTION
# Summary

This PR introduces in the configuration the new setting to run the widget in dapp mode, or standalone mode

Dapp mode:
<img width="1170" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/0f8f7bc6-9ccd-4c8a-b2d6-6d14a53026ca">

Standalone mode:
<img width="1328" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/4ec96488-b5f3-4814-8d55-4d2087296b57">
