### PR TITLE
Fix order submitted

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/OrderSubmittedContent/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderSubmittedContent/index.tsx
@@ -9,6 +9,7 @@ import { EnhancedTransactionLink } from 'legacy/components/EnhancedTransactionLi
 import { HashType } from 'legacy/state/enhancedTransactions/reducer'
 
 import AnimatedConfirmation from 'common/pure/AnimatedConfirmation'
+import { GnosisSafeInfo, useGnosisSafeInfo } from '@cowprotocol/wallet'
 
 const Wrapper = styled.div`
   width: 100%;
@@ -32,15 +33,16 @@ const ActionButton = styled(ButtonPrimary)`
 export interface OrderSubmittedContentProps {
   onDismiss(): void
   chainId: SupportedChainId
-  isSafeWallet: boolean
+  safeWallet: GnosisSafeInfo | undefined
   account: string
   hash: string
 }
 
-export function OrderSubmittedContent({ chainId, account, isSafeWallet, hash, onDismiss }: OrderSubmittedContentProps) {
+export function OrderSubmittedContent({ chainId, account, safeWallet, hash, onDismiss }: OrderSubmittedContentProps) {
+
   const tx = {
     hash,
-    hashType: isSafeWallet && !isCowOrder('transaction', hash) ? HashType.GNOSIS_SAFE_TX : HashType.ETHEREUM_TX,
+    hashType: safeWallet && !isCowOrder('transaction', hash) ? HashType.GNOSIS_SAFE_TX : HashType.ETHEREUM_TX,
     safeTransaction: {
       safeTxHash: hash,
       safe: account,
@@ -51,7 +53,11 @@ export function OrderSubmittedContent({ chainId, account, isSafeWallet, hash, on
     <Wrapper>
       <AnimatedConfirmation />
       <Caption>
-        <Trans>Order Submitted</Trans>
+        {safeWallet && safeWallet.threshold > 1 ? (
+          <Trans>{`Order Submitted, but won't be processed until the transaction is signed by all your Safe{Wallet} signers.`}</Trans>
+        ) : (
+          <Trans>Order Submitted</Trans>
+        )}
       </Caption>
       <EnhancedTransactionLink chainId={chainId} tx={tx} />
       <ActionButton onClick={onDismiss}>

--- a/apps/cowswap-frontend/src/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
@@ -102,6 +102,7 @@ export function ConfirmSwapModalSetup(props: ConfirmSwapModalSetupProps) {
         hash={order?.id}
         onDismiss={onDismiss}
         activityDerivedState={activityDerivedState}
+        safeWallet={gnosisSafeInfo}
       />
     )
   }

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeConfirmModal/index.tsx
@@ -3,7 +3,7 @@ import { useCallback } from 'react'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { Command } from '@cowprotocol/types'
 import { UI } from '@cowprotocol/ui'
-import { useIsSafeWallet, useWalletInfo } from '@cowprotocol/wallet'
+import { GnosisSafeInfo, useGnosisSafeInfo, useIsSafeWallet, useWalletInfo } from '@cowprotocol/wallet'
 
 import styled from 'styled-components/macro'
 
@@ -40,7 +40,7 @@ export function TradeConfirmModal(props: TradeConfirmModalProps) {
   const { children, submittedContent, title } = props
 
   const { chainId, account } = useWalletInfo()
-  const isSafeWallet = useIsSafeWallet()
+  const safeWallet = useGnosisSafeInfo()
   const { permitSignatureState, pendingTrade, transactionHash, error } = useTradeConfirmState()
   const { onDismiss } = useTradeConfirmActions()
   const setShowFollowPendingTxPopup = useSetShowFollowPendingTxPopup()
@@ -65,7 +65,7 @@ export function TradeConfirmModal(props: TradeConfirmModalProps) {
         transactionHash={transactionHash}
         onDismiss={dismissConfirmation}
         permitSignatureState={permitSignatureState}
-        isSafeWallet={isSafeWallet}
+        safeWallet={safeWallet}
         submittedContent={submittedContent}
         order={order}
       >
@@ -85,7 +85,7 @@ type InnerComponentProps = {
   transactionHash: string | null
   onDismiss: Command
   permitSignatureState: string | undefined
-  isSafeWallet: boolean
+  safeWallet: GnosisSafeInfo | undefined
   submittedContent?: CustomSubmittedContent
   order?: Order
 }
@@ -95,7 +95,7 @@ function InnerComponent(props: InnerComponentProps) {
     chainId,
     children,
     error,
-    isSafeWallet,
+    safeWallet,
     onDismiss,
     title,
     pendingTrade,
@@ -131,7 +131,7 @@ function InnerComponent(props: InnerComponentProps) {
       <OrderSubmittedContent
         chainId={chainId}
         account={account}
-        isSafeWallet={isSafeWallet}
+        safeWallet={safeWallet}
         onDismiss={onDismiss}
         hash={transactionHash}
       />


### PR DESCRIPTION
# Summary
If the user is working with a multisignature safes the “order submitted”
message is often quite confusing, because other users of the safe need
to sign before the order is considered submitted.

With this change on a multisig safes we’ll show a custom message
explaining to the user that he needs to gather all signatures.

There is one edge case - on a 1:1 Safe if you decide to sign, instead of
sign & execute you would still see “Order submitted”, despite the fact
that it won’t ever execute.

@anxolin or whoever reviews this PR. I wanted to base it on top of this PR: https://github.com/cowprotocol/cowswap/pull/4508, so please ignore all commits except for the last one. If this passes review, it should be mergedafter #4508 



# To Test

1. 1:1 Safe
- no changes should be observed
2. On a multisig Safe, you should see a custom message when you sign the Tx:
![grafik](https://github.com/cowprotocol/cowswap/assets/693770/78e29498-c3b7-48c5-95e7-a353ed139877)

