### PR TITLE
fix(notifications): don't fail when CMS API is down

### DIFF
--- a/apps/cowswap-frontend/src/modules/notifications/hooks/useAccountNotifications.ts
+++ b/apps/cowswap-frontend/src/modules/notifications/hooks/useAccountNotifications.ts
@@ -19,7 +19,15 @@ export function useAccountNotifications() {
   const { data: notifications } = useSWR<NotificationModel[]>(
     account ? `/notification-list/${account}` : null,
     (url: string | null) => {
-      return url ? cmsClient.GET(url).then((res: { data: NotificationModel[] }) => res.data) : null
+      return url
+        ? cmsClient
+            .GET(url)
+            .then((res: { data: NotificationModel[] }) => res.data)
+            .catch((error: Error) => {
+              console.error('Failed to fetch notifications', error)
+              return []
+            })
+        : null
     },
     swrOptions
   )


### PR DESCRIPTION
# Summary

<img width="407" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/9adaa243-361d-47b9-a44a-15adb0345613">


# To Test

1. Block https://cms.cow.fi/api/notification-list/* request
2. Reload page
- [ ] you should see "Nothing new yet"