### PR TITLE
feat(cms): add blog page with an article

### DIFF
--- a/apps/cow-fi/components/Article.tsx
+++ b/apps/cow-fi/components/Article.tsx
@@ -1,11 +1,9 @@
 import Link from 'next/link'
 
 import React from 'react'
-import Head from 'next/head'
-import Layout from '@/components/Layout'
-import ReactMarkdown, { Components } from 'react-markdown'
+import ReactMarkdown from 'react-markdown'
 
-import { Color, Media } from '@/styles/variables'
+import { Color } from '@/styles/variables'
 import {
   Article,
   ArticleBlock,
@@ -52,7 +50,7 @@ const ArticleItemWrapper = styled.li`
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   margin: 1.5rem 0;
   padding: 2.5rem;
-  color: ${Color.text1};
+  color: ${Color.text1};  
 
   a.link {
     font-size: 2rem;
@@ -69,15 +67,32 @@ const ArticleBlocksWrapper = styled.ul`
   list-style-type: none;
   padding: 0;
 
+  p, p a, strong {
+    font-size: 1.8rem;
+  }
 
   p {
-    font-size: 2rem;
     line-height: 1.8;
-    margin: 2.15rem 0;    
+    margin: 2rem 0;
+  }
 
-    a {
-      font-size: 2rem;
-    }
+  h2 {
+    font-size: 24px;
+    font-weight: bold;
+    margin: 2.5rem 0 1.5rem 0;
+  }
+
+  li {
+    line-height: 32px;
+    margin: 1.5rem 0;
+  }
+
+  img {
+    max-width: 100%;
+  }
+
+  strong {
+    color: ${Color.text1};
   }
 `
 
@@ -201,14 +216,19 @@ export function ArticleContent({ article }: ArticleProps) {
         </SectionContent>
       </Section>
 
+      
       {/* <Section fullWidth colorVariant={'white'} flow="column" gap={14} padding="4rem 8rem 12rem 8rem">
         <SectionContent flow={'row'} maxWidth={100} textAlign={'left'}>
           <div className="container">
             <h3>DEBUG DATA</h3>
+            <ArticleContentWrapper>
+
             <pre style={{ lineHeight: '1.5em', fontSize: '14px' }}>{JSON.stringify(article, null, 2)}</pre> 
+            </ArticleContentWrapper>
           </div>
         </SectionContent>
-      </Section> */}
+      </Section>  */}
+     
     </>    
   )
 }

--- a/apps/cow-fi/pages/learn/articles/[articleSlug].tsx
+++ b/apps/cow-fi/pages/learn/articles/[articleSlug].tsx
@@ -3,7 +3,10 @@ import React from 'react'
 import { GetStaticPaths, GetStaticProps } from 'next'
 import { getArticleBySlug, getAllArticleSlugs, Article } from 'services/cms'
 
-import { ArticleContent } from '@/components/Article'
+import { ArticleContent, GetInTouchSection } from '@/components/Article'
+import Layout from '@/components/Layout'
+import Head from 'next/head'
+import Link from 'next/link'
 
 const DATA_CACHE_TIME_SECONDS = 10 * 60 // 10 minutes
 
@@ -12,7 +15,38 @@ export interface BlogPostProps {
 }
 
 export default function BlogPostPage({ article }: BlogPostProps) {
-  return <ArticleContent article={article} />
+  const { id } = article
+  const { title, description, slug, seo } =
+    article?.attributes || {}
+  const { metaTitle, shareImage, metaDescription } = seo || {}
+  const shareImageUrl = shareImage?.data?.attributes?.url
+
+  // TODO: Add SEO information
+
+  return (
+    <Layout fullWidthGradientVariant={true} data-article-id={id} data-slug={slug}>
+      <Head>
+        <title>{title}</title>
+
+        <meta name="description" content={metaDescription || description} key="description" />
+        <meta property="og:description" content={metaDescription || description} key="og-description" />
+        <meta property="og:title" content={metaTitle || title} key="og-title" />
+        <meta name="twitter:title" content={title} key="twitter-title" />
+        {shareImageUrl && (
+          <>
+            <meta key="ogImage" property="og:image" content={shareImageUrl} />
+            <meta key="twitterImage" name="twitter:image" content={shareImageUrl} />
+          </>
+        )}
+      </Head>
+
+      <ArticleContent article={article} />
+
+
+      <GetInTouchSection />
+    </Layout>
+  )
+  
 }
 
 type ArticleQuery = { articleSlug: string }

--- a/apps/cow-fi/pages/learn/categories/[categorySlug].tsx
+++ b/apps/cow-fi/pages/learn/categories/[categorySlug].tsx
@@ -14,6 +14,7 @@ import { CategoryContent, CategoryList } from '@/components/Category'
 import { CONFIG } from '@/const/meta'
 import SocialList from '@/components/SocialList'
 import Link from 'next/link'
+import { GetInTouchSection } from '@/components/Article'
 
 const DATA_CACHE_TIME_SECONDS = 10 * 60 // 10 minutes
 
@@ -64,17 +65,7 @@ export default function CategoryPage({ category, categories }: CategoryPageProps
         </SectionContent>
       </Section>
 
-      <Section fullWidth>
-        <SectionContent flow={'column'}>
-          <div>
-            <h3>Get in touch</h3>
-            <SubTitle maxWidth={60} color={Color.text1} lineHeight={1.4}>
-              You would like to suggest or even make your own article, reach out on Twitter or Discord!
-            </SubTitle>
-            <SocialList social={CONFIG.social} color={Color.darkBlue} />
-          </div>
-        </SectionContent>
-      </Section>
+      <GetInTouchSection />
     </Layout>
   )
 }

--- a/apps/cow-fi/pages/learn/index.tsx
+++ b/apps/cow-fi/pages/learn/index.tsx
@@ -8,10 +8,9 @@ import { Section, SectionContent, SubTitle, SectionImage } from '@/components/Ho
 import { CONFIG } from '@/const/meta'
 import { Color } from '@/styles/variables'
 import { Article, Category, getArticles, getCategories } from 'services/cms'
-import { ArticleList } from '@/components/Article'
+import { ArticleList, GetInTouchSection } from '@/components/Article'
 
 import { IMAGE_PATH } from '@/const/paths'
-import SocialList from '@/components/SocialList'
 import { LinkWithUtm } from 'modules/utm'
 import { CategoryList } from '@/components/Category'
 
@@ -87,17 +86,7 @@ export default function LearnPage({ categories, articles }: LearnProps) {
         </SectionContent>
       </Section>
 
-      <Section fullWidth>
-        <SectionContent flow={'column'}>
-          <div>
-            <h3>Get in touch</h3>
-            <SubTitle maxWidth={60} color={Color.text1} lineHeight={1.4}>
-              You would like to suggest or even make your own article, reach out on Twitter or Discord!
-            </SubTitle>
-            <SocialList social={CONFIG.social} color={Color.darkBlue} />
-          </div>
-        </SectionContent>
-      </Section>
+      <GetInTouchSection />
     </Layout>
   )
 }

--- a/apps/cow-fi/services/cms/index.ts
+++ b/apps/cow-fi/services/cms/index.ts
@@ -11,6 +11,8 @@ export type SharedRichTextComponent = Schemas['SharedRichTextComponent']
 export type SharedSliderComponent = Schemas['SharedSliderComponent']
 export type SharedVideoEmbedComponent = Schemas['SharedVideoEmbedComponent']
 export type Category = Schemas['CategoryListResponseDataItem']
+export type ArticleCover = Schemas['Article']['cover']
+export type ArticleBlocks = Schemas['Article']['blocks']
 
 export type ArticleBlock =
   | SharedMediaComponent
@@ -28,7 +30,7 @@ export function isSharedQuoteComponent(component: ArticleBlock): component is Sh
 }
 
 export function isSharedRichTextComponent(component: ArticleBlock): component is SharedRichTextComponent {
-  return component.__component === 'SharedRichTextComponent'
+  return component.__component === 'shared.rich-text'
 }
 
 export function isSharedSliderComponent(component: ArticleBlock): component is SharedMediaComponent {


### PR DESCRIPTION
# Summary

Adds a basic layout for an article page inside learn

<img width="1481" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/7d2b0db8-f9db-40e6-b9f2-cd09e597a91a">

<img width="1360" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/cd4cf14b-cb61-42c4-874a-cf0cfdb113a3">


## Test
Check out some articles, for example: https://cowfi-git-add-blog-page-cowswap.vercel.app/learn/articles/cow-protocol-april-2023-highlights

Although I added a few styles, the final ironing will be done by Michel, so don't focus too much on how this is presented. The goal was to show the page, basic content, cover image and format the markdown