### PR TITLE
fix(recreate): add limit to recreate limit order modal title

### DIFF
--- a/apps/cowswap-frontend/src/pages/LimitOrders/AlternativeLimitOrder.tsx
+++ b/apps/cowswap-frontend/src/pages/LimitOrders/AlternativeLimitOrder.tsx
@@ -23,7 +23,7 @@ export function AlternativeLimitOrder() {
 
   return (
     <Wrapper>
-      <NewModal modalMode title={'Recreate order'} onDismiss={onDismiss} maxWidth={MODAL_MAX_WIDTH}>
+      <NewModal modalMode title={'Recreate limit order'} onDismiss={onDismiss} maxWidth={MODAL_MAX_WIDTH}>
         <LimitOrdersWidget />
       </NewModal>
     </Wrapper>

--- a/apps/cowswap-frontend/src/pages/LimitOrders/AlternativeLimitOrder.tsx
+++ b/apps/cowswap-frontend/src/pages/LimitOrders/AlternativeLimitOrder.tsx
@@ -23,7 +23,7 @@ export function AlternativeLimitOrder() {
 
   return (
     <Wrapper>
-      <NewModal modalMode title={'Recreate limit order'} onDismiss={onDismiss} maxWidth={MODAL_MAX_WIDTH}>
+      <NewModal modalMode title="Recreate limit order" onDismiss={onDismiss} maxWidth={MODAL_MAX_WIDTH}>
         <LimitOrdersWidget />
       </NewModal>
     </Wrapper>


### PR DESCRIPTION
# Summary

Fixes #3960 

Right now just hard-coding the order type to the modal, as only LIMIT orders can be recreated

![image](https://github.com/cowprotocol/cowswap/assets/43217/8d53a7fa-e7db-46f2-adf0-d4e629ecf561)

When this is added to more order types we can make it dynamic.

# To Test

1. Open recreate modal
* Title should be: Recreate limit order