### PR TITLE
fix: cow-fi - generate non existing paths

### DIFF
--- a/apps/cow-fi/pages/learn/[article].tsx
+++ b/apps/cow-fi/pages/learn/[article].tsx
@@ -357,5 +357,5 @@ export const getStaticPaths: GetStaticPaths = async () => {
   const slugs = await getAllArticleSlugs()
   const paths = slugs.map((slug) => ({ params: { article: slug } }))
 
-  return { paths, fallback: false }
+  return { paths, fallback: 'blocking' }
 }

--- a/apps/explorer/src/components/orders/DetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/index.tsx
@@ -22,6 +22,7 @@ import { OrderPriceDisplay } from 'components/orders/OrderPriceDisplay'
 import { OrderSurplusDisplay } from 'components/orders/OrderSurplusDisplay'
 import { StatusLabel } from 'components/orders/StatusLabel'
 import { HelpTooltip } from 'components/Tooltip'
+import { Link } from 'react-router-dom'
 import styled from 'styled-components/macro'
 import { capitalize } from 'utils'
 
@@ -29,7 +30,6 @@ import { Order } from 'api/operator'
 import { getUiOrderType } from 'utils/getUiOrderType'
 
 import { TAB_QUERY_PARAM_KEY } from '../../../explorer/const'
-import { Link } from 'react-router-dom'
 
 const tooltip = {
   orderID: 'A unique identifier ID for this order.',


### PR DESCRIPTION
# Summary

- Right now new pages to the CMS aren't directly available as (url) paths on cow.fi. By changing the `fallback` setting in `getStaticPaths` from `false` to `blocking` as per https://nextjs.org/docs/pages/api-reference/functions/get-static-paths#fallback-blocking it should fix that