### PR TITLE
fix(widget): always open links from widget markdown in a new tab

### DIFF
--- a/apps/cowswap-frontend/src/modules/injectedWidget/index.ts
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/index.ts
@@ -4,3 +4,4 @@ export { useInjectedWidgetParams, useWidgetPartnerFee } from './hooks/useInjecte
 export { useInjectedWidgetMetaData } from './hooks/useInjectedWidgetMetaData'
 export { useInjectedWidgetPalette } from './hooks/useInjectedWidgetPalette'
 export { injectedWidgetPartnerFeeAtom } from './state/injectedWidgetParamsAtom'
+export { WidgetMarkdownContent } from './pure/WidgetMarkdownContent'

--- a/apps/cowswap-frontend/src/modules/injectedWidget/pure/WidgetMarkdownContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/pure/WidgetMarkdownContent/index.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from 'react'
+
+import ReactMarkdown, { Components } from 'react-markdown'
+
+interface ExternalLinkProps {
+  href: string
+  children: ReactNode
+  className?: string
+}
+
+// Any link in widget should be opened in new tab
+function ExternalLink(props: ExternalLinkProps) {
+  return (
+    <a {...props} target="_blank">
+      {props.children}
+    </a>
+  )
+}
+
+const components = { a: ExternalLink } as Components
+
+export function WidgetMarkdownContent({ children }: { children?: string }) {
+  return <ReactMarkdown components={components}>{children}</ReactMarkdown>
+}

--- a/apps/cowswap-frontend/src/modules/trade/pure/PartnerFeeRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/PartnerFeeRow/index.tsx
@@ -2,8 +2,9 @@ import { bpsToPercent, formatPercent } from '@cowprotocol/common-utils'
 import { CowSwapWidgetContent } from '@cowprotocol/widget-lib'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
-import ReactMarkdown from 'react-markdown'
 import { Nullish } from 'types'
+
+import { WidgetMarkdownContent } from 'modules/injectedWidget'
 
 import * as styledEl from '../../containers/TradeBasicConfirmDetails/styled'
 import { ReviewOrderModalAmountRow } from '../ReviewOrderModalAmountRow'
@@ -40,7 +41,7 @@ export function PartnerFeeRow({
           alwaysRow={alwaysRow}
           tooltip={
             widgetContent?.feeTooltipMarkdown ? (
-              <ReactMarkdown>{widgetContent.feeTooltipMarkdown}</ReactMarkdown>
+              <WidgetMarkdownContent>{widgetContent.feeTooltipMarkdown}</WidgetMarkdownContent>
             ) : (
               <>
                 This fee helps pay for maintenance & improvements to the trade experience.


### PR DESCRIPTION
# Summary

In Widget we provide an option to customize some texts using Markdown.
Markdown might contain links.
Due to widget links policy, we have to open any of them in a new tab.

![image](https://github.com/cowprotocol/cowswap/assets/7122625/960f1699-35dd-44ca-9a98-3a2b29041679)

# To Test

1. Open https://feat_swaps_fees--walletweb.review.5afe.dev/
2. Go to Swap page
3. Setup some trade
4. Open "Widget Fee (0.35%)" tooltip
5. Click to "tiered widget fee" link
6. ER: the link should be open in a new tab

