### PR TITLE
fix(limit): do not allow wrap without full balance

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
@@ -27,7 +27,7 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
   const isBalanceGreaterThan1Atom = inputCurrencyBalance
     ? BigInt(inputCurrencyBalance.quotient.toString()) > BigInt(0)
     : false
-  const canPlaceOrderWithoutBalance = isBalanceGreaterThan1Atom && isInsufficientBalanceOrderAllowed
+  const canPlaceOrderWithoutBalance = isBalanceGreaterThan1Atom && isInsufficientBalanceOrderAllowed && !isWrapUnwrap
   const isNativeIn = inputCurrency && getIsNativeToken(inputCurrency) && !isWrapUnwrap
 
   const approvalRequired =

--- a/apps/cowswap-frontend/src/modules/usdAmount/apis/getCoingeckoUsdPrice.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/apis/getCoingeckoUsdPrice.ts
@@ -1,3 +1,4 @@
+import { BFF_BASE_URL } from '@cowprotocol/common-const'
 import { FractionUtils } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { Fraction, Token } from '@uniswap/sdk-core'
@@ -7,7 +8,6 @@ import ms from 'ms.macro'
 import { fetchWithRateLimit } from 'common/utils/fetch'
 
 import { RateLimitError, UnknownCurrencyError, UnsupportedPlatformError } from './errors'
-import { BFF_BASE_URL } from '@cowprotocol/common-const'
 
 type SuccessCoingeckoUsdQuoteResponse = {
   [address: string]: {


### PR DESCRIPTION
# Summary

With https://github.com/cowprotocol/cowswap/pull/3742 a bug was introduced for wrapping on LIMIT.

![image](https://github.com/cowprotocol/cowswap/assets/43217/ea235158-1485-48dc-9a47-dc5387548fd9)

[Described here](https://www.notion.so/cownation/Arbitrum-One-pre-launch-2024-05-29-e504c9b3f7cb4b459101b374608cb8d9?pvs=4#da3355ddfac14735addb0884a056b0e9).

This change makes sure it's no longer possible to try to wrap more than what's available.

# To Test

1. Go to limit, pick native as sell, wrapped native as buy
2. Insert in the sell input more than your balance
* You should see `insufficient balance`
![image](https://github.com/cowprotocol/cowswap/assets/43217/1f332125-d1ef-4ea3-b46d-2db1ff95dcc7)
