### PR TITLE
fix: sentry error toLowerCase

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/utils/swapErrorHelper.ts
+++ b/apps/cowswap-frontend/src/modules/trade/utils/swapErrorHelper.ts
@@ -8,7 +8,7 @@ export function getSwapErrorMessage(error: Error): string {
   if (isRejectRequestProviderError(error)) {
     return USER_SWAP_REJECTED_ERROR
   } else {
-    const defaultErrorMessage = getProviderErrorMessage(error)
+    const defaultErrorMessage = getProviderErrorMessage(error) || String(error)
 
     if (isValidOperatorError(error)) {
       return capitalizeFirstLetter(error.message) || defaultErrorMessage

--- a/libs/common-utils/src/misc.ts
+++ b/libs/common-utils/src/misc.ts
@@ -139,9 +139,9 @@ export function hashCode(text: string): number {
  * Some providers return some description in the error.message, and some others the error message is itself a String
  * with the error message
  */
-export function getProviderErrorMessage(error: any) {
+export function getProviderErrorMessage(error: unknown): string | undefined {
   if (typeof error === 'string') return error
-  if (error && 'message' in error) return error.message
+  if (error && typeof error === 'object' && 'message' in error) return error.message as string
   return error?.toString()
 }
 


### PR DESCRIPTION
# Summary

Fixes #4190 

Fixes the sentry error caused by calling `toLowerCase` in an undefined obj.

![image](https://github.com/cowprotocol/cowswap/assets/43217/da4f173a-6978-45e3-b7e8-880ce45903d0)

# To Test

I have no reproducible steps.

Looking at the error and the current code, I can see that https://github.com/cowprotocol/cowswap/blob/1c724eff12ea93763679408ea94860323c6cb5d8/src/custom/utils/misc.ts#L132 can return `undefined` if error is not a string or doesn't have a `message` property.
This change makes sure `toLowerCase` is only called if the values exist.

# Background

Related to https://github.com/cowprotocol/cowswap/issues/4178, although might not be the root cause.
It throws a similar error, that's how I got to it.