### PR TITLE
feat: add analytics event for closing CoW AMM banner

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/CoWAMMBanner/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/CoWAMMBanner/index.tsx
@@ -209,7 +209,16 @@ export function CoWAmmBanner() {
   return ClosableBanner('cow_amm_banner', (close) => (
     <BannerWrapper>
       <i></i>
-      <CloseButton size={24} onClick={close} />
+      <CloseButton
+        size={24}
+        onClick={() => {
+          cowAnalytics.sendEvent({
+            category: 'CoW Swap',
+            action: 'CoW AMM Banner CTA Closed',
+          })
+          close()
+        }}
+      />
       <div>
         <Title>Now live: the first MEV-capturing AMM</Title>
         <Description>


### PR DESCRIPTION
# Summary

Adds a new event to the closing of the banner
<img width="1463" alt="image" src="https://github.com/user-attachments/assets/41712786-a971-4097-ac30-219b38d3a8ac">


# To Test

- Enable debug for analytics
- Click on the close button for the cow amm banner
- Inspect the event