### PR TITLE
fix(explorer): fix browser crashing

### DIFF
--- a/apps/explorer/src/hooks/useErc20.ts
+++ b/apps/explorer/src/hooks/useErc20.ts
@@ -140,10 +140,6 @@ export function useMultipleErc20(
     if (!running.current.isRunning || running.current.networkId !== networkId) {
       updateErc20s()
     }
-
-    return () => {
-      running.current.isRunning = false
-    }
   }, [updateErc20s, saveErc20s, networkId])
 
   return {


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C036JAGRQ04/p1713783667693619?thread_ts=1713783227.686239&cid=C036JAGRQ04

The bug was introduced in [the recent fix](https://github.com/cowprotocol/cowswap/pull/4245/files#diff-6e4096a863530b89050cf7a7215d5c281af6f9c62533a7ac6f9af39b8b640e63R145).

I'm not 100% sure why do we need this callback, anyway, I think we should extinguish the fire first of all.

# To Test

1. Open https://explorer-dev-git-hotfix-explorer-crashing-cowswap.vercel.app/orders/0x23f2bca97398e803562db9d4631fd9769a472f8e3ec56f1e87eca2ca7a08bf8d4f9e9e757645af8a6fbe877f3f7c66c5b79854a16625d4f0?tab=overview
- [ ] AR: browser crashes
- [ ] ER: browser don't crashe