### PR TITLE
fix(trade): display recipient on confirm screen

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/pure/LimitOrdersDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/pure/LimitOrdersDetails/index.tsx
@@ -126,7 +126,7 @@ export function LimitOrdersDetails(props: LimitOrdersDetailsProps) {
         </div>
       </styledEl.DetailsRow>
       <OrderType isPartiallyFillable={partiallyFillable} partiallyFillableOverride={partiallyFillableOverride} />
-      <RecipientRow recipient={recipient} account={account} recipientAddressOrName={recipientAddressOrName} />
+      <RecipientRow recipient={recipientAddressOrName || recipient} account={account} />
     </Wrapper>
   )
 }

--- a/apps/cowswap-frontend/src/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
@@ -131,6 +131,7 @@ export function ConfirmSwapModalSetup(props: ConfirmSwapModalSetupProps) {
               receiveAmountInfo={receiveAmountInfo}
               widgetParams={widgetParams}
               labelsAndTooltips={labelsAndTooltips}
+              recipient={recipient}
               hideLimitPrice
               hideUsdValues
               withTimelineDot={false}

--- a/apps/cowswap-frontend/src/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
@@ -132,6 +132,7 @@ export function ConfirmSwapModalSetup(props: ConfirmSwapModalSetupProps) {
               widgetParams={widgetParams}
               labelsAndTooltips={labelsAndTooltips}
               recipient={recipient}
+              account={account}
               hideLimitPrice
               hideUsdValues
               withTimelineDot={false}

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeBasicConfirmDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeBasicConfirmDetails/index.tsx
@@ -1,5 +1,6 @@
 import { Dispatch, ReactNode, SetStateAction, useMemo } from 'react'
 
+import { isAddress, shortenAddress } from '@cowprotocol/common-utils'
 import { CowSwapWidgetAppParams } from '@cowprotocol/widget-lib'
 import { Percent, Price } from '@uniswap/sdk-core'
 
@@ -11,6 +12,7 @@ import { RateInfoParams } from 'common/pure/RateInfo'
 import { LimitPriceRow } from './LimitPriceRow'
 import * as styledEl from './styled'
 
+import { ConfirmDetailsItem } from '../../pure/ConfirmDetailsItem'
 import { ReviewOrderModalAmountRow } from '../../pure/ReviewOrderModalAmountRow'
 import { DividerHorizontal } from '../../pure/Row/styled'
 import { ReceiveAmountInfo } from '../../types'
@@ -25,6 +27,7 @@ type Props = {
   widgetParams: Partial<CowSwapWidgetAppParams>
   labelsAndTooltips?: LabelsAndTooltips
   children?: ReactNode
+  recipient?: string | null
   hideLimitPrice?: boolean
   hideUsdValues?: boolean
   withTimelineDot?: boolean
@@ -57,6 +60,7 @@ export function TradeBasicConfirmDetails(props: Props) {
     withTimelineDot = true,
     alwaysRow,
     children,
+    recipient,
   } = props
   const { amountAfterFees, amountAfterSlippage } = getOrderTypeReceiveAmounts(receiveAmountInfo)
   const { networkCostsSuffix, networkCostsTooltipSuffix } = labelsAndTooltips || {}
@@ -143,6 +147,18 @@ export function TradeBasicConfirmDetails(props: Props) {
         />
       )}
 
+      {/*Recipient*/}
+
+      {recipient && (
+        <ConfirmDetailsItem
+          tooltip="The tokens received from this order will automatically be sent to this address. No need to do a second transaction!"
+          label="Recipient"
+          alwaysRow={alwaysRow}
+          withTimelineDot={withTimelineDot}
+        >
+          <span>{isAddress(recipient) ? shortenAddress(recipient) : recipient}</span>
+        </ConfirmDetailsItem>
+      )}
       {children}
     </styledEl.Wrapper>
   )

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeBasicConfirmDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeBasicConfirmDetails/index.tsx
@@ -151,8 +151,6 @@ export function TradeBasicConfirmDetails(props: Props) {
       )}
 
       {/*Recipient*/}
