### PR TITLE
fix: remove widget-lib dep from ui lib and inner ui lib imports

### DIFF
--- a/libs/ui/src/consts.ts
+++ b/libs/ui/src/consts.ts
@@ -1,9 +1,5 @@
-import { CowSwapTheme } from '@cowprotocol/widget-lib'
-import { createGlobalStyle, css, DefaultTheme } from 'styled-components'
 
 // Fonts
-import FONT_STUDIO_FEIXEN_REGULAR from '@cowprotocol/assets/fonts/StudioFeixenSans-Regular.woff2'
-import FONT_STUDIO_FEIXEN_REGULAR_ITALIC from '@cowprotocol/assets/fonts/StudioFeixenSans-RegularItalic.woff2'
 import FONT_STUDIO_FEIXEN_BOLD from '@cowprotocol/assets/fonts/StudioFeixenSans-Bold.woff2'
 import FONT_STUDIO_FEIXEN_BOLD_ITALIC from '@cowprotocol/assets/fonts/StudioFeixenSans-BoldItalic.woff2'
 import FONT_STUDIO_FEIXEN_BOOK from '@cowprotocol/assets/fonts/StudioFeixenSans-Book.woff2'
@@ -12,10 +8,16 @@ import FONT_STUDIO_FEIXEN_LIGHT from '@cowprotocol/assets/fonts/StudioFeixenSans
 import FONT_STUDIO_FEIXEN_LIGHT_ITALIC from '@cowprotocol/assets/fonts/StudioFeixenSans-LightItalic.woff2'
 import FONT_STUDIO_FEIXEN_MEDIUM from '@cowprotocol/assets/fonts/StudioFeixenSans-Medium.woff2'
 import FONT_STUDIO_FEIXEN_MEDIUM_ITALIC from '@cowprotocol/assets/fonts/StudioFeixenSans-MediumItalic.woff2'
+import FONT_STUDIO_FEIXEN_REGULAR from '@cowprotocol/assets/fonts/StudioFeixenSans-Regular.woff2'
+import FONT_STUDIO_FEIXEN_REGULAR_ITALIC from '@cowprotocol/assets/fonts/StudioFeixenSans-RegularItalic.woff2'
 import FONT_STUDIO_FEIXEN_SEMIBOLD from '@cowprotocol/assets/fonts/StudioFeixenSans-Semibold.woff2'
 import FONT_STUDIO_FEIXEN_SEMIBOLD_ITALIC from '@cowprotocol/assets/fonts/StudioFeixenSans-SemiboldItalic.woff2'
 import FONT_STUDIO_FEIXEN_ULTRALIGHT from '@cowprotocol/assets/fonts/StudioFeixenSans-Ultralight.woff2'
 import FONT_STUDIO_FEIXEN_ULTRALIGHT_ITALIC from '@cowprotocol/assets/fonts/StudioFeixenSans-UltralightItalic.woff2'
+
+import { createGlobalStyle, css, DefaultTheme } from 'styled-components'
+
+import { CowSwapTheme } from './types'
 
 export const AMOUNTS_FORMATTING_FEATURE_FLAG = 'highlight-amounts-formatting'
 export const SAFE_COW_APP_LINK = 'https://app.safe.global/share/safe-app?appUrl=https%3A%2F%2Fswap.cow.fi&chain=eth'

