### PR TITLE
fix(recreate): fix 1h duration orders

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/updaters/AlternativeLimitOrderUpdater.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/updaters/AlternativeLimitOrderUpdater.ts
@@ -165,7 +165,11 @@ function getDuration(order: Order | ParsedOrder): number {
  */
 function getMatchingDeadline(duration: number) {
   // Match duration with approximate time
-  return limitOrdersDeadlines.find(({ value }) => Math.round(value / duration) === 1)
+  return limitOrdersDeadlines.find(({ value }) => {
+    const ratio = value / duration
+    // If the ratio is +/-10% off of 1, consider it a match
+    return ratio > 0.9 && ratio < 1.1
+  })
 }
 
 /**


### PR DESCRIPTION
# Summary

Fixes #4017

# To Test

1. Place a limit order with 5min duration
2. Cancel, let it expire or execute
3. Recreate it
* Should have 5min duration
4. Repeat with all predefined durations
* Should match the original duration