### PR TITLE
fix(widget): allow using walletconnect in widget mobile

### DIFF
--- a/apps/cowswap-frontend/src/modules/injectedWidget/updaters/InjectedWidgetUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/updaters/InjectedWidgetUpdater.tsx
@@ -59,9 +59,15 @@ const cacheMessages = (event: MessageEvent) => {
   window.open = function (...args) {
     const [href = '', target = '', rel = ''] = args
 
-    postMessageToWindow(top, WidgetMethodsEmit.INTERCEPT_WINDOW_OPEN, { href, target, rel })
+    try {
+      return originalWinOpen.apply(this, args)
+    } catch (e) {
+      console.log('Error in window.open', e)
 
-    return originalWinOpen.apply(this, args)
+      postMessageToWindow(top, WidgetMethodsEmit.INTERCEPT_WINDOW_OPEN, { href, target, rel })
+
+      return null
+    }
   }
 
   document.body.addEventListener('click', (event) => {

--- a/apps/cowswap-frontend/src/modules/injectedWidget/updaters/InjectedWidgetUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/updaters/InjectedWidgetUpdater.tsx
@@ -59,15 +59,9 @@ const cacheMessages = (event: MessageEvent) => {
   window.open = function (...args) {
     const [href = '', target = '', rel = ''] = args
 
-    try {
-      return originalWinOpen.apply(this, args)
-    } catch (e) {
-      console.log('Error in window.open', e)
+    postMessageToWindow(top, WidgetMethodsEmit.INTERCEPT_WINDOW_OPEN, { href, target, rel })
 
-      postMessageToWindow(top, WidgetMethodsEmit.INTERCEPT_WINDOW_OPEN, { href, target, rel })
-
-      return null
-    }
+    return originalWinOpen.apply(this, args)
   }
 
   document.body.addEventListener('click', (event) => {

--- a/apps/cowswap-frontend/src/modules/wallet/containers/ConnectWalletOptions.tsx
+++ b/apps/cowswap-frontend/src/modules/wallet/containers/ConnectWalletOptions.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from '@cowprotocol/common-hooks'
-import { isMobile } from '@cowprotocol/common-utils'
+import { isInjectedWidget, isMobile } from '@cowprotocol/common-utils'
 import {
   CoinbaseWalletOption,
   InjectedOption as DefaultInjectedOption,
@@ -25,12 +25,14 @@ export function ConnectWalletOptions({ tryActivation }: { tryActivation: TryActi
 
   const hasCoinbaseEip6963 = multiInjectedProviders.some((provider) => provider.info.rdns === COINBASE_WALLET_RDNS)
 
+  const isWidget = isInjectedWidget()
   const isInjectedMobileBrowser = getIsInjectedMobileBrowser()
 
   const connectionProps = { darkMode, selectedWallet, tryActivation }
 
   const coinbaseWalletOption = (!hasCoinbaseEip6963 && <CoinbaseWalletOption {...connectionProps} />) ?? null
-  const walletConnectionV2Option = (!isInjectedMobileBrowser && <WalletConnectV2Option {...connectionProps} />) ?? null
+  const walletConnectionV2Option =
+    ((!isInjectedMobileBrowser || isWidget) && <WalletConnectV2Option {...connectionProps} />) ?? null
   const trezorOption = (!isInjectedMobileBrowser && !isMobile && <TrezorOption {...connectionProps} />) ?? null
 
   return (

--- a/libs/widget-lib/src/types.ts
+++ b/libs/widget-lib/src/types.ts
@@ -8,6 +8,7 @@ export enum WidgetMethodsEmit {
   SET_FULL_HEIGHT = 'SET_FULL_HEIGHT',
   EMIT_COW_EVENT = 'EMIT_COW_EVENT',
   PROVIDER_RPC_REQUEST = 'PROVIDER_RPC_REQUEST',
+  INTERCEPT_WINDOW_OPEN = 'INTERCEPT_WINDOW_OPEN',
 }
 
 export enum WidgetMethodsListen {
@@ -302,6 +303,7 @@ export interface WidgetMethodsEmitPayloadMap {
   [WidgetMethodsEmit.UPDATE_HEIGHT]: UpdateWidgetHeightPayload
   [WidgetMethodsEmit.SET_FULL_HEIGHT]: SetWidgetFullHeightPayload
   [WidgetMethodsEmit.PROVIDER_RPC_REQUEST]: ProviderRpcRequestPayload
+  [WidgetMethodsEmit.INTERCEPT_WINDOW_OPEN]: WindowOpenPayload
 }
 
 export interface WidgetMethodsListenPayloadMap {
@@ -353,6 +355,12 @@ export type WidgetMethodHandler<T extends WidgetMethodsEmit> = (payload: WidgetM
 
 export interface ProviderRpcRequestPayload {
   rpcRequest: JsonRpcRequestMessage
+}
+
+export interface WindowOpenPayload {
+  href: string | URL
+  target: string
+  rel: string
 }
 
 export interface JsonRpcRequestMessage {


### PR DESCRIPTION
# Summary

Fixes #4155 
This fix works only in mobile browsers (checked Chrome, Safari, Firefox on IOS) and doesn't work in Desktop:

<img width="966" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/2baaa04b-cd58-4505-aa7a-b2e818b4b7b3">

Since deeplinks make sense only in mobile I think it's ok.

There is one problem with Firefox, it opens deeplinks twice, probably because it allows using depplinks from Iframes. I've tried adding try/catch for `window.open` but it doesn't help. Since the fix helps for Chrome and Safari I think it worth to keep it. In Firefox users will have to cancel the second deeplink request.

# To Test

1. Open https://widget-configurator-git-fix-widget-deeplinks-cowswap.vercel.app/ in mobile browser
2. Switch to standalone mode
3. Try to connect via wallet connect to some wallet (e.g. Trust)
- [ ] AR: nothing happens
- [ ] ER: there is a request for connection in the wallet
4. Wallet should be successfuly connected after connection approve