### PR TITLE
ci: fix react-hooks eslint rules

### DIFF
--- a/apps/cowswap-frontend/src/cosmos.decorator.tsx
+++ b/apps/cowswap-frontend/src/cosmos.decorator.tsx
@@ -37,6 +37,7 @@ const DarkModeToggle = ({ children }: { children?: ReactNode }) => {
   const [darkMode, toggleDarkModeAux] = useDarkModeManager()
   const toggleDarkMode = useCallback(() => {
     toggleDarkModeAux()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [toggleDarkModeAux, darkMode])
   const label = (darkMode ? 'Light' : 'Dark') + ' Mode'
   const description = `${darkMode ? 'Sun/light' : 'Moon/dark'} mode icon`

--- a/apps/cowswap-frontend/src/legacy/components/AddressInputPanel/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/AddressInputPanel/index.tsx
@@ -102,6 +102,7 @@ export function AddressInputPanel({
 }) {
   const { chainId } = useWalletInfo()
   const chainInfo = getChainInfo(chainId)
+  const addressPrefix = chainInfo?.addressPrefix
   const { address, loading, name } = useENS(value)
   const [chainPrefixWarning, setChainPrefixWarning] = useState('')
 
@@ -114,7 +115,7 @@ export function AddressInputPanel({
       if (isPrefixedAddress(value)) {
         const { prefix, address } = parsePrefixedAddress(value)
 
-        if (prefix && chainInfo?.addressPrefix !== prefix) {
+        if (prefix && addressPrefix !== prefix) {
           setChainPrefixWarning(prefix)
         }
 
@@ -125,15 +126,15 @@ export function AddressInputPanel({
 
       onChange(value)
     },
-    [onChange, chainInfo?.addressPrefix]
+    [onChange, addressPrefix]
   )
 
   // clear warning if chainId changes and we are now on the right network
   useEffect(() => {
-    if (chainPrefixWarning && chainPrefixWarning === chainInfo?.addressPrefix) {
+    if (chainPrefixWarning && chainPrefixWarning === addressPrefix) {
       setChainPrefixWarning('')
     }
-  }, [chainId, chainPrefixWarning])
+  }, [chainId, chainPrefixWarning, addressPrefix])
 
   const error = Boolean(value.length > 0 && !loading && !address)
 

--- a/apps/cowswap-frontend/src/modules/notifications/containers/NotificationsList/index.tsx
+++ b/apps/cowswap-frontend/src/modules/notifications/containers/NotificationsList/index.tsx
@@ -25,7 +25,7 @@ export function NotificationsList({ children }: { children: ReactNode }) {
     setTimeout(() => {
       markNotificationsAsRead(notifications.map(({ id }) => id) || [])
     }, 1000)
-  }, [notifications])
+  }, [notifications, markNotificationsAsRead])
 
   return (
     <>

--- a/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
@@ -75,6 +75,7 @@ export function useSetupTradeState(): void {
       tradeNavigate(providerChainId, getDefaultTradeRawState(providerChainId))
     }
     // Triggering only when chainId was changed in the provider
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [providerChainId, prevProviderChainId])
 
   /**
@@ -161,6 +162,7 @@ export function useSetupTradeState(): void {
     console.debug('[TRADE STATE]', 'Applying a new state from URL', tradeStateFromUrl)
 
     // Triggering only on changes from URL
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tradeStateFromUrl])
 
   /**
@@ -190,6 +192,7 @@ export function useSetupTradeState(): void {
 
     console.debug('[TRADE STATE]', 'Set chainId to provider', { provider, urlChainId })
     // Triggering only when chainId in URL is changes, provider is changed or rememberedUrlState is changed
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [provider, urlChainId])
 
   /**
@@ -212,6 +215,7 @@ export function useSetupTradeState(): void {
       providerChainId,
       urlChanges: rememberedUrlStateRef.current,
     })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onProviderNetworkChanges])
 
   /**

--- a/apps/cowswap-frontend/src/modules/wallet/containers/WalletModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/wallet/containers/WalletModal/index.tsx
@@ -74,7 +74,7 @@ export function WalletModal() {
           )
         },
       }),
-      [isWalletChangingFlow]
+      [isWalletChangingFlow, closeWalletModal, dispatch, setWalletConnectionError, toggleAccountSelectorModal]
     )
   )
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,9 +14,18 @@ module.exports = [
   {
     plugins: {
       '@nx': nxEslintPlugin,
-      'react-hooks': reactHooks,
       'unused-imports': unusedImports,
       import: eslintImport,
+    },
+  },
+  {
+    ...js.configs.recommended,
+    files: ['**/*.ts', '**/*.tsx'],
+    plugins: {
+      'react-hooks': reactHooks,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
     },
   },
   {


### PR DESCRIPTION
# Summary

`eslint-plugin-react-hooks` stopped working after [the recent eslint upgrade](https://github.com/cowprotocol/cowswap/pull/4326).

Mainly, the problem comes from the new [eslint flat config format](https://eslint.org/docs/latest/use/configure/migration-guide).

I've tried several solutions, but only one helped me: https://stackoverflow.com/a/78369201/5151460

# To Test

There should not be any functional changes, but I've changed a bit code of:

1. Wallet connection functionality
2. Marking notifications as read
3. Using addresses with network prefix (gno:0x0000...)