### PR TITLE
feat: support counterfactual safes

### DIFF
--- a/libs/wallet/src/web3-react/hooks/useWalletMetadata.ts
+++ b/libs/wallet/src/web3-react/hooks/useWalletMetadata.ts
@@ -9,6 +9,7 @@ import { useGnosisSafeInfo } from '../../api/hooks'
 import { ConnectionType } from '../../api/types'
 import { getIsAlphaWallet } from '../../api/utils/connection'
 import { getWeb3ReactConnection } from '../utils/getWeb3ReactConnection'
+import { useSafeAppsSdkInfo } from './useSafeAppsSdkInfo'
 
 const SAFE_APP_NAME = 'Safe App'
 
@@ -109,7 +110,10 @@ export function useIsSafeApp(): boolean {
  * regardless of the connection method (WalletConnect or inside Safe as an App)
  */
 export function useIsSafeWallet(): boolean {
-  return !!useGnosisSafeInfo()
+  const { safeAddress } = useSafeAppsSdkInfo() || {}
+  const hasSafeInfo = !!useGnosisSafeInfo()
+
+  return !!safeAddress || hasSafeInfo
 }
 
 /**


### PR DESCRIPTION
# Summary

This PR is an attempt to fix the issue with counterfactual safes.

The underlying issue, is that we fail to detect that the connected wallet is a Safe, because we rely on the Safe API to get the Safe information, and it's not there yet (as the safe is not even deployed)

We will assume is a Safe if we detect the Safe provider and this one returns a valid safe address. Also, we keep the old check, as its useful for Wallet Connect.

Send TWAP:

<img width="1483" alt="Screenshot at Mar 19 21-30-21" src="https://github.com/cowprotocol/cowswap/assets/2352112/65ee1941-7274-4dfa-8415-172f22215689">


Activating Safe onchain:
<img width="1727" alt="Screenshot at Mar 19 21-31-11" src="https://github.com/cowprotocol/cowswap/assets/2352112/a5a7fb21-4a61-4f57-869f-21c3cf59ac57">

Safe activated:
<img width="1691" alt="Screenshot at Mar 19 21-31-23" src="https://github.com/cowprotocol/cowswap/assets/2352112/83ba58eb-4f89-41e8-94c4-bfc71561af29">

TWAP created:
<img width="1727" alt="Screenshot at Mar 19 21-31-39" src="https://github.com/cowprotocol/cowswap/assets/2352112/cfeea124-74a1-4dab-bdc0-8c443a88dcc2">



## Known issues
- The detection will fail if you check with Wallet Connect, because the API will not know this safe exists (actually doesn't), and we are also not using the Safe Web Apps connector, so we can't tell! I think is enough to fix it for Safe Web for now
- Unrelated to this PR: Even after I sent the TWAP, the confirmation modal was being displayed
<img width="1166" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/7cd65aa7-86c4-4f04-b595-6b950c187d74">


## Test
- Try to make a TWAP using a counterfactual Safe (when you create a Safe, you mark as pay later)
- Add https://swap-dev-git-change-detection-safe-cowswap.vercel.app as custom app
- Send some money to your counterfactual safe
- Create a TWAP


## If merged..
We should revert #4061 