### PR TITLE
fix: fix race condition with unsuported tokens

### DIFF
--- a/apps/cowswap-frontend/src/legacy/hooks/useRefetchPriceCallback.tsx
+++ b/apps/cowswap-frontend/src/legacy/hooks/useRefetchPriceCallback.tsx
@@ -8,7 +8,7 @@ import {
   isPromiseFulfilled,
   onlyResolvesLast,
 } from '@cowprotocol/common-utils'
-import { PriceQuality } from '@cowprotocol/cow-sdk'
+import { PriceQuality, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { useAddUnsupportedToken, useIsUnsupportedToken, useRemoveUnsupportedToken } from '@cowprotocol/tokens'
 
 import { useGetGpPriceStrategy } from 'legacy/hooks/useGetGpPriceStrategy'
@@ -31,7 +31,7 @@ import QuoteApiError, {
 interface HandleQuoteErrorParams {
   quoteData: QuoteInformationObject | LegacyFeeQuoteParams
   error: unknown
-  addUnsupportedToken: (tokenAddress: string) => void
+  addUnsupportedToken: (chainId: SupportedChainId, tokenAddress: string) => void
 }
 
 type QuoteParamsForFetching = Omit<LegacyQuoteParams, 'strategy'>
@@ -45,7 +45,7 @@ function handleQuoteError({ quoteData, error, addUnsupportedToken }: HandleQuote
 
         // Add token to unsupported token list
         if (unsupportedTokenAddress) {
-          addUnsupportedToken(unsupportedTokenAddress)
+          addUnsupportedToken(quoteData.chainId, unsupportedTokenAddress)
         }
 
         return 'unsupported-token'
@@ -82,7 +82,7 @@ function handleQuoteError({ quoteData, error, addUnsupportedToken }: HandleQuote
 
         // Add token to unsupported token list
         if (unsupportedTokenAddress) {
-          addUnsupportedToken(unsupportedTokenAddress)
+          addUnsupportedToken(quoteData.chainId, unsupportedTokenAddress)
         }
 
         return 'unsupported-token'

--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useProcessUnsupportedTokenError.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useProcessUnsupportedTokenError.ts
@@ -4,16 +4,17 @@ import { getQuoteUnsupportedToken } from '@cowprotocol/common-utils'
 import { useAddUnsupportedToken } from '@cowprotocol/tokens'
 
 import QuoteApiError from 'api/cowProtocol/errors/QuoteError'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 export function useProcessUnsupportedTokenError() {
   const addGpUnsupportedToken = useAddUnsupportedToken()
 
   return useCallback(
-    (error: QuoteApiError, quoteParams: { sellToken: string; buyToken: string }) => {
+    (error: QuoteApiError, quoteParams: { chainId: SupportedChainId; sellToken: string; buyToken: string }) => {
       const unsupportedTokenAddress = getQuoteUnsupportedToken(error, quoteParams)
 
       if (unsupportedTokenAddress) {
-        addGpUnsupportedToken(unsupportedTokenAddress)
+        addGpUnsupportedToken(quoteParams.chainId, unsupportedTokenAddress)
       }
     },
     [addGpUnsupportedToken]

--- a/libs/tokens/src/state/tokens/unsupportedTokensAtom.ts
+++ b/libs/tokens/src/state/tokens/unsupportedTokensAtom.ts
@@ -7,7 +7,6 @@ import { mapSupportedNetworks, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { UnsupportedTokensState } from '../../types'
 import { environmentAtom } from '../environmentAtom'
 
-
 export const unsupportedTokensAtom = atomWithStorage<Record<SupportedChainId, UnsupportedTokensState>>(
   'unsupportedTokensAtom:v2',
   mapSupportedNetworks({}),
@@ -20,8 +19,7 @@ export const currentUnsupportedTokensAtom = atom((get) => {
   return get(unsupportedTokensAtom)[chainId]
 })
 
-export const addUnsupportedTokenAtom = atom(null, (get, set, tokenAddress: string) => {
-  const { chainId } = get(environmentAtom)
+export const addUnsupportedTokenAtom = atom(null, (get, set, chainId: SupportedChainId, tokenAddress: string) => {
   const tokenId = tokenAddress.toLowerCase()
   const tokenList = get(unsupportedTokensAtom)
 


### PR DESCRIPTION
# Summary

This PR is an attempt to solve the issue with unsupported tokens

https://github.com/cowprotocol/cowswap/issues/4759

Overhauls https://github.com/cowprotocol/cowswap/pull/4760 

Basically, we should NOT get the chainId from the context, it might be newer than the chainId of the request. 

Fetch requests are asynchronous, so we can change the chainId before the response is back. So we should make sure we don't rely on global state to deduce what was the chainId used for getting the quote.