### PR TITLE
fix(swap): show TWAP suggestion banner only in Safe app

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
@@ -5,6 +5,7 @@ import { NATIVE_CURRENCIES, TokenWithLogo } from '@cowprotocol/common-const'
 import { isFractionFalsy } from '@cowprotocol/common-utils'
 import { useIsTradeUnsupported } from '@cowprotocol/tokens'
 import { useIsSafeViaWc, useWalletDetails, useWalletInfo } from '@cowprotocol/wallet'
+import { TradeType } from '@cowprotocol/widget-lib'
 
 import { NetworkAlert } from 'legacy/components/NetworkAlert/NetworkAlert'
 import SettingsTab from 'legacy/components/Settings'
@@ -202,16 +203,19 @@ export function SwapWidget() {
   const showWrapBundlingBanner = BUTTON_STATES_TO_SHOW_BUNDLE_WRAP_BANNER.includes(swapButtonContext.swapButtonState)
 
   const isSafeViaWc = useIsSafeViaWc()
+  const isSwapEth = useIsSwapEth()
 
   const showSafeWcApprovalBundlingBanner =
     !showApprovalBundlingBanner && isSafeViaWc && swapButtonContext.swapButtonState === SwapButtonState.NeedApprove
 
-  const isSwapEth = useIsSwapEth()
   const showSafeWcWrapBundlingBanner = !showWrapBundlingBanner && isSafeViaWc && isSwapEth
 
   // Show the same banner when approval is needed or selling native token
   const showSafeWcBundlingBanner =
     (showSafeWcApprovalBundlingBanner || showSafeWcWrapBundlingBanner) && !widgetParams.banners?.hideSafeWebAppBanner
+
+  const showTwapSuggestionBanner =
+    !widgetParams.enabledTradeTypes || widgetParams.enabledTradeTypes.includes(TradeType.ADVANCED)
 
   const nativeCurrencySymbol = useNativeCurrency().symbol || 'ETH'
   const wrappedCurrencySymbol = useWrappedToken().symbol || 'WETH'
@@ -226,6 +230,7 @@ export function SwapWidget() {
     showApprovalBundlingBanner,
     showWrapBundlingBanner,
     showSafeWcBundlingBanner,
+    showTwapSuggestionBanner,
     nativeCurrencySymbol,
     wrappedCurrencySymbol,
     setFeeWarningAccepted,

--- a/apps/cowswap-frontend/src/modules/swap/pure/warnings.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/warnings.tsx
@@ -29,6 +29,7 @@ export interface SwapWarningsTopProps {
   showWrapBundlingBanner: boolean
   shouldZeroApprove: boolean
   showSafeWcBundlingBanner: boolean
+  showTwapSuggestionBanner: boolean
   nativeCurrencySymbol: string
   wrappedCurrencySymbol: string
   buyingFiatAmount: CurrencyAmount<Currency> | null
@@ -61,6 +62,7 @@ export const SwapWarningsTop = React.memo(function (props: SwapWarningsTopProps)
     showApprovalBundlingBanner,
     showWrapBundlingBanner,
     showSafeWcBundlingBanner,
+    showTwapSuggestionBanner,
     nativeCurrencySymbol,
     wrappedCurrencySymbol,
     setFeeWarningAccepted,
@@ -98,13 +100,15 @@ export const SwapWarningsTop = React.memo(function (props: SwapWarningsTopProps)
         <BundleTxSafeWcBanner nativeCurrencySymbol={nativeCurrencySymbol} supportsWrapping />
       )}
 
-      <TwapSuggestionBanner
-        chainId={chainId}
-        priceImpact={priceImpact}
-        buyingFiatAmount={buyingFiatAmount}
-        tradeUrlParams={tradeUrlParams}
-        sellAmount={trade?.inputAmount.toExact()}
-      />
+      {showTwapSuggestionBanner && (
+        <TwapSuggestionBanner
+          chainId={chainId}
+          priceImpact={priceImpact}
+          buyingFiatAmount={buyingFiatAmount}
+          tradeUrlParams={tradeUrlParams}
+          sellAmount={trade?.inputAmount.toExact()}
+        />
+      )}
     </>
   )
 }, genericPropsChecker)


### PR DESCRIPTION
# Summary

Fixes #4166

Display the banner only in widget mode, when `enabledTradeTypes` contains `TradeType.ADVANCED`

<img width="637" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/3e754048-f244-4495-823d-1a03706dd9c2">

<img width="1728" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/db477c0b-c4ad-4e67-ad77-b81568fa20bd">


# To Test

1. Open widget configurator (by default all trade types are enabled)
2. Setup a trade with high price impact (>1%) and enough amount (Sepolia >100$, GC >500$, Mainnet > 50k$)
- [ ] the banner should displayed
3. Disable "advanced" trade type in the configurator
- [ ] the banner should not be displayed
