### PR TITLE
chore(swap): fix slippage button disabled style

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/TransactionSettings/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/TransactionSettings/index.tsx
@@ -1,7 +1,6 @@
 import { RowBetween, RowFixed } from '@cowprotocol/ui'
 import { UI } from '@cowprotocol/ui'
 
-import { darken } from 'color2k'
 import styled from 'styled-components/macro'
 
 import SlippageTabsMod, { TransactionSettingsProps, OptionCustom } from './TransactionSettingsMod'
@@ -9,7 +8,8 @@ import SlippageTabsMod, { TransactionSettingsProps, OptionCustom } from './Trans
 const Wrapper = styled.div`
   ${RowBetween} > button, ${OptionCustom} {
     &:disabled {
-      background-color: ${({ theme }) => darken(theme.background, 0.031)};
+      color: var(${UI.COLOR_TEXT_OPACITY_50});
+      background-color: var(${UI.COLOR_PAPER});
       border: none;
       pointer-events: none;
     }


### PR DESCRIPTION
# Summary

<img width="532" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/0de48e06-a8d2-43e7-994f-2c0ca572c3c2">

# To Test

1. Set ETH as sell token in Swap
2. Open settings
- [ ] ER: "Auto" should be visible and not clicakble
