### PR TITLE
chore: fix widget-cfg vite config

### DIFF
--- a/apps/widget-configurator/package.json
+++ b/apps/widget-configurator/package.json
@@ -2,7 +2,7 @@
   "name": "@cowprotocol/widget-configurator",
   "version": "1.0.1",
   "description": "CoW Swap widget configurator",
-  "main": "index.js",
+  "main": "src/main.tsx",
   "author": "",
   "license": "ISC",
   "scripts": {},
@@ -22,6 +22,5 @@
     ]
   },
   "dependencies": {},
-  "devDependencies": {},
-  "nx": {}
+  "devDependencies": {}
 }

--- a/apps/widget-configurator/vite.config.ts
+++ b/apps/widget-configurator/vite.config.ts
@@ -1,6 +1,6 @@
 /// <reference types="vitest" />
 import react from '@vitejs/plugin-react-swc'
-import { defineConfig } from 'vite'
+import { defineConfig, searchForWorkspaceRoot } from 'vite'
 import macrosPlugin from 'vite-plugin-babel-macros'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 import viteTsConfigPaths from 'vite-tsconfig-paths'
@@ -35,6 +35,15 @@ export default defineConfig(({ mode }) => {
     server: {
       port: 4200,
       host: 'localhost',
+      fs: {
+        allow: [
+          // search up for workspace root
+          searchForWorkspaceRoot(process.cwd()),
+          // your custom rules
+          'apps/widget-configurator/src',
+          'libs',
+        ],
+      },
     },
 
     preview: {


### PR DESCRIPTION
# Summary

After adding [the fix](https://github.com/cowprotocol/cowswap/pull/4123), widget-configurator stopped working locally.
Just added `server.fs.allow` value similarly with other apps.