### PR TITLE
fix: fix safe read-only button tooltip

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/pure/SwapButtons/SafeReadOnlyButton.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/SwapButtons/SafeReadOnlyButton.tsx
@@ -1,8 +1,6 @@
-
-import { ButtonPrimary, ButtonSize, HoverTooltip } from '@cowprotocol/ui'
+import { ButtonPrimary, ButtonSize, HelpTooltip } from '@cowprotocol/ui'
 
 import { Trans } from '@lingui/macro'
-import { HelpCircle } from 'react-feather'
 import styled from 'styled-components/macro'
 
 const Container = styled.div`
@@ -11,29 +9,21 @@ const Container = styled.div`
   gap: 10px;
 `
 
-const TooltipWrapper = styled(HoverTooltip)`
-  width: 100%;
-  color: red !important;
-  z-index: 9876;
-`
-
 export function SafeReadOnlyButton() {
   return (
-      <TooltipWrapper wrapInContainer
-          content={
+    <ButtonPrimary disabled={true} buttonSize={ButtonSize.BIG} title="Connect signer">
+      <Container>
+        <Trans>Connect signer</Trans>
+        <HelpTooltip
+          text={
             <div>
               Your Safe is not connected with a signer.
               <br />
               To place an order, you must connect using a signer of the Safe and refresh the page.
             </div>
           }
-        >          
-        <ButtonPrimary disabled={true} buttonSize={ButtonSize.BIG} title="Connect signer">
-          <Container>
-              <Trans>Connect signer</Trans>
-              <HelpCircle size={18} />
-            </Container>        
-        </ButtonPrimary>
-      </TooltipWrapper>
+        />
+      </Container>
+    </ButtonPrimary>
   )
 }

--- a/libs/ui/src/pure/HelpTooltip/index.tsx
+++ b/libs/ui/src/pure/HelpTooltip/index.tsx
@@ -39,6 +39,7 @@ const HelpTooltipContainer = styled.span`
   display: flex;
   align-items: center;
   color: inherit;
+  pointer-events: auto;
 `
 
 export interface HelpTooltipProps extends Omit<HoverTooltipProps, 'QuestionMark' | 'children' | 'content'> {


### PR DESCRIPTION
# Summary

Fixes #4431

<img width="542" alt="Screenshot 2024-05-23 at 16 18 33" src="https://github.com/cowprotocol/cowswap/assets/7122625/8a85e5ad-3ce7-45e0-82a3-a97888df987d">

# To Test

See #4431
