### PR TITLE
fix: fix broken links in gnosis chain

### DIFF
--- a/apps/explorer/src/components/orders/DetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/index.tsx
@@ -29,14 +29,13 @@ import { Order } from 'api/operator'
 import { getUiOrderType } from 'utils/getUiOrderType'
 
 import { TAB_QUERY_PARAM_KEY } from '../../../explorer/const'
+import { Link } from 'react-router-dom'
 
 const Table = styled(SimpleTable)`
   > tbody > tr {
     grid-template-columns: 27rem auto;
     grid-template-rows: max-content;
     padding: 1.4rem 0 1.4rem 1.1rem;
-
-    
 
     ${media.mediumDown} {
       grid-template-columns: 17rem auto;
@@ -239,12 +238,15 @@ export function DetailsTable(props: DetailsTableProps): React.ReactNode | null {
               <HelpTooltip tooltip={tooltip.from} /> From
             </td>
             <td>
-
               <Wrapper>
                 <RowWithCopyButton
                   textToCopy={owner}
                   onCopy={(): void => onCopy('ownerAddress')}
-                  contentsToDisplay={<LinkWithPrefixNetwork to={getExplorerLink(chainId, owner, ExplorerDataType.ADDRESS)} target='_blank'>{owner}↗</LinkWithPrefixNetwork>}
+                  contentsToDisplay={
+                    <Link to={getExplorerLink(chainId, owner, ExplorerDataType.ADDRESS)} target="_blank">
+                      {owner}↗
+                    </Link>
+                  }
                 />
                 <LinkButton to={`/address/${owner}`}>
                   <FontAwesomeIcon icon={faHistory} />
@@ -262,14 +264,17 @@ export function DetailsTable(props: DetailsTableProps): React.ReactNode | null {
                 <RowWithCopyButton
                   textToCopy={receiver}
                   onCopy={(): void => onCopy('receiverAddress')}
-                  contentsToDisplay={<LinkWithPrefixNetwork to={getExplorerLink(chainId, receiver, ExplorerDataType.ADDRESS)} target='_blank'>{receiver}↗</LinkWithPrefixNetwork>}
+                  contentsToDisplay={
+                    <Link to={getExplorerLink(chainId, receiver, ExplorerDataType.ADDRESS)} target="_blank">
+                      {receiver}↗
+                    </Link>
+                  }
                 />
                 <LinkButton to={`/address/${receiver}`}>
                   <FontAwesomeIcon icon={faHistory} />
                   Order History
                 </LinkButton>
               </Wrapper>
-
             </td>
           </tr>
           {(!partiallyFillable || txHash) && (
@@ -285,7 +290,11 @@ export function DetailsTable(props: DetailsTableProps): React.ReactNode | null {
                     <RowWithCopyButton
                       textToCopy={txHash}
                       onCopy={(): void => onCopy('settlementTx')}
-                      contentsToDisplay={<LinkWithPrefixNetwork to={getExplorerLink(chainId, txHash, ExplorerDataType.TRANSACTION)} target='_blank'>{txHash}↗</LinkWithPrefixNetwork>}
+                      contentsToDisplay={
+                        <Link to={getExplorerLink(chainId, txHash, ExplorerDataType.TRANSACTION)} target="_blank">
+                          {txHash}↗
+                        </Link>
+                      }
                     />
                     <Wrapper gap={false}>
                       <LinkButton to={`/tx/${txHash}`}>


### PR DESCRIPTION
# Summary

Fixes the issue with broken links for gnosis chain

You can see staging broken for GC if you click here: https://staging.explorer.cow.fi/gc/orders/0x0520043f5c8f642ddeefaa2648239b5681413686c5c1c11f9b3ec4241441b84179063d9173c09887d536924e2f6eadbabac099f566867f85?tab=overview 

<img width="1333" alt="image" src="https://github.com/cowprotocol/cowswap/assets/2352112/552515ba-e3c9-428c-bb9b-cd3f6ce0d95c">

But works in staging mainnet:
https://staging.explorer.cow.fi/orders/0x22fe1a6ac14870eb6784d61ee3f06821b342f6b9a4526255edd5f7ebd0d2aecc79063d9173c09887d536924e2f6eadbabac099f5668d635d?tab=overview

## Test 
Test those links for all networks

