### PR TITLE
fix(widget-cfg): don't request network switching with standalone mode

### DIFF
--- a/apps/cowswap-frontend/index.html
+++ b/apps/cowswap-frontend/index.html
@@ -35,6 +35,7 @@
     <meta name="twitter:title" content="CoW Swap | The smartest way to trade cryptocurrencies" />
     <meta name="twitter:image" content="https://swap.cow.fi/images/og-meta-cowswap.png?v=3" />
   </head>
+
   <body>
     <noscript>
       <style>

--- a/apps/widget-configurator/src/app/configurator/controls/NetworkControl.tsx
+++ b/apps/widget-configurator/src/app/configurator/controls/NetworkControl.tsx
@@ -24,7 +24,13 @@ const LABEL = 'Network'
 
 export const getNetworkOption = (chainId: SupportedChainId) => NetworkOptions.find((item) => item.chainId === chainId)
 
-export function NetworkControl({ state }: { state: [NetworkOption, Dispatch<SetStateAction<NetworkOption>>] }) {
+export function NetworkControl({
+  state,
+  standaloneMode,
+}: {
+  standaloneMode: boolean
+  state: [NetworkOption, Dispatch<SetStateAction<NetworkOption>>]
+}) {
   const [network, setNetwork] = state
 
   const switchNetwork = (chainId: number) => {
@@ -37,7 +43,7 @@ export function NetworkControl({ state }: { state: [NetworkOption, Dispatch<SetS
   }
 
   return (
-    <FormControl sx={{ width: '100%' }}>
+    <FormControl sx={{ width: '100%' }} disabled={standaloneMode}>
       <InputLabel>{LABEL}</InputLabel>
       <Select
         id="controllable-states-network"
@@ -45,6 +51,7 @@ export function NetworkControl({ state }: { state: [NetworkOption, Dispatch<SetS
         onChange={(event) => switchNetwork(event.target.value as number)}
         autoWidth
         label={LABEL}
+        disabled={standaloneMode}
         size="small"
       >
         {NetworkOptions.map((option) => (

--- a/apps/widget-configurator/src/app/configurator/hooks/useSyncWidgetNetwork.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useSyncWidgetNetwork.ts
@@ -8,7 +8,8 @@ import { getNetworkOption, NetworkOption } from '../controls/NetworkControl'
 
 export function useSyncWidgetNetwork(
   chainId: SupportedChainId,
-  setNetworkControlState: (option: NetworkOption) => void
+  setNetworkControlState: (option: NetworkOption) => void,
+  standaloneMode: boolean
 ) {
   const { chainId: walletChainId, isConnected } = useWeb3ModalAccount()
   const { switchNetwork } = useSwitchNetwork()
@@ -34,11 +35,12 @@ export function useSyncWidgetNetwork(
     if (
       !switchNetwork ||
       !isConnected ||
+      standaloneMode ||
       walletChainIdRef.current === chainId ||
       currentChainIdRef.current === walletChainIdRef.current
     )
       return
 
     switchNetwork(chainId)
-  }, [chainId, isConnected, switchNetwork, setNetworkControlState])
+  }, [chainId, isConnected, switchNetwork, setNetworkControlState, standaloneMode])
 }

--- a/apps/widget-configurator/src/app/configurator/index.tsx
+++ b/apps/widget-configurator/src/app/configurator/index.tsx
@@ -173,7 +173,7 @@ export function Configurator({ title }: { title: string }) {
     }
   }, [isConnected])
 
-  useSyncWidgetNetwork(chainId, setNetworkControlState)
+  useSyncWidgetNetwork(chainId, setNetworkControlState, standaloneMode)
 
   return (
     <Box sx={WrapperStyled}>
@@ -224,7 +224,7 @@ export function Configurator({ title }: { title: string }) {
 
         <CurrentTradeTypeControl state={tradeTypeState} />
 
-        {!IS_IFRAME && <NetworkControl state={networkControlState} />}
+        {!IS_IFRAME && <NetworkControl state={networkControlState} standaloneMode={standaloneMode} />}
 
         <Divider variant="middle">Tokens</Divider>
 


### PR DESCRIPTION
# Summary

Fixes #4459

Standalone mode means that widget doesn't depend on external wallet provider and works autonomously.
The "Network" field in the configurator is related only to the wallet connected in the configurator UI.

# To Test

1. Open configurator
2. Choose dapp mode and connect Metamask
3. Change network in the configurator UI
- [ ] Metamask should receive a request to switch network
4. Change mode to standalone
5. Change network in the configurator UI
- [ ] Metamask should NOT receive a request to switch network
