### PR TITLE
feat: improve message for wrong prefix on networks

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/ChainPrefixWarning/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ChainPrefixWarning/index.tsx
@@ -1,21 +1,49 @@
 import { BaseChainInfo } from '@cowprotocol/common-const'
 
 import { WarningCard } from '../WarningCard'
+import styled from 'styled-components/macro'
 
-type Props = {
+const NetworkImg = styled.img`
+  width: 12px;
+  height: 12px;
+`
+
+const Label = styled.span<{color: string}>`
+  display: inline-block;
+  background-color: white;
+  border: 2px ${({ color }) => color} solid;
+  padding: 4px 4px;
+  margin: 0 0 0 0.5em;
+`
+
+const Format = styled.strong`
+
+  font-family: monospace;
+  color: ${({ theme }) => theme.text3};
+
+  white-space: nowrap;
+  
+`
+
+
+
+type ChainPrefixWarningProps = {
   chainPrefixWarning: string
   chainInfo: BaseChainInfo
 }
-export default function ChainPrefixWarning({ chainPrefixWarning, chainInfo }: Props) {
+export default function ChainPrefixWarning({ chainPrefixWarning, chainInfo }: ChainPrefixWarningProps) {
+  const { label, addressPrefix, logoUrl, color,  } = chainInfo
   return (
-    <div style={{ margin: 10 }}>
-      <WarningCard>
-        <div>
-          The recipient address you inputted had the chainPrefix <strong>{chainPrefixWarning}</strong>, but your wallet
-          is on {chainInfo.label} which uses the chain prefix <strong>{chainInfo.addressPrefix}</strong>. Please,
-          double-check that the recipient address is for the correct network.
-        </div>
-      </WarningCard>
-    </div>
+    <WarningCard>
+      <div>
+        The recipient address you inputted had the chain prefix <strong>{chainPrefixWarning}</strong>, which is not 
+        not the expected for the network you are in ({label}).
+      </div>
+      <p>
+      You are connected to
+      <Label color={color}><NetworkImg src={logoUrl} /> {label}</Label>
+      </p>
+      <p>Please, make sure your address follows the format <Format>{addressPrefix}:&lt;your-address&gt;</Format> or make sure it is compatible with <strong>{label}</strong> network.</p>
+    </WarningCard>
   )
 }

--- a/apps/cowswap-frontend/src/common/pure/ChainPrefixWarning/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ChainPrefixWarning/index.tsx
@@ -3,6 +3,13 @@ import { BaseChainInfo } from '@cowprotocol/common-const'
 import { WarningCard } from '../WarningCard'
 import styled from 'styled-components/macro'
 
+const Wrapper = styled(WarningCard)`
+  p {
+    margin-block-start: 0.3em;
+    margin-block-end: 0.3em;
+  }
+`
+
 const NetworkImg = styled.img`
   width: 12px;
   height: 12px;
@@ -30,7 +37,7 @@ type ChainPrefixWarningProps = {
 export default function ChainPrefixWarning({ chainPrefixWarning, chainInfo }: ChainPrefixWarningProps) {
   const { label, addressPrefix, logoUrl, color } = chainInfo
   return (
-    <WarningCard>
+    <Wrapper>
       <p>
         The recipient address you inputted had the chain prefix <strong>{chainPrefixWarning}</strong>, which is not not
         the expected for the network you are in.
@@ -42,9 +49,9 @@ export default function ChainPrefixWarning({ chainPrefixWarning, chainInfo }: Ch
         </Label>
       </p>
       <p>
-        Please, make sure your address follows the format <Format>{addressPrefix}:&lt;your-address&gt;</Format> or make
-        sure it is compatible with <strong>{label}</strong> network.
+        Please, make sure your address follows the format <Format>{addressPrefix}:&lt;your-address&gt;</Format> or
+        double-check if it is compatible with <strong>{label}</strong> network.
       </p>
-    </WarningCard>
+    </Wrapper>
   )
 }

--- a/apps/cowswap-frontend/src/common/pure/ChainPrefixWarning/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ChainPrefixWarning/index.tsx
@@ -21,7 +21,7 @@ const Label = styled.span<{ color: string }>`
   border: 2px ${({ color }) => color} solid;
   padding: 4px 4px;
   margin: 0 0 0 0.5em;
-  border-radius: 1rem;
+  border-radius: 8px;
 `
 
 const Format = styled.strong`

--- a/apps/cowswap-frontend/src/common/pure/ChainPrefixWarning/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ChainPrefixWarning/index.tsx
@@ -11,8 +11,8 @@ const Wrapper = styled(WarningCard)`
 `
 
 const NetworkImg = styled.img`
-  width: 12px;
-  height: 12px;
+  width: 15px;
+  height: 15px;
 `
 
 const Label = styled.span<{ color: string }>`
@@ -21,6 +21,7 @@ const Label = styled.span<{ color: string }>`
   border: 2px ${({ color }) => color} solid;
   padding: 4px 4px;
   margin: 0 0 0 0.5em;
+  border-radius: 1rem;
 `
 
 const Format = styled.strong`

--- a/apps/cowswap-frontend/src/common/pure/ChainPrefixWarning/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ChainPrefixWarning/index.tsx
@@ -8,7 +8,7 @@ const NetworkImg = styled.img`
   height: 12px;
 `
 
-const Label = styled.span<{color: string}>`
+const Label = styled.span<{ color: string }>`
   display: inline-block;
   background-color: white;
   border: 2px ${({ color }) => color} solid;
@@ -17,33 +17,34 @@ const Label = styled.span<{color: string}>`
 `
 
 const Format = styled.strong`
-
   font-family: monospace;
   color: ${({ theme }) => theme.text3};
 
   white-space: nowrap;
-  
 `
-
-
 
 type ChainPrefixWarningProps = {
   chainPrefixWarning: string
   chainInfo: BaseChainInfo
 }
 export default function ChainPrefixWarning({ chainPrefixWarning, chainInfo }: ChainPrefixWarningProps) {
-  const { label, addressPrefix, logoUrl, color,  } = chainInfo
+  const { label, addressPrefix, logoUrl, color } = chainInfo
   return (
     <WarningCard>
-      <div>
-        The recipient address you inputted had the chain prefix <strong>{chainPrefixWarning}</strong>, which is not 
-        not the expected for the network you are in.
-      </div>
       <p>
-      You are connected to
-      <Label color={color}><NetworkImg src={logoUrl} /> {label}</Label>
+        The recipient address you inputted had the chain prefix <strong>{chainPrefixWarning}</strong>, which is not not
+        the expected for the network you are in.
       </p>
-      <p>Please, make sure your address follows the format <Format>{addressPrefix}:&lt;your-address&gt;</Format> or make sure it is compatible with <strong>{label}</strong> network.</p>
+      <p>
+        You are connected to
+        <Label color={color}>
+          <NetworkImg src={logoUrl} /> {label}
+        </Label>
+      </p>
+      <p>
+        Please, make sure your address follows the format <Format>{addressPrefix}:&lt;your-address&gt;</Format> or make
+        sure it is compatible with <strong>{label}</strong> network.
+      </p>
     </WarningCard>
   )
 }

--- a/apps/cowswap-frontend/src/common/pure/ChainPrefixWarning/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ChainPrefixWarning/index.tsx
@@ -37,7 +37,7 @@ export default function ChainPrefixWarning({ chainPrefixWarning, chainInfo }: Ch
     <WarningCard>
       <div>
         The recipient address you inputted had the chain prefix <strong>{chainPrefixWarning}</strong>, which is not 
-        not the expected for the network you are in ({label}).
+        not the expected for the network you are in.
       </div>
       <p>
       You are connected to

--- a/apps/cowswap-frontend/src/common/pure/ChainPrefixWarning/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ChainPrefixWarning/index.tsx
@@ -13,10 +13,11 @@ const Wrapper = styled(WarningCard)`
 const NetworkImg = styled.img`
   width: 15px;
   height: 15px;
+  margin-right: 0.5em;
 `
 
 const Label = styled.span<{ color: string }>`
-  display: inline-block;
+  display: inline-flex;
   background-color: white;
   border: 2px ${({ color }) => color} solid;
   padding: 4px 4px;

--- a/apps/cowswap-frontend/src/common/pure/WarningCard/WarningCard.tsx
+++ b/apps/cowswap-frontend/src/common/pure/WarningCard/WarningCard.tsx
@@ -36,9 +36,9 @@ const WarningIcon = styled(AlertCircle)`
   color: #764e0766;
 `
 
-export function WarningCard({ children }: PropsWithChildren) {
+export function WarningCard({ children, className }: PropsWithChildren & { className?: string }) {
   return (
-    <Wrapper>
+    <Wrapper className={className}>
       <LeftContainer>
         <WarningIcon />
       </LeftContainer>

--- a/apps/cowswap-frontend/src/legacy/components/AddressInputPanel/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/AddressInputPanel/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, ReactNode, useCallback, useState } from 'react'
+import { ChangeEvent, ReactNode, useCallback, useEffect, useState } from 'react'
 
 import { getChainInfo } from '@cowprotocol/common-const'
 import {
@@ -19,7 +19,6 @@ import { AutoColumn } from 'legacy/components/Column'
 
 import ChainPrefixWarning from 'common/pure/ChainPrefixWarning'
 import { autofocus } from 'common/utils/autofocus'
-
 
 const InputPanel = styled.div`
   ${({ theme }) => theme.flexColumnNoWrap}
@@ -128,6 +127,13 @@ export function AddressInputPanel({
     },
     [onChange, chainInfo?.addressPrefix]
   )
+
+  // clear warning if chainId changes and we are now on the right network
+  useEffect(() => {
+    if (chainPrefixWarning && chainPrefixWarning === chainInfo?.addressPrefix) {
+      setChainPrefixWarning('')
+    }
+  }, [chainId, chainPrefixWarning])
 
   const error = Boolean(value.length > 0 && !loading && !address)
 


### PR DESCRIPTION
# Summary
Follow up on @elena-zh 's comments on https://github.com/cowprotocol/cowswap/pull/4418 from @compojoom

I made some small changes on the message.


Before:
![image](https://github.com/cowprotocol/cowswap/assets/2352112/3ae27d83-b28e-4f83-bc2a-303831486757)

After:
<img width="615" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/0d894561-5f33-4a8e-953c-69d6a0cfba66">

