### PR TITLE
fix(explorer): add sepolia token list

### DIFF
--- a/apps/explorer/src/hooks/useTokenList.ts
+++ b/apps/explorer/src/hooks/useTokenList.ts
@@ -1,7 +1,7 @@
-import { ALL_SUPPORTED_CHAIN_IDS, SupportedChainId } from '@cowprotocol/cow-sdk'
-import useSWR from 'swr'
 import { SWR_NO_REFRESH_OPTIONS } from '@cowprotocol/common-const'
+import { ALL_SUPPORTED_CHAIN_IDS, SupportedChainId } from '@cowprotocol/cow-sdk'
 import type { TokenInfo, TokenList } from '@uniswap/token-lists'
+import useSWR from 'swr'
 
 type TokenListByAddress = Record<string, TokenInfo>
 type TokenListPerNetwork = Record<SupportedChainId, TokenListByAddress>
@@ -14,10 +14,10 @@ const INITIAL_TOKEN_LIST_PER_NETWORK: TokenListPerNetwork = {
 
 export function useTokenList(chainId: SupportedChainId | undefined): { data: TokenListByAddress; isLoading: boolean } {
   const { data: cowSwapList, isLoading: isCowListLoading } = useTokenListByUrl(
-    'https://files.cow.fi/tokens/CowSwap.json'
+    chainId !== SupportedChainId.SEPOLIA ? 'https://files.cow.fi/tokens/CowSwap.json' : ''
   )
   const { data: coingeckoList, isLoading: isCoingeckoListLoading } = useTokenListByUrl(
-    'https://tokens.coingecko.com/uniswap/all.json'
+    chainId !== SupportedChainId.SEPOLIA ? 'https://tokens.coingecko.com/uniswap/all.json' : ''
   )
   const { data: honeyswapList, isLoading: isHoneyswapListLoading } = useTokenListByUrl(
     chainId === SupportedChainId.GNOSIS_CHAIN ? 'https://tokens.honeyswap.org' : ''

--- a/apps/explorer/src/hooks/useTokenList.ts
+++ b/apps/explorer/src/hooks/useTokenList.ts
@@ -19,7 +19,7 @@ export function useTokenList(chainId: SupportedChainId | undefined): { data: Tok
       : 'https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/CowSwapSepolia.json'
   )
   const { data: coingeckoList, isLoading: isCoingeckoListLoading } = useTokenListByUrl(
-    chainId !== SupportedChainId.SEPOLIA ? 'https://tokens.coingecko.com/uniswap/all.json' : ''
+    chainId === SupportedChainId.MAINNET ? 'https://tokens.coingecko.com/uniswap/all.json' : ''
   )
   const { data: honeyswapList, isLoading: isHoneyswapListLoading } = useTokenListByUrl(
     chainId === SupportedChainId.GNOSIS_CHAIN ? 'https://tokens.honeyswap.org' : ''

--- a/apps/explorer/src/hooks/useTokenList.ts
+++ b/apps/explorer/src/hooks/useTokenList.ts
@@ -14,7 +14,9 @@ const INITIAL_TOKEN_LIST_PER_NETWORK: TokenListPerNetwork = {
 
 export function useTokenList(chainId: SupportedChainId | undefined): { data: TokenListByAddress; isLoading: boolean } {
   const { data: cowSwapList, isLoading: isCowListLoading } = useTokenListByUrl(
-    chainId !== SupportedChainId.SEPOLIA ? 'https://files.cow.fi/tokens/CowSwap.json' : ''
+    chainId !== SupportedChainId.SEPOLIA
+      ? 'https://files.cow.fi/tokens/CowSwap.json'
+      : 'https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/CowSwapSepolia.json'
   )
   const { data: coingeckoList, isLoading: isCoingeckoListLoading } = useTokenListByUrl(
     chainId !== SupportedChainId.SEPOLIA ? 'https://tokens.coingecko.com/uniswap/all.json' : ''


### PR DESCRIPTION
# Summary

Fixes #4276

HOTFIX

Partially fixes the issue by:
1. Loading sepolia token list
2. Adding more tokens to the token list (https://github.com/cowprotocol/token-lists/pull/328)

Needs a bigger refactor to fix it, but this change is only stopping the bleeding.

# To Test

1. Open the mentioned order in the PR link without opening another page before `0x9dc9232cc93b8644c45f6cffa731ba1ece5916bfc6046b45f613d10d00caf64705e6b5eb1d0e6aabab082057d5bb91f2ee6d11be66223eda` [direct link](https://explorer-dev-git-fix-4276explorer-sepolia-issue-cowswap.vercel.app/sepolia/orders/0x9dc9232cc93b8644c45f6cffa731ba1ece5916bfc6046b45f613d10d00caf64705e6b5eb1d0e6aabab082057d5bb91f2ee6d11be66223eda?tab=overview)
* Should load