### PR TITLE
feat(widget): option to hide safe banner

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
@@ -9,6 +9,7 @@ import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import styled from 'styled-components/macro'
 import { Nullish } from 'types'
 
+import { useInjectedWidgetParams } from 'modules/injectedWidget'
 import { useLimitOrdersDerivedState } from 'modules/limitOrders/hooks/useLimitOrdersDerivedState'
 import { useLimitOrdersFormState } from 'modules/limitOrders/hooks/useLimitOrdersFormState'
 import { useRateImpact } from 'modules/limitOrders/hooks/useRateImpact'
@@ -64,6 +65,7 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
     useLimitOrdersDerivedState()
   const tradeQuote = useTradeQuote()
   const priceImpactParams = useTradePriceImpact()
+  const widgetParams = useInjectedWidgetParams()
 
   const isBundling = primaryFormValidation && FORM_STATES_TO_SHOW_BUNDLE_BANNER.includes(primaryFormValidation)
 
@@ -145,7 +147,7 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
       {/*// TODO: must be replaced by <NotificationBanner>*/}
       {showHighFeeWarning && <SmallVolumeWarningBanner feeAmount={feeAmount} feePercentage={feePercentage} />}
       {showApprovalBundlingBanner && <BundleTxApprovalBanner />}
-      {showSafeWcBundlingBanner && <BundleTxSafeWcBanner />}
+      {showSafeWcBundlingBanner && !widgetParams?.banners?.hideSafeWebAppBanner && <BundleTxSafeWcBanner />}
       {showNativeSellWarning && <SellNativeWarningBanner />}
     </Wrapper>
   ) : null

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
@@ -88,7 +88,8 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
     !isConfirmScreen &&
     !showApprovalBundlingBanner &&
     isSafeViaWc &&
-    primaryFormValidation === TradeFormValidation.ApproveRequired
+    primaryFormValidation === TradeFormValidation.ApproveRequired &&
+    !widgetParams?.banners?.hideSafeWebAppBanner
 
   // TODO: implement Safe App EthFlow bundling for LIMIT and disable the warning in that case
   const showNativeSellWarning = primaryFormValidation === TradeFormValidation.SellNativeToken
@@ -147,7 +148,7 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
       {/*// TODO: must be replaced by <NotificationBanner>*/}
       {showHighFeeWarning && <SmallVolumeWarningBanner feeAmount={feeAmount} feePercentage={feePercentage} />}
       {showApprovalBundlingBanner && <BundleTxApprovalBanner />}
-      {showSafeWcBundlingBanner && !widgetParams?.banners?.hideSafeWebAppBanner && <BundleTxSafeWcBanner />}
+      {showSafeWcBundlingBanner && <BundleTxSafeWcBanner />}
       {showNativeSellWarning && <SellNativeWarningBanner />}
     </Wrapper>
   ) : null

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
@@ -14,6 +14,7 @@ import { ApplicationModal } from 'legacy/state/application/reducer'
 import { Field } from 'legacy/state/types'
 import { useUserSlippageTolerance } from 'legacy/state/user/hooks'
 
+import { useInjectedWidgetParams } from 'modules/injectedWidget'
 import { EthFlowModal, EthFlowProps } from 'modules/swap/containers/EthFlow'
 import { SwapModals, SwapModalsProps } from 'modules/swap/containers/SwapModals'
 import { SwapButtonState } from 'modules/swap/helpers/getSwapButtonState'
