### PR TITLE
fix: increase quote refresh interval for Swap and TWAP

### DIFF
--- a/apps/cowswap-frontend/src/common/updaters/FeesUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/FeesUpdater.ts
@@ -28,7 +28,7 @@ import { getPriceQuality } from 'api/gnosisProtocol/api'
 import { useVerifiedQuotesEnabled } from '../hooks/featureFlags/useVerifiedQuotesEnabled'
 
 export const TYPED_VALUE_DEBOUNCE_TIME = 350
-export const SWAP_QUOTE_CHECK_INTERVAL = ms`10s` // Every 10s
+export const SWAP_QUOTE_CHECK_INTERVAL = ms`30s` // Every 30s
 const RENEW_FEE_QUOTES_BEFORE_EXPIRATION_TIME = ms`30s` // Will renew the quote if there's less than 30 seconds left for the quote to expire
 const WAITING_TIME_BETWEEN_EQUAL_REQUESTS = ms`5s` // Prevents from sending the same request to often (max, every 5s)
 

--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useTradeQuotePolling.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useTradeQuotePolling.ts
@@ -19,8 +19,7 @@ import { useQuoteParams } from './useQuoteParams'
 
 import { tradeQuoteParamsAtom } from '../state/tradeQuoteParamsAtom'
 
-// Every 10s
-export const PRICE_UPDATE_INTERVAL = 10_000
+export const PRICE_UPDATE_INTERVAL = ms`30s`
 const AMOUNT_CHANGE_DEBOUNCE_TIME = ms`300`
 
 // Solves the problem of multiple requests


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C036G0J90BU/p1708361093191469

Just up the refresh interval from 10 to 30 sec.

  # To Test
  
1. Swap page should fetch quote not more often than 30 sec
2. TWAP page should fetch quote not more often than 30 sec
3. The "Quote refresh in ..." on the confirmation modal should tick from 30 sec

![image](https://github.com/cowprotocol/cowswap/assets/7122625/26936dc3-f37e-4792-9c0f-98a482df9d61)

