### PR TITLE
fix(sentry): handle unhandled exception calling PUBLIC_disconnectSite

### DIFF
--- a/libs/wallet/src/web3-react/Web3Provider/hooks/useEagerlyConnect.ts
+++ b/libs/wallet/src/web3-react/Web3Provider/hooks/useEagerlyConnect.ts
@@ -63,7 +63,7 @@ export function useEagerlyConnect(selectedWallet: ConnectionType | undefined) {
       connect(connection.connector)
     }
     // The dependency list is empty so this is only run once on mount
-  }, [])
+  }, [selectedWallet])
 
   /**
    * Activate the selected eip6963 provider

--- a/libs/wallet/src/web3-react/connectors/Injected/index.tsx
+++ b/libs/wallet/src/web3-react/connectors/Injected/index.tsx
@@ -19,7 +19,9 @@ export class InjectedWallet extends Connector {
   walletUrl: string
   searchKeywords: string[]
   eagerConnection?: boolean
+
   onConnect?(provider: EIP1193Provider): void
+
   onDisconnect?: Command
 
   constructor({ actions, onError, walletUrl, searchKeywords }: injectedWalletConstructorArgs) {
@@ -145,7 +147,9 @@ export class InjectedWallet extends Connector {
       const onDisconnect = (error: ProviderRpcError): void => {
         if (!doesProviderMatches()) return
 
-        this.provider?.request({ method: 'PUBLIC_disconnectSite' })
+        this.provider
+          ?.request({ method: 'PUBLIC_disconnectSite' })
+          .catch((e) => console.log('Failed to call "PUBLIC_disconnectSite", ignoring'))
 
         this.deactivate()
         this.onError?.(error)

--- a/libs/wallet/src/web3-react/connectors/Injected/index.tsx
+++ b/libs/wallet/src/web3-react/connectors/Injected/index.tsx
@@ -149,7 +149,7 @@ export class InjectedWallet extends Connector {
 
         this.provider
           ?.request({ method: 'PUBLIC_disconnectSite' })
-          .catch((e) => console.log('Failed to call "PUBLIC_disconnectSite", ignoring'))
+          .catch(() => console.log('Failed to call "PUBLIC_disconnectSite", ignoring'))
 
         this.deactivate()
         this.onError?.(error)

--- a/libs/wallet/src/web3-react/hooks/useActivateConnector.ts
+++ b/libs/wallet/src/web3-react/hooks/useActivateConnector.ts
@@ -50,7 +50,7 @@ export function useActivateConnector({
         onActivationError(error)
       }
     },
-    [chainId, pendingConnector, skipNetworkChanging]
+    [chainId, pendingConnector, skipNetworkChanging, afterActivation, beforeActivation, onActivationError]
   )
 
   return {


### PR DESCRIPTION
# Summary

Handles sentry error https://cowprotocol.sentry.io/issues/4526834066/?environment=production&project=5905822&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&statsPeriod=90d&stream_index=15

![image](https://github.com/cowprotocol/cowswap/assets/43217/482639ff-9082-400c-9ca3-d399864d5768)

# To Test

Actually, I can't trigger this anywhere (prod nor here), but these would be the test steps, I think.

1. Connect with MM
2. Disconnect
* `Failed to call "PUBLIC_disconnectSite", ignoring` should be logged to the console, instead of the exception