### PR TITLE
fix(explorer): use same RPC urls as in CoW Swap

### DIFF
--- a/apps/explorer/src/api/web3/index.ts
+++ b/apps/explorer/src/api/web3/index.ts
@@ -1,17 +1,14 @@
+import { RPC_URLS } from '@cowprotocol/common-const'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
-import { ETH_NODE_URL, NODE_PROVIDER_ID } from 'const'
 import Web3 from 'web3'
 
 import type { HttpProvider } from 'web3-core'
 
-// TODO connect to mainnet if we need AUTOCONNECT at all
-export const getDefaultProvider = (): string | null => (process.env.NODE_ENV === 'test' ? null : ETH_NODE_URL)
-
 const web3cache: { [key: string]: Web3 } = {}
 
 export function createWeb3Api(provider?: string): Web3 {
-  const _provider = provider || getDefaultProvider() || ''
+  const _provider = provider || getProviderByNetwork(SupportedChainId.MAINNET)
 
   if (web3cache[_provider]) {
     return web3cache[_provider]
@@ -43,15 +40,8 @@ export function createWeb3Api(provider?: string): Web3 {
   return web3
 }
 
-const PROVIDER_ENDPOINTS: Record<SupportedChainId, string> = {
-  [SupportedChainId.MAINNET]: 'https://eth-mainnet.nodereal.io/v1/' + NODE_PROVIDER_ID,
-  [SupportedChainId.GNOSIS_CHAIN]: 'https://rpc.gnosis.gateway.fm/',
-  [SupportedChainId.SEPOLIA]: 'https://eth-sepolia.nodereal.io/v1/' + NODE_PROVIDER_ID,
-  [SupportedChainId.ARBITRUM_ONE]: 'https://open-platform.nodereal.io/' + NODE_PROVIDER_ID + '/arbitrum-nitro',
-}
-
-export function getProviderByNetwork(networkId: SupportedChainId): string | undefined {
-  return PROVIDER_ENDPOINTS[networkId]
+export function getProviderByNetwork(networkId: SupportedChainId): string {
+  return RPC_URLS[networkId]
 }
 
 // Approach 2: update the provider in a single web3 instance

--- a/apps/explorer/src/const.ts
+++ b/apps/explorer/src/const.ts
@@ -103,9 +103,6 @@ export const MEDIA = {
   },
 }
 
-export const NODE_PROVIDER_ID = process.env.NODE_PROVIDER_ID || 'ed3c6720eb3f470e9ceac8f8f12e8b14'
-export const ETH_NODE_URL = process.env.ETH_NODE_URL || 'wss://eth-mainnet.nodereal.io/ws/v1/' + NODE_PROVIDER_ID
-
 export const WETH_ADDRESS_MAINNET = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
 export const WXDAI_ADDRESS_XDAI = '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d'
 export const WXDAI_ADDRESS_ARBITRUM_ONE = '0x82af49447d8a07e3bd95bd0d56f35241523fbab1'


### PR DESCRIPTION
# Summary

We have `RPC_URLS` in `@cowprotocol/common-consts` and use them in CoW Swap.
To be consistent we should use them in Explorer as well.

@alfetopito already set `REACT_APP_NETWORK_URL_{chainId}` variables in Vercel env.

<img width="939" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/51e9e7e2-296c-427c-a012-b7bb8e18b7ff">


# To Test

1. Explorer should use RPC endponts specified in Vercel env (nodereal)
