### PR TITLE
feat(usd-estimation): add defillama price source

### DIFF
--- a/apps/cowswap-frontend/src/modules/usdAmount/apis/errors.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/apis/errors.ts
@@ -1,0 +1,11 @@
+export class RateLimitError extends Error {
+  constructor() {
+    super('RateLimitError')
+  }
+}
+
+export class UnknownCurrencyError extends Error {
+  constructor() {
+    super('UnknownCurrencyError')
+  }
+}

--- a/apps/cowswap-frontend/src/modules/usdAmount/apis/errors.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/apis/errors.ts
@@ -1,11 +1,17 @@
 export class RateLimitError extends Error {
-  constructor() {
-    super('RateLimitError')
+  constructor(options?: ErrorOptions) {
+    super('RateLimitError', options)
   }
 }
 
 export class UnknownCurrencyError extends Error {
-  constructor() {
-    super('UnknownCurrencyError')
+  constructor(options?: ErrorOptions) {
+    super('UnknownCurrencyError', options)
+  }
+}
+
+export class UnsupportedPlatformError extends Error {
+  constructor(options?: ErrorOptions) {
+    super('UnsupportedPlatformError', options)
   }
 }

--- a/apps/cowswap-frontend/src/modules/usdAmount/apis/getCoingeckoUsdPrice.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/apis/getCoingeckoUsdPrice.ts
@@ -62,7 +62,6 @@ export async function getCoingeckoUsdPrice(currency: Token): Promise<Fraction | 
       if (error.message.includes(FAILED_FETCH_ERROR)) {
         throw new RateLimitError({ cause: error })
       }
-      console.log('[UsdPricesUpdater]: Something failed?', error)
 
       return Promise.reject(error)
     })
@@ -84,7 +83,7 @@ export async function getCoingeckoUsdPrice(currency: Token): Promise<Fraction | 
           cause: `Coingecko did not return a price for '${currency.address}' on chain '${currency.chainId}'`,
         })
       }
-      console.log('[UsdPricesUpdater]: Fetched coingecko price', value, currency.symbol)
+
       return FractionUtils.fromNumber(value)
     })
 }

--- a/apps/cowswap-frontend/src/modules/usdAmount/apis/getCoingeckoUsdPrice.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/apis/getCoingeckoUsdPrice.ts
@@ -6,13 +6,16 @@ import ms from 'ms.macro'
 
 import { fetchWithRateLimit } from 'common/utils/fetch'
 
