### PR TITLE
fix(limit-orders): use ff for zero balance orders

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -31,14 +31,15 @@ import { LimitOrdersConfirmModal } from '../LimitOrdersConfirmModal'
 import { RateInput } from '../RateInput'
 import { SettingsWidget } from '../SettingsWidget'
 
-export const LIMIT_BULLET_LIST_CONTENT: BulletListItem[] = [
+const LIMIT_BULLET_LIST_CONTENT: BulletListItem[] = [
   { content: 'Set any limit price and time horizon' },
   { content: 'FREE order placement and cancellation' },
   { content: 'Place multiple orders using the same balance' },
   { content: 'Receive surplus of your order' },
   { content: 'Protection from MEV by default' },
   {
-    content: <span>Place orders for higher than available balance!</span>,
+    featureFlag: 'isZeroBalanceOrdersEnabled',
+    content: 'Place orders for higher than available balance!',
   },
 ]
 

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
@@ -22,6 +22,7 @@ import { wasImFeelingLuckyClickedAtom } from 'modules/swap/hooks/useImFeelingLuc
 import { useOpenTokenSelectWidget } from 'modules/tokensList'
 import { useIsAlternativeOrderModalVisible } from 'modules/trade/state/alternativeOrder'
 
+import { FeatureGuard } from 'common/containers/FeatureGuard'
 import { useCategorizeRecentActivity } from 'common/hooks/useCategorizeRecentActivity'
 import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetworkUnsupported'
 import { useThrottleFn } from 'common/hooks/useThrottleFn'
@@ -107,7 +108,6 @@ export function TradeWidgetForm(props: TradeWidgetProps) {
 
   const showDropdown = shouldShowMyOrdersButton || isInjectedWidgetMode
 
-
   const currencyInputCommonProps = {
     isChainIdUnsupported,
     chainId,
@@ -172,24 +172,26 @@ export function TradeWidgetForm(props: TradeWidgetProps) {
                 {...currencyInputCommonProps}
               />
 
-              {isLimitOrderMode &&
-                !isWrapOrUnwrap &&
-                ClosableBanner(ZERO_BANNER_STORAGE_KEY, (onClose) => (
-                  <InlineBanner
-                    bannerType="success"
-                    orientation={BannerOrientation.Horizontal}
-                    customIcon={ICON_TOKENS}
-                    iconSize={32}
-                    margin={'10px 0 0'}
-                    onClose={onClose}
-                  >
-                    <p>
-                      <b>NEW: </b>You can now place limit orders for amounts larger than your wallet balance. Partial
-                      fill orders will execute until you run out of sell tokens. Fill-or-kill orders will become active
-                      once you top up your balance.
-                    </p>
-                  </InlineBanner>
-                ))}
+              <FeatureGuard featureFlag="isZeroBalanceOrdersEnabled">
+                {isLimitOrderMode &&
+                  !isWrapOrUnwrap &&
+                  ClosableBanner(ZERO_BANNER_STORAGE_KEY, (onClose) => (
+                    <InlineBanner
+                      bannerType="success"
+                      orientation={BannerOrientation.Horizontal}
+                      customIcon={ICON_TOKENS}
+                      iconSize={32}
+                      margin={'10px 0 0'}
+                      onClose={onClose}
+                    >
+                      <p>
+                        <b>NEW: </b>You can now place limit orders for amounts larger than your wallet balance. Partial
+                        fill orders will execute until you run out of sell tokens. Fill-or-kill orders will become
+                        active once you top up your balance.
+                      </p>
+                    </InlineBanner>
+                  ))}
+              </FeatureGuard>
             </div>
             {!isWrapOrUnwrap && middleContent}
             {!hideBuyTokenInput && (

--- a/apps/cowswap-frontend/src/modules/trade/pure/UnlockWidgetScreen/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/UnlockWidgetScreen/index.tsx
@@ -5,11 +5,14 @@ import { ExternalLink } from '@cowprotocol/ui'
 
 import SVG from 'react-inlinesvg'
 
+import { FeatureGuard } from 'common/containers/FeatureGuard'
+
 import * as styledEl from './styled'
 
 export type BulletListItem = {
   content: string | React.ReactNode
   isNew?: boolean
+  featureFlag?: string
 }
 
 type UnlockWidgetProps = {
@@ -42,14 +45,18 @@ export function UnlockWidgetScreen({
 
       {items && (
         <styledEl.List>
-          {items.map(({ isNew, content }, index) => (
-            <li key={index} data-is-new={isNew || null}>
-              <span>
-                <SVG src={iconCompleted} />
-              </span>{' '}
-              {content}
-            </li>
-          ))}
+          {items.map(({ isNew, content, featureFlag }, index) => {
+            const item = (
+              <li key={index} data-is-new={isNew || null}>
+                <span>
+                  <SVG src={iconCompleted} />
+                </span>{' '}
+                {content}
+              </li>
+            )
+
+            return featureFlag ? <FeatureGuard featureFlag={featureFlag}>{item}</FeatureGuard> : item
+          })}
         </styledEl.List>
       )}
 

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormValidationContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormValidationContext.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 
+import { useFeatureFlags } from '@cowprotocol/common-hooks'
 import { useENSAddress } from '@cowprotocol/ens'
 import { useIsTradeUnsupported } from '@cowprotocol/tokens'
 import { useGnosisSafeInfo, useIsBundlingSupported, useWalletDetails, useWalletInfo } from '@cowprotocol/wallet'
@@ -19,6 +20,7 @@ export function useTradeFormValidationContext(): TradeFormValidationCommonContex
   const { account } = useWalletInfo()
   const { state: derivedTradeState } = useDerivedTradeState()
   const tradeQuote = useTradeQuote()
+  const { isZeroBalanceOrdersEnabled } = useFeatureFlags()
 
   const { inputCurrency, outputCurrency, slippageAdjustedSellAmount, recipient, tradeType } = derivedTradeState || {}
   const { state: approvalState } = useApproveState(slippageAdjustedSellAmount)
@@ -35,7 +37,7 @@ export function useTradeFormValidationContext(): TradeFormValidationCommonContex
 
   const isPermitSupported = useTokenSupportsPermit(inputCurrency, tradeType)
 
-  const isInsufficientBalanceOrderAllowed = tradeType === TradeType.LIMIT_ORDER
+  const isInsufficientBalanceOrderAllowed = isZeroBalanceOrdersEnabled && tradeType === TradeType.LIMIT_ORDER
 
   const commonContext = {
     account,


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C036G0J90BU/p1711698714785519?thread_ts=1711649246.114269&cid=C036G0J90BU

When feature-flag is disabled, then:

1. The banner with zero balance orders feature should not be displayed
2. The limit orders form should not allow creating orders without balance

<img width="505" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/f0968378-a860-48d1-93f4-796142d5b22c">

