### PR TITLE
fix: change uniswap token list url

### DIFF
--- a/apps/widget-configurator/src/app/configurator/consts.ts
+++ b/apps/widget-configurator/src/app/configurator/consts.ts
@@ -31,7 +31,7 @@ export const DEFAULT_TOKEN_LISTS: TokenListItem[] = [
   { url: 'https://raw.githubusercontent.com/SetProtocol/uniswap-tokenlist/main/set.tokenlist.json', enabled: false },
   { url: 'https://synths.snx.eth.link', enabled: false },
   { url: 'https://testnet.tokenlist.eth.link', enabled: false },
-  { url: 'https://gateway.ipfs.io/ipns/tokens.uniswap.org', enabled: false },
+  { url: 'https://cloudflare-ipfs.com/ipns/tokens.uniswap.org', enabled: false },
   { url: 'https://wrapped.tokensoft.eth.link', enabled: false },
 ]
 // TODO: Move default palette to a new lib that only exposes the palette colors.

--- a/libs/tokens/src/const/tokensLists.ts
+++ b/libs/tokens/src/const/tokensLists.ts
@@ -4,7 +4,7 @@ import { ListsSourcesByNetwork } from '../types'
 
 export const DEFAULT_TOKENS_LISTS: ListsSourcesByNetwork = tokensList
 
-export const UNISWAP_TOKENS_LIST = 'https://gateway.ipfs.io/ipns/tokens.uniswap.org'
+export const UNISWAP_TOKENS_LIST = 'https://cloudflare-ipfs.com/ipns/tokens.uniswap.org'
 
 export const GNOSIS_UNISWAP_TOKENS_LIST =
   'https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/GnosisUniswapTokensList.json'


### PR DESCRIPTION
# Summary

Fixes #4460

For some reason, gateway.ipfs.io started blocking cross-domain requests.
I just changed IPFS service to cloudflare-ipfs.com for the uniswap token list request.

# To Test

1. Switch on USA location in VPN
2. Open this PR Vercel
3. Try opening a token list (I tried in Chrome, FF+Win11)

- [ ] AR: token list is not loaded, CORS issues on console
- [ ] ER: token list is loaded, there is request https://cloudflare-ipfs.com/ipns/tokens.uniswap.org

