### PR TITLE
fix(snackbars): remove scrollbar from body when overlay is displayed

### DIFF
--- a/libs/snackbars/src/containers/SnackbarsWidget/index.tsx
+++ b/libs/snackbars/src/containers/SnackbarsWidget/index.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/macro'
 import { SnackbarPopup } from '../../pure/SnackbarPopup'
 import ms from 'ms.macro'
 import { AlertCircle, CheckCircle } from 'react-feather'
-import { ReactElement, useCallback, useMemo } from 'react'
+import { ReactElement, useCallback, useEffect, useMemo } from 'react'
 import { useResetAtom } from 'jotai/utils'
 import { UI } from '@cowprotocol/ui'
 
@@ -91,6 +91,12 @@ export function SnackbarsWidget({ hidden }: SnackbarsWidgetProps) {
     [removeSnackbar]
   )
 
+  const isOverlayDisplayed = snackbars.length > 0 && !hidden
+
+  useEffect(() => {
+    document.body.style.overflow = isOverlayDisplayed ? 'hidden' : ''
+  }, [isOverlayDisplayed])
+
   return (
     <Host hidden$={!!hidden}>
       <List>
@@ -110,7 +116,7 @@ export function SnackbarsWidget({ hidden }: SnackbarsWidgetProps) {
           )
         })}
       </List>
-      {snackbars.length > 0 && !hidden && <Overlay onClick={resetSnackbarsState} />}
+      {isOverlayDisplayed && <Overlay onClick={resetSnackbarsState} />}
     </Host>
   )
 }


### PR DESCRIPTION
# Summary

Fixes https://github.com/cowprotocol/cow-fi/issues/166

This fix is only about the last case in the issue (scroll bar when snackbar is displayed in mobile view).
The first case is not relevant anymore.
Second one is "ok", we should display the scrollbar here since this is a modal and we use fixed height for that cases.
@elena-zh I remember you already have an issue for styling scrollbars for Windows in the whole CoW Swap.

![image](https://github.com/cowprotocol/cowswap/assets/7122625/9febe2a3-abe5-4153-9f7b-92553659cd43)

# To Test

1. Open the widget in mobile resolution
2. Post an order
- [ ] the "Order submitted" snackbar should be displayed
- [ ] there is no scroll bar at the page bottom