### PR TITLE
fix(widget): allow using clipboard in iframe

### DIFF
--- a/libs/widget-lib/src/cowSwapWidget.ts
+++ b/libs/widget-lib/src/cowSwapWidget.ts
@@ -155,6 +155,7 @@ function createIframe(params: CowSwapWidgetParams): HTMLIFrameElement {
   iframe.width = width
   iframe.height = height
   iframe.style.border = '0'
+  iframe.allow = 'clipboard-read; clipboard-write'
 
   return iframe
 }


### PR DESCRIPTION
# Summary

Fixes #4541

<img width="416" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/a38d69ea-17fa-435e-aa4d-5b914611cd6a">

# To Test

See #4541
