### PR TITLE
chore: remove outdated legacy price sources

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useProcessUnsupportedTokenError.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useProcessUnsupportedTokenError.ts
@@ -1,10 +1,10 @@
 import { useCallback } from 'react'
 
 import { getQuoteUnsupportedToken } from '@cowprotocol/common-utils'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { useAddUnsupportedToken } from '@cowprotocol/tokens'
 
 import QuoteApiError from 'api/cowProtocol/errors/QuoteError'
-import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 export function useProcessUnsupportedTokenError() {
   const addGpUnsupportedToken = useAddUnsupportedToken()


### PR DESCRIPTION
# Summary

Remove `0x` price source
Remove `paraswap` (was already disabled but some code was still there)
Remove legacy `gp` price source (same as paraswap)

# To Test

1. Place order with short expiration
2. Let it expire
3. Observe the console network tab
* When `quote` endpoint fails, there should be no `0x` api calls