### PR TITLE
fix(safe): update signer tooltip decription

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/pure/SwapButtons/SafeReadOnlyButton.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/SwapButtons/SafeReadOnlyButton.tsx
@@ -19,7 +19,7 @@ export function SafeReadOnlyButton() {
             <div>
               Your Safe is not connected with a signer.
               <br />
-              To place an order, you must connect using a signer of the Safe.
+              To place an order, you must connect using a signer of this Safe.
             </div>
           }
         />

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 
 import { getIsNativeToken, getWrappedToken } from '@cowprotocol/common-utils'
 import { HelpTooltip, TokenSymbol } from '@cowprotocol/ui'
@@ -116,7 +115,7 @@ export const tradeButtonsMap: Record<TradeFormValidation, ButtonErrorConfig | Bu
             <div>
               Your Safe is not connected with a signer.
               <br />
-              To place an order, you must connect using a signer of the Safe and refresh the page.
+              To place an order, you must connect using a signer of this Safe.
             </div>
           }
         />


### PR DESCRIPTION
# Summary

Fixes #4596 

Remove the bit where we ask to refresh the page in the Safe signer tooltip.

# To Test

Check the issue description