### PR TITLE
fix: reset isDropdownVisible status in large screen

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidgetLinks/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidgetLinks/index.tsx
@@ -82,7 +82,7 @@ export function TradeWidgetLinks({
         badgeText={item.badgeText || highlightedBadgeText}
         badgeType={item.badgeType || highlightedBadgeType}
         onClick={() => handleMenuItemClick(item)}
-        isDropdownVisible={isDropdownVisible}
+        isDropdownVisible={isDropdown && isDropdownVisible}
       />
     )
 


### PR DESCRIPTION
# Summary

Fixes #4536

# To Test
Described in the issue

# Background
So here `isDropdownVisible` prop should be false here, when `isDropdown` became false after the screen is expanded again.