### PR TITLE
fix(widget): remove favorite tooltip for widget

### DIFF
--- a/apps/cowswap-frontend/src/modules/tokensList/containers/SelectTokenWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/containers/SelectTokenWidget/index.tsx
@@ -3,6 +3,7 @@ import { useCallback, useState } from 'react'
 import { addListAnalytics } from '@cowprotocol/analytics'
 import { useTokensBalances } from '@cowprotocol/balances-and-allowances'
 import { TokenWithLogo } from '@cowprotocol/common-const'
+import { isInjectedWidget } from '@cowprotocol/common-utils'
 import {
   ListState,
   useAddList,
@@ -53,6 +54,8 @@ export function SelectTokenWidget() {
   const unsupportedTokens = useUnsupportedTokens()
   const permitCompatibleTokens = usePermitCompatibleTokens()
   const onTokenListAddingError = useOnTokenListAddingError()
+
+  const isInjectedWidgetMode = isInjectedWidget()
 
   const closeTokenSelectWidget = useCallback(() => {
     updateSelectTokenWidget({
@@ -142,6 +145,7 @@ export function SelectTokenWidget() {
             onInputPressEnter={onInputPressEnter}
             onDismiss={onDismiss}
             onOpenManageWidget={() => setIsManageWidgetOpen(true)}
+            hideFavoriteTokensTooltip={isInjectedWidgetMode}
           ></SelectTokenModal>
         )
       })()}

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/FavouriteTokensList/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/FavouriteTokensList/index.tsx
@@ -6,18 +6,20 @@ import * as styledEl from './styled'
 
 export interface FavouriteTokensListProps {
   tokens: TokenWithLogo[]
+  hideTooltip?: boolean
   selectedToken?: string
+
   onSelectToken(token: TokenWithLogo): void
 }
 
 export function FavouriteTokensList(props: FavouriteTokensListProps) {
-  const { tokens, selectedToken, onSelectToken } = props
+  const { tokens, hideTooltip, selectedToken, onSelectToken } = props
 
   return (
     <div>
       <styledEl.Header>
         <h4>Favorite tokens</h4>
-        <HelpTooltip text="Your favorite saved tokens. Edit this list in your account page." />
+        {!hideTooltip && <HelpTooltip text="Your favorite saved tokens. Edit this list in your account page." />}
       </styledEl.Header>
       <styledEl.List>
         {tokens.map((token) => {

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/SelectTokenModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/SelectTokenModal/index.tsx
@@ -23,10 +23,16 @@ export interface SelectTokenModalProps {
   unsupportedTokens: UnsupportedTokensState
   selectedToken?: string
   permitCompatibleTokens: PermitCompatibleTokens
+  hideFavoriteTokensTooltip?: boolean
+
   onSelectToken(token: TokenWithLogo): void
+
   onInputPressEnter?(): void
+
   defaultInputValue?: string
+
   onOpenManageWidget(): void
+
   onDismiss(): void
 }
 
@@ -39,6 +45,7 @@ export function SelectTokenModal(props: SelectTokenModalProps) {
     balancesState,
     unsupportedTokens,
     permitCompatibleTokens,
+    hideFavoriteTokensTooltip,
     onSelectToken,
     onDismiss,
     onOpenManageWidget,
@@ -72,7 +79,12 @@ export function SelectTokenModal(props: SelectTokenModalProps) {
         />
       </styledEl.Row>
       <styledEl.Row>
-        <FavouriteTokensList onSelectToken={onSelectToken} selectedToken={selectedToken} tokens={favouriteTokens} />
+        <FavouriteTokensList
+          onSelectToken={onSelectToken}
+          selectedToken={selectedToken}
+          tokens={favouriteTokens}
+          hideTooltip={hideFavoriteTokensTooltip}
+        />
       </styledEl.Row>
       <styledEl.Separator />
       {inputValue.trim() ? (

--- a/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
@@ -11,8 +11,8 @@ const getBaseUrl = (): string => {
   if (isLocalHost) return 'http://localhost:3000'
   if (isDev) return 'https://dev.swap.cow.fi/'
   if (isVercel) {
-    const prKey = window.location.hostname.replace('widget-configurator-git-', '').replace('-cowswap.vercel.app', '')
-    return `https://swap-dev-git-${prKey}-cowswap.vercel.app`
+    // const prKey = window.location.hostname.replace('widget-configurator-git-', '').replace('-cowswap.vercel.app', '')
+    return `https://swap-dev-git-fix-4289favorite-tooltip-for-widget-cowswap.vercel.app`
   }
 
   return 'https://swap.cow.fi'

--- a/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
@@ -11,8 +11,8 @@ const getBaseUrl = (): string => {
   if (isLocalHost) return 'http://localhost:3000'
   if (isDev) return 'https://dev.swap.cow.fi/'
   if (isVercel) {
-    // const prKey = window.location.hostname.replace('widget-configurator-git-', '').replace('-cowswap.vercel.app', '')
-    return `https://swap-dev-git-fix-4289favorite-tooltip-for-widget-cowswap.vercel.app`
+    const prKey = window.location.hostname.replace('widget-configurator-git-', '').replace('-cowswap.vercel.app', '')
+    return `https://swap-dev-git-${prKey}-cowswap.vercel.app`
   }
 
   return 'https://swap.cow.fi'


### PR DESCRIPTION
# Summary

Fixes #4289

Remove favourite tooltip for widget, as it's not possible to edit them.

| Regular/Before | Widget now |
|-|-|
| ![image](https://github.com/cowprotocol/cowswap/assets/43217/fae38056-3c2f-405d-9156-7db8ce8c107b) | ![image](https://github.com/cowprotocol/cowswap/assets/43217/1a963720-263f-458b-a24f-8fc98215a848) |


# To Test

1. Open widget
2. Open token selector
* There should be no tooltip in the favorite tokens header
3. Open CoW Swap
* There should be a tooltip in the favorite tokens header