### PR TITLE
refactor: memoize hook objs

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useApproveState.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useApproveState.ts
@@ -73,7 +73,7 @@ export function useApproveState(
 
   const state = useAuxApprovalState(approvalStateBase, currentAllowance)
 
-  return { state, currentAllowance }
+  return useSafeMemo(() => ({ state, currentAllowance }), [state, currentAllowance])
 }
 
 /**

--- a/apps/cowswap-frontend/src/common/hooks/useCategorizeRecentActivity.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useCategorizeRecentActivity.ts
@@ -41,7 +41,7 @@ export function useCategorizeRecentActivity() {
       [[], []]
     )
   }, [allRecentActivity, allTransactions])
-  return { pendingActivity, confirmedActivity }
+  return useMemo(() => ({ pendingActivity, confirmedActivity }), [pendingActivity, confirmedActivity])
 }
 
 function isEthFlowOrderNotCreated(

--- a/apps/cowswap-frontend/src/common/hooks/useConfirmPriceImpactWithoutFee.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useConfirmPriceImpactWithoutFee.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import { ALLOWED_PRICE_IMPACT_HIGH, PRICE_IMPACT_WITHOUT_FEE_CONFIRM_MIN } from '@cowprotocol/common-const'
 import { Percent } from '@uniswap/sdk-core'
@@ -60,8 +60,11 @@ export function useConfirmPriceImpactWithoutFee() {
     [triggerConfirmation]
   )
 
-  return {
-    confirmPriceImpactWithoutFee,
-    isConfirmed,
-  }
+  return useMemo(
+    () => ({
+      confirmPriceImpactWithoutFee,
+      isConfirmed,
+    }),
+    [confirmPriceImpactWithoutFee, isConfirmed]
+  )
 }

--- a/apps/cowswap-frontend/src/common/hooks/useModalState.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useModalState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { Command } from '@cowprotocol/types'
 export interface ModalState<T> {
@@ -32,5 +32,5 @@ export function useModalState<T>(trigger?: boolean): ModalState<T> {
     }
   }, [trigger, openModal, closeModal])
 
-  return { isModalOpen, context, openModal, closeModal }
+  return useMemo(() => ({ isModalOpen, context, openModal, closeModal }), [isModalOpen, context, openModal, closeModal])
 }

--- a/apps/cowswap-frontend/src/common/hooks/usePendingApprovalModal.tsx
+++ b/apps/cowswap-frontend/src/common/hooks/usePendingApprovalModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { Command } from '@cowprotocol/types'
 
@@ -18,26 +18,29 @@ export function usePendingApprovalModal(params?: PendingApprovalModalParams) {
   const state = useModalState<string>()
   const { closeModal, context } = state
 
-  const onDismissCallback = () => {
+  const onDismissCallback = useCallback(() => {
     closeModal()
     onDismiss?.()
-  }
+  }, [closeModal, onDismiss])
 
-  const Title = (
-    <>
-      Approving <strong>{currencySymbol || context}</strong> for trading
-    </>
-  )
+  return useMemo(() => {
 
-  const Modal = (
-    <ConfirmationPendingContent
-      modalMode={!!modalMode}
-      onDismiss={onDismissCallback}
-      title={Title}
-      description="Approving token"
-      operationLabel="token approval"
-    />
-  )
+    const Title = (
+      <>
+        Approving <strong>{currencySymbol || context}</strong> for trading
+      </>
+    )
 
-  return { Modal, state }
+    const Modal = (
+      <ConfirmationPendingContent
+        modalMode={!!modalMode}
+        onDismiss={onDismissCallback}
+        title={Title}
+        description="Approving token"
+        operationLabel="token approval"
+      />
+    )
+
+    return ({ Modal, state })
+  }, [currencySymbol, context, modalMode, onDismissCallback, state])
 }

--- a/apps/cowswap-frontend/src/cosmos.decorator.tsx
+++ b/apps/cowswap-frontend/src/cosmos.decorator.tsx
@@ -1,7 +1,7 @@
 import '@reach/dialog/styles.css'
 import './polyfills'
 
-import React, { ReactNode, StrictMode, useCallback, useContext } from 'react'
+import { ReactNode, StrictMode, useCallback, useContext } from 'react'
 
 import IMAGE_MOON from '@cowprotocol/assets/cow-swap/moon.svg'
 import IMAGE_SUN from '@cowprotocol/assets/cow-swap/sun.svg'
@@ -37,7 +37,7 @@ const DarkModeToggle = ({ children }: { children?: ReactNode }) => {
   const [darkMode, toggleDarkModeAux] = useDarkModeManager()
   const toggleDarkMode = useCallback(() => {
     toggleDarkModeAux()
-  }, [toggleDarkModeAux, darkMode])
+  }, [toggleDarkModeAux])
   const label = (darkMode ? 'Light' : 'Dark') + ' Mode'
   const description = `${darkMode ? 'Sun/light' : 'Moon/dark'} mode icon`
 

--- a/apps/cowswap-frontend/src/legacy/components/OrderProgressBar/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/OrderProgressBar/index.tsx
@@ -22,21 +22,21 @@ import { useCancelOrder } from 'common/hooks/useCancelOrder'
 import { CancelButton } from 'common/pure/CancelButton'
 
 import {
-  ProgressBarWrapper,
-  ProgressBarInnerWrapper,
-  SuccessProgress,
   CowProtocolIcon,
+  DelayedProgress,
+  GreenCheckIcon,
   GreenClockIcon,
+  OrangeClockIcon,
+  ProgressBarInnerWrapper,
+  ProgressBarWrapper,
+  StatusGraph,
+  StatusMsg,
   StatusMsgContainer,
   StatusWrapper,
-  StatusMsg,
-  StatusGraph,
-  OrangeClockIcon,
-  DelayedProgress,
-  WarningLogo,
-  GreenCheckIcon,
-  StyledExternalLink,
   StyledCoWLink,
+  StyledExternalLink,
+  SuccessProgress,
+  WarningLogo,
 } from './styled'
 
 import { TransactionExecutedContent } from '../TransactionExecutedContent'

--- a/apps/cowswap-frontend/src/legacy/hooks/useTransactionErrorModal.tsx
+++ b/apps/cowswap-frontend/src/legacy/hooks/useTransactionErrorModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { Command } from '@cowprotocol/types'
 
@@ -7,21 +7,24 @@ import { ApplicationModal } from 'legacy/state/application/reducer'
 
 import { CowModal } from 'common/pure/Modal'
 import { TransactionErrorContent } from 'common/pure/TransactionErrorContent'
+
 export default function useTransactionErrorModal() {
   const openModal = useOpenModal(ApplicationModal.TRANSACTION_ERROR)
   const closeModal = useCloseModals()
   const showTransactionErrorModal = useModalIsOpen(ApplicationModal.TRANSACTION_ERROR)
 
-  return {
+  const TransactionErrorModal = useCallback(
+    ({ message, onDismiss }: { message?: string; onDismiss: Command }) => (
+      <CowModal isOpen={!!message && showTransactionErrorModal} onDismiss={closeModal}>
+        <TransactionErrorContent modalMode onDismiss={onDismiss} message={message || ''} />
+      </CowModal>
+    ),
+    [closeModal, showTransactionErrorModal]
+  )
+
+  return useMemo(() => ({
     openModal,
     closeModal,
-    TransactionErrorModal: useCallback(
-      ({ message, onDismiss }: { message?: string; onDismiss: Command }) => (
-        <CowModal isOpen={!!message && showTransactionErrorModal} onDismiss={closeModal}>
-          <TransactionErrorContent modalMode onDismiss={onDismiss} message={message || ''} />
-        </CowModal>
-      ),
-      [closeModal, showTransactionErrorModal]
-    ),
-  }
+    TransactionErrorModal,
+  }), [openModal, closeModal, TransactionErrorModal])
 }

--- a/apps/cowswap-frontend/src/legacy/state/cowToken/hooks.ts
+++ b/apps/cowswap-frontend/src/legacy/state/cowToken/hooks.ts
@@ -84,7 +84,7 @@ export function useVCowData(): VCowData {
 
   const isLoading = isVestedLoading || isTotalLoading
 
-  return { isLoading, vested, unvested, total }
+  return useMemo(() => ({ isLoading, vested, unvested, total }), [isLoading, vested, unvested, total])
 }
 
 /**
@@ -97,7 +97,7 @@ export function useSwapVCowCallback({ openModal, closeModal }: SwapVCowCallbackP
   const addTransaction = useTransactionAdder()
   const vCowToken = chainId ? V_COW[chainId] : undefined
 
-  const swapCallback = useCallback(async () => {
+  return useCallback(async () => {
     if (!account) {
       throw new Error('Not connected')
     }
@@ -137,10 +137,6 @@ export function useSwapVCowCallback({ openModal, closeModal }: SwapVCowCallbackP
       })
       .finally(closeModal)
   }, [account, addTransaction, chainId, closeModal, openModal, vCowContract, vCowToken])
-
-  return {
-    swapCallback,
-  }
 }
 
 /**

--- a/apps/cowswap-frontend/src/modules/advancedOrders/hooks/useAdvancedOrdersActions.ts
+++ b/apps/cowswap-frontend/src/modules/advancedOrders/hooks/useAdvancedOrdersActions.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { changeSwapAmountAnalytics } from '@cowprotocol/analytics'
 import { Currency } from '@uniswap/sdk-core'
@@ -64,10 +64,13 @@ export function useAdvancedOrdersActions() {
     resetTradeQuote()
   }, [resetTradeQuote, onSwitchTokensDefault])
 
-  return {
-    onCurrencySelection,
-    onUserInput,
-    onChangeRecipient,
-    onSwitchTokens,
-  }
+  return useMemo(
+    () => ({
+      onCurrencySelection,
+      onUserInput,
+      onChangeRecipient,
+      onSwitchTokens,
+    }),
+    [onCurrencySelection, onUserInput, onChangeRecipient, onSwitchTokens]
+  )
 }

--- a/apps/cowswap-frontend/src/modules/appData/state/atoms.ts
+++ b/apps/cowswap-frontend/src/modules/appData/state/atoms.ts
@@ -1,6 +1,8 @@
 import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 
+import { deepEqual } from '@cowprotocol/common-utils'
+
 import { buildDocFilterFn, buildInverseDocFilterFn } from './utils'
 
 import {
@@ -18,9 +20,16 @@ import { updateFullAppData } from '../utils/fullAppData'
  */
 export const appDataInfoAtom = atom<AppDataInfo | null, [AppDataInfo | null], unknown>(
   null,
-  (_get, set, appDataInfo) => {
+  (get, set, appDataInfo) => {
+    const previous = get(appDataInfoAtom)
+
+    // Do not update if both are equal to avoid unnecessary re-renders
+    if (previous && appDataInfo && deepEqual(previous, appDataInfo)) {
+      return
+    }
+
     set(appDataInfoAtom, appDataInfo)
-    updateFullAppData(appDataInfo?.fullAppData ?? undefined)
+    updateFullAppData(appDataInfo?.fullAppData)
   }
 )
 

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWidget/hooks/useLimitOrdersWidgetActions.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWidget/hooks/useLimitOrdersWidgetActions.ts
@@ -1,5 +1,5 @@
 import { useAtomValue } from 'jotai'
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { changeSwapAmountAnalytics } from '@cowprotocol/analytics'
 import { isSellOrder, tryParseCurrencyAmount } from '@cowprotocol/common-utils'
@@ -56,5 +56,8 @@ export function useLimitOrdersWidgetActions(): TradeWidgetActions {
     [updateLimitOrdersState]
   )
 
-  return { onUserInput, onSwitchTokens, onChangeRecipient, onCurrencySelection }
+  return useMemo(
+    () => ({ onUserInput, onSwitchTokens, onChangeRecipient, onCurrencySelection }),
+    [onUserInput, onSwitchTokens, onChangeRecipient, onCurrencySelection]
+  )
 }

