### PR TITLE
fix(twap): lower minimum sell amount

### DIFF
--- a/apps/cowswap-frontend/src/modules/twap/const.ts
+++ b/apps/cowswap-frontend/src/modules/twap/const.ts
@@ -38,7 +38,7 @@ export const TWAP_PENDING_STATUSES = [TwapOrderStatus.WaitSigning, TwapOrderStat
 export const TWAP_FINAL_STATUSES = [TwapOrderStatus.Fulfilled, TwapOrderStatus.Expired, TwapOrderStatus.Cancelled]
 
 export const MINIMUM_PART_SELL_AMOUNT_FIAT: Record<SupportedChainId, CurrencyAmount<Currency>> = {
-  [SupportedChainId.MAINNET]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.MAINNET], 5_000e6), // 5k
+  [SupportedChainId.MAINNET]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.MAINNET], 1_000e6), // 1k
   [SupportedChainId.SEPOLIA]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.SEPOLIA], 100e6), // 100
   [SupportedChainId.GNOSIS_CHAIN]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.GNOSIS_CHAIN], 5e6), // 5
 }


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C035N0YEB6J/p1715262180866269?thread_ts=1714975213.305109&cid=C035N0YEB6J

Changed the threshold from 5k to 1k on Mainnet

# To Test

1. The warning should be displayed on Mainnet only if the amount is less than 1k USD
