### PR TITLE
fix(widget): make account modal background transparent

### DIFF
--- a/apps/cowswap-frontend/src/modules/account/containers/OrdersPanel/index.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/OrdersPanel/index.tsx
@@ -54,7 +54,7 @@ const SidebarBackground = styled.div`
   z-index: 4;
   width: 100%;
   height: 100%;
-  background: ${({ theme }) => transparentize(theme.black, 0.1)};
+  background: ${({ theme }) => (theme.isInjectedWidgetMode ? 'transparent' : transparentize(theme.black, 0.1))};
   backdrop-filter: blur(3px);
 
   ${({ theme }) => theme.mediaWidth.upToSmall`


### PR DESCRIPTION
# Summary

Fixes #4254

In widget mode, the account modal background should be transparent

![image](https://github.com/cowprotocol/cowswap/assets/7122625/a94c59a8-74f9-480c-a13b-ecb0d63666f4)

![image](https://github.com/cowprotocol/cowswap/assets/7122625/bbad94c9-acc4-40c0-9602-da6b1512b294)
