### PR TITLE
fix(limit-orders): revert use ff for zero balance orders

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -31,15 +31,14 @@ import { LimitOrdersConfirmModal } from '../LimitOrdersConfirmModal'
 import { RateInput } from '../RateInput'
 import { SettingsWidget } from '../SettingsWidget'
 
-const LIMIT_BULLET_LIST_CONTENT: BulletListItem[] = [
+export const LIMIT_BULLET_LIST_CONTENT: BulletListItem[] = [
   { content: 'Set any limit price and time horizon' },
   { content: 'FREE order placement and cancellation' },
   { content: 'Place multiple orders using the same balance' },
   { content: 'Receive surplus of your order' },
   { content: 'Protection from MEV by default' },
   {
-    featureFlag: 'isZeroBalanceOrdersEnabled',
-    content: 'Place orders for higher than available balance!',
+    content: <span>Place orders for higher than available balance!</span>,
   },
 ]
 

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
@@ -20,7 +20,6 @@ import { useIsWidgetUnlocked } from 'modules/limitOrders'
 import { useOpenTokenSelectWidget } from 'modules/tokensList'
 import { useIsAlternativeOrderModalVisible } from 'modules/trade/state/alternativeOrder'
 
-import { FeatureGuard } from 'common/containers/FeatureGuard'
 import { useCategorizeRecentActivity } from 'common/hooks/useCategorizeRecentActivity'
 import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetworkUnsupported'
 import { useThrottleFn } from 'common/hooks/useThrottleFn'
@@ -104,6 +103,7 @@ export function TradeWidgetForm(props: TradeWidgetProps) {
 
   const showDropdown = shouldShowMyOrdersButton || isInjectedWidgetMode
 
+
   const currencyInputCommonProps = {
     isChainIdUnsupported,
     chainId,
@@ -168,26 +168,24 @@ export function TradeWidgetForm(props: TradeWidgetProps) {
                 {...currencyInputCommonProps}
               />
 
-              <FeatureGuard featureFlag="isZeroBalanceOrdersEnabled">
-                {isLimitOrderMode &&
-                  !isWrapOrUnwrap &&
-                  ClosableBanner(ZERO_BANNER_STORAGE_KEY, (onClose) => (
-                    <InlineBanner
-                      bannerType="success"
-                      orientation={BannerOrientation.Horizontal}
-                      customIcon={ICON_TOKENS}
-                      iconSize={32}
-                      margin={'10px 0 0'}
-                      onClose={onClose}
-                    >
-                      <p>
-                        <b>NEW: </b>You can now place limit orders for amounts larger than your wallet balance. Partial
-                        fill orders will execute until you run out of sell tokens. Fill-or-kill orders will become
-                        active once you top up your balance.
-                      </p>
-                    </InlineBanner>
-                  ))}
-              </FeatureGuard>
+              {isLimitOrderMode &&
+                !isWrapOrUnwrap &&
+                ClosableBanner(ZERO_BANNER_STORAGE_KEY, (onClose) => (
+                  <InlineBanner
+                    bannerType="success"
+                    orientation={BannerOrientation.Horizontal}
+                    customIcon={ICON_TOKENS}
+                    iconSize={32}
+                    margin={'10px 0 0'}
+                    onClose={onClose}
+                  >
+                    <p>
+                      <b>NEW: </b>You can now place limit orders for amounts larger than your wallet balance. Partial
+                      fill orders will execute until you run out of sell tokens. Fill-or-kill orders will become active
+                      once you top up your balance.
+                    </p>
+                  </InlineBanner>
+                ))}
             </div>
             {!isWrapOrUnwrap && middleContent}
             <styledEl.CurrencySeparatorBox compactView={compactView} withRecipient={withRecipient}>

--- a/apps/cowswap-frontend/src/modules/trade/pure/UnlockWidgetScreen/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/UnlockWidgetScreen/index.tsx
@@ -5,14 +5,11 @@ import { ExternalLink } from '@cowprotocol/ui'
 
 import SVG from 'react-inlinesvg'
 
-import { FeatureGuard } from 'common/containers/FeatureGuard'
-
 import * as styledEl from './styled'
 
 export type BulletListItem = {
   content: string | React.ReactNode
   isNew?: boolean
-  featureFlag?: string
 }
 
 type UnlockWidgetProps = {
@@ -45,18 +42,14 @@ export function UnlockWidgetScreen({
 
       {items && (
         <styledEl.List>
-          {items.map(({ isNew, content, featureFlag }, index) => {
-            const item = (
-              <li key={index} data-is-new={isNew || null}>
-                <span>
-                  <SVG src={iconCompleted} />
-                </span>{' '}
-                {content}
-              </li>
-            )
-
-            return featureFlag ? <FeatureGuard featureFlag={featureFlag}>{item}</FeatureGuard> : item
-          })}
+          {items.map(({ isNew, content }, index) => (
+            <li key={index} data-is-new={isNew || null}>
+              <span>
+                <SVG src={iconCompleted} />
+              </span>{' '}
+              {content}
+            </li>
+          ))}
         </styledEl.List>
       )}
 

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormValidationContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormValidationContext.ts
@@ -1,6 +1,5 @@
 import { useMemo } from 'react'
 
-import { useFeatureFlags } from '@cowprotocol/common-hooks'
 import { useENSAddress } from '@cowprotocol/ens'
 import { useIsTradeUnsupported } from '@cowprotocol/tokens'
 import { useGnosisSafeInfo, useIsBundlingSupported, useWalletDetails, useWalletInfo } from '@cowprotocol/wallet'
@@ -20,7 +19,6 @@ export function useTradeFormValidationContext(): TradeFormValidationCommonContex
   const { account } = useWalletInfo()
   const { state: derivedTradeState } = useDerivedTradeState()
   const tradeQuote = useTradeQuote()
-  const { isZeroBalanceOrdersEnabled } = useFeatureFlags()
 
   const { inputCurrency, outputCurrency, slippageAdjustedSellAmount, recipient, tradeType } = derivedTradeState || {}
   const { state: approvalState } = useApproveState(slippageAdjustedSellAmount)
@@ -37,7 +35,7 @@ export function useTradeFormValidationContext(): TradeFormValidationCommonContex
 
   const isPermitSupported = useTokenSupportsPermit(inputCurrency, tradeType)
 
-  const isInsufficientBalanceOrderAllowed = isZeroBalanceOrdersEnabled && tradeType === TradeType.LIMIT_ORDER
+  const isInsufficientBalanceOrderAllowed = tradeType === TradeType.LIMIT_ORDER
 
   const commonContext = {
     account,


### PR DESCRIPTION
# Summary

This reverts commit 28c60bda7b8817ff7156e9e24f253f57da427b36.

No balance limit orders have been enabled.
No need for feature flag.

# To Test

1. Limit orders should work as usual
2. Limit orders banner should be displayed
3. Should be possible to place `partial fills` and `fill or kill` orders without enough balance