### PR TITLE
feat(progress-bar-v2): wire up cancellation

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo } from 'react'
 
 import { SWR_NO_REFRESH_OPTIONS } from '@cowprotocol/common-const'
 import { CompetitionOrderStatus, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { Command } from '@cowprotocol/types'
 
 import ms from 'ms.macro'
 import useSWR from 'swr'
@@ -11,10 +12,10 @@ import { ActivityDerivedState } from 'modules/account/containers/Transaction'
 import { useInjectedWidgetParams } from 'modules/injectedWidget'
 
 import { getOrderCompetitionStatus } from 'api/cowProtocol/api'
+import { useCancelOrder } from 'common/hooks/useCancelOrder'
 import { getIsFinalizedOrder } from 'utils/orderUtils/getIsFinalizedOrder'
 
-import { Command } from '@cowprotocol/types'
-import { useCancelOrder } from 'common/hooks/useCancelOrder'
+
 import {
   ordersProgressBarStateAtom,
   setOrderProgressBarCancellationTriggered,

--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
@@ -13,6 +13,8 @@ import { useInjectedWidgetParams } from 'modules/injectedWidget'
 import { getOrderCompetitionStatus } from 'api/cowProtocol/api'
 import { getIsFinalizedOrder } from 'utils/orderUtils/getIsFinalizedOrder'
 
+import { Command } from '@cowprotocol/types'
+import { useCancelOrder } from 'common/hooks/useCancelOrder'
 import {
   ordersProgressBarStateAtom,
   setOrderProgressBarCancellationTriggered,
@@ -29,6 +31,7 @@ export type UseOrderProgressBarPropsParams = {
 
 export type UseOrderProgressBarV2Result = Pick<OrderProgressBarState, 'countdown' | 'solverCompetition'> & {
   stepName: Exclude<OrderProgressBarState['progressBarStepName'], undefined>
+  showCancellationModal: Command | null
 }
 
 const MINIMUM_STEP_DISPLAY_TIME = ms`5s`
@@ -56,6 +59,9 @@ export function useOrderProgressBarV2Props(
   const doNotQuery = !!(order && getIsFinalizedOrder(order)) || disableProgressBar
 
   const orderId = order?.id || ''
+
+  const getCancelOrder = useCancelOrder()
+  const showCancellationModal = order && getCancelOrder ? getCancelOrder(order) : null
 
   // Fetch state from atom
   const {
@@ -95,8 +101,9 @@ export function useOrderProgressBarV2Props(
       countdown,
       solverCompetition,
       stepName: progressBarStepName || 'initial',
+      showCancellationModal,
     }
-  }, [disableProgressBar, countdown, solverCompetition, progressBarStepName])
+  }, [disableProgressBar, countdown, solverCompetition, progressBarStepName, showCancellationModal])
 }
 
 // atom related hooks

--- a/apps/cowswap-frontend/src/common/pure/CancelButton/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/CancelButton/index.tsx
@@ -1,11 +1,13 @@
+import { PropsWithChildren } from 'react'
+
 import { Command } from '@cowprotocol/types'
 
 import { LinkStyledButton } from 'theme'
 
 export type CancelButtonProps = {
   onClick: Command
-}
+} & PropsWithChildren
 
