### PR TITLE
Fix fortune/appzi appearance initial render

### DIFF
--- a/apps/cowswap-frontend/src/modules/mainMenu/pure/MenuTree/index.tsx
+++ b/apps/cowswap-frontend/src/modules/mainMenu/pure/MenuTree/index.tsx
@@ -192,7 +192,7 @@ export function MenuTree({ items = MAIN_MENU, isMobileMenuOpen, context, handleM
         return <MenuItemWithDropDown key={index} menuItem={menuItem} context={context} />
       })}
       {/* Medium and down only to show the fortune widget and feedback button */}
-      {isUpToMedium && (
+      {isUpToMedium && isMobileMenuOpen && (
         <>
           <FeatureGuard featureFlag="cowFortuneEnabled">
             <FortuneWidget menuTitle="Get your fortune cookie" isMobileMenuOpen={isMobileMenuOpen} />


### PR DESCRIPTION
# Summary

- Fixes a bug where the fortune/appzi button is shown on initial render:

<img width="799" alt="Screenshot 2024-03-27 at 11 11 18" src="https://github.com/cowprotocol/cowswap/assets/31534717/822a54af-5767-439f-a8fe-e3242cb40e5d">
