### PR TITLE
Hotfix/fix race condition

### DIFF
--- a/apps/cowswap-frontend/index.html
+++ b/apps/cowswap-frontend/index.html
@@ -8,6 +8,7 @@
       name="description"
       content="CoW Swap finds the lowest prices from all decentralized exchanges and DEX aggregators & saves you more with p2p trading and protection from MEV"
     />
+    
     <script src="/emergency.js"></script>
 
     <!-- Manifest, theme & colors  -->

--- a/libs/tokens/src/updaters/UnsupportedTokensUpdater/index.ts
+++ b/libs/tokens/src/updaters/UnsupportedTokensUpdater/index.ts
@@ -8,7 +8,7 @@ import ms from 'ms.macro'
 import { useUnsupportedTokens } from '../../hooks/tokens/unsupported/useUnsupportedTokens'
 import { removeUnsupportedTokensAtom } from '../../state/tokens/unsupportedTokensAtom'
 
-const UNSUPPORTED_TOKEN_TTL = ms`1h`
+const UNSUPPORTED_TOKEN_TTL = 0 // TODO: Set to 1h after fixing race condition (see https://github.com/cowprotocol/cowswap/issues/4759)
 
 /**
  * Since an unsupported token might become supported in the future, we should periodically reset the list of unsupported tokens.


### PR DESCRIPTION
# Summary

This PR is an attempt to solve the issue with unsupported tokens

https://github.com/cowprotocol/cowswap/issues/4759

Overhauls https://github.com/cowprotocol/cowswap/pull/4760 

Basically, we should NOT get the chainId from the context, it might be newer than the chainId of the request. 

Fetch requests are asynchronous, so we can change the chainId before the response is back. So we should make sure we don't rely on global state to deduce what was the chainId used for getting the quote.