### PR TITLE
feat(recreate): add analytics events for recreate modal

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.ts
@@ -1,6 +1,7 @@
 import { useAtom } from 'jotai'
 import { useCallback } from 'react'
 
+import { alternativeModalAnalytics } from '@cowprotocol/analytics'
 import { getAddress } from '@cowprotocol/common-utils'
 
 import { PriceImpact } from 'legacy/hooks/usePriceImpact'
@@ -15,7 +16,7 @@ import { partiallyFillableOverrideAtom } from 'modules/limitOrders/state/partial
 import { useNavigateToOpenOrdersTable } from 'modules/ordersTable'
 import { useCloseReceiptModal } from 'modules/ordersTable/containers/OrdersReceiptModal/hooks'
 import { TradeConfirmActions } from 'modules/trade/hooks/useTradeConfirmActions'
-import { useHideAlternativeOrderModal } from 'modules/trade/state/alternativeOrder'
+import { useAlternativeOrder, useHideAlternativeOrderModal } from 'modules/trade/state/alternativeOrder'
 import { getSwapErrorMessage } from 'modules/trade/utils/swapErrorHelper'
 
 import OperatorError from 'api/gnosisProtocol/errors/OperatorError'
@@ -32,6 +33,7 @@ export function useHandleOrderPlacement(
   const { confirmPriceImpactWithoutFee } = useConfirmPriceImpactWithoutFee()
   const updateLimitOrdersState = useUpdateLimitOrdersRawState()
   const hideAlternativeOrderModal = useHideAlternativeOrderModal()
+  const { isEdit: isAlternativeOrderEdit } = useAlternativeOrder() || {}
   const closeReceiptModal = useCloseReceiptModal()
   const navigateToOpenOrdersTable = useNavigateToOpenOrdersTable()
   const [partiallyFillableOverride, setPartiallyFillableOverride] = useAtom(partiallyFillableOverrideAtom)
@@ -109,6 +111,11 @@ export function useHandleOrderPlacement(
         navigateToOpenOrdersTable()
         // Close receipt modal
         closeReceiptModal()
+
+        // Analytics event to track alternative modal usage, only if was using alternative modal
+        if (isAlternativeOrderEdit !== undefined) {
+          alternativeModalAnalytics(isAlternativeOrderEdit, 'placed')
+        }
       })
       .catch((error) => {
         if (error instanceof PriceImpactDeclineError) return
@@ -124,9 +131,10 @@ export function useHandleOrderPlacement(
     tradeConfirmActions,
     updateLimitOrdersState,
     setPartiallyFillableOverride,
-    hideAlternativeOrderModal,
+    isAlternativeOrderEdit,
     navigateToOpenOrdersTable,
     closeReceiptModal,
+    hideAlternativeOrderModal,
   ])
 }
 

--- a/apps/cowswap-frontend/src/modules/trade/state/alternativeOrder/hooks.ts
+++ b/apps/cowswap-frontend/src/modules/trade/state/alternativeOrder/hooks.ts
@@ -1,6 +1,8 @@
 import { useAtomValue, useSetAtom } from 'jotai'
 import { useCallback } from 'react'
 
+import { alternativeModalAnalytics } from '@cowprotocol/analytics'
+
 import { Order } from 'legacy/state/orders/actions'
 
 import { ParsedOrder } from 'utils/orderUtils/parseOrder'
@@ -25,7 +27,11 @@ export function useSetAlternativeOrder() {
   const setAlternativeOrder = useSetAtom(alternativeOrderAtom)
 
   return useCallback(
-    (order: Order | ParsedOrder, isEdit = false) => setAlternativeOrder({ order, isEdit }),
+    (order: Order | ParsedOrder, isEdit = false) => {
+      alternativeModalAnalytics(isEdit, 'clicked')
+
+      return setAlternativeOrder({ order, isEdit })
+    },
     [setAlternativeOrder]
   )
 }

--- a/libs/analytics/src/events/transactionEvents.ts
+++ b/libs/analytics/src/events/transactionEvents.ts
@@ -1,7 +1,7 @@
+import { UiOrderType } from '@cowprotocol/types'
 import { sendEvent } from '../googleAnalytics'
 import { PixelEvent, sendAllPixels } from '../pixel'
 import { Category } from '../types'
-import { UiOrderType } from '@cowprotocol/types'
 
 const LABEL_FROM_TYPE: Record<UiOrderType, string> = {
   [UiOrderType.LIMIT]: 'Limit Order',
@@ -93,5 +93,12 @@ export function priceOutOfRangeAnalytics(isUnfillable: boolean, label: string) {
     category: Category.TRADE,
     action: `Order price is ${isUnfillable ? 'out of' : 'back to'} market`,
     label,
+  })
+}
+
+export function alternativeModalAnalytics(isEdit: boolean, action: 'clicked' | 'placed') {
+  sendEvent({
+    category: Category.TRADE,
+    action: `${isEdit ? 'Edit' : 'Recreate'} order: ${action}`,
   })
 }


### PR DESCRIPTION
# Summary

Closes #4096 

Add analytics events for clicking on recreate and placing recreate orders.

Edit orders are not enabled but the events are already prepared for that.

# To Test

1. Click on recreate
* Analytics event `Recreate order: clicked` should be fired
2. Place recreate order
* Analytics event `Recreate order: placed` should be fired