### PR TITLE
fix(hooks): link hooks page to swap trade state

### DIFF
--- a/apps/cowswap-frontend/src/common/constants/routes.ts
+++ b/apps/cowswap-frontend/src/common/constants/routes.ts
@@ -5,9 +5,9 @@ export const TRADE_WIDGET_PREFIX = isInjectedWidget() ? '/widget' : ''
 export const Routes = {
   HOME: '/',
   SWAP: `/:chainId?${TRADE_WIDGET_PREFIX}/swap/:inputCurrencyId?/:outputCurrencyId?`,
+  HOOKS: `/:chainId?${TRADE_WIDGET_PREFIX}/swap/hooks/:inputCurrencyId?/:outputCurrencyId?`,
   LIMIT_ORDER: `/:chainId?${TRADE_WIDGET_PREFIX}/limit/:inputCurrencyId?/:outputCurrencyId?`,
   ADVANCED_ORDERS: `/:chainId?${TRADE_WIDGET_PREFIX}/advanced/:inputCurrencyId?/:outputCurrencyId?`,
-  HOOKS: `/:chainId?${TRADE_WIDGET_PREFIX}/hooks/:inputCurrencyId?/:outputCurrencyId?`,
   LONG_LIMIT_ORDER: `/:chainId?${TRADE_WIDGET_PREFIX}/limit-orders/:inputCurrencyId?/:outputCurrencyId?`,
   LONG_ADVANCED_ORDERS: `/:chainId?${TRADE_WIDGET_PREFIX}/advanced-orders/:inputCurrencyId?/:outputCurrencyId?`,
   SEND: '/send',

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useTradeTypeInfoFromUrl.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useTradeTypeInfoFromUrl.tsx
@@ -9,10 +9,12 @@ import { TradeType, TradeTypeInfo } from '../types'
 
 export function useTradeTypeInfoFromUrl(): TradeTypeInfo | null {
   const swapMatch = !!useMatchTradeRoute('swap')
+  const hooksMatch = !!useMatchTradeRoute('swap/hooks')
   const limitOrderMatch = !!useMatchTradeRoute('limit')
   const advancedOrdersMatch = !!useMatchTradeRoute('advanced')
 
   return useMemo(() => {
+    if (hooksMatch) return { tradeType: TradeType.SWAP, route: Routes.HOOKS }
     if (swapMatch) return { tradeType: TradeType.SWAP, route: Routes.SWAP }
     if (limitOrderMatch) return { tradeType: TradeType.LIMIT_ORDER, route: Routes.LIMIT_ORDER }
     if (advancedOrdersMatch) return { tradeType: TradeType.ADVANCED_ORDERS, route: Routes.ADVANCED_ORDERS }


### PR DESCRIPTION
# Summary

Fixes #4662 (only points 1 and 2)

>When I specify a hook first (pre or post, or both), then try selecting a buy token, the buy token can't be picked. Same for a sell token if I'd like to change it.

>When I change a chain in the app, additional chain indicator appears in the URL  ?chain=gnosis_chain. And this looks a bit weird to have 2 different chain indicators in the URL. And when I navigate between pages, the app asks to change the chain according to the numeric indicator in the URL

1. Changed the URL path from `/hooks` to `/swap/hooks` because it's more specific
2. Adjusted trade type detection for Hooks page

# To Test

1. Open hooks page
2. Try changing sell/buy tokens
- [ ] tokens should be displayed on the page corresponding to the selected value