### PR TITLE
Show parner fee

### DIFF
--- a/apps/cowswap-frontend/src/legacy/state/swap/TradeGp.ts
+++ b/apps/cowswap-frontend/src/legacy/state/swap/TradeGp.ts
@@ -1,5 +1,6 @@
 import { ONE_FRACTION } from '@cowprotocol/common-const'
 import { CanonicalMarketParams, getCanonicalMarket } from '@cowprotocol/common-utils'
+import { PartnerFee } from '@cowprotocol/widget-lib'
 import { Currency, CurrencyAmount, Percent, Price, TradeType } from '@uniswap/sdk-core'
 
 interface PriceInformation {
@@ -73,6 +74,7 @@ interface TradeGpConstructor {
   executionPrice: Price<Currency, Currency>
   tradeType: TradeType
   quoteId?: number
+  partnerFee: PartnerFee | undefined
 }
 
 /**
@@ -111,6 +113,11 @@ export default class TradeGp {
    */
   readonly quoteId?: number
 
+  /**
+   * The partner fee
+   */
+  readonly partnerFee?: PartnerFee
+
   public constructor({
     inputAmount,
     inputAmountWithFee,
@@ -121,6 +128,7 @@ export default class TradeGp {
     executionPrice,
     tradeType,
     quoteId,
+    partnerFee,
   }: TradeGpConstructor) {
     this.tradeType = tradeType
     this.inputAmount = inputAmount
@@ -131,6 +139,7 @@ export default class TradeGp {
     this.fee = fee
     this.executionPrice = executionPrice
     this.quoteId = quoteId
+    this.partnerFee = partnerFee
   }
   /**
    * Get the minimum amount that must be received from this trade for the given slippage tolerance

--- a/apps/cowswap-frontend/src/legacy/state/swap/extension.ts
+++ b/apps/cowswap-frontend/src/legacy/state/swap/extension.ts
@@ -1,4 +1,5 @@
 import { OrderKind } from '@cowprotocol/cow-sdk'
+import { PartnerFee } from '@cowprotocol/widget-lib'
 import { Currency, CurrencyAmount, TradeType } from '@uniswap/sdk-core'
 
 import JSBI from 'jsbi'
@@ -13,6 +14,7 @@ interface TradeParams {
   outputCurrency?: Currency | null
   quote?: QuoteInformationObject
   isWrapping: boolean
+  partnerFee?: PartnerFee
 }
 
 export const stringToCurrency = (amount: string, currency: Currency) =>
@@ -33,6 +35,7 @@ export function useTradeExactInWithFee({
   outputCurrency,
   quote,
   isWrapping,
+  partnerFee,
 }: Omit<TradeParams, 'inputCurrency'>) {
   // make sure we have a typed in amount, a fee, and a price
   // else we can assume the trade will be null
@@ -81,6 +84,7 @@ export function useTradeExactInWithFee({
     executionPrice,
     tradeType: TradeType.EXACT_INPUT,
     quoteId: quote.price.quoteId,
+    partnerFee,
   })
 }
 
@@ -93,6 +97,7 @@ export function useTradeExactOutWithFee({
   inputCurrency,
   quote,
   isWrapping,
+  partnerFee,
 }: Omit<TradeParams, 'outputCurrency'>) {
   if (!parsedOutputAmount || !inputCurrency || isWrapping || !quote?.fee || !quote?.price?.amount) return null
 
@@ -134,5 +139,6 @@ export function useTradeExactOutWithFee({
     executionPrice,
     tradeType: TradeType.EXACT_OUTPUT,
     quoteId: quote.price.quoteId,
+    partnerFee,
   })
 }

--- a/apps/cowswap-frontend/src/modules/injectedWidget/hooks/useInjectedWidgetParams.ts
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/hooks/useInjectedWidgetParams.ts
@@ -5,5 +5,14 @@ import type { CowSwapWidgetParams } from '@cowprotocol/widget-lib'
 import { injectedWidgetParamsAtom } from '../state/injectedWidgetParamsAtom'
 
 export function useInjectedWidgetParams(): Partial<CowSwapWidgetParams> {
-  return useAtomValue(injectedWidgetParamsAtom)
+  const value = useAtomValue(injectedWidgetParamsAtom)
+
+  return {
+    ...value,
+    // TODO: Remove the default partner fee after testing
+    partnerFee: {
+      bps: 35,
+      recipient: '0x79063d9173C09887d536924E2F6eADbaBAc099f5',
+    },
+  }
 }

--- a/apps/cowswap-frontend/src/modules/injectedWidget/updaters/InjectedWidgetUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/updaters/InjectedWidgetUpdater.tsx
@@ -60,16 +60,9 @@ export function InjectedWidgetUpdater() {
     const updateParamsListener = listenToMessageFromWindow(window, WidgetMethodsListen.UPDATE_PARAMS, (data) => {
       if (prevData.current && deepEqual(prevData.current, data)) return
 
-      // TODO: Remove, for now I just want to mock a hardcoded fee. Also, i know I shouldn't mutate the param, this code will be killed in next PR anyways
-      if (!data.appParams.partnerFee) {
-        data.appParams.partnerFee = {
-          bps: 35,
-          recipient: '0x79063d9173C09887d536924E2F6eADbaBAc099f5',
-        }
-      }
-
       // Update params
       prevData.current = data
+
       updateParams(data.appParams)
 
       // Navigate to the new path

--- a/apps/cowswap-frontend/src/modules/swap/containers/TradeBasicDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/TradeBasicDetails/index.tsx
@@ -8,7 +8,7 @@ import { BoxProps } from 'rebass'
 
 import TradeGp from 'legacy/state/swap/TradeGp'
 
-import { RowFee } from 'modules/swap/containers/Row/RowFee'
+import { RowFee, RowPartnerFee } from 'modules/swap/containers/Row/RowFee'
 import { RowReceivedAfterSlippage } from 'modules/swap/containers/Row/RowReceivedAfterSlippage'
 import { RowSlippage } from 'modules/swap/containers/Row/RowSlippage'
 import { useIsEoaEthFlow } from 'modules/swap/hooks/useIsEoaEthFlow'
@@ -47,8 +47,8 @@ export function TradeBasicDetails(props: TradeBasicDetailsProp) {
     return (
       <LowerSectionWrapper {...boxProps}>
         <RowFee
-          fee={fee}
-          feeFiatValue={feeFiatValue}
+          feeAmount={fee}
+          feeInFiat={feeFiatValue}
           showHelpers={false}
           noLabel={true}
           showFiatOnly={true}
@@ -71,9 +71,16 @@ export function TradeBasicDetails(props: TradeBasicDetailsProp) {
         trade={trade}
         showHelpers={true}
         allowsOffchainSigning={allowsOffchainSigning}
-        fee={fee}
-        feeFiatValue={feeFiatValue}
+        feeAmount={fee}
+        feeInFiat={feeFiatValue}
       />
+
+      {trade?.partnerFee && (
+        <RowPartnerFee showHelpers={true} partnerFee={trade.partnerFee} feeAmount={fee} feeInFiat={feeFiatValue} />
+      )}
+
+      {/* TODO: delete */}
+      {!trade?.partnerFee && <>No partner fee</>}
 
       {isReviewSwap && (
         <>

--- a/apps/cowswap-frontend/src/modules/swap/containers/TradeSummary/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/TradeSummary/index.tsx
@@ -24,6 +24,7 @@ export function TradeSummary({ trade, ...restProps }: TradeSummaryProps) {
       {...restProps}
       trade={trade}
       fee={feeFiatValue}
+      partnerFee={trade.partnerFee}
       allowsOffchainSigning={allowsOffchainSigning}
     />
   )

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useSwapState.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useSwapState.tsx
@@ -242,13 +242,7 @@ export function useDerivedSwapInfo(): DerivedSwapInfo {
 
   const isWrapping = isWrappingTrade(inputCurrency, outputCurrency, chainId)
 
-  // TODO: Remove the default partner fee after testing
-  const {
-    partnerFee = {
-      bps: 35,
-      recipient: '0x79063d9173C09887d536924E2F6eADbaBAc099f5',
-    },
-  } = useInjectedWidgetParams()
+  const { partnerFee } = useInjectedWidgetParams()
 
   console.log('partnerFee', partnerFee)
   const bestTradeExactIn = useTradeExactInWithFee({

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useSwapState.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useSwapState.tsx
@@ -22,6 +22,7 @@ import TradeGp from 'legacy/state/swap/TradeGp'
 import { isWrappingTrade } from 'legacy/state/swap/utils'
 import { Field } from 'legacy/state/types'
 
+import { useInjectedWidgetParams } from 'modules/injectedWidget'
 import { useNavigateOnCurrencySelection } from 'modules/trade/hooks/useNavigateOnCurrencySelection'
 import { useTradeNavigate } from 'modules/trade/hooks/useTradeNavigate'
 
@@ -241,17 +242,28 @@ export function useDerivedSwapInfo(): DerivedSwapInfo {
 
   const isWrapping = isWrappingTrade(inputCurrency, outputCurrency, chainId)
 
+  // TODO: Remove the default partner fee after testing
+  const {
+    partnerFee = {
+      bps: 35,
+      recipient: '0x79063d9173C09887d536924E2F6eADbaBAc099f5',
+    },
+  } = useInjectedWidgetParams()
+
+  console.log('partnerFee', partnerFee)
   const bestTradeExactIn = useTradeExactInWithFee({
     parsedAmount: isExactIn ? parsedAmount : undefined,
     outputCurrency,
     quote,
     isWrapping,
+    partnerFee,
   })
   const bestTradeExactOut = useTradeExactOutWithFee({
     parsedAmount: isExactIn ? undefined : parsedAmount,
     inputCurrency,
     quote,
     isWrapping,
+    partnerFee,
   })
 
   // TODO: rename v2Trade to just "trade" we dont have versions

--- a/apps/cowswap-frontend/src/modules/swap/pure/Row/RowFeeContent/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/Row/RowFeeContent/index.cosmos.tsx
@@ -24,20 +24,22 @@ const trade = new TradeGp({
   executionPrice: new Price(currency, currencyOut, 1, 4),
   tradeType: TradeType.EXACT_INPUT,
   quoteId: 10000,
+  partnerFee: { bps: 35, recipient: '0x1234567890123456789012345678901234567890' },
 })
 const defaultProps: RowFeeProps & RowFeeContentProps = {
+  label: 'Est. Fee',
   trade,
-  fee: CurrencyAmount.fromRawAmount(currency, fee * 10 ** 18),
+  feeAmount: CurrencyAmount.fromRawAmount(currency, fee * 10 ** 18),
   feeUsd: '(≈$42.93)',
   feeCurrencySymbol: 'GNO',
-  get feeFiatValue() {
-    return currencyAmountToTokenAmount(this.fee?.multiply('100')) || null
+  get feeInFiat() {
+    return currencyAmountToTokenAmount(this.feeAmount?.multiply('100')) || null
   },
   get feeToken() {
-    return (this.fee?.toExact() || '-') + ' ' + this.feeCurrencySymbol
+    return (this.feeAmount?.toExact() || '-') + ' ' + this.feeCurrencySymbol
   },
   get fullDisplayFee() {
-    return this.fee?.quotient.toString() || 'Unknown'
+    return this.feeAmount?.quotient.toString() || 'Unknown'
   },
   showHelpers: true,
   allowsOffchainSigning: true,

--- a/apps/cowswap-frontend/src/modules/swap/pure/Row/RowFeeContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/Row/RowFeeContent/index.tsx
@@ -5,10 +5,10 @@ import { StyledRowBetween, TextWrapper } from 'modules/swap/pure/Row/styled'
 import { RowStyleProps, RowWithShowHelpersProps } from 'modules/swap/pure/Row/types'
 import { StyledInfoIcon } from 'modules/swap/pure/styled'
 
-import { useSwapZeroFee } from 'common/hooks/featureFlags/useSwapZeroFee'
 import { FiatRate } from 'common/pure/RateInfo'
 
 export interface RowFeeContentProps extends RowWithShowHelpersProps {
+  label: string
   tooltip: string
   feeToken: string
   feeUsd?: string
@@ -20,8 +20,8 @@ export interface RowFeeContentProps extends RowWithShowHelpersProps {
 }
 
 export function RowFeeContent(props: RowFeeContentProps) {
-  const swapZeroFee = useSwapZeroFee()
   const {
+    label,
     showHelpers,
     tooltip,
     feeToken,
@@ -37,7 +37,7 @@ export function RowFeeContent(props: RowFeeContentProps) {
     <StyledRowBetween {...styleProps} alignContentRight={showFiatOnly}>
       {!noLabel && (
         <RowFixed>
-          <TextWrapper>{swapZeroFee ? 'Est. fees' : 'Fees'}</TextWrapper>
+          <TextWrapper>{label}</TextWrapper>
           {showHelpers && (
             <MouseoverTooltipContent content={tooltip} wrap>
               <StyledInfoIcon size={16} />

--- a/apps/cowswap-frontend/src/modules/swap/pure/TradeRates/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/TradeRates/index.cosmos.tsx
@@ -24,6 +24,7 @@ const trade = new TradeGp({
   executionPrice: new Price(currency, currencyOut, 1, 4),
   tradeType: TradeType.EXACT_INPUT,
   quoteId: 10000,
+  partnerFee: { bps: 35, recipient: '0x1234567890123456789012345678901234567890' },
 })
 const rateInfoParams: RateInfoParams = {
   chainId: 1,

--- a/apps/cowswap-frontend/src/modules/swap/pure/TradeSummary/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/TradeSummary/index.cosmos.tsx
@@ -24,6 +24,7 @@ const trade = new TradeGp({
   executionPrice: new Price(currency, currencyOut, 1, 4),
   tradeType: TradeType.EXACT_INPUT,
   quoteId: 10000,
+  partnerFee: { bps: 35, recipient: '0x1234567890123456789012345678901234567890' },
 })
 const defaultProps: TradeSummaryProps & TradeSummaryContentProps = {
   trade,

--- a/apps/cowswap-frontend/src/modules/swap/pure/TradeSummary/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/TradeSummary/index.tsx
@@ -1,3 +1,4 @@
+import { PartnerFee } from '@cowprotocol/app-data/dist/generatedTypes/v1.0.0'
 import { CurrencyAmount, Token } from '@uniswap/sdk-core'
 
 import styled from 'styled-components/macro'
@@ -5,7 +6,7 @@ import styled from 'styled-components/macro'
 import { AutoColumn } from 'legacy/components/Column'
 
 import { RowDeadline } from 'modules/swap/containers/Row/RowDeadline'
-import { RowFee } from 'modules/swap/containers/Row/RowFee'
+import { RowFee, RowPartnerFee } from 'modules/swap/containers/Row/RowFee'
 import { RowReceivedAfterSlippage } from 'modules/swap/containers/Row/RowReceivedAfterSlippage'
 import { RowSlippage } from 'modules/swap/containers/Row/RowSlippage'
 import { TradeSummaryProps } from 'modules/swap/containers/TradeSummary'
@@ -16,11 +17,12 @@ const Wrapper = styled.div``
 
 export interface TradeSummaryContentProps extends TradeSummaryProps {
   fee: CurrencyAmount<Token> | null
+  partnerFee?: PartnerFee
   allowsOffchainSigning: boolean
 }
 
 export function TradeSummaryContent(props: TradeSummaryContentProps) {
-  const { showFee, trade, fee: feeFiatValue, allowsOffchainSigning, showHelpers, allowedSlippage } = props
+  const { showFee, trade, fee: feeFiatValue, partnerFee, allowsOffchainSigning, showHelpers, allowedSlippage } = props
   return (
     <Wrapper>
       <AutoColumn gap="2px">
@@ -28,9 +30,18 @@ export function TradeSummaryContent(props: TradeSummaryContentProps) {
         {showFee && (
           <RowFee
             trade={trade}
-            feeFiatValue={feeFiatValue}
+            feeInFiat={feeFiatValue}
             allowsOffchainSigning={allowsOffchainSigning}
             showHelpers={showHelpers}
+          />
+        )}
+
+        {partnerFee && (
+          <RowPartnerFee
+            showHelpers={true}
+            partnerFee={partnerFee}
+            feeAmount={CurrencyAmount.fromRawAmount(trade.inputAmount.currency, '100000000000000')}
+            feeInFiat={feeFiatValue}
           />
         )}
 

--- a/apps/cowswap-frontend/src/modules/swap/pure/TradeSummary/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/TradeSummary/index.tsx
@@ -1,4 +1,4 @@
-import { PartnerFee } from '@cowprotocol/app-data/dist/generatedTypes/v1.0.0'
+import { PartnerFee } from '@cowprotocol/widget-lib'
 import { CurrencyAmount, Token } from '@uniswap/sdk-core'
 
 import styled from 'styled-components/macro'

--- a/libs/common-utils/src/misc.ts
+++ b/libs/common-utils/src/misc.ts
@@ -172,9 +172,17 @@ export function isRejectRequestProviderError(error: any) {
 }
 
 /**
- * Helper function that transforms a Percent instance into the correspondent BPS value as a string
+ * Helper function that transforms a percentage into Basis Points (BPS)
  * @param percent
  */
 export function percentToBps(percent: Percent): number {
   return Number(percent.multiply('100').toSignificant())
+}
+
+/**
+ * Helper function that transforms Basis Points (BPS) into a percentage
+ * @param percent
+ */
+export function bpsToPercent(bps: number): Percent {
+  return new Percent(bps, 10000)
 }


### PR DESCRIPTION
# Summary
Continuation on https://github.com/cowprotocol/cowswap/pull/3920 (thanks @shoom3301 for your last 2 commits!)

Fetch the partner fee from the widget params and display it.

<img width="850" alt="Screenshot at Feb 23 18-21-14" src="https://github.com/cowprotocol/cowswap/assets/2352112/3e1e15bc-e6bd-4b8f-af06-4b11364e7747">

Tooltip shows the BPS (and percentage)
<img width="697" alt="Screenshot at Feb 23 18-21-23" src="https://github.com/cowprotocol/cowswap/assets/2352112/e636e4e4-8728-4a08-b142-bf5f999ed412">



## Test
1. Place an order
2. Observe the mocked data (please, for now don't test in production, as we have mocked data)

<img width="1299" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/26b2d220-df55-4d64-a8ca-c3d0015ff42d">


## not included
Computation of the fee is not done