### PR TITLE
fix(widget-cfg): hardcode partner fee recipient address

### DIFF
--- a/apps/widget-configurator/src/app/configurator/consts.ts
+++ b/apps/widget-configurator/src/app/configurator/consts.ts
@@ -3,7 +3,8 @@ import { TradeType, TokenInfo } from '@cowprotocol/widget-lib'
 
 import { TokenListItem } from './types'
 
-export const DEFAULT_PARTNER_FEE_RECIPIENT = '0x8BFE784432C91169Bdf3469B52ac589912dE21C3'
+// CoW DAO address
+export const DEFAULT_PARTNER_FEE_RECIPIENT = '0xcA771eda0c70aA7d053aB1B25004559B918FE662'
 export const TRADE_MODES = [TradeType.SWAP, TradeType.LIMIT, TradeType.ADVANCED]
 
 // Sourced from https://tokenlists.org/

--- a/apps/widget-configurator/src/app/configurator/consts.ts
+++ b/apps/widget-configurator/src/app/configurator/consts.ts
@@ -3,6 +3,7 @@ import { TradeType, TokenInfo } from '@cowprotocol/widget-lib'
 
 import { TokenListItem } from './types'
 
+export const DEFAULT_PARTNER_FEE_RECIPIENT = '0x8BFE784432C91169Bdf3469B52ac589912dE21C3'
 export const TRADE_MODES = [TradeType.SWAP, TradeType.LIMIT, TradeType.ADVANCED]
 
 // Sourced from https://tokenlists.org/

--- a/apps/widget-configurator/src/app/configurator/controls/PartnerFeeControl.tsx
+++ b/apps/widget-configurator/src/app/configurator/controls/PartnerFeeControl.tsx
@@ -4,12 +4,10 @@ import TextField from '@mui/material/TextField'
 
 export interface PartnerFeeControlProps {
   feeBpsState: [number, Dispatch<SetStateAction<number>>]
-  recipientState: [string, Dispatch<SetStateAction<string>>]
 }
 export function PartnerFeeControl(props: PartnerFeeControlProps) {
-  const { feeBpsState, recipientState } = props
+  const { feeBpsState } = props
   const [feeBps, setFeeBps] = feeBpsState
-  const [recipient, setRecipient] = recipientState
 
   const onFeeBpsChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -28,14 +26,6 @@ export function PartnerFeeControl(props: PartnerFeeControlProps) {
         value={feeBps}
         onChange={onFeeBpsChange}
         type="number"
-        size="small"
-      />
-      <TextField
-        id="partnerFeeRecipient"
-        label="Partner fee recipient"
-        value={recipient}
-        onChange={(e: ChangeEvent<HTMLInputElement>) => setRecipient(e.target.value || '')}
-        type="text"
         size="small"
       />
     </>

--- a/apps/widget-configurator/src/app/configurator/index.tsx
+++ b/apps/widget-configurator/src/app/configurator/index.tsx
@@ -22,7 +22,7 @@ import ListItemText from '@mui/material/ListItemText'
 import Typography from '@mui/material/Typography'
 import { useAccount, useNetwork } from 'wagmi'
 
-import { COW_LISTENERS, DEFAULT_TOKEN_LISTS, TRADE_MODES } from './consts'
+import { COW_LISTENERS, DEFAULT_PARTNER_FEE_RECIPIENT, DEFAULT_TOKEN_LISTS, TRADE_MODES } from './consts'
 import { CurrencyInputControl } from './controls/CurrencyInputControl'
 import { CurrentTradeTypeControl } from './controls/CurrentTradeTypeControl'
 import { CustomImagesControl } from './controls/CustomImagesControl'
@@ -52,8 +52,6 @@ declare global {
     cowSwapWidgetParams?: Partial<CowSwapWidgetParams>
   }
 }
-
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 const DEFAULT_STATE = {
   sellToken: 'USDC',
@@ -110,10 +108,7 @@ export function Configurator({ title }: { title: string }) {
   const [customTokens] = customTokensState
 
   const partnerFeeBpsState = useState<number>(0)
-  const partnerFeeRecipientState = useState<string>(ZERO_ADDRESS)
-
   const [partnerFeeBps] = partnerFeeBpsState
-  const [partnerFeeRecipient] = partnerFeeRecipientState
 
   const customImagesState = useState<CowSwapWidgetParams['images']>({})
   const customSoundsState = useState<CowSwapWidgetParams['sounds']>({})
@@ -153,7 +148,7 @@ export function Configurator({ title }: { title: string }) {
     customColors: colorPalette,
     defaultColors: defaultPalette,
     partnerFeeBps,
-    partnerFeeRecipient,
+    partnerFeeRecipient: DEFAULT_PARTNER_FEE_RECIPIENT,
     standaloneMode,
     disableToastMessages,
   }
@@ -244,7 +239,7 @@ export function Configurator({ title }: { title: string }) {
 
         <Divider variant="middle">Integrations</Divider>
 
-        <PartnerFeeControl feeBpsState={partnerFeeBpsState} recipientState={partnerFeeRecipientState} />
+        <PartnerFeeControl feeBpsState={partnerFeeBpsState} />
 
         <Divider variant="middle">Customization</Divider>
 

--- a/apps/widget-configurator/src/app/embedDialog/const.ts
+++ b/apps/widget-configurator/src/app/embedDialog/const.ts
@@ -15,7 +15,7 @@ export const COMMENTS_BY_PARAM_NAME: Record<string, string> = {
   sell: 'Sell token. Optionally add amount for sell orders',
   buy: 'Buy token. Optionally add amount for buy orders',
   enabledTradeTypes: 'swap, limit and/or advanced',
-  partnerFee: 'Partner fee, in Basis Points (BPS) and a receiver address. Fill the form above if you are interested',
+  partnerFee: 'Partner fee, in Basis Points (BPS) and a receiver address',
 }
 
 export const COMMENTS_BY_PARAM_NAME_TYPESCRIPT: Record<string, string> = {


### PR DESCRIPTION
# Summary

Fixes #3977

1. Removed Partner fee recipient input from the widget configurator
2. Hardcoded "0x8BFE784432C91169Bdf3469B52ac589912dE21C3" as a recipient in the widget configurator
3. Added pk of the address into 1password

# To Test

1. The partner fee recipient input should be removed
2. An order app-data with partner fee should contain the address above as a partner fee recipient