-export interface CoinGeckoUsdQuote {
+import { RateLimitError, UnknownCurrencyError } from './errors'
+
+type SuccessCoingeckoUsdQuoteResponse = {
   [address: string]: {
     usd: number
   }
 }
+type ErrorCoingeckoResponse = { status: { error_code: number; error_message: string } }
 
-export const COINGECK_PLATFORMS: Record<SupportedChainId, string | null> = {
+export const COINGECKO_PLATFORMS: Record<SupportedChainId, string | null> = {
   [SupportedChainId.MAINNET]: 'ethereum',
   [SupportedChainId.GNOSIS_CHAIN]: 'xdai',
   [SupportedChainId.SEPOLIA]: null,
@@ -26,7 +29,7 @@ const VS_CURRENCY = 'usd'
  */
 const FAILED_FETCH_ERROR = 'Failed to fetch'
 
-const fetchRateLimitted = fetchWithRateLimit({
+const fetchRateLimited = fetchWithRateLimit({
   // Allow 2 requests per second
   rateLimit: {
     tokensPerInterval: 2,
@@ -41,20 +44,8 @@ const fetchRateLimitted = fetchWithRateLimit({
 
 export const COINGECKO_RATE_LIMIT_TIMEOUT = ms`1m`
 
-export class CoingeckoRateLimitError extends Error {
-  constructor() {
-    super('CoingeckoRateLimitError')
-  }
-}
-
-export class CoingeckoUnknownCurrency extends Error {
-  constructor() {
-    super('CoingeckoUnknownCurrency')
-  }
-}
-
 export async function getCoingeckoUsdPrice(currency: Token): Promise<Fraction | null> {
-  const platform = COINGECK_PLATFORMS[currency.chainId as SupportedChainId]
+  const platform = COINGECKO_PLATFORMS[currency.chainId as SupportedChainId]
 
   if (!platform) throw new Error('UnsupporedCoingeckoPlatformError')
 
@@ -65,26 +56,39 @@ export async function getCoingeckoUsdPrice(currency: Token): Promise<Fraction | 
 
   const url = `${BASE_URL}/simple/token_price/${platform}?${new URLSearchParams(params)}`
 
-  return fetchRateLimitted(url)
-    .then((res) => {
-      return res.json()
-    })
+  return fetchRateLimited(url)
+    .then((res) => res.json())
     .catch((error) => {
       if (error.message.includes(FAILED_FETCH_ERROR)) {
-        throw new CoingeckoRateLimitError()
+        throw new RateLimitError()
       }
+      console.log('[UsdPricesUpdater]: Something failed?', error)
 
       return Promise.reject(error)
     })
-    .then((res: CoinGeckoUsdQuote) => {
+    .then((res: SuccessCoingeckoUsdQuoteResponse | ErrorCoingeckoResponse) => {
+      if (isErrorResponse(res)) {
+        if (res.status.error_code === 429) {
+          throw new RateLimitError()
+        } else {
+          throw new Error(res.status.error_message)
+        }
+      }
+
       const value = res[currency.address.toLowerCase()]?.usd
 
       // If coingecko API returns an empty response
       // It means Coingecko doesn't know about the currency
       if (value === undefined) {
-        throw new CoingeckoUnknownCurrency()
+        throw new UnknownCurrencyError()
       }
-
+      console.log('[UsdPricesUpdater]: Fetched coingecko price', value, currency.symbol)
       return typeof value === 'number' ? FractionUtils.fromNumber(value) : null
     })
+}
+
+function isErrorResponse(
+  res: SuccessCoingeckoUsdQuoteResponse | ErrorCoingeckoResponse
+): res is ErrorCoingeckoResponse {
+  return 'status' in res
 }

--- a/apps/cowswap-frontend/src/modules/usdAmount/apis/getCoingeckoUsdPrice.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/apis/getCoingeckoUsdPrice.ts
@@ -85,7 +85,7 @@ export async function getCoingeckoUsdPrice(currency: Token): Promise<Fraction | 
         })
       }
       console.log('[UsdPricesUpdater]: Fetched coingecko price', value, currency.symbol)
-      return typeof value === 'number' ? FractionUtils.fromNumber(value) : null
+      return FractionUtils.fromNumber(value)
     })
 }
 

--- a/apps/cowswap-frontend/src/modules/usdAmount/apis/getCowProtocolUsdPrice.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/apis/getCowProtocolUsdPrice.ts
@@ -19,11 +19,7 @@ export async function getCowProtocolUsdPrice(
 
     if (tokenPrice.equalTo(0)) return null
 
-    const value = usdPrice.divide(tokenPrice)
-
-    console.log('[UsdPricesUpdater]: Fetched cowprotocol price', value.toFixed(6), currency.symbol)
-
-    return value
+    return usdPrice.divide(tokenPrice)
   }
 
   return null

--- a/apps/cowswap-frontend/src/modules/usdAmount/apis/getCowProtocolUsdPrice.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/apis/getCowProtocolUsdPrice.ts
@@ -19,7 +19,11 @@ export async function getCowProtocolUsdPrice(
 
     if (tokenPrice.equalTo(0)) return null
 
-    return usdPrice.divide(tokenPrice)
+    const value = usdPrice.divide(tokenPrice)
+
+    console.log('[UsdPricesUpdater]: Fetched cowprotocol price', value.toFixed(6), currency.symbol)
+
+    return value
   }
 
   return null

--- a/apps/cowswap-frontend/src/modules/usdAmount/apis/getDefillamaUsdPrice.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/apis/getDefillamaUsdPrice.ts
@@ -70,6 +70,6 @@ export async function getDefillamaUsdPrice(currency: Token): Promise<Fraction | 
         })
       }
       console.log('[UsdPricesUpdater]: Fetched defillama price', value, currency.symbol)
-      return typeof value === 'number' ? FractionUtils.fromNumber(value) : null
+      return FractionUtils.fromNumber(value)
     })
 }

