### PR TITLE
feat(explorer): show execution time when available

### DIFF
--- a/apps/explorer/src/api/operator/types.ts
+++ b/apps/explorer/src/api/operator/types.ts
@@ -24,6 +24,7 @@ export type Order = Pick<
   txHash?: string
   creationDate: Date
   expirationDate: Date
+  executionDate?: Date
   buyTokenAddress: string
   buyToken?: TokenErc20 | null // undefined when not set, null when not found
   sellTokenAddress: string

--- a/apps/explorer/src/components/orders/DetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/index.tsx
@@ -81,6 +81,8 @@ const tooltip = {
     'The date and time at which the order was submitted. The timezone is based on the browser locale settings.',
   expiration:
     'The date and time at which an order will expire and effectively be cancelled. Depending on the type of order, it may have partial fills upon expiration.',
+  execution:
+    'The date and time at which the order has been executed. The timezone is based on the browser locale settings.',
   type: (
     <div>
       CoW Protocol supports three type of orders – market, limit and liquidity:
@@ -184,6 +186,7 @@ export function DetailsTable(props: Props): JSX.Element | null {
     partiallyFillable,
     creationDate,
     expirationDate,
+    executionDate,
     buyAmount,
     sellAmount,
     executedBuyAmount,
@@ -293,6 +296,16 @@ export function DetailsTable(props: Props): JSX.Element | null {
               <DateDisplay date={creationDate} showIcon={true} />
             </td>
           </tr>
+          {executionDate && !showFillsButton && (
+            <tr>
+              <td>
+                <HelpTooltip tooltip={tooltip.execution} /> Execution Time
+              </td>
+              <td>
+                <DateDisplay date={executionDate} showIcon={true} />
+              </td>
+            </tr>
+          )}
           <tr>
             <td>
               <HelpTooltip tooltip={tooltip.expiration} /> Expiration Time

--- a/apps/explorer/src/components/orders/OrderDetails/index.tsx
+++ b/apps/explorer/src/components/orders/OrderDetails/index.tsx
@@ -150,7 +150,7 @@ const tabItems = (
  */
 function getOrderWithTxHash(order: Order | null, trades: Trade[]): Order | null {
   if (order && trades.length === 1) {
-    return { ...order, txHash: trades[0].txHash || undefined }
+    return { ...order, txHash: trades[0].txHash || undefined, executionDate: trades[0].executionTime || undefined }
   }
   return order
 }


### PR DESCRIPTION
# Summary

![image](https://github.com/cowprotocol/cowswap/assets/43217/4ce8ca51-5be6-482b-aeff-f0c694859d66)

Show execution time based on first tx when order is executed and (in case of partially fillable) there's a single fill.

# To Test

1. Open order details page for an executed order
* `Execution time` should be displayed
2. Open order details page for a partially fillable order with a single fill
* `Execution time` should be displayed
3. Open order details page for an order not executed
* `Execution time` should not be present
4. Open order details page for a partially fillable order with multiple fills
* `Execution time` should not be present