### PR TITLE
fix(eth-flow): fix classic eth flow crash

### DIFF
--- a/apps/cowswap-frontend/src/modules/advancedOrders/containers/AdvancedOrdersWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/advancedOrders/containers/AdvancedOrdersWidget/index.tsx
@@ -117,18 +117,15 @@ export function AdvancedOrdersWidget({ children, updaters, params, confirmConten
   }
 
   return (
-    <>
-      <TradeWidget
-        id="advanced-orders-page"
-        disableOutput={true}
-        slots={slots}
-        actions={actions}
-        params={tradeWidgetParams}
-        inputCurrencyInfo={inputCurrencyInfo}
-        outputCurrencyInfo={outputCurrencyInfo}
-      >
-        {confirmContent}
-      </TradeWidget>
-    </>
+    <TradeWidget
+      id="advanced-orders-page"
+      disableOutput={true}
+      slots={slots}
+      actions={actions}
+      params={tradeWidgetParams}
+      inputCurrencyInfo={inputCurrencyInfo}
+      outputCurrencyInfo={outputCurrencyInfo}
+      confirmModal={confirmContent}
+    />
   )
 }

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -230,8 +230,7 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
       params={params}
       inputCurrencyInfo={inputCurrencyInfo}
       outputCurrencyInfo={outputCurrencyInfo}
-    >
-      {tradeContext && (
+      confirmModal={tradeContext && (
         <LimitOrdersConfirmModal
           recipient={recipient}
           tradeContext={tradeContext}
@@ -240,6 +239,6 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
           outputCurrencyInfo={outputCurrencyPreviewInfo}
         />
       )}
-    </TradeWidget>
+    />
   )
 }, limitOrdersPropsChecker)

--- a/apps/cowswap-frontend/src/modules/swap/containers/EthFlow/hooks/useHandleChainChange.ts
+++ b/apps/cowswap-frontend/src/modules/swap/containers/EthFlow/hooks/useHandleChainChange.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+
+import { usePrevious } from '@cowprotocol/common-hooks'
+import { Command } from '@cowprotocol/types'
+import { useWalletInfo } from '@cowprotocol/wallet'
+
+/**
+ * Handles EthFlow chain change by calling onDismiss when it happens
+ */
+export function useHandleChainChange(onDismiss: Command): null {
+  const { chainId } = useWalletInfo()
+  const prevChainId = usePrevious(chainId)
+
+  useEffect(() => {
+    if (chainId && prevChainId && chainId !== prevChainId) onDismiss()
+  }, [chainId, onDismiss, prevChainId])
+
+  return null
+}

--- a/apps/cowswap-frontend/src/modules/swap/containers/EthFlow/hooks/useRemainingNativeTxsAndCosts.ts
+++ b/apps/cowswap-frontend/src/modules/swap/containers/EthFlow/hooks/useRemainingNativeTxsAndCosts.ts
@@ -4,7 +4,7 @@ import { AVG_APPROVE_COST_GWEI } from '@cowprotocol/common-const'
 import { getIsNativeToken } from '@cowprotocol/common-utils'
 import { useWalletInfo } from '@cowprotocol/wallet'
 import { BigNumber } from '@ethersproject/bignumber'
-import { CurrencyAmount, Currency } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
 import { parseUnits } from 'ethers/lib/utils'
 
@@ -60,7 +60,7 @@ export function _isLowBalanceCheck({
   nativeInput?: CurrencyAmount<Currency>
   balance?: CurrencyAmount<Currency>
 }) {
-  if (!threshold || !txCost) return false
+  if (!threshold || !txCost || (nativeInput && !txCost.currency.equals(nativeInput?.currency))) return false
   if (!nativeInput || !balance || nativeInput.add(txCost).greaterThan(balance)) return true
   // OK if: users_balance - (amt_input + 1_tx_cost) > low_balance_threshold
   return balance.subtract(nativeInput.add(txCost)).lessThan(threshold)
@@ -84,7 +84,8 @@ export default function useRemainingNativeTxsAndCosts({
   // does the user have a lower than set threshold balance? show error
   const balanceChecks: BalanceChecks = useMemo(() => {
     // we only check this for native currencies, otherwise stop
-    if (nativeInput?.currency && !getIsNativeToken(nativeInput.currency)) return undefined
+    if ((nativeInput?.currency && !getIsNativeToken(nativeInput.currency)) || chainId !== nativeInput?.currency.chainId)
+      return undefined
     const { multiTxCost, singleTxCost } = txCosts
 
     return {
@@ -96,7 +97,7 @@ export default function useRemainingNativeTxsAndCosts({
       }),
       txsRemaining: _getAvailableTransactions({ nativeBalance, nativeInput, singleTxCost }),
     }
-  }, [txCosts, nativeBalance, nativeInput])
+  }, [nativeInput, chainId, txCosts, nativeBalance])
 
   return { balanceChecks, ...txCosts }
 }

