### PR TITLE
fix: clean outdated localStorage stores

### DIFF
--- a/apps/cowswap-frontend/public/emergency.js
+++ b/apps/cowswap-frontend/public/emergency.js
@@ -8,6 +8,41 @@ if (window.location.host === 'barn.cowswap.exchange') {
 }
 
 /**
+ * Remove old versions of the local storage atom stores
+ * We rely on the fact that store names are in the format {name}Atom:v{version}
+ * Since outdated versions of the stores are not used anymore, we should remove them to not exceed the storage limit
+ */
+;(function () {
+  const atomStoreRegex = /Atom\:v\d/
+
+  // Find the latest version of each store
+  const storePerVersion = Object.keys(localStorage)
+    // Take only the atom stores with versions
+    .filter((key) => key.match(atomStoreRegex))
+    .reduce((acc, key) => {
+      const [name, version] = key.split(':v')
+      const versionNum = +version
+
+      // Find the latest version of the store
+      if (!acc[name] || acc[name] < versionNum) {
+        acc[name] = versionNum
+      }
+
+      return acc
+    }, {})
+
+  // Remove all the old versions
+  Object.keys(storePerVersion).forEach((name) => {
+    const version = storePerVersion[name]
+
+    for (let i = 0; i < version; i++) {
+      localStorage.removeItem(`${name}:v${i}`)
+    }
+    console.log(name, version)
+  })
+})()
+
+/**
  * In case of problems with the service worker cache we can urgently reset the cache.
  * Just set resetCacheInCaseOfEmergency to true and release a new version
  */

--- a/apps/cowswap-frontend/public/emergency.js
+++ b/apps/cowswap-frontend/public/emergency.js
@@ -14,13 +14,16 @@ if (window.location.host === 'barn.cowswap.exchange') {
  */
 ;(function () {
   const atomStoreRegex = /Atom\:v\d/
+  const versionSeparator = ':v'
 
   // Find the latest version of each store
   const storePerVersion = Object.keys(localStorage)
     // Take only the atom stores with versions
     .filter((key) => key.match(atomStoreRegex))
     .reduce((acc, key) => {
-      const [name, version] = key.split(':v')
+      const parts = key.split(versionSeparator)
+      const version = parts[parts.length - 1]
+      const name = parts.slice(0, -1).join(versionSeparator)
       const versionNum = +version
 
       // Find the latest version of the store

--- a/apps/cowswap-frontend/public/emergency.js
+++ b/apps/cowswap-frontend/public/emergency.js
@@ -13,17 +13,17 @@ if (window.location.host === 'barn.cowswap.exchange') {
  * Since outdated versions of the stores are not used anymore, we should remove them to not exceed the storage limit
  */
 ;(function () {
-  const atomStoreRegex = /Atom\:v\d/
-  const versionSeparator = ':v'
+  const atomStoreRegex = /^(.+Atom):v(\d{1,3})$/
 
   // Find the latest version of each store
   const storePerVersion = Object.keys(localStorage)
     // Take only the atom stores with versions
-    .filter((key) => key.match(atomStoreRegex))
     .reduce((acc, key) => {
-      const parts = key.split(versionSeparator)
-      const version = parts[parts.length - 1]
-      const name = parts.slice(0, -1).join(versionSeparator)
+      const match = key.match(atomStoreRegex)
+
+      if (!match) return acc
+
+      const [, name, version] = match
       const versionNum = +version
 
       // Find the latest version of the store


### PR DESCRIPTION
# Summary

Follow up of #3809

Reported:
https://cowservices.slack.com/archives/C036MD8ADMG/p1715085509788589
https://cowservices.slack.com/archives/C03DVQREAH0/p1715583745060159

In #3881 we have fixed the reason of the issue, be it's not enough, we also have to clean consequences of this problem.
In this PR I've added universal solutions for `localStorage` stores with versioning.
The fix is added into `emergency.js` because this script loads before all (we must to clean localStorage before run the app).

# To Test

1. Block `emergency.js` request
2. Flood your localStorage. Create `allTokenListsInfoAtom:v2` localStorage record and put a lot of data into it
3. Reload the page
- [ ] you should see `localStorage exceeded the quota` error
4. Unblock `emergency.js` request and reload the page
- [ ] the error should not be displayed 
- [ ] `allTokenListsInfoAtom:v2` should be deleted from localStorage