### PR TITLE
feat(limit): show order link to replaced order

### DIFF
--- a/apps/cowswap-frontend/src/modules/appData/types.ts
+++ b/apps/cowswap-frontend/src/modules/appData/types.ts
@@ -43,3 +43,5 @@ export type AppDataRootSchema = latest.AppDataRootSchema
 export type AppDataWidget = latest.Widget
 
 export type AppDataPartnerFee = latest.PartnerFee
+
+export type AppDataReplacedOrder = latest.ReplacedOrder

--- a/apps/cowswap-frontend/src/modules/appData/utils/getAppDataReplacedOrderUid.ts
+++ b/apps/cowswap-frontend/src/modules/appData/utils/getAppDataReplacedOrderUid.ts
@@ -1,0 +1,24 @@
+import { AnyAppDataDocVersion } from '@cowprotocol/app-data'
+
+import { Nullish } from 'types'
+
+import { decodeAppData } from './decodeAppData'
+
+import { AppDataReplacedOrder } from '../types'
+
+/**
+ * Get replacedOrderUid from fullAppData, which can be JSON stringified or the instance
+ *
+ * Returns undefined if the fullAppData is falsy or if the metadata isn't present
+ */
+export function getAppDataReplacedOrderUid(fullAppData: Nullish<AnyAppDataDocVersion | string>): string | undefined {
+  const decodedAppData = typeof fullAppData === 'string' ? decodeAppData(fullAppData) : fullAppData
+
+  if (!decodedAppData || !('replacedOrder' in decodedAppData.metadata) || !decodedAppData.metadata.replacedOrder) {
+    return undefined
+  }
+
+  const { uid } = decodedAppData.metadata.replacedOrder as AppDataReplacedOrder
+
+  return uid
+}

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/ReceiptModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/ReceiptModal/index.tsx
@@ -88,6 +88,7 @@ const tooltips: { [key: string]: string | JSX.Element } = {
       also be changed to <i>Fill or kill</i> through your order settings.
     </span>
   ),
+  REPLACED_ORDER: 'The current order was based on and replaced this order.',
 }
 
 const TWAP_PART_ORDER_EXISTS_STATES = new Set([OrderStatus.PENDING, OrderStatus.FULFILLED, OrderStatus.EXPIRED])
@@ -126,6 +127,7 @@ export function ReceiptModal({
   const inputLabel = isSell ? 'You sell' : 'You sell at most'
   const outputLabel = isSell ? 'You receive at least' : 'You receive exactly'
   const safeTxParams = twapOrder?.safeTxParams
+  const replacedOrderId = order.replacedOrderId
 
   return (
     <CowModal onDismiss={onDismiss} isOpen={isOpen}>
@@ -249,6 +251,13 @@ export function ReceiptModal({
               <FieldLabel label="Order type" tooltip={tooltips.ORDER_TYPE} />
               <OrderTypeField order={order} />
             </styledEl.Field>
+
+            {replacedOrderId && (
+              <styledEl.Field>
+                <FieldLabel label="Replaced order" tooltip={tooltips.REPLACED_ORDER} />
+                <IdField id={replacedOrderId} chainId={chainId} />
+              </styledEl.Field>
+            )}
 
             {/*TODO: add a link to explorer when it will support TWAP orders*/}
             {(!twapOrder || twapPartOrderExists) && (

--- a/apps/cowswap-frontend/src/utils/orderUtils/parseOrder.ts
+++ b/apps/cowswap-frontend/src/utils/orderUtils/parseOrder.ts
@@ -6,6 +6,8 @@ import JSBI from 'jsbi'
 
 import { Order, OrderStatus } from 'legacy/state/orders/actions'
 
+import { getAppDataReplacedOrderUid } from 'modules/appData/utils/getAppDataReplacedOrderUid'
+
 import { ComposableCowInfo } from 'common/types'
 
 import { getOrderExecutedAmounts } from './getOrderExecutedAmounts'
@@ -50,7 +52,7 @@ export interface ParsedOrder {
   composableCowInfo?: ComposableCowInfo
   fullAppData: Order['fullAppData']
   signingScheme: SigningScheme
-
+  replacedOrderId?: string
   executionData: ParsedOrderExecutionData
 }
 
@@ -115,6 +117,7 @@ export const parseOrder = (order: Order): ParsedOrder => {
     fullAppData: order.fullAppData,
     executionData,
     signingScheme: order.signingScheme,
+    replacedOrderId: getAppDataReplacedOrderUid(order.fullAppData),
   }
 }
 


### PR DESCRIPTION
# Summary

Part of #425 

The new order created after "editing" an existing limit order will have a link to the replaced order:

![image](https://github.com/cowprotocol/cowswap/assets/43217/da7c5ae1-39e5-4450-abcc-bef1d6e844c1)

Tooltips, positioning, data, etc - nothing is final! Please give me suggestions.

# To Test

1. Edit one order and place it
2. In the new order, open the receipt modal
* Should have a link to the original order