### PR TITLE
fix: disable appzi in widget mode

### DIFF
--- a/libs/common-utils/src/appzi.ts
+++ b/libs/common-utils/src/appzi.ts
@@ -14,7 +14,7 @@ const isOldChrome =
 
 const isFeedbackEnabled = process.env.REACT_APP_FEEDBACK_ENABLED_DEV === 'true' || process.env.NODE_ENV === 'production'
 const isImTokenIosBrowser = isImTokenBrowser && userAgent.os.name === 'iOS'
-export const isAppziEnabled = !isOldChrome && !isImTokenIosBrowser && isFeedbackEnabled
+export const isAppziEnabled = !isOldChrome && !isImTokenIosBrowser && isFeedbackEnabled && !isInjectedWidget()
 
 const PROD_FEEDBACK_KEY = 'f7591eca-72f7-4888-b15f-e7ff5fcd60cd'
 const TEST_FEEDBACK_KEY = '6da8bf10-4904-4952-9a34-12db70e9194e'


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C0361CDG8GP/p1718197114575339

I haven't found what exactly wrong with Appzi, but I just disabled it in widget mode since it's not relevant here

# To Test

1. Open widget configurator
2. Change "Current trade type" to "Limit"
- [ ] AR: the app crashes
- [ ] ER: no crashes
