### PR TITLE
feat(tooltip): make tooltips sticky

### DIFF
--- a/libs/ui/src/pure/Tooltip/index.tsx
+++ b/libs/ui/src/pure/Tooltip/index.tsx
@@ -62,19 +62,19 @@ export function MouseoverTooltipContent({
     onOpen?.()
   }, [onOpen])
 
-  const close = useCallback(() => {
-    if (!sticky) {
+  const close = useCallback((force = false) => {
+    if (!sticky || force) {
       setShow(false)
     }
   }, [setShow, sticky])
 
-  const toggleSticky = useCallback< React.MouseEventHandler<HTMLDivElement>>((event) => {
+  const toggleSticky = useCallback<React.MouseEventHandler<HTMLDivElement>>((event) => {
     event.stopPropagation()
     if (show) {
       setSticky(sticky => {
         if (sticky) {
           // Tooltip was visible, but sticky. Closing it.
-          close()
+          close(true)
           return false
         } else {
           // Tooltip was visible, and not sticky. Making it sticky.
@@ -108,7 +108,7 @@ export function MouseoverTooltipContent({
 
   return (
     <TooltipContent {...rest} show={show} content={c}>
-      <div onMouseEnter={open} onMouseLeave={close} onClick={toggleSticky} >
+      <div onMouseEnter={open} onMouseLeave={() => close()} onClick={toggleSticky} >
 
         {children}
       </div>


### PR DESCRIPTION
# Summary

This PR is some feature I wanted to have for quite some time and now I have a excuse to implement :) 

Let me explain giving some context

## Context: The problem

The problem: Tooltips show up when you hover, and they hide when you move the mouse. This is OK most of the time, but sometimes there's something in the tooltip you want to copy paste, and you can't because the moment you move the mouse to the tooltip content.... IT DISSAPEARS 💨 

More importantly. Normally tooltips are created to give some additional context. They are supposed to be short, however, the user might want to read more about it, so it would be great to add links to blog posts, FAQ or external sites.
The problem is again, when you try to move your mouse away of the tooltip icon.... PUFFFFF... 💨  VANISHED!

Furthermore, when we are developing, sometimes we want to style the content on tooltips. If you show it and you want to check the HTML or CSS using the dev tools, the moment you move the mouse to go to the dev tools... PUFFFFF... 💨  GONE FOREVER! (you get the idea)

## Real motivation

All of the above are nice enough, but is not the reason I did this PR. 

The reason is that the Safe team will use the widget with some custom tooltips, and they want to add a link them to their policies. 

With the former implementation, it was impossible to click on the link

## Solution
Now you can make the tooltip sticky by clicking on the tooltip icon. 

## Test

**SPEC 1: Everything works as before**
  `1.`Check the fee tooltips. Hover on it, you should be able to see the tooltip
  `2.` Move the mouse away, now it should disappear (so far, same behaviour as before)

**SPEC 2: The tooltip is sticky**
  `3.` Click now on the icon. Apparently nothing changed, you were seeing the tooltip, and after the click it should still be visible
  `4.` Move away from the icon and the mouse, now the tooltip should not hide. It is STICKY!

**SPEC 3: You can still hide the sticky tooltips**
  `5.` Click anywhere in the screen... the tooltip should disappear 

**SPEC 4: You can also hide a sticky tooltip by clicking one more time in the icon**
  `6.` When you click in the tooltip to make it sticky, now try to click a second time. it should hide it!