### PR TITLE
fix(twap): improve output amount resetting logic

### DIFF
--- a/apps/cowswap-frontend/src/modules/advancedOrders/hooks/useAdvancedOrdersActions.ts
+++ b/apps/cowswap-frontend/src/modules/advancedOrders/hooks/useAdvancedOrdersActions.ts
@@ -50,10 +50,6 @@ export function useAdvancedOrdersActions() {
         currency: inputCurrency,
         field,
       })
-
-      if (field === Field.INPUT) {
-        updateState?.({ outputCurrencyAmount: null })
-      }
     },
     [updateState, inputCurrency, updateCurrencyAmount]
   )

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useTradeQuoteStateFromLegacy.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useTradeQuoteStateFromLegacy.ts
@@ -25,7 +25,8 @@ export function useTradeQuoteStateFromLegacy(): TradeQuoteState | null {
       isLoading,
       quoteParams: quote || null,
       localQuoteTimestamp: quote?.localQuoteTimestamp || null,
+      hasParamsChanged: isGettingNewQuote,
     }),
-    [quote, isLoading]
+    [quote, isLoading, isGettingNewQuote]
   )
 }

--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useTradeQuotePolling.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useTradeQuotePolling.ts
@@ -51,8 +51,8 @@ export function useTradeQuotePolling() {
       return
     }
 
-    const fetchQuote = () => {
-      updateQuoteState({ isLoading: true })
+    const fetchQuote = (hasParamsChanged: boolean) => {
+      updateQuoteState({ isLoading: true, hasParamsChanged })
 
       getQuoteOnlyResolveLast(quoteParams)
         .then((response) => {
@@ -62,11 +62,11 @@ export function useTradeQuotePolling() {
             return
           }
 
-          updateQuoteState({ response: data, quoteParams, isLoading: false, error: null })
+          updateQuoteState({ response: data, quoteParams, isLoading: false, error: null, hasParamsChanged: false })
         })
         .catch((error: QuoteApiError) => {
           console.log('[useGetQuote]:: fetchQuote error', error)
-          updateQuoteState({ isLoading: false, error })
+          updateQuoteState({ isLoading: false, error, hasParamsChanged: false })
 
           if (error.type === QuoteApiErrorCodes.UnsupportedToken) {
             processUnsupportedTokenError(error, quoteParams)
@@ -74,9 +74,9 @@ export function useTradeQuotePolling() {
         })
     }
 
-    fetchQuote()
+    fetchQuote(true)
 
-    const intervalId = setInterval(fetchQuote, PRICE_UPDATE_INTERVAL)
+    const intervalId = setInterval(() => fetchQuote(false), PRICE_UPDATE_INTERVAL)
 
     return () => clearInterval(intervalId)
   }, [quoteParams, updateQuoteState, updateCurrencyAmount, processUnsupportedTokenError, getIsUnsupportedTokens])

--- a/apps/cowswap-frontend/src/modules/tradeQuote/state/tradeQuoteAtom.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/state/tradeQuoteAtom.ts
@@ -10,6 +10,7 @@ export interface TradeQuoteState {
   response: OrderQuoteResponse | null
   error: QuoteApiError | null
   isLoading: boolean
+  hasParamsChanged: boolean
   quoteParams: LegacyFeeQuoteParams | null
   localQuoteTimestamp: number | null
 }
@@ -18,6 +19,7 @@ export const DEFAULT_TRADE_QUOTE_STATE: TradeQuoteState = {
   response: null,
   error: null,
   isLoading: false,
+  hasParamsChanged: false,
   quoteParams: null,
   localQuoteTimestamp: null,
 }

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWidget/index.tsx
@@ -1,5 +1,5 @@
 import { useAtomValue, useSetAtom } from 'jotai'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useState } from 'react'
 
 import { openAdvancedOrdersTabAnalytics, twapWalletCompatibilityAnalytics } from '@cowprotocol/analytics'
 import { renderTooltip } from '@cowprotocol/ui'
@@ -7,6 +7,7 @@ import { useWalletInfo } from '@cowprotocol/wallet'
 
 import { useAdvancedOrdersDerivedState } from 'modules/advancedOrders'
 import { useReceiveAmountInfo } from 'modules/trade'
+import { useTradeQuote } from 'modules/tradeQuote'
 import { useIsWrapOrUnwrap } from 'modules/trade/hooks/useIsWrapOrUnwrap'
 import { useTradeState } from 'modules/trade/hooks/useTradeState'
 import { TradeNumberInput } from 'modules/trade/pure/TradeNumberInput'
@@ -44,6 +45,7 @@ export function TwapFormWidget() {
 
   const { inputCurrencyAmount, outputCurrencyAmount } = useAdvancedOrdersDerivedState()
   const { updateState } = useTradeState()
+  const tradeQuote = useTradeQuote()
   const isFallbackHandlerRequired = useIsFallbackHandlerRequired()
   const isFallbackHandlerCompatible = useIsFallbackHandlerCompatible()
   const verification = useFallbackHandlerVerification()
@@ -86,6 +88,13 @@ export function TwapFormWidget() {
       }
     }
   }, [account, isFallbackHandlerRequired, isFallbackHandlerCompatible, localFormValidation, verification])
+
+  // Reset output amount when quote params are changed
+  useLayoutEffect(() => {
+    if (tradeQuote.hasParamsChanged) {
+      updateState?.({ outputCurrencyAmount: null })
+    }
+  }, [tradeQuote.hasParamsChanged, updateState])
 
   const isInvertedState = useState(false)
   const [isInverted] = isInvertedState


### PR DESCRIPTION
# Summary

Fixes #4562

In TWAP, we reset output amount every time when input amount changes, but it has a race condition with `QuoteUpdater`.
To avoid this, I added a new boolean flag `hasParamsChanged` to `tradeQuoteState` and reset output amount only when the flag is true.

# To Test

The bug is reproducible on PROD as well.

1. Change input amount 
2. Wait for nose-picking cow
3. Start changing the input amount quickly (add 0 -> remove 0 -> repeat)
- [ ] AR: the output amount is 0 even after quote fetching finish
- [ ] ER: the output amount contains a value from the fetched quote


https://github.com/cowprotocol/cowswap/assets/7122625/39ac1d6b-056c-44a7-88b2-9faab1ad9ac1

