### PR TITLE
feat: hide tooltip on mobile

### DIFF
--- a/libs/ui/src/pure/Tooltip/index.tsx
+++ b/libs/ui/src/pure/Tooltip/index.tsx
@@ -63,9 +63,10 @@ export function MouseoverTooltipContent({
   }, [onOpen])
 
   const close = useCallback((force = false) => {
-    if (!sticky || force) {
-      setShow(false)
-    }
+    if (sticky && !force) return
+
+    setSticky(false)
+    setShow(false)
   }, [setShow, sticky])
 
   const toggleSticky = useCallback<React.MouseEventHandler<HTMLDivElement>>((event) => {
@@ -88,6 +89,7 @@ export function MouseoverTooltipContent({
     }    
   }, [close, open, setSticky, show])
 
+  // Remove the stickiness when clicking outside the tooltip
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (sticky && divRef.current && !divRef.current.contains(event.target as Node)) {
@@ -101,6 +103,20 @@ export function MouseoverTooltipContent({
       document.removeEventListener('click', handleClickOutside);
     };
   }, [toggleSticky, setShow, sticky]);
+
+  // Remove the stickiness when scrolling
+  useEffect(() => {
+    const handleScroll = () => {
+      if (sticky) {
+        close(true)
+      }
+    }
+    
+    document.addEventListener('scroll', handleScroll);
+    return () => {
+      document.removeEventListener('scroll', handleScroll);
+    }
+  }, [sticky])
 
   
 

--- a/libs/ui/src/pure/Tooltip/index.tsx
+++ b/libs/ui/src/pure/Tooltip/index.tsx
@@ -120,10 +120,10 @@ export function MouseoverTooltipContent({
 
   
 
-  const c = disableHover ? null : <div ref={divRef}>{content}</div>
+  const tooltipContent = disableHover ? null : <div ref={divRef}>{content}</div>
 
   return (
-    <TooltipContent {...rest} show={show} content={c}>
+    <TooltipContent {...rest} show={show} content={tooltipContent}>
       <div onMouseEnter={open} onMouseLeave={() => close()} onClick={toggleSticky} >
 
         {children}


### PR DESCRIPTION
# Summary

Follow up on https://github.com/cowprotocol/cowswap/pull/4330, more specifically on @elena-zh comment:

> I have also noticed that tooltips are shaking and are not closed in a mobile device (iOS). I think, it would be great to close them when start scrolling the content. LMK please if I need to open a separate issue for this.

The PR will hide on scroll the tooltip.

## Test
1. Open the tooltip and make it sticky (click on the icon)
2. Scroll. It should hide
