### PR TITLE
fix(blocknative): ignore websocket errors

### DIFF
--- a/apps/cowswap-frontend/src/api/blocknative.ts
+++ b/apps/cowswap-frontend/src/api/blocknative.ts
@@ -20,6 +20,8 @@ if (!BLOCKNATIVE_API_KEY) {
   })
 }
 
+const BLOCKNATIVE_ERRORS_TO_IGNORE = /WebSocket error/
+
 export const sdk = !BLOCKNATIVE_API_KEY
   ? {}
   : ALL_SUPPORTED_CHAIN_IDS.reduce<Record<number, BlocknativeSdk | null>>((acc, networkId) => {
@@ -34,12 +36,15 @@ export const sdk = !BLOCKNATIVE_API_KEY
           name: 'bnc_' + networkId,
           onerror: (sdkError: SDKError) => {
             console.log('[blocknative]', sdkError)
-            const { sentryError, tags } = constructSentryError(sdkError.error, { message: sdkError.message })
-            Sentry.captureException(sentryError, {
-              tags,
-              contexts: { params },
-              extra: { ...sdkError },
-            })
+
+            if (!BLOCKNATIVE_ERRORS_TO_IGNORE.test(sdkError.message)) {
+              const { sentryError, tags } = constructSentryError(sdkError.error, { message: sdkError.message })
+              Sentry.captureException(sentryError, {
+                tags,
+                contexts: { params },
+                extra: { ...sdkError },
+              })
+            }
           },
         })
       } catch (error: any) {


### PR DESCRIPTION
# Summary

Fixes #4216 

Ignore blocknative websocket errors

# To Test

1. Connect from a country blocked by blocknative
2. Switch to ethereum
3. Check the console logs contain an error message similar to
![image](https://github.com/cowprotocol/cowswap/assets/43217/f5140801-f7bd-4f8a-9b4f-25c919d952e1)
* It should not be logged to Sentry
(How to check that locally? not sure... maybe only on the sentry panel?)