### PR TITLE
chore: remove isArbitrumOneEnabled feature flag

### DIFF
--- a/libs/common-hooks/src/useAvailableChains.ts
+++ b/libs/common-hooks/src/useAvailableChains.ts
@@ -3,13 +3,21 @@ import { useMemo } from 'react'
 import { getAvailableChains } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
-import { useFeatureFlags } from './index'
-
+/**
+ * Hook to get a list of SupportedChainId currently available/enabled
+ *
+ * Normally it is the exact same list of chains in the SupportChainId enum.
+ * It'll be different when a chain is behind a feature flag.
+ * Set the flag in this hook.
+ */
 export function useAvailableChains(): SupportedChainId[] {
-  const { isArbitrumOneEnabled } = useFeatureFlags()
+  // 1. Load feature flag for chain being enabled
+  // const { isArbitrumOneEnabled } = useFeatureFlags()
 
   return useMemo(
-    () => getAvailableChains(isArbitrumOneEnabled ? undefined : [SupportedChainId.ARBITRUM_ONE]),
-    [isArbitrumOneEnabled]
+    // 2. Conditionally build a list of chain ids to exclude
+    // () => getAvailableChains(isArbitrumOneEnabled ? undefined : [SupportedChainId.ARBITRUM_ONE]),
+    () => getAvailableChains(),
+    []
   )
 }


### PR DESCRIPTION
# Summary

Remove arb1 feature flag

# To Test

1. Open CoW Swap
* Should have Arbitrum One enabled
2. Open Explorer
* Should have Arbitrum One enabled
3. Open widget
* Should have Arbitrum One enabled