### PR TITLE
fix(sentry): ignore apple devices TypeError

### DIFF
--- a/apps/cowswap-frontend/src/cow-react/sentry.ts
+++ b/apps/cowswap-frontend/src/cow-react/sentry.ts
@@ -1,6 +1,7 @@
 import { environmentName } from '@cowprotocol/common-utils'
 
 import * as Sentry from '@sentry/react'
+import { ErrorEvent as SentryErrorEvent } from '@sentry/types'
 
 import { SENTRY_IGNORED_GP_QUOTE_ERRORS } from 'api/gnosisProtocol/errors/QuoteError'
 
@@ -17,10 +18,40 @@ if (SENTRY_DSN) {
     release: 'CowSwap@v' + pkg.version,
     environment: environmentName,
     ignoreErrors: [...SENTRY_IGNORED_GP_QUOTE_ERRORS, `Can't find variable: bytecode`],
-
+    beforeSend: (event: SentryErrorEvent, _hint: Sentry.EventHint) => {
+      if (isAppleDeviceLoadFailedError(event)) {
+        console.debug('Sentry: Ignoring Apple device load failed error', event)
+        return null
+      } else {
+        return event
+      }
+    },
     // Set tracesSampleRate to 1.0 to capture 100%
     // of transactions for performance monitoring.
     // We recommend adjusting this value in production
     tracesSampleRate: SENTRY_TRACES_SAMPLE_RATE ? Number(SENTRY_TRACES_SAMPLE_RATE) : 1.0,
   })
 }
+
+function isAppleDeviceLoadFailedError(error: SentryErrorEvent): boolean {
+  const exception = error.exception?.values?.[0]
+  const os = error.tags?.['os.name']
+  if (
+    exception?.type !== 'TypeError' ||
+    !exception?.value ||
+    !TYPE_ERROR_FETCH_FAILED_VALUES.has(exception.value) ||
+    !os
+  ) {
+    return false
+  }
+
+  return typeof os === 'string' && APPLE_OSES.has(os)
+}
+
+const TYPE_ERROR_FETCH_FAILED_VALUES = new Set([
+  'Failed to fetch',
+  'NetworkError when attempting to fetch resource.',
+  'Load failed',
+])
+
+const APPLE_OSES = new Set(['iOS', 'Mac OS X'])


### PR DESCRIPTION
# Summary

Fixes #4251 

Ignore errors like [this](https://cowprotocol.sentry.io/issues/2741336407/?environment=production&project=5905822&sort=freq&statsPeriod=90d&stream_index=0)

![image](https://github.com/cowprotocol/cowswap/assets/43217/06a12d09-5f4f-4ed4-b90f-78b457f619db)

[According to Sentry](https://sentry.io/answers/load-failed-javascript/), those happen when `fetch` calls fails for Apple devices.
This doesn't seem to be actionable either, so this PR ignores them.

This is more specific and filters out based on error urls seens in the last ~80 error occurrences or so (there are 5.6k in total, I'm not going through them all 😬)

![Screenshot 2024-04-17 at 11 54 18](https://github.com/cowprotocol/cowswap/assets/43217/3200ebee-b2b0-4dd3-923d-9c382e453375)
![Screenshot 2024-04-17 at 11 54 30](https://github.com/cowprotocol/cowswap/assets/43217/5c51db02-5bf2-4f61-83c0-4b070a35a7e6)
![Screenshot 2024-04-17 at 11 55 22](https://github.com/cowprotocol/cowswap/assets/43217/cbfe37ea-9f2f-4a5c-b961-6619581ad2e7)
![Screenshot 2024-04-17 at 13 51 47](https://github.com/cowprotocol/cowswap/assets/43217/aafb202e-4aee-4d0c-a516-7497f8e2a1db)
![Screenshot 2024-04-17 at 13 52 09](https://github.com/cowprotocol/cowswap/assets/43217/62210b86-f281-4eeb-a3ca-0d0d96f548cf)
![Screenshot 2024-04-17 at 14 01 26](https://github.com/cowprotocol/cowswap/assets/43217/fc82d30e-b129-409e-a85a-592295f8562b)


# To Test

1. Try to reproduce with an Apple device? (most of them happen on iOS)
* Observe `Sentry: Ignoring Apple device load failed error` is logged to the console