### PR TITLE
Fee display style

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/TradeDetailsAccordion/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/TradeDetailsAccordion/index.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react'
+
+import CarretIcon from '@cowprotocol/assets/cow-swap/carret-down.svg'
+import { UI } from '@cowprotocol/ui'
+
+import SVG from 'react-inlinesvg'
+import styled from 'styled-components/macro'
+
+const Wrapper = styled.div<{ isOpen: boolean }>`
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
+  width: 100%;
+  border: 1px solid var(${UI.COLOR_PAPER_DARKER});
+  border-radius: 16px;
+  padding: 9px 10px;
+  height: auto;
+  font-size: 13px;
+`
+
+const Details = styled.div`
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
+  width: 100%;
+`
+
+const Summary = styled.div`
+  display: grid;
+  grid-template-columns: auto 1fr;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  gap: 8px;
+  font-size: inherit;
+`
+
+const SummaryClickable = styled.div`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  font-size: inherit;
+  opacity: 0.7;
+  transition: opacity ${UI.ANIMATION_DURATION_SLOW} ease-in-out;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  // If it's the only child, make it take all the space
+  &:only-child {
+    grid-column: 1 / -1;
+  }
+`
+
+const ToggleIcon = styled.div<{ isOpen: boolean }>`
+  --size: var(${UI.ICON_SIZE_SMALL});
+  transform: ${({ isOpen }) => (isOpen ? 'rotate(180deg)' : 'rotate(0deg)')};
+  transition: transform var(${UI.ANIMATION_DURATION_SLOW}) ease-in-out;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--size);
+  height: var(--size);
+
+  > svg {
+    --size: var(${UI.ICON_SIZE_TINY});
+    width: var(--size);
+    height: var(--size);
+    object-fit: contain;
+    fill: currentColor;
+  }
+`
+
+interface TradeDetailsAccordionProps {
+  rateInfo: React.ReactNode
+  feeSummary?: React.ReactNode // TODO: pass actual CurrencyAmount<Currency> here
+  children?: React.ReactNode
+}
+
+export const TradeDetailsAccordion = ({ rateInfo, feeSummary, children }: TradeDetailsAccordionProps) => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const toggleAccordion = () => {
+    setIsOpen(!isOpen)
+  }
+
+  // Accessibility enhancement: manage focus and aria-expanded attribute
+  const handleKeyDown = (e: { key: string; preventDefault: () => void }) => {
+    if (['Enter', ' ', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
+      e.preventDefault()
+      toggleAccordion()
+    }
+  }
+
+  return (
+    <Wrapper isOpen={isOpen}>
+      <Summary>
+        {rateInfo}
+        <SummaryClickable onClick={toggleAccordion} onKeyDown={handleKeyDown} aria-expanded={isOpen} tabIndex={0}>
+          {!isOpen && feeSummary}
+          <ToggleIcon isOpen={isOpen}>
+            <SVG src={CarretIcon} title={isOpen ? 'Close' : 'Open'} />
+          </ToggleIcon>
+        </SummaryClickable>
+      </Summary>
+      {isOpen && <Details>{children}</Details>}
+    </Wrapper>
+  )
+}
+
+export default TradeDetailsAccordion

--- a/apps/cowswap-frontend/src/legacy/theme/baseTheme.tsx
+++ b/apps/cowswap-frontend/src/legacy/theme/baseTheme.tsx
@@ -517,6 +517,7 @@ export const UniThemedGlobalStyle = css`
     ${UI.ICON_SIZE_NORMAL}: 20px;
     ${UI.ICON_SIZE_SMALL}: 16px;
     ${UI.ICON_SIZE_XSMALL}: 14px;
+    ${UI.ICON_SIZE_TINY}: 10px;
     ${UI.ICON_COLOR_NORMAL}: ${({ theme }) => theme.text};
 
     // Text
@@ -540,6 +541,7 @@ export const UniThemedGlobalStyle = css`
 
     // Animation
     ${UI.ANIMATION_DURATION}: 0.1s;