-
-      {/* Recipient */}
       <RecipientRow recipient={recipient} account={account} />
       {children}
     </styledEl.Wrapper>

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeBasicConfirmDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeBasicConfirmDetails/index.tsx
@@ -1,8 +1,9 @@
-import { Dispatch, ReactNode, SetStateAction, useMemo } from 'react'
+import React, { Dispatch, ReactNode, SetStateAction, useMemo } from 'react'
 
-import { isAddress, shortenAddress } from '@cowprotocol/common-utils'
 import { CowSwapWidgetAppParams } from '@cowprotocol/widget-lib'
 import { Percent, Price } from '@uniswap/sdk-core'
+
+import { Nullish } from 'types'
 
 import { useUsdAmount } from 'modules/usdAmount'
 
@@ -12,7 +13,7 @@ import { RateInfoParams } from 'common/pure/RateInfo'
 import { LimitPriceRow } from './LimitPriceRow'
 import * as styledEl from './styled'
 
-import { ConfirmDetailsItem } from '../../pure/ConfirmDetailsItem'
+import { RecipientRow } from '../../pure/RecipientRow'
 import { ReviewOrderModalAmountRow } from '../../pure/ReviewOrderModalAmountRow'
 import { DividerHorizontal } from '../../pure/Row/styled'
 import { ReceiveAmountInfo } from '../../types'
