### PR TITLE
fix: add partner fee too app-data only for swap orders

### DIFF
--- a/apps/cowswap-frontend/src/modules/appData/updater/AppDataUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/appData/updater/AppDataUpdater.tsx
@@ -15,6 +15,8 @@ import { AppDataInfoUpdater, UseAppDataParams } from './AppDataInfoUpdater'
 import { useAppCode, useAppDataHooks } from '../hooks'
 import { AppDataOrderClass } from '../types'
 
+const ORDERS_WITH_PARTNER_FEE: AppDataOrderClass[] = ['market']
+
 interface AppDataUpdaterProps {
   slippage: Percent
   orderClass: AppDataOrderClass
@@ -28,10 +30,12 @@ export const AppDataUpdater = React.memo(({ slippage, orderClass }: AppDataUpdat
   const utm = useUtm()
   const hooks = useAppDataHooks()
   const appCodeWithWidgetMetadata = useAppCodeWidgetAware(appCode)
-  const { partnerFee } = useInjectedWidgetParams()
+  const widgetParams = useInjectedWidgetParams()
   const replacedOrderUid = useReplacedOrderUid()
 
   if (!chainId) return null
+
+  const partnerFee = ORDERS_WITH_PARTNER_FEE.includes(orderClass) ? widgetParams.partnerFee : undefined
 
   return (
     <AppDataUpdaterMemo


### PR DESCRIPTION
# Summary

Since partner fee program is currently working only with swap orders, we don't even need to add the data to limit/twap orders app-data.

# To Test

1. Create a swap order with partner-fee
- [ ] the fee value should be displayed in the order app-data (check in Explorer)
2. Create a limit order with partner-fee
- [ ] the fee value should NOT be displayed in the order app-data (check in Explorer)
3. Create a TWAP order with partner-fee
- [ ] the fee value should NOT be displayed in the order app-data (check in Explorer)