### PR TITLE
fix(wallet): reset safe info when there's no safe data

### DIFF
--- a/libs/wallet/src/web3-react/updater.ts
+++ b/libs/wallet/src/web3-react/updater.ts
@@ -1,10 +1,12 @@
+import { useWeb3React } from '@web3-react/core'
 import { useSetAtom } from 'jotai'
+import ms from 'ms.macro'
 import { useEffect, useMemo, useState } from 'react'
 
-import { useWeb3React } from '@web3-react/core'
-
-import { getSafeInfo } from '@cowprotocol/core'
 import { getCurrentChainIdFromUrl } from '@cowprotocol/common-utils'
+import { getSafeInfo } from '@cowprotocol/core'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { useENSName } from '@cowprotocol/ens'
 
 import { useSafeAppsSdkInfo } from './hooks/useSafeAppsSdkInfo'
 import { useWalletMetaData } from './hooks/useWalletMetadata'
@@ -14,9 +16,6 @@ import { GnosisSafeInfo, WalletDetails, WalletInfo } from '../api/types'
 import { getWalletType } from '../api/utils/getWalletType'
 import { getWalletTypeLabel } from '../api/utils/getWalletTypeLabel'
 import { useIsSmartContractWallet } from './hooks/useIsSmartContractWallet'
-import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { useENSName } from '@cowprotocol/ens'
-import ms from 'ms.macro'
 
 const SAFE_INFO_UPDATE_INTERVAL = ms`30s`
 
@@ -79,6 +78,7 @@ function _useSafeInfo(walletInfo: WalletInfo): GnosisSafeInfo | undefined {
           )
           .catch((error) => {
             console.debug(`[WalletUpdater] Address ${account} is likely not a Safe (API didn't return Safe info)`)
+            setSafeInfo(undefined)
           })
       } else {
         setSafeInfo(undefined)


### PR DESCRIPTION
# Summary

Fixes #2366

Reset Safe info when there's no Safe data

# To Test

1. Connect using Rabby wallet and an EOA address
2. Pick native as sell token
* Should show eth flow
3. Switch to a Safe address within Rabby wallet
* Should suggest eth flow bundling
4. Switch back to EOA
* Bundling banner should be gone

* Wallet interactions should work as before