@@ -27,7 +28,8 @@ type Props = {
   widgetParams: Partial<CowSwapWidgetAppParams>
   labelsAndTooltips?: LabelsAndTooltips
   children?: ReactNode
-  recipient?: string | null
+  recipient?: Nullish<string>
+  account: Nullish<string>
   hideLimitPrice?: boolean
   hideUsdValues?: boolean
   withTimelineDot?: boolean
@@ -61,6 +63,7 @@ export function TradeBasicConfirmDetails(props: Props) {
     alwaysRow,
     children,
     recipient,
+    account,
   } = props
   const { amountAfterFees, amountAfterSlippage } = getOrderTypeReceiveAmounts(receiveAmountInfo)
   const { networkCostsSuffix, networkCostsTooltipSuffix } = labelsAndTooltips || {}
@@ -149,16 +152,8 @@ export function TradeBasicConfirmDetails(props: Props) {
 
       {/*Recipient*/}
 
-      {recipient && (
-        <ConfirmDetailsItem
-          tooltip="The tokens received from this order will automatically be sent to this address. No need to do a second transaction!"
-          label="Recipient"
-          alwaysRow={alwaysRow}
-          withTimelineDot={withTimelineDot}
-        >
-          <span>{isAddress(recipient) ? shortenAddress(recipient) : recipient}</span>
-        </ConfirmDetailsItem>
-      )}
+      {/* Recipient */}
+      <RecipientRow recipient={recipient} account={account} />
       {children}
     </styledEl.Wrapper>
   )

--- a/apps/cowswap-frontend/src/modules/trade/pure/RecipientRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/RecipientRow/index.tsx
@@ -2,6 +2,7 @@ import { isAddress, shortenAddress } from '@cowprotocol/common-utils'
 import { InfoTooltip } from '@cowprotocol/ui'
 
 import styled from 'styled-components/macro'
+import { Nullish } from 'types'
 
 const Row = styled.div`
   display: flex;
@@ -14,16 +15,15 @@ const Row = styled.div`
 `
 
 interface RecipientRowProps {
-  recipient: string | null
-  recipientAddressOrName: string | null
-  account: string | undefined
+  recipient: Nullish<string>
+  account: Nullish<string>
 }
 
 export function RecipientRow(props: RecipientRowProps) {
-  const { recipientAddressOrName, recipient, account } = props
+  const { recipient, account } = props
   return (
     <>
-      {recipientAddressOrName && recipient !== account && (
+      {recipient && recipient.toLowerCase() !== account?.toLowerCase() && (
         <Row>
           <div>
             <span>Recipient</span>{' '}
@@ -34,9 +34,7 @@ export function RecipientRow(props: RecipientRowProps) {
             />
           </div>
           <div>
-            <span title={recipientAddressOrName}>
-              {isAddress(recipientAddressOrName) ? shortenAddress(recipientAddressOrName) : recipientAddressOrName}
-            </span>
+            <span title={recipient}>{isAddress(recipient) ? shortenAddress(recipient) : recipient}</span>
           </div>
         </Row>
       )}

--- a/apps/cowswap-frontend/src/modules/twap/const.ts
+++ b/apps/cowswap-frontend/src/modules/twap/const.ts
@@ -41,7 +41,7 @@ export const MINIMUM_PART_SELL_AMOUNT_FIAT: Record<SupportedChainId, CurrencyAmo
   [SupportedChainId.MAINNET]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.MAINNET], 1_000e6), // 1k
   [SupportedChainId.GNOSIS_CHAIN]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.GNOSIS_CHAIN], 5e6), // 5
   [SupportedChainId.ARBITRUM_ONE]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.ARBITRUM_ONE], 5e6), // 5
-  [SupportedChainId.SEPOLIA]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.SEPOLIA], 100e6), // 100
+  [SupportedChainId.SEPOLIA]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.SEPOLIA], 100e18), // 100
 }
 
 export const MINIMUM_PART_TIME = ms`5min` / 1000 // in seconds

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/TwapConfirmDetails.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/TwapConfirmDetails.tsx
@@ -1,11 +1,8 @@
 import React from 'react'
 
-import { useWalletInfo } from '@cowprotocol/wallet'
-
 import styled from 'styled-components/macro'
 
-import { useAdvancedOrdersDerivedState } from 'modules/advancedOrders'
-import { RecipientRow, useReceiveAmountInfo } from 'modules/trade'
+import { useReceiveAmountInfo } from 'modules/trade'
 import { ConfirmDetailsItem } from 'modules/trade/pure/ConfirmDetailsItem'
 import { ReviewOrderModalAmountRow } from 'modules/trade/pure/ReviewOrderModalAmountRow'
 import { useUsdAmount } from 'modules/usdAmount'
@@ -53,10 +50,6 @@ export const TwapConfirmDetails = React.memo(function TwapConfirmDetails(props: 
 
   const partDurationDisplay = partDuration ? deadlinePartsDisplay(partDuration, true) : ''
   const totalDurationDisplay = totalDuration ? deadlinePartsDisplay(totalDuration, true) : ''
-
-  const { account } = useWalletInfo()
-  const { recipient, recipientAddress } = useAdvancedOrdersDerivedState()
-  const recipientAddressOrName = recipient || recipientAddress
 
   const receiveAmountInfo = useReceiveAmountInfo()
   const { sellAmount: inputPartAfterSlippageAmount, buyAmount: outputPartAfterSlippageAmount } =
@@ -116,9 +109,6 @@ export const TwapConfirmDetails = React.memo(function TwapConfirmDetails(props: 
       >
         {totalDurationDisplay}
       </ConfirmDetailsItem>
-
-      {/* Recipient */}
-      <RecipientRow recipient={recipient} account={account} recipientAddressOrName={recipientAddressOrName} />
     </Wrapper>
   )
 })

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/index.tsx
@@ -129,6 +129,7 @@ export function TwapConfirmModal() {
               receiveAmountInfo={receiveAmountInfo}
               isInvertedState={isInvertedState}
               slippage={slippage}
+              recipient={recipient}
               labelsAndTooltips={{
                 ...CONFIRM_MODAL_CONFIG,
                 networkCostsSuffix: !allowsOffchainSigning ? <NetworkCostsSuffix /> : null,

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/index.tsx
@@ -130,6 +130,7 @@ export function TwapConfirmModal() {
               isInvertedState={isInvertedState}
               slippage={slippage}
               recipient={recipient}
+              account={account}
               labelsAndTooltips={{
                 ...CONFIRM_MODAL_CONFIG,
                 networkCostsSuffix: !allowsOffchainSigning ? <NetworkCostsSuffix /> : null,


### PR DESCRIPTION
# Summary

<img width="522" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/9f319057-0a67-4632-941f-e43b81c75230">

# To test

1. When recipient is set it should be displayed on confirm screen (swap/limit/twap)
