### PR TITLE
feat: add a link to recipient address

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/pure/LimitOrdersDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/pure/LimitOrdersDetails/index.tsx
@@ -126,7 +126,7 @@ export function LimitOrdersDetails(props: LimitOrdersDetailsProps) {
         </div>
       </styledEl.DetailsRow>
       <OrderType isPartiallyFillable={partiallyFillable} partiallyFillableOverride={partiallyFillableOverride} />
-      <RecipientRow recipient={recipientAddressOrName || recipient} account={account} />
+      <RecipientRow chainId={tradeContext.chainId} recipient={recipientAddressOrName || recipient} account={account} />
     </Wrapper>
   )
 }

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeBasicConfirmDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeBasicConfirmDetails/index.tsx
@@ -151,7 +151,7 @@ export function TradeBasicConfirmDetails(props: Props) {
       )}
 
       {/*Recipient*/}
-      <RecipientRow recipient={recipient} account={account} />
+      <RecipientRow chainId={rateInfoParams.chainId} recipient={recipient} account={account} />
       {children}
     </styledEl.Wrapper>
   )

--- a/apps/cowswap-frontend/src/modules/trade/pure/RecipientRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/RecipientRow/index.tsx
@@ -1,4 +1,5 @@
-import { isAddress, shortenAddress } from '@cowprotocol/common-utils'
+import { ExplorerDataType, getExplorerLink, isAddress, shortenAddress } from '@cowprotocol/common-utils'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { InfoTooltip } from '@cowprotocol/ui'
 
 import styled from 'styled-components/macro'
@@ -14,13 +15,22 @@ const Row = styled.div`
   gap: 3px;
 `
 
+const Link = styled.a`
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`
+
 interface RecipientRowProps {
+  chainId: SupportedChainId
   recipient: Nullish<string>
   account: Nullish<string>
 }
 
 export function RecipientRow(props: RecipientRowProps) {
-  const { recipient, account } = props
+  const { chainId, recipient, account } = props
   return (
     <>
       {recipient && recipient.toLowerCase() !== account?.toLowerCase() && (
@@ -34,7 +44,13 @@ export function RecipientRow(props: RecipientRowProps) {
             />
           </div>
           <div>
-            <span title={recipient}>{isAddress(recipient) ? shortenAddress(recipient) : recipient}</span>
+            <Link
+              title={recipient}
+              href={getExplorerLink(chainId, recipient, ExplorerDataType.ADDRESS)}
+              target="_blank"
+            >
+              {isAddress(recipient) ? shortenAddress(recipient) : recipient}
+            </Link>
           </div>
         </Row>
       )}


### PR DESCRIPTION
# Summary

<img width="517" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/3d13c5e8-51be-4b4a-95d0-d8630550ef14">

# To Test

Swap/Limit/Twap:
When custom recipient is set, then it should be displayed on confirm screen. The recipient value should be a link to etherscan. 
