### PR TITLE
fix(wallets): don't reset wallet on network switching

### DIFF
--- a/libs/wallet/src/web3-react/connectors/Injected/index.tsx
+++ b/libs/wallet/src/web3-react/connectors/Injected/index.tsx
@@ -30,8 +30,16 @@ export class InjectedWallet extends Connector {
     this.searchKeywords = searchKeywords
   }
 
+  /**
+   * When desiredChainIdOrChainParameters is set it means this is a network switching request
+   * We have to call startActivation() for switching between wallets, but we mustn't do it on network switch
+   */
   async activate(desiredChainIdOrChainParameters?: number | AddEthereumChainParameter): Promise<void> {
-    const cancelActivation = this.actions.startActivation()
+    let cancelActivation: Command
+
+    if (!desiredChainIdOrChainParameters || !this.provider?.isConnected?.()) {
+      cancelActivation = this.actions.startActivation()
+    }
 
     return this.isomorphicInitialize()
       .then(async () => {


### PR DESCRIPTION
# Summary

The bug comes from https://github.com/cowprotocol/cowswap/pull/4483/files

This fix should be still relevant for both https://github.com/cowprotocol/cowswap/issues/4480 and https://github.com/cowprotocol/cowswap/pull/4493#issuecomment-2135708730

The cause of the problem that I undoubtedly called `startActivation()` even for network switching, but we must not do it for the case.

# To Test

1. Connect to Metamask
2. Switch network in the CoW Swap UI
- [ ] ER: there is a request to Metamask and it keeps connected to CoW Swap
3. See #4480
