### PR TITLE
feat: add easy link for Etherscan

### DIFF
--- a/apps/explorer/src/components/orders/DetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/index.tsx
@@ -181,7 +181,7 @@ export type DetailsTableProps = {
   invertPrice: Command
 }
 
-export function DetailsTable(props: DetailsTableProps): JSX.Element | null {
+export function DetailsTable(props: DetailsTableProps): React.ReactNode | null {
   const { chainId, order, areTradesLoading, showFillsButton, viewFills, isPriceInverted, invertPrice } = props
   const {
     uid,

--- a/apps/explorer/src/components/orders/DetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/index.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { Command } from '@cowprotocol/types'
 import { TruncatedText } from '@cowprotocol/ui/pure/TruncatedText'
 
-import { faFill, faProjectDiagram } from '@fortawesome/free-solid-svg-icons'
+import { faFill, faProjectDiagram, faGroupArrowsRotate } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { sendEvent } from 'components/analytics'
 import DecodeAppData from 'components/AppData/DecodeAppData'
@@ -27,6 +27,8 @@ import { Order } from 'api/operator'
 import { getUiOrderType } from 'utils/getUiOrderType'
 
 import { TAB_QUERY_PARAM_KEY } from '../../../explorer/const'
+import { ExplorerDataType, getExplorerLink } from '../../../../../../libs/common-utils/src/getExplorerLink'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 const Table = styled(SimpleTable)`
   > tbody > tr {
@@ -166,7 +168,8 @@ export const LinkButton = styled(LinkWithPrefixNetwork)`
   }
 `
 
-export type Props = {
+export type DetailsTableProps = {
+  chainId: SupportedChainId
   order: Order
   showFillsButton: boolean | undefined
   areTradesLoading: boolean
@@ -175,8 +178,8 @@ export type Props = {
   invertPrice: Command
 }
 
-export function DetailsTable(props: Props): JSX.Element | null {
-  const { order, areTradesLoading, showFillsButton, viewFills, isPriceInverted, invertPrice } = props
+export function DetailsTable(props: DetailsTableProps): JSX.Element | null {
+  const { chainId, order, areTradesLoading, showFillsButton, viewFills, isPriceInverted, invertPrice } = props
   const {
     uid,
     owner,
@@ -199,6 +202,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
     sellToken,
     appData,
     fullAppData,
+
   } = order
 
   if (!buyToken || !sellToken) {
@@ -267,11 +271,16 @@ export function DetailsTable(props: Props): JSX.Element | null {
                     <RowWithCopyButton
                       textToCopy={txHash}
                       onCopy={(): void => onCopy('settlementTx')}
-                      contentsToDisplay={<LinkWithPrefixNetwork to={`/tx/${txHash}`}>{txHash}</LinkWithPrefixNetwork>}
+                      contentsToDisplay={<LinkWithPrefixNetwork to={getExplorerLink(chainId, txHash, ExplorerDataType.TRANSACTION)} target='_blank'>{txHash}</LinkWithPrefixNetwork>}
                     />
+                    <LinkButton to={`/tx/${txHash}/?${TAB_QUERY_PARAM_KEY}`}>
+                      <FontAwesomeIcon icon={faGroupArrowsRotate} />
+                      Batch
+                    </LinkButton>
+
                     <LinkButton to={`/tx/${txHash}/?${TAB_QUERY_PARAM_KEY}=graph`}>
                       <FontAwesomeIcon icon={faProjectDiagram} />
-                      View batch graph
+                      Graph
                     </LinkButton>
                   </Wrapper>
                 ) : (

--- a/apps/explorer/src/components/orders/DetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/index.tsx
@@ -160,10 +160,6 @@ export const LinkButton = styled(LinkWithPrefixNetwork)`
     margin: 1rem 0 0 0;
   }
 
-  ${media.mediumDown} {
-    // min-width: 18rem;    
-  }
-
   :hover {
     // opacity: 0.8;
     color: ${({ theme }): string => theme.white};

--- a/apps/explorer/src/components/orders/DetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/index.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { Command } from '@cowprotocol/types'
 import { TruncatedText } from '@cowprotocol/ui/pure/TruncatedText'
 
-import { faFill, faProjectDiagram, faGroupArrowsRotate } from '@fortawesome/free-solid-svg-icons'
+import { faFill, faProjectDiagram, faGroupArrowsRotate, faHistory } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { sendEvent } from 'components/analytics'
 import DecodeAppData from 'components/AppData/DecodeAppData'
@@ -36,9 +36,15 @@ const Table = styled(SimpleTable)`
     grid-template-rows: max-content;
     padding: 1.4rem 0 1.4rem 1.1rem;
 
+    
+
     ${media.mediumDown} {
       grid-template-columns: 17rem auto;
       padding: 1.4rem 0;
+
+      :hover {
+        background: inherit;
+      }
     }
 
     > td {
@@ -124,12 +130,13 @@ const tooltip = {
   fees: 'The amount of fees paid for this order. This will show a progressive number for orders with partial fills. Might take a few minutes to show the final value.',
 }
 
-export const Wrapper = styled.div`
+export const Wrapper = styled.div<{ gap?: boolean }>`
   display: flex;
   flex-direction: row;
 
   ${media.mobile} {
     flex-direction: column;
+    ${({ gap = true }) => gap && 'gap: 1rem;'}
   }
 `
 
@@ -139,12 +146,12 @@ export const LinkButton = styled(LinkWithPrefixNetwork)`
   justify-content: center;
   text-align: center;
   font-weight: ${({ theme }): string => theme.fontBold};
-  font-size: 1.3rem;
+  font-size: 1.1rem;
   color: ${({ theme }): string => theme.orange1};
   border: 1px solid ${({ theme }): string => theme.orange1};
   background-color: ${({ theme }): string => theme.orangeOpacity};
   border-radius: 0.4rem;
-  padding: 0.8rem 1.5rem;
+  padding: 0.5rem 1.5rem;
   margin: 0 0 0 2rem;
   transition-duration: 0.2s;
   transition-timing-function: ease-in-out;
@@ -154,11 +161,11 @@ export const LinkButton = styled(LinkWithPrefixNetwork)`
   }
 
   ${media.mediumDown} {
-    min-width: 18rem;
+    // min-width: 18rem;    
   }
 
   :hover {
-    opacity: 0.8;
+    // opacity: 0.8;
     color: ${({ theme }): string => theme.white};
     text-decoration: none;
   }
@@ -237,11 +244,18 @@ export function DetailsTable(props: DetailsTableProps): JSX.Element | null {
               <HelpTooltip tooltip={tooltip.from} /> From
             </td>
             <td>
-              <RowWithCopyButton
-                textToCopy={owner}
-                onCopy={(): void => onCopy('ownerAddress')}
-                contentsToDisplay={<LinkWithPrefixNetwork to={`/address/${owner}`}>{owner}</LinkWithPrefixNetwork>}
-              />
+
+              <Wrapper>
+                <RowWithCopyButton
+                  textToCopy={owner}
+                  onCopy={(): void => onCopy('ownerAddress')}
+                  contentsToDisplay={<LinkWithPrefixNetwork to={getExplorerLink(chainId, owner, ExplorerDataType.ADDRESS)} target='_blank'>{owner}↗</LinkWithPrefixNetwork>}
+                />
+                <LinkButton to={`/address/${owner}`}>
+                  <FontAwesomeIcon icon={faHistory} />
+                  History
+                </LinkButton>
+              </Wrapper>
             </td>
           </tr>
           <tr>
@@ -249,13 +263,18 @@ export function DetailsTable(props: DetailsTableProps): JSX.Element | null {
               <HelpTooltip tooltip={tooltip.to} /> To
             </td>
             <td>
-              <RowWithCopyButton
-                textToCopy={receiver}
-                onCopy={(): void => onCopy('receiverAddress')}
-                contentsToDisplay={
-                  <LinkWithPrefixNetwork to={`/address/${receiver}`}>{receiver}</LinkWithPrefixNetwork>
-                }
-              />
+              <Wrapper>
+                <RowWithCopyButton
+                  textToCopy={receiver}
+                  onCopy={(): void => onCopy('receiverAddress')}
+                  contentsToDisplay={<LinkWithPrefixNetwork to={getExplorerLink(chainId, receiver, ExplorerDataType.ADDRESS)} target='_blank'>{receiver}↗</LinkWithPrefixNetwork>}
+                />
+                <LinkButton to={`/address/${receiver}`}>
+                  <FontAwesomeIcon icon={faHistory} />
+                  History
+                </LinkButton>
+              </Wrapper>
+
             </td>
           </tr>
           {(!partiallyFillable || txHash) && (
@@ -271,17 +290,19 @@ export function DetailsTable(props: DetailsTableProps): JSX.Element | null {
                     <RowWithCopyButton
                       textToCopy={txHash}
                       onCopy={(): void => onCopy('settlementTx')}
-                      contentsToDisplay={<LinkWithPrefixNetwork to={getExplorerLink(chainId, txHash, ExplorerDataType.TRANSACTION)} target='_blank'>{txHash}</LinkWithPrefixNetwork>}
+                      contentsToDisplay={<LinkWithPrefixNetwork to={getExplorerLink(chainId, txHash, ExplorerDataType.TRANSACTION)} target='_blank'>{txHash}↗</LinkWithPrefixNetwork>}
                     />
-                    <LinkButton to={`/tx/${txHash}/?${TAB_QUERY_PARAM_KEY}`}>
-                      <FontAwesomeIcon icon={faGroupArrowsRotate} />
-                      Batch
-                    </LinkButton>
+                    <Wrapper gap={false}>
+                      <LinkButton to={`/tx/${txHash}/?${TAB_QUERY_PARAM_KEY}`}>
+                        <FontAwesomeIcon icon={faGroupArrowsRotate} />
+                        Batch
+                      </LinkButton>
 
-                    <LinkButton to={`/tx/${txHash}/?${TAB_QUERY_PARAM_KEY}=graph`}>
-                      <FontAwesomeIcon icon={faProjectDiagram} />
-                      Graph
-                    </LinkButton>
+                      <LinkButton to={`/tx/${txHash}/?${TAB_QUERY_PARAM_KEY}=graph`}>
+                        <FontAwesomeIcon icon={faProjectDiagram} />
+                        Graph
+                      </LinkButton>
+                    </Wrapper>
                   </Wrapper>
                 ) : (
                   '-'

--- a/apps/explorer/src/components/orders/DetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/index.tsx
@@ -161,7 +161,7 @@ export const LinkButton = styled(LinkWithPrefixNetwork)`
   }
 
   :hover {
-    // opacity: 0.8;
+    opacity: 0.8;
     color: ${({ theme }): string => theme.white};
     text-decoration: none;
   }

--- a/apps/explorer/src/components/orders/DetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/index.tsx
@@ -27,7 +27,7 @@ import { Order } from 'api/operator'
 import { getUiOrderType } from 'utils/getUiOrderType'
 
 import { TAB_QUERY_PARAM_KEY } from '../../../explorer/const'
-import { ExplorerDataType, getExplorerLink } from '../../../../../../libs/common-utils/src/getExplorerLink'
+import { ExplorerDataType, getExplorerLink } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 const Table = styled(SimpleTable)`

--- a/apps/explorer/src/components/orders/DetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/index.tsx
@@ -209,7 +209,6 @@ export function DetailsTable(props: DetailsTableProps): JSX.Element | null {
     sellToken,
     appData,
     fullAppData,
-
   } = order
 
   if (!buyToken || !sellToken) {

--- a/apps/explorer/src/components/orders/DetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/index.tsx
@@ -252,7 +252,7 @@ export function DetailsTable(props: DetailsTableProps): JSX.Element | null {
                 />
                 <LinkButton to={`/address/${owner}`}>
                   <FontAwesomeIcon icon={faHistory} />
-                  History
+                  Order History
                 </LinkButton>
               </Wrapper>
             </td>
@@ -270,7 +270,7 @@ export function DetailsTable(props: DetailsTableProps): JSX.Element | null {
                 />
                 <LinkButton to={`/address/${receiver}`}>
                   <FontAwesomeIcon icon={faHistory} />
-                  History
+                  Order History
                 </LinkButton>
               </Wrapper>
 

--- a/apps/explorer/src/components/orders/DetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/index.tsx
@@ -293,7 +293,7 @@ export function DetailsTable(props: DetailsTableProps): JSX.Element | null {
                       contentsToDisplay={<LinkWithPrefixNetwork to={getExplorerLink(chainId, txHash, ExplorerDataType.TRANSACTION)} target='_blank'>{txHash}↗</LinkWithPrefixNetwork>}
                     />
                     <Wrapper gap={false}>
-                      <LinkButton to={`/tx/${txHash}/?${TAB_QUERY_PARAM_KEY}`}>
+                      <LinkButton to={`/tx/${txHash}`}>
                         <FontAwesomeIcon icon={faGroupArrowsRotate} />
                         Batch
                       </LinkButton>

--- a/apps/explorer/src/components/orders/OrderDetails/index.tsx
+++ b/apps/explorer/src/components/orders/OrderDetails/index.tsx
@@ -26,6 +26,9 @@ import { Order, Trade } from 'api/operator'
 import { FillsTableContext } from './context/FillsTableContext'
 import { FillsTableWithData } from './FillsTableWithData'
 
+import { useNetworkId } from 'state/network'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
 const TitleUid = styled(RowWithCopyButton)`
   color: ${({ theme }): string => theme.grey};
   font-size: ${({ theme }): string => theme.fontSizeDefault};
@@ -84,6 +87,7 @@ function useQueryViewParams(): { tab: string } {
 }
 
 const tabItems = (
+  chainId: SupportedChainId,
   _order: Order | null,
   trades: Trade[],
   areTradesLoading: boolean,
@@ -105,6 +109,7 @@ const tabItems = (
       <>
         {order && areTokensLoaded && (
           <DetailsTable
+            chainId={chainId}
             order={order}
             showFillsButton={showFills}
             viewFills={(): void => onChangeTab(TabView.FILLS)}
@@ -159,6 +164,7 @@ const RESULTS_PER_PAGE = 10
 
 export const OrderDetails: React.FC<Props> = (props) => {
   const { order, isOrderLoading, areTradesLoading, errors, trades } = props
+  const chainId = useNetworkId()
   const { tab } = useQueryViewParams()
   const [tabViewSelected, setTabViewSelected] = useState<TabView>(TabView[tab] || TabView[DEFAULT_TAB]) // use DEFAULT when URL param is outside the enum
   const {
@@ -206,6 +212,10 @@ export const OrderDetails: React.FC<Props> = (props) => {
     [tabViewSelected, updateQueryString]
   )
 
+  if (!chainId) {
+    return null
+  }
+
   if (redirectTo) {
     return <RedirectToSearch from="orders" />
   }
@@ -234,6 +244,7 @@ export const OrderDetails: React.FC<Props> = (props) => {
         <StyledExplorerTabs
           className={`orderDetails-tab--${TabView[tabViewSelected].toLowerCase()}`}
           tabItems={tabItems(
+            chainId,
             order,
             trades,
             areTradesLoading,


### PR DESCRIPTION
# Summary

This PR is a personal suggestion of something that I didn't love of the explorer, and decided to suggest in for of a PR. 

Basically, I find it always very difficult to check the Etherscan transaction of a settlement. This is something users like to be able to easily check. Among other things, you can see the actual execution time (not displayed right now in the CoW Explorer) and also you can see the actual transfer amounts.

Before, if you wanted to go to the explorer you have to:

<img width="1430" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/384910d4-701d-49d2-ab23-a89a4760bec5">

<img width="1419" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/4817c50e-d9e2-4e00-b419-29819a895a3c">

Alternatively, you can:
1. Copy the hash
2. Open a new tab in Etherscan
3. Search by hash

I do regularly both approaches, and I don't love the UX  😢

## Proposal

I just made the link to take you to Etherscan directly. I also added an additional button and shorten the labels of the buttons:

<img width="1366" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/f22ee4cd-8a19-4dab-9e30-3b6baaa9e400">

# Edit 26/06/2024
After discussing what we should do here, I went for:
- Making the text links coherent for the owner and receiver. Now it sends you also to the external explorer
- Adding a button to to see the history for the owner and receiver
- Making the text links to have a emoji that shows is an external link

I also styled a bit for responsive, to solve the issues reported by Elena. 
I also, saw it was adding a background on hover  which was messing a bit with the hover of the links. So I removed
Additionally, I made the buttons smaller (removed some padding and made the text smaller)

Desktop:
<img width="1241" alt="Screenshot at Jun 26 14-15-28" src="https://github.com/cowprotocol/cowswap/assets/2352112/d2f66d5b-bd00-4b3f-aa5a-8cb4b20279de">


Tablet:
<img width="746" alt="Screenshot at Jun 26 14-15-19" src="https://github.com/cowprotocol/cowswap/assets/2352112/f5cadb4b-fb8a-4510-b5a1-8118fb0fd420">

Mobile:
<img width="717" alt="Screenshot at Jun 26 14-14-44" src="https://github.com/cowprotocol/cowswap/assets/2352112/40ae8554-2a2b-4337-907e-3cb3cb67be85">



# To Test
Search for `0xd929693c3e057acc5b66b466aaca07c866ef1224115878e68544e579cc0770bb79063d9173c09887d536924e2f6eadbabac099f565e702be` in https://explorer.cow.fi/ and this PR preview, and compare

- OLD: https://explorer.cow.fi/orders/0xd929693c3e057acc5b66b466aaca07c866ef1224115878e68544e579cc0770bb79063d9173c09887d536924e2f6eadbabac099f565e702be?tab=overview
- NEW: https://explorer-dev-git-change-link-explorer-cowswap.vercel.app/orders/0xd929693c3e057acc5b66b466aaca07c866ef1224115878e68544e579cc0770bb79063d9173c09887d536924e2f6eadbabac099f565e702be?tab=overview