### PR TITLE
fix: migrate to nodereal api from infura

### DIFF
--- a/apps/explorer/src/api/web3/index.ts
+++ b/apps/explorer/src/api/web3/index.ts
@@ -1,7 +1,7 @@
 import Web3 from 'web3'
 import { parseUserAgent } from 'detect-browser'
 
-import { ETH_NODE_URL, INFURA_ID } from 'const'
+import { ETH_NODE_URL, NODE_PROVIDER_ID } from 'const'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 // TODO connect to mainnet if we need AUTOCONNECT at all
@@ -42,26 +42,10 @@ export function createWeb3Api(provider?: string): Web3 {
   return web3
 }
 
-const INFURA_NETWORK_NAME_MAP: Record<SupportedChainId, string> = {
-  [SupportedChainId.MAINNET]: 'Mainnet',
-  [SupportedChainId.GNOSIS_CHAIN]: 'xDai',
-  [SupportedChainId.SEPOLIA]: 'Sepolia',
-}
-
-function infuraProvider(networkId: SupportedChainId): string {
-  // INFURA_ID relies on mesa `config` file logic.
-  // We can be independent of that config by relying on the env var directly
-  if (!INFURA_ID) {
-    throw new Error(`INFURA_ID not set`)
-  }
-
-  const network = INFURA_NETWORK_NAME_MAP[networkId]
-
-  if (isWebsocketConnection()) {
-    return `wss://${network}.infura.io/ws/v3/${INFURA_ID}`
-  } else {
-    return `https://${network}.infura.io/v3/${INFURA_ID}`
-  }
+const PROVIDER_ENDPOINTS: Record<SupportedChainId, string> = {
+  [SupportedChainId.MAINNET]: 'https://eth-mainnet.nodereal.io/v1/' + NODE_PROVIDER_ID,
+  [SupportedChainId.GNOSIS_CHAIN]: 'https://rpc.gnosis.gateway.fm/',
+  [SupportedChainId.SEPOLIA]: 'https://eth-sepolia.nodereal.io/v1/' + NODE_PROVIDER_ID,
 }
 
 function isWebsocketConnection(): boolean {
@@ -84,16 +68,12 @@ function isWebsocketConnection(): boolean {
     return false
   }
 
-  return true
+  // TODO: fix this to return true when the issue with WSS is fixed
+  return false
 }
 
-// For now only infura provider is available
 export function getProviderByNetwork(networkId: SupportedChainId): string | undefined {
-  if (networkId === SupportedChainId.GNOSIS_CHAIN) {
-    return 'https://rpc.gnosis.gateway.fm/'
-  }
-
-  return infuraProvider(networkId)
+  return PROVIDER_ENDPOINTS[networkId]
 }
 
 // Approach 2: update the provider in a single web3 instance

--- a/apps/explorer/src/const.ts
+++ b/apps/explorer/src/const.ts
@@ -102,8 +102,8 @@ export const MEDIA = {
   },
 }
 
-export const INFURA_ID = process.env.INFURA_ID || 'e941376b017d4dada26dc7891456fa3b'
-export const ETH_NODE_URL = process.env.ETH_NODE_URL || 'wss://mainnet.infura.io/ws/v3/' + INFURA_ID
+export const NODE_PROVIDER_ID = process.env.NODE_PROVIDER_ID || 'ed3c6720eb3f470e9ceac8f8f12e8b14'
+export const ETH_NODE_URL = process.env.ETH_NODE_URL || 'wss://eth-mainnet.nodereal.io/ws/v1/' + NODE_PROVIDER_ID
 
 export const WETH_ADDRESS_MAINNET = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
 export const WETH_ADDRESS_SEPOLIA = '0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14'


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C0361CDG8GP/p1710342925949649

Infura seems not working.
I couldn't make Nodereal work via Websocket so temporary changed provider to https.
