### PR TITLE
fix(permit): filter out permit signer and rotate it

### DIFF
--- a/apps/cowswap-frontend/src/modules/appData/index.ts
+++ b/apps/cowswap-frontend/src/modules/appData/index.ts
@@ -1,6 +1,7 @@
 export { getAppData } from './utils/fullAppData'
 export * from './updater/AppDataUpdater'
 export { useAppData, useUploadAppData } from './hooks'
+export { filterPermitSignerPermit } from './utils/appDataFilter'
 export { updateHooksOnAppData, buildAppData } from './utils/buildAppData'
 export { buildAppDataHooks } from './utils/buildAppDataHooks'
 export * from './utils/getAppDataHooks'

--- a/apps/cowswap-frontend/src/modules/appData/types.ts
+++ b/apps/cowswap-frontend/src/modules/appData/types.ts
@@ -43,3 +43,5 @@ export type AppDataRootSchema = latest.AppDataRootSchema
 export type AppDataWidget = latest.Widget
 
 export type AppDataPartnerFee = latest.PartnerFee
+
+export type OrderInteractionHooks = latest.OrderInteractionHooks

--- a/apps/cowswap-frontend/src/modules/appData/utils/appDataFilter.ts
+++ b/apps/cowswap-frontend/src/modules/appData/utils/appDataFilter.ts
@@ -7,7 +7,7 @@ export type HooksFilter = (cowHook: CowHook) => boolean
 
 // Address used when bug with multiple permits per order was introduced
 // Should not be the case once we rotate the key, but kept for sanity check
