### PR TITLE
feat: don't pollute the history with widget changes

### DIFF
--- a/apps/cowswap-frontend/src/modules/injectedWidget/updaters/InjectedWidgetUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/updaters/InjectedWidgetUpdater.tsx
@@ -84,7 +84,7 @@ export function InjectedWidgetUpdater() {
       })
 
       // Navigate to the new path
-      navigate(data.urlParams)
+      navigate(data.urlParams, { replace: true })
     })
 
     const updateAppDataListener = listenToMessageFromWindow(window, WidgetMethodsListen.UPDATE_APP_DATA, (data) => {


### PR DESCRIPTION
# Summary

Solves the issue Den is experimenting with the history being polluted with URL changes in the widget

CTX: https://cowservices.slack.com/archives/C036G0J90BU/p1716290729183899

## Test
- Open configurator https://widget-configurator-git-fix-navigation-history-issue-cowswap.vercel.app/
- Change the colors of the PAPER a few times
- Navigate back, it should go to wherever you were before CoW Swap (or the home of your browser)

These steps would not work in here, where going back would be changing the colors back:
https://widget.cow.fi