--- a/apps/cowswap-frontend/src/modules/usdAmount/apis/getDefillamaUsdPrice.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/apis/getDefillamaUsdPrice.ts
@@ -1,0 +1,73 @@
+import { FractionUtils } from '@cowprotocol/common-utils'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { Fraction, Token } from '@uniswap/sdk-core'
+
+import ms from 'ms.macro'
+
+import { fetchWithRateLimit } from 'common/utils/fetch'
+
+import { RateLimitError, UnknownCurrencyError } from './errors'
+
+interface DefillamaUsdQuote {
+  coins: {
+    [chainAndAddress: string]: {
+      price: number
+    }
+  }
+}
+
+export const DEFILLAMA_PLATFORMS: Record<SupportedChainId, string | null> = {
+  [SupportedChainId.MAINNET]: 'ethereum',
+  [SupportedChainId.GNOSIS_CHAIN]: 'xdai',
+  [SupportedChainId.SEPOLIA]: null,
+}
+
+const BASE_URL = 'https://coins.llama.fi/prices/current'
+/**
+ * This is a text of 429 HTTP code
+ * https://saturncloud.io/blog/catching-javascript-fetch-failing-with-cloudflare-429-missing-cors-header/
+ */
+const FAILED_FETCH_ERROR = 'Failed to fetch'
+
+const fetchRateLimited = fetchWithRateLimit({
+  // Allow 2 requests per second
+  rateLimit: {
+    tokensPerInterval: 2,
+    interval: 'second',
+  },
+  // 2 retry attempts with 100ms delay
+  backoff: {
+    maxDelay: ms`0.1s`,
+    numOfAttempts: 2,
+  },
+})
+
+export const DEFILLAMA_RATE_LIMIT_TIMEOUT = ms`1m`
+
+export async function getDefillamaUsdPrice(currency: Token): Promise<Fraction | null> {
+  const platform = DEFILLAMA_PLATFORMS[currency.chainId as SupportedChainId]
+
+  if (!platform) throw new Error('UnsupportedDefillamaPlatformError')
+
+  const key = `${platform}:${currency.address}`.toLowerCase()
+  const url = `${BASE_URL}/${key}`
+
+  return fetchRateLimited(url)
+    .then((res) => res.json())
+    .catch((error) => {
+      if (error.message.includes(FAILED_FETCH_ERROR)) {
+        throw new RateLimitError()
+      }
+
+      return Promise.reject(error)
+    })
+    .then((res: DefillamaUsdQuote) => {
+      const value = res.coins[key]?.price
+
+      if (value === undefined) {
+        throw new UnknownCurrencyError()
+      }
+      console.log('[UsdPricesUpdater]: Fetched defillama price', value, currency.symbol)
+      return typeof value === 'number' ? FractionUtils.fromNumber(value) : null
+    })
+}

--- a/apps/cowswap-frontend/src/modules/usdAmount/apis/getDefillamaUsdPrice.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/apis/getDefillamaUsdPrice.ts
@@ -69,7 +69,7 @@ export async function getDefillamaUsdPrice(currency: Token): Promise<Fraction | 
           cause: `Defillama did not return a price for '${currency.address}' on chain '${currency.chainId}'`,
         })
       }
-      console.log('[UsdPricesUpdater]: Fetched defillama price', value, currency.symbol)
+
       return FractionUtils.fromNumber(value)
     })
 }

--- a/apps/cowswap-frontend/src/modules/usdAmount/services/fetchCurrencyUsdPrice.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/services/fetchCurrencyUsdPrice.ts
@@ -2,7 +2,7 @@ import { SupportedChainId, mapSupportedNetworks } from '@cowprotocol/cow-sdk'
 import { Fraction, Token } from '@uniswap/sdk-core'
 
 import { RateLimitError, UnknownCurrencyError } from '../apis/errors'
-import { COINGECKO_PLATFORMS, getCoingeckoUsdPrice } from '../apis/getCoingeckoUsdPrice'
+import { COINGECKO_PLATFORMS, COINGECKO_RATE_LIMIT_TIMEOUT, getCoingeckoUsdPrice } from '../apis/getCoingeckoUsdPrice'
 import { getCowProtocolUsdPrice } from '../apis/getCowProtocolUsdPrice'
 import { DEFILLAMA_PLATFORMS, DEFILLAMA_RATE_LIMIT_TIMEOUT, getDefillamaUsdPrice } from '../apis/getDefillamaUsdPrice'
 
@@ -20,7 +20,8 @@ function getShouldSkipCoingecko(currency: Token): boolean {
     currency,
     COINGECKO_PLATFORMS,
     coingeckoUnknownCurrencies,
-    coingeckoRateLimitHitTimestamp
+    coingeckoRateLimitHitTimestamp,
+    COINGECKO_RATE_LIMIT_TIMEOUT
   )
 }
 
@@ -29,7 +30,8 @@ function getShouldSkipDefillama(currency: Token): boolean {
     currency,
     DEFILLAMA_PLATFORMS,
     defillamaUnknownCurrencies,
-    defillamaRateLimitHitTimestamp
+    defillamaRateLimitHitTimestamp,
+    DEFILLAMA_RATE_LIMIT_TIMEOUT
   )
 }
 
