### PR TITLE
feat(usd-estimation): replace coingecko endpoint

### DIFF
--- a/apps/cowswap-frontend/src/modules/usdAmount/apis/getCoingeckoUsdPrice.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/apis/getCoingeckoUsdPrice.ts
@@ -18,7 +18,7 @@ export const COINGECK_PLATFORMS: Record<SupportedChainId, string | null> = {
   [SupportedChainId.SEPOLIA]: null,
 }
 
-const BASE_URL = 'https://api.coingecko.com/api/v3/simple/token_price'
+const BASE_URL = 'https://cow-web-services-git-feat-usd-proxy-cowswap.vercel.app/api/serverless/coingeckoProxy'
 const VS_CURRENCY = 'usd'
 /**
  * This is a text of 429 HTTP code
@@ -63,7 +63,7 @@ export async function getCoingeckoUsdPrice(currency: Token): Promise<Fraction | 
     vs_currencies: VS_CURRENCY,
   }
 
-  const url = `${BASE_URL}/${platform}?${new URLSearchParams(params)}`
+  const url = `${BASE_URL}/token_price/${platform}?${new URLSearchParams(params)}`
 
   return fetchRateLimitted(url)
     .then((res) => {

--- a/apps/cowswap-frontend/src/modules/usdAmount/apis/getCoingeckoUsdPrice.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/apis/getCoingeckoUsdPrice.ts
@@ -18,7 +18,7 @@ export const COINGECK_PLATFORMS: Record<SupportedChainId, string | null> = {
   [SupportedChainId.SEPOLIA]: null,
 }
 
-const BASE_URL = 'https://cow-web-services.vercel.app/api/serverless/coingeckoProxy'
+const BASE_URL = 'https://cow-web-services.vercel.app/api/serverless/proxies/coingecko'
 const VS_CURRENCY = 'usd'
 /**
  * This is a text of 429 HTTP code

--- a/apps/cowswap-frontend/src/modules/usdAmount/apis/getCoingeckoUsdPrice.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/apis/getCoingeckoUsdPrice.ts
@@ -18,7 +18,7 @@ export const COINGECK_PLATFORMS: Record<SupportedChainId, string | null> = {
   [SupportedChainId.SEPOLIA]: null,
 }
 
-const BASE_URL = 'https://cow-web-services-git-feat-usd-proxy-cowswap.vercel.app/api/serverless/coingeckoProxy'
+const BASE_URL = 'https://cow-web-services.vercel.app/api/serverless/coingeckoProxy'
 const VS_CURRENCY = 'usd'
 /**
  * This is a text of 429 HTTP code
@@ -63,7 +63,7 @@ export async function getCoingeckoUsdPrice(currency: Token): Promise<Fraction | 
     vs_currencies: VS_CURRENCY,
   }
 
-  const url = `${BASE_URL}/token_price/${platform}?${new URLSearchParams(params)}`
+  const url = `${BASE_URL}/simple/token_price/${platform}?${new URLSearchParams(params)}`
 
   return fetchRateLimitted(url)
     .then((res) => {

--- a/apps/cowswap-frontend/src/modules/usdAmount/updaters/UsdPricesUpdater.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/updaters/UsdPricesUpdater.ts
@@ -22,6 +22,7 @@ import {
 
 const swrOptions: SWRConfiguration = {
   refreshInterval: ms`60s`,
+  focusThrottleInterval: ms`30s`,
   refreshWhenHidden: false,
   refreshWhenOffline: false,
   revalidateOnFocus: true,

--- a/apps/cowswap-frontend/src/modules/usdAmount/updaters/UsdPricesUpdater.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/updaters/UsdPricesUpdater.ts
@@ -21,7 +21,7 @@ import {
 } from '../state/usdRawPricesAtom'
 
 const swrOptions: SWRConfiguration = {
-  refreshInterval: ms`30s`,
+  refreshInterval: ms`60s`,
   refreshWhenHidden: false,
   refreshWhenOffline: false,
   revalidateOnFocus: true,


### PR DESCRIPTION
# Summary

Part of #4238

- Using new proxy endpoint from https://github.com/cowprotocol/bff/pull/10
- Bumping usd refresh interval from 30s to 1m

# To Test

1. Open the console in the `network` tab and filter for `geckoProxy`
2. On mainnet/gchain, you should see the requests _mostly_ all 200.
* Some of them should be `cached`

![image](https://github.com/cowprotocol/cowswap/assets/43217/e064f131-bf9d-40b1-876f-076e2d8109ed)

3. Open the tokens page
* Should load usd prices for the ones where there's is balance
4. Open the activity modal
* Should load usd prices for the ones with surplus

in general should behave the same or better in regards to usd amounts loading.