### PR TITLE
fix: show link to Explorer for twap orders

### DIFF
--- a/apps/cowswap-frontend/src/modules/onchainTransactions/updaters/FinalizeTxUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/onchainTransactions/updaters/FinalizeTxUpdater.tsx
@@ -214,6 +214,7 @@ function finalizeOnChainCancellation(
       emitCancelledOrderEvent({
         chainId,
         order,
+        transactionHash: hash,
       })
     })
   } else {

--- a/apps/cowswap-frontend/src/modules/orders/containers/OrderNotification/index.tsx
+++ b/apps/cowswap-frontend/src/modules/orders/containers/OrderNotification/index.tsx
@@ -9,11 +9,11 @@ import { TokenInfo, UiOrderType } from '@cowprotocol/types'
 import { useOrder } from 'legacy/state/orders/hooks'
 
 import {
-  OrderInfo,
   getToastMessageCallback,
+  isEnrichedOrder,
   mapEnrichedOrderToInfo,
   mapStoreOrderToInfo,
-  isEnrichedOrder,
+  OrderInfo,
 } from './utils'
 
 import { OrderSummary } from '../../pure/OrderSummary'
@@ -28,11 +28,12 @@ export interface BaseOrderNotificationProps {
   orderType: UiOrderType
   orderInfo?: OrderInfo | EnrichedOrder
   transactionHash?: string
+  isEthFlow?: boolean
   children?: JSX.Element
 }
 
 export function OrderNotification(props: BaseOrderNotificationProps) {
-  const { title, orderUid, orderType, transactionHash, chainId, messageType, children, orderInfo } = props
+  const { title, orderUid, orderType, transactionHash, chainId, messageType, children, orderInfo, isEthFlow } = props
 
   const allTokens = useTokensByAddressMap()
 
@@ -65,7 +66,7 @@ export function OrderNotification(props: BaseOrderNotificationProps) {
   if (!order) return
 
   return (
-    <TransactionContentWithLink transactionHash={transactionHash} orderUid={orderUid}>
+    <TransactionContentWithLink isEthFlow={isEthFlow} transactionHash={transactionHash} orderUid={orderUid}>
       <div ref={ref}>
         <strong>{title}</strong>
         <br />

--- a/apps/cowswap-frontend/src/modules/orders/containers/TransactionContentWithLink/index.tsx
+++ b/apps/cowswap-frontend/src/modules/orders/containers/TransactionContentWithLink/index.tsx
@@ -20,19 +20,21 @@ interface TransactionContentWithLinkProps {
   transactionHash: string | undefined
   orderUid?: string
   children?: JSX.Element
+  isEthFlow?: boolean
 }
 export function TransactionContentWithLink(props: TransactionContentWithLinkProps) {
   const { chainId } = useWalletInfo()
   const safeInfo = useGnosisSafeInfo()
   const isSafeWallet = !!safeInfo
-  const { transactionHash, orderUid, children } = props
+  const { transactionHash, orderUid, children, isEthFlow } = props
+
+  const isOrder = isCowOrder('transaction', orderUid)
+  const isSafeOrder = !!(isSafeWallet && orderUid && !isCowOrder('transaction', orderUid))
+  const isSafeTx = !!(isSafeWallet && transactionHash && !isCowOrder('transaction', transactionHash))
 
   const tx = {
-    hash: transactionHash || orderUid || '',
-    hashType:
-      isSafeWallet && transactionHash && !isCowOrder('transaction', transactionHash)
-        ? HashType.GNOSIS_SAFE_TX
-        : HashType.ETHEREUM_TX,
+    hash: (isOrder && !isEthFlow ? orderUid : transactionHash || orderUid) || '',
+    hashType: (isSafeOrder || isSafeTx) && !isOrder ? HashType.GNOSIS_SAFE_TX : HashType.ETHEREUM_TX,
     safeTransaction: {
       safeTxHash: transactionHash || '',
       safe: safeInfo?.address || '',

--- a/apps/cowswap-frontend/src/modules/orders/updaters/OrdersNotificationsUpdater/handlers.tsx
+++ b/apps/cowswap-frontend/src/modules/orders/updaters/OrdersNotificationsUpdater/handlers.tsx
@@ -24,7 +24,7 @@ export const ORDERS_NOTIFICATION_HANDLERS: Record<CowEvents, OrdersNotifications
   [CowEvents.ON_POSTED_ORDER]: {
     icon: 'success',
     handler: (payload: OnPostedOrderPayload) => {
-      const { chainId, orderUid, orderType } = payload
+      const { chainId, orderUid, orderType, orderCreationHash, isEthFlow } = payload
 
       return (
         <OrderNotification
@@ -33,6 +33,8 @@ export const ORDERS_NOTIFICATION_HANDLERS: Record<CowEvents, OrdersNotifications
           orderType={orderType}
           orderUid={orderUid}
           orderInfo={payload}
+          transactionHash={orderCreationHash}
+          isEthFlow={isEthFlow}
           messageType={ToastMessageType.ORDER_CREATED}
         />
       )


### PR DESCRIPTION
# Summary

"Order submitted" popup should contain link to Safe instead of Etherscan.

![image](https://github.com/cowprotocol/cowswap/assets/7122625/894886ba-641f-415b-aaf2-78bb4314c096)
