### PR TITLE
fix(slippage): always reset ethflow slippage when changing networks

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/state/EthFlow/updaters/EthFlowSlippageUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/state/EthFlow/updaters/EthFlowSlippageUpdater.tsx
@@ -43,7 +43,7 @@ export function EthFlowSlippageUpdater() {
 
   useEffect(() => {
     // Reset state when chain changes and ethflow was active
-    wasEthFlowActive.current && _resetSlippage(setUserSlippageTolerance, false)
+    _saveSlippage({})
     wasEthFlowActive.current = false
   }, [chainId, setUserSlippageTolerance])
 


### PR DESCRIPTION
# Summary

Fix ethflow slippage not being reset between network changes

# To Test

1. Open app
2. Change network to arb1, gchain or sepolia
3. Change default slippage to `0`
4. Pick native as sell
* Slippage should be set to 0.5% 
* You should not be able to set it to less than that
5. Pick any other token as sell
* Slippage should be back to `0`
6. Change network to mainnet
* Slippage should remain at `0`
7. Pick native as sell
* Slippage should be set to 2% 
* You should not be able to set it to less than that
8. Pick any other token as sell
* Slippage should be back to `0`
9. Change to any other network
* Slippage should remain at `0`
10. Pick native as sell
* Slippage should be set to 0.5% 