### PR TITLE
fix: replace dpaste lists with a version stored on github

### DIFF
--- a/libs/tokens/src/const/tokensList.json
+++ b/libs/tokens/src/const/tokensList.json
@@ -13,7 +13,7 @@
     {
       "priority": 13,
       "enabledByDefault": true,
-      "source": "https://dpaste.com/3SCBYM7GS.txt"
+      "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/imFeelingLucky/src/public/imFeelingLucky.json"
     },
     {
       "priority": 3,

--- a/libs/tokens/src/const/tokensLists.ts
+++ b/libs/tokens/src/const/tokensLists.ts
@@ -5,4 +5,5 @@ export const DEFAULT_TOKENS_LISTS: ListsSourcesByNetwork = tokensList
 
 // TODO: combined uniswap and lucky list
 // TODO: revert
-export const UNISWAP_TOKENS_LIST = 'https://dpaste.com/75C9XDTGP.txt' //'https://gateway.ipfs.io/ipns/tokens.uniswap.org'
+export const UNISWAP_TOKENS_LIST =
+  'https://raw.githubusercontent.com/cowprotocol/token-lists/imFeelingLucky/src/public/imFeelingLuckyUniswap.json' //'https://gateway.ipfs.io/ipns/tokens.uniswap.org'


### PR DESCRIPTION
# Summary

Should fix https://github.com/cowprotocol/cowswap/issues/4106

# To Test

1. With geoblock on, load the app
2. Token list should be loaded