### PR TITLE
feat: make widget to use all space

### DIFF
--- a/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
@@ -47,7 +47,7 @@ export function useWidgetParams(configuratorState: ConfiguratorState): CowSwapWi
 
     const params: CowSwapWidgetParams = {
       appCode: 'CoW Widget: Configurator',
-      width: '450px',
+      width: '100%',
       height: '640px',
       chainId,
       tokenLists: tokenListUrls.filter((list) => list.enabled).map((list) => list.url),

--- a/apps/widget-configurator/src/app/configurator/index.tsx
+++ b/apps/widget-configurator/src/app/configurator/index.tsx
@@ -300,7 +300,7 @@ export function Configurator({ title }: { title: string }) {
         </List>
       </Drawer>
 
-      <Box sx={ContentStyled}>
+      <Box sx={{ ...ContentStyled, pl: isDrawerOpen ? '300px' : 0 }}>
         {params && (
           <>
             <EmbedDialog

--- a/apps/widget-configurator/src/app/configurator/styled.ts
+++ b/apps/widget-configurator/src/app/configurator/styled.ts
@@ -21,6 +21,7 @@ export const DrawerStyled = (theme: Theme) => ({
 })
 
 export const ContentStyled = {
+  width: '100%',
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',

--- a/libs/widget-react/src/lib/CowSwapWidget.tsx
+++ b/libs/widget-react/src/lib/CowSwapWidget.tsx
@@ -98,5 +98,5 @@ export function CowSwapWidget(props: CowSwapWidgetProps) {
     )
   }
 
-  return <div ref={containerRef}></div>
+  return <div ref={containerRef} style={{ width: '100%' }}></div>
 }


### PR DESCRIPTION
# Summary

To show the widget, it would be nice to allow to show two version:
* Small responsive: We show it with a width of`450px`
* Big!: Will use as much space as available

For example, for limit orders, instead of:
<img width="1725" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/67a6db95-9718-422e-9e04-c1ce856fd2ff">

Now it tries to use all the space:

https://github.com/cowprotocol/cowswap/assets/2352112/db090d80-3259-491f-81cc-77a248207169

## Not included
It would be great to give an option on how to select Small/Big options. @fairlighteth how is best to show this control? 

