### PR TITLE
chore: simplify ux and code

### DIFF
--- a/libs/ui/src/pure/Tooltip/index.tsx
+++ b/libs/ui/src/pure/Tooltip/index.tsx
@@ -35,16 +35,9 @@ export function TooltipContent({ content, wrap = false, ...rest }: TooltipConten
   return <Popover content={wrap ? <TooltipContainer>{content}</TooltipContainer> : content} {...rest} />
 }
 
-export function MouseoverTooltip({ children, ...rest }: Omit<TooltipProps, 'show'>) {
-  const [show, setShow] = useState(false)
-  const open = useCallback(() => setShow(true), [setShow])
-  const close = useCallback(() => setShow(false), [setShow])
+export function MouseoverTooltip({ children, text, ...rest }: Omit<TooltipProps, 'show'>) {
   return (
-    <Tooltip {...rest} show={show}>
-      <div onMouseEnter={open} onMouseLeave={close}>
-        {children}
-      </div>
-    </Tooltip>
+    <MouseoverTooltipContent content={text} {...rest} >{children}</MouseoverTooltipContent>
   )
 }
 

--- a/libs/ui/src/pure/Tooltip/index.tsx
+++ b/libs/ui/src/pure/Tooltip/index.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useEffect, useRef, useState } from 'react'
+import { ReactNode, useCallback, useRef, useState } from 'react'
 
 import styled from 'styled-components'
 
@@ -6,7 +6,7 @@ import Popover, { PopoverProps } from '../Popover'
 
 import { Command } from '@cowprotocol/types'
 
-const TOOLTIP_CLOSE_DELAY = 300
+const TOOLTIP_CLOSE_DELAY = 300 // in milliseconds
 
 export const TooltipContainer = styled.div`
   max-width: 320px;

--- a/libs/ui/src/pure/Tooltip/index.tsx
+++ b/libs/ui/src/pure/Tooltip/index.tsx
@@ -63,9 +63,10 @@ export function MouseoverTooltipContent({
   }, [onOpen])
 
   const close = useCallback((force = false) => {
-    if (!sticky || force) {
-      setShow(false)
-    }
+    if (sticky && !force) return
+
+    setSticky(false)
+    setShow(false)
   }, [setShow, sticky])
 
   const toggleSticky = useCallback<React.MouseEventHandler<HTMLDivElement>>((event) => {
@@ -88,6 +89,7 @@ export function MouseoverTooltipContent({
     }    
   }, [close, open, setSticky, show])
 
+  // Remove the stickiness when clicking outside the tooltip
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (sticky && divRef.current && !divRef.current.contains(event.target as Node)) {
@@ -101,6 +103,20 @@ export function MouseoverTooltipContent({
       document.removeEventListener('click', handleClickOutside);
     };
   }, [toggleSticky, setShow, sticky]);
+
+  // Remove the stickiness when scrolling
+  useEffect(() => {
+    const handleScroll = () => {
+      if (sticky) {
+        close(true)
+      }
+    }
+    
+    document.addEventListener('scroll', handleScroll);
+    return () => {
+      document.removeEventListener('scroll', handleScroll);
+    }
+  }, [sticky])
 
   
 

--- a/libs/ui/src/pure/Tooltip/index.tsx
+++ b/libs/ui/src/pure/Tooltip/index.tsx
@@ -120,10 +120,10 @@ export function MouseoverTooltipContent({
 
   
 
-  const c = disableHover ? null : <div ref={divRef}>{content}</div>
+  const tooltipContent = disableHover ? null : <div ref={divRef}>{content}</div>
 
   return (
-    <TooltipContent {...rest} show={show} content={c}>
+    <TooltipContent {...rest} show={show} content={tooltipContent}>
       <div onMouseEnter={open} onMouseLeave={() => close()} onClick={toggleSticky} >
 
         {children}

--- a/libs/ui/src/pure/Tooltip/index.tsx
+++ b/libs/ui/src/pure/Tooltip/index.tsx
@@ -57,7 +57,7 @@ export function MouseoverTooltipContent({
 }: Omit<TooltipContentProps, 'show'>) {
   const [sticky, setSticky] = useState(false)
   const [show, setShow] = useState(false)
-  const cancelCloseRef = useRef<(() => void) | null>()
+  const cancelCloseRef = useRef<Command | null>()
 
   const divRef = useRef<HTMLDivElement>(null);
   const open = useCallback(() => {

--- a/libs/ui/src/pure/Tooltip/index.tsx
+++ b/libs/ui/src/pure/Tooltip/index.tsx
@@ -6,6 +6,8 @@ import Popover, { PopoverProps } from '../Popover'
 
 import { Command } from '@cowprotocol/types'
 
+const TOOLTIP_CLOSE_DELAY = 300
+
 export const TooltipContainer = styled.div`
   max-width: 320px;
   padding: 4px 6px;
