### PR TITLE
fix(widget): fix modals displaying

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/Modal/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/Modal/index.tsx
@@ -60,11 +60,7 @@ export function Modal({
   }, [onDismiss, setOpenModal])
 
   useEffect(() => {
-    if (isOpen) {
-      setOpenModal(true)
-    } else {
-      setOpenModal(false)
-    }
+    setOpenModal(isOpen)
   }, [isOpen, setOpenModal])
 
   return (

--- a/apps/cowswap-frontend/src/common/pure/Modal/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/Modal/index.tsx
@@ -117,6 +117,19 @@ export const CowModal = styled(Modal)<{
       border-radius: 0;
     `}
 
+    ${({ theme }) =>
+      theme.isInjectedWidgetMode &&
+      theme.mediaWidth.upToLarge`
+      margin: 20px 0 0 0;
+      align-self: start;
+    `}
+
+    ${({ theme }) =>
+      theme.isInjectedWidgetMode &&
+      theme.mediaWidth.upToSmall`
+      margin: 0;
+    `}
+
     ${HeaderRow} {
       ${({ theme }) => theme.mediaWidth.upToSmall`
         position: fixed;

--- a/apps/cowswap-frontend/src/common/pure/Modal/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/Modal/index.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import { useSetAtom } from 'jotai'
+import React, { useCallback, useEffect } from 'react'
 
 import { isMobile } from '@cowprotocol/common-utils'
 import { Command } from '@cowprotocol/types'
@@ -9,6 +10,8 @@ import { useGesture } from '@use-gesture/react'
 import styled from 'styled-components/macro'
 
 import { CloseIcon, ContentWrapper, HeaderRow, HoverText, StyledDialogContent, StyledDialogOverlay } from './styled'
+
+import { openModalState } from '../../state/openModalState'
 
 export * from './styled'
 interface ModalProps {
@@ -33,6 +36,7 @@ export function Modal({
   className,
   children,
 }: ModalProps) {
+  const setOpenModal = useSetAtom(openModalState)
   const fadeTransition = useTransition(isOpen, {
     config: { duration: 200 },
     from: { opacity: 0 },
@@ -50,6 +54,19 @@ export function Modal({
     },
   })
 
+  const onDismissCallback = useCallback(() => {
+    onDismiss()
+    setOpenModal(false)
+  }, [onDismiss, setOpenModal])
+
+  useEffect(() => {
+    if (isOpen) {
+      setOpenModal(true)
+    } else {
+      setOpenModal(false)
+    }
+  }, [isOpen, setOpenModal])
+
   return (
     <>
       {fadeTransition((props, item) => {
@@ -58,7 +75,7 @@ export function Modal({
             <StyledDialogOverlay
               className={className}
               style={props}
-              onDismiss={onDismiss}
+              onDismiss={onDismissCallback}
               initialFocusRef={initialFocusRef}
               dangerouslyBypassFocusLock={true}
             >
@@ -115,19 +132,6 @@ export const CowModal = styled(Modal)<{
       height: 100%;
       width: 100vw;
       border-radius: 0;
-    `}
-
-    ${({ theme }) =>
-      theme.isInjectedWidgetMode &&
-      theme.mediaWidth.upToLarge`
-      margin: 20px 0 0 0;
-      align-self: start;
-    `}
-
-    ${({ theme }) =>
-      theme.isInjectedWidgetMode &&
-      theme.mediaWidth.upToSmall`
-      margin: 0;
     `}
 
     ${HeaderRow} {

--- a/apps/cowswap-frontend/src/common/state/openModalState.ts
+++ b/apps/cowswap-frontend/src/common/state/openModalState.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai'
+
+export const openModalState = atom(false)

--- a/apps/cowswap-frontend/src/modules/injectedWidget/updaters/IframeResizer.ts
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/updaters/IframeResizer.ts
@@ -1,14 +1,30 @@
+import { useAtomValue } from 'jotai'
 import { useLayoutEffect, useRef } from 'react'
 
 import { WidgetMethodsEmit, postMessageToWindow } from '@cowprotocol/widget-lib'
 
+import { openModalState } from 'common/state/openModalState'
+
+import { MEDIA_WIDTHS } from '../../../legacy/theme'
+
 export function IframeResizer() {
+  const isModalOpen = useAtomValue(openModalState)
   const previousHeightRef = useRef(0)
 
   useLayoutEffect(() => {
     // Initial height calculation and message
     const sendHeightUpdate = () => {
       const contentHeight = document.body.scrollHeight
+
+      if (isModalOpen) {
+        const isUpToSmall = document.body.offsetWidth <= MEDIA_WIDTHS.upToSmall
+
+        postMessageToWindow(window.parent, WidgetMethodsEmit.SET_FULL_HEIGHT, { isUpToSmall })
+
+        previousHeightRef.current = 0
+        return
+      }
+
       if (contentHeight !== previousHeightRef.current) {
         postMessageToWindow(window.parent, WidgetMethodsEmit.UPDATE_HEIGHT, { height: contentHeight })
         previousHeightRef.current = contentHeight
@@ -28,7 +44,7 @@ export function IframeResizer() {
     return () => {
       observer.disconnect()
     }
-  }, [])
+  }, [isModalOpen])
 
   return null
 }

--- a/apps/widget-configurator/src/app/configurator/index.tsx
+++ b/apps/widget-configurator/src/app/configurator/index.tsx
@@ -300,7 +300,7 @@ export function Configurator({ title }: { title: string }) {
         </List>
       </Drawer>
 
-      <Box sx={{ ...ContentStyled, pl: isDrawerOpen ? '300px' : 0 }}>
+      <Box sx={{ ...ContentStyled, pl: isDrawerOpen ? '290px' : 0 }}>
         {params && (
           <>
             <EmbedDialog
@@ -309,7 +309,6 @@ export function Configurator({ title }: { title: string }) {
               open={dialogOpen}
               handleClose={handleDialogClose}
             />
-            <br />
             <CowSwapWidget
               params={params}
               provider={!IS_IFRAME && !standaloneMode ? provider : undefined}

--- a/apps/widget-configurator/src/app/configurator/styled.ts
+++ b/apps/widget-configurator/src/app/configurator/styled.ts
@@ -27,7 +27,7 @@ export const ContentStyled = {
   alignItems: 'center',
   flexFlow: 'column',
   flex: '1 1 auto',
-  margin: '4.2rem auto',
+  margin: '0 auto',
 
   '> iframe': {
     border: 0,

--- a/libs/widget-lib/src/cowSwapWidget.ts
+++ b/libs/widget-lib/src/cowSwapWidget.ts
@@ -62,7 +62,7 @@ export function createCowSwapWidget(container: HTMLElement, props: CowSwapWidget
   windowListeners.push(sendAppCodeOnActivation(iframeWindow, params.appCode))
 
   // 4. Handle widget height changes
-  windowListeners.push(listenToHeightChanges(iframe, params.height))
+  windowListeners.push(...listenToHeightChanges(iframe, params.height))
 
   // 5. Handle and forward widget events to the listeners
   const iFrameCowEventEmitter = new IframeCowEventEmitter(window, listeners)
@@ -206,8 +206,13 @@ function sendAppCodeOnActivation(contentWindow: Window, appCode: string | undefi
  * @param iframe - The HTMLIFrameElement of the widget.
  * @param defaultHeight - Default height for the widget.
  */
-function listenToHeightChanges(iframe: HTMLIFrameElement, defaultHeight = DEFAULT_HEIGHT): WindowListener {
-  return listenToMessageFromWindow(window, WidgetMethodsEmit.UPDATE_HEIGHT, (data) => {
-    iframe.style.height = data.height ? `${data.height + HEIGHT_THRESHOLD}px` : defaultHeight
-  })
+function listenToHeightChanges(iframe: HTMLIFrameElement, defaultHeight = DEFAULT_HEIGHT): WindowListener[] {
+  return [
+    listenToMessageFromWindow(window, WidgetMethodsEmit.UPDATE_HEIGHT, (data) => {
+      iframe.style.height = data.height ? `${data.height + HEIGHT_THRESHOLD}px` : defaultHeight
+    }),
+    listenToMessageFromWindow(window, WidgetMethodsEmit.SET_FULL_HEIGHT, ({ isUpToSmall }) => {
+      iframe.style.height = isUpToSmall ? defaultHeight : `${document.body.offsetHeight}px`
+    }),
+  ]
 }

--- a/libs/widget-lib/src/types.ts
+++ b/libs/widget-lib/src/types.ts
@@ -5,6 +5,7 @@ export type { SupportedChainId } from '@cowprotocol/cow-sdk'
 export enum WidgetMethodsEmit {
   ACTIVATE = 'ACTIVATE',
   UPDATE_HEIGHT = 'UPDATE_HEIGHT',
+  SET_FULL_HEIGHT = 'SET_FULL_HEIGHT',
   EMIT_COW_EVENT = 'EMIT_COW_EVENT',
   PROVIDER_RPC_REQUEST = 'PROVIDER_RPC_REQUEST',
 }
@@ -289,6 +290,7 @@ export interface WidgetMethodsEmitPayloadMap {
   [WidgetMethodsEmit.ACTIVATE]: void
   [WidgetMethodsEmit.EMIT_COW_EVENT]: EmitCowEventPayload<CowEvents>
   [WidgetMethodsEmit.UPDATE_HEIGHT]: UpdateWidgetHeightPayload
+  [WidgetMethodsEmit.SET_FULL_HEIGHT]: SetWidgetFullHeightPayload
   [WidgetMethodsEmit.PROVIDER_RPC_REQUEST]: ProviderRpcRequestPayload
 }
 
@@ -322,6 +324,10 @@ export interface UpdateAppDataPayload {
 
 export interface UpdateWidgetHeightPayload {
   height?: number
+}
+
+export interface SetWidgetFullHeightPayload {
+  isUpToSmall?: boolean
 }
 
 export interface EmitCowEventPayload<T extends CowEvents> {


### PR DESCRIPTION
# Summary

Fixes #4279

Modals are dispalyed with `posotion: fixed`, so they don't impact on the widget height, because of that `IframeResizer` didn't react on it.
To fix that, I've added an additional trigger when modal is open.
Modals are displaying differently, depending on the screen width (`isUpToSmall`).
When widget container width > 720px, then the widget height will be set to the window height, otherwise it will be set to the defaultHeight (by default 640px).

<img width="1728" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/69315498-4cf7-435e-999d-a58e90877504">

<img width="1113" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/827e5929-0048-482d-b465-b26a7e01018a">

<img width="990" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/b10bd525-e078-4ae2-ab64-8ef32566707d">

# To Test

See #4279

1. Modals displaying with different screen width
2. After merging this PR, we should update and test https://cow.fi/widget as well