+    ${UI.ANIMATION_DURATION_SLOW}: 0.2s;
   }
 
   body {

--- a/apps/cowswap-frontend/src/modules/swap/containers/Row/RowFee/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/Row/RowFee/index.tsx
@@ -45,6 +45,8 @@ export interface RowFeeProps extends RowWithShowHelpersProps {
   fee?: CurrencyAmount<Currency>
   feeFiatValue: CurrencyAmount<Token> | null
   allowsOffchainSigning: boolean
+  noLabel?: boolean
+  showFiatOnly?: boolean
 }
 
 function isValidNonZeroAmount(value: string): boolean {
@@ -57,7 +59,15 @@ function isValidNonZeroAmount(value: string): boolean {
   }
 }
 
-export function RowFee({ trade, fee, feeFiatValue, allowsOffchainSigning, showHelpers }: RowFeeProps) {
+export function RowFee({
+  trade,
+  fee,
+  feeFiatValue,
+  allowsOffchainSigning,
+  showHelpers,
+  noLabel,
+  showFiatOnly,
+}: RowFeeProps) {
   const { realizedFee } = useMemo(() => computeTradePriceBreakdown(trade), [trade])
 
   const isEoaEthFlow = useIsEoaEthFlow()
@@ -88,7 +98,10 @@ export function RowFee({ trade, fee, feeFiatValue, allowsOffchainSigning, showHe
     const feeToken = isValidNonZeroAmount(smartFeeTokenValue)
       ? feeAmountWithCurrency
       : `🎉 Free!${isEoaEthFlow ? ' (+ gas)' : ''}`
-    const feeUsd = isValidNonZeroAmount(smartFeeFiatValue) ? smartFeeFiatValue && `(≈$${smartFeeFiatValue})` : ''
+    const feeUsd = isValidNonZeroAmount(smartFeeFiatValue)
+      ? `${showFiatOnly ? '' : '('}≈$${smartFeeFiatValue}${showFiatOnly ? '' : ')'}`
+      : ''
+
     const fullDisplayFee = FractionUtils.fractionLikeToExactString(displayFee) || '-'
 
     return {
@@ -98,8 +111,10 @@ export function RowFee({ trade, fee, feeFiatValue, allowsOffchainSigning, showHe
       fullDisplayFee,
       feeCurrencySymbol,
       tooltip,
+      noLabel,
+      showFiatOnly,
     }
-  }, [fee, feeFiatValue, isEoaEthFlow, realizedFee, showHelpers, tooltip])
+  }, [fee, feeFiatValue, isEoaEthFlow, realizedFee, showHelpers, tooltip, noLabel, showFiatOnly])
 
   return <RowFeeContent {...props} />
 }

--- a/apps/cowswap-frontend/src/modules/swap/containers/TradeBasicDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/TradeBasicDetails/index.tsx
@@ -24,11 +24,12 @@ interface TradeBasicDetailsProp extends BoxProps {
   allowsOffchainSigning: boolean
   trade?: TradeGp
   fee: CurrencyAmount<Currency>
+  fiatFeeOnly?: boolean
   isReviewSwap?: boolean
 }
 
 export function TradeBasicDetails(props: TradeBasicDetailsProp) {
-  const { trade, allowedSlippage, allowsOffchainSigning, fee, isReviewSwap, ...boxProps } = props
+  const { trade, allowedSlippage, allowsOffchainSigning, fee, isReviewSwap, fiatFeeOnly, ...boxProps } = props
   const allowedSlippagePercent = !(allowedSlippage instanceof Percent)
     ? INITIAL_ALLOWED_SLIPPAGE_PERCENT
     : allowedSlippage
@@ -40,6 +41,22 @@ export function TradeBasicDetails(props: TradeBasicDetailsProp) {
   const isWrapOrUnwrap = useIsWrapOrUnwrap()
 
   const isExactIn = trade?.tradeType === TradeType.EXACT_INPUT
+
+  if (fiatFeeOnly) {
+    // Render and return only the fee's fiat value
+    return (
+      <LowerSectionWrapper {...boxProps}>
+        <RowFee
+          fee={fee}
+          feeFiatValue={feeFiatValue}
+          showHelpers={false}
+          noLabel={true}
+          showFiatOnly={true}
+          allowsOffchainSigning={allowsOffchainSigning}
+        />
+      </LowerSectionWrapper>
+    )
+  }
 
   const showRowSlippage =
     (isReviewSwap || isEoaEthFlow || !allowedSlippagePercent.equalTo(INITIAL_ALLOWED_SLIPPAGE_PERCENT)) &&

--- a/apps/cowswap-frontend/src/modules/swap/pure/ReceiveAmount/styled.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/ReceiveAmount/styled.tsx
@@ -12,7 +12,7 @@ export const ReceiveAmountBox = styled.div`
   font-size: 14px;
   font-weight: 600;
   background: var(${UI.COLOR_PAPER});
-  border: 2px solid var(${UI.COLOR_PAPER_DARKER});
+  border: 1px solid var(${UI.COLOR_PAPER_DARKER});
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
     flex-direction: column;

--- a/apps/cowswap-frontend/src/modules/swap/pure/Row/RowFeeContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/Row/RowFeeContent/index.tsx
@@ -15,26 +15,44 @@ export interface RowFeeContentProps extends RowWithShowHelpersProps {
   fullDisplayFee: string
   feeCurrencySymbol: string
   styleProps?: RowStyleProps
+  noLabel?: boolean
+  showFiatOnly?: boolean
 }
 
 export function RowFeeContent(props: RowFeeContentProps) {
   const swapZeroFee = useSwapZeroFee()
-  const { showHelpers, tooltip, feeToken, feeUsd, fullDisplayFee, feeCurrencySymbol, styleProps = {} } = props
+  const {
+    showHelpers,
+    tooltip,
+    feeToken,
+    feeUsd,
+    fullDisplayFee,
+    feeCurrencySymbol,
+    noLabel,
+    showFiatOnly,
+    styleProps = {},
+  } = props
 
   return (
-    <StyledRowBetween {...styleProps}>
-      <RowFixed>
-        <TextWrapper>{swapZeroFee ? 'Est. fees' : 'Fees'}</TextWrapper>
-        {showHelpers && (
-          <MouseoverTooltipContent content={tooltip} wrap>
-            <StyledInfoIcon size={16} />
-          </MouseoverTooltipContent>
-        )}
-      </RowFixed>
+    <StyledRowBetween {...styleProps} alignContentRight={showFiatOnly}>
+      {!noLabel && (
+        <RowFixed>
+          <TextWrapper>{swapZeroFee ? 'Est. fees' : 'Fees'}</TextWrapper>
+          {showHelpers && (
+            <MouseoverTooltipContent content={tooltip} wrap>
+              <StyledInfoIcon size={16} />
+            </MouseoverTooltipContent>
+          )}
+        </RowFixed>
+      )}
 
-      <TextWrapper title={`${fullDisplayFee} ${feeCurrencySymbol}`}>
-        {feeToken} {feeUsd && <FiatRate>{feeUsd}</FiatRate>}
-      </TextWrapper>
+      {showFiatOnly ? (
+        <TextWrapper title={feeToken}>{feeUsd ? feeUsd : feeToken}</TextWrapper>
+      ) : (
+        <TextWrapper title={`${fullDisplayFee} ${feeCurrencySymbol}`}>
+          {feeToken} {feeUsd && <FiatRate>{feeUsd}</FiatRate>}
+        </TextWrapper>
+      )}
     </StyledRowBetween>
   )
 }

--- a/apps/cowswap-frontend/src/modules/swap/pure/Row/styled.ts
+++ b/apps/cowswap-frontend/src/modules/swap/pure/Row/styled.ts
@@ -17,6 +17,9 @@ export const StyledRowBetween = styled(RowBetween)<RowStyleProps>`
   gap: 3px;
   color: inherit;
 
+  // if prop alignContentRight is true, then set justify-content to flex-end
+  justify-content: ${({ alignContentRight }) => (alignContentRight ? 'flex-end' : 'space-between')};
+
   ${RowFixed} {
     gap: 4px;
     min-width: 150px;

--- a/apps/cowswap-frontend/src/modules/swap/pure/Row/types.ts
+++ b/apps/cowswap-frontend/src/modules/swap/pure/Row/types.ts
@@ -1,6 +1,7 @@
 export interface RowStyleProps {
   fontWeight?: number
   fontSize?: number
+  alignContentRight?: boolean
 }
 
 export interface RowWithShowHelpersProps {

--- a/apps/cowswap-frontend/src/modules/swap/pure/TradeRates/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/TradeRates/index.tsx
@@ -9,6 +9,7 @@ import { RowDeadline } from 'modules/swap/containers/Row/RowDeadline'
 import { TradeBasicDetails } from 'modules/swap/containers/TradeBasicDetails'
 
 import { RateInfoParams } from 'common/pure/RateInfo'
+import { TradeDetailsAccordion } from 'common/pure/TradeDetailsAccordion'
 
 import * as styledEl from './styled'
 
@@ -49,36 +50,36 @@ export const TradeRates = React.memo(function (props: TradeRatesProps) {
   const showRowDeadline = !!trade
 
   return (
-    <styledEl.Box>
-      {showPrice && <styledEl.StyledRateInfo label={priceLabel} stylized={true} rateInfoParams={rateInfoParams} />}
-      {/* SLIPPAGE & FEE */}
-      {showTradeBasicDetails && (
-        <TradeBasicDetails
-          allowedSlippage={userAllowedSlippage}
-          allowsOffchainSigning={allowsOffchainSigning}
-          trade={trade}
-          fee={fee}
-          isReviewSwap={isReviewSwap}
-        />
-      )}
+    <TradeDetailsAccordion
+      rateInfo={showPrice && <styledEl.StyledRateInfo noLabel={true} stylized={true} rateInfoParams={rateInfoParams} />}
+      feeSummary={
+        showTradeBasicDetails && (
+          <TradeBasicDetails
+            allowedSlippage={userAllowedSlippage}
+            allowsOffchainSigning={allowsOffchainSigning}
+            trade={trade}
+            fee={fee}
+            fiatFeeOnly={true}
+          />
+        )
+      }
+    >
+      <styledEl.Box>
+        {showPrice && <styledEl.StyledRateInfo label={priceLabel} stylized={true} rateInfoParams={rateInfoParams} />}
 
-      {/* TRANSACTION DEADLINE */}
-      {showRowDeadline && <RowDeadline />}
+        {showTradeBasicDetails && (
+          <TradeBasicDetails
+            allowedSlippage={userAllowedSlippage}
+            allowsOffchainSigning={allowsOffchainSigning}
+            trade={trade}
+            fee={fee}
+            isReviewSwap={isReviewSwap}
+          />
+        )}
 
-      {/* DISCOUNTS */}
-      {/* TODO: Re-enable modal once subsidy is back */}
-      {/*
-      <styledEl.Row>
-        <div>
-          <span>Fees discount</span>
-          <InfoIcon content={SUBSIDY_INFO_MESSAGE_EXTENDED} />
-        </div>
-        <div>
-          <styledEl.Discount onClick={openCowSubsidyModal}>{discount}% discount</styledEl.Discount>
-        </div>
-      </styledEl.Row>
-      */}
-      {children}
-    </styledEl.Box>
+        {showRowDeadline && <RowDeadline />}
+        {children}
+      </styledEl.Box>
+    </TradeDetailsAccordion>
   )
 }, genericPropsChecker)

--- a/apps/cowswap-frontend/src/modules/swap/pure/TradeRates/styled.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/TradeRates/styled.tsx
@@ -8,6 +8,9 @@ import QuestionHelper from 'legacy/components/QuestionHelper'
 import { RateInfo } from 'common/pure/RateInfo'
 
 export const Box = styled.div`
+  display: flex;
+  flex-flow: column wrap;
+  width: 100%;
   margin: 6px 8px;
 `
 

--- a/libs/ui/src/enum.ts
+++ b/libs/ui/src/enum.ts
@@ -91,12 +91,14 @@ export enum UI {
   // Misc
   MODAL_BACKDROP = '--cow-modal-backdrop',
   BORDER_RADIUS_NORMAL = '--cow-border-radius-normal',
+  BORDER_RADIUS_LARGE = '--cow-border-radius-large',
   PADDING_NORMAL = '--cow-padding-normal',
 
   // Icons
   ICON_SIZE_NORMAL = '--cow-icon-size-normal',
   ICON_SIZE_SMALL = '--cow-icon-size-small',
   ICON_SIZE_XSMALL = '--cow-icon-size-xsmall',
+  ICON_SIZE_TINY = '--cow-icon-size-tiny',
   ICON_SIZE_LARGE = '--cow-icon-size-large',
   ICON_COLOR_NORMAL = '--cow-icon-color-normal',
 
@@ -123,4 +125,5 @@ export enum UI {
 
   // Animation
   ANIMATION_DURATION = '--cow-animation-duration',
+  ANIMATION_DURATION_SLOW = '--cow-animation-duration-slow',
 }


### PR DESCRIPTION
# Summary

Adds basic accordion to show the sum of all fees:


<img width="681" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/d301faca-5331-483d-9fe4-9cad0df4a693">


When expanded, it shows the details:

<img width="738" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/a8cd805d-8ce1-4337-bbeb-473482ade20a">


## Not included
Future PRs will include some changes to make this production ready, and the review of tooltips, labels and all flows. 

This is the figma, and future PRs will add for example the Network fee:
https://www.figma.com/file/iPRnzK11XUvcaW6uBti7BE/Fee-display?type=design&node-id=160%3A2112&mode=design&t=spV2KT0KREOVkfaX-1
