### PR TITLE
feat(progress-bar-v2): custom recipient

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.cosmos.tsx
@@ -16,6 +16,7 @@ const order = {
 
 const defaultProps: OrderProgressBarV2Props = {
   order,
+  chainId: 1,
   stepName: 'initial',
   showCancellationModal: () => {
     alert('cancellation triggered o/')
@@ -90,6 +91,25 @@ const Fixtures = {
   '4-finished': (
     <Wrapper>
       <OrderProgressBarV2 {...defaultProps} stepName="finished" />
+    </Wrapper>
+  ),
+  '4-finished-customReceiver': (
+    <Wrapper>
+      <OrderProgressBarV2
+        {...defaultProps}
+        order={{ ...order, receiver: '0xdd9EB88C5C6D2A85A08a96c7F0ccccE27Cb843cb' }}
+        stepName="finished"
+      />
+    </Wrapper>
+  ),
+  '4-finished-customReceiver-ensName': (
+    <Wrapper>
+      <OrderProgressBarV2
+        {...defaultProps}
+        order={{ ...order, receiver: '0xdd9EB88C5C6D2A85A08a96c7F0ccccE27Cb843cb' }}
+        receiverEnsName={'ihaveaname.eth'}
+        stepName="finished"
+      />
     </Wrapper>
   ),
   '4a-cancellationFailed': (

--- a/apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
@@ -398,7 +398,13 @@ export function ActivityDetails(props: {
 
       <EthFlowStepper order={order} />
       {showProgressBar && orderProgressBarV2Props && orderProgressBarV2Props.stepName !== 'finished' && (
-        <OrderProgressBarV2 {...orderProgressBarV2Props} order={order} surplusData={surplusData} />
+        <OrderProgressBarV2
+          {...orderProgressBarV2Props}
+          order={order}
+          surplusData={surplusData}
+          chainId={chainId}
+          receiverEnsName={receiverEnsName || undefined}
+        />
       )}
     </>
   )

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/ReceiptModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/ReceiptModal/index.tsx
@@ -25,6 +25,7 @@ import {
   useHideReceiverWalletBanner,
   useIsReceiverWalletBannerHidden,
 } from 'common/state/receiverWalletBannerVisibility'
+import { getIsCustomRecipient } from 'utils/orderUtils/getIsCustomRecipient'
 import { getSellAmountWithFee } from 'utils/orderUtils/getSellAmountWithFee'
 import { ParsedOrder } from 'utils/orderUtils/parseOrder'
 
@@ -116,8 +117,7 @@ export function ReceiptModal({
   const isCustomRecipientWarningBannerVisible = !useIsReceiverWalletBannerHidden(order.id)
   const hideCustomRecipientWarning = useHideReceiverWalletBanner()
 
-  const isCustomRecipient = Boolean(order.receiver && order.owner !== order.receiver)
-
+  const isCustomRecipient = getIsCustomRecipient(order)
   const showCustomRecipientBanner = isCustomRecipient && isCustomRecipientWarningBannerVisible && isPending(order)
 
   if (!order || !chainId) {

--- a/apps/cowswap-frontend/src/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from 'react'
 
 import { getMinimumReceivedTooltip } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { useENS } from '@cowprotocol/ens'
 import { Command } from '@cowprotocol/types'
 import { GnosisSafeInfo, useGnosisSafeInfo, useWalletDetails, useWalletInfo } from '@cowprotocol/wallet'
 import { Percent, TradeType } from '@uniswap/sdk-core'
@@ -161,14 +162,15 @@ function useSubmittedContent(chainId: SupportedChainId, gnosisSafeInfo: GnosisSa
     [orderProgressBarV2Props?.showCancellationModal, order, getCancellation]
   )
   const surplusData = useGetSurplusData(order)
+  const receiverEnsName = useENS(order?.receiver).name || undefined
 
-  const orderProgressBarV2PropsWithSurplusData = useMemo(() => {
+  const completeOrderProgressBarV2Props = useMemo(() => {
     if (!orderProgressBarV2Props) {
       return undefined
     }
-    // Add surplus data
-    return { ...orderProgressBarV2Props, surplusData }
-  }, [orderProgressBarV2Props, surplusData])
+    // Add supplementary stuff
+    return { ...orderProgressBarV2Props, surplusData, chainId, receiverEnsName }
+  }, [orderProgressBarV2Props, surplusData, chainId, receiverEnsName])
 
   return useCallback(
     (onDismiss: Command) => (
@@ -177,17 +179,10 @@ function useSubmittedContent(chainId: SupportedChainId, gnosisSafeInfo: GnosisSa
         hash={transactionHash || undefined}
         onDismiss={onDismiss}
         activityDerivedState={activityDerivedState}
-        orderProgressBarV2Props={orderProgressBarV2PropsWithSurplusData}
+        orderProgressBarV2Props={completeOrderProgressBarV2Props}
         showCancellationModal={showCancellationModal}
       />
     ),
-    [
-      chainId,
-      transactionHash,
-      activityDerivedState,
-      orderProgressBarV2PropsWithSurplusData,
-      order,
-      showCancellationModal,
-    ]
+    [chainId, transactionHash, activityDerivedState, completeOrderProgressBarV2Props, order, showCancellationModal]
   )
 }

--- a/apps/cowswap-frontend/src/utils/orderUtils/getIsCustomRecipient.ts
+++ b/apps/cowswap-frontend/src/utils/orderUtils/getIsCustomRecipient.ts
@@ -1,0 +1,5 @@
+import { Order } from 'legacy/state/orders/actions'
+
+export function getIsCustomRecipient({ owner, receiver }: Pick<Order, 'owner' | 'receiver'>): boolean {
+  return Boolean(receiver && owner !== receiver)
+}


### PR DESCRIPTION
# Summary

Add recipient address (including ENS name) to finished screen, if any

![image](https://github.com/user-attachments/assets/aff49592-5311-4029-9dc7-d9b7539e41ae)

# To Test

1. Place a swap with a custom recipient
* Should be mentioned in the success screen
2. Place a swap without custom recipient
* Should look like before, and not have the recipient