### PR TITLE
fix(explorer): invert fills table order (newest first)

### DIFF
--- a/apps/explorer/src/hooks/useOperatorTrades.ts
+++ b/apps/explorer/src/hooks/useOperatorTrades.ts
@@ -104,7 +104,8 @@ export function useOrderTrades(order: Order | null): Result {
       return { ...transformTrade(trade, order, timestamp), buyToken, sellToken }
     })
 
-    setTrades(trades)
+    // Reverse trades, to show the newest on top
+    setTrades(trades.reverse())
   }, [order, rawTrades, tradesTimestamps])
 
   const executedSellAmount = order?.executedSellAmount.toString()


### PR DESCRIPTION
# Summary

Fixes #4417 

Invert Explorer fills table sorting order.
Newest trades are shown first.

# To Test

1. Open an order with lots of fills, such as `0x403bdded2c50f727ea3c38f951d1a4f89b0f7313beeb4bd86da4ee1d06b642a6ce8c14435fe642f2af259a768e060c4e845606c3671e957a`
* Newest trades should be shown first