### PR TITLE
fix(widget): call disconnect when destroying the widget

### DIFF
--- a/libs/widget-lib/src/cowSwapWidget.ts
+++ b/libs/widget-lib/src/cowSwapWidget.ts
@@ -1,5 +1,7 @@
 import { CowEventListeners } from '@cowprotocol/events'
+import { IframeCowEventEmitter } from './IframeCowEventEmitter'
 import { IframeRpcProviderBridge } from './IframeRpcProviderBridge'
+import { WindowListener, listenToMessageFromWindow, postMessageToWindow, stopListeningWindowListener } from './messages'
 import {
   CowSwapWidgetParams,
   CowSwapWidgetProps,
@@ -8,8 +10,6 @@ import {
   WidgetMethodsListen,
 } from './types'
 import { buildTradeAmountsQuery, buildWidgetPath, buildWidgetUrl } from './urlUtils'
-import { IframeCowEventEmitter } from './IframeCowEventEmitter'
-import { WindowListener, listenToMessageFromWindow, postMessageToWindow, stopListeningWindowListener } from './messages'
 
 const DEFAULT_HEIGHT = '640px'
 const DEFAULT_WIDTH = '450px'
@@ -81,6 +81,8 @@ export function createCowSwapWidget(container: HTMLElement, props: CowSwapWidget
     },
 
     destroy: () => {
+      // Disconnet rpc provider and unsubscribe to events
+      iframeRpcProviderBridge.disconnect()
       // Stop listening for cow events
       iFrameCowEventEmitter.stopListeningIframe()
 


### PR DESCRIPTION
# Summary

Fixes #3952 

Fix issue causing widget to duplicate events every time the network is changed when on `Dapp` mode.

# To Test

1. Open widget configurator
2. Change to `standalone` then change back to `dapp`
3. Connect with Wagmi modal
4. Change the network in the configurator panel
5. Fill in the form and proceed placing the order until the wallet signature is requested
* There should be *only 1* signature requested
* The rest of the app should behave as usual