@@ -37,7 +39,8 @@ function getShouldSkipPriceSource(
   currency: Token,
   platforms: Record<SupportedChainId, string | null>,
   unknownCurrenciesMap: UnknownCurrenciesMap,
-  rateLimitTimestamp: null | number
+  rateLimitTimestamp: null | number,
+  timeout: number
 ): boolean {
   const chainId = currency.chainId as SupportedChainId
 
@@ -45,7 +48,7 @@ function getShouldSkipPriceSource(
 
   if (unknownCurrenciesMap[chainId][currency.address.toLowerCase()]) return true
 
-  return !!rateLimitTimestamp && Date.now() - rateLimitTimestamp < DEFILLAMA_RATE_LIMIT_TIMEOUT
+  return !!rateLimitTimestamp && Date.now() - rateLimitTimestamp < timeout
 }
 
 /**

--- a/apps/cowswap-frontend/src/modules/usdAmount/services/fetchCurrencyUsdPrice.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/services/fetchCurrencyUsdPrice.ts
@@ -107,15 +107,12 @@ function handleErrorFactory(
   return (error) => {
     if (error instanceof RateLimitError) {
       rateLimitTimestamp = Date.now()
-      console.error('[UsdPricesUpdater]: request limit reached', currency.symbol)
     } else if (error instanceof UnknownCurrencyError) {
       // Mark currency as unknown
       unknownCurrenciesMap[currency.chainId as SupportedChainId][currency.address.toLowerCase()] = true
-      console.error('[UsdPricesUpdater]: unknown currency', currency.symbol, error)
     } else {
-      console.error('[UsdPricesUpdater]: Cannot fetch price', currency.symbol, error)
     }
-    console.error('[UsdPricesUpdater]: Using fallback', currency.symbol)
+
     return fetchPriceFallback(currency)
   }
 }

--- a/apps/cowswap-frontend/src/modules/usdAmount/updaters/UsdPricesUpdater.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/updaters/UsdPricesUpdater.ts
@@ -95,7 +95,6 @@ async function processQueue(queue: Token[], getUsdcPrice: () => Promise<Fraction
         if (price) {
           state.price = price
           state.updatedAt = Date.now()
-          console.debug(`[UsdPricesUpdater]: Fetched price for`, currency.symbol, price?.toFixed(6))
         }
       } catch (e) {
         console.debug(`[UsdPricesUpdater]: Failed to fetch price for`, currency.symbol)

--- a/apps/cowswap-frontend/src/modules/usdAmount/updaters/UsdPricesUpdater.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/updaters/UsdPricesUpdater.ts
@@ -95,9 +95,10 @@ async function processQueue(queue: Token[], getUsdcPrice: () => Promise<Fraction
         if (price) {
           state.price = price
           state.updatedAt = Date.now()
+          console.debug(`[UsdPricesUpdater]: Fetched price for`, currency.symbol, price?.toFixed(6))
         }
       } catch (e) {
-        console.debug(`[UsdPricesUpdater]: Failed to fetch price for `, currency.address)
+        console.debug(`[UsdPricesUpdater]: Failed to fetch price for`, currency.symbol)
       }
 
       return { [currency.address.toLowerCase()]: state }

--- a/libs/wallet/src/web3-react/connectors/Injected/index.tsx
+++ b/libs/wallet/src/web3-react/connectors/Injected/index.tsx
@@ -38,7 +38,7 @@ function parseChainId(chainId: string | number): number {
 }
 
 export class InjectedWallet extends Connector {
-  provider?: InjectedWalletProvider
+  provider?: InjectedWalletProvider = undefined
   walletUrl: string
   searchKeywords: string[]
   eagerConnection?: boolean

--- a/libs/wallet/src/web3-react/connectors/TrezorConnector/index.ts
+++ b/libs/wallet/src/web3-react/connectors/TrezorConnector/index.ts
@@ -24,7 +24,7 @@ const trezorConfig: Parameters<TrezorConnect['init']>[0] = {
 const ACCOUNTS_LIMIT = 100
 
 export class TrezorConnector extends Connector {
-  public customProvider?: TrezorProvider
+  public customProvider?: TrezorProvider = undefined
 
   private currentAccountIndex = 0
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,9 +3,12 @@
   "compilerOptions": {
     "rootDir": ".",
     "moduleResolution": "node",
-    "target": "es2015",
+    "target": "es2022",
     "module": "esnext",
-    "lib": ["es2020", "dom"],
+    "lib": [
+      "es2022",
+      "dom"
+    ],
     "allowJs": true,
     "sourceMap": true,
     "declaration": false,


### PR DESCRIPTION
# Summary

Part of #4238

- Add Defillama price source as fallback
- Fix Coingecko rate limit detection
- Refactor usd price fetching

# To Test

1. On mainnet/gchain, load an account that has many funds and/or many trades with surplus for different tokens
2. Open the tokens page, open the activity modal page
3. Open the console in the `network` tab
* Once there are `coingeckoProxy` requests failing with `429` errors, there should be requests for `defillama`
4. Open the console logs and filter by `UsdPricesUpdater`
* There should be logs indicating when coingecko, defillama or cowprotocol prices are being used

## Note

The console logs are noise, I know.
Will remove them before merging.