### PR TITLE
fix(recreate): fix recreate buy amount for pairs with different decimal precision

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/updaters/AlternativeLimitOrderUpdater.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/updaters/AlternativeLimitOrderUpdater.ts
@@ -2,6 +2,7 @@ import { useSetAtom } from 'jotai'
 import { useEffect, useState } from 'react'
 
 import { usePrevious } from '@cowprotocol/common-hooks'
+import { FractionUtils } from '@cowprotocol/common-utils'
 import { useENS } from '@cowprotocol/ens'
 import { useWalletInfo } from '@cowprotocol/wallet'
 import { Price } from '@uniswap/sdk-core'
@@ -115,7 +116,11 @@ function useSetAlternativeRate(): null {
       updateLimitRateState({ marketRate: null })
 
       // Set new active rate
-      const activeRate = new Price({ baseAmount: inputCurrencyAmount, quoteAmount: outputCurrencyAmount })
+      // The rate expects a raw fraction which is NOT a Price instace
+      const activeRate = FractionUtils.fromPrice(
+        new Price({ baseAmount: inputCurrencyAmount, quoteAmount: outputCurrencyAmount })
+      )
+
       updateRate({ activeRate, isTypedValue: false, isRateFromUrl: false, isAlternativeOrderRate: true })
     }
   }, [inputCurrencyAmount, hasSetRate, outputCurrencyAmount, updateRate, updateLimitRateState])

--- a/libs/common-utils/src/fractionUtils.ts
+++ b/libs/common-utils/src/fractionUtils.ts
@@ -11,7 +11,7 @@ export class FractionUtils {
   static serializeFractionToJSON(fraction: Nullish<Fraction>): string {
     if (!fraction) return ''
     const { numerator, denominator } = fraction
-    return JSON.stringify({ numerator: numerator + '', denominator: denominator + '' })
+    return JSON.stringify({ numerator: numerator.toString(), denominator: denominator.toString() })
   }
 
   static parseFractionFromJSON(s: Nullish<string>): Fraction | null {


### PR DESCRIPTION
# Summary

Fixes #4040 

Changing the amounts for recreating limit order with tokens of different decimal precision should work now.

# To Test

1. Place a limit order between a pair with different decimal precision (e.g.: WETH/USDC mainnet)
2. Have the order execute/cancel/expire
3. Go to history and recreate it
4. Change the sell or buy amounts
* Opposite amount should be equal to the current amount times/divided by (depends on the field changed and the price display notation) the current price