### PR TITLE
fix(limit-orders): don't override price from URL with initial value

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/state/limitRateAtom.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/state/limitRateAtom.ts
@@ -17,6 +17,7 @@ export interface LimitRateState {
   readonly typedValue: string | null
   // Respect alternative order initial rate
   readonly isAlternativeOrderRate: boolean
+  readonly isInitialPriceSet?: boolean
 }
 
 export const initLimitRateState = () => ({

--- a/apps/cowswap-frontend/src/modules/limitOrders/updaters/InitialPriceUpdater/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/updaters/InitialPriceUpdater/index.tsx
@@ -40,7 +40,13 @@ export function InitialPriceUpdater() {
     if (!price || isInitialPriceSet || isLoading || prevPrice?.equalTo(price)) return
 
     setIsInitialPriceSet(true)
-    updateRate({ activeRate: price, isTypedValue: false, isRateFromUrl: false, isAlternativeOrderRate: false })
+    updateRate({
+      activeRate: price,
+      isInitialPriceSet: true,
+      isTypedValue: false,
+      isRateFromUrl: false,
+      isAlternativeOrderRate: false,
+    })
     updateLimitRateState({ isLoading })
   }, [isInitialPriceSet, updateLimitRateState, updateRate, price, isLoading, prevPrice])
 

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useSetupTradeAmountsFromUrl.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useSetupTradeAmountsFromUrl.ts
@@ -71,6 +71,7 @@ export function useSetupTradeAmountsFromUrl({ onAmountsUpdate, onlySell }: Setup
     }
 
     if (onlySell) {
+      debugger
       update.outputCurrencyAmount = null
 
       update.orderKind = OrderKind.SELL

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useSetupTradeAmountsFromUrl.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useSetupTradeAmountsFromUrl.ts
@@ -71,7 +71,6 @@ export function useSetupTradeAmountsFromUrl({ onAmountsUpdate, onlySell }: Setup
     }
 
     if (onlySell) {
-      debugger
       update.outputCurrencyAmount = null
 
       update.orderKind = OrderKind.SELL


### PR DESCRIPTION
# Summary

Fixes #4666

In limit orders we have initial price which is a value derrived from `/native_price` API.
Recently I added `SetupLimitOrderAmountsFromUrlUpdater` which fills limit-orders state with amounts from URL.
Those two mechanisms were conflicting and it caused from price values.

After this fix:
 - if state was filled from URL
 - then don't updated it with an initial price


# To Test

1. Open Swap, set Sell 4000 WETH
2. Remember the output amount 
3. Navigate to Limit orders
4. ER: the form contains exactly the same sell/buy amounts as in Swap page
5. ER: the limit price = buyAmount / selAmount
