### PR TITLE
feat: add support for ERC-3770 on recipient addr

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/ChainPrefixWarning/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ChainPrefixWarning/index.tsx
@@ -1,0 +1,21 @@
+import { BaseChainInfo } from '@cowprotocol/common-const'
+
+import { WarningCard } from '../WarningCard'
+
+type Props = {
+  chainPrefixWarning: string
+  chainInfo: BaseChainInfo
+}
+export default function ChainPrefixWarning({ chainPrefixWarning, chainInfo }: Props) {
+  return (
+    <div style={{ margin: 10 }}>
+      <WarningCard>
+        <div>
+          The recipient address you inputted had the chainPrefix <strong>{chainPrefixWarning}</strong>, but your wallet
+          is on {chainInfo.label} which uses the chain prefix <strong>{chainInfo.addressPrefix}</strong>. Please,
+          double-check that the recipient address is for the correct network.
+        </div>
+      </WarningCard>
+    </div>
+  )
+}

--- a/apps/cowswap-frontend/src/legacy/components/AddressInputPanel/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/AddressInputPanel/index.tsx
@@ -1,6 +1,11 @@
-import { ChangeEvent, ReactNode, useCallback } from 'react'
+import { ChangeEvent, ReactNode, useCallback, useState } from 'react'
 
-import { getBlockExplorerUrl as getExplorerLink } from '@cowprotocol/common-utils'
+import { getChainInfo } from '@cowprotocol/common-const'
+import {
+  getBlockExplorerUrl as getExplorerLink,
+  isPrefixedAddress,
+  parsePrefixedAddress,
+} from '@cowprotocol/common-utils'
 import { useENS } from '@cowprotocol/ens'
 import { RowBetween } from '@cowprotocol/ui'
 import { ExternalLink } from '@cowprotocol/ui'
@@ -12,7 +17,9 @@ import styled from 'styled-components/macro'
 
 import { AutoColumn } from 'legacy/components/Column'
 
+import ChainPrefixWarning from 'common/pure/ChainPrefixWarning'
 import { autofocus } from 'common/utils/autofocus'
+
 
 const InputPanel = styled.div`
   ${({ theme }) => theme.flexColumnNoWrap}
@@ -95,22 +102,38 @@ export function AddressInputPanel({
   onChange: (value: string) => void
 }) {
   const { chainId } = useWalletInfo()
-
+  const chainInfo = getChainInfo(chainId)
   const { address, loading, name } = useENS(value)
+  const [chainPrefixWarning, setChainPrefixWarning] = useState('')
 
   const handleInput = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       const input = event.target.value
-      const withoutSpaces = input.replace(/\s+/g, '')
-      onChange(withoutSpaces)
+      setChainPrefixWarning('')
+      let value = input.replace(/\s+/g, '')
+
+      if (isPrefixedAddress(value)) {
+        const { prefix, address } = parsePrefixedAddress(value)
+
+        if (prefix && chainInfo?.addressPrefix !== prefix) {
+          setChainPrefixWarning(prefix)
+        }
+
+        if (address) {
+          value = address
+        }
+      }
+
+      onChange(value)
     },
-    [onChange]
+    [onChange, chainInfo?.addressPrefix]
   )
 
   const error = Boolean(value.length > 0 && !loading && !address)
 
   return (
     <InputPanel id={id}>
+      {chainPrefixWarning && <ChainPrefixWarning chainPrefixWarning={chainPrefixWarning} chainInfo={chainInfo} />}
       <ContainerRow error={error}>
         <InputContainer>
           <AutoColumn gap="md">

--- a/libs/common-const/src/chainInfo.ts
+++ b/libs/common-const/src/chainInfo.ts
@@ -15,6 +15,7 @@ export interface BaseChainInfo {
   readonly infoLink: string
   readonly logoUrl: string
   readonly name: string
+  readonly addressPrefix: string
   readonly label: string
   readonly urlAlias: string
   readonly helpCenterUrl?: string
@@ -32,6 +33,7 @@ export const CHAIN_INFO: ChainInfoMap = {
     infoLink: COW_PROTOCOL_LINK,
     label: 'Ethereum',
     name: 'mainnet',
+    addressPrefix: 'eth',
     explorerTitle: 'Etherscan',
     urlAlias: '',
     logoUrl: EthereumLogo,
@@ -44,6 +46,7 @@ export const CHAIN_INFO: ChainInfoMap = {
     infoLink: COW_PROTOCOL_LINK,
     label: 'Sepolia',
     name: 'sepolia',
+    addressPrefix: 'sep',
     explorerTitle: 'Etherscan',
     urlAlias: 'sepolia',
     logoUrl: SepoliaLogo,
@@ -57,6 +60,7 @@ export const CHAIN_INFO: ChainInfoMap = {
     infoLink: 'https://www.gnosischain.com',
     label: 'Gnosis Chain',
     name: 'gnosis_chain',
+    addressPrefix: 'gno',
     explorerTitle: 'Gnosisscan',
     urlAlias: 'gc',
     logoUrl: GnosisChainLogo,

--- a/libs/common-utils/src/address.ts
+++ b/libs/common-utils/src/address.ts
@@ -1,0 +1,28 @@
+import { getAddress } from '@ethersproject/address'
+
+export const getChecksumAddressOrOriginal = (address: string): string => {
+  try {
+    return getAddress(address)
+  } catch (error) {
+    console.error('Failed to checksum address:', error);
+    return address
+  }
+}
+
+/**
+ * Parses a string that may/may not contain an address and returns the `prefix` and checksummed `address`
+ * @param value (prefixed) address
+ * @returns `prefix` and checksummed `address`
+ */
+export const parsePrefixedAddress = (value: string) => {
+  const [prefix, address] = value.split(':')
+
+  return {
+    prefix: prefix || undefined,
+    address: getChecksumAddressOrOriginal(address || value),
+  }
+}
+
+export const isPrefixedAddress = (value: string): boolean => {
+  return value.includes(':')
+}

--- a/libs/common-utils/src/index.ts
+++ b/libs/common-utils/src/index.ts
@@ -1,3 +1,4 @@
+export * from './address'
 export * from './amountFormat/index'
 export * from './anonymizeLink'
 export * from './appzi'


### PR DESCRIPTION


# Summary

Currently if you paste an ERC-3770 formatted address into the recipient list, you’ll get an error and have to delete the chain prefix.

With this change we will detect a prefix in an address and return just the address. If the address pasted was having the same address as the current chain, there won’t be any warning to the user, but if he has pasted an address for a different chain we’ll output a warning.

<img width="564" alt="grafik" src="https://github.com/cowprotocol/cowswap/assets/693770/7d0a73ae-e046-4d2e-ab5f-e120f8158cc1">

This improves the compatibility with the Safe app as addresses there are by default output with a prefix. 

# To Test

1. Enable custom recipient
2. If you enter an address with a prefix, then the prefix will be stripped out and only the address will be left in the field.
- if the prefix was for the same chain the user is currently on - no warning will be output
- if the prefix was for a different chain, then a warning will be output

3. If you paste an address without prefix, then it should continue to work as before.
