### PR TITLE
chore: add custom build settings

### DIFF
--- a/apps/cowswap-frontend/vercel.json
+++ b/apps/cowswap-frontend/vercel.json
@@ -5,5 +5,8 @@
       "destination": "/",
       "permanent": false
     }
-  ]
+  ],
+  "buildCommand": "cd ../../ && yarn build:cowswap",
+  "outputDirectory": "../../build/cowswap",
+  "installCommand": "cd ../../ && yarn"
 }


### PR DESCRIPTION
# Summary

To properly configure redirects due to the usage of the HashRouter on https://github.com/cowprotocol/cowswap/pull/4643, the use of vercel.json for cowswap-frontend app was introduced.

To make it work though, the build settings needed to be updated, as well as the app's root directory.

Based on [this answer](https://github.com/orgs/vercel/discussions/2074).

![image](https://github.com/cowprotocol/cowswap/assets/43217/b81a0229-0f95-4613-80c4-34ebad077863)

In this PR, I'm adding the build settings to vercel.json, to more easily visualize and version control the settings changes.

The [vercel.json settings available](https://vercel.com/docs/projects/project-configuration) do not include however the root directory. That can be configured in the UI only.

# To Test

Not testable.