### PR TITLE
fix(blocknative): fix blocknative invalid tx hash

### DIFF
--- a/apps/cowswap-frontend/src/common/updaters/CancelReplaceTxUpdater.tsx
+++ b/apps/cowswap-frontend/src/common/updaters/CancelReplaceTxUpdater.tsx
@@ -7,6 +7,7 @@ import { Dispatch } from 'redux'
 
 import { replaceTransaction } from 'legacy/state/enhancedTransactions/actions'
 import { useAllTransactionHashes } from 'legacy/state/enhancedTransactions/hooks'
+import { HashType } from 'legacy/state/enhancedTransactions/reducer'
 import { useAppDispatch } from 'legacy/state/hooks'
 
 import { sdk } from 'api/blocknative'
@@ -67,7 +68,7 @@ export function CancelReplaceTxUpdater(): null {
   const accountLowerCase = account?.toLowerCase() || ''
   const pendingHashes = useAllTransactionHashes(
     (tx) =>
-      !tx.receipt && !tx.replacementType && !tx.linkedTransactionHash && tx.from.toLowerCase() === accountLowerCase
+      !tx.receipt && !tx.replacementType && !tx.linkedTransactionHash && tx.hashType === HashType.ETHEREUM_TX && tx.from.toLowerCase() === accountLowerCase
   )
 
   useEffect(() => {

--- a/apps/cowswap-frontend/src/common/updaters/CancelReplaceTxUpdater.tsx
+++ b/apps/cowswap-frontend/src/common/updaters/CancelReplaceTxUpdater.tsx
@@ -68,7 +68,7 @@ export function CancelReplaceTxUpdater(): null {
   const accountLowerCase = account?.toLowerCase() || ''
   const pendingHashes = useAllTransactionHashes(
     (tx) =>
-      !tx.receipt && !tx.replacementType && !tx.linkedTransactionHash && tx.hashType === HashType.ETHEREUM_TX && tx.from.toLowerCase() === accountLowerCase
+      !!tx.hash && !tx.receipt && !tx.replacementType && !tx.linkedTransactionHash && tx.hashType === HashType.ETHEREUM_TX && tx.from.toLowerCase() === accountLowerCase
   )
 
   useEffect(() => {


### PR DESCRIPTION
# Summary

Fixes #4255 
Fixes #4256 

In some cases we were passing down Safe tx hashes as well as no tx hashes to query with blocknative

# To Test

1. Do a Safe tx
* Should not log blocknative related errors