### PR TITLE
Rebrand labels and improve tooltips

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/OrderExecutionStatusList/RateTooltipHeader.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderExecutionStatusList/RateTooltipHeader.tsx
@@ -38,7 +38,10 @@ interface RateTooltipHeaderProps {
 export function RateTooltipHeader({ isOpenOrdersTab }: RateTooltipHeaderProps) {
   return (
     <Content>
-      <p>Fees (incl. gas) are covered by filling your order when the market price is better than your limit price.</p>
+      <p>
+        Network costs (incl. gas) are covered by filling your order when the market price is better than your limit
+        price.
+      </p>
 
       {isOpenOrdersTab && (
         <>

--- a/apps/cowswap-frontend/src/legacy/components/SwapWarnings/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/SwapWarnings/index.tsx
@@ -119,17 +119,17 @@ function _getWarningInfo(feePercentage?: Fraction) {
 const HighFeeWarningMessage = ({ feePercentage }: { feePercentage?: Fraction }) => (
   <div>
     <small>
-      Current fees on this network make up{' '}
+      Current network costs make up{' '}
       <u>
         <strong>{feePercentage?.toFixed(2)}%</strong>
       </u>{' '}
       of your swap amount.
       <br />
       <br />
-      Consider waiting for lower fees.
+      Consider waiting for lower network costs.
       <br />
       <br />
-      You may still move forward with this swap but a high percentage of it will be consumed by fees.
+      You may still move forward with this swap but a high percentage of it will be consumed by network costs.
     </small>
   </div>
 )
@@ -158,7 +158,7 @@ export const HighFeeWarning = (props: WarningProps) => {
     <WarningContainer {...props} level={level} isDarkMode={darkMode}>
       <div>
         <AlertTriangle size={24} />
-        Fees exceed {level}% of the swap amount!{' '}
+        Costs exceed {level}% of the swap amount!{' '}
         <MouseoverTooltipContent wrap content={<HighFeeWarningMessage feePercentage={feePercentage} />}>
           <ErrorStyledInfoIcon />
         </MouseoverTooltipContent>{' '}

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/EstimatedExecutionPrice.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/EstimatedExecutionPrice.tsx
@@ -172,7 +172,7 @@ export function UnlikelyToExecuteWarning(props: UnlikelyToExecuteWarningProps) {
         content={
           <styledEl.WarningContent>
             <h3>Order unlikely to execute</h3>
-            For this order, network fees would be <b>{feePercentage?.toFixed(2)}%</b>{' '}
+            For this order, network costs would be <b>{feePercentage?.toFixed(2)}%</b>{' '}
             <b>
               <i>
                 (<TokenAmount amount={feeAmount} round={false} tokenSymbol={feeAmount.currency} />)

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/ReceiptModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/ReceiptModal/index.tsx
@@ -225,7 +225,7 @@ export function ReceiptModal({
             {(!twapOrder || isTwapPartOrder) && (
               <>
                 <styledEl.Field>
-                  <FieldLabel label="Fee" tooltip={tooltips.NETWORK_COSTS} />
+                  <FieldLabel label="Network costs" tooltip={tooltips.NETWORK_COSTS} />
                   <FeeField order={order} />
                 </styledEl.Field>
               </>

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/ReceiptModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/ReceiptModal/index.tsx
@@ -60,9 +60,9 @@ const FILLED_COMMON_TOOLTIP = 'How much of the order has been filled.'
 
 const tooltips: { [key: string]: string | JSX.Element } = {
   LIMIT_PRICE: 'You will receive this price or better for your tokens.',
-  EXECUTION_PRICE: 'An order’s actual execution price will vary based on the market price and network fees.',
+  EXECUTION_PRICE: 'An order’s actual execution price will vary based on the market price and network costs.',
   EXECUTES_AT:
-    'Fees (incl. gas) are covered by filling your order when the market price is better than your limit price.',
+    'Network costs (incl. gas) are covered by filling your order when the market price is better than your limit price.',
   FILLED_TWAP: FILLED_COMMON_TOOLTIP,
   FILLED: (
     <span>
@@ -73,7 +73,8 @@ const tooltips: { [key: string]: string | JSX.Element } = {
     </span>
   ),
   SURPLUS: 'The amount of extra tokens you get on top of your limit price.',
-  FEE: 'CoW Protocol covers the fees by executing your order at a slightly better price than your limit price.',
+  NETWORK_COSTS:
+    'CoW Protocol covers the costs by executing your order at a slightly better price than your limit price.',
   CREATED: 'Your order was created on this date & time. It will remain open until it expires or is filled.',
   RECEIVER: 'The account address which will/did receive the bought amount.',
   EXPIRY:
@@ -224,7 +225,7 @@ export function ReceiptModal({
             {(!twapOrder || isTwapPartOrder) && (
               <>
                 <styledEl.Field>
-                  <FieldLabel label="Fee" tooltip={tooltips.FEE} />
+                  <FieldLabel label="Fee" tooltip={tooltips.NETWORK_COSTS} />
                   <FeeField order={order} />
                 </styledEl.Field>
               </>

--- a/apps/cowswap-frontend/src/modules/swap/containers/Row/RowFee/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/Row/RowFee/index.tsx
@@ -12,8 +12,14 @@ import { RowFeeContent } from 'modules/swap/pure/Row/RowFeeContent'
 
 import useNativeCurrency from 'lib/hooks/useNativeCurrency'
 
-export const GASLESS_FEE_TOOLTIP_MSG =
-  'On CoW Swap you sign your order (hence no gas costs!). The fees are covering your gas costs already.'
+export const GASLESS_FEE_TOOLTIP_MSG = (
+  <>
+    This covers the cost of executing your trade, including gas and any LP fees.
+    <br />
+    <br />
+    CoW Swap will try to lower this cost when possible
+  </>
+)
 
 export const PRESIGN_FEE_TOOLTIP_MSG =
   'These fees cover the gas costs for executing the order once it has been placed. However - since you are using a smart contract wallet - you will need to pay the gas for signing an on-chain tx in order to place it.'
@@ -76,7 +82,7 @@ export function RowFee({ trade, feeAmount, feeInFiat, allowsOffchainSigning, noL
   // trades are null when there is a fee quote error e.g
   // so we can take both
   const props = useMemo(() => {
-    const label = 'Est. fees'
+    const label = 'Network costs (est.)'
     const displayFee = realizedFee || feeAmount
     const feeCurrencySymbol = displayFee?.currency.symbol || '-'
     // TODO: delegate formatting to the view layer
@@ -125,14 +131,19 @@ export function RowPartnerFee({ partnerFee, feeAmount, feeInFiat }: PartnerRowPa
     const { bps } = partnerFee
 
     return {
-      label: 'Partner fee',
+      label: 'Total fee',
       feeToken: feeAmountWithCurrency,
       feeUsd,
       fullDisplayFee,
       feeCurrencySymbol,
-      tooltip: `Partner fee of ${bps} BPS (${formatPercent(
-        bpsToPercent(bps)
-      )}%). Applied only if the trade is executed.`,
+      tooltip: (
+        <>
+          This fee helps pay for maintenance & improvements to the swap experience.
+          <br />
+          <br />
+          The fee is {bps} BPS (${formatPercent(bpsToPercent(bps))}%), applied only if the trade is executed.
+        </>
+      ),
     }
   }, [partnerFee, feeAmount, feeInFiat])
 

--- a/apps/cowswap-frontend/src/modules/swap/containers/Row/RowFee/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/Row/RowFee/index.tsx
@@ -55,7 +55,7 @@ export const getTooltipPartnerFee = (bps: number) => (
     This fee helps pay for maintenance & improvements to the swap experience.
     <br />
     <br />
-    The fee is {bps} BPS (${formatPercent(bpsToPercent(bps))}%), applied only if the trade is executed.
+    The fee is {bps} BPS ({formatPercent(bpsToPercent(bps))}%), applied only if the trade is executed.
   </>
 )
 

--- a/apps/cowswap-frontend/src/modules/swap/containers/Row/RowFee/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/Row/RowFee/index.tsx
@@ -22,7 +22,7 @@ export const tooltipNetworkCosts = (props: { isPresign: boolean; ethFlow: boolea
   return (
     <>
       This is the cost of settling your order on-chain
-      {!requireGas && ', including gas and any LP fees.'}.
+      {!requireGas && ', including gas and any LP fees'}.
       <br />
       <br />
       CoW Swap will try to lower this cost where possible.

--- a/apps/cowswap-frontend/src/modules/swap/containers/Row/RowFee/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/Row/RowFee/index.tsx
@@ -15,7 +15,7 @@ import { RowFeeContent } from 'modules/swap/pure/Row/RowFeeContent'
 
 import useNativeCurrency from 'lib/hooks/useNativeCurrency'
 
-export const getTooltipNetworkCosts = (props: { isPresign: boolean; ethFlow: boolean; nativeSymbol?: string }) => {
+export const tooltipNetworkCosts = (props: { isPresign: boolean; ethFlow: boolean; nativeSymbol?: string }) => {
   const { isPresign, ethFlow, nativeSymbol = 'a native currency' } = props
   const requireGas = isPresign || ethFlow
 
@@ -43,14 +43,14 @@ export const PlusGas = styled.span`
   font-weight: 400;
 `
 
-const getLabelPlusGas = (label: string, plusGas?: boolean) => (
+const labelWithPlusGas = (label: string, plusGas?: boolean) => (
   <>
     {label}
     {plusGas && <PlusGas>&nbsp;+ gas</PlusGas>}
   </>
 )
 
-export const getTooltipPartnerFee = (bps: number) => (
+export const tooltipPartnerFee = (bps: number) => (
   <>
     This fee helps pay for maintenance & improvements to the swap experience.
     <br />
@@ -106,7 +106,7 @@ export function RowNetworkCosts({ trade, feeAmount, feeInFiat, allowsOffchainSig
   const isPresign = !isEoaEthFlow && !allowsOffchainSigning
   const props = useMemo(() => {
     const label = 'Network costs (est.)'
-    const tooltip = getTooltipNetworkCosts({
+    const tooltip = tooltipNetworkCosts({
       ethFlow: isEoaEthFlow,
       isPresign,
       nativeSymbol: native.symbol,
@@ -121,7 +121,7 @@ export function RowNetworkCosts({ trade, feeAmount, feeInFiat, allowsOffchainSig
     const isFree = !isValidNonZeroAmount(displayFeeFormatted)
 
     const requireGas = isEoaEthFlow || isPresign
-    const feeToken = getLabelPlusGas(isFree ? 'FREE' : '≈ ' + feeAmountWithCurrency, requireGas)
+    const feeToken = labelWithPlusGas(isFree ? 'FREE' : '≈ ' + feeAmountWithCurrency, requireGas)
     const feeUsd = isValidNonZeroAmount(feeInFiatFormatted) ? `(≈$${feeInFiatFormatted})` : ''
 
     const fullDisplayFee = FractionUtils.fractionLikeToExactString(displayFee) || '-'
@@ -166,7 +166,7 @@ export function RowPartnerFee({ partnerFee, feeAmount, feeInFiat }: PartnerRowPa
       fullDisplayFee,
       feeCurrencySymbol,
       isFree,
-      tooltip: isFree ? TOOLTIP_PARTNER_FEE_FREE : getTooltipPartnerFee(bps),
+      tooltip: isFree ? TOOLTIP_PARTNER_FEE_FREE : tooltipPartnerFee(bps),
     }
   }, [partnerFee, feeAmount, feeInFiat])
 

--- a/apps/cowswap-frontend/src/modules/swap/containers/Row/RowReceivedAfterSlippage/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/Row/RowReceivedAfterSlippage/index.tsx
@@ -42,9 +42,9 @@ export function RowReceivedAfterSlippage({
         {children || (
           <TextWrapper>
             {trade.tradeType === TradeType.EXACT_INPUT ? (
-              <Trans>Minimum received (incl. fee)</Trans>
+              <Trans>Minimum received (incl. costs)</Trans>
             ) : (
-              <Trans>Maximum sent (incl. fee)</Trans>
+              <Trans>Maximum sent (incl. costs)</Trans>
             )}
           </TextWrapper>
         )}

--- a/apps/cowswap-frontend/src/modules/swap/containers/TradeBasicDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/TradeBasicDetails/index.tsx
@@ -8,7 +8,7 @@ import { BoxProps } from 'rebass'
 
 import TradeGp from 'legacy/state/swap/TradeGp'
 
-import { RowFee, RowPartnerFee } from 'modules/swap/containers/Row/RowFee'
+import { RowNetworkCosts, RowPartnerFee } from 'modules/swap/containers/Row/RowFee'
 import { RowReceivedAfterSlippage } from 'modules/swap/containers/Row/RowReceivedAfterSlippage'
 import { RowSlippage } from 'modules/swap/containers/Row/RowSlippage'
 import { useIsEoaEthFlow } from 'modules/swap/hooks/useIsEoaEthFlow'
@@ -52,16 +52,22 @@ export function TradeBasicDetails(props: TradeBasicDetailsProp) {
 
   return (
     <LowerSectionWrapper {...boxProps}>
-      {/* Fees */}
-      <RowFee trade={trade} allowsOffchainSigning={allowsOffchainSigning} feeAmount={fee} feeInFiat={feeFiatValue} />
-
-      {trade?.partnerFeeAmount && trade.partnerFee && (
+      {/* Fee (partnerFee) */}
+      {trade && (
         <RowPartnerFee
           partnerFee={trade.partnerFee}
           feeAmount={trade.partnerFeeAmount}
           feeInFiat={partnerFeeFiatValue}
         />
       )}
+
+      {/* Network costs */}
+      <RowNetworkCosts
+        trade={trade}
+        allowsOffchainSigning={allowsOffchainSigning}
+        feeAmount={fee}
+        feeInFiat={feeFiatValue}
+      />
 
       {isReviewSwap && (
         <>

--- a/apps/cowswap-frontend/src/modules/swap/pure/EthFlow/EthFlowBanner/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/EthFlow/EthFlowBanner/index.tsx
@@ -58,7 +58,7 @@ export function EthFlowBannerContent(props: EthFlowBannerContentProps) {
               This way, you&apos;ll take advantage of:
             </p>
             <ul>
-              <li>Lower overall fees</li>
+              <li>Lower overall network costs</li>
               <li>
                 Lower default slippage (instead of {MINIMUM_ETH_FLOW_SLIPPAGE.toSignificant(PERCENTAGE_PRECISION)}%
                 minimum)

--- a/apps/cowswap-frontend/src/modules/swap/pure/ReceiveAmount/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/ReceiveAmount/index.tsx
@@ -24,7 +24,7 @@ export function ReceiveAmount(props: ReceiveAmountProps) {
     <styledEl.ReceiveAmountBox>
       <div>
         <span>
-          <Trans>{type === 'from' ? 'From (incl. fee)' : 'Receive (incl. fee)'}</Trans>
+          <Trans>{type === 'from' ? 'From (incl. costs)' : 'Receive (incl. costs)'}</Trans>
         </span>
 
         <styledEl.QuestionHelperWrapped text={<ReceiveAmountInfoTooltip {...props} />} />

--- a/apps/cowswap-frontend/src/modules/swap/pure/ReceiveAmountInfo/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/ReceiveAmountInfo/index.tsx
@@ -39,13 +39,16 @@ export function ReceiveAmountInfoTooltip(props: ReceiveAmountInfoTooltipProps) {
   const { discount } = subsidy
 
   const typeString = type === 'from' ? '+' : '-'
-  const hasFee = feeAmountRaw && feeAmountRaw.greaterThan(0)
-  const hasPartnerFee = partnerFeeAmountRaw && partnerFeeAmountRaw.greaterThan(0)
+  const hasPartnerFee = !!partnerFeeAmountRaw && partnerFeeAmountRaw.greaterThan(0)
+  const hasNetworkFee = !!feeAmountRaw && feeAmountRaw.greaterThan(0)
+  const hasFee = hasNetworkFee || hasPartnerFee
+
+  const isEoaNotEthFlow = allowsOffchainSigning && !isEoaEthFlow
 
   const FeePercent = (
     <span>
       <Trans>Network costs</Trans>
-      {hasFee && discount ? ` [-${discount}%]` : ''}
+      {hasNetworkFee && discount ? ` [-${discount}%]` : ''}
     </span>
   )
 
@@ -74,25 +77,23 @@ export function ReceiveAmountInfoTooltip(props: ReceiveAmountInfoTooltipProps) {
           </styledEl.GreenText>
         )}
       </div>
-      {hasPartnerFee && (
-        <div>
-          <Trans>Partner fee</Trans>
-          <span>
-            {typeString}
-            {partnerFeeAmount} {<TokenSymbol token={currency} length={MAX_TOKEN_SYMBOL_LENGTH} />}
-          </span>
-        </div>
-      )}
-      {allowsOffchainSigning && !isEoaEthFlow && (
+      {(isEoaNotEthFlow || hasPartnerFee) && (
         <div>
           <span>
             <Trans>Fee</Trans>
           </span>
-          <styledEl.GreenText>
-            <strong>
-              <Trans>Free</Trans>
-            </strong>
-          </styledEl.GreenText>
+          {hasPartnerFee ? (
+            <span>
+              {typeString}
+              {partnerFeeAmount} {<TokenSymbol token={currency} length={MAX_TOKEN_SYMBOL_LENGTH} />}
+            </span>
+          ) : (
+            <styledEl.GreenText>
+              <strong>
+                <Trans>Free</Trans>
+              </strong>
+            </styledEl.GreenText>
+          )}
         </div>
       )}
       {amountAfterFeesRaw.greaterThan(0) && (

--- a/apps/cowswap-frontend/src/modules/swap/pure/ReceiveAmountInfo/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/ReceiveAmountInfo/index.tsx
@@ -44,7 +44,7 @@ export function ReceiveAmountInfoTooltip(props: ReceiveAmountInfoTooltipProps) {
 
   const FeePercent = (
     <span>
-      <Trans>Fee</Trans>
+      <Trans>Network costs</Trans>
       {hasFee && discount ? ` [-${discount}%]` : ''}
     </span>
   )
@@ -53,7 +53,7 @@ export function ReceiveAmountInfoTooltip(props: ReceiveAmountInfoTooltipProps) {
     <styledEl.Box>
       <div>
         <span>
-          <Trans>Before fee</Trans>
+          <Trans>Before costs</Trans>
         </span>
         <span>
           {amountBeforeFees} {<TokenSymbol token={currency} length={MAX_TOKEN_SYMBOL_LENGTH} />}
@@ -86,7 +86,7 @@ export function ReceiveAmountInfoTooltip(props: ReceiveAmountInfoTooltipProps) {
       {allowsOffchainSigning && !isEoaEthFlow && (
         <div>
           <span>
-            <Trans>Gas cost</Trans>
+            <Trans>Fee</Trans>
           </span>
           <styledEl.GreenText>
             <strong>

--- a/apps/cowswap-frontend/src/modules/swap/pure/Row/RowFeeContent/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/Row/RowFeeContent/index.cosmos.tsx
@@ -38,6 +38,7 @@ const defaultProps: RowNetworkCostsProps & RowFeeContentProps = {
   feeAmount: CurrencyAmount.fromRawAmount(currency, fee * 10 ** 18),
   feeUsd: '(≈$42.93)',
   feeCurrencySymbol: 'GNO',
+  isFree: false,
   get feeInFiat() {
     return currencyAmountToTokenAmount(this.feeAmount?.multiply('100')) || null
   },

--- a/apps/cowswap-frontend/src/modules/swap/pure/Row/RowFeeContent/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/Row/RowFeeContent/index.cosmos.tsx
@@ -5,7 +5,7 @@ import { CurrencyAmount, Price, TradeType } from '@uniswap/sdk-core'
 
 import TradeGp from 'legacy/state/swap/TradeGp'
 
-import { RowFeeProps } from 'modules/swap/containers/Row/RowFee'
+import { RowNetworkCostsProps } from 'modules/swap/containers/Row/RowFee'
 import { RowFeeContent, RowFeeContentProps } from 'modules/swap/pure/Row/RowFeeContent'
 
 const currency = COW[SupportedChainId.MAINNET]
@@ -26,12 +26,13 @@ const trade = new TradeGp({
     feeAsCurrency: CurrencyAmount.fromRawAmount(currency, 3 * 10 ** 18),
     amount: '50',
     expirationDate: new Date().toISOString(),
-  },executionPrice: new Price(currency, currencyOut, 1, 4),
+  },
+  executionPrice: new Price(currency, currencyOut, 1, 4),
   tradeType: TradeType.EXACT_INPUT,
   quoteId: 10000,
   partnerFee: { bps: 35, recipient: '0x1234567890123456789012345678901234567890' },
 })
-const defaultProps: RowFeeProps & RowFeeContentProps = {
+const defaultProps: RowNetworkCostsProps & RowFeeContentProps = {
   label: 'Est. Fee',
   trade,
   feeAmount: CurrencyAmount.fromRawAmount(currency, fee * 10 ** 18),

--- a/apps/cowswap-frontend/src/modules/swap/pure/Row/RowFeeContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/Row/RowFeeContent/index.tsx
@@ -18,10 +18,21 @@ export interface RowFeeContentProps {
   feeCurrencySymbol: string
   styleProps?: RowStyleProps
   noLabel?: boolean
+  isFree: boolean
 }
 
 export function RowFeeContent(props: RowFeeContentProps) {
-  const { label, tooltip, feeToken, feeUsd, fullDisplayFee, feeCurrencySymbol, noLabel, styleProps = {} } = props
+  const {
+    label,
+    tooltip,
+    isFree,
+    feeToken,
+    feeUsd,
+    fullDisplayFee,
+    feeCurrencySymbol,
+    noLabel,
+    styleProps = {},
+  } = props
 
   return (
     <StyledRowBetween {...styleProps}>
@@ -34,7 +45,7 @@ export function RowFeeContent(props: RowFeeContentProps) {
         </RowFixed>
       )}
 
-      <TextWrapper title={`${fullDisplayFee} ${feeCurrencySymbol}`}>
+      <TextWrapper title={`${fullDisplayFee} ${feeCurrencySymbol}`} success={isFree}>
         {feeToken} {feeUsd && <FiatRate>{feeUsd}</FiatRate>}
       </TextWrapper>
     </StyledRowBetween>

--- a/apps/cowswap-frontend/src/modules/swap/pure/Row/RowFeeContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/Row/RowFeeContent/index.tsx
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react'
+
 import { RowFixed } from '@cowprotocol/ui'
 import { MouseoverTooltipContent } from '@cowprotocol/ui'
 
@@ -9,7 +11,7 @@ import { FiatRate } from 'common/pure/RateInfo'
 
 export interface RowFeeContentProps {
   label: string
-  tooltip: string
+  tooltip: ReactNode
   feeToken: string
   feeUsd?: string
   fullDisplayFee: string

--- a/apps/cowswap-frontend/src/modules/swap/pure/Row/RowFeeContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/Row/RowFeeContent/index.tsx
@@ -12,7 +12,7 @@ import { FiatRate } from 'common/pure/RateInfo'
 export interface RowFeeContentProps {
   label: string
   tooltip: ReactNode
-  feeToken: string
+  feeToken: ReactNode
   feeUsd?: string
   fullDisplayFee: string
   feeCurrencySymbol: string

--- a/apps/cowswap-frontend/src/modules/swap/pure/Row/styled.ts
+++ b/apps/cowswap-frontend/src/modules/swap/pure/Row/styled.ts
@@ -31,8 +31,6 @@ export const StyledRowBetween = styled(RowBetween)<RowStyleProps>`
   }
 
   ${TextWrapper} {
-    // ${(success) => (success ? 'color: red !important;' : '')}
-
     font-size: ${({ fontSize = 13 }) => fontSize}px;
     font-weight: ${({ fontWeight = 500 }) => fontWeight};
     transition: opacity var(${UI.ANIMATION_DURATION}) ease-in-out;

--- a/apps/cowswap-frontend/src/modules/swap/pure/Row/styled.ts
+++ b/apps/cowswap-frontend/src/modules/swap/pure/Row/styled.ts
@@ -8,8 +8,9 @@ import styled from 'styled-components/macro'
 import { RowStyleProps } from './types'
 
 const StyledMouseoverTooltipContent = styled(MouseoverTooltipContent)``
-
-export const TextWrapper = styled(Text)``
+export const TextWrapper = styled(Text)<{ success?: boolean }>`
+  ${({ success }) => (success ? `color: var(${UI.COLOR_GREEN}) !important;` : 'color: inherit;')}
+`
 
 export const StyledRowBetween = styled(RowBetween)<RowStyleProps>`
   flex-flow: row wrap;
@@ -30,7 +31,8 @@ export const StyledRowBetween = styled(RowBetween)<RowStyleProps>`
   }
 
   ${TextWrapper} {
-    color: inherit;
+    // ${(success) => (success ? 'color: red !important;' : '')}
+
     font-size: ${({ fontSize = 13 }) => fontSize}px;
     font-weight: ${({ fontWeight = 500 }) => fontWeight};
     transition: opacity var(${UI.ANIMATION_DURATION}) ease-in-out;

--- a/apps/cowswap-frontend/src/modules/swap/pure/SwapButtons/styled.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/SwapButtons/styled.tsx
@@ -23,7 +23,7 @@ export function FeesExceedFromAmountMessage() {
     <RowBetween>
       <ButtonError buttonSize={ButtonSize.BIG} error id="swap-button" disabled>
         <Text fontSize={20} fontWeight={500}>
-          Fees exceed from amount
+          Costs exceed from amount
         </Text>
       </ButtonError>
     </RowBetween>

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeBasicConfirmDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeBasicConfirmDetails/index.tsx
@@ -39,7 +39,7 @@ export function TradeBasicConfirmDetails(props: Props) {
   const { inputCurrencyAmount } = rateInfoParams
 
   const priceLabel = additionalProps?.priceLabel || 'Price'
-  const minReceivedLabel = additionalProps?.minReceivedLabel || 'Min received (incl. fee)'
+  const minReceivedLabel = additionalProps?.minReceivedLabel || 'Min received (incl. costs)'
   const minReceivedTooltip = additionalProps?.minReceivedTooltip || 'This is the minimum amount that you will receive.'
 
   const minReceivedUsdAmount = useUsdAmount(minReceiveAmount).value

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/index.tsx
@@ -98,7 +98,7 @@ export function TwapConfirmModal() {
             isInvertedState={isInvertedState}
             slippage={slippage}
             additionalProps={{
-              priceLabel: 'Rate (incl. fee)',
+              priceLabel: 'Rate (incl. costs)',
               slippageLabel: 'Price protection',
               slippageTooltip: (
                 <>

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/warnings/SwapPriceDifferenceWarning.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/warnings/SwapPriceDifferenceWarning.tsx
@@ -62,7 +62,7 @@ export function SwapPriceDifferenceWarning({
         <>
           <strong>Trade Smart, Save More!</strong>
           <p>
-            Considering current market fees (
+            Considering current network costs (
             <b>
               <FiatAmount amount={feeFiatAmount} />
             </b>{' '}

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWidget/tooltips.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWidget/tooltips.tsx
@@ -71,7 +71,7 @@ export const LABELS_TOOLTIPS: LabelTooltipItems = {
     ),
   },
   price: {
-    label: 'Rate (incl. fee)',
+    label: 'Rate (incl. costs)',
     tooltip: 'This is the current market price, including the fee.',
   },
   sellAmount: {

--- a/apps/cowswap-frontend/src/pages/Faq/TradingFaq.tsx
+++ b/apps/cowswap-frontend/src/pages/Faq/TradingFaq.tsx
@@ -125,8 +125,8 @@ export default function TokenFaq() {
               on-chain cancellation. For more information, check the Smart Contract implementation.
             </p>
 
-            <h3 id="why-does-the-ui-dapp-have-a-warning-fees-exceed-from-amount">
-              Why does the UI dapp have a warning &ldquo;Fees exceed From amount&rdquo;?
+            <h3 id="why-does-the-ui-dapp-have-a-warning-costs-exceed-from-amount">
+              Why does the UI dapp have a warning &ldquo;Costs exceed From amount&rdquo;?
             </h3>
 
             <p>

--- a/libs/ui/src/pure/InlineBanner/banners.tsx
+++ b/libs/ui/src/pure/InlineBanner/banners.tsx
@@ -76,7 +76,7 @@ export function SmallVolumeWarningBanner({ feePercentage, feeAmount }: SmallVolu
     <InlineBanner iconSize={32}>
       <strong>Small orders are unlikely to be executed</strong>
       <p>
-        For this order, network fees would be{' '}
+        For this order, network costs would be{' '}
         <b>
           {feePercentage?.toFixed(2)}% (
           <TokenAmount amount={feeAmount} tokenSymbol={feeAmount?.currency} />)


### PR DESCRIPTION
# Summary

Rebrand all the fee concepts as described in #3974

Adapt labels, values and tooltips for
- [x] Normal Flow
- [x] Eth Flow
- [x] Presign flow
- [x] Widget with partner fee
- [x] Widget without partner fee


## For CoW Swap
It will show 2 concepts:
- Fee: which should always be FREE as there's not protocol fee
- Total costs (the fee used for settlement) --> depending on the flow will show different information. See the TEST instructions

<img width="599" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/160bdfe5-9921-4673-a3ff-5b767cae99e0">

## For the Widget (if the widget adds a partner fee)
It will show 2 concepts:
- Total fee (the partner fee, if it has one)
- Total costs (the fee used for settlement) --> depending on the flow will show different information. See the TEST instructions


<img width="1588" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/3cb052de-964a-46b2-8645-0d2393dbe509">


# Test

To review the label and tooltips in the following flows:

- ETH Flow: Just sell ETH or xDAI - [URL](https://swap-dev-git-fee-labels-cowswap.vercel.app/#/1/swap/WETH)
- Presign Flow: Use the Safe App- [URL](https://swap-dev-git-fee-labels-cowswap.vercel.app/#/1/swap/WETH)
- Normal Flow: Sell WETH- [URL](https://swap-dev-git-fee-labels-cowswap.vercel.app/#/1/swap/WETH)
- Gass-less approval flow: Pick a permittable token you don't have the approval for yet. Select it as sell token - [URL](https://swap-dev-git-fee-labels-cowswap.vercel.app/#/1/swap/WETH)
- Widget mode with `partnerFee` : Use configurator, pick a partner fee greater than 0 - [URL]( https://widget-configurator-git-fee-labels-cowswap.vercel.app/)
- Widget mode without `partnerFee` : Use configurator, pick a partner fee equal to 0 - [URL]( https://widget-configurator-git-fee-labels-cowswap.vercel.app/)

Make sure the Fee is correct:
- always shows `FREE` in CoW Swap
- shows `FREE` in the widget, if there's no partner fee
- shows a non zero `Total fee` for the widget when `partnerFee`

Make sure the Network Costs is correct.
- If using an EOA and normal tokens: shows the costs (our good old fee)
- If presign/eth flow, will include the +GAS label to show the fee don't include posting the order
- Tooltips are coherent and understandable, and explains the current flow


