### PR TITLE
refactor: update useSwr usage

### DIFF
--- a/apps/cowswap-frontend/src/api/cowProtocol/hooks.ts
+++ b/apps/cowswap-frontend/src/api/cowProtocol/hooks.ts
@@ -14,13 +14,9 @@ export function useOrdersFromOrderBook(): EnrichedOrder[] {
   const requestParams = useSWROrdersRequest()
 
   // Fetch orders for the current environment
-  const { data: currentEnvOrders } = useSWR<EnrichedOrder[]>(
-    ['orders', requestParams, chainId],
-    () => {
-      if (!chainId || !requestParams) return []
-
-      return getOrders(requestParams, { chainId })
-    },
+  const { data: currentEnvOrders } = useSWR(
+    requestParams && chainId ? ['orders', requestParams, chainId] : null,
+    ([, params, _chainId]) => getOrders(params, { chainId: _chainId }),
     { refreshInterval: ORDER_BOOK_API_UPDATE_INTERVAL }
   )
 

--- a/apps/cowswap-frontend/src/legacy/hooks/useGasPrice.ts
+++ b/apps/cowswap-frontend/src/legacy/hooks/useGasPrice.ts
@@ -24,9 +24,9 @@ export default function useGasPrice(): JSBI | undefined {
   const { address } = useENSAddress('fast-gas-gwei.data.eth')
   const contract = useContract(address ?? undefined, CHAIN_DATA_ABI, false)
 
-  const { data: result } = useSWR(['useGasPrice', contract], async () => {
-    return contract?.callStatic.latestAnswer()
-  })
+  const { data: result } = useSWR(contract ? ['useGasPrice', contract] : null, async ([, _contract]) =>
+    _contract.callStatic.latestAnswer()
+  )
   const resultStr = result?.toString()
 
   return useMemo(() => (typeof resultStr === 'string' ? JSBI.BigInt(resultStr) : undefined), [resultStr])

--- a/apps/cowswap-frontend/src/legacy/hooks/useTokenAllowance.ts
+++ b/apps/cowswap-frontend/src/legacy/hooks/useTokenAllowance.ts
@@ -22,12 +22,8 @@ export function useTokenAllowance(
   const contract = useTokenContract(tokenAddress, false)
 
   const { data: allowance } = useSWR(
-    ['useTokenAllowance', tokenAddress, owner, spender],
-    async () => {
-      if (!owner || !spender) return undefined
-
-      return contract?.callStatic.allowance(owner, spender)
-    },
+    owner && spender && contract ? ['useTokenAllowance', tokenAddress, owner, spender, contract] : null,
+    async ([, , _owner, _spender, _contract]) => _contract?.callStatic.allowance(_owner, _spender),
     ALLOWANCES_SWR_CONFIG
   )
 

--- a/apps/cowswap-frontend/src/legacy/state/cowToken/hooks.ts
+++ b/apps/cowswap-frontend/src/legacy/state/cowToken/hooks.ts
@@ -26,6 +26,7 @@ type VCowData = {
   unvested: CurrencyAmount<Currency> | undefined | null
   vested: CurrencyAmount<Currency> | undefined | null
 }
+
 interface SwapVCowCallbackParams {
   openModal: (message: string) => void
   closeModal: Command
@@ -56,21 +57,13 @@ export function useVCowData(): VCowData {
   const { account } = useWalletInfo()
 
   const { data: vestedResult, isLoading: isVestedLoading } = useSWR(
-    ['useVCowData.swappableBalanceOf', account, vCowContract],
-    async () => {
-      if (!account || !vCowContract) return undefined
-
-      return vCowContract.swappableBalanceOf(account)
-    }
+    account && vCowContract ? ['useVCowData.swappableBalanceOf', account, vCowContract] : null,
+    async ([, _account, contract]) => contract.swappableBalanceOf(_account)
   )
 
   const { data: totalResult, isLoading: isTotalLoading } = useSWR(
-    ['useVCowData.balanceOf', account, vCowContract],
-    async () => {
-      if (!account || !vCowContract) return undefined
-
-      return vCowContract.balanceOf(account)
-    }
+    account && vCowContract ? ['useVCowData.balanceOf', account, vCowContract] : null,
+    async ([, _account, contract]) => contract.balanceOf(_account)
   )
 
   const vested = useParseVCowResult(vestedResult)

--- a/apps/cowswap-frontend/src/modules/notifications/hooks/useUnreadNotifications.ts
+++ b/apps/cowswap-frontend/src/modules/notifications/hooks/useUnreadNotifications.ts
@@ -18,18 +18,19 @@ export function useUnreadNotifications(): UnreadNotifications {
   const readNotifications = useAtomValue(readNotificationsAtom)
 
   return (
-    useSWR([account, notifications, readNotifications], () => {
-      if (!account || !notifications) return EMPTY
+    useSWR(
+      account && notifications ? [account, notifications, readNotifications] : null,
+      ([, _notifications, _readNotifications]) => {
+        return _notifications.reduce<UnreadNotifications>((acc, notification) => {
+          const isRead = _readNotifications.includes(notification.id)
 
-      return notifications.reduce<UnreadNotifications>((acc, notification) => {
-        const isRead = readNotifications.includes(notification.id)
+          if (!isRead) {
+            acc[notification.id] = true
+          }
 
-        if (!isRead) {
-          acc[notification.id] = true
-        }
-
-        return acc
-      }, {})
-    }).data || EMPTY
+          return acc
+        }, {})
+      }
+    ).data || EMPTY
   )
 }

--- a/apps/cowswap-frontend/src/pages/Account/LockedGnoVesting/hooks.ts
+++ b/apps/cowswap-frontend/src/pages/Account/LockedGnoVesting/hooks.ts
@@ -61,13 +61,12 @@ export const useCowFromLockedGnoBalances = () => {
 
   const tokenDistro = useTokenDistroContract()
 
-  const { data, isLoading } = useSWR(['useCowFromLockedGnoBalances', account, allocated, tokenDistro], async () => {
-    if (account && tokenDistro && allocated.greaterThan(0)) {
-      return tokenDistro.balances(account)
-    }
-
-    return null
-  })
+  const { data, isLoading } = useSWR(
+    account && tokenDistro && allocated?.greaterThan(0)
+      ? ['useCowFromLockedGnoBalances', account, allocated, tokenDistro]
+      : null,
+    async ([, _account, , _tokenDistro]) => _tokenDistro.balances(_account)
+  )
 
   const claimed = useMemo(() => CurrencyAmount.fromRawAmount(_COW, data ? data.claimed.toString() : 0), [data])
 
@@ -84,6 +83,7 @@ interface ClaimCallbackParams {
   closeModal: Command
   isFirstClaim: boolean
 }
+
 export function useClaimCowFromLockedGnoCallback({
   openModal,
   closeModal,

--- a/libs/balances-and-allowances/src/hooks/useNativeTokenBalance.ts
+++ b/libs/balances-and-allowances/src/hooks/useNativeTokenBalance.ts
@@ -7,17 +7,15 @@ import useSWR, { SWRResponse } from 'swr'
 
 const SWR_CONFIG = { refreshInterval: ms`11s` }
 
-export function useNativeTokenBalance(account: string | undefined): SWRResponse<BigNumber | undefined> {
+export function useNativeTokenBalance(account: string | undefined): SWRResponse<BigNumber> {
   const provider = useWalletProvider()
 
   return useSWR(
-    ['useNativeTokenBalance', account, provider],
-    async () => {
-      if (!provider || !account) return undefined
+    account && provider ? ['useNativeTokenBalance', account, provider] : null,
+    async ([, _account, _provider]) => {
+      const contract = getMulticallContract(_provider)
 
-      const contract = getMulticallContract(provider)
-
-      return contract.callStatic.getEthBalance(account)
+      return contract.callStatic.getEthBalance(_account)
     },
     SWR_CONFIG
   )

--- a/libs/ens/src/hooks/useENSRegistrarContract.ts
+++ b/libs/ens/src/hooks/useENSRegistrarContract.ts
@@ -18,15 +18,13 @@ export function useENSRegistrarContract(): EnsRegistrar | undefined {
   const chainId = useWalletChainId()
 
   const { data } = useSWR(
-    ['useENSRegistrarContract', provider, chainId],
-    () => {
-      if (!chainId || !provider) return undefined
-
-      const address = ENS_REGISTRAR_ADDRESSES[chainId as SupportedChainId]
+    provider && chainId ? ['useENSRegistrarContract', provider, chainId] : null,
+    ([, _provider, _chainId]) => {
+      const address = ENS_REGISTRAR_ADDRESSES[_chainId as SupportedChainId]
 
       if (!address) return undefined
 
-      return getContract(address, EnsAbi, provider) as EnsRegistrar
+      return getContract(address, EnsAbi, _provider) as EnsRegistrar
     },
     SWR_NO_REFRESH_OPTIONS
   )

--- a/libs/ens/src/hooks/useENSResolver.ts
+++ b/libs/ens/src/hooks/useENSResolver.ts
@@ -4,16 +4,12 @@ import useSWR, { SWRResponse } from 'swr'
 
 import { useENSRegistrarContract } from './useENSRegistrarContract'
 
-export function useENSResolver(node: string | undefined): SWRResponse<string | undefined> {
+export function useENSResolver(node: string | undefined): SWRResponse<string> {
   const registrarContract = useENSRegistrarContract()
 
   return useSWR(
-    ['useENSResolver', node, registrarContract],
-    async () => {
-      if (!registrarContract || !node) return undefined
-
-      return registrarContract.callStatic.resolver(node)
-    },
+    node && registrarContract ? ['useENSResolver', node, registrarContract] : null,
+    async ([_, _node, contract]) => contract.callStatic.resolver(_node),
     SWR_NO_REFRESH_OPTIONS
   )
 }

--- a/libs/ens/src/hooks/useENSResolverContract.ts
+++ b/libs/ens/src/hooks/useENSResolverContract.ts
@@ -10,11 +10,9 @@ export function useENSResolverContract(address: string | undefined): EnsPublicRe
   const chainId = useWalletChainId()
 
   const { data } = useSWR(
-    ['useENSResolverContract', provider, chainId, address],
-    () => {
-      if (!chainId || !provider || !address) return undefined
-
-      return getContract(address, EnsPublicResolverAbi, provider) as EnsPublicResolver
+    provider && chainId && address ? ['useENSResolverContract', provider, chainId, address] : null,
+    ([, _provider, , _address]) => {
+      return getContract(_address, EnsPublicResolverAbi, _provider) as EnsPublicResolver
     },
     SWR_NO_REFRESH_OPTIONS
   )

--- a/libs/ens/src/hooks/useENSResolverMethod.ts
+++ b/libs/ens/src/hooks/useENSResolverMethod.ts
@@ -19,12 +19,8 @@ export function useENSResolverMethod(
   )
 
   const { data, isLoading } = useSWR(
-    ['useENSResolverMethod' + method, resolverContract, ensNodeArgument],
-    async () => {
-      if (!resolverContract || !ensNodeArgument) return undefined
-
-      return resolverContract.callStatic[method](ensNodeArgument)
-    },
+    resolverContract && ensNodeArgument ? ['useENSResolverMethod', method, resolverContract, ensNodeArgument] : null,
+    async ([, _method, contract, arg]) => contract.callStatic[_method](arg),
     SWR_NO_REFRESH_OPTIONS
   )
 

--- a/libs/wallet/src/web3-react/hooks/useIsSmartContractWallet.ts
+++ b/libs/wallet/src/web3-react/hooks/useIsSmartContractWallet.ts
@@ -19,17 +19,13 @@ function useHasContractAtAddress(): boolean | undefined {
   const { account } = useWalletInfo()
 
   const { data } = useSWR(
-    ['isSmartContract', account, provider],
-    async () => {
-      if (!account || !provider) {
-        return false
-      }
-
+    account && provider ? ['isSmartContract', account, provider] : null,
+    async ([, _account, _provider]) => {
       try {
-        const code = await provider.getCode(account)
+        const code = await _provider.getCode(_account)
         return code !== '0x'
       } catch (e: any) {
-        console.debug(`checkIsSmartContractWallet: failed to check address ${account}`, e.message)
+        console.debug(`checkIsSmartContractWallet: failed to check address ${_account}`, e.message)
         return false
       }
     },


### PR DESCRIPTION
# Summary

No function changes, just refactor SWR usage.

Not sure whether it was working 100% before or not, but I noticed that we were not properly passing the arguments to the fetcher fns when using `useSwr`.



See the examples in their docs for reference https://swr.vercel.app/docs/arguments

The changes here mostly:
1. Short circuit the conditions to run the query one level above
2. Pass all the fetcher arguments as parameters

# To Test

Everything should work as before...

1. Orders fetching
4. Gas price fetching
5. Allowance fetching
6. vCow balances/swappable amount
7. Everything ENS related
8. Notifications
9. Native token balance
10. Locked GNO
11. Smart contract detection (besides the Safe)
