### PR TITLE
feat: expose the address of a token in the HTML

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
+++ b/apps/cowswap-frontend/src/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
@@ -144,6 +144,7 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
       <styledEl.Wrapper
         id={id}
         className={className}
+        data-address={selectedTokenAddress}
         withReceiveAmountInfo={!!receiveAmountInfo}
         pointerDisabled={disabled}
         readOnly={inputDisabled}

--- a/apps/cowswap-frontend/src/legacy/components/Tokens/TokensTable.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Tokens/TokensTable.tsx
@@ -104,30 +104,30 @@ export default function TokenTable({
   const sortedTokens = useMemo(() => {
     return tokensData
       ? tokensData
-          .filter((x) => !!x)
-          .sort((tokenA, tokenB) => {
-            if (!sortField) {
-              // If there is no sort field selected (default)
-              return tokenComparator(tokenA, tokenB)
-            } else if (sortField === SORT_FIELD.BALANCE) {
-              // If the sort field is Balance
-              if (!balances) return 0
+        .filter((x) => !!x)
+        .sort((tokenA, tokenB) => {
+          if (!sortField) {
+            // If there is no sort field selected (default)
+            return tokenComparator(tokenA, tokenB)
+          } else if (sortField === SORT_FIELD.BALANCE) {
+            // If the sort field is Balance
+            if (!balances) return 0
 
-              const balanceA = balances[tokenA.address.toLowerCase()]
-              const balanceB = balances[tokenB.address.toLowerCase()]
-              const balanceComp = balanceComparator(balanceA, balanceB)
+            const balanceA = balances[tokenA.address.toLowerCase()]
+            const balanceB = balances[tokenB.address.toLowerCase()]
+            const balanceComp = balanceComparator(balanceA, balanceB)
 
-              return applyDirection(balanceComp > 0, sortDirection)
-            } else {
-              // If the sort field is something else
-              const sortA = tokenA[sortField]
-              const sortB = tokenB[sortField]
+            return applyDirection(balanceComp > 0, sortDirection)
+          } else {
+            // If the sort field is something else
+            const sortA = tokenA[sortField]
+            const sortB = tokenB[sortField]
 
-              if (!sortA || !sortB) return 0
-              return applyDirection(sortA > sortB, sortDirection)
-            }
-          })
-          .slice(maxItems * (page - 1), page * maxItems)
+            if (!sortA || !sortB) return 0
+            return applyDirection(sortA > sortB, sortDirection)
+          }
+        })
+        .slice(maxItems * (page - 1), page * maxItems)
       : []
   }, [tokensData, maxItems, page, sortField, tokenComparator, balances, applyDirection, sortDirection])
 
@@ -209,7 +209,7 @@ export default function TokenTable({
 
               if (data) {
                 return (
-                  <Row key={data.address}>
+                  <Row key={data.address} data-address={data.address}>
                     <TokensTableRow
                       key={data.address}
                       toggleWalletModal={toggleWalletModal}


### PR DESCRIPTION
# Summary

This is just some personal annoyance I have. Sometimes is super hard to find the token address of the selected token. I don't think this PR is a solution to it, we should allow the user to open a link in an explorer. 

This PR only adds it in the HTLM so nerdies can look it up. I hope we can add in the future the proper links for the final users. @fairlighteth  pls make sure we come back to this one as it will be a low effort to add, so we can have a small discussion on what we want to do exactly


Added to the token selector:

<img width="1490" alt="Screenshot at Jun 03 12-02-25" src="https://github.com/cowprotocol/cowswap/assets/2352112/6d006480-6139-4a0c-ba53-d1456ab84ee1">


Added to the token table too:

<img width="1281" alt="Screenshot at Jun 03 11-57-50" src="https://github.com/cowprotocol/cowswap/assets/2352112/c2982af5-c338-4645-acab-1d5855e0ac3a">




