### PR TITLE
fix(limit): missing price error takes precedence over missing approval

### DIFF
--- a/apps/cowswap-frontend/src/assets/icon/caret.svg
+++ b/apps/cowswap-frontend/src/assets/icon/caret.svg
@@ -1,0 +1,1 @@
+<svg fill="none" height="8" viewBox="0 0 12 8" width="12" xmlns="http://www.w3.org/2000/svg"><path d="m10.59.589966-4.59 4.580004-4.59-4.580004-1.41 1.410004 6 6 6-6z" fill="#0f2c61"/></svg>

--- a/apps/cowswap-frontend/src/assets/icon/carret.svg
+++ b/apps/cowswap-frontend/src/assets/icon/carret.svg
@@ -1,1 +1,0 @@
-<svg fill="none" height="8" viewBox="0 0 12 8" width="12" xmlns="http://www.w3.org/2000/svg"><path d="m10.59.589966-4.59 4.580004-4.59-4.580004-1.41 1.410004 6 6 6-6z" fill="#0f2c61"/></svg>

--- a/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
@@ -2,7 +2,7 @@ import { useContext, useMemo } from 'react'
 
 import { TokenLogo } from '@cowprotocol/tokens'
 import { Command } from '@cowprotocol/types'
-import { ButtonSize, Loader, TokenSymbol, AutoRow, ButtonConfirmed, HoverTooltip } from '@cowprotocol/ui'
+import { AutoRow, ButtonConfirmed, ButtonSize, HoverTooltip, Loader, TokenSymbol } from '@cowprotocol/ui'
 import { Currency } from '@uniswap/sdk-core'
 
 import { Trans } from '@lingui/macro'
@@ -45,7 +45,8 @@ export function ApproveButton(props: ApproveButtonProps) {
               Allow CoW Swap to use your <TokenSymbol token={currency} />
             </Trans>
           </span>
-          <HoverTooltip wrapInContainer 
+          <HoverTooltip
+            wrapInContainer
             content={
               <Trans>
                 You must give the CoW Protocol smart contracts permission to use your <TokenSymbol token={currency} />.

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/TradeButtons/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/TradeButtons/index.tsx
@@ -7,6 +7,7 @@ import { useTradeConfirmActions } from 'modules/trade'
 import {
   TradeFormBlankButton,
   TradeFormButtons,
+  TradeFormValidation,
   useGetTradeFormValidation,
   useTradeFormButtonContext,
 } from 'modules/tradeFormValidation'
@@ -16,6 +17,11 @@ import { limitOrdersTradeButtonsMap } from './limitOrdersTradeButtonsMap'
 import { useLimitOrdersFormState } from '../../hooks/useLimitOrdersFormState'
 
 const CONFIRM_TEXT = 'Review limit order'
+
+const PRIMARY_VALIDATION_OVERRIDEN_BY_LOCAL_VALIDATION: TradeFormValidation[] = [
+  TradeFormValidation.ApproveAndSwap,
+  TradeFormValidation.ApproveRequired,
+]
 
 interface TradeButtonsProps {
   isTradeContextReady: boolean
@@ -29,16 +35,18 @@ export function TradeButtons({ isTradeContextReady }: TradeButtonsProps) {
 
   const confirmTrade = tradeConfirmActions.onOpen
 
-  const defaultText = CONFIRM_TEXT
-
-  const tradeFormButtonContext = useTradeFormButtonContext(defaultText, confirmTrade)
+  const tradeFormButtonContext = useTradeFormButtonContext(CONFIRM_TEXT, confirmTrade)
 
   const isDisabled = !warningsAccepted || !isTradeContextReady
 
   if (!tradeFormButtonContext) return null
 
   // Display local form validation errors only when there are no primary errors
-  if (!primaryFormValidation && localFormValidation) {
+  if (
+    (!primaryFormValidation ||
+      PRIMARY_VALIDATION_OVERRIDEN_BY_LOCAL_VALIDATION.indexOf(primaryFormValidation) !== -1) &&
+    localFormValidation
+  ) {
     const buttonFactory = limitOrdersTradeButtonsMap[localFormValidation]
 
     return typeof buttonFactory === 'function' ? (

--- a/apps/cowswap-frontend/src/modules/swap/updaters/SmartSlippageUpdater.ts
+++ b/apps/cowswap-frontend/src/modules/swap/updaters/SmartSlippageUpdater.ts
@@ -47,7 +47,7 @@ export function SmartSlippageUpdater() {
 
   useEffect(() => {
     setSmartSwapSlippage(typeof slippageBps === 'number' ? slippageBps : null)
-  }, [slippageBps])
+  }, [slippageBps, setSmartSwapSlippage])
 
   return null
 }

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidgetLinks/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidgetLinks/index.tsx
@@ -5,7 +5,7 @@ import { BadgeType } from '@cowprotocol/ui'
 import type { TradeType } from '@cowprotocol/widget-lib'
 
 import { Trans } from '@lingui/macro'
-import IMAGE_CARRET from 'assets/icon/carret.svg'
+import IMAGE_CARET from 'assets/icon/caret.svg'
 import SVG from 'react-inlinesvg'
 import { matchPath, useLocation } from 'react-router-dom'
 
@@ -101,7 +101,7 @@ export function TradeWidgetLinks({
         <styledEl.Link to={menuItemsElements.find((item) => item.props.isActive)?.props.routePath || '#'}>
           <Trans>
             {menuItemsElements.find((item) => item.props.isActive)?.props.item.label}
-            {!singleMenuItem ? <SVG src={IMAGE_CARRET} title="select" /> : null}
+            {!singleMenuItem ? <SVG src={IMAGE_CARET} title="select" /> : null}
           </Trans>
         </styledEl.Link>
       </styledEl.MenuItem>

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidgetLinks/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidgetLinks/index.tsx
@@ -87,6 +87,7 @@ export function TradeWidgetLinks({
     location.pathname,
     highlightedBadgeText,
     highlightedBadgeType,
+    handleMenuItemClick
   ])
 
   const singleMenuItem = menuItemsElements.length === 1

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useResetRecipient.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useResetRecipient.ts
@@ -27,7 +27,7 @@ export function useResetRecipient(onChangeRecipient: (recipient: string | null) 
    */
   useEffect(() => {
     onChangeRecipient(null)
-  }, [chainId])
+  }, [chainId, onChangeRecipient])
 
   return null
 }

--- a/apps/cowswap-frontend/src/modules/trade/updaters/RecipientAddressUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/updaters/RecipientAddressUpdater.tsx
@@ -12,7 +12,7 @@ export function RecipientAddressUpdater() {
     if (state?.recipientAddress !== recipientAddress) {
       updateState?.({ ...state, recipientAddress })
     }
-  }, [recipientAddress, state?.recipientAddress, updateState])
+  }, [recipientAddress, state?.recipientAddress, updateState, state])
 
   return null
 }

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
@@ -146,7 +146,7 @@ export const tradeButtonsMap: Record<TradeFormValidation, ButtonErrorConfig | Bu
       </TradeFormBlankButton>
     )
   },
