### PR TITLE
fix(progress-bar-v2): fix min display time

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/atoms.ts
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/atoms.ts
@@ -6,7 +6,7 @@ import {
   OrderProgressBarState,
   OrderProgressBarStepName,
   OrdersProgressBarCountdown,
-  OrdersProgressBarState,
+  OrdersProgressBarState
 } from './types'
 
 /**
@@ -92,10 +92,8 @@ export const updateOrderProgressBarStepName = atom(
     singleOrderState.previousStepName = singleOrderState.progressBarStepName
     // Update current status
     singleOrderState.progressBarStepName = value
-    // We need to know when it was last changed
-    singleOrderState.lastTimeChangedSteps = singleOrderState.currentTimeChangedSteps
-    // For this reason, we use another variable to keep track of when the change happens
-    singleOrderState.currentTimeChangedSteps = Date.now()
+    // Keep track when state was changed
+    singleOrderState.lastTimeChangedSteps = Date.now()
 
     set(ordersProgressBarStateAtom, { ...fullState, [orderId]: singleOrderState })
   }

--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/types.ts
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/types.ts
@@ -7,7 +7,6 @@ export type OrderProgressBarState = {
   progressBarStepName?: OrderProgressBarStepName
   previousStepName?: OrderProgressBarStepName
   lastTimeChangedSteps?: number
-  currentTimeChangedSteps?: number
   cancellationTriggered?: true
 }
 

--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
@@ -35,7 +35,7 @@ export type UseOrderProgressBarV2Result = Pick<OrderProgressBarState, 'countdown
   showCancellationModal: Command | null
 }
 
-const MINIMUM_STEP_DISPLAY_TIME = ms`5s`
+const MINIMUM_STEP_DISPLAY_TIME = ms`2s`
 export const PROGRESS_BAR_TIMER_DURATION = 15 // in seconds
 
 /**

--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
@@ -25,7 +25,6 @@ import {
 } from './atoms'
 import { OrderProgressBarState, OrderProgressBarStepName } from './types'
 
-
 export type UseOrderProgressBarPropsParams = {
   activityDerivedState: ActivityDerivedState | null
   chainId: SupportedChainId


### PR DESCRIPTION
# Summary

Fix enforcement of min 5s display time for any screen

# To Test

1. Place order
2. Observe screen switching
* Any screen should be displayed for at least 5s
* No hard reproduction steps, but very likely after the countdown reaches 0 the next screen should be displayed for 5s now, which before was just a blink