@@ -55,6 +57,7 @@ export function MouseoverTooltipContent({
 }: Omit<TooltipContentProps, 'show'>) {
   const [sticky, setSticky] = useState(false)
   const [show, setShow] = useState(false)
+  const cancelCloseRef = useRef<(() => void) | null>()
 
   const divRef = useRef<HTMLDivElement>(null);
   const open = useCallback(() => {
@@ -62,20 +65,40 @@ export function MouseoverTooltipContent({
     onOpen?.()
   }, [onOpen])
 
-  const close = useCallback((force = false) => {
+  // Close the tooltip
+  const close = useCallback((props: {force: boolean, delayed: boolean}) => {
+    const {force, delayed} = props
     if (sticky && !force) return
 
-    setSticky(false)
-    setShow(false)
+    const closeSticky = () => {
+      cancelCloseRef.current = null
+      setSticky(false)
+      setShow(false)
+    }
+    
+
+    // Cancel any previous scheduled close
+    if (cancelCloseRef.current) {
+      cancelCloseRef.current() 
+    }
+
+    // Create a delayed timeout
+    const timeout = setTimeout(closeSticky, delayed ? TOOLTIP_CLOSE_DELAY : 0)
+    cancelCloseRef.current = () => {
+      cancelCloseRef.current = null
+      clearTimeout(timeout)
+    }
+    return () => cancelCloseRef.current && cancelCloseRef.current()
   }, [setShow, sticky])
 
+  // Toggle the stickiness
   const toggleSticky = useCallback<React.MouseEventHandler<HTMLDivElement>>((event) => {
     event.stopPropagation()
     if (show) {
       setSticky(sticky => {
         if (sticky) {
           // Tooltip was visible, but sticky. Closing it.
-          close(true)
+          close({ force: true, delayed: false})
           return false
         } else {
           // Tooltip was visible, and not sticky. Making it sticky.
@@ -108,7 +131,7 @@ export function MouseoverTooltipContent({
   useEffect(() => {
     const handleScroll = () => {
       if (sticky) {
-        close(true)
+        close({ force: true, delayed: false})
       }
     }
     
@@ -118,13 +141,21 @@ export function MouseoverTooltipContent({
     }
   }, [sticky])
 
+  // Stop the delayed close when hovering the tooltip
+  const stopDelayedClose = useCallback(() => {
+    // Cancel any previous scheduled close
+    if (cancelCloseRef.current) {
+      cancelCloseRef.current()
+    }
+  }, [])
+
   
 
-  const tooltipContent = disableHover ? null : <div ref={divRef}>{content}</div>
+  const tooltipContent = disableHover ? null : <div ref={divRef} onMouseEnter={stopDelayedClose} onMouseLeave={() => close({ force: false, delayed: true })}>{content}</div>
 
   return (
     <TooltipContent {...rest} show={show} content={tooltipContent}>
-      <div onMouseEnter={open} onMouseLeave={() => close()} onClick={toggleSticky} >
+      <div onMouseEnter={open} onMouseLeave={() => close({force: false, delayed: true })} onClick={toggleSticky} >
 
         {children}
       </div>


### PR DESCRIPTION
# Summary
This PR replaces https://github.com/cowprotocol/cowswap/pull/4337 and https://github.com/cowprotocol/cowswap/pull/4330 (so if approved, I will close these 2 PRs without merging)

## Contex
I tried a couple of approaches for improving the tooltips. This PR is another simpler approach that comes from a re-iteration of https://github.com/cowprotocol/cowswap/pull/4337

It removes the STICKY behavior of https://github.com/cowprotocol/cowswap/pull/4330 and allows you to toggle the tooltip by clicking the icon.

The code should also be simpler. Check the test steps to understand the expectations on the current behavior

# To Test

SPEC 2: `Tooltip works like before`
1. Over the icon shows it
2. Move away to hide it

SPEC 2: `Toggle the tooltip with the click`
1. Click to show
2. Click to hide. This is especially interesting for mobile (but also for desktop). If you check in production, we don't have this behavior, and feels more natural like this IMO.

SPEC 3: `Delay the closing, and allow to prevent the closing if you over in the tooltip`
This is the main addition and goal why I attempted to improve tooltips, so we can click on links on the tooltips
1. Hover the icon. Tooltip shows
2. Quickly move the mouse from the icon and into the tooltip. The tooltip should remain open
3. Move the mouse away. The tooltip should close