### PR TITLE
chore: fix trade widget links menu style

### DIFF
--- a/apps/cowswap-frontend/src/modules/tokensList/pure/ModalHeader/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/ModalHeader/index.tsx
@@ -11,7 +11,7 @@ const Header = styled.div`
   flex-direction: row;
   justify-content: space-between;
   font-weight: 500;
-  padding: 0 0 14px;
+  padding: 16px;
   align-items: center;
   font-size: 17px;
   border-bottom: 1px solid var(${UI.COLOR_BORDER});

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidgetLinks/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidgetLinks/index.tsx
@@ -10,6 +10,7 @@ import SVG from 'react-inlinesvg'
 import { matchPath, useLocation } from 'react-router-dom'
 
 import { useInjectedWidgetParams } from 'modules/injectedWidget'
+// TODO: extract the component to common
 import { ModalHeader } from 'modules/tokensList/pure/ModalHeader'
 
 import { Routes, RoutesValues } from 'common/constants/routes'
@@ -113,7 +114,7 @@ export function TradeWidgetLinks({
       {isDropdownVisible && (
         <styledEl.SelectMenu>
           <ModalHeader onBack={handleMenuItemClick}>Trading mode</ModalHeader>
-          {menuItems}
+          <styledEl.TradeWidgetContent>{menuItems}</styledEl.TradeWidgetContent>
         </styledEl.SelectMenu>
       )}
     </>

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidgetLinks/styled.ts
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidgetLinks/styled.ts
@@ -122,6 +122,7 @@ export const MenuItem = styled.div<{ isActive?: boolean; isDropdownVisible: bool
       css`
         padding: 16px;
         width: 100%;
+        margin-bottom: 20px;
       `}
   }
 `
@@ -135,8 +136,11 @@ export const SelectMenu = styled.div`
   z-index: 100;
   left: 0;
   top: 0;
-  padding: 16px;
   gap: ${({ theme }) => (theme.isInjectedWidgetMode ? '16px' : '24px')};
   background: var(${UI.COLOR_PAPER});
   border-radius: var(${UI.BORDER_RADIUS_NORMAL});
+`
+
+export const TradeWidgetContent = styled.div`
+  padding: 0 16px 16px 16px;
 `


### PR DESCRIPTION
# Summary

Fixes # 4098

The issue comes from https://github.com/cowprotocol/cowswap/pull/4079

![image](https://github.com/cowprotocol/cowswap/assets/7122625/3a2c4953-4c35-4606-864e-1aeb67dd03dc)

![image](https://github.com/cowprotocol/cowswap/assets/7122625/e8667bcc-5838-40d3-8099-3b294b35508c)

<img width="516" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/0e067cb3-c302-49ab-859b-b88e313360eb">


  # To Test

1. Manage tokens modal
2. Import token modal
3. Trade menu (mobile view)