### PR TITLE
fix: display network selector for Rabby + Safe

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/Header/NetworkSelector/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Header/NetworkSelector/index.tsx
@@ -3,7 +3,7 @@ import { useRef } from 'react'
 import { getChainInfo } from '@cowprotocol/common-const'
 import { useAvailableChains } from '@cowprotocol/common-hooks'
 import { UI } from '@cowprotocol/ui'
-import { useIsSmartContractWallet, useWalletInfo } from '@cowprotocol/wallet'
+import { useIsRabbyWallet, useIsSmartContractWallet, useWalletInfo } from '@cowprotocol/wallet'
 import { useWalletProvider } from '@cowprotocol/wallet-provider'
 
 import { Trans } from '@lingui/macro'
@@ -159,7 +159,9 @@ export function NetworkSelector() {
   const openModal = useOpenModal(ApplicationModal.NETWORK_SELECTOR)
   const closeModal = useCloseModal(ApplicationModal.NETWORK_SELECTOR)
   const toggleModal = useToggleModal(ApplicationModal.NETWORK_SELECTOR)
+
   const isSmartContractWallet = useIsSmartContractWallet()
+  const isRabbyWallet = useIsRabbyWallet()
   const isChainIdUnsupported = useIsProviderNetworkUnsupported()
   const info = getChainInfo(chainId)
 
@@ -170,7 +172,7 @@ export function NetworkSelector() {
 
   const availableChains = useAvailableChains()
 
-  if (!provider || isSmartContractWallet) {
+  if (!provider || (isSmartContractWallet && !isRabbyWallet)) {
     return null
   }
 

--- a/libs/wallet/src/api/hooks.ts
+++ b/libs/wallet/src/api/hooks.ts
@@ -8,7 +8,7 @@ import {
 } from './state/multiInjectedProvidersAtom'
 import { ConnectionType, GnosisSafeInfo, WalletDetails, WalletInfo } from './types'
 
-import { WATCH_ASSET_SUPPORED_WALLETS } from '../constants'
+import { RABBY_RDNS, WATCH_ASSET_SUPPORED_WALLETS } from '../constants'
 import { useConnectionType } from '../web3-react/hooks/useConnectionType'
 import { useIsSafeApp } from '../web3-react/hooks/useWalletMetadata'
 
@@ -59,4 +59,13 @@ export function useIsAssetWatchingSupported(): boolean {
 
   // TODO: check other wallets and extend the array
   return WATCH_ASSET_SUPPORED_WALLETS.includes(info.info.rdns)
+}
+
+export function useIsRabbyWallet(): boolean {
+  const connectionType = useConnectionType()
+  const info = useSelectedEip6963ProviderInfo()
+
+  if (!info || connectionType !== ConnectionType.INJECTED) return false
+
+  return RABBY_RDNS === info.info.rdns
 }


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C036G0J90BU/p1717512366621489

Rabby is special :) It allows using Safe inside, which is a great feature.
We used to hide network selector in CoW Swap UI for smart-contract wallets, because as a rule they do not support network switching from client side. But the case with Rabby is special, so I added an exeption for it.
Anyway, it displays "Safe address does not support" warning when you select a network that doesn't match to the Safe address.

<img width="409" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/924b0c7c-a6d8-4c56-a9fc-8410a878f9dd">

<img width="411" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/9e157c5b-a530-47d4-8331-af21eaa18e46">

<img width="522" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/d0fe2dc5-e05a-4887-91e0-616de0272543">


# To Test

1. Connect a Safe to Rabby (see the pic above)
2. Connect Rabby to CoW Swap

- [ ] network selector must be displayed in CoW Swap UI
- [ ] you should be able to switch network from UI