### PR TITLE
fix(widget): use custom label and content for partner fee

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/TradeRateDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/TradeRateDetails/index.tsx
@@ -26,7 +26,7 @@ export function TradeRateDetails({ rateInfoParams }: TradeRateDetailsProps) {
       partnerFeeUsd={partnerFeeUsd}
       partnerFeeAmount={partnerFeeAmount}
       partnerFeeBps={partnerFeeBps}
-      feeTooltipMarkdown={widgetParams.content?.feeTooltipMarkdown}
+      widgetContent={widgetParams.content}
     />
   )
 

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeFeesAndCosts/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeFeesAndCosts/index.tsx
@@ -45,7 +45,7 @@ export function TradeFeesAndCosts(props: TradeFeesAndCostsProps) {
         partnerFeeUsd={partnerFeeUsd}
         partnerFeeAmount={partnerFeeAmount}
         partnerFeeBps={partnerFeeBps}
-        feeTooltipMarkdown={widgetParams.content?.feeTooltipMarkdown}
+        widgetContent={widgetParams.content}
       />
 
       {/*Network cost*/}

--- a/apps/cowswap-frontend/src/modules/trade/pure/PartnerFeeRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/PartnerFeeRow/index.tsx
@@ -1,6 +1,8 @@
 import { bpsToPercent, formatPercent } from '@cowprotocol/common-utils'
+import { CowSwapWidgetContent } from '@cowprotocol/widget-lib'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
+import ReactMarkdown from 'react-markdown'
 import { Nullish } from 'types'
 
 import * as styledEl from '../../containers/TradeBasicConfirmDetails/styled'
@@ -12,7 +14,7 @@ interface PartnerFeeRowProps {
   partnerFeeBps: number | undefined
   withTimelineDot: boolean
   alwaysRow?: boolean
-  feeTooltipMarkdown?: string
+  widgetContent?: CowSwapWidgetContent
 }
 
 export function PartnerFeeRow({
@@ -21,7 +23,7 @@ export function PartnerFeeRow({
   partnerFeeBps,
   withTimelineDot,
   alwaysRow,
-  feeTooltipMarkdown,
+  widgetContent,
 }: PartnerFeeRowProps) {
   const feeAsPercent = partnerFeeBps ? formatPercent(bpsToPercent(partnerFeeBps)) : null
   const minPartnerFeeAmount = partnerFeeAmount?.equalTo(0)
@@ -37,7 +39,9 @@ export function PartnerFeeRow({
           fiatAmount={partnerFeeUsd}
           alwaysRow={alwaysRow}
           tooltip={
-            feeTooltipMarkdown || (
+            widgetContent?.feeTooltipMarkdown ? (
+              <ReactMarkdown>{widgetContent.feeTooltipMarkdown}</ReactMarkdown>
+            ) : (
               <>
                 This fee helps pay for maintenance & improvements to the trade experience.
                 <br />
@@ -46,7 +50,7 @@ export function PartnerFeeRow({
               </>
             )
           }
-          label={`Total fee (${feeAsPercent}%)`}
+          label={`${widgetContent?.feeLabel || 'Total fee'} (${feeAsPercent}%)`}
         />
       ) : (
         <ReviewOrderModalAmountRow


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C03DVQREAH0/p1719589472229209

<img width="484" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/a0c4485e-74b6-4528-98a4-934e59606c54">

# To Test

1. Open windget configirator
2. Execute the following code in the browser console (configurator window)

```
window.cowSwapWidgetParams = {
  content: {
    feeTooltipMarkdown: `# Summary
I added it to both CoW Swap and cow.fi

Additionally:
- Configured Vercel preview to point to BARN
- Configured GH dev to point to BARN
- All the other envs (prod, staging and barn), will point to production.`,
    feeLabel: 'my fee',
  },
}
```
3. Input some partner fee in the widget configurator
4. Open fee details
5. ER: entered values are displayed in the UI
