### PR TITLE
chore: fix limit orders table width

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/pure/TradePageLayout/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/TradePageLayout/index.tsx
@@ -36,6 +36,7 @@ export const PrimaryWrapper = styled.div`
 export const SecondaryWrapper = styled.div`
   display: flex;
   width: 100%;
+  overflow: hidden;
 
   ${Media.upToLargeAlt()} {
     flex-flow: column wrap;


### PR DESCRIPTION
# Summary

<img width="749" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/a8b174c6-16e5-4d21-8222-73e8675a083c">

# To Test

1. Create at least one limit order
2. Adjust the window width to be less than 1300px
- [ ] AR: the order table goes out of the window
- [ ] ER: the order table becomes horizontally scrollable
