### PR TITLE
fix(tokens): don't list tokens from other chains

### DIFF
--- a/libs/tokens/src/state/tokens/allTokensAtom.ts
+++ b/libs/tokens/src/state/tokens/allTokensAtom.ts
@@ -81,18 +81,22 @@ export const activeTokensAtom = atom<TokenWithLogo[]>((get) => {
   const tokensMap = get(tokensStateAtom)
   const nativeToken = NATIVE_CURRENCIES[chainId]
 
-  return tokenMapToListWithLogo({
-    [nativeToken.address.toLowerCase()]: nativeToken as TokenInfo,
-    ...tokensMap.activeTokens,
-    ...lowerCaseTokensMap(userAddedTokens[chainId]),
-    ...lowerCaseTokensMap(favouriteTokensState[chainId]),
-  })
+  return tokenMapToListWithLogo(
+    {
+      [nativeToken.address.toLowerCase()]: nativeToken as TokenInfo,
+      ...tokensMap.activeTokens,
+      ...lowerCaseTokensMap(userAddedTokens[chainId]),
+      ...lowerCaseTokensMap(favouriteTokensState[chainId]),
+    },
+    chainId
+  )
 })
 
 export const inactiveTokensAtom = atom<TokenWithLogo[]>((get) => {
+  const { chainId } = get(environmentAtom)
   const tokensMap = get(tokensStateAtom)
 
-  return tokenMapToListWithLogo(tokensMap.inactiveTokens)
+  return tokenMapToListWithLogo(tokensMap.inactiveTokens, chainId)
 })
 
 export const tokensByAddressAtom = atom<TokensByAddress>((get) => {

--- a/libs/tokens/src/state/tokens/userAddedTokensAtom.ts
+++ b/libs/tokens/src/state/tokens/userAddedTokensAtom.ts
@@ -29,7 +29,10 @@ export const addUserTokenAtom = atom(null, (get, set, tokens: TokenWithLogo[]) =
     [chainId]: {
       ...userAddedTokensState[chainId],
       ...tokens.reduce<{ [key: string]: Token }>((acc, token) => {
-        acc[token.address.toLowerCase()] = token
+        if (token.chainId === chainId) {
+          // Only add token if its chainId matches the current chainId
+          acc[token.address.toLowerCase()] = token
+        }
         return acc
       }, {}),
     },

--- a/libs/tokens/src/utils/tokenMapToListWithLogo.ts
+++ b/libs/tokens/src/utils/tokenMapToListWithLogo.ts
@@ -5,8 +5,9 @@ import { TokensMap } from '../types'
 /**
  * Convert a tokens map to a list of tokens and sort them alphabetically
  */
-export function tokenMapToListWithLogo(tokenMap: TokensMap): TokenWithLogo[] {
+export function tokenMapToListWithLogo(tokenMap: TokensMap, chainId: number): TokenWithLogo[] {
   return Object.values(tokenMap)
+    .filter((token) => token.chainId === chainId)
     .sort((a, b) => a.symbol.localeCompare(b.symbol))
     .map((token) => TokenWithLogo.fromToken(token, token.logoURI))
 }


### PR DESCRIPTION
# Summary

Fixes #3841 

# To Test

There are no clear steps to reproduce AFAICT.
Probably load the shared localStorage into the app and load the app.
Should NOT show tokens from a different chain.