### PR TITLE
fix: close account modal on navigation

### DIFF
--- a/apps/cowswap-frontend/src/modules/account/containers/OrdersPanel/index.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/OrdersPanel/index.tsx
@@ -1,7 +1,7 @@
 import { useSetAtom } from 'jotai'
 
 import Close from '@cowprotocol/assets/images/x.svg?react'
-import { UI, Media } from '@cowprotocol/ui'
+import { Media, UI } from '@cowprotocol/ui'
 import { useWalletDetails, useWalletInfo } from '@cowprotocol/wallet'
 
 import { transparentize } from 'color2k'
@@ -14,6 +14,7 @@ import { toggleAccountSelectorModalAtom } from 'modules/wallet/containers/Accoun
 import { useCategorizeRecentActivity } from 'common/hooks/useCategorizeRecentActivity'
 
 import { useAccountModalState } from '../../hooks/useAccountModalState'
+import { useCloseAccountModalOnNavigate } from '../../hooks/useCloseAccountModalOnNavigate'
 import { useToggleAccountModal } from '../../hooks/useToggleAccountModal'
 import { AccountDetails } from '../AccountDetails'
 
@@ -75,7 +76,6 @@ const Header = styled.div`
   position: sticky;
   top: 0;
   left: 0;
-  width: 100%;
   z-index: 20;
 
   ${Media.upToMedium()} {
@@ -138,6 +138,8 @@ export function OrdersPanel() {
   const { pendingActivity, confirmedActivity } = useCategorizeRecentActivity()
 
   const handleCloseOrdersPanel = useToggleAccountModal()
+
+  useCloseAccountModalOnNavigate()
 
   if (!active || !isOpen || !account) {
     return null

--- a/apps/cowswap-frontend/src/modules/account/hooks/useCloseAccountModalOnNavigate.ts
+++ b/apps/cowswap-frontend/src/modules/account/hooks/useCloseAccountModalOnNavigate.ts
@@ -1,5 +1,7 @@
 import { useLayoutEffect } from 'react'
+
 import { useLocation } from 'react-router-dom'
+
 import { useCloseAccountModal } from './useToggleAccountModal'
 
 /**

--- a/apps/cowswap-frontend/src/modules/account/hooks/useCloseAccountModalOnNavigate.ts
+++ b/apps/cowswap-frontend/src/modules/account/hooks/useCloseAccountModalOnNavigate.ts
@@ -1,0 +1,18 @@
+import { useLayoutEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+import { useCloseAccountModal } from './useToggleAccountModal'
+
+/**
+ * Every time the url changes, closes the account modal
+ * If it's not open it has no effect
+ */
+export function useCloseAccountModalOnNavigate(): null {
+  const location = useLocation()
+  const closeAccountModal = useCloseAccountModal()
+
+  useLayoutEffect(() => {
+    closeAccountModal()
+  }, [location.pathname])
+
+  return null
+}

--- a/apps/cowswap-frontend/src/modules/account/hooks/useCloseAccountModalOnNavigate.ts
+++ b/apps/cowswap-frontend/src/modules/account/hooks/useCloseAccountModalOnNavigate.ts
@@ -14,7 +14,7 @@ export function useCloseAccountModalOnNavigate(): null {
 
   useLayoutEffect(() => {
     closeAccountModal()
-  }, [location.pathname])
+  }, [location.pathname, closeAccountModal])
 
   return null
 }

--- a/apps/cowswap-frontend/src/modules/account/hooks/useToggleAccountModal.ts
+++ b/apps/cowswap-frontend/src/modules/account/hooks/useToggleAccountModal.ts
@@ -7,3 +7,9 @@ export function useToggleAccountModal() {
 
   return () => updateAccountModalState((prev) => ({ isOpen: !prev.isOpen }))
 }
+
+export function useCloseAccountModal() {
+  const updateAccountModalState = useSetAtom(updateAccountModalStateAtom)
+
+  return () => updateAccountModalState({ isOpen: false })
+}

--- a/apps/cowswap-frontend/src/modules/account/hooks/useToggleAccountModal.ts
+++ b/apps/cowswap-frontend/src/modules/account/hooks/useToggleAccountModal.ts
@@ -1,15 +1,16 @@
 import { useSetAtom } from 'jotai'
+import { useCallback } from 'react'
 
 import { updateAccountModalStateAtom } from '../state/accountModalState'
 
 export function useToggleAccountModal() {
   const updateAccountModalState = useSetAtom(updateAccountModalStateAtom)
 
-  return () => updateAccountModalState((prev) => ({ isOpen: !prev.isOpen }))
+  return useCallback(() => updateAccountModalState((prev) => ({ isOpen: !prev.isOpen })), [updateAccountModalState])
 }
 
 export function useCloseAccountModal() {
   const updateAccountModalState = useSetAtom(updateAccountModalStateAtom)
 
-  return () => updateAccountModalState({ isOpen: false })
+  return useCallback(() => updateAccountModalState({ isOpen: false }), [updateAccountModalState])
 }


### PR DESCRIPTION
# Summary

Close account modal when changing the current page

# To Test

1. Open account modal
2. On the header menu, select a different page (SWAP, LIMIT, TWAP, Tokens, Account, etc)
* Account modal should be closed