### PR TITLE
fix(trade): check recipient against account and ens name

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersConfirmModal/index.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react'
 
 import { getWrappedToken } from '@cowprotocol/common-utils'
 import { TokenSymbol } from '@cowprotocol/ui'
-import { useWalletInfo } from '@cowprotocol/wallet'
+import { useWalletDetails, useWalletInfo } from '@cowprotocol/wallet'
 
 import { PriceImpact } from 'legacy/hooks/usePriceImpact'
 
@@ -47,6 +47,7 @@ export function LimitOrdersConfirmModal(props: LimitOrdersConfirmModalProps) {
   const tradeContext = useMemo(() => tradeContextInitial, [])
 
   const { account } = useWalletInfo()
+  const { ensName } = useWalletDetails()
   const warningsAccepted = useLimitOrdersWarningsAccepted(true)
   const settingsState = useAtomValue(limitOrdersSettingsAtom)
   const executionPrice = useAtomValue(executionPriceAtom)
@@ -81,6 +82,7 @@ export function LimitOrdersConfirmModal(props: LimitOrdersConfirmModalProps) {
       <TradeConfirmation
         title={CONFIRM_TITLE}
         account={account}
+        ensName={ensName}
         inputCurrencyInfo={inputCurrencyInfo}
         outputCurrencyInfo={outputCurrencyInfo}
         onConfirm={doTrade}

--- a/apps/cowswap-frontend/src/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { Command } from '@cowprotocol/types'
-import { useGnosisSafeInfo, useWalletInfo } from '@cowprotocol/wallet'
+import { useGnosisSafeInfo, useWalletDetails, useWalletInfo } from '@cowprotocol/wallet'
 
 import { HighFeeWarning } from 'legacy/components/SwapWarnings'
 import { getActivityDerivedState } from 'legacy/hooks/useActivityDerivedState'
@@ -46,6 +46,7 @@ export function ConfirmSwapModalSetup(props: ConfirmSwapModalSetupProps) {
   } = props
 
   const { account } = useWalletInfo()
+  const { ensName } = useWalletDetails()
   const { recipient } = useSwapState()
   const gnosisSafeInfo = useGnosisSafeInfo()
   const tradeConfirmActions = useTradeConfirmActions()
@@ -74,6 +75,7 @@ export function ConfirmSwapModalSetup(props: ConfirmSwapModalSetupProps) {
       <TradeConfirmation
         title={CONFIRM_TITLE}
         account={account}
+        ensName={ensName}
         refreshInterval={refreshInterval}
         inputCurrencyInfo={inputCurrencyInfo}
         outputCurrencyInfo={outputCurrencyInfo}

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeConfirmModal/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeConfirmModal/index.cosmos.tsx
@@ -25,6 +25,7 @@ const tradeAmounts: TradeAmounts = {
 const confirmationState: TradeConfirmationProps = {
   title: 'Review order',
   account: undefined,
+  ensName: undefined,
   inputCurrencyInfo: inputCurrencyInfoMock,
   outputCurrencyInfo: outputCurrencyInfoMock,
   priceImpact: priceImpactMock,

--- a/apps/cowswap-frontend/src/modules/trade/pure/TradeConfirmation/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/TradeConfirmation/index.cosmos.tsx
@@ -9,6 +9,7 @@ const Fixtures = {
     <TradeConfirmation
       title="Review order"
       account={undefined}
+      ensName={undefined}
       inputCurrencyInfo={inputCurrencyInfoMock}
       outputCurrencyInfo={outputCurrencyInfoMock}
       onConfirm={() => void 0}

--- a/apps/cowswap-frontend/src/modules/trade/pure/TradeConfirmation/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/TradeConfirmation/index.tsx
@@ -31,6 +31,7 @@ export interface TradeConfirmationProps {
   onConfirm(): void
   onDismiss(): void
   account: string | undefined
+  ensName: string | undefined
   inputCurrencyInfo: CurrencyPreviewInfo
   outputCurrencyInfo: CurrencyPreviewInfo
   isConfirmDisabled: boolean
@@ -56,6 +57,7 @@ export function TradeConfirmation(props: TradeConfirmationProps) {
     onConfirm,
     onDismiss,
     account,
+    ensName,
     inputCurrencyInfo,
     outputCurrencyInfo,
     isConfirmDisabled,
@@ -75,7 +77,11 @@ export function TradeConfirmation(props: TradeConfirmationProps) {
     setFrozenProps(hasPendingTrade ? propsRef.current : null)
   }, [hasPendingTrade])
 
-  const showRecipientWarning = recipient && account && recipient.toLowerCase() !== account.toLowerCase()
+  const showRecipientWarning =
+    recipient &&
+    (account || ensName) &&
+    ![account?.toLowerCase(), ensName?.toLowerCase()].includes(recipient.toLowerCase())
+
   const inputAmount = inputCurrencyInfo.amount?.toExact()
   const outputAmount = outputCurrencyInfo.amount?.toExact()
 

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/index.tsx
@@ -1,7 +1,7 @@
 import { useAtomValue } from 'jotai'
 import { useState } from 'react'
 
-import { useWalletInfo } from '@cowprotocol/wallet'
+import { useWalletDetails, useWalletInfo } from '@cowprotocol/wallet'
 
 import { useAdvancedOrdersDerivedState } from 'modules/advancedOrders'
 import { TradeConfirmation, TradeConfirmModal, useTradeConfirmActions, useTradePriceImpact } from 'modules/trade'
@@ -27,6 +27,7 @@ const CONFIRM_TITLE = 'TWAP'
 
 export function TwapConfirmModal() {
   const { account } = useWalletInfo()
+  const { ensName } = useWalletDetails()
   const {
     inputCurrencyAmount,
     inputCurrencyFiatAmount,
@@ -81,6 +82,7 @@ export function TwapConfirmModal() {
       <TradeConfirmation
         title={CONFIRM_TITLE}
         account={account}
+        ensName={ensName}
         inputCurrencyInfo={inputCurrencyInfo}
         outputCurrencyInfo={outputCurrencyInfo}
         onConfirm={() => createTwapOrder(fallbackHandlerIsNotSet)}


### PR DESCRIPTION
# Summary

Fixes #4307

"Order recipient address differs from order owner!" banner should not be displayed with recipient ens name matches current account ens name.

<img width="505" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/000f9b8e-353b-4a34-87c9-ae536cce697a">

# To Test

See #4307
