### PR TITLE
fix: fix doesTokenMatchSymbolOrAddress app crash

### DIFF
--- a/libs/common-utils/src/doesTokenMatchSymbolOrAddress.ts
+++ b/libs/common-utils/src/doesTokenMatchSymbolOrAddress.ts
@@ -1,6 +1,6 @@
-import { Token } from '@uniswap/sdk-core'
 import { TokenInfo } from '@cowprotocol/types'
+import { Token } from '@uniswap/sdk-core'
 
-export const doesTokenMatchSymbolOrAddress = (token: Token | TokenInfo, symbolOrAddress: string) =>
-  token.address.toLowerCase() === symbolOrAddress.toLowerCase() ||
-  token.symbol?.toLowerCase() === symbolOrAddress.toLowerCase()
+export const doesTokenMatchSymbolOrAddress = (token: Token | TokenInfo, symbolOrAddress?: string) =>
+  token.address.toLowerCase() === symbolOrAddress?.toLowerCase() ||
+  token.symbol?.toLowerCase() === symbolOrAddress?.toLowerCase()


### PR DESCRIPTION
# Summary

Fixes #4192 

![image](https://github.com/cowprotocol/cowswap/assets/43217/df99ef08-56df-45ff-bcd0-02623966da58)

Typing wise this shouldn't be possible, but it did happen quite a few times.
Although not that much recently.
Still, addressing it anyway.

# To Test

No testing steps, addressing based on sentry error.