### PR TITLE
chore: update unsupported FAQ link

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/swap/UnsupportedCurrencyFooter/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/swap/UnsupportedCurrencyFooter/index.tsx
@@ -1,7 +1,7 @@
 import { UNSUPPORTED_TOKENS_FAQ_URL } from '@cowprotocol/common-const'
 
 import { transparentize } from 'color2k'
-import { HashLink } from 'react-router-hash-link'
+import { NavLink } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
 import UnsupportedCurrencyFooterMod, {
@@ -15,9 +15,9 @@ const DEFAULT_DETAILS_TEXT = (
     which do not operate optimally with CoW Protocol.
     <p>
       For more information, please refer to the{' '}
-      <HashLink target="_blank" to={UNSUPPORTED_TOKENS_FAQ_URL}>
+      <NavLink target="_blank" to={UNSUPPORTED_TOKENS_FAQ_URL}>
         FAQ
-      </HashLink>
+      </NavLink>
       .
     </p>
   </div>

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokenTags/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokenTags/index.tsx
@@ -3,7 +3,7 @@ import { HoverTooltip } from '@cowprotocol/ui'
 
 import ICON_GAS_FREE from 'assets/icon/gas-free.svg'
 import SVG from 'react-inlinesvg'
-import { HashLink } from 'react-router-hash-link'
+import { NavLink } from 'react-router-dom'
 
 import * as styledEl from './styled'
 
@@ -57,9 +57,9 @@ export function TokenTags({
     <TagDescriptor tags={tagsToShow}>
       {isUnsupported && (
         <styledEl.TagLink>
-          <HashLink to={UNSUPPORTED_TOKENS_FAQ_URL} target="_blank" onClick={(e) => e.stopPropagation()}>
+          <NavLink to={UNSUPPORTED_TOKENS_FAQ_URL} target="_blank">
             FAQ
-          </HashLink>
+          </NavLink>
         </styledEl.TagLink>
       )}
     </TagDescriptor>

--- a/libs/common-const/src/common.ts
+++ b/libs/common-const/src/common.ts
@@ -1,11 +1,9 @@
 import { ethFlowBarnJson, ethFlowProdJson } from '@cowprotocol/abis'
-import { IpfsConfig, mapSupportedNetworks, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { mapSupportedNetworks, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { Fraction, Percent } from '@uniswap/sdk-core'
 
 import BigNumber from 'bignumber.js'
 import ms from 'ms.macro'
-
-import { PINATA_API_KEY, PINATA_SECRET_API_KEY } from './ipfs'
 
 // TODO: move those consts to src/constants/common
 
@@ -123,7 +121,7 @@ export const GAS_API_KEYS: Record<SupportedChainId, string | null> = {
   [SupportedChainId.SEPOLIA]: null,
 }
 
-export const UNSUPPORTED_TOKENS_FAQ_URL = '/faq/trading#what-token-pairs-does-cowswap-allow-to-trade'
+export const UNSUPPORTED_TOKENS_FAQ_URL = 'https://docs.cow.fi/cow-protocol/reference/core/tokens'
 
 // fee threshold - should be greater than percentage, show warning
 export const FEE_SIZE_THRESHOLD = 10 // 10%
@@ -162,28 +160,12 @@ export const SWR_NO_REFRESH_OPTIONS = {
   refreshInterval: 0,
 }
 
-// TODO: show banner warning when PINATA env vars are missing
-export const COW_IPFS_OPTIONS: IpfsConfig = {
-  pinataApiKey: PINATA_API_KEY,
-  pinataApiSecret: PINATA_SECRET_API_KEY,
-}
-
 // These are used for Account sidebar menu
 export const ACCOUNT_MENU_LINKS = [
   { title: 'Overview', url: '/account' },
   { title: 'Tokens', url: '/account/tokens' },
   // { title: 'Governance', url: '/account/governance' },
   // { title: 'Affiliate', url: '/account/affiliate' },
-]
-
-// These are used for FAQ sidebar menu
-export const FAQ_MENU_LINKS = [
-  { title: 'General', url: '/faq' },
-  { title: 'Protocol', url: '/faq/protocol' },
-  { title: 'Token', url: '/faq/token' },
-  { title: 'Trading', url: '/faq/trading' },
-  { title: 'Limit orders', url: '/faq/limit-order' },
-  { title: 'Selling Native tokens', url: '/faq/sell-native' },
 ]
 
 // Min USD value to show surplus


### PR DESCRIPTION
# Summary

<img width="1211" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/2844542d-3f0c-4d7e-acf9-b011c06c955f">


# To Test

The FAQ link should lead to https://docs.cow.fi/cow-protocol/reference/core/tokens
