### PR TITLE
fix(widget): disable connect wallet button in dapp mode

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/hooks/useSwapButtonContext.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useSwapButtonContext.ts
@@ -15,6 +15,7 @@ import { useToggleWalletModal } from 'legacy/state/application/hooks'
 import { useGetQuoteAndStatus, useIsBestQuoteLoading } from 'legacy/state/price/hooks'
 import { Field } from 'legacy/state/types'
 
+import { useInjectedWidgetParams } from 'modules/injectedWidget'
 import { useTokenSupportsPermit } from 'modules/permit'
 import { getSwapButtonState } from 'modules/swap/helpers/getSwapButtonState'
 import { useEthFlowContext } from 'modules/swap/hooks/useEthFlowContext'
@@ -60,6 +61,7 @@ export function useSwapButtonContext(input: SwapButtonInput): SwapButtonsContext
   const { onCurrencySelection } = useSwapActionHandlers()
   const isBestQuoteLoading = useIsBestQuoteLoading()
   const tradeConfirmActions = useTradeConfirmActions()
+  const { standaloneMode } = useInjectedWidgetParams()
 
   const currencyIn = currencies[Field.INPUT]
   const currencyOut = currencies[Field.OUTPUT]
@@ -130,6 +132,7 @@ export function useSwapButtonContext(input: SwapButtonInput): SwapButtonsContext
     swapInputError,
     onCurrencySelection,
     recipientAddressOrName,
+    widgetStandaloneMode: standaloneMode,
   }
 }
 

--- a/apps/cowswap-frontend/src/modules/swap/pure/SwapButtons/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/SwapButtons/index.tsx
@@ -37,6 +37,7 @@ export interface SwapButtonsContext {
   swapInputError?: ReactNode
   onCurrencySelection: (field: Field, currency: Currency) => void
   recipientAddressOrName: string | null
+  widgetStandaloneMode?: boolean
 }
 
 const swapButtonStateMap: { [key in SwapButtonState]: (props: SwapButtonsContext) => JSX.Element } = {
@@ -107,7 +108,7 @@ const swapButtonStateMap: { [key in SwapButtonState]: (props: SwapButtonsContext
     <ButtonPrimary
       buttonSize={ButtonSize.BIG}
       onClick={props.toggleWalletModal || undefined}
-      disabled={!props.toggleWalletModal}
+      disabled={!props.toggleWalletModal || props.widgetStandaloneMode === false}
     >
       <styledEl.SwapButtonBox>Connect Wallet</styledEl.SwapButtonBox>
     </ButtonPrimary>

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormButtonContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormButtonContext.ts
@@ -4,6 +4,7 @@ import { useWalletDetails } from '@cowprotocol/wallet'
 
 import { useToggleWalletModal } from 'legacy/state/application/hooks'
 
+import { useInjectedWidgetParams } from 'modules/injectedWidget'
 import { useWrapNativeFlow } from 'modules/trade'
 import { useDerivedTradeState } from 'modules/trade/hooks/useDerivedTradeState'
 import { useTradeQuote } from 'modules/tradeQuote'
@@ -24,6 +25,7 @@ export function useTradeFormButtonContext(
   const { isSupportedWallet } = useWalletDetails()
   const quote = useTradeQuote()
   const toggleWalletModal = useToggleWalletModal()
+  const { standaloneMode } = useInjectedWidgetParams()
 
   return useMemo(() => {
     if (!derivedState) return null
@@ -36,6 +38,16 @@ export function useTradeFormButtonContext(
       ...callbacks,
       wrapNativeFlow,
       connectWallet: toggleWalletModal,
+      widgetStandaloneMode: standaloneMode,
     }
-  }, [defaultText, derivedState, quote, isSupportedWallet, callbacks, wrapNativeFlow, toggleWalletModal])
+  }, [
+    defaultText,
+    derivedState,
+    quote,
+    isSupportedWallet,
+    callbacks,
+    wrapNativeFlow,
+    toggleWalletModal,
+    standaloneMode,
+  ])
 }

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
@@ -99,7 +99,10 @@ export const tradeButtonsMap: Record<TradeFormValidation, ButtonErrorConfig | Bu
   [TradeFormValidation.QuoteExpired]: { text: 'Quote expired. Refreshing...' },
   [TradeFormValidation.WalletNotConnected]: (context) => {
     return (
-      <TradeFormBlankButton onClick={context.connectWallet || undefined} disabled={!context.connectWallet}>
+      <TradeFormBlankButton
+        onClick={context.connectWallet || undefined}
+        disabled={!context.connectWallet || context.widgetStandaloneMode === false}
+      >
         <Trans>Connect Wallet</Trans>
       </TradeFormBlankButton>
     )

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/types.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/types.ts
@@ -61,6 +61,7 @@ export interface TradeFormButtonContext {
   derivedState: TradeDerivedState
   quote: TradeQuoteState
   isSupportedWallet: boolean
+  widgetStandaloneMode?: boolean
 
   doTrade(): void
   confirmTrade(): void


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C0361CDG8GP/p1712239854250149

<img width="1125" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/ca42a80d-2a6b-428f-ac84-0b96c4d28f46">


# To Test

1. Clean localStorage in CowSwap
2. Open widget-cfg and disconnect wallet
- [ ] AR: wallet is not connected and the button is active
- [ ] ER: wallet is not connected and the button is disabled (because integrator controls wallet connection)