### PR TITLE
Custom fee labels

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/containers/Row/RowFee/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/Row/RowFee/index.tsx
@@ -5,8 +5,10 @@ import { UI } from '@cowprotocol/ui'
 import { PartnerFee } from '@cowprotocol/widget-lib'
 import { Currency, CurrencyAmount, Token, TradeType } from '@uniswap/sdk-core'
 
+import ReactMarkdown, { Components } from 'react-markdown'
 import styled from 'styled-components/macro'
 
+import { markdownComponents } from 'legacy/components/Markdown/components'
 import TradeGp from 'legacy/state/swap/TradeGp'
 
 import { useIsEoaEthFlow } from 'modules/swap/hooks/useIsEoaEthFlow'
@@ -143,9 +145,11 @@ export interface PartnerRowPartnerFeeProps {
   partnerFee?: PartnerFee
   feeAmount?: CurrencyAmount<Currency>
   feeInFiat: CurrencyAmount<Token> | null
+  label?: string
+  tooltipMarkdown?: string
 }
 
-export function RowPartnerFee({ partnerFee, feeAmount, feeInFiat }: PartnerRowPartnerFeeProps) {
+export function RowPartnerFee({ partnerFee, feeAmount, feeInFiat, label, tooltipMarkdown }: PartnerRowPartnerFeeProps) {
   const props = useMemo(() => {
     const feeCurrencySymbol = feeAmount?.currency.symbol || '-' // TODO: Once we implement the computation of the fee, we should express it in the relevant fee currency (buy token for sell orders)
     const feeInFiatFormatted = formatFiatAmount(feeInFiat)
@@ -157,16 +161,18 @@ export function RowPartnerFee({ partnerFee, feeAmount, feeInFiat }: PartnerRowPa
     const { bps } = partnerFee || { bps: 0 }
     const isFree = bps === 0
 
+    const markdownContent = tooltipMarkdown ? <ReactMarkdown components={markdownComponents as Components}>{tooltipMarkdown}</ReactMarkdown> : undefined
+
     return {
-      label: isFree ? 'Fee' : 'Total fee',
+      label: label ? label : isFree ? 'Fee' : 'Total fee',
       feeToken: isFree ? 'FREE' : feeAmountWithCurrency,
       feeUsd,
       fullDisplayFee,
       feeCurrencySymbol,
       isFree,
-      tooltip: isFree ? TOOLTIP_PARTNER_FEE_FREE : tooltipPartnerFee(bps),
+      tooltip: markdownContent ? markdownContent : isFree ? TOOLTIP_PARTNER_FEE_FREE : tooltipPartnerFee(bps),
     }
-  }, [partnerFee, feeAmount, feeInFiat])
+  }, [partnerFee, feeAmount, feeInFiat, label, tooltipMarkdown])
 
   return <RowFeeContent {...props} />
 }

--- a/apps/cowswap-frontend/src/modules/swap/containers/TradeBasicDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/TradeBasicDetails/index.tsx
@@ -8,6 +8,7 @@ import { BoxProps } from 'rebass'
 
 import TradeGp from 'legacy/state/swap/TradeGp'
 
+import { useInjectedWidgetParams } from 'modules/injectedWidget'
 import { RowNetworkCosts, RowPartnerFee } from 'modules/swap/containers/Row/RowFee'
 import { RowReceivedAfterSlippage } from 'modules/swap/containers/Row/RowReceivedAfterSlippage'
 import { RowSlippage } from 'modules/swap/containers/Row/RowSlippage'
@@ -40,6 +41,7 @@ export function TradeBasicDetails(props: TradeBasicDetailsProp) {
   const partnerFeeFiatValue = useUsdAmount(trade?.partnerFeeAmount).value
   const isEoaEthFlow = useIsEoaEthFlow()
   const isWrapOrUnwrap = useIsWrapOrUnwrap()
+  const { content } = useInjectedWidgetParams()
 
   const isExactIn = trade?.tradeType === TradeType.EXACT_INPUT
 
@@ -58,6 +60,8 @@ export function TradeBasicDetails(props: TradeBasicDetailsProp) {
           partnerFee={trade.partnerFee}
           feeAmount={trade.partnerFeeAmount}
           feeInFiat={partnerFeeFiatValue}
+          label={content?.feeLabel || undefined}
+          tooltipMarkdown={content?.feeTooltipMarkdown}
         />
       )}
 

--- a/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
@@ -82,22 +82,6 @@ export function useWidgetParams(configuratorState: ConfiguratorState): CowSwapWi
               recipient: partnerFeeRecipient,
             }
           : undefined,