-export function CancelButton({ onClick }: CancelButtonProps) {
-  return <LinkStyledButton onClick={onClick}>Cancel order</LinkStyledButton>
+export function CancelButton({ onClick, children }: CancelButtonProps) {
+  return <LinkStyledButton onClick={onClick}>{children || 'Cancel order'}</LinkStyledButton>
 }

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.cosmos.tsx
@@ -8,13 +8,16 @@ import { OrderProgressBarV2, OrderProgressBarV2Props } from './index'
 const defaultProps: OrderProgressBarV2Props = {
   order: getOrderMock(SupportedChainId.MAINNET),
   stepName: 'initial',
+  showCancellationModal: () => {
+    alert('cancellation triggered o/')
+  },
   solverCompetition: [
     {
       solver: 'naive',
       executedAmounts: {
         sell: '5000000000000000000',
         buy: '1000000000000000000000',
-      }
+      },
     },
     { solver: 'uniswap', executedAmounts: { sell: '5000000000000000000', buy: '500000000000000000000' } },
     { solver: 'oneinch', executedAmounts: { sell: '5000000000000000000', buy: '400000000000000000000' } },

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import PROGRESS_BAR_BAD_NEWS from '@cowprotocol/assets/cow-swap/progressbar-bad-news.svg'
 import PROGRESSBAR_COW_SURPLUS from '@cowprotocol/assets/cow-swap/progressbar-cow-surplus.svg'
@@ -12,18 +12,17 @@ import { TokenWithLogo } from '@cowprotocol/common-const'
 import { isSellOrder } from '@cowprotocol/common-utils'
 import type { CompetitionOrderStatus } from '@cowprotocol/cow-sdk'
 import { TokenLogo } from '@cowprotocol/tokens'
-import { UI } from '@cowprotocol/ui'
-import { ProductLogo, ProductVariant } from '@cowprotocol/ui'
+import { ProductLogo, ProductVariant, UI } from '@cowprotocol/ui'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
 import { MdOutlineMotionPhotosPause } from 'react-icons/md'
 import {
-  PiDotsThreeCircle,
-  PiCheckCircleFill,
-  PiSpinnerBallFill,
-  PiClockCountdown,
   PiCaretDown,
   PiCaretUp,
+  PiCheckCircleFill,
+  PiClockCountdown,
+  PiDotsThreeCircle,
+  PiSpinnerBallFill,
   PiTrophyFill,
 } from 'react-icons/pi'
 import SVG from 'react-inlinesvg'
@@ -42,8 +41,11 @@ export type OrderProgressBarV2Props = {
   solverCompetition?: CompetitionOrderStatus['value']
   order?: Order
   debugMode?: boolean
+  // cancelOrder: () => void // TODO: pass down cancel fn
+  // surplus: // TODO: pass down surplus data
 }
 
+// TODO: const, capitalize
 const steps = [
   {
     title: 'Placing order',
@@ -55,6 +57,7 @@ const steps = [
   { title: 'Executing', description: 'The winning solver will execute your order.' },
 ]
 
+// TODO: move to another file?
 const StepComponent: React.FC<{
   status: string
   isFirst: boolean
@@ -217,6 +220,7 @@ function InitialStep({ order }: OrderProgressBarV2Props) {
 }
 
 function SolvingStep({ order }: OrderProgressBarV2Props) {
+  // TODO: use countdown from props
   const [countdown, setCountdown] = useState(15)
 
   useEffect(() => {
@@ -319,16 +323,19 @@ const mockSolvers = [
   { solver: 'FlashSolve', logo: 'flashsolve-logo.png' },
   { solver: 'LiquidityPro', logo: 'liquiditypro-logo.png' },
 ]
+
 // END TEMP ==========================
 
 interface FinishedStepProps {
   solverCompetition?: CompetitionOrderStatus['value']
   order?: Order
   cancellationFailed?: boolean
+  // TODO: add surplus info
 }
 
 export const FinishedStep: React.FC<FinishedStepProps> = ({ solverCompetition, order, cancellationFailed }) => {
   const [showAllSolvers, setShowAllSolvers] = useState(false)
+  // TODO: move out of pure component
   const { surplusFiatValue, surplusPercent } = useGetSurplusData(order)
 
   const toggleSolvers = () => setShowAllSolvers(!showAllSolvers)
@@ -742,4 +749,5 @@ const STEP_NAME_TO_STEP_COMPONENT: Record<StepNameWithoutSolved, React.Component
   cancellationFailed: (props) => <FinishedStep {...props} cancellationFailed={true} />,
 }
 
+// TODO: unused, remove
 export default OrderProgressBarV2

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
@@ -12,6 +12,7 @@ import { TokenWithLogo } from '@cowprotocol/common-const'
 import { isSellOrder } from '@cowprotocol/common-utils'
 import type { CompetitionOrderStatus } from '@cowprotocol/cow-sdk'
 import { TokenLogo } from '@cowprotocol/tokens'
+import { Command } from '@cowprotocol/types'
 import { ProductLogo, ProductVariant, UI } from '@cowprotocol/ui'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
@@ -35,13 +36,15 @@ import { useGetSurplusData } from 'common/hooks/useGetSurplusFiatValue'
 
 import * as styledEl from './styled'
 
+import { CancelButton } from '../CancelButton'
+
 export type OrderProgressBarV2Props = {
   stepName: OrderProgressBarStepName
   countdown?: number | null | undefined
   solverCompetition?: CompetitionOrderStatus['value']
   order?: Order
   debugMode?: boolean
-  // cancelOrder: () => void // TODO: pass down cancel fn
+  showCancellationModal: Command | null
   // surplus: // TODO: pass down surplus data
 }
 
@@ -570,7 +573,7 @@ function DelayedStep({ order }: OrderProgressBarV2Props) {
   )
 }
 
-function UnfillableStep({ order }: OrderProgressBarV2Props) {
+function UnfillableStep({ order, showCancellationModal }: OrderProgressBarV2Props) {
   return (
     <styledEl.ProgressContainer>
       <styledEl.ProgressTopSection>
@@ -589,11 +592,12 @@ function UnfillableStep({ order }: OrderProgressBarV2Props) {
           customColor={'#996815'}
           extraContent={
             <styledEl.Description>
-              Your order's price is currently out of market. You can either wait or{' '}
-              <styledEl.Link href={'#'} underline>
-                cancel the order
-              </styledEl.Link>
-              .
+              Your order's price is currently out of market.{' '}
+              {showCancellationModal && (
+                <>
+                  You can either wait or <CancelButton onClick={showCancellationModal}>cancel the order</CancelButton>.
+                </>
+              )}
             </styledEl.Description>
           }
         />

--- a/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/index.cosmos.tsx
@@ -19,6 +19,9 @@ const defaultProps = {
     ...activityDerivedStateMock,
     order,
   },
+  showCancellationModal: () => {
+    alert('Cancellation triggered!!')
+  },
 }
 
 const Wrapper = styled.div`
@@ -29,7 +32,7 @@ const Wrapper = styled.div`
 const Fixtures = {
   default: (
     <Wrapper>
-      <TransactionSubmittedContent {...defaultProps} showCancellationModal={() => {}} />
+      <TransactionSubmittedContent {...defaultProps} />
     </Wrapper>
   ),
 }

--- a/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/index.tsx
@@ -1,7 +1,7 @@
-import { Order } from '@cowprotocol/cow-sdk'
 // import GameIcon from '@cowprotocol/assets/cow-swap/game.gif'
 // import { isInjectedWidget } from '@cowprotocol/common-utils'
 import { SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
+import { Command } from '@cowprotocol/types'
 import { BackButton } from '@cowprotocol/ui'
 import { Currency } from '@uniswap/sdk-core'
 
@@ -17,10 +17,9 @@ import { EthFlowStepper } from 'modules/swap/containers/EthFlowStepper'
 import { WatchAssetInWallet } from 'modules/wallet/containers/WatchAssetInWallet'
 
 // import { Routes } from 'common/constants/routes'
-
 import * as styledEl from './styled'
-// import { SurplusModal } from './SurplusModal'
 
+// import { SurplusModal } from './SurplusModal'
 import { CancelButton } from '../CancelButton'
 import { OrderProgressBarV2, OrderProgressBarV2Props } from '../OrderProgressBarV2'
 
@@ -52,7 +51,7 @@ export interface TransactionSubmittedContentProps {
   currencyToAdd?: Nullish<Currency>
   showSurplus?: boolean | null
   orderProgressBarV2Props?: OrderProgressBarV2Props | null
-  showCancellationModal: ((order: Order) => void) | null
+  showCancellationModal: Command | null
 }
 
 export function TransactionSubmittedContent({
@@ -66,7 +65,7 @@ export function TransactionSubmittedContent({
   showCancellationModal,
 }: TransactionSubmittedContentProps) {
   const { order, isOrder, isCreating, isPending } = activityDerivedState || {}
-  const showCancellationButton = isOrder && (isCreating || isPending)
+  const showCancellationButton = isOrder && (isCreating || isPending) && showCancellationModal
 
   if (!chainId) {
     return null
@@ -85,11 +84,7 @@ export function TransactionSubmittedContent({
         <styledEl.Header>
           <BackButton onClick={onDismiss} />
           <styledEl.ActionsWrapper>
-            {showCancellationButton && (
-              <CancelButton
-                onClick={() => order && showCancellationModal && showCancellationModal(order as unknown as Order)}
-              />
-            )}
+            {showCancellationButton && <CancelButton onClick={showCancellationModal}>Cancel</CancelButton>}
             <DisplayLink id={hash} chainId={chainId} />
           </styledEl.ActionsWrapper>
         </styledEl.Header>

--- a/apps/cowswap-frontend/src/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
@@ -31,7 +31,6 @@ import { NetworkCostsSuffix } from 'common/pure/NetworkCostsSuffix'
 import { RateInfoParams } from 'common/pure/RateInfo'
 import { TransactionSubmittedContent } from 'common/pure/TransactionSubmittedContent'
 import useNativeCurrency from 'lib/hooks/useNativeCurrency'
-
 import { useIsEoaEthFlow } from '../../hooks/useIsEoaEthFlow'
 import { useShouldPayGas } from '../../hooks/useShouldPayGas'
 import { useSwapConfirmButtonText } from '../../hooks/useSwapConfirmButtonText'
@@ -152,7 +151,13 @@ function useSubmittedContent(chainId: SupportedChainId, gnosisSafeInfo: GnosisSa
   const activity = createActivityDescriptor(chainId, undefined, order)
   const activityDerivedState = getActivityDerivedState({ chainId, activityData: activity, gnosisSafeInfo })
   const orderProgressBarV2Props = useOrderProgressBarV2Props({ activityDerivedState, chainId })
-  const cancelOrder = useCancelOrder()
+
+  const getCancellation = useCancelOrder()
+  const showCancellationModal = useMemo(
+    // Sort of duplicate cancellation logic since ethflow on creating state don't have progress bar props
+    () => orderProgressBarV2Props?.showCancellationModal || (order && getCancellation ? getCancellation(order) : null),
+    [orderProgressBarV2Props?.showCancellationModal, order, getCancellation]
+  )
 
   return useCallback(
     (onDismiss: Command) => (
@@ -162,9 +167,9 @@ function useSubmittedContent(chainId: SupportedChainId, gnosisSafeInfo: GnosisSa
         onDismiss={onDismiss}
         activityDerivedState={activityDerivedState}
         orderProgressBarV2Props={orderProgressBarV2Props}
-        showCancellationModal={order ? cancelOrder(order) : null}
+        showCancellationModal={showCancellationModal}
       />
     ),
-    [chainId, transactionHash, activityDerivedState, orderProgressBarV2Props, cancelOrder, order]
+    [chainId, transactionHash, activityDerivedState, orderProgressBarV2Props, order]
   )
 }

--- a/apps/cowswap-frontend/src/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
@@ -31,6 +31,7 @@ import { NetworkCostsSuffix } from 'common/pure/NetworkCostsSuffix'
 import { RateInfoParams } from 'common/pure/RateInfo'
 import { TransactionSubmittedContent } from 'common/pure/TransactionSubmittedContent'
 import useNativeCurrency from 'lib/hooks/useNativeCurrency'
+
 import { useIsEoaEthFlow } from '../../hooks/useIsEoaEthFlow'
 import { useShouldPayGas } from '../../hooks/useShouldPayGas'
 import { useSwapConfirmButtonText } from '../../hooks/useSwapConfirmButtonText'


### PR DESCRIPTION
# Summary

Wire up cancellation

Pipes into https://github.com/cowprotocol/cowswap/pull/4033

# To Test

1. Place regular order
2. Click on `cancel` from top right
* Should trigger cancellation
3. Place Ethflow order
4. Click on `cancel` from top right
* Should trigger cancellation
5. Place order and make it out of market
* Should show out of market screen and offer cancellation button
6. Click cancellation button
* Should trigger cancellation