--- a/apps/cowswap-frontend/src/modules/swap/containers/EthFlow/hooks/useSetupEthFlow.ts
+++ b/apps/cowswap-frontend/src/modules/swap/containers/EthFlow/hooks/useSetupEthFlow.ts
@@ -1,9 +1,13 @@
 import { useSetAtom } from 'jotai'
 import { useEffect } from 'react'
 
+import { Command } from '@cowprotocol/types'
+
 import { ActivityDescriptors } from 'legacy/hooks/useRecentActivity'
 
 import { ApprovalState } from 'common/hooks/useApproveState'
+
+import { useHandleChainChange } from './useHandleChainChange'
 
 import { resetEthFlowContextAtom, updateEthFlowContextAtom } from '../../../state/EthFlow/ethFlowContextAtom'
 
@@ -12,6 +16,7 @@ interface EthFlowSetupParams {
   approveActivity: ActivityDescriptors | null
   wrapActivity: ActivityDescriptors | null
   hasEnoughWrappedBalanceForSwap: boolean
+  onDismiss: Command
 }
 
 export function useSetupEthFlow({
@@ -19,15 +24,17 @@ export function useSetupEthFlow({
   approvalState,
   approveActivity,
   wrapActivity,
+  onDismiss,
 }: EthFlowSetupParams) {
   const updateEthFlowContext = useSetAtom(updateEthFlowContextAtom)
   const resetEthFlowContext = useSetAtom(resetEthFlowContextAtom)
 
-  // Reset context once
+  useHandleChainChange(onDismiss)
+
+  // Reset once on start
   useEffect(() => {
     resetEthFlowContext()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [resetEthFlowContext])
 
   // Bind isNeeded flags
   useEffect(() => {

--- a/apps/cowswap-frontend/src/modules/swap/containers/EthFlow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/EthFlow/index.tsx
@@ -25,6 +25,7 @@ import { useEthFlowActions } from './hooks/useEthFlowActions'
 import useRemainingNativeTxsAndCosts from './hooks/useRemainingNativeTxsAndCosts'
 import { useSetupEthFlow } from './hooks/useSetupEthFlow'
 
+
 export interface EthFlowProps {
   nativeInput?: CurrencyAmount<Currency>
   hasEnoughWrappedBalanceForSwap: boolean
@@ -85,9 +86,8 @@ export function EthFlowModal({
     approvalState,
     approveActivity,
     wrapActivity,
+    onDismiss
   })
-
-  console.debug('ETH FLOW MODAL RENDER', ethFlowContext, state)
 
   return (
     <EthFlowModalContent

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapModals/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapModals/index.tsx
@@ -12,8 +12,6 @@ export interface SwapModalsProps {
 export const SwapModals = React.memo(function (props: SwapModalsProps) {
   const { showNativeWrapModal } = props
 
-  console.debug('RENDER SWAP MODALS: ', props)
-
   return (
     <>
       {/* TODO: Re-enable modal once subsidy is back  */}

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import { useCurrencyAmountBalance } from '@cowprotocol/balances-and-allowances'
 import { NATIVE_CURRENCIES, TokenWithLogo } from '@cowprotocol/common-const'
@@ -285,27 +285,24 @@ export function SwapWidget() {
       <SwapModals {...swapModalsProps} />
       <TradeWidgetContainer>
         {showNativeWrapModal && <EthFlowModal {...ethFlowProps} />}
-        {!showNativeWrapModal && (
-          <TradeWidget
-            id="swap-page"
-            slots={slots}
-            actions={swapActions}
-            params={params}
-            inputCurrencyInfo={inputCurrencyInfo}
-            outputCurrencyInfo={outputCurrencyInfo}
-          >
-            <ConfirmSwapModalSetup
-              chainId={chainId}
-              recipientAddressOrName={swapButtonContext.recipientAddressOrName}
-              doTrade={swapButtonContext.handleSwap}
-              priceImpact={priceImpactParams}
-              inputCurrencyInfo={inputCurrencyPreviewInfo}
-              outputCurrencyInfo={outputCurrencyPreviewInfo}
-              tradeRatesProps={tradeRatesProps}
-              refreshInterval={SWAP_QUOTE_CHECK_INTERVAL}
-            />
-          </TradeWidget>
-        )}
+        <TradeWidget
+          id="swap-page"
+          slots={slots}
+          actions={swapActions}
+          params={params}
+          inputCurrencyInfo={inputCurrencyInfo}
+          outputCurrencyInfo={outputCurrencyInfo}
+          confirmModal={<ConfirmSwapModalSetup
+            chainId={chainId}
+            recipientAddressOrName={swapButtonContext.recipientAddressOrName}
+            doTrade={swapButtonContext.handleSwap}
+            priceImpact={priceImpactParams}
+            inputCurrencyInfo={inputCurrencyPreviewInfo}
+            outputCurrencyInfo={outputCurrencyPreviewInfo}
+            tradeRatesProps={tradeRatesProps}
+            refreshInterval={SWAP_QUOTE_CHECK_INTERVAL}
+          />}
+        />
         <NetworkAlert />
       </TradeWidgetContainer>
     </>

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
@@ -284,7 +284,6 @@ export function SwapWidget() {
     <>
       <SwapModals {...swapModalsProps} />
       <TradeWidgetContainer>
-        {showNativeWrapModal && <EthFlowModal {...ethFlowProps} />}
         <TradeWidget
           id="swap-page"
           slots={slots}
@@ -302,6 +301,7 @@ export function SwapWidget() {
             tradeRatesProps={tradeRatesProps}
             refreshInterval={SWAP_QUOTE_CHECK_INTERVAL}
           />}
+          genericModal={showNativeWrapModal && <EthFlowModal {...ethFlowProps} />}
         />
         <NetworkAlert />
       </TradeWidgetContainer>

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetModals.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetModals.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useCallback, useEffect } from 'react'
+import { ReactNode, useCallback, useEffect } from 'react'
 
 import { useAddUserToken } from '@cowprotocol/tokens'
 import { useWalletInfo } from '@cowprotocol/wallet'
@@ -7,10 +7,10 @@ import {
   ImportTokenModal,
   SelectTokenWidget,
   useSelectTokenWidgetState,
-  useUpdateSelectTokenWidgetState,
   useTokenListAddingError,
+  useUpdateSelectTokenWidgetState,
 } from 'modules/tokensList'
-import { useZeroApproveModalState, ZeroApprovalModal } from 'modules/zeroApproval'
+import { ZeroApprovalModal, useZeroApproveModalState } from 'modules/zeroApproval'
 
 import { TradeApproveModal } from 'common/containers/TradeApprove'
 import { useTradeApproveState } from 'common/hooks/useTradeApproveState'

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetModals.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetModals.tsx
@@ -24,7 +24,7 @@ import { useTradeState } from '../../hooks/useTradeState'
 import { useWrapNativeScreenState } from '../../hooks/useWrapNativeScreenState'
 import { WrapNativeModal } from '../WrapNativeModal'
 
-export function TradeWidgetModals(confirmModal: ReactNode | undefined) {
+export function TradeWidgetModals(confirmModal: ReactNode | undefined, genericModal: ReactNode | undefined) {
   const { chainId, account } = useWalletInfo()
   const { state: rawState } = useTradeState()
   const importTokenCallback = useAddUserToken()
@@ -69,8 +69,11 @@ export function TradeWidgetModals(confirmModal: ReactNode | undefined) {
    */
   useEffect(() => {
     resetAllScreens()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chainId, account])
+  }, [chainId, account, resetAllScreens])
+
+  if (genericModal) {
+    return genericModal
+  }
 
   if (isTradeReviewOpen || pendingTrade) {
     return confirmModal

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 
 import * as styledEl from './styled'
 import { TradeWidgetForm } from './TradeWidgetForm'
@@ -9,7 +8,7 @@ import { TradeWidgetProps } from './types'
 export const TradeWidgetContainer = styledEl.Container
 
 export function TradeWidget(props: TradeWidgetProps) {
-  const { id, slots, params, children: confirmModal } = props
+  const { id, slots, params, confirmModal } = props
   const { disableQuotePolling = false, disableNativeSelling = false } = params
   const modals = TradeWidgetModals(confirmModal)
 

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/index.tsx
@@ -8,9 +8,9 @@ import { TradeWidgetProps } from './types'
 export const TradeWidgetContainer = styledEl.Container
 
 export function TradeWidget(props: TradeWidgetProps) {
-  const { id, slots, params, confirmModal } = props
+  const { id, slots, params, confirmModal, genericModal } = props
   const { disableQuotePolling = false, disableNativeSelling = false } = params
-  const modals = TradeWidgetModals(confirmModal)
+  const modals = TradeWidgetModals(confirmModal, genericModal)
 
   return (
     <>

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/types.ts
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/types.ts
@@ -42,5 +42,5 @@ export interface TradeWidgetProps {
   actions: TradeWidgetActions
   params: TradeWidgetParams
   disableOutput?: boolean
-  children?: ReactNode
+  confirmModal?: ReactNode
 }

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/types.ts
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/types.ts
@@ -43,4 +43,5 @@ export interface TradeWidgetProps {
   params: TradeWidgetParams
   disableOutput?: boolean
   confirmModal?: ReactNode
+  genericModal?: ReactNode
 }


### PR DESCRIPTION
# Summary

Fixes #4092 

Fix ethflow crash

New behaviour: when switching networks, ethflow modal/history is cleared.

# To Test

Steps from the issue:

1. Connect to the wallet in Sepolia chain
2. Select ETH as a sell token
3. ETH amount should be > WETH balance in the wallet, WETH should not be approved
4. Expand the 'Switch to the classic mode' dropdown and press on the Wrap ETH and Swap button
5. Run the Wrap transaction
6. When it is mined, switch to the GC in the connected wallet
* Should NOT crash
* Should be returned to SWAP