--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useGetInitialPrice.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useGetInitialPrice.ts
@@ -13,6 +13,7 @@ import { useLimitOrdersDerivedState } from 'modules/limitOrders/hooks/useLimitOr
 import { parsePrice } from 'modules/limitOrders/utils/parsePrice'
 
 import { getNativePrice } from 'api/cowProtocol'
+import { useSafeMemo } from 'common/hooks/useSafeMemo'
 
 type PriceResult = number | Error | undefined
 
@@ -126,5 +127,5 @@ export function useGetInitialPrice(): { price: Fraction | null; isLoading: boole
     return () => clearInterval(interval)
   }, [isWindowVisible])
 
-  return { price, isLoading }
+  return useSafeMemo(() => ({ price, isLoading }), [price, isLoading])
 }

--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useSafeBundleFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useSafeBundleFlowContext.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { useSafeAppsSdk } from '@cowprotocol/wallet'
 
 import { SafeBundleFlowContext, TradeFlowContext } from 'modules/limitOrders/services/types'
@@ -11,9 +13,11 @@ export function useSafeBundleFlowContext(tradeContext: TradeFlowContext | null):
   const spender = useTradeSpenderAddress()
   const safeAppsSdk = useSafeAppsSdk()
 
-  if (!tradeContext || !erc20Contract || !spender || !safeAppsSdk) {
-    return null
-  }
+  return useMemo(() => {
+    if (!tradeContext || !erc20Contract || !spender || !safeAppsSdk) {
+      return null
+    }
 
-  return { ...tradeContext, erc20Contract, spender, safeAppsSdk }
+    return { ...tradeContext, erc20Contract, spender, safeAppsSdk }
+  }, [tradeContext, erc20Contract, spender, safeAppsSdk])
 }

--- a/apps/cowswap-frontend/src/modules/permit/hooks/usePreGeneratedPermitInfo.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/usePreGeneratedPermitInfo.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { SWR_NO_REFRESH_OPTIONS } from '@cowprotocol/common-const'
 import { PermitInfo } from '@cowprotocol/permit-utils'
 import { useWalletInfo } from '@cowprotocol/wallet'
@@ -25,5 +27,5 @@ export function usePreGeneratedPermitInfo(): {
     { ...SWR_NO_REFRESH_OPTIONS, fallbackData: {} }
   )
 
-  return { allPermitInfo: data, isLoading }
+  return useMemo(() => ({ allPermitInfo: data, isLoading }), [data, isLoading])
 }

--- a/apps/cowswap-frontend/src/modules/permit/hooks/usePreGeneratedPermitInfoForToken.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/usePreGeneratedPermitInfoForToken.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { Nullish } from 'types'
 
 import { usePreGeneratedPermitInfo } from './usePreGeneratedPermitInfo'
@@ -17,8 +19,11 @@ export function usePreGeneratedPermitInfoForToken(token: Nullish<{ address: stri
 
   const permitInfo = address ? allPermitInfo[address] : undefined
 
-  return {
-    permitInfo,
-    isLoading,
-  }
+  return useMemo(
+    () => ({
+      permitInfo,
+      isLoading,
+    }),
+    [permitInfo, isLoading]
+  )
 }

--- a/apps/cowswap-frontend/src/modules/swap/containers/EthFlow/hooks/useRemainingNativeTxsAndCosts.ts
+++ b/apps/cowswap-frontend/src/modules/swap/containers/EthFlow/hooks/useRemainingNativeTxsAndCosts.ts
@@ -99,5 +99,5 @@ export default function useRemainingNativeTxsAndCosts({
     }
   }, [nativeInput, chainId, txCosts, nativeBalance])
 
-  return { balanceChecks, ...txCosts }
+  return useMemo(() => ({ balanceChecks, ...txCosts }), [balanceChecks, txCosts])
 }

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useBaseSafeBundleFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useBaseSafeBundleFlowContext.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { getWrappedToken } from '@cowprotocol/common-utils'
 import { OrderKind } from '@cowprotocol/cow-sdk'
 import { useSafeAppsSdk } from '@cowprotocol/wallet'
@@ -19,21 +21,23 @@ export function useBaseSafeBundleFlowContext(): BaseSafeFlowContext | null {
   const safeAppsSdk = useSafeAppsSdk()
   const provider = useWalletProvider()
 
-  if (!baseProps.trade || !settlementContract || !spender || !safeAppsSdk || !provider) return null
+  return useMemo(() => {
+    if (!baseProps.trade || !settlementContract || !spender || !safeAppsSdk || !provider) return null
 
-  const baseContext = getFlowContext({
-    baseProps,
-    sellToken,
-    kind: baseProps.trade.tradeType === TradeType.EXACT_INPUT ? OrderKind.SELL : OrderKind.BUY,
-  })
+    const baseContext = getFlowContext({
+      baseProps,
+      sellToken,
+      kind: baseProps.trade.tradeType === TradeType.EXACT_INPUT ? OrderKind.SELL : OrderKind.BUY,
+    })
 
-  if (!baseContext) return null
+    if (!baseContext) return null
 
-  return {
-    ...baseContext,
-    settlementContract,
-    spender,
-    safeAppsSdk,
-    provider,
-  }
+    return {
+      ...baseContext,
+      settlementContract,
+      spender,
+      safeAppsSdk,
+      provider,
+    }
+  }, [baseProps, settlementContract, spender, safeAppsSdk, provider, sellToken])
 }

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useEthFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useEthFlowContext.ts
@@ -1,4 +1,5 @@
 import { useSetAtom } from 'jotai'
+import { useMemo } from 'react'
 
 import { NATIVE_CURRENCIES } from '@cowprotocol/common-const'
 import { OrderKind, SupportedChainId } from '@cowprotocol/cow-sdk'
@@ -24,19 +25,25 @@ export function useEthFlowContext(): EthFlowContext | null {
 
   const checkEthFlowOrderExists = useCheckEthFlowOrderExists()
 
-  const baseContext = getFlowContext({
-    baseProps,
-    sellToken,
-    kind: OrderKind.SELL,
-  })
+  const baseContext = useMemo(
+    () =>
+      getFlowContext({
+        baseProps,
+        sellToken,
+        kind: OrderKind.SELL,
+      }),
+    [baseProps, sellToken]
+  )
 
-  if (!baseContext || !contract || baseProps.flowType !== FlowType.EOA_ETH_FLOW) return null
+  return useMemo(() => {
+    if (!baseContext || !contract || baseProps.flowType !== FlowType.EOA_ETH_FLOW) return null
 
-  return {
-    ...baseContext,
-    contract,
-    addTransaction,
-    checkEthFlowOrderExists,
-    addInFlightOrderId,
-  }
+    return {
+      ...baseContext,
+      contract,
+      addTransaction,
+      checkEthFlowOrderExists,
+      addInFlightOrderId,
+    }
+  }, [baseContext, contract, addTransaction, checkEthFlowOrderExists, addInFlightOrderId, baseProps.flowType])
 }

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useFlowContext.ts
@@ -31,6 +31,7 @@ import { TradeFlowAnalyticsContext } from 'modules/trade/utils/analytics'
 
 import { useTokenContract, useWETHContract } from 'common/hooks/useContract'
 import { useIsSafeApprovalBundle } from 'common/hooks/useIsSafeApprovalBundle'
