### PR TITLE
fix(amounts-display): increase precision for small amounts

### DIFF
--- a/libs/common-utils/src/amountFormat/index.test.ts
+++ b/libs/common-utils/src/amountFormat/index.test.ts
@@ -1,7 +1,6 @@
 import { USDC_GNOSIS_CHAIN, USDC_SEPOLIA, WETH_SEPOLIA } from '@cowprotocol/common-const'
 import { CurrencyAmount, Percent } from '@uniswap/sdk-core'
 
-
 import { formatAmountWithPrecision, formatFiatAmount, formatPercent, formatTokenAmount } from './index'
 
 describe('Amounts formatting', () => {
@@ -19,7 +18,7 @@ describe('Amounts formatting', () => {
     it('Extra small amount', () => {
       const result = formatTokenAmount(getAmount('1', -decimals)) // 1e-18 WETH
 
-      expect(result).toBe('< 0.000001')
+      expect(result).toBe('0.000000000000000001')
     })
 
     it('Small amount', () => {
@@ -150,8 +149,8 @@ describe('Amounts formatting', () => {
         CurrencyAmount.fromFractionalAmount(
           USDC_GNOSIS_CHAIN,
           '994582567877074269904770000000000000000000',
-          '999200146079960203000000000000000000'
-        )
+          '999200146079960203000000000000000000',
+        ),
       )
 
       expect(result).toBe('1')

--- a/libs/common-utils/src/amountFormat/utils.ts
+++ b/libs/common-utils/src/amountFormat/utils.ts
@@ -5,7 +5,6 @@ import JSBI from 'jsbi'
 import { FractionUtils } from '../fractionUtils'
 import { FractionLike, Nullish } from '../types'
 
-
 const ONE = JSBI.BigInt(1)
 const HUNDRED_K = JSBI.BigInt(100_000)
 const MILLION = JSBI.BigInt(1_000_000)
@@ -14,7 +13,7 @@ const BILLION = JSBI.BigInt(1_000_000_000)
 const TRILLION = JSBI.BigInt(1_000_000_000_000)
 
 function getPrecisionForFraction(fraction: Fraction): number {
-  if (FractionUtils.lte(fraction, ONE)) return 6
+  if (FractionUtils.lte(fraction, ONE)) return 8
   if (FractionUtils.lte(fraction, HUNDRED_K)) return 4
   if (FractionUtils.lte(fraction, MILLION)) return 3
   if (FractionUtils.lte(fraction, TEN_MILLION)) return 2

--- a/libs/common-utils/src/amountFormat/utils.ts
+++ b/libs/common-utils/src/amountFormat/utils.ts
@@ -5,6 +5,8 @@ import JSBI from 'jsbi'
 import { FractionUtils } from '../fractionUtils'
 import { FractionLike, Nullish } from '../types'
 
+const TINIEST = new Fraction(1, 100_000_000)
+const TINY = new Fraction(1, 100_000)
 const ONE = JSBI.BigInt(1)
 const HUNDRED_K = JSBI.BigInt(100_000)
 const MILLION = JSBI.BigInt(1_000_000)
@@ -13,7 +15,9 @@ const BILLION = JSBI.BigInt(1_000_000_000)
 const TRILLION = JSBI.BigInt(1_000_000_000_000)
 
 function getPrecisionForFraction(fraction: Fraction): number {
-  if (FractionUtils.lte(fraction, ONE)) return 8
+  if (FractionUtils.lte(fraction, TINIEST)) return 18
+  if (FractionUtils.lte(fraction, TINY)) return 12
+  if (FractionUtils.lte(fraction, ONE)) return 6
   if (FractionUtils.lte(fraction, HUNDRED_K)) return 4
   if (FractionUtils.lte(fraction, MILLION)) return 3
   if (FractionUtils.lte(fraction, TEN_MILLION)) return 2


### PR DESCRIPTION
# Summary

Now it'll show up to 18 decimals, if the value is small enough.
Side effect is that the UI might break a little (see pic).

![image](https://github.com/user-attachments/assets/a0cdc0f1-7661-43ae-980a-a771e81e2ee0)

# To Test

1. Place order with huuuuuuuge price difference
* Observe the amounts being properly visible