### PR TITLE
feat(limit): fix price impact on load

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useRateImpact.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useRateImpact.ts
@@ -3,6 +3,8 @@ import { useMemo } from 'react'
 
 import { limitRateAtom } from 'modules/limitOrders/state/limitRateAtom'
 
+const FRACTION_DIGITS = 15
+
 export function useRateImpact(): number {
   const { activeRate, marketRate, isLoading, isLoadingMarketRate } = useAtomValue(limitRateAtom)
 
@@ -12,7 +14,12 @@ export function useRateImpact(): number {
 
     if (noActiveRate || noExecutionRate || isLoading || isLoadingMarketRate) return 0
 
-    const ratePercent = +activeRate.divide(marketRate).multiply(100).subtract(100).toFixed(1)
+    const ar = +activeRate.toFixed(FRACTION_DIGITS)
+    const mr = +marketRate.toFixed(FRACTION_DIGITS)
+    const ratio = ar / mr
+    const percent = ratio * 100 - 100
+
+    const ratePercent = +percent.toFixed(1)
 
     return !ratePercent || !Number.isFinite(ratePercent) || Number.isNaN(ratePercent) ? 0 : ratePercent
   }, [activeRate, marketRate, isLoading, isLoadingMarketRate])

--- a/apps/cowswap-frontend/src/modules/limitOrders/updaters/AlternativeLimitOrderUpdater.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/updaters/AlternativeLimitOrderUpdater.ts
@@ -23,6 +23,7 @@ import { ParsedOrder } from 'utils/orderUtils/parseOrder'
 import { DEFAULT_TRADE_DERIVED_STATE } from '../../trade'
 import { useLimitOrdersDerivedState } from '../hooks/useLimitOrdersDerivedState'
 import { useUpdateActiveRate } from '../hooks/useUpdateActiveRate'
+import { updateLimitRateAtom } from '../state/limitRateAtom'
 
 export function AlternativeLimitOrderUpdater(): null {
   // Update raw state and related settings once on load
@@ -93,6 +94,7 @@ function useUpdateAlternativeRawState(): null {
 
 function useSetAlternativeRate(): null {
   const updateRate = useUpdateActiveRate()
+  const updateLimitRateState = useSetAtom(updateLimitRateAtom)
   const { inputCurrencyAmount, outputCurrencyAmount } = useLimitOrdersDerivedState()
 
   const [hasSetRate, setHasSetRate] = useState(false)
@@ -109,10 +111,14 @@ function useSetAlternativeRate(): null {
     if (!hasSetRate && inputCurrencyAmount && outputCurrencyAmount) {
       setHasSetRate(true)
 
+      // Clear existing market rate
+      updateLimitRateState({ marketRate: null })
+
+      // Set new active rate
       const activeRate = new Price({ baseAmount: inputCurrencyAmount, quoteAmount: outputCurrencyAmount })
       updateRate({ activeRate, isTypedValue: false, isRateFromUrl: false, isAlternativeOrderRate: true })
     }
-  }, [inputCurrencyAmount, hasSetRate, outputCurrencyAmount, updateRate])
+  }, [inputCurrencyAmount, hasSetRate, outputCurrencyAmount, updateRate, updateLimitRateState])
 
   return null
 }


### PR DESCRIPTION
# Summary

Follow up to https://github.com/cowprotocol/cowswap/pull/3845

[Thread](https://cowservices.slack.com/archives/C0361CDG8GP/p1708944696384479?thread_ts=1708711157.372369&cid=C0361CDG8GP) where it was reported.

Price impact is "stuck" on first load of recreate form.

This PR clears it on load.

# To Test

1. Recreate an existing limit order
* Price impact should not start filled
* Price impact should be filled in after quote is loaded