### PR TITLE
feat(widget): support different partnerFee recipient for networks

### DIFF
--- a/apps/cowswap-frontend/src/modules/appData/updater/AppDataUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/appData/updater/AppDataUpdater.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 
 import { percentToBps } from '@cowprotocol/common-utils'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { useWalletInfo } from '@cowprotocol/wallet'
+import { PartnerFee } from '@cowprotocol/widget-lib'
 import { Percent } from '@uniswap/sdk-core'
 
 import { useInjectedWidgetParams } from 'modules/injectedWidget'
@@ -16,6 +18,21 @@ import { useAppCode, useAppDataHooks } from '../hooks'
 import { AppDataOrderClass } from '../types'
 
 const ORDERS_WITH_PARTNER_FEE: AppDataOrderClass[] = ['market']
+
+const mapPartnerFee = (
+  partnerFee: PartnerFee | undefined,
+  orderClass: AppDataOrderClass,
+  chainId: SupportedChainId
+) => {
+  if (!partnerFee || !ORDERS_WITH_PARTNER_FEE.includes(orderClass)) return undefined
+
+  const { recipient } = partnerFee
+
+  return {
+    bps: partnerFee.bps,
+    recipient: typeof recipient === 'string' ? recipient : recipient[chainId],
+  }
+}
 
 interface AppDataUpdaterProps {
   slippage: Percent
@@ -35,8 +52,6 @@ export const AppDataUpdater = React.memo(({ slippage, orderClass }: AppDataUpdat
 
   if (!chainId) return null
 
-  const partnerFee = ORDERS_WITH_PARTNER_FEE.includes(orderClass) ? widgetParams.partnerFee : undefined
-
   return (
     <AppDataUpdaterMemo
       appCodeWithWidgetMetadata={appCodeWithWidgetMetadata}
@@ -45,7 +60,7 @@ export const AppDataUpdater = React.memo(({ slippage, orderClass }: AppDataUpdat
       orderClass={orderClass}
       utm={utm}
       hooks={hooks}
-      partnerFee={partnerFee}
+      partnerFee={mapPartnerFee(widgetParams.partnerFee, orderClass, chainId)}
       replacedOrderUid={replacedOrderUid}
     />
   )

--- a/apps/cowswap-frontend/src/modules/injectedWidget/utils/validatePartnerFee.test.ts
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/utils/validatePartnerFee.test.ts
@@ -1,0 +1,86 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import { validatePartnerFee } from './validatePartnerFee'
+
+import { PARTNER_FEE_MAX_BPS } from '../consts'
+
+describe('validatePartnerFee()', () => {
+  it(`When BPS is higher than ${PARTNER_FEE_MAX_BPS}, then should return error`, () => {
+    const result = validatePartnerFee({
+      bps: 200,
+      recipient: '0x0000000000000000000000000000000000000000',
+    })
+
+    expect(result).toEqual(['Partner fee can not be more than 100 BPS!'])
+  })
+
+  it('When BPS is less than zero, then should return error', () => {
+    const result = validatePartnerFee({
+      bps: -1,
+      recipient: '0x0000000000000000000000000000000000000000',
+    })
+
+    expect(result).toEqual(['Partner fee can not be less than 0!'])
+  })
+
+  it('When recipient is empty, then should return error', () => {
+    const result = validatePartnerFee({
+      bps: 100,
+      recipient: '',
+    })
+
+    expect(result).toEqual(['Partner fee recipient must be set!'])
+  })
+
+  describe('When recipient is a string', () => {
+    it('When recipient is not a valid address, then should return error', () => {
+      const result = validatePartnerFee({
+        bps: 100,
+        recipient: 'asvbfbdf',
+      })
+
+      expect(result).toEqual([
+        'invalid address (argument="address", value="asvbfbdf", code=INVALID_ARGUMENT, version=address/5.7.0)',
+      ])
+    })
+
+    it('When the recipient is valid, then should return undefined', () => {
+      const result = validatePartnerFee({
+        bps: 100,
+        recipient: '0x0000000000000000000000000000000000000000',
+      })
+
+      expect(result).toBe(undefined)
+    })
+  })
+
+  describe('When recipient is a map', () => {
+    it('When one of addresses is not a valid address, then should return error', () => {
+      const result = validatePartnerFee({
+        bps: 100,
+        recipient: {
+          [SupportedChainId.MAINNET]: '0x0000000000000000000000000000000000000000',
+          [SupportedChainId.GNOSIS_CHAIN]: 'rtrth',
+          [SupportedChainId.SEPOLIA]: '0x0000000000000000000000000000000000000000',
+        },
+      })
+
+      expect(result).toEqual([
+        'invalid address (argument="address", value="rtrth", code=INVALID_ARGUMENT, version=address/5.7.0)',
+      ])
+    })
+
+    it('When all addresses are valid, then should return undefined', () => {
+      const result = validatePartnerFee({
+        bps: 100,
+        recipient: {
+          [SupportedChainId.MAINNET]: '0x0000000000000000000000000000000000000000',
+          [SupportedChainId.GNOSIS_CHAIN]: '0x0000000000000000000000000000000000000000',
+          [SupportedChainId.SEPOLIA]: '0x0000000000000000000000000000000000000000',
+        },
+      })
+
+      expect(result).toBe(undefined)
+    })
+  })
+})

--- a/apps/cowswap-frontend/src/modules/injectedWidget/utils/validatePartnerFee.ts
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/utils/validatePartnerFee.ts
@@ -19,9 +19,17 @@ export function validatePartnerFee(input: PartnerFee | undefined): string[] | un
   return errors.length > 0 ? errors : undefined
 }
 
-function validateRecipient(recipient: string): string | undefined {
+function validateRecipient(recipient: PartnerFee['recipient']): string | undefined {
   if (!recipient) return 'Partner fee recipient must be set!'
 
+  if (typeof recipient === 'string') return validateRecipientAddress(recipient)
+
+  const errors = Object.values(recipient).map(validateRecipientAddress).filter(isTruthy)
+
+  return errors.length > 0 ? errors.join(', ') : undefined
+}
+
+function validateRecipientAddress(recipient: string): string | undefined {
   try {
     getAddress(recipient)
   } catch (error) {

--- a/libs/widget-lib/src/types.ts
+++ b/libs/widget-lib/src/types.ts
@@ -93,7 +93,7 @@ export interface PartnerFee {
   /**
    * The Ethereum address of the partner to receive the fee.
    */
-  recipient: string
+  recipient: string | Record<SupportedChainId, string>
 }
 
 /**


### PR DESCRIPTION
# Summary

Fixes #4160

Since users might want or have to use different partnerFee recipient addresses depending on network, we should provide an option to this.
To keep backward compatibility, I changed the recipient type from `string` to `string | Record<SupportedChainId, string>`.

Docs update: https://github.com/cowprotocol/docs/pull/359/files

# To Test

1. App data for orders with partnerFee should contain specified bps and address
2. Only swap orders should have partnerFee

How to test:

```
window.cowSwapWidgetParams = {
  partnerFee: {
    bps: 100,
    recipient: {
      1: '0x000...1',
      100: '0x000...100',
      11155111: '0x000...11155111',
    },
  },
}
```

1. Run the code above in the widget configurator console
2. Change smth in the configurator inputs (to update widget state)
3. Create an order