-  [TradeFormValidation.ApproveRequired]: (context, isDisabled = false) => {
+  [TradeFormValidation.ApproveRequired]: (context) => {
     const amountToApprove = context.derivedState.slippageAdjustedSellAmount
 
     if (!amountToApprove) return null

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
@@ -1,4 +1,3 @@
-
 import { getIsNativeToken, getWrappedToken } from '@cowprotocol/common-utils'
 import { HelpTooltip, TokenSymbol } from '@cowprotocol/ui'
 
@@ -153,7 +152,7 @@ export const tradeButtonsMap: Record<TradeFormValidation, ButtonErrorConfig | Bu
     if (!amountToApprove) return null
 
     return (
-      <TradeApproveButton isDisabled={isDisabled} amountToApprove={amountToApprove}>
+      <TradeApproveButton amountToApprove={amountToApprove}>
         <TradeFormBlankButton disabled={true}>
           <Trans>{context.defaultText}</Trans>
         </TradeFormBlankButton>


### PR DESCRIPTION
# Summary

Follow up to https://github.com/cowprotocol/cowswap/pull/4672 and/or https://github.com/cowprotocol/cowswap/pull/4678 (not sure which introduced the bug or not).

Show `enter a price` when LIMIT price is missing, even when approval is required.

# To Test

1. On LIMIT with an EOA, select a buy token and a sell token that needs approval (and is not permittable)
* Approval button should be displayed
![image](https://github.com/cowprotocol/cowswap/assets/43217/9fc5e0b0-1eb7-4f46-b671-16e2ecb6839c)

2. Clear out the price
* Approval button should NOT be displayed
* Button should be disabled and display `Enter a price`
![image](https://github.com/cowprotocol/cowswap/assets/43217/cf718f2f-9d9c-4d61-96df-e8e3f205dd6d)

3. Repeat with Safe app
* Bundling button should be displayed and enabled
![image](https://github.com/cowprotocol/cowswap/assets/43217/fa700d75-5bcc-496a-a7bc-178b79aba581)

4. Clear out the price
* Button should be disabled and display `Enter a price`
![image](https://github.com/cowprotocol/cowswap/assets/43217/e68864b3-8fa8-4019-a7d3-321230162b6f)


5. LIMIT, SWAP and TWAP should work as before