### PR TITLE
feat(tokens-table): do not show explorer link for native token

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/Tokens/TokensTableRow.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Tokens/TokensTableRow.tsx
@@ -7,7 +7,7 @@ import { getBlockExplorerUrl, getIsNativeToken } from '@cowprotocol/common-utils
 import { SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
 import { useAreThereTokensWithSameSymbol } from '@cowprotocol/tokens'
 import { Command } from '@cowprotocol/types'
-import { TokenAmount, TokenSymbol, Loader, TokenName } from '@cowprotocol/ui'
+import { Loader, TokenAmount, TokenName, TokenSymbol } from '@cowprotocol/ui'
 import { useWalletInfo } from '@cowprotocol/wallet'
 import { CurrencyAmount, MaxUint256, Token } from '@uniswap/sdk-core'
 
@@ -184,12 +184,16 @@ export const TokensTableRow = ({
       <Cell>{fiatValue}</Cell>
 
       <Cell>
-        <ExtLink href={getBlockExplorerUrl(chainId, 'token', tokenData.address)}>
-          <TableButton>
-            <SVG src={EtherscanImage} title="View token contract" description="View token contract" />
-          </TableButton>
-        </ExtLink>
-        {displayApproveContent}
+        {displayApproveContent && (
+          <>
+            <ExtLink href={getBlockExplorerUrl(chainId, 'token', tokenData.address)}>
+              <TableButton>
+                <SVG src={EtherscanImage} title="View token contract" description="View token contract" />
+              </TableButton>
+            </ExtLink>
+            {displayApproveContent}
+          </>
+        )}
       </Cell>
     </>
   )


### PR DESCRIPTION
# Summary

Fixes #4035 

No explorer link for Native token on tokens page

![image](https://github.com/cowprotocol/cowswap/assets/43217/9a4dc6db-1f25-4a8a-b5fb-8bbc417395f6)


# To Test

1. Go to tokens page
2. Native token should have no explorer link