### PR TITLE
fix(limit-orders): price updated warning should not be displayed

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersConfirmModal/index.tsx
@@ -81,6 +81,7 @@ export function LimitOrdersConfirmModal(props: LimitOrdersConfirmModalProps) {
         priceImpact={priceImpact}
         buttonText={buttonText}
         recipient={recipient}
+        isPriceStatic={true}
       >
         <>
           <LimitOrdersDetails

--- a/apps/cowswap-frontend/src/modules/trade/pure/TradeConfirmation/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/TradeConfirmation/index.tsx
@@ -30,6 +30,7 @@ export interface TradeConfirmationProps {
   priceImpact: PriceImpact
   title: JSX.Element | string
   refreshInterval?: number
+  isPriceStatic?: boolean
   recipient: string | null
   buttonText?: React.ReactNode
   children?: JSX.Element
@@ -57,6 +58,7 @@ export function TradeConfirmation(props: TradeConfirmationProps) {
     buttonText = 'Confirm',
     children,
     recipient,
+    isPriceStatic,
   } = frozenProps || props
 
   /**
@@ -128,7 +130,7 @@ export function TradeConfirmation(props: TradeConfirmationProps) {
         {children}
         {/*Banners*/}
         {showRecipientWarning && <CustomRecipientWarningBanner orientation={BannerOrientation.Horizontal} />}
-        {isPriceChanged && <PriceUpdatedBanner onClick={resetPriceChanged} />}
+        {isPriceChanged && !isPriceStatic && <PriceUpdatedBanner onClick={resetPriceChanged} />}
         <ButtonPrimary onClick={handleConfirmClick} disabled={isButtonDisabled} buttonSize={ButtonSize.BIG}>
           {hasPendingTrade ? (
             <LongLoadText fontSize={15} fontWeight={500}>


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C0361CDG8GP/p1708939359762889

Since the last confirmation screen refactoring we got a bug.
"Price Updated" is displayed in Limit orders confirmation screen, but it should not.

  # To Test

1. Initiate a limit order creation (better to use volatile assets)
- [ ] "Price Updated" warning should never be displayed
- [ ]  for Swap or TWAP should work as before
