### PR TITLE
fix(widget): don't crash on dev env

### DIFF
--- a/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
@@ -9,7 +9,7 @@ const getBaseUrl = (): string => {
   if (typeof window === 'undefined' || !window) return ''
 
   if (isLocalHost) return 'http://localhost:3000'
-  if (isDev) return 'https://dev.swap.cow.fi/'
+  if (isDev) return 'https://dev.swap.cow.fi'
   if (isVercel) {
     const prKey = window.location.hostname.replace('widget-configurator-git-', '').replace('-cowswap.vercel.app', '')
     return `https://swap-dev-git-${prKey}-cowswap.vercel.app`


### PR DESCRIPTION
# Summary

When widget baseUrl has double slash, then cowswap crashes:

![image](https://github.com/cowprotocol/cowswap/assets/7122625/a8da3926-cc44-4b32-a457-e6a876b27d97)

# To Test

The bug can be reproduced only in dev environment.

1. Open widget configurator
2. In the widget preview go to Limit orders and then back to Swap

- [ ] AR: app crashes
- [ ] ER: no crashes
