### PR TITLE
fix(explorer): reduce retries for tx orders requests

### DIFF
--- a/apps/explorer/src/api/operator/operatorApi.ts
+++ b/apps/explorer/src/api/operator/operatorApi.ts
@@ -6,6 +6,8 @@ import { GetOrderParams, RawOrder, RawTrade, GetTxOrdersParams, WithNetworkId } 
 
 export { getAccountOrders } from './accountOrderUtils'
 
+const backoffOpts = { numOfAttempts: 2 }
+
 /**
  * Gets a single order by id
  */
@@ -23,11 +25,17 @@ export async function getTxOrders(params: GetTxOrdersParams): Promise<RawOrder[]
 
   console.log(`[getTxOrders] Fetching tx orders on network ${networkId}`)
 
-  const orderPromises = orderBookSDK.getTxOrders(txHash, { chainId: networkId })
-  const orderPromisesBarn = orderBookSDK.getTxOrders(txHash, { chainId: networkId, env: 'staging' }).catch((error) => {
-    console.error('[getTxOrders] Error getting the orders for Barn', error)
-    return []
-  })
+  const orderPromises = orderBookSDK.getTxOrders(txHash, { chainId: networkId, backoffOpts })
+  const orderPromisesBarn = orderBookSDK
+    .getTxOrders(txHash, {
+      chainId: networkId,
+      env: 'staging',
+      backoffOpts,
+    })
+    .catch((error) => {
+      console.error('[getTxOrders] Error getting the orders for Barn', error)
+      return []
+    })
 
   // sdk not merging array responses yet
   const orders = await Promise.all([orderPromises, orderPromisesBarn])

--- a/apps/explorer/src/api/web3/index.ts
+++ b/apps/explorer/src/api/web3/index.ts
@@ -3,6 +3,7 @@ import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { ETH_NODE_URL, NODE_PROVIDER_ID } from 'const'
 import Web3 from 'web3'
 
+import type { HttpProvider } from 'web3-core'
 
 // TODO connect to mainnet if we need AUTOCONNECT at all
 export const getDefaultProvider = (): string | null => (process.env.NODE_ENV === 'test' ? null : ETH_NODE_URL)
@@ -62,7 +63,12 @@ export function updateWeb3Provider(web3: Web3, networkId?: SupportedChainId | nu
   }
 
   const provider = getProviderByNetwork(networkId)
-  console.log('[api:web3] updateWeb3Provider', provider, networkId)
+
+  if (web3.currentProvider === provider || (web3.currentProvider as HttpProvider)?.host === provider) {
+    return
+  }
+
+  console.log('[api:web3] updateWeb3Provider', web3.currentProvider, provider, networkId)
 
   provider && web3.setProvider(provider)
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@cowprotocol/cms": "^0.2.2",
     "@cowprotocol/contracts": "^1.3.1",
     "@cowprotocol/cow-runner-game": "^0.2.9",
-    "@cowprotocol/cow-sdk": "^5.0.0",
+    "@cowprotocol/cow-sdk": "^5.2.1",
     "@cowprotocol/ethflowcontract": "cowprotocol/ethflowcontract.git#v1.1.1-artifacts",
     "@davatar/react": "1.8.1",
     "@emotion/react": "^11.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2383,10 +2383,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/cow-runner-game/-/cow-runner-game-0.2.9.tgz#3f94b3f370bd114f77db8b1d238cba3ef4e9d644"
   integrity sha512-rX7HnoV+HYEEkBaqVUsAkGGo0oBrExi+d6Io+8nQZYwZk+IYLmS9jdcIObsLviM2h4YX8+iin6NuKl35AaiHmg==
 
-"@cowprotocol/cow-sdk@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-5.0.0.tgz#16252d3f27e90f94944b60c284bfd3ce2724938f"
-  integrity sha512-ZdNN5GJe+amyfKFG9Fg/8pNHjvV9IxjeNsUh3gw1eUqpcao2elcaeuSogi8TEaSlbVh6PXa5l+QRHdJIjUqplQ==
+"@cowprotocol/cow-sdk@^5.2.1":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-5.2.1.tgz#a53eb2b0e7439602bd3ba8ce7d085e12f24b1c3c"
+  integrity sha512-s3h/7YL3UdPDh5q7+Q1WCDR8cJuhJXk8rGeEzdqtSBhFMvb6ErzGvXCkYOg/K9rKpIa7sfQkKkVAS1PWc9h2pQ==
   dependencies:
     "@cowprotocol/contracts" "^1.4.0"
     "@ethersproject/abstract-signer" "^5.7.0"


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C0361CDG8GP/p1715851334267859

SDK changes: https://github.com/cowprotocol/cow-sdk/pull/208

By default `cow-sdk` uses backoff strategy with 10 retries which makes significant delays when API is down.
For the search page it doesn't make sense to make so many retries, so I changed the value to 2. It means that sdk will make up to 2 requests. Why not 1? I'm not sure, just in case left 2 since it doesn't create significant delays.

# To Test

1.  Open http://localhost:4200/search/0xc104cea97d7590bb8dd0c32b72cab147bf85b052859ca0b0f157361186a9d8c6
2. Open browser console (network tab) and reload page
 - [ ] there should be **6** `/api/v1/transactions/xxx/orders` requests, each network * 2 (prod / barn)
3. Block barn.api.cow.fi/mainnet/api/v1/transactions/0xc104cea97d7590bb8dd0c32b72cab147bf85b052859ca0b0f157361186a9d8c6/orders request
4. Block barn.api.cow.fi/xdai/api/v1/transactions/0xc104cea97d7590bb8dd0c32b72cab147bf85b052859ca0b0f157361186a9d8c6/orders request
5. Reload the page
- [ ] There should be **8** `/api/v1/transactions/xxx/orders` requests, **4** of them should be failed