### PR TITLE
fix(trade): keep trade state after navigating from trade widgets

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/hooks/useTradeRouteContext.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useTradeRouteContext.ts
@@ -1,28 +1,48 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
+
+import { useWalletInfo } from '@cowprotocol/wallet'
 
 import { useDerivedTradeState } from './useDerivedTradeState'
 import { useTradeState } from './useTradeState'
 
-import { TradeUrlParams } from '../types/TradeRawState'
+import { getDefaultTradeRawState, TradeUrlParams } from '../types/TradeRawState'
 
 export function useTradeRouteContext(): TradeUrlParams {
+  const { chainId: walletChainId } = useWalletInfo()
   const { state } = useTradeState()
   const derivedState = useDerivedTradeState()
+  const prevContextRef = useRef<TradeUrlParams>()
+
   const { orderKind, inputCurrencyAmount, outputCurrencyAmount } = derivedState || {}
-  const { inputCurrencyId, outputCurrencyId, chainId } = state || {}
+  const targetChainId = state?.chainId || walletChainId
+  const { inputCurrencyId, outputCurrencyId } = state || getDefaultTradeRawState(targetChainId)
+
+  const prevContext = prevContextRef.current
 
   const inputCurrencyAmountStr = inputCurrencyAmount?.toExact()
   const outputCurrencyAmountStr = outputCurrencyAmount?.toExact()
 
-  return useMemo(
+  const context: TradeUrlParams = useMemo(
     () => ({
       inputCurrencyId: inputCurrencyId || undefined,
       outputCurrencyId: outputCurrencyId || undefined,
       inputCurrencyAmount: inputCurrencyAmountStr,
       outputCurrencyAmount: outputCurrencyAmountStr,
-      chainId: chainId?.toString(),
+      chainId: targetChainId?.toString(),
       orderKind,
     }),
-    [orderKind, inputCurrencyId, outputCurrencyId, chainId, inputCurrencyAmountStr, outputCurrencyAmountStr]
+    [orderKind, inputCurrencyId, outputCurrencyId, targetChainId, inputCurrencyAmountStr, outputCurrencyAmountStr]
   )
+
+  useEffect(() => {
+    if (state) {
+      prevContextRef.current = context
+    }
+  }, [state, context])
+
+  /**
+   * If there is no state, it means that current page is not a trade widget page. For example: account page.
+   * In this case, we should take the previous context to keep the trade widget state.
+   */
+  return !state && prevContext ? prevContext : context
 }


### PR DESCRIPTION
# Summary

Fixes #4595

The header menu "Trade" uses `useTradeRouteContext()` for building links.
This hook wasn't considering the case when we navigate to not trade page (e.g. account page).
When we in Account page, then `useTradeState()` returns undefined and the links in the menu are not correct.
There are two cases:
1. We came to Account page from trade widget
2. Account page was just open (there are no items in the History API)

In the first case we should just take the previous value of the context.
In the second case we don't have previous context and we should use default one (`getDefaultTradeRawState`).


# To Test

See #4595
