### PR TITLE
fix(progress-bar-v2): use global state countdown

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
@@ -35,6 +35,7 @@ export type UseOrderProgressBarV2Result = Pick<OrderProgressBarState, 'countdown
 }
 
 const MINIMUM_STEP_DISPLAY_TIME = ms`5s`
+export const PROGRESS_BAR_TIMER_DURATION = 15 // in seconds
 
 /**
  * Hook for fetching ProgressBarV2 props
@@ -145,7 +146,7 @@ function useCountdownStartUpdater(
   useEffect(() => {
     if (!countdown && countdown !== 0 && backendApiStatus === 'active') {
       // Start countdown when it becomes active
-      setCountdown(orderId, 15)
+      setCountdown(orderId, PROGRESS_BAR_TIMER_DURATION)
     } else if (backendApiStatus === 'scheduled' || backendApiStatus === 'open') {
       // If for some reason it went back to start, reset it
       setCountdown(orderId, null)

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 
 import PROGRESS_BAR_BAD_NEWS from '@cowprotocol/assets/cow-swap/progressbar-bad-news.svg'
 import PROGRESSBAR_COW_SURPLUS from '@cowprotocol/assets/cow-swap/progressbar-cow-surplus.svg'
@@ -164,7 +164,7 @@ const CircularCountdown: React.FC<CircularCountdownProps> = ({ countdown }) => {
   return (
     <styledEl.CountdownWrapper>
       <styledEl.CircularProgress viewBox="0 0 100 100">
-        <styledEl.CircleProgress cx="50" cy="50" r={radius} strokeDasharray={circumference} />
+        <styledEl.CircleProgress cx="50" cy="50" r={radius} strokeDasharray={circumference} duration={countdown} />
       </styledEl.CircularProgress>
       <styledEl.CountdownText>{countdown}</styledEl.CountdownText>
     </styledEl.CountdownWrapper>
@@ -239,24 +239,13 @@ function InitialStep({ order }: OrderProgressBarV2Props) {
   )
 }
 
-function SolvingStep({ order }: OrderProgressBarV2Props) {
-  // TODO: use countdown from props
-  const [countdown, setCountdown] = useState(15)
-
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setCountdown((prevCountdown) => (prevCountdown > 1 ? prevCountdown - 1 : 15))
-    }, 1000)
-
-    return () => clearInterval(timer)
-  }, [])
-
+function SolvingStep({ order, countdown }: OrderProgressBarV2Props) {
   return (
     <styledEl.ProgressContainer>
       <styledEl.ProgressTopSection>
         <styledEl.ProgressImageWrapper bgColor={'#65D9FF'} padding={'24px'}>
           <SVG src={STEP_IMAGE_SOLVING} />
-          <CircularCountdown countdown={countdown} />
+          <CircularCountdown countdown={countdown || 0} />
         </styledEl.ProgressImageWrapper>
         <OrderIntent order={order} />
       </styledEl.ProgressTopSection>

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
@@ -48,8 +48,7 @@ export type OrderProgressBarV2Props = {
   surplusData?: SurplusData
 }
 
-// TODO: const, capitalize
-const steps = [
+const STEPS = [
   {
     title: 'Placing order',
     description: 'Your order has been submitted and will be included in the next solver auction',
@@ -209,7 +208,7 @@ function InitialStep({ order }: OrderProgressBarV2Props) {
         <StepComponent
           status="active"
           isFirst={true}
-          step={steps[0]}
+          step={STEPS[0]}
           _index={0}
           extraContent={
             <styledEl.Description>
@@ -220,7 +219,7 @@ function InitialStep({ order }: OrderProgressBarV2Props) {
         <StepComponent
           status="next"
           isFirst={false}
-          step={steps[1]}
+          step={STEPS[1]}
           _index={1}
           extraContent={
             <styledEl.Description>
@@ -231,7 +230,7 @@ function InitialStep({ order }: OrderProgressBarV2Props) {
         <StepComponent
           status="next"
           isFirst={false}
-          step={steps[2]}
+          step={STEPS[2]}
           _index={2}
           extraContent={<styledEl.Description>The winning solver will execute your order.</styledEl.Description>}
         />
@@ -262,11 +261,11 @@ function SolvingStep({ order }: OrderProgressBarV2Props) {
         <OrderIntent order={order} />
       </styledEl.ProgressTopSection>
       <styledEl.StepsWrapper>
-        <StepComponent status="done" isFirst={false} step={steps[0]} _index={0} />
+        <StepComponent status="done" isFirst={false} step={STEPS[0]} _index={0} />
         <StepComponent
           status="active"
           isFirst={false}
-          step={steps[1]}
+          step={STEPS[1]}
           _index={1}
           extraContent={
             <styledEl.Description>
@@ -282,7 +281,7 @@ function SolvingStep({ order }: OrderProgressBarV2Props) {
         <StepComponent
           status="next"
           isFirst={false}
-          step={steps[2]}
+          step={STEPS[2]}
           _index={2}
           extraContent={<styledEl.Description>The winning solver will execute your order.</styledEl.Description>}
         />
@@ -303,11 +302,11 @@ function ExecutingStep({ solverCompetition, order }: OrderProgressBarV2Props) {
         <OrderIntent order={order} />
       </styledEl.ProgressTopSection>
       <styledEl.StepsWrapper>
-        <StepComponent status="done" isFirst={false} step={steps[0]} _index={0} />
+        <StepComponent status="done" isFirst={false} step={STEPS[0]} _index={0} />
         <StepComponent
           status="active"
           isFirst={false}
-          step={{ ...steps[1], title: 'Executing' }}
+          step={{ ...STEPS[1], title: 'Executing' }}
           _index={1}
           extraContent={
             <styledEl.Description>
@@ -505,11 +504,11 @@ function NextBatchStep({ solverCompetition, order }: OrderProgressBarV2Props) {
         <OrderIntent order={order} />
       </styledEl.ProgressTopSection>
       <styledEl.StepsWrapper>
-        <StepComponent status="done" isFirst={false} step={steps[0]} _index={0} />
+        <StepComponent status="done" isFirst={false} step={STEPS[0]} _index={0} />
         <StepComponent
           status="active"
           isFirst={false}
-          step={{ ...steps[1], title: 'Solving: Finding new solution' }}
+          step={{ ...STEPS[1], title: 'Solving: Finding new solution' }}
           _index={1}
           customColor={'#996815'}
           extraContent={
@@ -531,7 +530,7 @@ function NextBatchStep({ solverCompetition, order }: OrderProgressBarV2Props) {
         <StepComponent
           status="next"
           isFirst={false}
-          step={steps[2]}
+          step={STEPS[2]}
           _index={2}
           extraContent={<styledEl.Description>The winning solver will execute your order.</styledEl.Description>}
         />
@@ -550,11 +549,11 @@ function DelayedStep({ order }: OrderProgressBarV2Props) {
         <OrderIntent order={order} />
       </styledEl.ProgressTopSection>
       <styledEl.StepsWrapper>
-        <StepComponent status="done" isFirst={false} step={steps[0]} _index={0} />
+        <StepComponent status="done" isFirst={false} step={STEPS[0]} _index={0} />
         <StepComponent
           status="active"
           isFirst={false}
-          step={{ ...steps[1], title: 'Solving: Still searching' }}
+          step={{ ...STEPS[1], title: 'Solving: Still searching' }}
           _index={1}
           extraContent={
             <styledEl.Description>
@@ -562,7 +561,7 @@ function DelayedStep({ order }: OrderProgressBarV2Props) {
             </styledEl.Description>
           }
         />
-        <StepComponent status="next" isFirst={false} step={steps[2]} _index={2} />
+        <StepComponent status="next" isFirst={false} step={STEPS[2]} _index={2} />
       </styledEl.StepsWrapper>
     </styledEl.ProgressContainer>
   )
@@ -578,11 +577,11 @@ function UnfillableStep({ order, showCancellationModal }: OrderProgressBarV2Prop
         <OrderIntent order={order} />
       </styledEl.ProgressTopSection>
       <styledEl.StepsWrapper>
-        <StepComponent status="done" isFirst={false} step={steps[0]} _index={0} />
+        <StepComponent status="done" isFirst={false} step={STEPS[0]} _index={0} />
         <StepComponent
           status="unfillable"
           isFirst={false}
-          step={{ ...steps[1], title: 'Solving: out of market' }}
+          step={{ ...STEPS[1], title: 'Solving: out of market' }}
           _index={1}
           customColor={'#996815'}
           extraContent={
@@ -599,7 +598,7 @@ function UnfillableStep({ order, showCancellationModal }: OrderProgressBarV2Prop
         <StepComponent
           status="disabled"
           isFirst={false}
-          step={steps[2]}
+          step={STEPS[2]}
           _index={2}
           extraContent={<styledEl.Description>The winning solver will execute your order.</styledEl.Description>}
         />
@@ -618,11 +617,11 @@ function SubmissionFailedStep({ order }: OrderProgressBarV2Props) {
         <OrderIntent order={order} />
       </styledEl.ProgressTopSection>
       <styledEl.StepsWrapper>
-        <StepComponent status="done" isFirst={false} step={steps[0]} _index={0} />
+        <StepComponent status="done" isFirst={false} step={STEPS[0]} _index={0} />
         <StepComponent
           status="active"
           isFirst={false}
-          step={{ ...steps[1], title: 'Solving: Finding new solution' }}
+          step={{ ...STEPS[1], title: 'Solving: Finding new solution' }}
           _index={1}
           customColor={'#996815'}
           extraContent={
@@ -634,7 +633,7 @@ function SubmissionFailedStep({ order }: OrderProgressBarV2Props) {
         <StepComponent
           status="next"
           isFirst={false}
-          step={steps[2]}
+          step={STEPS[2]}
           _index={2}
           extraContent={<styledEl.Description>The winning solver will execute your order.</styledEl.Description>}
         />
@@ -653,11 +652,11 @@ function CancellingStep({ order }: OrderProgressBarV2Props) {
         <OrderIntent order={order} />
       </styledEl.ProgressTopSection>
       <styledEl.StepsWrapper>
-        <StepComponent status="done" isFirst={false} step={steps[0]} _index={0} />
+        <StepComponent status="done" isFirst={false} step={STEPS[0]} _index={0} />
         <StepComponent
           status="active"
           isFirst={false}
-          step={{ ...steps[1], title: 'Cancelling order' }}
+          step={{ ...STEPS[1], title: 'Cancelling order' }}
           _index={1}
           customColor={`var(${UI.COLOR_DANGER_TEXT})`}
           extraContent={<styledEl.Description>Your order is being cancelled.</styledEl.Description>}

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
@@ -31,7 +31,7 @@ import SVG from 'react-inlinesvg'
 import { AMM_LOGOS } from 'legacy/components/AMMsLogo'
 import { Order } from 'legacy/state/orders/actions'
 
-import { OrderProgressBarStepName } from 'common/hooks/orderProgressBarV2'
+import { OrderProgressBarStepName, PROGRESS_BAR_TIMER_DURATION } from 'common/hooks/orderProgressBarV2'
 import { SurplusData } from 'common/hooks/useGetSurplusFiatValue'
 
 import * as styledEl from './styled'
@@ -164,7 +164,14 @@ const CircularCountdown: React.FC<CircularCountdownProps> = ({ countdown }) => {
   return (
     <styledEl.CountdownWrapper>
       <styledEl.CircularProgress viewBox="0 0 100 100">
-        <styledEl.CircleProgress cx="50" cy="50" r={radius} strokeDasharray={circumference} duration={countdown} />
+        <styledEl.CircleProgress
+          cx="50"
+          cy="50"
+          r={radius}
+          strokeDasharray={circumference}
+          duration={countdown}
+          max={PROGRESS_BAR_TIMER_DURATION}
+        />
       </styledEl.CircularProgress>
       <styledEl.CountdownText>{countdown}</styledEl.CountdownText>
     </styledEl.CountdownWrapper>

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/styled.ts
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/styled.ts
@@ -318,12 +318,12 @@ export const CircularProgress = styled.svg`
   padding: 8px;
 `
 
-export const CircleProgress = styled.circle`
+export const CircleProgress = styled.circle<{ duration: number }>`
   fill: none;
   stroke: #012f7a;
   stroke-width: 7;
   stroke-linecap: round;
-  animation: ${progressAnimation} 15s linear infinite;
+  animation: ${progressAnimation} ${({ duration }) => duration}s linear infinite;
 `
 
 export const CountdownText = styled.div`

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/styled.ts
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/styled.ts
@@ -3,6 +3,8 @@ import { Media, UI } from '@cowprotocol/ui'
 
 import styled, { css, keyframes } from 'styled-components/macro'
 
+import { PROGRESS_BAR_TIMER_DURATION } from 'common/hooks/orderProgressBarV2'
+
 const SUCCESS_COLOR = '#04795b' // TODO: Fix hardcoded color
 
 export const Icon = styled.div<{ status: string; customColor?: string }>`
@@ -324,7 +326,7 @@ export const CircleProgress = styled.circle<{ duration: number }>`
   stroke-width: 7;
   stroke-linecap: round;
   // TODO: start animation at different position based on how far from 15s it is
-  animation: ${progressAnimation} ${({ duration }) => duration}s linear infinite;
+  animation: ${progressAnimation} ${PROGRESS_BAR_TIMER_DURATION}s linear infinite;
 `
 
 export const CountdownText = styled.div`

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/styled.ts
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/styled.ts
@@ -3,8 +3,6 @@ import { Media, UI } from '@cowprotocol/ui'
 
 import styled, { css, keyframes } from 'styled-components/macro'
 
-import { PROGRESS_BAR_TIMER_DURATION } from 'common/hooks/orderProgressBarV2'
-
 const SUCCESS_COLOR = '#04795b' // TODO: Fix hardcoded color
 
 export const Icon = styled.div<{ status: string; customColor?: string }>`
@@ -287,14 +285,18 @@ export const TokenWrapper = styled.div<{ position: 'left' | 'center' | 'right' }
   }
 `
 
-const progressAnimation = keyframes`
-  0% {
-    stroke-dashoffset: 0;
-  }
-  100% {
-    stroke-dashoffset: -283; // Approximately 2 * PI * 45
-  }
-`
+const progressAnimation = (duration: number, max: number) => {
+  const start = max - duration
+
+  return keyframes`
+    0% {
+      stroke-dashoffset: ${-(start * 283) / max};
+    }
+    100% {
+      stroke-dashoffset: -283; // Approximately 2 * PI * 45
+    }
+  `
+}
 
 export const CountdownWrapper = styled.div`
   --size: 172px;
@@ -320,13 +322,16 @@ export const CircularProgress = styled.svg`
   padding: 8px;
 `
 
-export const CircleProgress = styled.circle<{ duration: number }>`
+export const CircleProgress = styled.circle<{ duration: number; max: number }>`
   fill: none;
   stroke: #012f7a;
   stroke-width: 7;
   stroke-linecap: round;
   // TODO: start animation at different position based on how far from 15s it is
-  animation: ${progressAnimation} ${PROGRESS_BAR_TIMER_DURATION}s linear infinite;
+  ${({ duration, max }) =>
+    css`
+      animation: ${progressAnimation(duration, max)} ${duration}s linear infinite;
+    `};
 `
 
 export const CountdownText = styled.div`

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/styled.ts
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/styled.ts
@@ -323,6 +323,7 @@ export const CircleProgress = styled.circle<{ duration: number }>`
   stroke: #012f7a;
   stroke-width: 7;
   stroke-linecap: round;
+  // TODO: start animation at different position based on how far from 15s it is
   animation: ${progressAnimation} ${({ duration }) => duration}s linear infinite;
 `
 


### PR DESCRIPTION
# Summary

Use global rather than local state for the countdown

# To Test

1. Place order
2. While the countdown is running, open the activity modal
* Countdown should continue from where it was rather than start at 15s