### PR TITLE
fix(progress-bar-v2): disable progress bar when creating or presign pending

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
@@ -48,11 +48,16 @@ export function useOrderProgressBarV2Props(
     isCancelling = false,
     isCancelled = false,
     isExpired = false,
+    isCreating = false,
+    isPresignaturePending = false,
   } = activityDerivedState || {}
 
-  const { disableProgressBar = false } = useInjectedWidgetParams()
+  const { disableProgressBar: widgetDisabled = false } = useInjectedWidgetParams()
 
-  // When the order is in a final state, avoid querying backend unnecessarily
+  // Do not build progress bar data when these conditions are set
+  const disableProgressBar = widgetDisabled || isCreating || isPresignaturePending
+
+  // When the order is in a final state or progress bar is disabled, avoid querying backend unnecessarily
   const doNotQuery = !!(order && getIsFinalizedOrder(order)) || disableProgressBar
 
   const orderId = order?.id || ''

--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
@@ -285,7 +285,7 @@ const POOLING_SWR_OPTIONS = {
 
 function usePendingOrderStatus(chainId: SupportedChainId, orderId: string, doNotQuery?: boolean) {
   return useSWR(
-    chainId && orderId ? ['getOrderCompetitionStatus', chainId, orderId] : null,
+    chainId && orderId && !doNotQuery ? ['getOrderCompetitionStatus', chainId, orderId] : null,
     async ([, _chainId, _orderId]) => getOrderCompetitionStatus(_chainId, _orderId),
     doNotQuery ? SWR_NO_REFRESH_OPTIONS : POOLING_SWR_OPTIONS
   ).data

--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
@@ -50,12 +50,13 @@ export function useOrderProgressBarV2Props(
     isExpired = false,
     isCreating = false,
     isPresignaturePending = false,
+    isFailed = false,
   } = activityDerivedState || {}
 
   const { disableProgressBar: widgetDisabled = false } = useInjectedWidgetParams()
 
   // Do not build progress bar data when these conditions are set
-  const disableProgressBar = widgetDisabled || isCreating || isPresignaturePending
+  const disableProgressBar = widgetDisabled || isCreating || isFailed || isPresignaturePending
 
   // When the order is in a final state or progress bar is disabled, avoid querying backend unnecessarily
   const doNotQuery = !!(order && getIsFinalizedOrder(order)) || disableProgressBar


### PR DESCRIPTION
# Summary

Fix item `9` from https://github.com/cowprotocol/cowswap/pull/4748#pullrequestreview-2215924014

Disable progress bar when creating or presign pending.

Once order is created/signed, it'll start querying the status.

If in the mean time (from creation/signature) it might already have moved on from the initial state.

# To Test

1. Place eth flow order
* Progress bar should start only after order is created