### PR TITLE
fix(progress-bar-v2): deprioritize out of market stats

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/progressBarV2StateMachine.md
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/progressBarV2StateMachine.md
@@ -1,0 +1,67 @@
+# Progress bar flow
+
+```mermaid
+
+stateDiagram-v2
+    state place_order <<fork>>
+        [*] --> place_order: user place order
+        place_order --> EOA
+        place_order --> PreSign
+        place_order --> EthFlow
+
+    state pending_order <<join>>
+        EOA --> pending_order: once signed
+        PreSign --> pending_order: once presign mined
+        EthFlow --> pending_order: once ethflow mined
+
+        state initial
+            pending_order --> initial: backend [open, scheduled]
+        state solving
+            initial --> solving: backend [active]
+        state solved
+            solving --> solved: backend [solved]
+            solved --> solving: backend [active, initial]
+        state executing
+            solving --> executing: backend [executing]
+        state finished
+            executing --> finished: backend [traded]
+            finished --> [*]
+
+        state delayed
+            solving --> delayed: countdown reaches 0
+            delayed --> executing: backend [executing]
+        state unfillable
+            initial --> unfillable: out of market
+            solving --> unfillable: out of market
+            solved --> unfillable: out of market
+            executing --> unfillable: out of market
+            unfillable --> initial: back on market
+            unfillable --> solving: back on market
+            unfillable --> solved: back on market
+            unfillable --> executing: back on market
+        state expired
+            initial --> expired
+            solving --> expired
+            solved --> expired
+            executing --> expired
+            expired --> [*]
+        state cancelling
+            initial --> cancelling
+            solving --> cancelling
+            solved --> cancelling
+            executing --> cancelling
+            cancelling --> cancelled
+            cancelling --> cancellation_failed: backend [traded]
+        state cancelled
+            cancelling --> cancelled
+            cancelled --> cancellation_failed: backend [traded]
+            cancelled --> [*]
+        state cancellation_failed
+            cancellation_failed --> [*]
+        state submission_failed
+            executing --> submission_failed: backend [active, open, scheduled]
+            submission_failed --> solving: 5s timer
+        state next_batch
+            solved --> next_batch: backend [active, open, scheduled]
+            next_batch --> solving: 5s timer
+```

--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
@@ -214,10 +214,7 @@ function getProgressBarStepName(
   backendApiStatus: OrderProgressBarState['backendApiStatus'],
   previousStepName: OrderProgressBarState['previousStepName']
 ): OrderProgressBarStepName {
-  if (isUnfillable) {
-    // out of market order
-    return 'unfillable'
-  } else if (isExpired) {
+  if (isExpired) {
     return 'expired'
   } else if (isCancelled) {
     return 'cancelled'
@@ -241,6 +238,10 @@ function getProgressBarStepName(
   ) {
     // moved back from solving to active
     return 'nextBatch'
+  }
+  if (isUnfillable) {
+    // out of market order
+    return 'unfillable'
   } else if (backendApiStatus === 'active' && countdown === 0) {
     // solving, but took longer than stipulated countdown
     return 'delayed'


### PR DESCRIPTION
# Summary

Fix items `5` and `7` from https://github.com/cowprotocol/cowswap/pull/4748#pullrequestreview-2215924014

Out of market should not take precedence over expired, cancelled and so on.

# To Test

1. Place order
2. Somehow make it be out of market
3. Cancel it
* Screen should switch to cancelled screen
4. Set a short expiration time, repeat 1 and 2
5. Wait for it to expire
* Screen should switch to expired screen