-const FORMER_PERMIT_HOOK_ADDRESS = '4ed18E9489d82784F98118d5A6aB3AD4340802fb'
+const FORMER_PERMIT_HOOK_ADDRESS = '4ed18e9489d82784f98118d5a6ab3ad4340802fb'
 
 /**
  * Filter to identify any hook containing the permit signer address
@@ -16,8 +16,8 @@ const FORMER_PERMIT_HOOK_ADDRESS = '4ed18E9489d82784F98118d5A6aB3AD4340802fb'
  * @param cowHook
  */
 export const filterPermitSignerPermit: HooksFilter = (cowHook: CowHook): boolean => {
-  const hasFormerAddress = cowHook.target.includes(FORMER_PERMIT_HOOK_ADDRESS)
-  const hasCurrentAddress = cowHook.target.includes(PERMIT_SIGNER.address.slice(2))
+  const hasFormerAddress = cowHook.callData.toLowerCase().includes(FORMER_PERMIT_HOOK_ADDRESS)
+  const hasCurrentAddress = cowHook.callData.toLowerCase().includes(PERMIT_SIGNER.address.slice(2).toLowerCase())
 
   console.log(`bug:filterPermitSignerPermit`, cowHook, hasFormerAddress, hasCurrentAddress)
 

--- a/apps/cowswap-frontend/src/modules/appData/utils/appDataFilter.ts
+++ b/apps/cowswap-frontend/src/modules/appData/utils/appDataFilter.ts
@@ -1,0 +1,56 @@
+import { PERMIT_SIGNER } from '@cowprotocol/permit-utils'
+import { CowHook } from '@cowprotocol/types'
+
+import { OrderInteractionHooks } from '../types'
+
+export type HooksFilter = (cowHook: CowHook) => boolean
+
+// Address used when bug with multiple permits per order was introduced
+// Should not be the case once we rotate the key, but kept for sanity check
+const FORMER_PERMIT_HOOK_ADDRESS = '4ed18E9489d82784F98118d5A6aB3AD4340802fb'
+
+/**
+ * Filter to identify any hook containing the permit signer address
+ *
+ * Since we want to use it directly in an `Array.filter` fn, returns false when it DOES match
+ * @param cowHook
+ */
+export const filterPermitSignerPermit: HooksFilter = (cowHook: CowHook): boolean => {
+  const hasFormerAddress = cowHook.target.includes(FORMER_PERMIT_HOOK_ADDRESS)
+  const hasCurrentAddress = cowHook.target.includes(PERMIT_SIGNER.address.slice(2))
+
+  console.log(`bug:filterPermitSignerPermit`, cowHook, hasFormerAddress, hasCurrentAddress)
+
+  return !hasFormerAddress && !hasCurrentAddress
+}
+
+export function filterHooks(
+  hooks: OrderInteractionHooks | undefined,
+  preHooksFilter: HooksFilter | undefined,
+  postHooksFilter: HooksFilter | undefined
+): OrderInteractionHooks | undefined {
+  if (!hooks) {
+    console.log(`bug:filterHooks no hooks`)
+    return hooks
+  }
+
+  const { pre, post, ...rest } = hooks
+
+  const filteredPre = preHooksFilter ? pre?.filter(preHooksFilter) : pre
+  const filteredPost = postHooksFilter ? post?.filter(postHooksFilter) : post
+
+  // Remove metadata completely if nothing is left after filter
+  if (!filteredPre?.length && !filteredPost?.length) {
+    console.log(`bug:filterHooks filtered out everything`, hooks)
+    return undefined
+  }
+
+  console.log(`bug:filterHooks something left after filtering`, hooks, filteredPre, filteredPost)
+
+  return {
+    ...rest,
+    // Filter out if there's nothing in one of them
+    ...(filteredPre?.length ? { pre: filteredPre } : undefined),
+    ...(filteredPost?.length ? { post: filteredPost } : undefined),
+  }
+}

--- a/apps/cowswap-frontend/src/modules/appData/utils/buildAppData.ts
+++ b/apps/cowswap-frontend/src/modules/appData/utils/buildAppData.ts
@@ -6,6 +6,8 @@ import { keccak256, toUtf8Bytes } from 'ethers/lib/utils'
 
 import { UtmParams } from 'modules/utm'
 
+import { filterHooks, HooksFilter } from './appDataFilter'
+
 import {
   AppDataHooks,
   AppDataInfo,
@@ -85,11 +87,13 @@ export function toKeccak256(fullAppData: string) {
 
 export async function updateHooksOnAppData(
   appData: AppDataInfo,
-  hooks: AppDataHooks | undefined
+  hooks: AppDataHooks | undefined,
+  preHooksFilter?: HooksFilter,
+  postHooksFilter?: HooksFilter
 ): Promise<AppDataInfo> {
   const { doc } = appData
 
-  const existingHooks = doc.metadata.hooks
+  const existingHooks = filterHooks(doc.metadata.hooks, preHooksFilter, postHooksFilter)
 
   const newDoc = {
     ...doc,

--- a/apps/cowswap-frontend/src/modules/appData/utils/buildAppDataHooks.ts
+++ b/apps/cowswap-frontend/src/modules/appData/utils/buildAppDataHooks.ts
@@ -7,12 +7,12 @@ export function buildAppDataHooks({
   preInteractionHooks?: PreHooks
   postInteractionHooks?: PostHooks
 }): AppDataHooks | undefined {
-  if (!preInteractionHooks && !postInteractionHooks) {
+  if (!preInteractionHooks?.length && !postInteractionHooks?.length) {
     return undefined
   }
 
   return {
-    ...(preInteractionHooks ? { pre: preInteractionHooks } : undefined),
-    ...(postInteractionHooks ? { post: postInteractionHooks } : undefined),
+    ...(preInteractionHooks?.length ? { pre: preInteractionHooks } : undefined),
+    ...(postInteractionHooks?.length ? { post: postInteractionHooks } : undefined),
   }
 }

--- a/apps/cowswap-frontend/src/modules/permit/utils/handlePermit.ts
+++ b/apps/cowswap-frontend/src/modules/permit/utils/handlePermit.ts
@@ -1,6 +1,6 @@
 import { isSupportedPermitInfo } from '@cowprotocol/permit-utils'
 
-import { AppDataInfo, buildAppDataHooks, updateHooksOnAppData } from 'modules/appData'
+import { AppDataInfo, buildAppDataHooks, filterPermitSignerPermit, updateHooksOnAppData } from 'modules/appData'
 
 import { HandlePermitParams } from '../types'
 
@@ -34,7 +34,7 @@ export async function handlePermit(params: HandlePermitParams): Promise<AppDataI
       preInteractionHooks: [permitData],
     })
 
-    return updateHooksOnAppData(appData, hooks)
+    return updateHooksOnAppData(appData, hooks, filterPermitSignerPermit)
   } else {
     // Otherwise, remove hooks (if any) from appData to avoid stale data
     return updateHooksOnAppData(appData, undefined)

--- a/libs/permit-utils/src/const.ts
+++ b/libs/permit-utils/src/const.ts
@@ -5,7 +5,7 @@ import ms from 'ms.macro'
 
 // PK used only for signing permit requests for quoting and identifying token 'permittability'
 // Do not use or try to send funds to it. Or do. It'll be your funds 🤷
-const PERMIT_PK = '0x1b80501ea68b883241ac5b9f92e8635aa3df23c89b7bbb87e762be65b8c6eb75' // address: 0x4ed18E9489d82784F98118d5A6aB3AD4340802fb
+const PERMIT_PK = '0x68012a4467ce455b6b278b1a6815db9b7224deaa6bced68c3848ec21e6380f8a' // address: 0xD711bD26Bf5B153001a7C0ACcb289782b6f775e9
 
 export const PERMIT_SIGNER = new Wallet(PERMIT_PK)
 


### PR DESCRIPTION
# Summary

The permit hook address suddenly has tens of approvals starting today https://revoke.cash/address/0x4ed18E9489d82784F98118d5A6aB3AD4340802fb?chainId=1

The error linked in this sentry notification seems to match this order https://explorer.cow.fi/orders/0x78f14fa6fc379d2029ba467b97d25506efc0af5af8e806eb6736c999090d5f55488b99c4a94bb0027791e8e0eeb421187ec9a48766952228?tab=overview

The appData contains 2 hooks:
- 1 approving the permit
- 1 approving the user's trade

~While I have not been able to reproduce the issue, this change should prevent the order from ever including the permit signer hook.~

It's easily reproducible, every order should contain and log when the faulty permit is present.

# To Test

1. Pick a permittable sell token with no approvals
2. Proceed until the after the confirmation modal
* The permit signature should be requested
3. Place the order
4. Open the link to the explorer
* The appData should contain ONLY 1 pre hook
* The appData should NOT contain any of the strings: `4ed18E9489d82784F98118d5A6aB3AD4340802fb` (former signer), `D711bD26Bf5B153001a7C0ACcb289782b6f775e9` (new signer)
* Sell token should be approved as usual after order is executed

5. Check the console logs and filter by `bug:filterPermitSignerPermit`. 
* It'll end with `true`
![image](https://github.com/user-attachments/assets/807b6398-c99f-453a-a9ed-f634fc278f2b)
* The `callData` in that log will contain one of the bad strings (`D711bD26Bf5B153001a7C0ACcb289782b6f775e9` in this case)
