### PR TITLE
feat(partner-fee): don't use partner fee when feature flag is not enabled

### DIFF
--- a/apps/cowswap-frontend/src/modules/injectedWidget/updaters/InjectedWidgetUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/updaters/InjectedWidgetUpdater.tsx
@@ -9,9 +9,12 @@ import {
   listenToMessageFromWindow,
   postMessageToWindow,
   stopListeningWindowListener,
+  CowSwapWidgetParams,
 } from '@cowprotocol/widget-lib'
 
 import { useNavigate } from 'react-router-dom'
+
+import { useFeatureFlags } from 'common/hooks/featureFlags/useFeatureFlags'
 
 import { IframeResizer } from './IframeResizer'
 
@@ -34,6 +37,12 @@ const cacheMessages = (event: MessageEvent) => {
   messagesCache[method] = event.data
 }
 
+const paramsWithoutPartnerFee = (params: CowSwapWidgetParams) => {
+  delete params.partnerFee
+
+  return params
+}
+
 /**
  * To avoid delays, immediately send an activation message and start listening messages
  */
@@ -48,6 +57,7 @@ const cacheMessages = (event: MessageEvent) => {
 })()
 
 export function InjectedWidgetUpdater() {
+  const { isPartnerFeeEnabled } = useFeatureFlags()
   const [{ errors }, updateParams] = useAtom(injectedWidgetParamsAtom)
   const updateMetaData = useSetAtom(injectedWidgetMetaDataAtom)
 
@@ -65,10 +75,13 @@ export function InjectedWidgetUpdater() {
       // Update params
       prevData.current = data
 
-      const errors = validateWidgetParams(data.appParams)
+      // Ignore partner fee value when feature flag is not enabled
+      const appParams = isPartnerFeeEnabled ? data.appParams : paramsWithoutPartnerFee(data.appParams)
+
+      const errors = validateWidgetParams(appParams)
 
       updateParams({
-        params: data.appParams,
+        params: appParams,
         errors,
       })
 
@@ -93,7 +106,7 @@ export function InjectedWidgetUpdater() {
       stopListeningWindowListener(window, updateParamsListener)
       stopListeningWindowListener(window, updateAppDataListener)
     }
-  }, [updateMetaData, navigate, updateParams])
+  }, [updateMetaData, navigate, updateParams, isPartnerFeeEnabled])
 
   return (
     <>


### PR DESCRIPTION
# Summary

Fixes #3962

Feature flag: https://app.launchdarkly.com/default/production/features/isPartnerFeeEnabled/targeting

  # To Test

1. Disable the feature flag
2. Specify partner fee on the widget configurator side
- [ ] partner fee should not be used in CoW Swap app
3. Enable the feature flag
- [ ] partner fee should not be took into account in CoW Swap app

