### PR TITLE
chore: check standaloneMode as boolean

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/index.tsx
@@ -27,7 +27,7 @@ export function AccountElement({ className, standaloneMode, pendingActivities }:
 
   return (
     <Wrapper className={className} active={!!account} onClick={() => account && toggleAccountModal()}>
-      {standaloneMode && account && !isChainIdUnsupported && userEthBalance && chainId && (
+      {standaloneMode !== false && account && !isChainIdUnsupported && userEthBalance && chainId && (
         <BalanceText>
           <TokenAmount amount={userEthBalance} tokenSymbol={{ symbol: nativeToken }} />
         </BalanceText>

--- a/apps/cowswap-frontend/src/legacy/state/application/hooks.ts
+++ b/apps/cowswap-frontend/src/legacy/state/application/hooks.ts
@@ -37,7 +37,7 @@ export function useToggleWalletModal(): Command | null {
   const toggleWalletModal = useToggleModal(ApplicationModal.WALLET)
 
   return useMemo(() => {
-    if (!active || !standaloneMode) {
+    if (!active || standaloneMode === false) {
       return null
     }
 


### PR DESCRIPTION
# Summary

Since `standaloneMode` flag might be undefined, we should always check it agains true/false values

![image](https://github.com/cowprotocol/cowswap/assets/7122625/ea005241-17d7-4385-bdfc-5351da0805b9)