+import { useSafeMemo } from 'common/hooks/useSafeMemo'
 
 import { useIsSafeEthFlow } from './useIsSafeEthFlow'
 import { useDerivedSwapInfo, useSwapState } from './useSwapState'
@@ -44,6 +45,7 @@ export enum FlowType {
   SAFE_BUNDLE_APPROVAL = 'SAFE_BUNDLE_APPROVAL',
   SAFE_BUNDLE_ETH = 'SAFE_BUNDLE_ETH',
 }
+
 interface BaseFlowContextSetup {
   chainId: SupportedChainId
   account: string | undefined
@@ -79,7 +81,7 @@ export function useSwapAmountsWithSlippage(): [
 
   const { INPUT, OUTPUT } = computeSlippageAdjustedAmounts(trade, allowedSlippage)
 
-  return [INPUT, OUTPUT]
+  return useSafeMemo(() => [INPUT, OUTPUT], [INPUT, OUTPUT])
 }
 
 export function useBaseFlowContextSetup(): BaseFlowContextSetup {
@@ -115,32 +117,60 @@ export function useBaseFlowContextSetup(): BaseFlowContextSetup {
   const isSafeBundle = useIsSafeApprovalBundle(inputAmountWithSlippage)
   const flowType = _getFlowType(isSafeBundle, isEoaEthFlow, isSafeEthFlow)
 
-  return {
-    chainId,
-    account,
-    sellTokenContract,
-    provider,
-    trade,
-    appData,
-    wethContract,
-    inputAmountWithSlippage,
-    outputAmountWithSlippage,
-    gnosisSafeInfo,
-    recipient,
-    recipientAddressOrName,
-    deadline,
-    ensRecipientAddress,
-    allowsOffchainSigning,
-    uploadAppData,
-    flowType,
-    closeModals,
-    addOrderCallback,
-    dispatch,
-    allowedSlippage,
-    tradeConfirmActions,
-    getCachedPermit,
-    quote,
-  }
+  return useSafeMemo(
+    () => ({
+      chainId,
+      account,
+      sellTokenContract,
+      provider,
+      trade,
+      appData,
+      wethContract,
+      inputAmountWithSlippage,
+      outputAmountWithSlippage,
+      gnosisSafeInfo,
+      recipient,
+      recipientAddressOrName,
+      deadline,
+      ensRecipientAddress,
+      allowsOffchainSigning,
+      uploadAppData,
+      flowType,
+      closeModals,
+      addOrderCallback,
+      dispatch,
+      allowedSlippage,
+      tradeConfirmActions,
+      getCachedPermit,
+      quote,
+    }),
+    [
+      chainId,
+      account,
+      sellTokenContract,
+      provider,
+      trade,
+      appData,
+      wethContract,
+      inputAmountWithSlippage,
+      outputAmountWithSlippage,
+      gnosisSafeInfo,
+      recipient,
+      recipientAddressOrName,
+      deadline,
+      ensRecipientAddress,
+      allowsOffchainSigning,
+      uploadAppData,
+      flowType,
+      closeModals,
+      addOrderCallback,
+      dispatch,
+      allowedSlippage,
+      tradeConfirmActions,
+      getCachedPermit,
+      quote,
+    ]
+  )
 }
 
 function _getFlowType(isSafeBundle: boolean, isEoaEthFlow: boolean, isSafeEthFlow: boolean): FlowType {

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useSafeBundleApprovalFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useSafeBundleApprovalFlowContext.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { getWrappedToken } from '@cowprotocol/common-utils'
 
 import { FlowType } from 'modules/swap/hooks/useFlowContext'
@@ -14,12 +16,19 @@ export function useSafeBundleApprovalFlowContext(): SafeBundleApprovalFlowContex
   const sellToken = trade ? getWrappedToken(trade.inputAmount.currency) : undefined
   const erc20Contract = useTokenContract(sellToken?.address)
 
-  if (!trade || !erc20Contract) return null
+  return useMemo(() => {
+    if (
+      !baseContext ||
+      !baseContext.context.trade ||
+      !erc20Contract ||
+      baseContext.context.flowType !== FlowType.SAFE_BUNDLE_APPROVAL
+    ) {
+      return null
+    }
 
-  if (!baseContext || baseContext.context.flowType !== FlowType.SAFE_BUNDLE_APPROVAL) return null
-
-  return {
-    ...baseContext,
-    erc20Contract,
-  }
+    return {
+      ...baseContext,
+      erc20Contract,
+    }
+  }, [baseContext, erc20Contract])
 }

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useSafeBundleEthFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useSafeBundleEthFlowContext.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { FlowType } from 'modules/swap/hooks/useFlowContext'
 import { SafeBundleEthFlowContext } from 'modules/swap/services/types'
 
@@ -12,13 +14,13 @@ export function useSafeBundleEthFlowContext(): SafeBundleEthFlowContext | null {
   const wrappedNativeContract = useWETHContract()
   const needsApproval = useNeedsApproval(baseContext?.context.inputAmountWithSlippage)
 
-  if (!wrappedNativeContract) return null
+  return useMemo(() => {
+    if (!wrappedNativeContract || !baseContext || baseContext.context.flowType !== FlowType.SAFE_BUNDLE_ETH) return null
 
-  if (!baseContext || baseContext.context.flowType !== FlowType.SAFE_BUNDLE_ETH) return null
-
-  return {
-    ...baseContext,
-    wrappedNativeContract,
-    needsApproval,
-  }
+    return {
+      ...baseContext,
+      wrappedNativeContract,
+      needsApproval,
+    }
+  }, [baseContext, wrappedNativeContract, needsApproval])
 }

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useSwapButtonContext.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useSwapButtonContext.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { useCurrencyAmountBalance } from '@cowprotocol/balances-and-allowances'
 import { currencyAmountToTokenAmount, getWrappedToken } from '@cowprotocol/common-utils'
 import { useIsTradeUnsupported } from '@cowprotocol/tokens'
@@ -30,6 +32,7 @@ import { useWrappedToken } from 'modules/trade/hooks/useWrappedToken'
 import { QuoteDeadlineParams } from 'modules/tradeQuote'
 
 import { useApproveState } from 'common/hooks/useApproveState'
+import { useSafeMemo } from 'common/hooks/useSafeMemo'
 
 import { useSafeBundleEthFlowContext } from './useSafeBundleEthFlowContext'
 import { useDerivedSwapInfo, useSwapActionHandlers } from './useSwapState'
@@ -97,11 +100,14 @@ export function useSwapButtonContext(input: SwapButtonInput): SwapButtonsContext
   const isBundlingSupported = useIsBundlingSupported()
   const isPermitSupported = useTokenSupportsPermit(currencyIn, TradeType.SWAP)
 
-  const quoteDeadlineParams: QuoteDeadlineParams = {
-    validFor: quote?.validFor,
-    quoteValidTo: quote?.quoteValidTo,
-    localQuoteTimestamp: quote?.localQuoteTimestamp,
-  }
+  const quoteDeadlineParams: QuoteDeadlineParams = useMemo(
+    () => ({
+      validFor: quote?.validFor,
+      quoteValidTo: quote?.quoteValidTo,
+      localQuoteTimestamp: quote?.localQuoteTimestamp,
+    }),
+    [quote?.validFor, quote?.quoteValidTo, quote?.localQuoteTimestamp]
+  )
 
   const swapButtonState = getSwapButtonState({
     account,
@@ -126,23 +132,42 @@ export function useSwapButtonContext(input: SwapButtonInput): SwapButtonsContext
     quoteDeadlineParams,
   })
 
-  return {
-    swapButtonState,
-    inputAmount: slippageAdjustedSellAmount || undefined,
-    chainId,
-    wrappedToken,
-    handleSwap,
-    hasEnoughWrappedBalanceForSwap,
-    onWrapOrUnwrap: wrapCallback,
-    onEthFlow: openNativeWrapModal,
-    openSwapConfirm: tradeConfirmActions.onOpen,
-    toggleWalletModal,
-    swapInputError,
-    onCurrencySelection,
-    recipientAddressOrName,
-    widgetStandaloneMode: standaloneMode,
-    quoteDeadlineParams,
-  }
+  return useSafeMemo(
+    () => ({
+      swapButtonState,
+      inputAmount: slippageAdjustedSellAmount || undefined,
+      chainId,
+      wrappedToken,
+      handleSwap,
+      hasEnoughWrappedBalanceForSwap,
+      onWrapOrUnwrap: wrapCallback,
+      onEthFlow: openNativeWrapModal,
+      openSwapConfirm: tradeConfirmActions.onOpen,
+      toggleWalletModal,
+      swapInputError,
+      onCurrencySelection,
+      recipientAddressOrName,
+      widgetStandaloneMode: standaloneMode,
+      quoteDeadlineParams,
+    }),
+    [
+      swapButtonState,
+      slippageAdjustedSellAmount,
+      chainId,
+      wrappedToken,
+      handleSwap,
+      hasEnoughWrappedBalanceForSwap,
+      wrapCallback,
+      openNativeWrapModal,
+      tradeConfirmActions.onOpen,
+      toggleWalletModal,
+      swapInputError,
+      onCurrencySelection,
+      recipientAddressOrName,
+      standaloneMode,
+      quoteDeadlineParams,
+    ]
+  )
 }
 
 function useHasEnoughWrappedBalanceForSwap(inputAmount?: CurrencyAmount<Currency>): boolean {

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useSwapFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useSwapFlowContext.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { getWrappedToken } from '@cowprotocol/common-utils'
 import { COW_PROTOCOL_VAULT_RELAYER_ADDRESS, OrderKind, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { useWalletInfo } from '@cowprotocol/wallet'
@@ -30,22 +32,28 @@ export function useSwapFlowContext(): SwapFlowContext | null {
     checkAllowanceAddress,
   })
 
-  if (!baseProps.trade) return null
+  return useMemo(() => {
+    if (!baseProps.trade) {
+      return null
+    }
 
-  const baseContext = getFlowContext({
-    baseProps,
-    sellToken: getWrappedToken(baseProps.trade.inputAmount.currency),
-    kind: baseProps.trade.tradeType === UniTradeType.EXACT_INPUT ? OrderKind.SELL : OrderKind.BUY,
-  })
+    const baseContext = getFlowContext({
+      baseProps,
+      sellToken: getWrappedToken(baseProps.trade.inputAmount.currency),
+      kind: baseProps.trade.tradeType === UniTradeType.EXACT_INPUT ? OrderKind.SELL : OrderKind.BUY,
+    })
 
-  if (!contract || !baseContext || baseProps.flowType !== FlowType.REGULAR) return null
+    if (!contract || !baseContext || baseProps.flowType !== FlowType.REGULAR) {
+      return null
+    }
 
-  return {
-    ...baseContext,
-    contract,
-    permitInfo: !enoughAllowance ? permitInfo : undefined,
-    generatePermitHook,
-  }
+    return {
+      ...baseContext,
+      contract,
+      permitInfo: !enoughAllowance ? permitInfo : undefined,
+      generatePermitHook,
+    }
+  }, [baseProps, contract, enoughAllowance, permitInfo, generatePermitHook])
 }
 
 export function useSwapEnoughAllowance(): boolean | undefined {

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useSwapRawState.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useSwapRawState.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { useAppDispatch } from 'legacy/state/hooks'
 import { replaceOnlyTradeRawState, ReplaceOnlyTradeRawStatePayload } from 'legacy/state/swap/actions'
@@ -10,14 +10,24 @@ import { useSwapState } from './useSwapState'
 export function useSwapRawState(): TradeRawState {
   const swapState = useSwapState()
 
-  return {
-    chainId: swapState.chainId,
-    recipient: swapState.recipient,
-    recipientAddress: swapState.recipientAddress,
-    inputCurrencyId: swapState.INPUT.currencyId || null,
-    outputCurrencyId: swapState.OUTPUT.currencyId || null,
-  }
+  return useMemo(
+    () => ({
+      chainId: swapState.chainId,
+      recipient: swapState.recipient,
+      recipientAddress: swapState.recipientAddress,
+      inputCurrencyId: swapState.INPUT.currencyId || null,
+      outputCurrencyId: swapState.OUTPUT.currencyId || null,
+    }),
+    [
+      swapState.chainId,
+      swapState.recipient,
+      swapState.recipientAddress,
+      swapState.INPUT.currencyId,
+      swapState.OUTPUT.currencyId,
+    ]
+  )
 }
+
 export function useUpdateSwapRawState(): (update: Partial<ExtendedTradeRawState>) => void {
   const dispatch = useAppDispatch()
 

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useSwapState.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useSwapState.tsx
@@ -101,12 +101,17 @@ export function useSwapActionHandlers(): SwapActions {
     [dispatch]
   )
 
-  return {
+  return useMemo(() => ({
     onSwitchTokens,
     onCurrencySelection,
     onUserInput,
     onChangeRecipient,
-  }
+  }), [
+    onSwitchTokens,
+    onCurrencySelection,
+    onUserInput,
+    onChangeRecipient
+  ])
 }
 
 /**
@@ -140,13 +145,13 @@ export function useHighFeeWarning(trade?: TradeGp) {
     setFeeWarningAccepted(false)
   }, [INPUT.currencyId, OUTPUT.currencyId, independentField])
 
-  return {
+  return useSafeMemo(() => ({
     isHighFee,
     feePercentage,
     // we only care/check about feeWarning being accepted if the fee is actually high..
     feeWarningAccepted: _computeFeeWarningAcceptedState({ feeWarningAccepted, isHighFee }),
     setFeeWarningAccepted,
-  }
+  }), [isHighFee, feePercentage, feeWarningAccepted, setFeeWarningAccepted])
 }
 
 function _computeFeeWarningAcceptedState({
@@ -177,10 +182,10 @@ export function useUnknownImpactWarning() {
     setImpactWarningAccepted(false)
   }, [INPUT.currencyId, OUTPUT.currencyId, independentField])
 
-  return {
+  return useMemo(() => ({
     impactWarningAccepted,
     setImpactWarningAccepted,
-  }
+  }), [impactWarningAccepted, setImpactWarningAccepted])
 }
 
 // from the current swap inputs, compute the best trade and return it.

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useAutoImportTokensState.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useAutoImportTokensState.ts
@@ -27,5 +27,5 @@ export function useAutoImportTokensState(
 
   const modalState = useModalState<void>(tokensToImportCount > 0)
 
-  return { tokensToImport, modalState }
+  return useMemo(() => ({ tokensToImport, modalState }), [tokensToImport, modalState])
 }

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useWrapNativeFlow.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useWrapNativeFlow.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { useWalletInfo } from '@cowprotocol/wallet'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
@@ -38,32 +38,36 @@ function useWrapNativeContext(amount: Nullish<CurrencyAmount<Currency>>): WrapUn
   const addTransaction = useTransactionAdder()
   const [, setWrapNativeState] = useWrapNativeScreenState()
 
-  if (!wethContract || !chainId || !amount) {
-    return null
-  }
+  return useMemo(() => {
+    if (!wethContract || !chainId || !amount) {
+      return null
+    }
 
-  return {
-    chainId,
-    wethContract,
-    amount,
-    addTransaction,
-    closeModals() {
-      setWrapNativeState({ isOpen: false })
-    },
-    openTransactionConfirmationModal() {
-      setWrapNativeState({ isOpen: true })
-    },
-  }
+    return {
+      chainId,
+      wethContract,
+      amount,
+      addTransaction,
+      closeModals() {
+        setWrapNativeState({ isOpen: false })
+      },
+      openTransactionConfirmationModal() {
+        setWrapNativeState({ isOpen: true })
+      },
+    }
+  }, [chainId, wethContract, amount, addTransaction, setWrapNativeState])
 }
 
 function useWrapNativeCallback(inputAmount: Nullish<CurrencyAmount<Currency>>): WrapUnwrapCallback | null {
   const context = useWrapNativeContext(inputAmount)
 
-  if (!context) {
-    return null
-  }
+  return useMemo(() => {
+    if (!context) {
+      return null
+    }
 
-  return (params?: WrapUnwrapCallbackParams) => {
-    return wrapUnwrapCallback(context, params)
-  }
+    return (params?: WrapUnwrapCallbackParams) => {
+      return wrapUnwrapCallback(context, params)
+    }
+  }, [context])
 }

--- a/apps/cowswap-frontend/src/modules/trade/pure/TradeConfirmation/hooks/useIsPriceChanged.ts
+++ b/apps/cowswap-frontend/src/modules/trade/pure/TradeConfirmation/hooks/useIsPriceChanged.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 export function useIsPriceChanged(inputAmount: string | undefined, outputAmount: string | undefined) {
   const initialAmounts = useRef<{ inputAmount?: string; outputAmount?: string }>()
@@ -25,5 +25,5 @@ export function useIsPriceChanged(inputAmount: string | undefined, outputAmount:
     }
   }, [inputAmount, outputAmount])
 
-  return { isPriceChanged, resetPriceChanged }
+  return useMemo(() => ({ isPriceChanged, resetPriceChanged }), [isPriceChanged, resetPriceChanged])
 }

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useExtensibleFallbackContext.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useExtensibleFallbackContext.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { GPv2Settlement } from '@cowprotocol/abis'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { useWalletInfo } from '@cowprotocol/wallet'
@@ -18,7 +20,11 @@ export function useExtensibleFallbackContext(): ExtensibleFallbackContext | null
   const settlementContract = useGP2SettlementContract()
   const provider = useWalletProvider()
 
-  if (!account || !settlementContract || !provider) return null
+  return useMemo(() => {
+    if (!account || !settlementContract || !provider) {
+      return null
+    }
 
-  return { settlementContract, provider, chainId, safeAddress: account }
+    return { settlementContract, provider, chainId, safeAddress: account }
+  }, [account, settlementContract, provider, chainId])
 }

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useTwapOrderCreationContext.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useTwapOrderCreationContext.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { ComposableCoW, Erc20 } from '@cowprotocol/abis'
 import { useWalletInfo } from '@cowprotocol/wallet'
 import { CurrencyAmount, Token } from '@uniswap/sdk-core'
@@ -32,7 +34,16 @@ export function useTwapOrderCreationContext(
   const needsZeroApproval = useNeedsZeroApproval(erc20Contract, spender, inputAmount)
   const currentBlockFactoryAddress = chainId ? CURRENT_BLOCK_FACTORY_ADDRESS[chainId] : null
 
-  if (!composableCowContract || !erc20Contract || !spender || !currentBlockFactoryAddress) return null
+  return useMemo(() => {
+    if (!composableCowContract || !erc20Contract || !spender || !currentBlockFactoryAddress) return null
 
-  return { composableCowContract, erc20Contract, needsApproval, needsZeroApproval, spender, currentBlockFactoryAddress }
+    return {
+      composableCowContract,
+      erc20Contract,
+      needsApproval,
+      needsZeroApproval,
+      spender,
+      currentBlockFactoryAddress,
+    }
+  }, [composableCowContract, erc20Contract, spender, currentBlockFactoryAddress, needsApproval, needsZeroApproval])
 }

--- a/apps/cowswap-frontend/src/modules/usdAmount/hooks/useTradeUsdAmounts.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/hooks/useTradeUsdAmounts.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { TokenWithLogo } from '@cowprotocol/common-const'
 import { isFractionFalsy } from '@cowprotocol/common-utils'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
@@ -5,6 +7,8 @@ import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import { Nullish } from 'types'
 
 import { useIsWrapOrUnwrap } from 'modules/trade/hooks/useIsWrapOrUnwrap'
+
+import { useSafeMemo } from 'common/hooks/useSafeMemo'
 
 import { UsdAmountInfo, useUsdAmount } from './useUsdAmount'
 
@@ -32,15 +36,22 @@ export function useTradeUsdAmounts(
   const areAmountsReady = !isFractionFalsy(inputAmount) && !isFractionFalsy(outputAmount)
   const isTradeReady = !isWrapOrUnwrap && (dontWaitBothAmounts || areAmountsReady)
 
-  const useUsdAmountInputParams: Parameters<typeof useUsdAmount> = isWrapOrUnwrap
-    ? [null, null] // disable usd estimation when it's wrap/unwrap
-    : [isTradeReady ? inputAmount : null, inputCurrency]
-  const useUsdAmountOutputParams: Parameters<typeof useUsdAmount> = isWrapOrUnwrap
-    ? [null, null]
-    : [isTradeReady ? outputAmount : null, outputCurrency]
+  const [useUsdAmountInputParams, useUsdAmountOutputParams] = useSafeMemo(() => {
+    const useUsdAmountInputParams: Parameters<typeof useUsdAmount> = isWrapOrUnwrap
+      ? [null, null] // disable usd estimation when it's wrap/unwrap
+      : [isTradeReady ? inputAmount : null, inputCurrency]
+    const useUsdAmountOutputParams: Parameters<typeof useUsdAmount> = isWrapOrUnwrap
+      ? [null, null]
+      : [isTradeReady ? outputAmount : null, outputCurrency]
 
-  return {
-    inputAmount: useUsdAmount(...useUsdAmountInputParams),
-    outputAmount: useUsdAmount(...useUsdAmountOutputParams),
-  }
+    return [useUsdAmountInputParams, useUsdAmountOutputParams]
+  }, [isWrapOrUnwrap, isTradeReady, inputAmount, outputAmount, inputCurrency, outputCurrency])
+
+  const usdInputAmount = useUsdAmount(...useUsdAmountInputParams)
+  const usdOutputAmount = useUsdAmount(...useUsdAmountOutputParams)
+
+  return useMemo(
+    () => ({ inputAmount: usdInputAmount, outputAmount: usdOutputAmount }),
+    [usdInputAmount, usdOutputAmount]
+  )
 }

--- a/apps/cowswap-frontend/src/modules/wallet/containers/FollowPendingTxPopup/index.tsx
+++ b/apps/cowswap-frontend/src/modules/wallet/containers/FollowPendingTxPopup/index.tsx
@@ -27,7 +27,7 @@ export function useLastPendingOrder(): { lastPendingOrder: Order | null; onClose
     setShowFollowPendingTxPopup(false)
   }, [lastPendingOrder, setLastOrderClosed, setShowFollowPendingTxPopup])
 
-  return { lastPendingOrder, onClose }
+  return useMemo(() => ({ lastPendingOrder, onClose }), [lastPendingOrder, onClose])
 }
 
 // Set pop up closed if it has not been closed and not fulfill a condition such as not pending tx
@@ -59,7 +59,7 @@ const useShowingPopupFirstTime = (orderId: string | undefined) => {
 
   const firstTimePopupOrderAppears = useAtomValue(_firstTimePopupOrderAppears)
 
-  return { showPopup: firstTimePopupOrderAppears && showingPopup, firstTimePopupOrderAppears }
+  return useMemo(() => ({ showPopup: firstTimePopupOrderAppears && showingPopup, firstTimePopupOrderAppears }), [firstTimePopupOrderAppears, showingPopup])
 }
 
 export const FollowPendingTxPopup: React.FC<PropsWithChildren> = ({ children }): JSX.Element => {

--- a/apps/cowswap-frontend/src/pages/Account/Balances.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/Balances.tsx
@@ -97,7 +97,7 @@ export default function Profile() {
   const { isModalOpen, openModal, closeModal } = useModalState<string>()
 
   // Handle swaping
-  const { swapCallback } = useSwapVCowCallback({
+  const swapCallback = useSwapVCowCallback({
     openModal,
     closeModal,
   })

--- a/apps/cowswap-frontend/src/pages/Account/LockedGnoVesting/hooks.ts
+++ b/apps/cowswap-frontend/src/pages/Account/LockedGnoVesting/hooks.ts
@@ -70,12 +70,15 @@ export const useCowFromLockedGnoBalances = () => {
 
   const claimed = useMemo(() => CurrencyAmount.fromRawAmount(_COW, data ? data.claimed.toString() : 0), [data])
 
-  return {
-    allocated,
-    vested,
-    claimed,
-    loading: isLoading,
-  }
+  return useMemo(
+    () => ({
+      allocated,
+      vested,
+      claimed,
+      loading: isLoading,
+    }),
+    [allocated, vested, claimed, isLoading]
+  )
 }
 
 interface ClaimCallbackParams {
@@ -95,7 +98,7 @@ export function useClaimCowFromLockedGnoCallback({
 
   const addTransaction = useTransactionAdder()
 
-  const claimCallback = useCallback(async () => {
+  return useCallback(async () => {
     if (!account) {
       throw new Error('Not connected')
     }
@@ -128,6 +131,4 @@ export function useClaimCowFromLockedGnoCallback({
       })
       .finally(closeModal)
   }, [account, addTransaction, chainId, closeModal, openModal, isFirstClaim, merkleDrop, tokenDistro])
-
-  return claimCallback
 }

--- a/apps/explorer/src/components/orders/OrderDetails/index.tsx
+++ b/apps/explorer/src/components/orders/OrderDetails/index.tsx
@@ -81,9 +81,9 @@ export enum TabView {
 
 const DEFAULT_TAB = TabView[1]
 
-function useQueryViewParams(): { tab: string } {
+function useQueryViewParams(): string {
   const query = useQuery()
-  return { tab: query.get(TAB_QUERY_PARAM_KEY)?.toUpperCase() || DEFAULT_TAB } // if URL param empty will be used DEFAULT
+  return query.get(TAB_QUERY_PARAM_KEY)?.toUpperCase() || DEFAULT_TAB // if URL param empty will be used DEFAULT
 }
 
 const tabItems = (
@@ -165,7 +165,7 @@ const RESULTS_PER_PAGE = 10
 export const OrderDetails: React.FC<Props> = (props) => {
   const { order, isOrderLoading, areTradesLoading, errors, trades } = props
   const chainId = useNetworkId()
-  const { tab } = useQueryViewParams()
+  const tab = useQueryViewParams()
   const [tabViewSelected, setTabViewSelected] = useState<TabView>(TabView[tab] || TabView[DEFAULT_TAB]) // use DEFAULT when URL param is outside the enum
   const {
     state: tableState,

--- a/apps/explorer/src/components/orders/OrderSurplusDisplay/index.tsx
+++ b/apps/explorer/src/components/orders/OrderSurplusDisplay/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 
 import { isSellOrder } from '@cowprotocol/common-utils'
 
@@ -39,11 +39,15 @@ function useGetSurplus(order: Order): OrderSurplus | null {
   // TODO: get USD estimation
   // const usdAmount = '55.555'
 
-  if (!surplusToken || surplusAmount.isZero()) {
-    return null
-  }
 
-  return { amount: surplusAmount, percentage: surplusPercentage, surplusToken }
+  return useMemo(() => {
+
+    if (!surplusToken || surplusAmount.isZero()) {
+      return null
+    }
+
+    return ({ amount: surplusAmount, percentage: surplusPercentage, surplusToken })
+  }, [surplusToken, surplusAmount, surplusPercentage])
 }
 
 export function OrderSurplusDisplay(props: Props): JSX.Element | null {

--- a/apps/explorer/src/explorer/components/OrdersTableWidget/useSearchInAnotherNetwork.tsx
+++ b/apps/explorer/src/explorer/components/OrdersTableWidget/useSearchInAnotherNetwork.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { CHAIN_INFO, getChainInfo } from '@cowprotocol/common-const'
 import { useAvailableChains } from '@cowprotocol/common-hooks'
@@ -188,5 +188,5 @@ export const useSearchInAnotherNetwork = (
     fetchAnotherNetworks(networkId)
   }, [fetchAnotherNetworks, isOrdersLengthZero, networkId])
 
-  return { isLoading, ordersInNetworks, setLoadingState: setIsLoading, errorMsg: error }
+  return useMemo(() => ({ isLoading, ordersInNetworks, setLoadingState: setIsLoading, errorMsg: error }), [isLoading, ordersInNetworks, setIsLoading, error])
 }

--- a/apps/explorer/src/explorer/components/OrdersTableWidget/useTable.tsx
+++ b/apps/explorer/src/explorer/components/OrdersTableWidget/useTable.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { Command } from '@cowprotocol/types'
 
@@ -36,34 +36,36 @@ export function useTable(options: TableOptions): TableStateAndSetters {
     ...initialState,
   })
 
-  const setPageSize = (newValue: number): void => {
-    const offsetRestarted = 0
-    setState({
-      ...state,
-      pageSize: newValue,
-      pageOffset: offsetRestarted,
-      pageIndex: getPageIndex(offsetRestarted, newValue),
-    })
-  }
+  return useMemo(() => {
+    const setPageSize = (newValue: number): void => {
+      const offsetRestarted = 0
+      setState({
+        ...state,
+        pageSize: newValue,
+        pageOffset: offsetRestarted,
+        pageIndex: getPageIndex(offsetRestarted, newValue),
+      })
+    }
 
-  const setPageOffset = (newOffset: number): void => {
-    setState({
-      ...state,
-      pageOffset: newOffset,
-      pageIndex: getPageIndex(newOffset, state.pageSize),
-    })
-  }
+    const setPageOffset = (newOffset: number): void => {
+      setState({
+        ...state,
+        pageOffset: newOffset,
+        pageIndex: getPageIndex(newOffset, state.pageSize),
+      })
+    }
 
-  const handleNextPage = (): void => {
-    const newOffset = state.pageOffset + state.pageSize
-    setPageOffset(newOffset)
-  }
+    const handleNextPage = (): void => {
+      const newOffset = state.pageOffset + state.pageSize
+      setPageOffset(newOffset)
+    }
 
-  const handlePreviousPage = (): void => {
-    let newOffset = state.pageOffset - state.pageSize
-    newOffset = newOffset < 0 ? 0 : newOffset
-    setPageOffset(newOffset)
-  }
+    const handlePreviousPage = (): void => {
+      let newOffset = state.pageOffset - state.pageSize
+      newOffset = newOffset < 0 ? 0 : newOffset
+      setPageOffset(newOffset)
+    }
 
-  return { state, setPageSize, handleNextPage, handlePreviousPage }
+    return ({ state, setPageSize, handleNextPage, handlePreviousPage }) as TableStateAndSetters
+  }, [state, setState])
 }

--- a/apps/explorer/src/explorer/components/TransactionsTableWidget/index.tsx
+++ b/apps/explorer/src/explorer/components/TransactionsTableWidget/index.tsx
@@ -33,9 +33,9 @@ enum TabView {
 
 const DEFAULT_TAB = TabView[1]
 
-function useQueryViewParams(): { tab: string } {
+function useQueryViewParams(): string {
   const query = useQuery()
-  return { tab: query.get(TAB_QUERY_PARAM_KEY)?.toUpperCase() || DEFAULT_TAB } // if URL param empty will be used DEFAULT
+  return query.get(TAB_QUERY_PARAM_KEY)?.toUpperCase() || DEFAULT_TAB  // if URL param empty will be used DEFAULT
 }
 
 const tabItems = (orders: Order[] | undefined, networkId: BlockchainNetwork, txHash: string): TabItemInterface[] => {
@@ -57,7 +57,7 @@ export const TransactionsTableWidget: React.FC<Props> = ({ txHash }) => {
   const { orders, isLoading: isTxLoading, errorTxPresentInNetworkId, error } = useGetTxOrders(txHash)
   const networkId = useNetworkId() || undefined
   const [redirectTo, setRedirectTo] = useState(false)
-  const { tab } = useQueryViewParams()
+  const tab = useQueryViewParams()
   const [tabViewSelected, setTabViewSelected] = useState<TabView>(TabView[tab] || TabView[DEFAULT_TAB]) // use DEFAULT when URL param is outside the enum
   const txHashParams = { networkId, txHash }
   const isZeroOrders = !!(orders && orders.length === 0)

--- a/apps/explorer/src/explorer/components/TransanctionBatchGraph/hooks.ts
+++ b/apps/explorer/src/explorer/components/TransanctionBatchGraph/hooks.ts
@@ -140,18 +140,32 @@ export function useCytoscape(params: UseCytoscapeParams): UseCytoscapeReturn {
     }
   }, [cytoscapeRef, elements.length])
 
-  return {
-    failedToLoadGraph,
-    heightSize,
-    resetZoom,
-    setResetZoom,
-    setCytoscape,
-    layout,
-    setLayout,
-    cyPopperRef,
-    elements,
-    tokensStylesheets,
-  }
+  return useMemo(
+    () => ({
+      failedToLoadGraph,
+      heightSize,
+      resetZoom,
+      setResetZoom,
+      setCytoscape,
+      layout,
+      setLayout,
+      cyPopperRef,
+      elements,
+      tokensStylesheets,
+    }),
+    [
+      failedToLoadGraph,
+      heightSize,
+      resetZoom,
+      setResetZoom,
+      setCytoscape,
+      layout,
+      setLayout,
+      cyPopperRef,
+      elements,
+      tokensStylesheets,
+    ]
+  )
 }
 
 function getStylesheets(
@@ -191,9 +205,9 @@ const DEFAULT_VIEW_NAME = ViewType[DEFAULT_VIEW_TYPE]
 
 const VISUALIZATION_PARAM_NAME = 'vis'
 
-function useQueryViewParams(): { visualization: string } {
+function useQueryViewParams(): string {
   const query = useQuery()
-  return { visualization: query.get(VISUALIZATION_PARAM_NAME)?.toUpperCase() || DEFAULT_VIEW_NAME }
+  return query.get(VISUALIZATION_PARAM_NAME)?.toUpperCase() || DEFAULT_VIEW_NAME
 }
 
 function useUpdateVisQuery(): (vis: string) => void {
@@ -269,7 +283,10 @@ export function useTxBatchData(
       : buildTransfersBasedSettlement(params)
   }, [networkId, orderTokens, missingTokens, txData, orders, trades, transfers, visualization])
 
-  return { txSettlement, error: txData.error, isLoading: txData.isLoading || areTokensLoading }
+  return useMemo(
+    () => ({ txSettlement, error: txData.error, isLoading: txData.isLoading || areTokensLoading }),
+    [txSettlement, txData.error, txData.isLoading, areTokensLoading]
+  )
 }
 
 type UseVisualizationReturn = {
@@ -278,7 +295,7 @@ type UseVisualizationReturn = {
 }
 
 export function useVisualization(): UseVisualizationReturn {
-  const { visualization } = useQueryViewParams()
+  const visualization = useQueryViewParams()
 
   const updateVisQuery = useUpdateVisQuery()
 

--- a/apps/explorer/src/explorer/pages/AppData/index.tsx
+++ b/apps/explorer/src/explorer/pages/AppData/index.tsx
@@ -28,9 +28,9 @@ export type TabData = {
 
 const DEFAULT_TAB = TabView[1]
 
-function useQueryViewParams(): { tab: string } {
+function useQueryViewParams(): string {
   const query = useQuery()
-  return { tab: query.get(TAB_QUERY_PARAM_KEY)?.toUpperCase() || DEFAULT_TAB } // if URL param empty will be used DEFAULT
+  return query.get(TAB_QUERY_PARAM_KEY)?.toUpperCase() || DEFAULT_TAB  // if URL param empty will be used DEFAULT
 }
 
 const tabItems = (
@@ -53,7 +53,7 @@ const tabItems = (
 }
 
 const AppDataPage: React.FC = () => {
-  const { tab } = useQueryViewParams()
+  const tab = useQueryViewParams()
   const [tabData, setTabData] = useState<TabData>({
     encode: { formData: {}, options: {} },
     decode: { formData: {}, options: {} },

--- a/apps/explorer/src/hooks/useAppData.ts
+++ b/apps/explorer/src/hooks/useAppData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { AnyAppDataDocVersion } from '@cowprotocol/app-data'
 
@@ -8,7 +8,7 @@ import { useNetworkId } from 'state/network'
 
 export const useAppData = (
   appDataHash: string,
-  isLegacyAppDataHex: boolean,
+  isLegacyAppDataHex: boolean
 ): { isLoading: boolean; appDataDoc: AnyAppDataDocVersion | void | undefined } => {
   const network = useNetworkId() || undefined
   const [isLoading, setLoading] = useState<boolean>(false)
@@ -30,12 +30,12 @@ export const useAppData = (
     getAppDataDoc()
   }, [appDataHash, network, isLegacyAppDataHex])
 
-  return { isLoading, appDataDoc }
+  return useMemo(() => ({ isLoading, appDataDoc }), [isLoading, appDataDoc])
 }
 
 export const fetchDocFromAppDataHex = (
   appDataHex: string,
-  isLegacyAppDataHex: boolean,
+  isLegacyAppDataHex: boolean
 ): Promise<void | AnyAppDataDocVersion> => {
   const method = isLegacyAppDataHex ? 'fetchDocFromAppDataHexLegacy' : 'fetchDocFromAppDataHex'
   return metadataApiSDK[method](appDataHex, DEFAULT_IPFS_READ_URI)

--- a/apps/explorer/src/hooks/useErc20.ts
+++ b/apps/explorer/src/hooks/useErc20.ts
@@ -139,9 +139,12 @@ export function useMultipleErc20(
     }
   }, [updateErc20s, saveErc20s, networkId])
 
-  return {
-    isLoading: isTokenListLoading || isLoading,
-    error: errors,
-    value: { ...erc20s, ...fromTokenList, ...nativeState },
-  }
+  return useMemo(
+    () => ({
+      isLoading: isTokenListLoading || isLoading,
+      error: errors,
+      value: { ...erc20s, ...fromTokenList, ...nativeState },
+    }),
+    [isTokenListLoading, isLoading, errors, erc20s, fromTokenList, nativeState]
+  )
 }

--- a/apps/explorer/src/hooks/useGetOrders.tsx
+++ b/apps/explorer/src/hooks/useGetOrders.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { ALL_SUPPORTED_CHAIN_IDS } from '@cowprotocol/cow-sdk'
 
@@ -22,7 +22,7 @@ import { web3 } from '../explorer/api'
 import { ORDERS_QUERY_INTERVAL } from '../explorer/const'
 
 function isObjectEmpty(object: Record<string, unknown>): boolean {
-  // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+
   for (const key in object) {
     if (key) return false
   }
@@ -107,7 +107,7 @@ function useOrdersWithTokenInfo(networkId: Network | undefined): UseOrdersWithTo
     setErc20Addresses([])
   }, [valueErc20s, networkId, areErc20Loading, mountNewOrders, orders])
 
-  return { orders, areErc20Loading, setOrders, setMountNewOrders, setErc20Addresses }
+  return useMemo(() => ({ orders, areErc20Loading, setOrders, setMountNewOrders, setErc20Addresses }), [orders, areErc20Loading, setOrders, setMountNewOrders, setErc20Addresses])
 }
 
 export function useGetTxOrders(txHash: string): GetTxOrdersResult {
@@ -156,7 +156,7 @@ export function useGetTxOrders(txHash: string): GetTxOrdersResult {
     fetchOrders(networkId, txHash)
   }, [fetchOrders, networkId, txHash])
 
-  return { orders, error, isLoading: isLoading || areErc20Loading, errorTxPresentInNetworkId }
+  return useMemo(() => ({ orders, error, isLoading: isLoading || areErc20Loading, errorTxPresentInNetworkId }), [orders, error, isLoading, areErc20Loading, errorTxPresentInNetworkId])
 }
 
 export function useTxOrderExplorerLink(
@@ -247,5 +247,5 @@ export function useGetAccountOrders(
     }
   }, [fetchOrders, networkId, ownerAddress, pageIndex])
 
-  return { orders, error, isLoading, isThereNext }
+  return useMemo(() => ({ orders, error, isLoading, isThereNext }), [orders, error, isLoading, isThereNext])
 }

--- a/apps/explorer/src/hooks/useGetTokens.ts
+++ b/apps/explorer/src/hooks/useGetTokens.ts
@@ -1,10 +1,10 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { gql } from '@apollo/client'
 import { TokenErc20 } from '@gnosis.pm/dex-js'
 import { NATIVE_TOKEN_PER_NETWORK } from 'const'
 import { subgraphApiSDK } from 'cowSdk'
-import { subDays, subHours, startOfToday, startOfYesterday } from 'date-fns'
+import { startOfToday, startOfYesterday, subDays, subHours } from 'date-fns'
 import { UTCTimestamp } from 'lightweight-charts'
 import { Network, UiError } from 'types'
 import { getPercentageDifference, isNativeToken } from 'utils'
@@ -22,10 +22,10 @@ export function useGetTokens(networkId: Network | undefined): GetTokensResult {
       const lastWeekTimestampFrom = Number(lastDaysTimestamp(8))
       const lastWeekTimestampTo = Number(lastDaysTimestamp(6))
       const lastDayPrice = data.tokenHourlyTotals.find(
-        (x) => x.timestamp >= lastDayTimestampFrom && x.timestamp <= lastDayTimestampTo,
+        (x) => x.timestamp >= lastDayTimestampFrom && x.timestamp <= lastDayTimestampTo
       )?.averagePrice
       const lastWeekPrice = data.tokenHourlyTotals.find(
-        (x) => x.timestamp >= lastWeekTimestampFrom && x.timestamp <= lastWeekTimestampTo,
+        (x) => x.timestamp >= lastWeekTimestampFrom && x.timestamp <= lastWeekTimestampTo
       )?.averagePrice
 
       return {
@@ -45,7 +45,7 @@ export function useGetTokens(networkId: Network | undefined): GetTokensResult {
           .sort((a, b) => a.time - b.time),
       }
     },
-    [],
+    []
   )
 
   const fetchTokens = useCallback(
@@ -63,7 +63,7 @@ export function useGetTokens(networkId: Network | undefined): GetTokensResult {
             yesterdayTimestamp,
             lastWeekTimestamp,
           },
-          { chainId: network },
+          { chainId: network }
         )
         if (response) {
           const tokensData: { [tokenId: string]: TokenData } = {}
@@ -72,13 +72,13 @@ export function useGetTokens(networkId: Network | undefined): GetTokensResult {
             const tokenData = processTokenData(
               { tokenHourlyTotals: token.hourlyTotals },
               Number(totalVolumeUsd),
-              timestamp,
+              timestamp
             )
             tokensData[token.address] = { ...tokenData }
           }
           const tokens = addHistoricalData(
             response.tokenDailyTotals.map((tokenDaily) => tokenDaily.token),
-            tokensData,
+            tokensData
           )
           setTokens(enhanceNativeToken(tokens, network))
         }
@@ -90,7 +90,7 @@ export function useGetTokens(networkId: Network | undefined): GetTokensResult {
         setIsLoading(false)
       }
     },
-    [processTokenData],
+    [processTokenData]
   )
 
   useEffect(() => {
@@ -101,7 +101,7 @@ export function useGetTokens(networkId: Network | undefined): GetTokensResult {
     fetchTokens(networkId)
   }, [fetchTokens, networkId])
 
-  return { tokens, error, isLoading }
+  return useMemo(() => ({ tokens, error, isLoading }), [tokens, error, isLoading])
 }
 
 type GetTokensResult = {

--- a/apps/explorer/src/hooks/useOperatorOrder.ts
+++ b/apps/explorer/src/hooks/useOperatorOrder.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { shortenOrderId } from '@cowprotocol/common-utils'
 import { Command } from '@cowprotocol/types'
@@ -91,7 +91,10 @@ export function useOrderByNetwork(orderId: string, networkId: Network | null, up
     }
   }, [forceUpdate, order, updateInterval])
 
-  return { order, isLoading, error, errorOrderPresentInNetworkId, forceUpdate }
+  return useMemo(
+    () => ({ order, isLoading, error, errorOrderPresentInNetworkId, forceUpdate }),
+    [order, isLoading, error, errorOrderPresentInNetworkId, forceUpdate]
+  )
 }
 
 export function useOrder(orderId: string, updateInterval?: number): UseOrderResult {
@@ -125,9 +128,8 @@ export function useOrderAndErc20s(orderId: string, updateInterval = 0): UseOrder
 
   const addresses = order ? [order.buyTokenAddress, order.sellTokenAddress] : []
 
-  const { value, isLoading: areErc20Loading, error: erc20Errors } = useMultipleErc20({ networkId, addresses })
+  const { value, isLoading: areErc20Loading, error: errors = {} } = useMultipleErc20({ networkId, addresses })
 
-  const errors = { ...erc20Errors }
   if (orderError) {
     errors[orderId] = orderError
   }
@@ -137,5 +139,8 @@ export function useOrderAndErc20s(orderId: string, updateInterval = 0): UseOrder
     order.sellToken = value[order?.sellTokenAddress?.toLowerCase() || '']
   }
 
-  return { order, isLoading: isOrderLoading || areErc20Loading, errors, errorOrderPresentInNetworkId }
+  return useMemo(
+    () => ({ order, isLoading: isOrderLoading || areErc20Loading, errors, errorOrderPresentInNetworkId }),
+    [order, isOrderLoading, areErc20Loading, errors, errorOrderPresentInNetworkId]
+  )
 }

--- a/apps/explorer/src/hooks/useOperatorOrder.ts
+++ b/apps/explorer/src/hooks/useOperatorOrder.ts
@@ -130,17 +130,16 @@ export function useOrderAndErc20s(orderId: string, updateInterval = 0): UseOrder
 
   const { value, isLoading: areErc20Loading, error: errors = {} } = useMultipleErc20({ networkId, addresses })
 
-  if (orderError) {
-    errors[orderId] = orderError
-  }
+  return useMemo(() => {
+    if (orderError) {
+      errors[orderId] = orderError
+    }
 
-  if (order && value) {
-    order.buyToken = value[order?.buyTokenAddress?.toLowerCase() || '']
-    order.sellToken = value[order?.sellTokenAddress?.toLowerCase() || '']
-  }
+    if (order && value) {
+      order.buyToken = value[order?.buyTokenAddress?.toLowerCase() || '']
+      order.sellToken = value[order?.sellTokenAddress?.toLowerCase() || '']
+    }
 
-  return useMemo(
-    () => ({ order, isLoading: isOrderLoading || areErc20Loading, errors, errorOrderPresentInNetworkId }),
-    [order, isOrderLoading, areErc20Loading, errors, errorOrderPresentInNetworkId]
-  )
+    return { order, isLoading: isOrderLoading || areErc20Loading, errors, errorOrderPresentInNetworkId }
+  }, [orderError, order, isOrderLoading, areErc20Loading, errors, errorOrderPresentInNetworkId, value])
 }

--- a/apps/explorer/src/hooks/useOperatorTrades.ts
+++ b/apps/explorer/src/hooks/useOperatorTrades.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { useNetworkId } from 'state/network'
 import { Network, UiError } from 'types'
@@ -122,8 +122,9 @@ export function useOrderTrades(order: Order | null): Result {
     // Depending on order UID to avoid re-fetching when obj changes but ID remains the same
     // Depending on `executedBuy/SellAmount`s string to force a refetch when there are new trades
     // using the string version because hooks are bad at detecting Object changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fetchTrades, networkId, order?.uid, executedSellAmount, executedBuyAmount])
 
-  return { trades, error, isLoading: rawTrades === null }
+  const isLoading = rawTrades === null
+
+  return useMemo(() => ({ trades, error, isLoading }), [trades, error, isLoading])
 }

--- a/apps/explorer/src/hooks/usePopper.ts
+++ b/apps/explorer/src/hooks/usePopper.ts
@@ -1,6 +1,6 @@
-import { useRef, useEffect, RefObject, useState, useMemo, useLayoutEffect } from 'react'
+import { RefObject, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 
-import { Instance, Options, State, Placement } from '@popperjs/core'
+import { Instance, Options, Placement, State } from '@popperjs/core'
 
 export const TOOLTIP_OFFSET = 12 // px
 
@@ -155,10 +155,13 @@ export const usePopperDefault = <T extends HTMLElement>(
     [hide, show, target]
   )
 
-  return {
-    targetProps,
-    tooltipProps,
-  }
+  return useMemo(
+    () => ({
+      targetProps,
+      tooltipProps,
+    }),
+    [targetProps, tooltipProps]
+  )
 }
 
 interface PopperOnClickResult<T extends HTMLElement> {
@@ -201,8 +204,11 @@ export const usePopperOnClick = <T extends HTMLElement>(
     [toggle, target]
   )
 
-  return {
-    targetProps,
-    tooltipProps,
-  }
+  return useMemo(
+    () => ({
+      targetProps,
+      tooltipProps,
+    }),
+    [targetProps, tooltipProps]
+  )
 }

--- a/apps/explorer/src/hooks/useTokenList.ts
+++ b/apps/explorer/src/hooks/useTokenList.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { SWR_NO_REFRESH_OPTIONS } from '@cowprotocol/common-const'
 import { ALL_SUPPORTED_CHAIN_IDS, SupportedChainId, mapSupportedNetworks } from '@cowprotocol/cow-sdk'
 import type { TokenInfo, TokenList } from '@uniswap/token-lists'
@@ -25,12 +27,15 @@ export function useTokenList(chainId: SupportedChainId | undefined): { data: Tok
     chainId === SupportedChainId.ARBITRUM_ONE ? 'https://tokens.coingecko.com/arbitrum-one/all.json' : ''
   )
 
-  const data = chainId ? { ...coingeckoList, ...honeyswapList, ...cowSwapList, ...arbitrumOneList }[chainId] : {}
   const isLoading = chainId
     ? isCowListLoading || isHoneyswapListLoading || isCoingeckoListLoading || isArbitrumOneListLoading
     : false
 
-  return { data, isLoading }
+  return useMemo(() => {
+    const data = chainId ? { ...coingeckoList, ...honeyswapList, ...cowSwapList, ...arbitrumOneList }[chainId] : {}
+
+    return { data, isLoading }
+  }, [chainId, coingeckoList, honeyswapList, cowSwapList, arbitrumOneList, isLoading])
 }
 
 function useTokenListByUrl(tokenListUrl: string) {

--- a/apps/explorer/src/hooks/useTransactionData.ts
+++ b/apps/explorer/src/hooks/useTransactionData.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { Network } from 'types'
 
@@ -49,7 +49,7 @@ function useTransactionTrace(network: Network | undefined, txHash: string): Load
     }
   }, [network, txHash, fetchTrace])
 
-  return { data: trace, isLoading, error }
+  return useMemo(() => ({ data: trace, isLoading, error }), [trace, isLoading, error])
 }
 
 const CONTRACTS_CACHE = new Map<string, Contract[]>()
@@ -86,7 +86,7 @@ function useTransactionContracts(network: Network | undefined, txHash: string): 
     }
   }, [network, txHash, fetchContracts])
 
-  return { data: contracts, isLoading, error }
+  return useMemo(() => ({ data: contracts, isLoading, error }), [contracts, isLoading, error])
 }
 
 export type TransactionData = {
@@ -100,10 +100,20 @@ export function useTransactionData(network: Network | undefined, txHash: string)
   const traceData = useTransactionTrace(network, txHash)
   const contractsData = useTransactionContracts(network, txHash)
 
-  return {
-    trace: traceData.data,
-    contracts: contractsData.data,
-    isLoading: traceData.isLoading || contractsData.isLoading,
-    error: traceData.error || contractsData.error,
-  }
+  return useMemo(
+    () => ({
+      trace: traceData.data,
+      contracts: contractsData.data,
+      isLoading: traceData.isLoading || contractsData.isLoading,
+      error: traceData.error || contractsData.error,
+    }),
+    [
+      traceData.data,
+      contractsData.data,
+      traceData.isLoading,
+      contractsData.isLoading,
+      traceData.error,
+      contractsData.error,
+    ]
+  )
 }

--- a/apps/widget-configurator/src/app/configurator/hooks/useColorPaletteManager.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useColorPaletteManager.ts
@@ -55,5 +55,8 @@ export function useColorPaletteManager(mode: PaletteMode): ColorPaletteManager {
     updateColorPalette(newPalette || defaultPalette)
   }, [mode, defaultPalette])
 
-  return { defaultPalette, colorPalette, setColorPalette, resetColorPalette }
+  return useMemo(
+    () => ({ defaultPalette, colorPalette, setColorPalette, resetColorPalette }),
+    [defaultPalette, colorPalette, setColorPalette, resetColorPalette]
+  )
 }

--- a/apps/widget-configurator/src/app/configurator/hooks/useEmbedDialogState.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useEmbedDialogState.ts
@@ -12,5 +12,5 @@ export function useEmbedDialogState(initialOpen = false) {
       handleDialogClose: handleClose,
       handleDialogOpen: handleOpen,
     }
-  }, [open, setOpen])
+  }, [open])
 }

--- a/apps/widget-configurator/src/app/configurator/hooks/useEmbedDialogState.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useEmbedDialogState.ts
@@ -1,14 +1,16 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 export function useEmbedDialogState(initialOpen = false) {
   const [open, setOpen] = useState(initialOpen)
 
-  const handleOpen = () => setOpen(true)
-  const handleClose = () => setOpen(false)
+  return useMemo(() => {
+    const handleOpen = () => setOpen(true)
+    const handleClose = () => setOpen(false)
 
-  return {
-    dialogOpen: open,
-    handleDialogClose: handleClose,
-    handleDialogOpen: handleOpen,
-  }
+    return {
+      dialogOpen: open,
+      handleDialogClose: handleClose,
+      handleDialogOpen: handleOpen,
+    }
+  }, [open, setOpen])
 }

--- a/libs/common-hooks/src/useFetchFile.ts
+++ b/libs/common-hooks/src/useFetchFile.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 function getErrorMessage(filePath: string, res: Response): string {
   return `Error fetching file ${filePath} - status: ${res.statusText}`
@@ -27,5 +27,5 @@ export function useFetchFile(filePath: string) {
     fetchFile()
   }, [filePath])
 
-  return { file, error }
+  return useMemo(() => ({ file, error }), [file, error])
 }

--- a/libs/wallet/src/web3-react/hooks/useActivateConnector.ts
+++ b/libs/wallet/src/web3-react/hooks/useActivateConnector.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import { getCurrentChainIdFromUrl } from '@cowprotocol/common-utils'
 import { Connector } from '@web3-react/types'
@@ -53,12 +53,15 @@ export function useActivateConnector({
     [chainId, pendingConnector, skipNetworkChanging, afterActivation, beforeActivation, onActivationError]
   )
 
-  return {
-    tryActivation,
-    retryPendingActivation: () => {
-      if (pendingConnector) {
-        tryActivation(pendingConnector)
-      }
-    },
-  }
+  return useMemo(
+    () => ({
+      tryActivation,
+      retryPendingActivation: () => {
+        if (pendingConnector) {
+          tryActivation(pendingConnector)
+        }
+      },
+    }),
+    [tryActivation, pendingConnector]
+  )
 }


### PR DESCRIPTION
# Summary

This is a big PR that doesn't change anything, other than (hopefully) optimizing the whole app, including CoW Swap and the Explorer.

I was debugging the ethflow and noticed some of the hooks used in the context were returning un-memoized objects.

The issue with that is, even if the obj parameters don't change, every re-render will trigger anything depending on those hooks to re-render, since it's always a new object.

I started updating that and realized there were more and more places.
Ended up searching everywhere in the repo for the string `return {`

I might have missed some, let me know if you know of any.

# To Test

1. Full CoW Swap and Explorer regression testing 😬 