### PR TITLE
fix(mobile): adjust fee display for tiny widths

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/RateInfo/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/RateInfo/index.tsx
@@ -2,8 +2,7 @@ import React, { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'r
 
 import { getAddress } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { FiatAmount, TokenAmount, TokenSymbol } from '@cowprotocol/ui'
-import { UI } from '@cowprotocol/ui'
+import { FiatAmount, TokenAmount, TokenSymbol, UI } from '@cowprotocol/ui'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
 import { Trans } from '@lingui/macro'
@@ -134,6 +133,7 @@ export const FiatRate = styled.span`
   opacity: 0.7;
   font-weight: 400;
   text-align: right;
+  white-space: nowrap;
 `
 
 export function InvertRateControl({ onClick, className }: { onClick(): void; className?: string }) {
@@ -232,8 +232,8 @@ export function RateInfo({
           <span
             title={
               currentActiveRate.toFixed(rateOutputCurrency.decimals || DEFAULT_DECIMALS) +
-                ' ' +
-                rateOutputCurrency.symbol || ''
+              ' ' +
+              rateOutputCurrency.symbol || ''
             }
           >
             {prependSymbol && (

--- a/apps/cowswap-frontend/src/common/pure/TradeDetailsAccordion/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/TradeDetailsAccordion/index.tsx
@@ -40,6 +40,7 @@ const Summary = styled.div`
   span {
     font-size: inherit;
     font-weight: inherit;
+    white-space: nowrap;
   }
 `
 


### PR DESCRIPTION
# Summary

Fixes #3953 

Do not wrap fee text

![image](https://github.com/cowprotocol/cowswap/assets/43217/27f114a4-dbef-4988-bfa9-bcccfe718f12)

# To Test

1. Fill in trade details to see the fee
2. Switch to a tiny width (up to 300px wide)
* USD fee amounts shouldn't wrap, but display in the next line instead