@@ -70,7 +71,7 @@ export function SwapWidget() {
   const showRecipientControls = useShowRecipientControls(recipient)
   const isEoaEthFlow = useIsEoaEthFlow()
   const shouldZeroApprove = useShouldZeroApprove(slippageAdjustedSellAmount)
-
+  const widgetParams = useInjectedWidgetParams()
   const priceImpactParams = useTradePriceImpact()
 
   const isTradePriceUpdating = useTradePricesUpdate()
@@ -209,7 +210,8 @@ export function SwapWidget() {
   const showSafeWcWrapBundlingBanner = !showWrapBundlingBanner && isSafeViaWc && isSwapEth
 
   // Show the same banner when approval is needed or selling native token
-  const showSafeWcBundlingBanner = showSafeWcApprovalBundlingBanner || showSafeWcWrapBundlingBanner
+  const showSafeWcBundlingBanner =
+    (showSafeWcApprovalBundlingBanner || showSafeWcWrapBundlingBanner) && !widgetParams.banners?.hideSafeWebAppBanner
 
   const nativeCurrencySymbol = useNativeCurrency().symbol || 'ETH'
   const wrappedCurrencySymbol = useWrappedToken().symbol || 'WETH'

--- a/apps/widget-configurator/src/app/configurator/index.tsx
+++ b/apps/widget-configurator/src/app/configurator/index.tsx
@@ -47,6 +47,12 @@ import { web3Modal } from '../../wagmiConfig'
 import { connectWalletToConfiguratorGA } from '../analytics'
 import { EmbedDialog } from '../embedDialog'
 
+declare global {
+  interface Window {
+    cowSwapWidgetParams?: Partial<CowSwapWidgetParams>
+  }
+}
+
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 const DEFAULT_STATE = {
@@ -159,6 +165,7 @@ export function Configurator({ title }: { title: string }) {
       images: customImages,
       sounds: customSounds,
       customTokens,
+      ...window.cowSwapWidgetParams,
     }),
     [computedParams, customImages, customSounds, customTokens]
   )

--- a/libs/widget-lib/src/types.ts
+++ b/libs/widget-lib/src/types.ts
@@ -250,6 +250,19 @@ export interface CowSwapWidgetParams {
     orderError?: string | null
   }
 
+  banners?: {
+    /**
+     * Banner text: "Use Safe web app..."
+     *
+     * Conditions of the banner displaying:
+     *  - Safe-like app is connected to CoW Swap via WalletConnect
+     *  - Selling native token via Swap
+     *
+     *  If the flag is set to true, the banner will not be displayed
+     */
+    hideSafeWebAppBanner?: boolean
+  }
+
   /**
    * In case when widget does not support some tokens, you can provide a list of tokens to be used in the widget
    */

--- a/libs/widget-lib/src/types.ts
+++ b/libs/widget-lib/src/types.ts
@@ -121,6 +121,47 @@ export interface CowSwapWidgetPalette {
   success: string
 }
 
+export interface CowSwapWidgetSounds {
+  /**
+   * The sound to play when the order is executed. Defaults to world wide famous CoW Swap moooooooooo!
+   * Alternatively, you can use a URL to a custom sound file, or set to null to disable the sound.
+   */
+  postOrder?: string | null
+
+  /**
+   * The sound to play when the order is executed. Defaults to world wide famous CoW Swap happy moooooooooo!
+   * Alternatively, you can use a URL to a custom sound file, or set to null to disable the sound.
+   */
+  orderExecuted?: string | null
+
+  /**
+   * The sound to play when the order is executed. Defaults to world wide famous CoW Swap unhappy moooooooooo!
+   * Alternatively, you can use a URL to a custom sound file, or set to null to disable the sound.
+   */
+  orderError?: string | null
+}
+
+export interface CowSwapWidgetImages {
+  /**
+   * The image to display when the orders table is empty (no orders yet). It defaults to "Yoga CoW" image.
+   * Alternatively, you can use a URL to a custom image file, or set to null to disable the image.
+   */
+  emptyOrders?: string | null
+}
+
+export interface CowSwapWidgetBanners {
+  /**
+   * Banner text: "Use Safe web app..."
+   *
+   * Conditions of the banner displaying:
+   *  - Safe-like app is connected to CoW Swap via WalletConnect
+   *  - Selling native token via Swap
+   *
+   *  If the flag is set to true, the banner will not be displayed
+   */
+  hideSafeWebAppBanner?: boolean
+}
+
 export interface CowSwapWidgetParams {
   /**
    * The unique identifier of the widget consumer.
@@ -219,49 +260,17 @@ export interface CowSwapWidgetParams {
   /**
    * Customizable images for the widget.
    */
-  images?: {
-    /**
-     * The image to display when the orders table is empty (no orders yet). It defaults to "Yoga CoW" image.
-     * Alternatively, you can use a URL to a custom image file, or set to null to disable the image.
-     */
-    emptyOrders?: string | null
-  }
+  images?: CowSwapWidgetImages
 
   /**
    * Sounds configuration for the app.
    */
-  sounds?: {
-    /**
-     * The sound to play when the order is executed. Defaults to world wide famous CoW Swap moooooooooo!
-     * Alternatively, you can use a URL to a custom sound file, or set to null to disable the sound.
-     */
-    postOrder?: string | null
+  sounds?: CowSwapWidgetSounds
 
-    /**
-     * The sound to play when the order is executed. Defaults to world wide famous CoW Swap happy moooooooooo!
-     * Alternatively, you can use a URL to a custom sound file, or set to null to disable the sound.
-     */
-    orderExecuted?: string | null
-
-    /**
-     * The sound to play when the order is executed. Defaults to world wide famous CoW Swap unhappy moooooooooo!
-     * Alternatively, you can use a URL to a custom sound file, or set to null to disable the sound.
-     */
-    orderError?: string | null
-  }
-
-  banners?: {
-    /**
-     * Banner text: "Use Safe web app..."
-     *
-     * Conditions of the banner displaying:
-     *  - Safe-like app is connected to CoW Swap via WalletConnect
-     *  - Selling native token via Swap
-     *
-     *  If the flag is set to true, the banner will not be displayed
-     */
-    hideSafeWebAppBanner?: boolean
-  }
+  /**
+   * Flags to control the display of banners in the widget.
+   */
+  banners?: CowSwapWidgetBanners
 
   /**
    * In case when widget does not support some tokens, you can provide a list of tokens to be used in the widget

--- a/libs/widget-lib/src/types.ts
+++ b/libs/widget-lib/src/types.ts
@@ -153,9 +153,10 @@ export interface CowSwapWidgetBanners {
   /**
    * Banner text: "Use Safe web app..."
    *
-   * Conditions of the banner displaying:
+   * Conditions for displaying the banner:
    *  - Safe-like app is connected to CoW Swap via WalletConnect
    *  - Selling native token via Swap
+   *  - Sell token needs approval
    *
    *  If the flag is set to true, the banner will not be displayed
    */


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C036G0J90BU/p1712267092933019

<img width="545" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/962ac0cb-9d1b-4f40-bf65-93c4a8a0ab73">

# To Test

1. Open widget configurator
2. Switch to standalone mode (or dapp-mode with connected Safe via WC)
3. Connect to Safe via WC
4. Setup sell ETH trade
- [ ] the banner should be displayed
5. Open browser console and execute `window.cowSwapWidgetParams = {banners: {hideSafeWebAppBanner: true}}`
6. Change some value in the configurator UI, for example: sell amount
7. Setup sell ETH trade again (if needed)
- [ ] the banner should not be displayed