### PR TITLE
chore: don't check US users on Gnosis chain

### DIFF
--- a/libs/tokens/src/updaters/TokensListsUpdater/index.ts
+++ b/libs/tokens/src/updaters/TokensListsUpdater/index.ts
@@ -27,7 +27,7 @@ const swrOptions: SWRConfiguration = {
   revalidateOnFocus: false,
 }
 
-const NETWORKS_WITHOUT_RESTRICTIONS = [SupportedChainId.SEPOLIA]
+const NETWORKS_WITHOUT_RESTRICTIONS = [SupportedChainId.SEPOLIA, SupportedChainId.GNOSIS_CHAIN]
 
 interface TokensListsUpdaterProps {
   chainId: SupportedChainId


### PR DESCRIPTION
# Summary

[The feature](https://github.com/cowprotocol/cowswap/pull/3853) should not work on Gnosis chain since we don't know how to derive Uniswap tokens list tokens on Gnosis chain
