### PR TITLE
feat: reduce ethflow slippage for non mainnet chains

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/containers/Row/RowSlippage/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/Row/RowSlippage/index.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 
 import { formatPercent } from '@cowprotocol/common-utils'
+import { useWalletInfo } from '@cowprotocol/wallet'
 import { Percent } from '@uniswap/sdk-core'
 
 import { useToggleSettingsMenu } from 'legacy/state/application/hooks'
@@ -27,9 +28,11 @@ export function RowSlippage({
 
   const isEoaEthFlow = useIsEoaEthFlow()
   const nativeCurrency = useNativeCurrency()
+  const { chainId } = useWalletInfo()
 
   const props = useMemo(
     () => ({
+      chainId,
       isEoaEthFlow,
       symbols: [nativeCurrency.symbol],
       showSettingOnClick,

--- a/apps/cowswap-frontend/src/modules/swap/pure/EthFlow/EthFlowBanner/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/EthFlow/EthFlowBanner/index.tsx
@@ -1,5 +1,6 @@
 import savingsIcon from '@cowprotocol/assets/cow-swap/savings.svg'
 import { MINIMUM_ETH_FLOW_SLIPPAGE, PERCENTAGE_PRECISION } from '@cowprotocol/common-const'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { Command } from '@cowprotocol/types'
 import { ButtonPrimary } from '@cowprotocol/ui'
 import { Currency, Token } from '@uniswap/sdk-core'
@@ -11,6 +12,7 @@ import SVG from 'react-inlinesvg'
 import { EthFlowBannerCallbacks } from 'modules/swap/containers/EthFlow/EthFlowBanner'
 
 import * as styledEl from './styleds'
+
 export interface EthFlowBannerContentProps extends EthFlowBannerCallbacks {
   native: Currency
   wrapped: Token
@@ -29,6 +31,10 @@ export function EthFlowBannerContent(props: EthFlowBannerContentProps) {
     switchCurrencyCallback,
     wrapCallback,
   } = props
+
+  const chainId = native.chainId as SupportedChainId
+  const minEthFlowSlippage = MINIMUM_ETH_FLOW_SLIPPAGE[chainId]
+
   return (
     <styledEl.BannerWrapper onClick={showBannerCallback} id="classic-eth-flow-banner">
       <styledEl.ClosedBannerWrapper>
@@ -60,8 +66,7 @@ export function EthFlowBannerContent(props: EthFlowBannerContentProps) {
             <ul>
               <li>Lower overall network costs</li>
               <li>
-                Lower default slippage (instead of {MINIMUM_ETH_FLOW_SLIPPAGE.toSignificant(PERCENTAGE_PRECISION)}%
-                minimum)
+                Lower default slippage (instead of {minEthFlowSlippage.toSignificant(PERCENTAGE_PRECISION)}% minimum)
               </li>
               <li>No fees for failed transactions</li>
             </ul>

--- a/apps/cowswap-frontend/src/modules/swap/pure/Row/RowSlippageContent/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/Row/RowSlippageContent/index.cosmos.tsx
@@ -4,6 +4,7 @@ import { RowSlippageProps } from 'modules/swap/containers/Row/RowSlippage'
 import { RowSlippageContent, RowSlippageContentProps } from 'modules/swap/pure/Row/RowSlippageContent'
 
 const defaultProps: RowSlippageProps & RowSlippageContentProps = {
+  chainId: 1,
   isEoaEthFlow: true,
   symbols: ['ETH', 'WETH'],
   allowedSlippage: new Percent(1, 100),

--- a/apps/cowswap-frontend/src/modules/swap/pure/Row/RowSlippageContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/Row/RowSlippageContent/index.tsx
@@ -1,4 +1,5 @@
 import { INPUT_OUTPUT_EXPLANATION, MINIMUM_ETH_FLOW_SLIPPAGE, PERCENTAGE_PRECISION } from '@cowprotocol/common-const'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { Command } from '@cowprotocol/types'
 import { HoverTooltip, RowFixed } from '@cowprotocol/ui'
 
@@ -25,26 +26,30 @@ export const ClickableText = styled.button`
   }
 `
 
-export const getNativeSlippageTooltip = (symbols: (string | undefined)[] | undefined) => (
+export const getNativeSlippageTooltip = (chainId: SupportedChainId, symbols: (string | undefined)[] | undefined) => (
   <Trans>
     When selling {symbols?.[0] || 'a native currency'}, the minimum slippage tolerance is set to{' '}
-    {MINIMUM_ETH_FLOW_SLIPPAGE.toSignificant(PERCENTAGE_PRECISION)}% to ensure a high likelihood of order matching,
-    even in volatile market conditions.
-    <br /><br />
+    {MINIMUM_ETH_FLOW_SLIPPAGE[chainId].toSignificant(PERCENTAGE_PRECISION)}% to ensure a high likelihood of order
+    matching, even in volatile market conditions.
+    <br />
+    <br />
     Orders on CoW Swap are always protected from MEV, so your slippage tolerance cannot be exploited.
   </Trans>
 )
 export const getNonNativeSlippageTooltip = () => (
   <Trans>
     Your slippage is MEV protected: all orders are submitted with tight spread (0.1%) on-chain.
-    <br /><br />
+    <br />
+    <br />
     The slippage you pick here enables a resubmission of your order in case of unfavourable price movements.
-    <br /><br />
+    <br />
+    <br />
     {INPUT_OUTPUT_EXPLANATION}
   </Trans>
 )
 
 export interface RowSlippageContentProps extends RowSlippageProps {
+  chainId: SupportedChainId
   toggleSettings: Command
   displaySlippage: string
   isEoaEthFlow: boolean
@@ -59,6 +64,7 @@ export interface RowSlippageContentProps extends RowSlippageProps {
 
 export function RowSlippageContent(props: RowSlippageContentProps) {
   const {
+    chainId,
     showSettingOnClick,
     toggleSettings,
     displaySlippage,
@@ -70,7 +76,7 @@ export function RowSlippageContent(props: RowSlippageContentProps) {
   } = props
 
   const tooltipContent =
-    slippageTooltip || (isEoaEthFlow ? getNativeSlippageTooltip(symbols) : getNonNativeSlippageTooltip())
+    slippageTooltip || (isEoaEthFlow ? getNativeSlippageTooltip(chainId, symbols) : getNonNativeSlippageTooltip())
 
   return (
     <StyledRowBetween {...styleProps}>

--- a/apps/cowswap-frontend/src/modules/swap/state/EthFlow/updaters/EthFlowSlippageUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/state/EthFlow/updaters/EthFlowSlippageUpdater.tsx
@@ -42,7 +42,15 @@ export function EthFlowSlippageUpdater() {
   const wasEthFlowActive = useRef(false)
 
   useEffect(() => {
+    // Reset state when chain changes and ethflow was active
+    wasEthFlowActive.current && _resetSlippage(setUserSlippageTolerance, false)
+    wasEthFlowActive.current = false
+  }, [chainId, setUserSlippageTolerance])
+
+  useEffect(() => {
     if (isEoaEthFlow) {
+      // Switching into ethflow.
+
       // Load what's stored
       const { regular, ethFlow } = _loadSlippage()
 
@@ -50,12 +58,12 @@ export function EthFlowSlippageUpdater() {
       wasEthFlowActive.current = true
 
       if (
+        !currentSlippage ||
         currentSlippage === 'auto' ||
-        (!currentSlippage.greaterThan(minEthFlowSlippage) && !currentSlippage.equalTo(minEthFlowSlippage))
+        (currentSlippage instanceof Percent && minEthFlowSlippage.greaterThan(currentSlippage))
       ) {
-        // If current slippage is auto or if it's smaller than ETH flow slippage, update it
-
-        // If the former ethFlow slippage was saved, use that. Otherwise pick the minimum
+        // Previous slippage cannot be used as is.
+        // Determine whether we should use stored ethflow value or the min ethflow value
         const newSlippage =
           ethFlow !== 'auto' && ethFlow && ethFlow.greaterThan(minEthFlowSlippage) ? ethFlow : minEthFlowSlippage
 
@@ -63,14 +71,20 @@ export function EthFlowSlippageUpdater() {
         setUserSlippageTolerance(newSlippage)
 
         // Update local storage
-        _saveSlippage({ regular: regular || currentSlippage, ethFlow: newSlippage })
+        _saveSlippage({
+          regular: regular || currentSlippage,
+          ethFlow: newSlippage.equalTo(minEthFlowSlippage) ? 'auto' : newSlippage,
+        })
       } else {
-        // If current slippage is NOT auto and it's greater than minimum, store that locally
-        _saveSlippage({ regular, ethFlow: currentSlippage })
+        // Previous slippage is valid for ethflow
+        _saveSlippage({
+          regular: regular || currentSlippage,
+          ethFlow: currentSlippage,
+        })
       }
     } else if (wasEthFlowActive.current) {
       // Only when disabling EthFlow, reset to previous regular value
-      _resetSlippage(setUserSlippageTolerance)
+      _resetSlippage(setUserSlippageTolerance, true)
       // Disable the flag
       wasEthFlowActive.current = false
     }
@@ -118,10 +132,10 @@ function _deserializeSlippage(slippage: SerializedSlippage | undefined): Slippag
   // return slippage === 'auto' || !slippage ? 'auto' : new Percent(slippage[0], slippage[1])
 }
 
-function _resetSlippage(setUserSlippageTolerance: (slippageTolerance: Slippage) => void): void {
+function _resetSlippage(setUserSlippageTolerance: (slippageTolerance: Slippage) => void, keepEthFlow?: boolean): void {
   const { regular, ethFlow } = _loadSlippage()
   // user switched back to non-native swap, set slippage back to previous value
   setUserSlippageTolerance(regular || 'auto')
   // Removing it from storage to avoid issues when coming back
-  _saveSlippage({ ethFlow })
+  _saveSlippage({ ethFlow: keepEthFlow ? ethFlow : 'auto' })
 }

--- a/libs/common-const/src/common.ts
+++ b/libs/common-const/src/common.ts
@@ -3,8 +3,8 @@ import {
   COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS,
   COW_PROTOCOL_VAULT_RELAYER_ADDRESS,
   IpfsConfig,
-  SupportedChainId,
   mapSupportedNetworks,
+  SupportedChainId,
 } from '@cowprotocol/cow-sdk'
 import { Fraction, Percent } from '@uniswap/sdk-core'
 
@@ -84,8 +84,15 @@ export const GP_ORDER_UPDATE_INTERVAL = ms`30s` // 30s
 export const MINIMUM_ORDER_VALID_TO_TIME_SECONDS = 120
 // Minimum deadline for EthFlow orders. Like the default deadline, anything smaller will be replaced by this
 export const MINIMUM_ETH_FLOW_DEADLINE_SECONDS = 600 // 10 minutes in SECONDS
-export const MINIMUM_ETH_FLOW_SLIPPAGE_BPS = 200 // 2%
-export const MINIMUM_ETH_FLOW_SLIPPAGE = new Percent(MINIMUM_ETH_FLOW_SLIPPAGE_BPS, 10_000) // 2%
+export const MINIMUM_ETH_FLOW_SLIPPAGE_BPS: Record<SupportedChainId, number> = {
+  [SupportedChainId.MAINNET]: 200, // 2%
+  [SupportedChainId.GNOSIS_CHAIN]: DEFAULT_SLIPPAGE_BPS,
+  [SupportedChainId.ARBITRUM_ONE]: DEFAULT_SLIPPAGE_BPS,
+  [SupportedChainId.SEPOLIA]: DEFAULT_SLIPPAGE_BPS,
+}
+export const MINIMUM_ETH_FLOW_SLIPPAGE: Record<SupportedChainId, Percent> = mapSupportedNetworks(
+  (chainId) => new Percent(MINIMUM_ETH_FLOW_SLIPPAGE_BPS[chainId], 10_000)
+)
 export const HIGH_ETH_FLOW_SLIPPAGE_BPS = 1_000 // 10%
 
 export const WETH_LOGO_URI =


### PR DESCRIPTION
# Summary

Ethflow orders have a default min slippage of 2%.
It doesn't make much sense for chains with cheaper gas costs.

This change reduces the min amount required for everything else (gchain, arb1 and sepolia) to the default minimum: `0.5%`

# To Test

1. Open on mainnet
2. Pick ETH as sell
3. Check the settings
* Min slippage allowed should be `2%`
4. Repeat for all other chains
* Min slippage allowed should be `0.5%`

* Regular slippage settings should not be affected