### PR TITLE
fix: display correct links for on-chain notifications

### DIFF
--- a/apps/cowswap-frontend/src/modules/onchainTransactions/updaters/FinalizeTxUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/onchainTransactions/updaters/FinalizeTxUpdater.tsx
@@ -80,7 +80,8 @@ interface CheckEthereumTransactions {
 function finalizeEthereumTransaction(
   receipt: TransactionReceipt,
   transaction: EnhancedTransactionDetails,
-  params: CheckEthereumTransactions
+  params: CheckEthereumTransactions,
+  safeTransactionHash?: string
 ) {
   const { chainId, account, dispatch, addPriorityAllowance } = params
   const { hash } = transaction
@@ -131,7 +132,7 @@ function finalizeEthereumTransaction(
       to: receipt.to,
       from: receipt.from,
       contractAddress: receipt.contractAddress,
-      transactionHash: receipt.transactionHash,
+      transactionHash: safeTransactionHash || receipt.transactionHash,
       blockNumber: receipt.blockNumber,
       status: receipt.status,
       replacementType: transaction.replacementType,
@@ -213,7 +214,6 @@ function finalizeOnChainCancellation(
       emitCancelledOrderEvent({
         chainId,
         order,
-        transactionHash: hash,
       })
     })
   } else {
@@ -264,7 +264,7 @@ function checkEthereumTransactions(params: CheckEthereumTransactions): Command[]
             const { promise: receiptPromise } = getReceipt(transactionHash)
 
             receiptPromise
-              .then((newReceipt) => finalizeEthereumTransaction(newReceipt, transaction, params))
+              .then((newReceipt) => finalizeEthereumTransaction(newReceipt, transaction, params, hash))
               .catch((error) => {
                 if (!error.isCancelledError) {
                   console.error(

--- a/apps/cowswap-frontend/src/modules/orders/updaters/OrdersNotificationsUpdater/handlers.tsx
+++ b/apps/cowswap-frontend/src/modules/orders/updaters/OrdersNotificationsUpdater/handlers.tsx
@@ -24,7 +24,7 @@ export const ORDERS_NOTIFICATION_HANDLERS: Record<CowEvents, OrdersNotifications
   [CowEvents.ON_POSTED_ORDER]: {
     icon: 'success',
     handler: (payload: OnPostedOrderPayload) => {
-      const { chainId, orderUid, orderType, orderCreationHash } = payload
+      const { chainId, orderUid, orderType } = payload
 
       return (
         <OrderNotification
@@ -32,7 +32,6 @@ export const ORDERS_NOTIFICATION_HANDLERS: Record<CowEvents, OrdersNotifications
           chainId={chainId}
           orderType={orderType}
           orderUid={orderUid}
-          transactionHash={orderCreationHash}
           orderInfo={payload}
           messageType={ToastMessageType.ORDER_CREATED}
         />


### PR DESCRIPTION
# Summary

Fixes #4071

1. For cancellation events always display a link to Explorer
Removed `transactionHash` from `emitCancelledOrderEvent()`call.

2. For on-chain transaction in Safe display correct link in "View on Safe"
Use `safeTransactionHash` in `emitOnchainTransactionEvent` call.

<img width="374" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/5673b8d1-06fd-479e-8479-3c533f7fc647">

  # To Test

1. Cancel an order using on-chain tx
- [ ] ER: the link in the notification should lead to Explorer
2. Do wrap/unwrap in Safe
- [ ] ER: the link in the notification should lead to Safe transaction