### PR TITLE
feat: add SEO image and fallback to cover image

### DIFF
--- a/apps/cow-fi/components/Article.tsx
+++ b/apps/cow-fi/components/Article.tsx
@@ -143,8 +143,6 @@ export function ArticleItem({ article }: ArticleItemProps) {
   if (!article.attributes) return null
 
   const { slug, title, description, publishedAt, categories, cover, authorsBio } = article.attributes
-
-  // TODO: For details: seo, §
   return (
     <ArticleItemWrapper key={slug} data-slug={slug} data-id={article.id}>
       <Link className="link" href={`/learn/articles/${slug}`} passHref>

--- a/apps/cow-fi/components/Category.tsx
+++ b/apps/cow-fi/components/Category.tsx
@@ -74,11 +74,13 @@ export function CategoryContent({ category }: CategoryContentProps) {
         </SectionContent>
       </Section>
 
+      
       <Section fullWidth colorVariant={'white'} flow="column" gap={14} padding="4rem 8rem 12rem 8rem">
         <SectionContent flow={'row'} maxWidth={100} textAlign={'left'}>
           <div className="container">
             <h3>Articles</h3>
 
+            {articles ? (
             <CategoryContentWrapper data-slug={slug} data-id={id}>
               <ArticleList articles={articles?.data as Article[]} />
 
@@ -89,6 +91,11 @@ export function CategoryContent({ category }: CategoryContentProps) {
             </pre>
             */}
             </CategoryContentWrapper>
+              
+            ): (
+              <>There are no articles for this category yet.</>
+            )}
+
           </div>
         </SectionContent>
       </Section>

--- a/apps/cow-fi/pages/learn/articles/[articleSlug].tsx
+++ b/apps/cow-fi/pages/learn/articles/[articleSlug].tsx
@@ -16,24 +16,25 @@ export interface BlogPostProps {
 
 export default function BlogPostPage({ article }: BlogPostProps) {
   const { id } = article
-  const { title, description, slug, seo, cover } =
-    article?.attributes || {}
-  const { metaTitle, shareImage, metaDescription } = seo || {}
-  const shareImageUrl = shareImage?.data?.attributes?.url || cover?.data?.attributes?.url
-
+  const { title, description, slug, seo, cover } = article?.attributes || {}
+  const { metaTitle, metaDescription, shareImage } = seo || {}
+  
+  const ogTitle = metaTitle || title
+  const ogDescription = metaDescription || description
+  const ogImage = shareImage?.data?.attributes?.url || cover?.data?.attributes?.url
   return (
     <Layout fullWidthGradientVariant={true} data-article-id={id} data-slug={slug}>
       <Head>
         <title>{title}</title>
 
-        <meta name="description" content={metaDescription || description} key="description" />
-        <meta property="og:description" content={metaDescription || description} key="og-description" />
-        <meta property="og:title" content={metaTitle || title} key="og-title" />
-        <meta name="twitter:title" content={title} key="twitter-title" />
-        {shareImageUrl && (
+        <meta name="description" content={ogDescription} key="description" />
+        <meta property="og:description" content={ogDescription} key="og-description" />
+        <meta property="og:title" content={ogTitle} key="og-title" />
+        <meta name="twitter:title" content={ogTitle} key="twitter-title" />
+        {ogImage && (
           <>
-            <meta key="ogImage" property="og:image" content={shareImageUrl} />
-            <meta key="twitterImage" name="twitter:image" content={shareImageUrl} />
+            <meta key="ogImage" property="og:image" content={ogImage} />
+            <meta key="twitterImage" name="twitter:image" content={ogImage} />
           </>
         )}
       </Head>

--- a/apps/cow-fi/pages/learn/articles/[articleSlug].tsx
+++ b/apps/cow-fi/pages/learn/articles/[articleSlug].tsx
@@ -16,12 +16,10 @@ export interface BlogPostProps {
 
 export default function BlogPostPage({ article }: BlogPostProps) {
   const { id } = article
-  const { title, description, slug, seo } =
+  const { title, description, slug, seo, cover } =
     article?.attributes || {}
   const { metaTitle, shareImage, metaDescription } = seo || {}
-  const shareImageUrl = shareImage?.data?.attributes?.url
-
-  // TODO: Add SEO information
+  const shareImageUrl = shareImage?.data?.attributes?.url || cover?.data?.attributes?.url
 
   return (
     <Layout fullWidthGradientVariant={true} data-article-id={id} data-slug={slug}>

--- a/apps/cow-fi/pages/learn/index.tsx
+++ b/apps/cow-fi/pages/learn/index.tsx
@@ -73,18 +73,20 @@ export default function LearnPage({ categories, articles }: LearnProps) {
         </SectionContent>
       </Section>
 
-      <Section fullWidth colorVariant={'white'} flow="column" gap={14}>
-        <SectionContent flow={'row'} maxWidth={100} textAlign={'left'}>
-          <div className="container">
-            <h3>Latest articles</h3>
-            <SubTitle lineHeight={1.4} textAlign={'left'}>
-              Every week we publish new articles about CoW DAO ecosystem. Stay tuned!
-            </SubTitle>
+      {articles && (
+        <Section fullWidth colorVariant={'white'} flow="column" gap={14}>
+          <SectionContent flow={'row'} maxWidth={100} textAlign={'left'}>
+            <div className="container">
+              <h3>Latest articles</h3>
+              <SubTitle lineHeight={1.4} textAlign={'left'}>
+                Every week we publish new articles about CoW DAO ecosystem. Stay tuned!
+              </SubTitle>
 
-            <ArticleList articles={articles} />
-          </div>
-        </SectionContent>
-      </Section>
+              <ArticleList articles={articles} />
+            </div>
+          </SectionContent>
+        </Section>
+      )}
 
       <GetInTouchSection />
     </Layout>

--- a/apps/cow-fi/services/cms/index.ts
+++ b/apps/cow-fi/services/cms/index.ts
@@ -1,6 +1,8 @@
 import { CmsClient, components } from '@cowprotocol/cms'
 import { PaginationParam } from 'types'
 
+import { toQueryParams } from 'util/queryParams'
+
 const PAGE_SIZE = 50
 
 type Schemas = components['schemas']
@@ -198,33 +200,56 @@ async function getBySlugAux(slug: string, endpoint: '/categories' | '/articles')
 
   const populate =
     endpoint === '/categories'
-      ? {
-          // Category
-          'populate[articles][populate][0]': 'authorsBio',
-          'populate[articles][populate][1]': 'seo',
+      ? // Category
+        {
+          articles: {
+            populate: {
+              authorsBio: {
+                fields: ['name'],
+              },
+              seo: '*',
+            },
+          },
         }
-      : {
-          // Article
-          'populate[0]': 'cover',
-          'populate[1]': 'blocks',
-          'populate[2]': 'seo',
-          'populate[3]': 'authorsBio',
+      : // Articles
+        {
+          cover: {
+            fields: ['url', 'width', 'height', 'alternativeText'],
+          },
+          blocks: '*',
+          seo: {
+            fields: ['metaTitle', 'metaDescription'],
+            populate: {
+              shareImage: {
+                fields: ['url'],
+              },
+            },
+          },
+          authorsBio: {
+            fields: ['name'],
+          },
         }
 
-  console.log(`[getArticleBySlug] get ${entity} for slug ${slug}`)
+  const query = toQueryParams({
+    filters: {
+      slug: {
+        $eq: slug,
+      },
+    },
+
+    pagination: {
+      page: 1,
+      pageSize: 2,
+    },
+
+    populate,
+  })
+
+  console.log(`[getArticleBySlug] get ${entity} for slug ${slug}`, query)
+
   const { data, error } = await client.GET(endpoint, {
     params: {
-      query: {
-        // Filter by slug
-        'filters[slug][$eq]': slug,
-
-        // Pagination
-        'pagination[page]': 1,
-        'pagination[pageSize]': 2, // Get 2 items to check for duplicates
-
-        // Populate: Use the query https://docs.strapi.io/dev-docs/api/rest/interactive-query-builder
-        ...populate,
-      },
+      query,
     },
   })
 

--- a/apps/cow-fi/util/queryParams.ts
+++ b/apps/cow-fi/util/queryParams.ts
@@ -1,0 +1,65 @@
+import qs from 'qs'
+
+/**
+ * Helper util to convert nested objects in qs format (https://www.npmjs.com/package/qs) to generate query params in key value format
+ * 
+ For example will convert this:
+
+ ```json
+ {
+  filters: {
+    slug: {
+      $eq: 'aave-trade-breakdown',
+    },
+  },
+
+  pagination: {
+    page: 1,
+    pageSize: 2,
+  },
+
+  populate: {
+    cover: '*',
+    blocks: '*',
+    seo: {
+      fields: ['metaTitle', 'metaDescription'],
+      populate: {
+        shareImage: {
+          fields: ['url'],
+        },
+      },
+    },
+    authorsBio: '*',
+  },
+}
+```
+
+into this:
+
+```json
+ {
+  'filters[slug][$eq]': 'aave-trade-breakdown',
+  'pagination[page]': '1',
+  'pagination[pageSize]': '2',
+  'populate[cover]': '*',
+  'populate[blocks]': '*',
+  'populate[seo][fields][0]': 'metaTitle',
+  'populate[seo][fields][1]': 'metaDescription',
+  'populate[seo][populate][shareImage][fields][0]': 'url',
+  'populate[authorsBio]': '*'
+}
+```
+ * 
+ * @param query the object in qs format
+ * 
+ * @returns the object in key value format
+ */
+export function toQueryParams(query: unknown): { [key: string]: string } {
+  const queryString = qs.stringify(query, { encode: false })
+
+  return queryString.split('&').reduce<{ [key: string]: string }>((acc, pair) => {
+    const [key, value] = pair.split('=')
+    acc[key] = value
+    return acc
+  }, {})
+}


### PR DESCRIPTION
# Summary

Make use of the SEO tags for the articles, with nice defaults (to use the article titles, description, etc as sane defaults

<img width="1696" alt="Screenshot at May 14 14-57-53" src="https://github.com/cowprotocol/cowswap/assets/2352112/f87b2a7a-8619-45aa-8776-c08d8e6f7f9b">


## Bonus
Creating the query string was a bit complicated because our CMS client library expect an object of key-value pairs, however the CMS allows a very rich nested object sintax that is very hard to do by hand in this format. 

This PR adds an utility that uses `qs` library to convert one format in the other. This makes it simpler to query the CMS. 
Probably we should move this to the CMS as it matures

## Test
https://www.opengraph.xyz/url/https%3A%2F%2Fcowfi-git-cms-seo-cowswap.vercel.app%2Flearn%2Farticles%2Fannouncing-gasless-approvals-on-cow-swap

You can try to go to the CMS admin and modify the SEO information, and make sure its reflected