### PR TITLE
fix: add on TWAP wallet requirements note about Safe not deployed

### DIFF
--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/warnings/UnsupportedWalletWarning.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/warnings/UnsupportedWalletWarning.tsx
@@ -24,8 +24,7 @@ export function UnsupportedWalletWarning({ isSafeViaWc }: { isSafeViaWc: boolean
         support!
       </p>
       <p>
-        <strong>Note:</strong> If you are using the Safe App already but still see this, make sure your Safe is
-        deployed!
+        <strong>Note:</strong> If you are using a Safe but still see this message, ensure your Safe is deployed!
       </p>
     </InlineBanner>
   )

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/warnings/UnsupportedWalletWarning.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/warnings/UnsupportedWalletWarning.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink, InlineBanner, CowSwapSafeAppLink } from '@cowprotocol/ui'
+import { CowSwapSafeAppLink, ExternalLink, InlineBanner } from '@cowprotocol/ui'
 
 import { UNSUPPORTED_WALLET_LINK } from 'modules/twap/const'
 
@@ -22,6 +22,10 @@ export function UnsupportedWalletWarning({ isSafeViaWc }: { isSafeViaWc: boolean
         TWAP orders currently require a Safe with a special fallback handler. Have one? Switch to it! Need setup?{' '}
         <ExternalLink href={UNSUPPORTED_WALLET_LINK}>Click here</ExternalLink>. Future updates may extend wallet
         support!
+      </p>
+      <p>
+        <strong>Note:</strong> If you are using the Safe App already but still see this, make sure your Safe is
+        deployed!
       </p>
     </InlineBanner>
   )


### PR DESCRIPTION
# Summary

In the past week, we had 2 cases of users trying to use TWAP with Safes, but not being able to because their Safes were not yet deployed!

This change does not add support for it, since we can't really support that use case.
It does however inform the users that deploying the Safe is required.

![Screenshot 2024-03-19 at 15 15 59](https://github.com/cowprotocol/cowswap/assets/43217/297fb911-b2f2-416f-a00d-42e8f493f6c1)

# To Test

1. Open TWAP with an unsupported wallet
* Should show the message like above