### PR TITLE
fix(widget): always open links from widget markdown in a new tab

### DIFF
--- a/apps/cowswap-frontend/src/modules/injectedWidget/index.ts
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/index.ts
@@ -4,3 +4,4 @@ export { useInjectedWidgetParams, useWidgetPartnerFee } from './hooks/useInjecte
 export { useInjectedWidgetMetaData } from './hooks/useInjectedWidgetMetaData'
 export { useInjectedWidgetPalette } from './hooks/useInjectedWidgetPalette'
 export { injectedWidgetPartnerFeeAtom } from './state/injectedWidgetParamsAtom'
+export { WidgetMarkdownContent } from './pure/WidgetMarkdownContent'

--- a/apps/cowswap-frontend/src/modules/injectedWidget/pure/WidgetMarkdownContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/pure/WidgetMarkdownContent/index.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from 'react'
+
+import ReactMarkdown, { Components } from 'react-markdown'
+
+interface ExternalLinkProps {
+  href: string
+  children: ReactNode
+  className?: string
+}
+
+// Any link in widget should be opened in new tab
+function ExternalLink(props: ExternalLinkProps) {
+  return (
+    <a {...props} target="_blank">
+      {props.children}
+    </a>
+  )
+}
+
+const components = { a: ExternalLink } as Components
+
+export function WidgetMarkdownContent({ children }: { children?: string }) {
+  return <ReactMarkdown components={components}>{children}</ReactMarkdown>
+}

--- a/apps/cowswap-frontend/src/modules/trade/pure/PartnerFeeRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/PartnerFeeRow/index.tsx
@@ -2,8 +2,9 @@ import { bpsToPercent, formatPercent } from '@cowprotocol/common-utils'
 import { CowSwapWidgetContent } from '@cowprotocol/widget-lib'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
-import ReactMarkdown from 'react-markdown'
 import { Nullish } from 'types'
+
+import { WidgetMarkdownContent } from 'modules/injectedWidget'
 
 import * as styledEl from '../../containers/TradeBasicConfirmDetails/styled'
 import { ReviewOrderModalAmountRow } from '../ReviewOrderModalAmountRow'
@@ -40,7 +41,7 @@ export function PartnerFeeRow({
           alwaysRow={alwaysRow}
           tooltip={
             widgetContent?.feeTooltipMarkdown ? (
-              <ReactMarkdown>{widgetContent.feeTooltipMarkdown}</ReactMarkdown>
+              <WidgetMarkdownContent>{widgetContent.feeTooltipMarkdown}</WidgetMarkdownContent>
             ) : (
               <>
                 This fee helps pay for maintenance & improvements to the trade experience.


### PR DESCRIPTION
# Summary

[The PR](https://github.com/cowprotocol/cowswap/pull/4671) was merged to the wrong branch, so, just cherry-pciked the commit in order to merge it into develop
