### PR TITLE
fix(swap): no quote expired when there's no input

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/helpers/getSwapButtonState.ts
+++ b/apps/cowswap-frontend/src/modules/swap/helpers/getSwapButtonState.ts
@@ -81,6 +81,7 @@ export function getSwapButtonState(input: SwapButtonStateParams): SwapButtonStat
 
   const isValid = !input.inputError && input.feeWarningAccepted && input.impactWarningAccepted
   const swapBlankState = !input.inputError && !input.trade
+  const hasInput = amountsForSignature?.inputAmount.greaterThan(0) || amountsForSignature?.outputAmount.greaterThan(0)
 
   if (quoteError) {
     const quoteErrorState = quoteErrorToSwapButtonState[quoteError]
@@ -108,7 +109,7 @@ export function getSwapButtonState(input: SwapButtonStateParams): SwapButtonStat
     return SwapButtonState.ReadonlyGnosisSafeUser
   }
 
-  if (isQuoteExpired(quote?.fee?.expirationDate) && !swapBlankState) {
+  if (isQuoteExpired(quote?.fee?.expirationDate) && !swapBlankState && hasInput) {
     return SwapButtonState.QuoteExpired
   }
 

--- a/apps/cowswap-frontend/src/modules/swap/helpers/getSwapButtonState.ts
+++ b/apps/cowswap-frontend/src/modules/swap/helpers/getSwapButtonState.ts
@@ -108,7 +108,7 @@ export function getSwapButtonState(input: SwapButtonStateParams): SwapButtonStat
     return SwapButtonState.ReadonlyGnosisSafeUser
   }
 
-  if (isQuoteExpired(quote?.fee?.expirationDate) === true) {
+  if (isQuoteExpired(quote?.fee?.expirationDate) && !swapBlankState) {
     return SwapButtonState.QuoteExpired
   }
 

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
@@ -70,6 +70,14 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
     if (!tradeQuote.response) {
       return TradeFormValidation.QuoteLoading
     }
+
+    if (
+      derivedTradeState.tradeType !== TradeType.LIMIT_ORDER &&
+      !tradeQuote.isLoading &&
+      isQuoteExpired(tradeQuote.response?.expiration)
+    ) {
+      return TradeFormValidation.QuoteExpired
+    }
   }
 
   if (!inputCurrencyBalance) {
@@ -89,15 +97,6 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
       return TradeFormValidation.ApproveAndSwap
     }
     return TradeFormValidation.ApproveRequired
-  }
-
-  if (
-    !isWrapUnwrap &&
-    derivedTradeState.tradeType !== TradeType.LIMIT_ORDER &&
-    !tradeQuote.isLoading &&
-    isQuoteExpired(tradeQuote.response?.expiration) === true
-  ) {
-    return TradeFormValidation.QuoteExpired
   }
 
   return null


### PR DESCRIPTION
# Summary

Fixes #3984

Fixes this bug:

![Screenshot 2024-03-04 at 18 00 13](https://github.com/cowprotocol/cowswap/assets/43217/7ca96887-94db-4552-a4e9-0398b3ac8cfc)

# To Test

1. Place non-ethflow SWAP (just because it's faster)
2. Close modals to get to the empty order form
3. Go to a different tab/window and wait 2+ min
4. Go back to the tab
* Should NOT show `quote expired` message
5. Repeat but this time on step `2`, fill in the exact same sell amount before moving to another tab/window
* Should show `quote expired` message, even if briefly