### PR TITLE
feat: add analytics for notifications

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/index.tsx
@@ -53,7 +53,9 @@ export function AccountElement({ className, standaloneMode, pendingActivities }:
           <NotificationBell
             unreadCount={unreadNotificationsCount}
             onClick={() => {
-              clickNotifications(unreadNotificationsCount ? 'click-bell' : 'click-bell-with-pending-notifications')
+              clickNotifications(
+                unreadNotificationsCount === 0 ? 'click-bell' : 'click-bell-with-pending-notifications'
+              )
               setSidebarOpen(true)
             }}
           />

--- a/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/index.tsx
@@ -5,6 +5,7 @@ import { NATIVE_CURRENCIES } from '@cowprotocol/common-const'
 import { useFeatureFlags } from '@cowprotocol/common-hooks'
 import { TokenAmount } from '@cowprotocol/ui'
 import { useWalletInfo } from '@cowprotocol/wallet'
+import { clickNotifications } from 'modules/analytics'
 
 import ReactDOM from 'react-dom'
 
@@ -17,6 +18,7 @@ import { Web3Status } from 'modules/wallet/containers/Web3Status'
 import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetworkUnsupported'
 
 import { BalanceText, Wrapper } from './styled'
+import { useUnreadNotifications } from 'modules/notifications/hooks/useUnreadNotifications'
 
 interface AccountElementProps {
   pendingActivities: string[]
@@ -33,6 +35,9 @@ export function AccountElement({ className, standaloneMode, pendingActivities }:
   const isUpToLarge = useMediaQuery(upToLarge)
   const { isNotificationsFeedEnabled } = useFeatureFlags()
 
+  const unreadNotifications = useUnreadNotifications()
+  const unreadNotificationsCount = Object.keys(unreadNotifications).length
+
   const [isSidebarOpen, setSidebarOpen] = useState(false)
 
   return (
@@ -44,7 +49,15 @@ export function AccountElement({ className, standaloneMode, pendingActivities }:
           </BalanceText>
         )}
         <Web3Status pendingActivities={pendingActivities} onClick={() => account && toggleAccountModal()} />
-        {account && isNotificationsFeedEnabled && <NotificationBell onClick={() => setSidebarOpen(true)} />}
+        {account && isNotificationsFeedEnabled && (
+          <NotificationBell
+            unreadCount={unreadNotificationsCount}
+            onClick={() => {
+              clickNotifications(unreadNotificationsCount ? 'click-bell' : 'click-bell-with-pending-notifications')
+              setSidebarOpen(true)
+            }}
+          />
+        )}
       </Wrapper>
 
       {ReactDOM.createPortal(

--- a/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/index.tsx
@@ -5,20 +5,22 @@ import { NATIVE_CURRENCIES } from '@cowprotocol/common-const'
 import { useFeatureFlags } from '@cowprotocol/common-hooks'
 import { TokenAmount } from '@cowprotocol/ui'
 import { useWalletInfo } from '@cowprotocol/wallet'
-import { clickNotifications } from 'modules/analytics'
 
 import ReactDOM from 'react-dom'
+
+
 
 import { upToLarge, useMediaQuery } from 'legacy/hooks/useMediaQuery'
 
 import { useToggleAccountModal } from 'modules/account'
+import { clickNotifications } from 'modules/analytics'
 import { NotificationBell, NotificationSidebar } from 'modules/notifications'
+import { useUnreadNotifications } from 'modules/notifications/hooks/useUnreadNotifications'
 import { Web3Status } from 'modules/wallet/containers/Web3Status'
 
 import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetworkUnsupported'
 
 import { BalanceText, Wrapper } from './styled'
-import { useUnreadNotifications } from 'modules/notifications/hooks/useUnreadNotifications'
 
 interface AccountElementProps {
   pendingActivities: string[]

--- a/apps/cowswap-frontend/src/modules/analytics/events.ts
+++ b/apps/cowswap-frontend/src/modules/analytics/events.ts
@@ -24,6 +24,7 @@ enum Category {
   TWAP = 'TWAP',
   COW_FORTUNE = 'CoWFortune',
   SURPLUS_MODAL = 'Surplus Modal',
+  NOTIFICATIONS = 'Notifications',
 }
 
 export function shareFortuneTwitterAnalytics() {
@@ -319,5 +320,13 @@ export function shareSurplusOnTwitter() {
   cowAnalytics.sendEvent({
     category: Category.SURPLUS_MODAL,
     action: `Share on Twitter`,
+  })
+}
+
+export function clickNotifications(event: string, notificationId?: number) {
+  cowAnalytics.sendEvent({
+    category: Category.NOTIFICATIONS,
+    action: event,
+    value: notificationId,
   })
 }

--- a/apps/cowswap-frontend/src/modules/analytics/events.ts
+++ b/apps/cowswap-frontend/src/modules/analytics/events.ts
@@ -323,10 +323,11 @@ export function shareSurplusOnTwitter() {
   })
 }
 
-export function clickNotifications(event: string, notificationId?: number) {
+export function clickNotifications(event: string, notificationId?: number, title?: string) {
   cowAnalytics.sendEvent({
     category: Category.NOTIFICATIONS,
     action: event,
     value: notificationId,
+    label: title,
   })
 }

--- a/apps/cowswap-frontend/src/modules/notifications/containers/NotificationBell.tsx
+++ b/apps/cowswap-frontend/src/modules/notifications/containers/NotificationBell.tsx
@@ -59,14 +59,12 @@ const Icon = styled.div<{ hasNotification?: boolean }>`
 
 interface NotificationBellProps {
   onClick: Command
+  unreadCount: number
 }
 
-export function NotificationBell({ onClick }: NotificationBellProps) {
-  const unreadNotifications = useUnreadNotifications()
-  const unreadNotificationsCount = Object.keys(unreadNotifications).length
-
+export function NotificationBell({ onClick, unreadCount }: NotificationBellProps) {
   return (
-    <Icon hasNotification={unreadNotificationsCount > 0} onClick={onClick}>
+    <Icon hasNotification={unreadCount > 0} onClick={onClick}>
       <SVG src={ICON_NOTIFICATION} />
     </Icon>
   )

--- a/apps/cowswap-frontend/src/modules/notifications/containers/NotificationBell.tsx
+++ b/apps/cowswap-frontend/src/modules/notifications/containers/NotificationBell.tsx
@@ -7,7 +7,6 @@ import { UI } from '@cowprotocol/ui'
 import SVG from 'react-inlinesvg'
 import styled from 'styled-components/macro'
 
-import { useUnreadNotifications } from '../hooks/useUnreadNotifications'
 
 const Icon = styled.div<{ hasNotification?: boolean }>`
   --size: 18px;

--- a/apps/cowswap-frontend/src/modules/notifications/containers/NotificationsList/index.tsx
+++ b/apps/cowswap-frontend/src/modules/notifications/containers/NotificationsList/index.tsx
@@ -1,13 +1,14 @@
 import { useSetAtom } from 'jotai/index'
 import React, { ReactNode, useEffect, useMemo } from 'react'
 
+import { clickNotifications } from 'modules/analytics'
+
 import { ListWrapper, NoNotifications, NotificationCard, NotificationsListWrapper, NotificationThumb } from './styled'
 
 import { useAccountNotifications } from '../../hooks/useAccountNotifications'
 import { useUnreadNotifications } from '../../hooks/useUnreadNotifications'
 import { markNotificationsAsReadAtom } from '../../state/readNotificationsAtom'
 import { groupNotificationsByDate } from '../../utils/groupNotificationsByDate'
-import { clickNotifications } from 'modules/analytics'
 
 const DATE_FORMAT_OPTION: Intl.DateTimeFormatOptions = {
   dateStyle: 'long',

--- a/apps/cowswap-frontend/src/modules/notifications/containers/NotificationsList/index.tsx
+++ b/apps/cowswap-frontend/src/modules/notifications/containers/NotificationsList/index.tsx
@@ -7,6 +7,7 @@ import { useAccountNotifications } from '../../hooks/useAccountNotifications'
 import { useUnreadNotifications } from '../../hooks/useUnreadNotifications'
 import { markNotificationsAsReadAtom } from '../../state/readNotificationsAtom'
 import { groupNotificationsByDate } from '../../utils/groupNotificationsByDate'
+import { clickNotifications } from 'modules/analytics'
 
 const DATE_FORMAT_OPTION: Intl.DateTimeFormatOptions = {
   dateStyle: 'long',
@@ -50,6 +51,7 @@ export function NotificationsList({ children }: { children: ReactNode }) {
                     target={target}
                     noImage={!thumbnail}
                     rel={target === '_blank' ? 'noopener noreferrer' : ''}
+                    onClick={() => clickNotifications('click-notification-card')}
                   >
                     {thumbnail && (
                       <NotificationThumb>

--- a/apps/cowswap-frontend/src/modules/notifications/containers/NotificationsList/index.tsx
+++ b/apps/cowswap-frontend/src/modules/notifications/containers/NotificationsList/index.tsx
@@ -51,7 +51,7 @@ export function NotificationsList({ children }: { children: ReactNode }) {
                     target={target}
                     noImage={!thumbnail}
                     rel={target === '_blank' ? 'noopener noreferrer' : ''}
-                    onClick={() => clickNotifications('click-notification-card')}
+                    onClick={() => clickNotifications('click-notification-card', id, title)}
                   >
                     {thumbnail && (
                       <NotificationThumb>


### PR DESCRIPTION
# Summary

Add analytics events for notifications. Tracks how effective are the notifications, and verify they have the desired effect


# To Test
Before you start, activate debugging for the analytic events

1- Create a notification in the CMS: I can help with this too 
2- Click on the bell --> make sure the event 
<img width="1726" alt="Screenshot at Aug 12 19-06-18" src="https://github.com/user-attachments/assets/7e76975a-2249-44fb-aa11-2abadc06d0b1">


3. Click on the event itself to open the link --> `click-notification-card` should be triggered. Also, as value should go the id and the label the title of the notification

<img width="1714" alt="image" src="https://github.com/user-attachments/assets/62afc032-a162-4750-a6a2-b3b5c383e5ab">


5. Once the notification is read. Click again in the bell to see the event now is different (because the bell don't have the red dot any more)

<img width="1596" alt="image" src="https://github.com/user-attachments/assets/67279112-5614-44a7-8ecc-5b9145e42166">

