### PR TITLE
fix(sentry): fix unhandled permit failure

### DIFF
--- a/apps/cowswap-frontend/src/modules/permit/hooks/useAccountAgnosticPermitHookData.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/useAccountAgnosticPermitHookData.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 
+import { getAddress } from '@cowprotocol/common-utils'
 import { isSupportedPermitInfo, PermitHookData } from '@cowprotocol/permit-utils'
 
 import { useDerivedTradeState } from 'modules/trade'
@@ -41,7 +42,7 @@ function useGeneratePermitHookParams(): GeneratePermitHookParams | undefined {
 
   const permitInfo = usePermitInfo(inputCurrency, tradeType)
 
-  const address = inputCurrency && 'address' in inputCurrency && inputCurrency.address
+  const address = getAddress(inputCurrency)
   const name = inputCurrency?.name
 
   return useMemo(() => {

--- a/apps/cowswap-frontend/src/modules/permit/hooks/useAccountAgnosticPermitHookData.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/useAccountAgnosticPermitHookData.ts
@@ -1,10 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { isSupportedPermitInfo, PermitHookData } from '@cowprotocol/permit-utils'
 
 import { useDerivedTradeState } from 'modules/trade'
-
-import { useSafeMemo } from 'common/hooks/useSafeMemo'
 
 import { useGeneratePermitHook } from './useGeneratePermitHook'
 import { usePermitInfo } from './usePermitInfo'
@@ -43,12 +41,15 @@ function useGeneratePermitHookParams(): GeneratePermitHookParams | undefined {
 
   const permitInfo = usePermitInfo(inputCurrency, tradeType)
 
-  return useSafeMemo(() => {
-    if (!inputCurrency || !('address' in inputCurrency) || !isSupportedPermitInfo(permitInfo)) return undefined
+  const address = inputCurrency && 'address' in inputCurrency && inputCurrency.address
+  const name = inputCurrency?.name
+
+  return useMemo(() => {
+    if (!address || !isSupportedPermitInfo(permitInfo)) return undefined
 
     return {
-      inputToken: { address: inputCurrency.address, name: inputCurrency.name },
+      inputToken: { address, name },
       permitInfo,
     }
-  }, [inputCurrency, permitInfo])
+  }, [address, name, permitInfo])
 }

--- a/apps/cowswap-frontend/src/modules/permit/hooks/useGeneratePermitHook.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/useGeneratePermitHook.ts
@@ -69,7 +69,7 @@ export function useGeneratePermitHook(): GeneratePermitHook {
         nonce,
       })
 
-      storePermit({ ...permitParams, hookData })
+      hookData && storePermit({ ...permitParams, hookData })
 
       return hookData
     },

--- a/apps/cowswap-frontend/src/modules/permit/hooks/useGetCachedPermit.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/useGetCachedPermit.ts
@@ -27,7 +27,7 @@ export function useGetCachedPermit(): (tokenAddress: Nullish<string>) => Promise
         // Static account should never need to pre-check the nonce as it'll never change once cached
         const nonce = account ? await eip2162Utils.getTokenNonce(tokenAddress, account) : undefined
 
-        const permitParams = { chainId, tokenAddress: tokenAddress, account, nonce }
+        const permitParams = { chainId, tokenAddress, account, nonce }
 
         return getCachedPermit(permitParams)
       } catch (e) {


### PR DESCRIPTION
# Summary

Fixes #4274

Permit hook generation failure wasn't properly handled, leading to [1.8k errors logged on Sentry](https://cowprotocol.sentry.io/issues/4564574974/?environment=production&project=5905822&query=is%3Aunresolved&sort=freq&statsPeriod=90d&stream_index=3)
![image](https://github.com/cowprotocol/cowswap/assets/43217/016acb85-8d74-49b7-b4b8-5e80609dd69c)

# To Test

1. Force a permit hook generation failure
2. See the exception is handled

I couldn't find a way to reproduce it, so locally I changed the code to always thrown an exception.
Did not include that in the PR, though.

* Permit should work as before

@elena-zh tagging you to double check the permit behaviour. The exception you can skip it as there are no clear reproduction steps.