### PR TITLE
chore: fix order progress bar style

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/OrderProgressBar/styled.ts
+++ b/apps/cowswap-frontend/src/legacy/components/OrderProgressBar/styled.ts
@@ -31,7 +31,7 @@ export const ProgressBarWrapper = animated(styled.div`
 `)
 
 export const ProgressBarInnerWrapper = styled.div`
-  background-color: var(${UI.COLOR_PAPER_DARKEST});
+  background-color: var(${UI.COLOR_PAPER});
   border-radius: 18px;
   overflow: visible !important;
   position: relative;

--- a/libs/snackbars/src/containers/SnackbarsWidget/index.tsx
+++ b/libs/snackbars/src/containers/SnackbarsWidget/index.tsx
@@ -2,6 +2,7 @@ import { useAtomValue, useSetAtom } from 'jotai'
 import { useResetAtom } from 'jotai/utils'
 import { ReactElement, useCallback, useEffect, useMemo } from 'react'
 
+import { useMediaQuery } from '@cowprotocol/common-hooks'
 import { Media, UI } from '@cowprotocol/ui'
 
 import ms from 'ms.macro'
@@ -93,7 +94,8 @@ export function SnackbarsWidget({ hidden }: SnackbarsWidgetProps) {
     [removeSnackbar]
   )
 
-  const isOverlayDisplayed = snackbars.length > 0 && !hidden
+  const isUpToSmall = useMediaQuery(Media.upToSmall(false))
+  const isOverlayDisplayed = snackbars.length > 0 && !hidden && isUpToSmall
 
   useEffect(() => {
     document.body.style.overflow = isOverlayDisplayed ? 'hidden' : ''


### PR DESCRIPTION
# Summary

1. Fixed order progress bar style
2. Fixed scrolling issue with snackbars. When a snackbar (order created, filled, etc.) is displayed the page is not scrollable. It's expected, but only for small (mobile) screen size, because overlay is displayed in this case.

<img width="686" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/0cf05da6-33bd-4946-8598-3c4d8b91523e">

<img width="525" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/f37bed3d-78c2-4e74-82b9-536fa4c9f46c">

# To Test

1. The order progress bar background should be lighter
2. When a snackbar is displayed not in mobile screen then page should be scrollable
