### PR TITLE
fix: connect wallet in e2e tests

### DIFF
--- a/apps/cowswap-frontend-e2e/src/support/ethereum.ts
+++ b/apps/cowswap-frontend-e2e/src/support/ethereum.ts
@@ -28,6 +28,8 @@ export const TEST_ADDRESS_NEVER_USE = new Wallet(INTEGRATION_TEST_PRIVATE_KEY).a
 // Redefined bridge to fix a supper annoying issue making some contract calls to fail
 //  See https://github.com/ethers-io/ethers.js/issues/1683
 class CustomizedBridge extends Eip1193Bridge {
+  autoConnect = true
+
   chainId = CHAIN_ID
 
   async sendAsync(...args: any[]) {

--- a/apps/cowswap-frontend/src/react-app-env.d.ts
+++ b/apps/cowswap-frontend/src/react-app-env.d.ts
@@ -15,6 +15,7 @@ interface Window {
     isCoinbaseWallet?: true
     isMetaMask?: true
     autoRefreshOnNetworkChange?: boolean
+    autoConnect?: boolean
     setSelectedProvider: (any) => void
     providers: [any]
     isTrust?: boolean

--- a/libs/wallet/src/web3-react/Web3Provider/hooks/useEagerlyConnect.ts
+++ b/libs/wallet/src/web3-react/Web3Provider/hooks/useEagerlyConnect.ts
@@ -35,7 +35,8 @@ export function useEagerlyConnect(selectedWallet: ConnectionType | undefined) {
   useEffect(() => {
     const isIframe = window.top !== window.self
 
-    if (isInjectedWidget() || getIsInjectedMobileBrowser()) {
+    // autoConnect is set to true in the e2e tests
+    if (isInjectedWidget() || getIsInjectedMobileBrowser() || window.ethereum?.autoConnect) {
       connect(injectedWalletConnection.connector)
     }
 


### PR DESCRIPTION
# Summary

Since [the last wallets refactoring](https://github.com/cowprotocol/cowswap/pull/4416), e2e tests started failing.
The cause of it is that after the refactoring we don't try connecting to injected provider automatically.
For e2e tests I've added special flag `window.ethereum.autoConnect`.

# To Test

E2E tests should be green