-
-      content: {
-        // TODO: Don't merge with this. This comment should be reverted.
-        feeLabel: "Anxo's cut",
-        feeTooltipMarkdown: `\
-Anxo has been working hard lately, and need to pay his bills.
-Anxo is a good guy, so you should pay him.
-
-This fee won't contribute to anything useful, but it will make Anxo happy.
-## Why
-Think about it
-
-## Read more
-[don't read more](https://google.com)
-`,
-      },
     }
 
     return params

--- a/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
@@ -82,6 +82,22 @@ export function useWidgetParams(configuratorState: ConfiguratorState): CowSwapWi
               recipient: partnerFeeRecipient,
             }
           : undefined,
+
+      content: {
+        // TODO: Don't merge with this. This comment should be reverted.
+        feeLabel: "Anxo's cut",
+        feeTooltipMarkdown: `\
+Anxo has been working hard lately, and need to pay his bills.
+Anxo is a good guy, so you should pay him.
+
+This fee won't contribute to anything useful, but it will make Anxo happy.
+## Why
+Think about it
+
+## Read more
+[don't read more](https://google.com)
+`,
+      },
     }
 
     return params

--- a/libs/ui/src/pure/Tooltip/index.tsx
+++ b/libs/ui/src/pure/Tooltip/index.tsx
@@ -62,19 +62,19 @@ export function MouseoverTooltipContent({
     onOpen?.()
   }, [onOpen])
 
-  const close = useCallback(() => {
-    if (!sticky) {
+  const close = useCallback((force = false) => {
+    if (!sticky || force) {
       setShow(false)
     }
   }, [setShow, sticky])
 
-  const toggleSticky = useCallback< React.MouseEventHandler<HTMLDivElement>>((event) => {
+  const toggleSticky = useCallback<React.MouseEventHandler<HTMLDivElement>>((event) => {
     event.stopPropagation()
     if (show) {
       setSticky(sticky => {
         if (sticky) {
           // Tooltip was visible, but sticky. Closing it.
-          close()
+          close(true)
           return false
         } else {
           // Tooltip was visible, and not sticky. Making it sticky.
@@ -108,7 +108,7 @@ export function MouseoverTooltipContent({
 
   return (
     <TooltipContent {...rest} show={show} content={c}>
-      <div onMouseEnter={open} onMouseLeave={close} onClick={toggleSticky} >
+      <div onMouseEnter={open} onMouseLeave={() => close()} onClick={toggleSticky} >
 
         {children}
       </div>

--- a/libs/widget-lib/src/types.ts
+++ b/libs/widget-lib/src/types.ts
@@ -168,6 +168,11 @@ export interface CowSwapWidgetBanners {
   hideSafeWebAppBanner?: boolean
 }
 
+export interface CowSwapWidgetContent {
+  feeLabel?: string
+  feeTooltipMarkdown?: string
+}
+
 export interface CowSwapWidgetParams {
   /**
    * The unique identifier of the widget consumer.
@@ -282,6 +287,11 @@ export interface CowSwapWidgetParams {
    * In case when widget does not support some tokens, you can provide a list of tokens to be used in the widget
    */
   customTokens?: TokenInfo[]
+
+  /**
+   * Customizable labels and content for the widget.
+   */
+  content?: CowSwapWidgetContent
 }
 
 // Define types for event payloads


### PR DESCRIPTION
# Summary

Follow up on https://github.com/cowprotocol/cowswap/pull/4330

This PR allows users of the widget to customize the tooltip and add any content they want. 


![Screenshot at Apr 29 19-01-22](https://github.com/cowprotocol/cowswap/assets/2352112/fcb51ff7-99a8-4066-9ccd-e4e4aa29f62c)

![Screenshot at Apr 29 19-02-54](https://github.com/cowprotocol/cowswap/assets/2352112/aad36147-a1f7-43b3-b337-eb609970bd2b)


## Config

The configuration allows you to provide a custom fee label and the markdown for the tooltip

```ts
{
content: {
        // TODO: Don't merge with this. This comment should be reverted.
        feeLabel: "Anxo's cut",
        feeTooltipMarkdown: `\
Anxo has been working hard lately, and need to pay his bills.
Anxo is a good guy, so you should pay him.
This fee won't contribute to anything useful, but it will make Anxo happy.
## Why
Think about it
## Read more
[don't read more](google.com)
`,
      },
}
```

## Fun fact
Copilot helped writing the tooltip message, so I think IA wants me to be payed more


## Test

1. Go to configurator https://widget-configurator-git-custom-fee-labels-cowswap.vercel.app/
2. Check the fee label
3. Check the fee tooltip

## Additional
DONT'T MERGE: Needs to revert a commit that modifies the configurator label before merging 