### PR TITLE
fix(widget): always listen activation event

### DIFF
--- a/libs/widget-lib/src/cowSwapWidget.ts
+++ b/libs/widget-lib/src/cowSwapWidget.ts
@@ -3,7 +3,7 @@ import { CowEventListeners } from '@cowprotocol/events'
 import { IframeCowEventEmitter } from './IframeCowEventEmitter'
 import { IframeRpcProviderBridge } from './IframeRpcProviderBridge'
 import { IframeSafeSdkBridge } from './IframeSafeSdkBridge'
-import { WindowListener, listenToMessageFromWindow, postMessageToWindow, stopListeningWindowListener } from './messages'
+import { WindowListener, listenToMessageFromWindow, postMessageToWindow } from './messages'
 import {
   CowSwapWidgetParams,
   CowSwapWidgetProps,
@@ -191,17 +191,12 @@ function updateParams(contentWindow: Window, params: CowSwapWidgetParams, provid
  * @param appCode - A unique identifier for the app.
  */
 function sendAppCodeOnActivation(contentWindow: Window, appCode: string | undefined) {
-  const listener = listenToMessageFromWindow(window, WidgetMethodsEmit.ACTIVATE, () => {
-    // Stop listening for the ACTIVATE (once is enough)
-    stopListeningWindowListener(window, listener)
-
+  return listenToMessageFromWindow(window, WidgetMethodsEmit.ACTIVATE, () => {
     // Update the appData
     postMessageToWindow(contentWindow, WidgetMethodsListen.UPDATE_APP_DATA, {
       metaData: appCode ? { appCode } : undefined,
     })
   })
-
-  return listener
 }
 
 /**


### PR DESCRIPTION
# Summary

The bug was reported by @compojoom 

When we navigate to some external link inside of widget iframe and go back, we don't "ACTIVATE" event and hence don't send "UPDATE_APP_DATA".

<img width="576" alt="image" src="https://github.com/cowprotocol/cowswap/assets/7122625/ec541315-a94c-4db7-9013-765413d9e4bb">

# To Test

The case might be tested only after releasing a new `@cowprotocol/widget-react` version and upping it in Safe app.

1. Open https://feat_swaps_fees--walletweb.review.5afe.dev/
2. Go to Swap page
3. Setup some trade
4. Open "Widget Fee (0.35%)" tooltip
5. Click to "tiered widget fee" link
6. Navigate back using history API
7. Create an order
8. AR:order appData contains "CoW Swap-SafeApp" code
9. ER: order appData contains "Safe Wallet Swaps" code