--- a/libs/ui/src/pure/ButtonSecondaryAlt/index.tsx
+++ b/libs/ui/src/pure/ButtonSecondaryAlt/index.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+
 import { UI } from '../../enum'
 
 export const ButtonSecondaryAlt = styled.button<{ padding?: string; minHeight?: string }>`

--- a/libs/ui/src/pure/Footer/footerAnimation.tsx
+++ b/libs/ui/src/pure/Footer/footerAnimation.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useRef } from 'react'
-import styled, { keyframes, ThemeProvider, DefaultTheme } from 'styled-components/macro'
-import { CowSwapTheme } from '@cowprotocol/widget-lib'
-import { themeMapper } from '@cowprotocol/ui'
-import SVG from 'react-inlinesvg'
+
 import IMG_FLYING_WINK_COW_DARK from '@cowprotocol/assets/images/flying-wink-cow-dark-mode.svg'
+
+import SVG from 'react-inlinesvg'
+import styled, { ThemeProvider, keyframes } from 'styled-components/macro'
+
+import { themeMapper } from '../../consts'
+import { CowSwapTheme } from '../../types'
 
 const scrollHorizontal = keyframes`
   0% {

--- a/libs/ui/src/pure/Footer/index.tsx
+++ b/libs/ui/src/pure/Footer/index.tsx
@@ -1,43 +1,45 @@
-import { useState, ReactNode, useEffect, useRef } from 'react'
-import { ProductLogo, MenuItem, themeMapper, ProductVariant, Color } from '@cowprotocol/ui'
+import { ReactNode, useEffect, useRef, useState } from 'react'
 
+import IMG_ICON_ARROW_RIGHT_CIRCULAR from '@cowprotocol/assets/images/arrow-right-circular.svg'
+import IMG_ICON_SOCIAL_DISCORD from '@cowprotocol/assets/images/icon-social-discord.svg'
+import IMG_ICON_SOCIAL_FORUM from '@cowprotocol/assets/images/icon-social-forum.svg'
+import IMG_ICON_SOCIAL_GITHUB from '@cowprotocol/assets/images/icon-social-github.svg'
+import IMG_ICON_SOCIAL_SNAPSHOT from '@cowprotocol/assets/images/icon-social-snapshot.svg'
+import IMG_ICON_SOCIAL_X from '@cowprotocol/assets/images/icon-social-x.svg'
+
+import SVG from 'react-inlinesvg'
+import { ThemeProvider } from 'styled-components'
+
+import { FooterAnimation } from './footerAnimation'
 import {
+  BottomRight,
+  BottomText,
+  Description,
+  FooterBottom,
+  FooterBottomLogos,
   FooterContainer,
   FooterContent,
-  FooterLogo,
   FooterDescriptionSection,
-  Description,
-  SocialIconsWrapper,
-  SocialIconLink,
-  SectionTitle,
-  LinkListWrapper,
-  LinkListGroup,
-  LinkList,
+  FooterLogo,
   Link,
-  FooterBottom,
-  BottomText,
-  FooterBottomLogos,
-  BottomRight,
+  LinkList,
+  LinkListGroup,
+  LinkListWrapper,
+  SectionTitle,
+  SocialIconLink,
+  SocialIconsWrapper,
   ToggleFooterButton,
 } from './styled'
 
-import { FooterAnimation } from './footerAnimation'
-
-import { ThemeProvider } from 'styled-components'
-import SVG from 'react-inlinesvg'
-
-import IMG_ICON_SOCIAL_X from '@cowprotocol/assets/images/icon-social-x.svg'
-import IMG_ICON_SOCIAL_DISCORD from '@cowprotocol/assets/images/icon-social-discord.svg'
-import IMG_ICON_SOCIAL_GITHUB from '@cowprotocol/assets/images/icon-social-github.svg'
-import IMG_ICON_SOCIAL_FORUM from '@cowprotocol/assets/images/icon-social-forum.svg'
-import IMG_ICON_SOCIAL_SNAPSHOT from '@cowprotocol/assets/images/icon-social-snapshot.svg'
-
-import IMG_ICON_ARROW_RIGHT_CIRCULAR from '@cowprotocol/assets/images/arrow-right-circular.svg'
+import { Color, themeMapper } from '../../consts'
+import { CowSwapTheme } from '../../types'
+import { MenuItem } from '../MenuBar'
+import { ProductLogo, ProductVariant } from '../ProductLogo'
 
 interface FooterProps {
   description?: string
   navItems: MenuItem[]
-  theme: 'light' | 'dark'
+  theme: CowSwapTheme
   productVariant: ProductVariant
   additionalFooterContent?: ReactNode
   expanded?: boolean

--- a/libs/ui/src/pure/Footer/styled.ts
+++ b/libs/ui/src/pure/Footer/styled.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
-import { CowSwapTheme } from '@cowprotocol/widget-lib'
+
 import { Color, Media } from '../../consts'
+import { CowSwapTheme } from '../../types'
 
 export const FooterContainer = styled.footer<{ theme: CowSwapTheme; expanded: boolean }>`
   --bgColor: ${Color.neutral10};

--- a/libs/ui/src/pure/MenuBar/index.tsx
+++ b/libs/ui/src/pure/MenuBar/index.tsx
@@ -1,38 +1,42 @@
-import React, { useState, useRef, RefObject } from 'react'
+import React, { RefObject, useRef, useState } from 'react'
 
-import {
-  RootNavItem,
-  MenuBarWrapper,
-  MenuBarInner,
-  NavDaoTriggerElement,
-  DropdownMenu,
-  DropdownContent,
-  DropdownContentItemButton,
-  DropdownContentItemImage,
-  DropdownContentItemIcon,
-  DropdownContentItemText,
-  DropdownContentItemTitle,
-  DropdownContentItemDescription,
-  GlobalSettingsWrapper,
-  GlobalSettingsButton,
-  NavItems,
-  StyledDropdownContentItem,
-  RightAligned,
-  MobileMenuTrigger,
-} from './styled'
-import SVG from 'react-inlinesvg'
-import { ProductLogo, ProductVariant, themeMapper, Media } from '@cowprotocol/ui'
-import { useOnClickOutside, useMediaQuery } from '@cowprotocol/common-hooks'
-import IMG_ICON_MENU_DOTS from '@cowprotocol/assets/images/menu-grid-dots.svg'
 import IMG_ICON_ARROW_RIGHT from '@cowprotocol/assets/images/arrow-right.svg'
 import IMG_ICON_CARRET_DOWN from '@cowprotocol/assets/images/carret-down.svg'
-import IMG_ICON_SETTINGS_GLOBAL from '@cowprotocol/assets/images/settings-global.svg'
+import IMG_ICON_MENU_DOTS from '@cowprotocol/assets/images/menu-grid-dots.svg'
 import IMG_ICON_MENU_HAMBURGER from '@cowprotocol/assets/images/menu-hamburger.svg'
+import IMG_ICON_SETTINGS_GLOBAL from '@cowprotocol/assets/images/settings-global.svg'
 import IMG_ICON_X from '@cowprotocol/assets/images/x.svg'
-
+import { useMediaQuery, useOnClickOutside } from '@cowprotocol/common-hooks'
 import { addBodyClass, removeBodyClass } from '@cowprotocol/common-utils'
-import { CowSwapTheme } from '@cowprotocol/widget-lib'
+
+import SVG from 'react-inlinesvg'
 import { ThemeProvider } from 'styled-components'
+
+import {
+  DropdownContent,
+  DropdownContentItemButton,
+  DropdownContentItemDescription,
+  DropdownContentItemIcon,
+  DropdownContentItemImage,
+  DropdownContentItemText,
+  DropdownContentItemTitle,
+  DropdownMenu,
+  GlobalSettingsButton,
+  GlobalSettingsWrapper,
+  MenuBarInner,
+  MenuBarWrapper,
+  MobileMenuTrigger,
+  NavDaoTriggerElement,
+  NavItems,
+  RightAligned,
+  RootNavItem,
+  StyledDropdownContentItem,
+} from './styled'
+
+
+import { Media, themeMapper } from '../../consts'
+import { CowSwapTheme } from '../../types'
+import { ProductLogo, ProductVariant } from '../ProductLogo'
 
 // NavItem Component: Handles individual navigation items, toggles dropdowns based on presence of children.
 // DropdownContentItem Component: Renders items within dropdowns, constructs logo variants based on the theme.

--- a/libs/ui/src/pure/MenuBar/styled.ts
+++ b/libs/ui/src/pure/MenuBar/styled.ts
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components'
-import { Color } from '@cowprotocol/ui'
-import { CowSwapTheme } from '@cowprotocol/widget-lib'
+
+import { Color } from '../../consts'
+import { CowSwapTheme } from '../../types'
 
 export const MenuBarWrapper = styled.div`
   display: flex;

--- a/libs/ui/src/pure/ProductLogo/index.tsx
+++ b/libs/ui/src/pure/ProductLogo/index.tsx
@@ -1,13 +1,15 @@
-import styled from 'styled-components'
-import SVG from 'react-inlinesvg'
 
-import LOGO_ICON_COW from '@cowprotocol/assets/images/logo-icon-cow.svg'
-import LOGO_COWSWAP from '@cowprotocol/assets/images/logo-cowswap.svg'
-import LOGO_COWPROTOCOL from '@cowprotocol/assets/images/logo-cowprotocol.svg'
 import LOGO_COWDAO from '@cowprotocol/assets/images/logo-cowdao.svg'
+import LOGO_COWPROTOCOL from '@cowprotocol/assets/images/logo-cowprotocol.svg'
+import LOGO_COWSWAP from '@cowprotocol/assets/images/logo-cowswap.svg'
+import LOGO_ICON_COW from '@cowprotocol/assets/images/logo-icon-cow.svg'
 import LOGO_MEVBLOCKER from '@cowprotocol/assets/images/logo-mevblocker.svg'
 
-import { CowSwapTheme } from '@cowprotocol/widget-lib'
+import SVG from 'react-inlinesvg'
+import styled from 'styled-components'
+
+import { CowSwapTheme } from '../../types'
+
 
 export enum ProductVariant {
   CowSwap = 'cowSwap',

--- a/libs/ui/src/types.ts
+++ b/libs/ui/src/types.ts
@@ -14,3 +14,5 @@ export type ComposableCowInfo = {
 }
 
 export type BadgeType = 'information' | 'success' | 'alert' | 'alert2' | 'default'
+
+export type CowSwapTheme = 'dark' | 'light'

--- a/libs/widget-lib/src/themeUtils.ts
+++ b/libs/widget-lib/src/themeUtils.ts
@@ -1,4 +1,4 @@
-import { CowSwapTheme } from '@cowprotocol/ui'
+import type { CowSwapTheme } from '@cowprotocol/ui'
 
 import { CowSwapWidgetPalette } from './types'
 

--- a/libs/widget-lib/src/themeUtils.ts
+++ b/libs/widget-lib/src/themeUtils.ts
@@ -1,4 +1,6 @@
-import { CowSwapTheme, CowSwapWidgetPalette } from './types'
+import { CowSwapTheme } from '@cowprotocol/ui'
+
+import { CowSwapWidgetPalette } from './types'
 
 export function isCowSwapWidgetPalette(
   palette: CowSwapTheme | CowSwapWidgetPalette | undefined

--- a/libs/widget-lib/src/types.ts
+++ b/libs/widget-lib/src/types.ts
@@ -1,5 +1,6 @@
 import type { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { CowEventListeners, CowEventPayloadMap, CowEvents } from '@cowprotocol/events'
+import { CowSwapTheme } from '@cowprotocol/ui'
 export type { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 export enum WidgetMethodsEmit {
@@ -51,8 +52,6 @@ export interface EthereumProvider {
    */
   enable(): Promise<void>
 }
-
-export type CowSwapTheme = 'dark' | 'light'
 
 /**
  *Trade asset parameters, for example:

--- a/libs/widget-lib/src/types.ts
+++ b/libs/widget-lib/src/types.ts
@@ -1,6 +1,6 @@
 import type { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { CowEventListeners, CowEventPayloadMap, CowEvents } from '@cowprotocol/events'
-import { CowSwapTheme } from '@cowprotocol/ui'
+import type { CowSwapTheme } from '@cowprotocol/ui'
 export type { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 export enum WidgetMethodsEmit {


### PR DESCRIPTION
# Summary

No functional changes.

Fix inverted dependency.
`ui` lib was depending on `widget-lib` for a type.
I moved the type to `ui` instead.

Also removed the inner references within the `ui` lib.
Inside the same lib we should use relative imports.