### PR TITLE
fix(widget-lib): exclude cow-sdk from the bundle

### DIFF
--- a/libs/widget-lib/src/flexibleConfig.ts
+++ b/libs/widget-lib/src/flexibleConfig.ts
@@ -1,4 +1,4 @@
-import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import type { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import { FlexibleConfig, PerNetworkConfig, PerTradeTypeConfig, TradeType } from './types'
 
@@ -30,8 +30,10 @@ export function isPerTradeTypeConfig<T>(config: FlexibleConfig<T>): config is Pe
   return Object.keys(config as object).every((key) => TradeTypes.includes(key as TradeType))
 }
 
+const D_REGEX = /^\d+$/
+
 export function isPerNetworkConfig<T>(config: FlexibleConfig<T>): config is PerNetworkConfig<T> {
   if (typeof config !== 'object') return false
 
-  return Object.keys(config as object).every((key) => key in SupportedChainId)
+  return Object.keys(config as object).every((key) => typeof key === 'number' || D_REGEX.test(key))
 }

--- a/libs/widget-lib/src/types.ts
+++ b/libs/widget-lib/src/types.ts
@@ -1,7 +1,6 @@
 import type { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { CowEventListeners, CowEventPayloadMap, CowEvents } from '@cowprotocol/events'
-
-export { SupportedChainId } from '@cowprotocol/cow-sdk'
+export type { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 export type PerTradeTypeConfig<T> = Partial<Record<TradeType, T>>
 


### PR DESCRIPTION
# Summary

Initially, the problem was with Next.js apps. They were crashing due to using `window`.

The problem was introduced in [this change](https://github.com/cowprotocol/cowswap/pull/4407/files#diff-381419bc0262706d9ab2bb2d885a8e794804ad54bf71dffe5d7a029d835eaf9fR3).

And then I also strengthened it [here](https://github.com/cowprotocol/cowswap/pull/4546/files#diff-92467ccfefe8743e757f1b45dac0986badce93e645f43416e4da35abdc28ad76R1).

So, the problem in the fact that cow-sdk was included in the widget-lib.

Before
```
[vite:dts] Start generate declaration files...
computing gzip size (0)...[vite:dts] Declaration files built in 391ms.

../../dist/libs/widget-lib/index.mjs  1,620.88 kB │ gzip: 328.53 kB
../../dist/libs/widget-lib/index.js  960.58 kB │ gzip: 286.46 kB
../../dist/libs/widget-lib/index.iife.js  960.45 kB │ gzip: 286.45 kB
✓ built in 2.27s
```

After
```
[vite:dts] Start generate declaration files...
../../dist/libs/widget-lib/index.mjs  10.39 kB │ gzip: 3.58 kB
[vite:dts] Declaration files built in 476ms.
```

# To Test

The widget lib bundle should weigh less than an elephant
