### PR TITLE
fix: replace cloudflare-ipfs.com with ipfs.io

### DIFF
--- a/apps/explorer/.env.example
+++ b/apps/explorer/.env.example
@@ -5,7 +5,7 @@ MOCK=true
 AUTOCONNECT=true
 
 # Public IPFS gateway
-REACT_APP_IPFS_READ_URI=https://cloudflare-ipfs.com/ipfs
+REACT_APP_IPFS_READ_URI=https://ipfs.io/ipfs
 
 # Sentry
 #REACT_APP_EXPLORER_SENTRY_DSN='https://<url>'

--- a/apps/explorer/src/const.ts
+++ b/apps/explorer/src/const.ts
@@ -129,7 +129,7 @@ export const NATIVE_TOKEN_PER_NETWORK: Record<SupportedChainId, TokenErc20> = {
 }
 
 export const TENDERLY_API_URL = 'https://api.tenderly.co/api/v1/public-contract'
-export const DEFAULT_IPFS_READ_URI = process.env.REACT_APP_IPFS_READ_URI || 'https://cloudflare-ipfs.com/ipfs'
+export const DEFAULT_IPFS_READ_URI = process.env.REACT_APP_IPFS_READ_URI || 'https://ipfs.io/ipfs'
 export const IPFS_INVALID_APP_IDS = [
   '0x0000000000000000000000000000000000000000000000000000000000000000',
   '0x0000000000000000000000000000000000000000000000000000000000000001',

--- a/libs/common-utils/src/environments.test.ts
+++ b/libs/common-utils/src/environments.test.ts
@@ -45,8 +45,8 @@ describe('Detect environments using host and path', () => {
       ).toEqual(isEns)
     })
 
-    it('cloudflare-ipfs.com/ipfs/<HASH>', () => {
-      expect(checkEnvironment('cloudflare-ipfs.com', '/ipfs/whatever')).toEqual(isEns)
+    it('ipfs.io/ipfs/<HASH>', () => {
+      expect(checkEnvironment('ipfs.io', '/ipfs/whatever')).toEqual(isEns)
     })
 
     it('gateway.pinata.cloud/ipfs/<HASH>', () => {

--- a/libs/common-utils/src/uriToHttp.test.ts
+++ b/libs/common-utils/src/uriToHttp.test.ts
@@ -12,15 +12,11 @@ describe('uriToHttp', () => {
   })
   it('returns ipfs gateways for ipfs:// urls', () => {
     expect(uriToHttp('ipfs://QmV8AfDE8GFSGQvt3vck8EwAzsPuNTmtP8VcQJE3qxRPaZ')).toEqual([
-      'https://cloudflare-ipfs.com/ipfs/QmV8AfDE8GFSGQvt3vck8EwAzsPuNTmtP8VcQJE3qxRPaZ/',
       'https://ipfs.io/ipfs/QmV8AfDE8GFSGQvt3vck8EwAzsPuNTmtP8VcQJE3qxRPaZ/',
     ])
   })
   it('returns ipns gateways for ipns:// urls', () => {
-    expect(uriToHttp('ipns://app.uniswap.org')).toEqual([
-      'https://cloudflare-ipfs.com/ipns/app.uniswap.org/',
-      'https://ipfs.io/ipns/app.uniswap.org/',
-    ])
+    expect(uriToHttp('ipns://app.uniswap.org')).toEqual(['https://ipfs.io/ipns/app.uniswap.org/'])
   })
   it('returns empty array for invalid scheme', () => {
     expect(uriToHttp('blah:test')).toEqual([])

--- a/libs/common-utils/src/uriToHttp.ts
+++ b/libs/common-utils/src/uriToHttp.ts
@@ -17,15 +17,12 @@ export function uriToHttp(uri: string): string[] {
     case 'http':
       return ['https' + uri.substr(4), uri]
     case 'ipfs':
-      // eslint-disable-next-line no-case-declarations
       const hash = uri.match(/^ipfs:(\/\/)?(ipfs\/)?(.*)$/i)?.[3] // TODO: probably a bug on original code
-      return [`https://cloudflare-ipfs.com/ipfs/${hash}/`, `https://ipfs.io/ipfs/${hash}/`]
+      return [`https://ipfs.io/ipfs/${hash}/`]
     case 'ipns':
-      // eslint-disable-next-line no-case-declarations
       const name = uri.match(/^ipns:(\/\/)?(.*)$/i)?.[2]
-      return [`https://cloudflare-ipfs.com/ipns/${name}/`, `https://ipfs.io/ipns/${name}/`]
+      return [`https://ipfs.io/ipns/${name}/`]
     case 'ar':
-      // eslint-disable-next-line no-case-declarations
       const tx = uri.match(/^ar:(\/\/)?(.*)$/i)?.[2]
       return [`https://arweave.net/${tx}`]
     default:


### PR DESCRIPTION
# Summary

cloudflare-ipfs.com domain is being removed

# To Test

1. Open the cowswap and exploerer and make sure it works as usual
2. Token lists should load