### PR TITLE
chore: fix fee warning calculations

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/hooks/useSwapState.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useSwapState.tsx
@@ -129,8 +129,7 @@ export function useHighFeeWarning(trade?: TradeGp) {
 
     const totalFeeAmount = partnerFeeAmount ? feeAsCurrency.add(partnerFeeAmount) : feeAsCurrency
     const targetAmount = isExactInput ? outputAmountWithoutFee : inputAmountAfterFees
-    const feePercentageRaw = totalFeeAmount.divide(targetAmount).asFraction
-    const feePercentage = isExactInput ? feePercentageRaw.multiply(100) : feePercentageRaw.subtract(100).multiply(-1)
+    const feePercentage = totalFeeAmount.divide(targetAmount).multiply(100).asFraction
 
     return [feePercentage.greaterThan(FEE_SIZE_THRESHOLD), feePercentage]
   }, [trade])

--- a/libs/common-const/src/common.ts
+++ b/libs/common-const/src/common.ts
@@ -133,7 +133,7 @@ export const GAS_API_KEYS: Record<SupportedChainId, string> = {
 export const UNSUPPORTED_TOKENS_FAQ_URL = '/faq/trading#what-token-pairs-does-cowswap-allow-to-trade'
 
 // fee threshold - should be greater than percentage, show warning
-export const FEE_SIZE_THRESHOLD = new Fraction(10, 100) // 30%
+export const FEE_SIZE_THRESHOLD = 10 // 10%
 
 // default value provided as userAddress to Paraswap API if the user wallet is not connected
 export const SOLVER_ADDRESS = '0xa6ddbd0de6b310819b49f680f65871bee85f517e'


### PR DESCRIPTION
# Summary

Fixes #3997

There was a bug in `useHighFeeWarning()` calculations.
We don't need to multiply fee percent to -1 for buy orders and we should multiply the percent before converting it to fraction.

  # To Test

1. Compare the warning values with Barn