### PR TITLE
Tooltip sticky improve ux

### DIFF
--- a/libs/ui/src/pure/Tooltip/index.tsx
+++ b/libs/ui/src/pure/Tooltip/index.tsx
@@ -57,7 +57,7 @@ export function MouseoverTooltipContent({
 }: Omit<TooltipContentProps, 'show'>) {
   const [sticky, setSticky] = useState(false)
   const [show, setShow] = useState(false)
-  const cancelCloseRef = useRef<(() => void) | null>()
+  const cancelCloseRef = useRef<Command | null>()
 
   const divRef = useRef<HTMLDivElement>(null);
   const open = useCallback(() => {

--- a/libs/ui/src/pure/Tooltip/index.tsx
+++ b/libs/ui/src/pure/Tooltip/index.tsx
@@ -6,6 +6,8 @@ import Popover, { PopoverProps } from '../Popover'
 
 import { Command } from '@cowprotocol/types'
 
+const TOOLTIP_CLOSE_DELAY = 300
+
 export const TooltipContainer = styled.div`
   max-width: 320px;
   padding: 4px 6px;
@@ -55,6 +57,7 @@ export function MouseoverTooltipContent({
 }: Omit<TooltipContentProps, 'show'>) {
   const [sticky, setSticky] = useState(false)
   const [show, setShow] = useState(false)
+  const cancelCloseRef = useRef<(() => void) | null>()
 
   const divRef = useRef<HTMLDivElement>(null);
   const open = useCallback(() => {
@@ -62,20 +65,40 @@ export function MouseoverTooltipContent({
     onOpen?.()
   }, [onOpen])
 
-  const close = useCallback((force = false) => {
+  // Close the tooltip
+  const close = useCallback((props: {force: boolean, delayed: boolean}) => {
+    const {force, delayed} = props
     if (sticky && !force) return
 
-    setSticky(false)
-    setShow(false)
+    const closeSticky = () => {
+      cancelCloseRef.current = null
+      setSticky(false)
+      setShow(false)
+    }
+    
+
+    // Cancel any previous scheduled close
+    if (cancelCloseRef.current) {
+      cancelCloseRef.current() 
+    }
+
+    // Create a delayed timeout
+    const timeout = setTimeout(closeSticky, delayed ? TOOLTIP_CLOSE_DELAY : 0)
+    cancelCloseRef.current = () => {
+      cancelCloseRef.current = null
+      clearTimeout(timeout)
+    }
+    return () => cancelCloseRef.current && cancelCloseRef.current()
   }, [setShow, sticky])
 
+  // Toggle the stickiness
   const toggleSticky = useCallback<React.MouseEventHandler<HTMLDivElement>>((event) => {
     event.stopPropagation()
     if (show) {
       setSticky(sticky => {
         if (sticky) {
           // Tooltip was visible, but sticky. Closing it.
-          close(true)
+          close({ force: true, delayed: false})
           return false
         } else {
           // Tooltip was visible, and not sticky. Making it sticky.
@@ -108,7 +131,7 @@ export function MouseoverTooltipContent({
   useEffect(() => {
     const handleScroll = () => {
       if (sticky) {
-        close(true)
+        close({ force: true, delayed: false})
       }
     }
     
@@ -118,13 +141,21 @@ export function MouseoverTooltipContent({
     }
   }, [sticky])
 
+  // Stop the delayed close when hovering the tooltip
+  const stopDelayedClose = useCallback(() => {
+    // Cancel any previous scheduled close
+    if (cancelCloseRef.current) {
+      cancelCloseRef.current()
+    }
+  }, [])
+
   
 
-  const tooltipContent = disableHover ? null : <div ref={divRef}>{content}</div>
+  const tooltipContent = disableHover ? null : <div ref={divRef} onMouseEnter={stopDelayedClose} onMouseLeave={() => close({ force: false, delayed: true })}>{content}</div>
 
   return (
     <TooltipContent {...rest} show={show} content={tooltipContent}>
-      <div onMouseEnter={open} onMouseLeave={() => close()} onClick={toggleSticky} >
+      <div onMouseEnter={open} onMouseLeave={() => close({force: false, delayed: true })} onClick={toggleSticky} >
 
         {children}
       </div>


### PR DESCRIPTION
# Summary

This PR follow up on https://github.com/cowprotocol/cowswap/pull/4336 and https://github.com/cowprotocol/cowswap/pull/4330

Tries to improve the UX by adding a small close delay (0.3s). 

If you over the tooltip before it closes, then it won't close. 

# To Test
1. Over the icon to show the tooltip
2. Move away, the tooltip should close with a delay
3. Over the icon again, the tooltip is visible
4. Try to over the tooltip.
- Before this PR when your mouse was on your way to the tooltip, the tooltip would close
- In this PR you should be able to prevent the closing by hovering on it
5. If you move away the mouse from the tooltip, then should close automatically (after a short delay)