### PR TITLE
feat(progress-bar-v2): wire up surplus

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
@@ -32,7 +32,7 @@ import { AMM_LOGOS } from 'legacy/components/AMMsLogo'
 import { Order } from 'legacy/state/orders/actions'
 
 import { OrderProgressBarStepName } from 'common/hooks/orderProgressBarV2'
-import { useGetSurplusData } from 'common/hooks/useGetSurplusFiatValue'
+import { SurplusData } from 'common/hooks/useGetSurplusFiatValue'
 
 import * as styledEl from './styled'
 
@@ -45,7 +45,7 @@ export type OrderProgressBarV2Props = {
   order?: Order
   debugMode?: boolean
   showCancellationModal: Command | null
-  // surplus: // TODO: pass down surplus data
+  surplusData?: SurplusData
 }
 
 // TODO: const, capitalize
@@ -329,17 +329,10 @@ const mockSolvers = [
 
 // END TEMP ==========================
 
-interface FinishedStepProps {
-  solverCompetition?: CompetitionOrderStatus['value']
-  order?: Order
-  cancellationFailed?: boolean
-  // TODO: add surplus info
-}
-
-export const FinishedStep: React.FC<FinishedStepProps> = ({ solverCompetition, order, cancellationFailed }) => {
+function FinishedStep({ stepName, solverCompetition, order, surplusData }: OrderProgressBarV2Props) {
   const [showAllSolvers, setShowAllSolvers] = useState(false)
-  // TODO: move out of pure component
-  const { surplusFiatValue, surplusPercent } = useGetSurplusData(order)
+  const { surplusFiatValue, surplusPercent, surplusAmount } = surplusData || {}
+  const cancellationFailed = stepName === 'cancellationFailed'
 
   const toggleSolvers = () => setShowAllSolvers(!showAllSolvers)
 
@@ -475,6 +468,7 @@ export const FinishedStep: React.FC<FinishedStepProps> = ({ solverCompetition, o
           </styledEl.ExtraAmount>
         ) : null}
         {/*TODO: Add states for when there's no surplus and/or when there's a custom recipient*/}
+        {/*TODO: use surplusData.showSurplus flag to determine when there's relevant surplus */}
       </styledEl.ConclusionContent>
     </styledEl.FinishedStepContainer>
   )
@@ -750,7 +744,7 @@ const STEP_NAME_TO_STEP_COMPONENT: Record<StepNameWithoutSolved, React.Component
   cancelling: CancellingStep,
   cancelled: CancelledStep,
   expired: ExpiredStep,
-  cancellationFailed: (props) => <FinishedStep {...props} cancellationFailed={true} />,
+  cancellationFailed: FinishedStep,
 }
 
 // TODO: unused, remove

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
@@ -335,6 +335,7 @@ function FinishedStep({ stepName, solverCompetition, order, surplusData }: Order
   // TODO: Don't use mock data if no solverCompetition is provided
   const solvers = solverCompetition?.length ? solverCompetition : mockSolvers
   const visibleSolvers = showAllSolvers ? solvers : solvers.slice(0, 3)
+  const isSell = order && isSellOrder(order.kind)
 
   return (
     <styledEl.FinishedStepContainer>
@@ -459,7 +460,7 @@ function FinishedStep({ stepName, solverCompetition, order, surplusData }: Order
         )}
         {surplusFiatValue ? (
           <styledEl.ExtraAmount>
-            and got an extra{' '}
+            {isSell ? 'and got an extra ' : 'and saved '}
             <i>
               +<TokenAmount amount={surplusAmount} tokenSymbol={surplusAmount?.currency} />
             </i>{' '}

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
@@ -442,17 +442,12 @@ function FinishedStep({ stepName, solverCompetition, order, surplusData }: Order
             </styledEl.ViewMoreButton>
           )}
         </styledEl.SolverRankings>
-        {order && (
+        {order?.apiAdditionalInfo?.executedBuyAmount && (
           <styledEl.ReceivedAmount>
             You received <TokenLogo token={order.outputToken} size={16} />{' '}
             <b>
               <TokenAmount
-                amount={CurrencyAmount.fromRawAmount(
-                  order.outputToken,
-                  isSellOrder(order.kind)
-                    ? order.apiAdditionalInfo?.executedBuyAmount || order.buyAmount
-                    : order.apiAdditionalInfo?.executedSellAmount || order.sellAmount
-                )}
+                amount={CurrencyAmount.fromRawAmount(order.outputToken, order.apiAdditionalInfo.executedBuyAmount)}
                 tokenSymbol={order.outputToken}
               />
             </b>

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
@@ -493,6 +493,7 @@ function NextBatchStep({ solverCompetition, order }: OrderProgressBarV2Props) {
           customColor={'#996815'}
           extraContent={
             <styledEl.Description>
+              {/*TODO: replace with actual data*/}
               The <strong>Gnosis_1inch</strong> solver had the best solution for this batch. Unfortunately, your order
               wasn't part of their winning solution, so we're waiting for solvers to find a new solution that includes
               your order for the next batch.{' '}

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
@@ -327,7 +327,7 @@ const mockSolvers = [
 
 function FinishedStep({ stepName, solverCompetition, order, surplusData }: OrderProgressBarV2Props) {
   const [showAllSolvers, setShowAllSolvers] = useState(false)
-  const { surplusFiatValue, surplusPercent, surplusAmount } = surplusData || {}
+  const { surplusFiatValue, surplusPercent, surplusAmount, showSurplus } = surplusData || {}
   const cancellationFailed = stepName === 'cancellationFailed'
 
   const toggleSolvers = () => setShowAllSolvers(!showAllSolvers)
@@ -359,22 +359,42 @@ function FinishedStep({ stepName, solverCompetition, order, surplusData }: Order
             />
           </styledEl.FinishedLogo>
           <styledEl.FinishedTagLine>
-            ...gets you <b>moooooore.</b>
+            {showSurplus ? (
+              <>
+                ...gets you <b>moooooore.</b>
+              </>
+            ) : (
+              <>
+                Did you <b>know?</b>
+              </>
+            )}
           </styledEl.FinishedTagLine>
           <styledEl.CowImage>
             <SVG src={PROGRESSBAR_COW_SURPLUS} />
           </styledEl.CowImage>
-          <styledEl.TokenPairTitle>
-            <span>Swap order</span>
-            <b>{order ? `${order.inputToken.symbol}/${order.outputToken.symbol}` : 'N/A'}</b>
-          </styledEl.TokenPairTitle>
-          <styledEl.TokenImages>
-            <TokenLogo token={order?.inputToken} size={34} />
-            <TokenLogo token={order?.outputToken} size={34} />
-          </styledEl.TokenImages>
-          <styledEl.Surplus>
-            <span>Your surplus</span>
-            {surplusPercent ? <b>+{parseFloat(surplusPercent).toFixed(2)}%</b> : <b>N/A</b>}
+          {showSurplus && (
+            <>
+              <styledEl.TokenPairTitle>
+                <span>Swap order</span>
+                <b>{order ? `${order.inputToken.symbol}/${order.outputToken.symbol}` : 'N/A'}</b>
+              </styledEl.TokenPairTitle>
+              <styledEl.TokenImages>
+                <TokenLogo token={order?.inputToken} size={34} />
+                <TokenLogo token={order?.outputToken} size={34} />
+              </styledEl.TokenImages>
+            </>
+          )}
+          <styledEl.Surplus showSurplus={!!showSurplus}>
+            {showSurplus ? (
+              <>
+                <span>Your surplus</span>
+                {surplusPercent ? <b>+{parseFloat(surplusPercent).toFixed(2)}%</b> : <b>N/A</b>}
+              </>
+            ) : (
+              <>
+                <span>Unlike other exchanges, here you don't pay any fees if your trade fails.</span>
+              </>
+            )}
           </styledEl.Surplus>
         </styledEl.ProgressImageWrapper>
       </styledEl.ProgressTopSection>
@@ -453,17 +473,16 @@ function FinishedStep({ stepName, solverCompetition, order, surplusData }: Order
             </b>
           </styledEl.ReceivedAmount>
         )}
-        {surplusFiatValue ? (
+        {showSurplus ? (
           <styledEl.ExtraAmount>
             {isSell ? 'and got an extra ' : 'and saved '}
             <i>
               +<TokenAmount amount={surplusAmount} tokenSymbol={surplusAmount?.currency} />
             </i>{' '}
-            (~${surplusFiatValue.toFixed(2)})
+            {surplusFiatValue && +surplusFiatValue.toFixed(2) > 0 && <>(~${surplusFiatValue.toFixed(2)})</>}
           </styledEl.ExtraAmount>
         ) : null}
-        {/*TODO: Add states for when there's no surplus and/or when there's a custom recipient*/}
-        {/*TODO: use surplusData.showSurplus flag to determine when there's relevant surplus */}
+        {/*TODO: Add states for when there's a custom recipient*/}
       </styledEl.ConclusionContent>
     </styledEl.FinishedStepContainer>
   )

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
@@ -105,12 +105,34 @@ const OrderIntent: React.FC<{ order?: Order }> = ({ order }) => {
   const { inputToken, outputToken, kind, sellAmount, buyAmount } = order
   const isSell = isSellOrder(kind)
 
+  const sellCurrencyAmount = CurrencyAmount.fromRawAmount(inputToken, sellAmount)
+  const buyCurrencyAmount = CurrencyAmount.fromRawAmount(outputToken, buyAmount)
+
+  const sellTokenPart = (
+    <>
+      <TokenLogo token={inputToken} size={20} />
+      <TokenAmount amount={sellCurrencyAmount} tokenSymbol={inputToken} />
+    </>
+  )
+
+  const buyTokenPart = (
+    <>
+      <TokenLogo token={outputToken} size={20} />
+      <TokenAmount amount={buyCurrencyAmount} tokenSymbol={outputToken} />
+    </>
+  )
+
   return (
     <styledEl.OriginalOrderIntent>
-      <TokenLogo token={inputToken} size={20} />
-      <TokenAmount amount={CurrencyAmount.fromRawAmount(inputToken, sellAmount)} tokenSymbol={inputToken} /> for{' '}
-      {isSell ? 'at least' : 'at most'} <TokenLogo token={outputToken} size={20} />
-      <TokenAmount amount={CurrencyAmount.fromRawAmount(outputToken, buyAmount)} tokenSymbol={outputToken} />
+      {isSell ? (
+        <>
+          {sellTokenPart} for at least {buyTokenPart}
+        </>
+      ) : (
+        <>
+          {buyTokenPart} for at most {sellTokenPart}
+        </>
+      )}
     </styledEl.OriginalOrderIntent>
   )
 }

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/styled.ts
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/styled.ts
@@ -1,5 +1,5 @@
 import IMAGE_STAR_SHINE from '@cowprotocol/assets/cow-swap/star-shine.svg'
-import { UI, Media } from '@cowprotocol/ui'
+import { Media, UI } from '@cowprotocol/ui'
 
 import styled, { css, keyframes } from 'styled-components/macro'
 
@@ -268,7 +268,6 @@ export const TokenWrapper = styled.div<{ position: 'left' | 'center' | 'right' }
     background-size: 100% 100%;
     animation: star-shine 1s infinite;
   }`}
-
   > span {
     padding: ${({ position }) => (position === 'right' ? '45px 40px 34px;' : '0')};
   }
@@ -291,7 +290,7 @@ const progressAnimation = keyframes`
     stroke-dashoffset: 0;
   }
   100% {
-    stroke-dashoffset: -283;  // Approximately 2 * PI * 45
+    stroke-dashoffset: -283; // Approximately 2 * PI * 45
   }
 `
 
@@ -363,6 +362,7 @@ export const CowImage = styled.div`
   justify-content: flex-start;
 
   // mobile from Media
+
   ${Media.upToSmall()} {
     left: -50px;
     width: 200px;
@@ -382,6 +382,7 @@ export const TokenPairTitle = styled.h3`
   align-items: flex-end;
 
   // mobile
+
   ${Media.upToSmall()} {
     display: none;
   }
@@ -404,16 +405,17 @@ export const TokenImages = styled.div`
   }
 `
 
-export const Surplus = styled.div`
+export const Surplus = styled.div<{ showSurplus: boolean }>`
   position: absolute;
-  top: 34px;
+  top: ${({ showSurplus }) => (showSurplus ? '34px' : '54px')};
   right: 20px;
   height: calc(100% - 86px);
   display: flex;
   align-items: flex-end;
   flex-flow: column wrap;
   justify-content: center;
-  color: #006922; // Todo: Fix hardcoded color
+  ${({ showSurplus }) =>
+    showSurplus ? 'color: #006922;' : 'text-align: right; width: 180px;'} // Todo: Fix hardcoded color
   font-size: 23px;
   font-weight: 400;
 
@@ -468,6 +470,7 @@ export const ShareButton = styled.button`
   left: 10px;
 
   // mobile
+
   ${Media.upToSmall()} {
     border: 1px solid var(${UI.COLOR_TEXT});
   }
@@ -542,9 +545,7 @@ export const SolverTableCell = styled.td<{ isFirst?: boolean; isSecond?: boolean
       border-top-left-radius: 5px;
       border-bottom-left-radius: 5px;
       padding: 10px 0 10px 10px;
-    `}
-
-  // isSecond
+    `} // isSecond
   ${({ isSecond }) =>
     isSecond &&
     css`

--- a/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/index.tsx
@@ -49,7 +49,6 @@ export interface TransactionSubmittedContentProps {
   chainId: ChainId
   activityDerivedState: ActivityDerivedState | null
   currencyToAdd?: Nullish<Currency>
-  showSurplus?: boolean | null
   orderProgressBarV2Props?: OrderProgressBarV2Props | null
   showCancellationModal: Command | null
 }
@@ -60,7 +59,6 @@ export function TransactionSubmittedContent({
   hash,
   currencyToAdd,
   activityDerivedState,
-  // showSurplus,
   orderProgressBarV2Props,
   showCancellationModal,
 }: TransactionSubmittedContentProps) {

--- a/apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
@@ -203,6 +203,7 @@ export function ActivityDetails(props: {
   const isCustomRecipientWarningBannerVisible = !useIsReceiverWalletBannerHidden(id) && order && isPending(order)
   const hideCustomRecipientWarning = useHideReceiverWalletBanner()
   const orderProgressBarV2Props = useOrderProgressBarV2Props({ activityDerivedState, chainId })
+  const surplusData = useGetSurplusData(order)
 
   if (!order && !enhancedTransaction) return null
 
@@ -397,7 +398,7 @@ export function ActivityDetails(props: {
 
       <EthFlowStepper order={order} />
       {showProgressBar && orderProgressBarV2Props && orderProgressBarV2Props.stepName !== 'finished' && (
-        <OrderProgressBarV2 {...orderProgressBarV2Props} order={order} />
+        <OrderProgressBarV2 {...orderProgressBarV2Props} order={order} surplusData={surplusData} />
       )}
     </>
   )

--- a/apps/cowswap-frontend/src/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
@@ -162,7 +162,7 @@ function useSubmittedContent(chainId: SupportedChainId, gnosisSafeInfo: GnosisSa
   )
   const surplusData = useGetSurplusData(order)
 
-  const props = useMemo(() => {
+  const orderProgressBarV2PropsWithSurplusData = useMemo(() => {
     if (!orderProgressBarV2Props) {
       return undefined
     }
@@ -177,7 +177,7 @@ function useSubmittedContent(chainId: SupportedChainId, gnosisSafeInfo: GnosisSa
         hash={transactionHash || undefined}
         onDismiss={onDismiss}
         activityDerivedState={activityDerivedState}
-        orderProgressBarV2Props={props}
+        orderProgressBarV2Props={orderProgressBarV2PropsWithSurplusData}
         showCancellationModal={showCancellationModal}
       />
     ),

--- a/apps/cowswap-frontend/src/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
@@ -26,6 +26,7 @@ import { NoImpactWarning } from 'modules/trade/pure/NoImpactWarning'
 
 import { useOrderProgressBarV2Props } from 'common/hooks/orderProgressBarV2'
 import { useCancelOrder } from 'common/hooks/useCancelOrder'
+import { useGetSurplusData } from 'common/hooks/useGetSurplusFiatValue'
 import { CurrencyPreviewInfo } from 'common/pure/CurrencyAmountPreview'
 import { NetworkCostsSuffix } from 'common/pure/NetworkCostsSuffix'
 import { RateInfoParams } from 'common/pure/RateInfo'
@@ -159,6 +160,15 @@ function useSubmittedContent(chainId: SupportedChainId, gnosisSafeInfo: GnosisSa
     () => orderProgressBarV2Props?.showCancellationModal || (order && getCancellation ? getCancellation(order) : null),
     [orderProgressBarV2Props?.showCancellationModal, order, getCancellation]
   )
+  const surplusData = useGetSurplusData(order)
+
+  const props = useMemo(() => {
+    if (!orderProgressBarV2Props) {
+      return undefined
+    }
+    // Add surplus data
+    return { ...orderProgressBarV2Props, surplusData }
+  }, [orderProgressBarV2Props, surplusData])
 
   return useCallback(
     (onDismiss: Command) => (
@@ -167,7 +177,7 @@ function useSubmittedContent(chainId: SupportedChainId, gnosisSafeInfo: GnosisSa
         hash={transactionHash || undefined}
         onDismiss={onDismiss}
         activityDerivedState={activityDerivedState}
-        orderProgressBarV2Props={orderProgressBarV2Props}
+        orderProgressBarV2Props={props}
         showCancellationModal={showCancellationModal}
       />
     ),

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapModals/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapModals/index.tsx
@@ -2,21 +2,18 @@ import React from 'react'
 
 import { genericPropsChecker } from '@cowprotocol/common-utils'
 
-import { SurplusModalSetup } from '../SurplusModalSetup'
-
 export interface SwapModalsProps {
   showNativeWrapModal: boolean
   showCowSubsidyModal: boolean
 }
 
 export const SwapModals = React.memo(function (props: SwapModalsProps) {
-  const { showNativeWrapModal } = props
-
   return (
     <>
       {/* TODO: Re-enable modal once subsidy is back  */}
       {/*<CowSubsidyModal isOpen={showCowSubsidyModal} onDismiss={closeModals} /> */}
-      {!showNativeWrapModal && <SurplusModalSetup />}
+      {/* TODO: Re-enable modal for displaying when progress bar is closed */}
+      {/*{!showNativeWrapModal && <SurplusModalSetup />}*/}
     </>
   )
 }, genericPropsChecker)


### PR DESCRIPTION
# Summary

- Update surplus logic
- Refactor some local formats to use `<TokenAmount/>` component
- Disable previous surplus modal 
  - ⚠️ now surplus is only visible while the progress bar modal is open! ⚠️ 
  - TODO: Use the new styles for the former surplus modal
- Updated the amount displayed at the bottom to show the surplus amount instead of USD twice

![Screenshot 2024-08-08 at 10 58 16](https://github.com/user-attachments/assets/6aa1a669-972c-4d60-85c2-eca474f8a3c3)

## Not included
- Pop up new modal when progress bar is closed
- `Share this win` button action

# To Test

1. Place order with high slippage
* Once traded, surplus will be shown