### PR TITLE
fix(wallets): update provider when eip6963 wallet changed

### DIFF
--- a/libs/wallet/src/web3-react/connectors/Injected/index.tsx
+++ b/libs/wallet/src/web3-react/connectors/Injected/index.tsx
@@ -30,13 +30,8 @@ export class InjectedWallet extends Connector {
     this.searchKeywords = searchKeywords
   }
 
-  // Based on https://github.com/Uniswap/web3-react/blob/de97c00c378b7909dfbd8a06558ed12e1f796caa/packages/metamask/src/index.ts#L130 with some changes
   async activate(desiredChainIdOrChainParameters?: number | AddEthereumChainParameter): Promise<void> {
-    let cancelActivation: Command
-
-    if (!this.provider?.isConnected?.()) {
-      cancelActivation = this.actions.startActivation()
-    }
+    const cancelActivation = this.actions.startActivation()
 
     return this.isomorphicInitialize()
       .then(async () => {


### PR DESCRIPTION
# Summary

Fixes #4480

The problem was in the fact that `web3react` didn't update provider in `Web3Context`.
In the code bellow you can see `useProvider()` hook which is responsible for updating the provider.
It depends on `[loaded, enabled, isActive, chainId, network]` and when you change one eip6963 provider to another already connected one, the provider will not be updated, because we call `startActivation()` only when `this.provider?.isConnected?.()` is falsy.

To avoid the problem, now we undoubtedly call `startActivation()` in order to reset `isActive` state.

<img width="1015" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/f3c35421-5a34-4a9b-a6f3-9554b110d6ca">

# To Test

See #4480
