### PR TITLE
feat(explorer): use token lists on explorer

### DIFF
--- a/apps/explorer/src/hooks/useErc20.ts
+++ b/apps/explorer/src/hooks/useErc20.ts
@@ -44,54 +44,7 @@ async function _fetchErc20FromNetwork(params: {
   }
 }
 
-type UseErc20Params = { address?: string; networkId?: Network }
-
 type Return<E, V> = { isLoading: boolean; error?: E; value: V }
-
-/**
- * Fetches single erc20 token details for given network and address
- *
- * Tries to get it from globalState.
- * If not found, tries to get it from the network.
- * Saves to globalState if found.
- * Value is `null` when not found.
- * Returns `isLoading` to indicate whether fetching the value
- * Returns `error` with the error message, if any.
- */
-export function useErc20(params: UseErc20Params): Return<UiError, SingleErc20State> {
-  const { address, networkId } = params
-
-  const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState<UiError>()
-
-  const erc20 = useErc20State({ networkId, address })
-  const saveErc20s = useSaveErc20s(networkId)
-
-  const fetchAndUpdateState = useCallback(async (): Promise<void> => {
-    if (!address || !networkId) {
-      return
-    }
-
-    setIsLoading(true)
-
-    const fetched = await _fetchErc20FromNetwork({ address, networkId, setError })
-    if (fetched) {
-      saveErc20s([fetched])
-    }
-
-    setError(undefined)
-    setIsLoading(false)
-  }, [address, networkId, saveErc20s])
-
-  useEffect(() => {
-    // Only try to fetch it if not on global state
-    if (!erc20) {
-      fetchAndUpdateState()
-    }
-  }, [erc20, fetchAndUpdateState])
-
-  return { isLoading, error, value: erc20 }
-}
 
 export type UseMultipleErc20Params = { addresses: string[]; networkId?: Network }
 

--- a/apps/explorer/src/hooks/useTokenList.ts
+++ b/apps/explorer/src/hooks/useTokenList.ts
@@ -1,0 +1,54 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import useSWR from 'swr'
+import { SWR_NO_REFRESH_OPTIONS } from '@cowprotocol/common-const'
+import type { TokenInfo, TokenList } from '@uniswap/token-lists'
+
+type TokenListByAddress = Record<string, TokenInfo>
+type TokenListPerNetwork = Record<SupportedChainId, TokenListByAddress>
+
+const INITIAL_TOKEN_LIST_PER_NETWORK: TokenListPerNetwork = {
+  [SupportedChainId.MAINNET]: {},
+  [SupportedChainId.GNOSIS_CHAIN]: {},
+  [SupportedChainId.SEPOLIA]: {},
+}
+
+export function useTokenList(chainId: SupportedChainId | undefined): { data: TokenListByAddress; isLoading: boolean } {
+  const { data: cowSwapList, isLoading: isCowListLoading } = useTokenListByUrl(
+    'https://files.cow.fi/tokens/CowSwap.json'
+  )
+  const { data: coingeckoList, isLoading: isCoingeckoListLoading } = useTokenListByUrl(
+    'https://tokens.coingecko.com/uniswap/all.json'
+  )
+  const { data: honeyswapList, isLoading: isHoneyswapListLoading } = useTokenListByUrl(
+    chainId === SupportedChainId.GNOSIS_CHAIN ? 'https://tokens.honeyswap.org' : ''
+  )
+
+  const data = chainId ? { ...coingeckoList, ...honeyswapList, ...cowSwapList }[chainId] : {}
+  const isLoading = chainId ? isCowListLoading || isHoneyswapListLoading || isCoingeckoListLoading : false
+
+  return { data, isLoading }
+}
+
+function useTokenListByUrl(tokenListUrl: string) {
+  return useSWR(tokenListUrl, fetcher, {
+    fallbackData: INITIAL_TOKEN_LIST_PER_NETWORK,
+    ...SWR_NO_REFRESH_OPTIONS,
+  })
+}
+
+const SUPPORTED_CHAIN_IDS_SET = new Set(Object.values(SupportedChainId))
+
+function fetcher(tokenListUrl: string): Promise<TokenListPerNetwork> {
+  return fetch(tokenListUrl)
+    .then<TokenList>((res) => res.json())
+    .then(({ tokens }) =>
+      // Create an object with token addresses as keys
+      tokens.reduce((acc, token) => {
+        // Pick only supported chains
+        if (SUPPORTED_CHAIN_IDS_SET.has(token.chainId)) {
+          acc[token.chainId][token.address.toLowerCase()] = token
+        }
+        return acc
+      }, INITIAL_TOKEN_LIST_PER_NETWORK)
+    )
+}

--- a/apps/explorer/src/hooks/useTokenList.ts
+++ b/apps/explorer/src/hooks/useTokenList.ts
@@ -1,4 +1,4 @@
-import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { ALL_SUPPORTED_CHAIN_IDS, SupportedChainId } from '@cowprotocol/cow-sdk'
 import useSWR from 'swr'
 import { SWR_NO_REFRESH_OPTIONS } from '@cowprotocol/common-const'
 import type { TokenInfo, TokenList } from '@uniswap/token-lists'
@@ -36,7 +36,7 @@ function useTokenListByUrl(tokenListUrl: string) {
   })
 }
 
-const SUPPORTED_CHAIN_IDS_SET = new Set(Object.values(SupportedChainId))
+const SUPPORTED_CHAIN_IDS_SET = new Set(ALL_SUPPORTED_CHAIN_IDS)
 
 function fetcher(tokenListUrl: string): Promise<TokenListPerNetwork> {
   return fetch(tokenListUrl)


### PR DESCRIPTION
# Summary

Fixes #4000

Use token lists on explorer for loading tokens and only fetch from chain if not found in any list.

# To Test

1. Load something with lots of different tokens like this `0x9008D19f58AAbD9eD0D60971565AA8510560ab41`
* Tokens should load fine
2. Browse different pages
* Most tokens should load super fast as well
3. Compare with prod version
* Should be faster

# Notes

1. This does not fixes all the pending issues with tokens that we have
2. This does not fixes all the token images
3. This does not make tokens loading from onchain efficient (using multicall for example)