### PR TITLE
fix: reduce decimals to percentage

### DIFF
--- a/apps/explorer/src/components/orders/FilledProgress/index.tsx
+++ b/apps/explorer/src/components/orders/FilledProgress/index.tsx
@@ -244,7 +244,7 @@ export function FilledProgress(props: Props): JSX.Element {
         <FilledContainer>
           <p className="title">Filled</p>
           <div>
-            <p className="percentage">{formattedPercentage}%</p>
+            <p className="percentage">{formattedPercentage.toFixed(2)}%</p>
             <OrderAssetsInfo />
           </div>
           <ProgressBar showLabel={false} percentage={formattedPercentage} />

--- a/apps/explorer/src/components/orders/FilledProgress/index.tsx
+++ b/apps/explorer/src/components/orders/FilledProgress/index.tsx
@@ -13,6 +13,7 @@ import { safeTokenName } from 'utils'
 import { Order } from 'api/operator'
 
 import { OrderPriceDisplay } from '../OrderPriceDisplay'
+import { PercentDisplay } from '@cowprotocol/ui/pure/PercentDisplay'
 
 export type Props = {
   order: Order
@@ -244,7 +245,7 @@ export function FilledProgress(props: Props): JSX.Element {
         <FilledContainer>
           <p className="title">Filled</p>
           <div>
-            <p className="percentage">{formattedPercentage.toFixed(2)}%</p>
+            <p className="percentage"><PercentDisplay percent={formattedPercentage} /></p>
             <OrderAssetsInfo />
           </div>
           <ProgressBar showLabel={false} percentage={formattedPercentage} />


### PR DESCRIPTION
# Summary

The filled percentage has way too many decimals

Before
<img width="1385" alt="Screenshot at Jun 20 11-01-19" src="https://github.com/cowprotocol/cowswap/assets/2352112/757a24f4-bd3c-4959-a950-85f82ef20f2b">


After
<img width="1422" alt="Screenshot at Jun 20 11-02-39" src="https://github.com/cowprotocol/cowswap/assets/2352112/51b87c73-713e-49f6-bd9a-dcd9ddf28833">


## Test
Search in the preview PR for orderId: `0x72198277f82a96d9ec2911c11f179d8605dedf5113a5194e98ac5235cdf6db709fa3c00a92ec5f96b1ad2527ab41b3932efeda58660ecabd`