### PR TITLE
feat(progress-bar-v2): show safe info when pending

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/index.tsx
@@ -11,6 +11,7 @@ import { DisplayLink } from 'legacy/components/TransactionConfirmationModal/Disp
 import { ActivityStatus } from 'legacy/hooks/useRecentActivity'
 
 import { ActivityDerivedState } from 'modules/account/containers/Transaction'
+import { GnosisSafeTxDetails } from 'modules/account/containers/Transaction/ActivityDetails'
 import { EthFlowStepper } from 'modules/swap/containers/EthFlowStepper'
 import { WatchAssetInWallet } from 'modules/wallet/containers/WatchAssetInWallet'
 
@@ -68,6 +69,11 @@ export function TransactionSubmittedContent({
 
   const isInjectedWidgetMode = isInjectedWidget()
 
+  const isPresignaturePending = activityDerivedState?.isPresignaturePending
+  const showSafeSigningInfo = isPresignaturePending && activityDerivedState && !!activityDerivedState.gnosisSafeInfo
+  const showProgressBar =
+    !showSafeSigningInfo && !isPresignaturePending && activityDerivedState && orderProgressBarV2Props
+
   return (
     <styledEl.Wrapper>
       <styledEl.Section>
@@ -81,9 +87,10 @@ export function TransactionSubmittedContent({
             </Text>
             <DisplayLink id={hash} chainId={chainId} />
             <EthFlowStepper order={order} />
-            {activityDerivedState && orderProgressBarV2Props && (
-              <OrderProgressBarV2 {...orderProgressBarV2Props} order={order} />
+            {showSafeSigningInfo && (
+              <GnosisSafeTxDetails chainId={chainId} activityDerivedState={activityDerivedState} />
             )}
+            {showProgressBar && <OrderProgressBarV2 {...orderProgressBarV2Props} order={order} />}
             <styledEl.ButtonGroup>
               <WatchAssetInWallet shortLabel currency={currencyToAdd} />
 

--- a/apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
@@ -59,7 +59,7 @@ const DEFAULT_ORDER_SUMMARY = {
   validTo: '',
 }
 
-function GnosisSafeTxDetails(props: {
+export function GnosisSafeTxDetails(props: {
   chainId: number
   activityDerivedState: ActivityDerivedState
 }): JSX.Element | null {
@@ -79,7 +79,7 @@ function GnosisSafeTxDetails(props: {
     ? order?.fulfillmentTime !== undefined
     : enhancedTransaction?.confirmedTime !== undefined
 
-  // Check if its in a state where we dont need more signatures. We do this, because this state comes from CoW Swap API, which
+  // Check if it's in a state where we don't need more signatures. We do this, because this state comes from CoW Swap API, which
   // sometimes can be faster getting the state than Gnosis Safe API (that would give us the pending signatures). We use
   // this check to infer that we don't need to sign anything anymore
   const alreadySigned = isOrder ? status !== ActivityStatus.PRESIGNATURE_PENDING : status !== ActivityStatus.PENDING


### PR DESCRIPTION
# Summary

Show Safe info after order is placed in the confirmation modal until it's executed.
Once executed, show progress bar.

Same logic applies for any other SC wallet, except the safe signers.

![Screenshot 2024-08-01 at 15 14 49](https://github.com/user-attachments/assets/ff93c7d0-f960-48b0-8e7e-4648ea03559b)

⚠️ Styling not included
⚠️ Progress bar will not move, pending backend changes

# To Test

1. With a 2/n Safe, place an order via Safe app
* After the first signature, the UI should show the number of signatures left
* Progress bar should not be shown
2. Finish signing but without executing
* Signatures count should update and should say it needs execution
* Progress bar should not be shown
3. Execute
* After tx is mined, progress bar should be displayed
4. Repeat with Safe via WC
* Should have the same result
5. Repeat with non-Safe based SC wallet (is there any?)
* Should not show Safe signatures
* Should not show Progress bar until executed on chain
6. Repeat with EOA
* Should show progress bar right away