### PR TITLE
fix(trezor): display correct message for connection error

### DIFF
--- a/libs/wallet/src/web3-react/connectors/TrezorConnector/index.ts
+++ b/libs/wallet/src/web3-react/connectors/TrezorConnector/index.ts
@@ -117,15 +117,15 @@ export class TrezorConnector extends Connector {
   }
 
   private getCurrentAccount(): string {
-    if (!this.accounts) {
-      throw new Error('Cannot load Trezor accounts')
+    if (!this.accounts || this.accounts.length === 0) {
+      throw new Error('Cannot load Trezor accounts. Make sure that the Trezor device is connected.')
     }
 
     const currentAccountIndex = getHwAccount().index
     const account = this.accounts[currentAccountIndex]
 
     if (!account) {
-      throw new Error('Current Trezor account index is out of bounds')
+      throw new Error('Current Trezor account index is out of bounds.')
     }
 
     return account


### PR DESCRIPTION
# Summary

Contexts:
https://cowservices.slack.com/archives/C03NXGFJA2U/p1709619078116629
https://cowservices.slack.com/archives/C0361CDD1FZ/p1709351188180749

The key of the problem in the wrong error message.
Before the fix we displayed "Current Trezor account index is out of bounds." error message in case when we can't connect to Trezor and it confuses people.
Technically, they key of the problem in `getCurrentAccount()` method, it didn't consider a case when `accounts` is an empty array.
After the fix we should display this error:

<img width="684" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/5032dcf2-f76b-45af-a97e-1b289bbff32a">

  # To Test

1. Open CowSwap, don't even connect Trezor device to your computer
2. Try to connect Trezor from the wallets list
- [ ] a new tab with "https://connect.trezor.io/9/popup.html" url must be open
3. Close the newly opened tab
- [ ] AR: "Current Trezor account index is out of bounds." error is displayed
- [ ] ER: "Cannot load Trezor accounts. Make sure that the Trezor device is connected." error is displayed
