### PR TITLE
feat(progress-bar-v2): add widget setting to disable progress bar

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
@@ -8,11 +8,11 @@ import ms from 'ms.macro'
 import useSWR from 'swr'
 
 import { ActivityDerivedState } from 'modules/account/containers/Transaction'
+import { useInjectedWidgetParams } from 'modules/injectedWidget'
 
 import { getOrderCompetitionStatus } from 'api/cowProtocol/api'
 import { getIsFinalizedOrder } from 'utils/orderUtils/getIsFinalizedOrder'
 
-import { useInjectedWidgetParams } from 'modules/injectedWidget'
 import {
   ordersProgressBarStateAtom,
   setOrderProgressBarCancellationTriggered,

--- a/apps/cowswap-frontend/src/modules/injectedWidget/hooks/useInjectedWidgetParams.ts
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/hooks/useInjectedWidgetParams.ts
@@ -5,9 +5,7 @@ import { CowSwapWidgetAppParams, PartnerFee } from '@cowprotocol/widget-lib'
 import { injectedWidgetParamsAtom, injectedWidgetPartnerFeeAtom } from '../state/injectedWidgetParamsAtom'
 
 export function useInjectedWidgetParams(): Partial<CowSwapWidgetAppParams> {
-  const { params } = useAtomValue(injectedWidgetParamsAtom)
-
-  return params
+  return useAtomValue(injectedWidgetParamsAtom).params
 }
 
 export function useWidgetPartnerFee(): PartnerFee | undefined {

--- a/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
@@ -38,6 +38,7 @@ export function useWidgetParams(configuratorState: ConfiguratorState): CowSwapWi
       partnerFeeRecipient,
       standaloneMode,
       disableToastMessages,
+      disableProgressBar,
     } = configuratorState
 
     const themeColors = {
@@ -74,6 +75,7 @@ export function useWidgetParams(configuratorState: ConfiguratorState): CowSwapWi
 
       standaloneMode,
       disableToastMessages,
+      disableProgressBar,
 
       partnerFee:
         partnerFeeBps > 0

--- a/apps/widget-configurator/src/app/configurator/index.tsx
+++ b/apps/widget-configurator/src/app/configurator/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useContext, useEffect, useMemo, useState } from 'react'
+import { ChangeEvent, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 
 import { useAvailableChains } from '@cowprotocol/common-hooks'
 import { CowEventListeners } from '@cowprotocol/events'
@@ -121,6 +121,9 @@ export function Configurator({ title }: { title: string }) {
   const { closeToast, toasts, selectDisableToastMessages, disableToastMessages } = useToastsManager(setListeners)
   const firstToast = toasts?.[0]
 
+  const [disableProgressBar, setDisableProgressBar] = useState<boolean>(false)
+  const toggleDisableProgressBar = useCallback(() => { setDisableProgressBar((curr) => !curr) }, [])
+
   const LINKS = [
     { icon: <CodeIcon />, label: 'View embed code', onClick: () => handleDialogOpen() },
     { icon: <LanguageIcon />, label: 'Widget web', url: `https://cow.fi/widget/?${UTM_PARAMS}` },
@@ -149,6 +152,7 @@ export function Configurator({ title }: { title: string }) {
     partnerFeeRecipient: DEFAULT_PARTNER_FEE_RECIPIENT,
     standaloneMode,
     disableToastMessages,
+    disableProgressBar,
   }
 
   const computedParams = useWidgetParams(state)
@@ -269,6 +273,19 @@ export function Configurator({ title }: { title: string }) {
           >
             <FormControlLabel value="false" control={<Radio />} label="Self-contain in Widget" />
             <FormControlLabel value="true" control={<Radio />} label="Dapp mode" />
+          </RadioGroup>
+        </FormControl>
+        <FormControl component="fieldset">
+          <FormLabel component="legend">Progress bar:</FormLabel>
+          <RadioGroup
+            row
+            aria-label="mode"
+            name="mode"
+            value={disableProgressBar}
+            onChange={toggleDisableProgressBar}
+          >
+            <FormControlLabel value="false" control={<Radio />} label="Show SWAP progress bar" />
+            <FormControlLabel value="true" control={<Radio />} label="Hide SWAP progress bar" />
           </RadioGroup>
         </FormControl>
 

--- a/apps/widget-configurator/src/app/configurator/types.ts
+++ b/apps/widget-configurator/src/app/configurator/types.ts
@@ -28,4 +28,5 @@ export interface ConfiguratorState {
   partnerFeeRecipient: string
   standaloneMode: boolean
   disableToastMessages: boolean
+  disableProgressBar: boolean
 }

--- a/libs/widget-lib/src/types.ts
+++ b/libs/widget-lib/src/types.ts
@@ -249,6 +249,15 @@ export interface CowSwapWidgetParams {
   disablePostedOrderConfirmationModal?: boolean
 
   /**
+   * Disables showing the progress bar after a SWAP order is placed.
+   * The SWAP progress bar offers a transparent view into CoW Protocol's unique solution finding mechanism.
+   * If you wish to not show it, set `disableProgressBar` to `true`.
+   *
+   * Defaults to false.
+   */
+  disableProgressBar?: boolean
+
+  /**
    * Disables showing the toast messages.
    * Some UI might want to disable it and subscribe to WidgetMethodsEmit.ON_TOAST_MESSAGE event to handle the toast messages itself.
    * Defaults to false.


### PR DESCRIPTION
# Summary

Add option to disable progress bar completely:
![image](https://github.com/user-attachments/assets/add781f3-0383-460b-919c-ea851cf7db48)

Once disabled, this is what will be shown after order placement:
![Screenshot 2024-07-30 at 17 17 10](https://github.com/user-attachments/assets/e91154d1-1c0e-417c-b2d8-6b78571276db)

# To Test

⚠️ Note: backend not yet working. Progress bar displayed will not move ⚠️ 

1. In the widget configurator, keep the progress bar enabled
2. Place order
* Should see progress bar (even though not moving)
3. In the widget configurator, disable the progress bar
4. Place order
* Should NOT see the progress bar
5. On regular CoW Swap, place order
* Should see progress bar (even though not moving)