### PR TITLE
feat: add standalone/dapp mode to params

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/index.tsx
@@ -14,11 +14,11 @@ import { Wrapper, BalanceText } from './styled'
 
 interface AccountElementProps {
   pendingActivities: string[]
-  isWidgetMode?: boolean
+  standaloneMode?: boolean
   className?: string
 }
 
-export function AccountElement({ className, isWidgetMode, pendingActivities }: AccountElementProps) {
+export function AccountElement({ className, standaloneMode, pendingActivities }: AccountElementProps) {
   const { account, chainId } = useWalletInfo()
   const isChainIdUnsupported = useIsProviderNetworkUnsupported()
   const userEthBalance = useNativeCurrencyAmount(chainId, account)
@@ -27,7 +27,7 @@ export function AccountElement({ className, isWidgetMode, pendingActivities }: A
 
   return (
     <Wrapper className={className} active={!!account} onClick={() => account && toggleAccountModal()}>
-      {!isWidgetMode && account && !isChainIdUnsupported && userEthBalance && chainId && (
+      {standaloneMode && account && !isChainIdUnsupported && userEthBalance && chainId && (
         <BalanceText>
           <TokenAmount amount={userEthBalance} tokenSymbol={{ symbol: nativeToken }} />
         </BalanceText>

--- a/apps/cowswap-frontend/src/legacy/state/application/hooks.ts
+++ b/apps/cowswap-frontend/src/legacy/state/application/hooks.ts
@@ -32,17 +32,17 @@ export function useCloseModal(_modal: ApplicationModal): Command {
 }
 export function useToggleWalletModal(): Command | null {
   const { active } = useWalletInfo()
-  const { hideConnectButton } = useInjectedWidgetParams()
+  const { standaloneMode } = useInjectedWidgetParams()
 
   const toggleWalletModal = useToggleModal(ApplicationModal.WALLET)
 
   return useMemo(() => {
-    if (!active || hideConnectButton) {
+    if (!active || !standaloneMode) {
       return null
     }
 
     return toggleWalletModal
-  }, [hideConnectButton, active, toggleWalletModal])
+  }, [standaloneMode, active, toggleWalletModal])
 }
 
 export function useToggleSettingsMenu(): Command {

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
@@ -96,7 +96,7 @@ export function TradeWidgetForm(props: TradeWidgetProps) {
         <styledEl.Header>
           {isAlternativeOrderModalVisible ? <div></div> : <TradeWidgetLinks isDropdown={isInjectedWidgetMode} />}
           {isInjectedWidgetMode && injectedWidgetParams.standaloneMode && (
-            <AccountElement standaloneMode={injectedWidgetParams.standaloneMode} pendingActivities={pendingActivity} />
+            <AccountElement standaloneMode pendingActivities={pendingActivity} />
           )}
           {!lockScreen && settingsWidget}
         </styledEl.Header>

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
@@ -95,8 +95,8 @@ export function TradeWidgetForm(props: TradeWidgetProps) {
       <styledEl.ContainerBox>
         <styledEl.Header>
           {isAlternativeOrderModalVisible ? <div></div> : <TradeWidgetLinks isDropdown={isInjectedWidgetMode} />}
-          {isInjectedWidgetMode && !injectedWidgetParams.hideConnectButton && (
-            <AccountElement isWidgetMode={isInjectedWidgetMode} pendingActivities={pendingActivity} />
+          {isInjectedWidgetMode && injectedWidgetParams.standaloneMode && (
+            <AccountElement standaloneMode={injectedWidgetParams.standaloneMode} pendingActivities={pendingActivity} />
           )}
           {!lockScreen && settingsWidget}
         </styledEl.Header>

--- a/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
@@ -13,7 +13,7 @@ const getEnv = (): CowSwapWidgetEnv => {
   return 'prod'
 }
 
-export function useWidgetParams(configuratorState: ConfiguratorState, isDappMode: boolean): CowSwapWidgetParams {
+export function useWidgetParams(configuratorState: ConfiguratorState, standaloneMode: boolean): CowSwapWidgetParams {
   return useMemo(() => {
     const {
       chainId,
@@ -60,7 +60,7 @@ export function useWidgetParams(configuratorState: ConfiguratorState, isDappMode
         success: themeColors.success,
       },
 
-      hideConnectButton: isDappMode,
+      standaloneMode,
 
       partnerFee:
         partnerFeeBps > 0
@@ -72,5 +72,5 @@ export function useWidgetParams(configuratorState: ConfiguratorState, isDappMode
     }
 
     return params
-  }, [configuratorState, isDappMode])
+  }, [configuratorState, standaloneMode])
 }

--- a/apps/widget-configurator/src/app/configurator/index.tsx
+++ b/apps/widget-configurator/src/app/configurator/index.tsx
@@ -104,7 +104,7 @@ export function Configurator({ title }: { title: string }) {
   const { mode } = useContext(ColorModeContext)
 
   const [widgetMode, setWidgetMode] = useState<WidgetMode>('dapp')
-  const isDappMode = widgetMode === 'dapp'
+  const standaloneMode = widgetMode === 'standalone'
 
   const selectWidgetMode = (event: ChangeEvent<HTMLInputElement>) => {
     setWidgetMode(event.target.value as WidgetMode)
@@ -181,7 +181,7 @@ export function Configurator({ title }: { title: string }) {
     partnerFeeRecipient,
   }
 
-  const params = useWidgetParams(state, isDappMode)
+  const params = useWidgetParams(state, standaloneMode)
 
   useEffect(() => {
     web3Modal.setThemeMode(mode)
@@ -223,7 +223,7 @@ export function Configurator({ title }: { title: string }) {
             <FormControlLabel value="standalone" control={<Radio />} label="Standalone mode" />
           </RadioGroup>
         </FormControl>
-        {isDappMode && (
+        {standaloneMode && (
           <div style={WalletConnectionWrapper}>
             <w3m-button />
           </div>
@@ -299,7 +299,7 @@ export function Configurator({ title }: { title: string }) {
               handleClose={handleDialogClose}
             />
             <br />
-            <CowSwapWidget params={params} provider={isDappMode ? provider : undefined} listeners={COW_LISTENERS} />
+            <CowSwapWidget params={params} provider={standaloneMode ? provider : undefined} listeners={COW_LISTENERS} />
           </>
         )}
       </Box>

--- a/apps/widget-configurator/src/app/configurator/index.tsx
+++ b/apps/widget-configurator/src/app/configurator/index.tsx
@@ -223,7 +223,7 @@ export function Configurator({ title }: { title: string }) {
             <FormControlLabel value="standalone" control={<Radio />} label="Standalone mode" />
           </RadioGroup>
         </FormControl>
-        {standaloneMode && (
+        {!standaloneMode && (
           <div style={WalletConnectionWrapper}>
             <w3m-button />
           </div>

--- a/libs/widget-lib/src/types.ts
+++ b/libs/widget-lib/src/types.ts
@@ -195,9 +195,13 @@ export interface CowSwapWidgetParams {
   hideNetworkSelector?: boolean
 
   /**
-   * Hides the connect buttons, and the connected account button. Defaults to false.
+   * Defines the widget mode.
+   *  - `true` (standalone mode): The widget is standalone, so it will use its own Ethereum provider. The user can connect from within the widget.
+   *  - `false` (dapp mode): The widget is embedded in a dapp which is responsible of providing the Ethereum provider. Therefore, there won't be a connect button in the widget as this should happen in the host app.
+   *
+   * Defaults to standalone.
    */
-  hideConnectButton?: boolean
+  standaloneMode?: boolean
 
   /**
    * The theme of the widget UI.


### PR DESCRIPTION
# Summary

This PR is just a small improvement on the params to reflect more clearly the two modes of execution. `standalone` and `dapp` 



<img width="490" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/33ade417-ce34-4196-9b72-5dd62f27aae6">

Before, this was decided with a flag that would "hide" the connect button. Before we release the new version of the widget, I preferred to change this to projects choose one of these two methods