### PR TITLE
chore: use mapped tokenlists for arb1

### DIFF
--- a/libs/tokens/src/const/tokensList.json
+++ b/libs/tokens/src/const/tokensList.json
@@ -82,7 +82,12 @@
     {
       "priority": 2,
       "enabledByDefault": true,
-      "source": "https://tokens.coingecko.com/arbitrum-one/all.json"
+      "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/ArbitrumOneUniswapTokensList.json"
+    },
+    {
+      "priority": 3,
+      "enabledByDefault": true,
+      "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/ArbitrumOneCoingeckoTokensList.json"
     }
   ],
   "11155111": [


### PR DESCRIPTION
# Summary

Use the 2 token lists mapped for arbitrum one created on https://github.com/cowprotocol/token-lists/pull/393

# To Test

1. Switch network to arbitrum one
2. Check the loaded token lists
* Should have cowswap, uniswap and coingecko
![image](https://github.com/cowprotocol/cowswap/assets/43217/352fd757-12de-4717-92ff-8ddb9ec91ed3)
* They all should point to the token-lists repo