### PR TITLE
feat(progress-bar-v2): load solvers info from cms

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/types.ts
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/types.ts
@@ -1,3 +1,4 @@
+import { SolverInfo } from '@cowprotocol/core'
 import type { CompetitionOrderStatus } from '@cowprotocol/cow-sdk'
 
 export type OrderProgressBarState = {
@@ -18,3 +19,7 @@ type happyPath = 'initial' | 'solving' | 'solved' | 'executing' | 'finished'
 type errorFlow = 'nextBatch' | 'delayed' | 'unfillable' | 'submissionFailed'
 type cancellationFlow = 'cancelling' | 'cancelled' | 'expired' | 'cancellationFailed'
 export type OrderProgressBarStepName = happyPath | errorFlow | cancellationFlow
+
+type Unpacked<T> = T extends (infer U)[] ? U : never
+export type ApiSolverCompetition = Unpacked<CompetitionOrderStatus['value']>
+export type SolverCompetition = ApiSolverCompetition & Partial<SolverInfo>

--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
@@ -2,6 +2,7 @@ import { useAtomValue, useSetAtom } from 'jotai'
 import { useCallback, useEffect, useMemo } from 'react'
 
 import { SWR_NO_REFRESH_OPTIONS } from '@cowprotocol/common-const'
+import { SolverInfo, useSolversInfo } from '@cowprotocol/core'
 import { CompetitionOrderStatus, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { Command } from '@cowprotocol/types'
 
@@ -23,16 +24,18 @@ import {
   updateOrderProgressBarCountdown,
   updateOrderProgressBarStepName,
 } from './atoms'
-import { OrderProgressBarState, OrderProgressBarStepName } from './types'
+import { ApiSolverCompetition, OrderProgressBarState, OrderProgressBarStepName, SolverCompetition } from './types'
 
 export type UseOrderProgressBarPropsParams = {
   activityDerivedState: ActivityDerivedState | null
   chainId: SupportedChainId
 }
 
-export type UseOrderProgressBarV2Result = Pick<OrderProgressBarState, 'countdown' | 'solverCompetition'> & {
+export type UseOrderProgressBarV2Result = Pick<OrderProgressBarState, 'countdown'> & {
   stepName: Exclude<OrderProgressBarState['progressBarStepName'], undefined>
   showCancellationModal: Command | null
+  solverCompetition?: SolverCompetition[]
+  totalSolvers: number
 }
 
 const MINIMUM_STEP_DISPLAY_TIME = ms`2s`
@@ -76,12 +79,14 @@ export function useOrderProgressBarV2Props(
   const {
     countdown,
     backendApiStatus,
-    solverCompetition,
+    solverCompetition: apiSolverCompetition,
     progressBarStepName,
     previousStepName,
     lastTimeChangedSteps,
     cancellationTriggered,
   } = useGetExecutingOrderState(orderId)
+  const solversInfo = useSolversInfo(chainId)
+  const totalSolvers = Object.keys(solversInfo).length
 
   // Local updaters of the respective atom
   useBackendApiStatusUpdater(chainId, orderId, doNotQuery)
@@ -101,6 +106,15 @@ export function useOrderProgressBarV2Props(
   useCancellingOrderUpdater(orderId, isCancelling)
   useCountdownStartUpdater(orderId, countdown, backendApiStatus)
 
+  const solverCompetition = useMemo(
+    () =>
+      apiSolverCompetition
+        ?.map((entry) => mergeSolverData(entry, solversInfo))
+        // Reverse it since backend returns the solutions ranked ascending. Winner is the last one.
+        .reverse(),
+    [apiSolverCompetition, solversInfo]
+  )
+
   return useMemo(() => {
     if (disableProgressBar) {
       return undefined
@@ -108,11 +122,12 @@ export function useOrderProgressBarV2Props(
 
     return {
       countdown,
+      totalSolvers,
       solverCompetition,
       stepName: progressBarStepName || 'initial',
       showCancellationModal,
     }
-  }, [disableProgressBar, countdown, solverCompetition, progressBarStepName, showCancellationModal])
+  }, [disableProgressBar, countdown, totalSolvers, solverCompetition, progressBarStepName, showCancellationModal])
 }
 
 // atom related hooks
@@ -300,4 +315,23 @@ function usePendingOrderStatus(chainId: SupportedChainId, orderId: string, doNot
     async ([, _chainId, _orderId]) => getOrderCompetitionStatus(_chainId, _orderId),
     doNotQuery ? SWR_NO_REFRESH_OPTIONS : POOLING_SWR_OPTIONS
   ).data
+}
+
+/**
+ * Merges solverCompetition data returned by the orderbook /status endpoint with
+ * solver info fetched from CMS
+ *
+ * @param solverCompetition
+ * @param solversInfo
+ */
+function mergeSolverData(
+  solverCompetition: ApiSolverCompetition,
+  solversInfo: Record<string, SolverInfo>
+): SolverCompetition {
+  // Backend has the prefix `-solve` on some solvers. We should discard that for now.
+  // In the future this prefix will be removed.
+  const solverId = solverCompetition.solver.replace(/-solve$/, '')
+  const solverInfo = solversInfo[solverId]
+
+  return { ...solverCompetition, ...solverInfo, solverId, solver: solverId }
 }

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.cosmos.tsx
@@ -32,6 +32,7 @@ const defaultProps: OrderProgressBarV2Props = {
     { solver: 'uniswap', executedAmounts: { sell: '5000000000000000000', buy: '500000000000000000000' } },
     { solver: 'oneinch', executedAmounts: { sell: '5000000000000000000', buy: '400000000000000000000' } },
   ],
+  totalSolvers: 52,
   surplusData: {
     surplusFiatValue: CurrencyAmount.fromRawAmount(USDC_GNOSIS_CHAIN, '10000000'),
     surplusAmount: CurrencyAmount.fromRawAmount(order.outputToken, '1000000000000000000'),

--- a/apps/cowswap-frontend/src/modules/application/containers/App/Updaters.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/App/Updaters.tsx
@@ -1,5 +1,6 @@
 import { BalancesAndAllowancesUpdater } from '@cowprotocol/balances-and-allowances'
 import { useFeatureFlags } from '@cowprotocol/common-hooks'
+import { SolversInfoUpdater } from '@cowprotocol/core'
 import { TokensListsUpdater, UnsupportedTokensUpdater, WidgetTokensListsUpdater } from '@cowprotocol/tokens'
 import { HwAccountIndexUpdater, useWalletInfo, WalletUpdater } from '@cowprotocol/wallet'
 
@@ -63,6 +64,7 @@ export function Updaters() {
       <UsdPricesUpdater />
       <OrdersNotificationsUpdater />
       <ProgressBarV2ExecutingOrdersUpdater />
+      <SolversInfoUpdater />
 
       <TokensListsUpdater chainId={chainId} isGeoBlockEnabled={isGeoBlockEnabled} />
       <WidgetTokensListsUpdater

--- a/libs/core/src/cms/hooks/index.ts
+++ b/libs/core/src/cms/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useCmsSolversInfo'
+export * from './useSolversInfo'

--- a/libs/core/src/cms/hooks/index.ts
+++ b/libs/core/src/cms/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useCmsSolversInfo'

--- a/libs/core/src/cms/hooks/useCmsSolversInfo.ts
+++ b/libs/core/src/cms/hooks/useCmsSolversInfo.ts
@@ -1,0 +1,18 @@
+import ms from 'ms.macro'
+import useSWR, { SWRConfiguration } from 'swr'
+
+import { CmsSolversInfo } from '../types'
+import { getSolversInfo } from '../utils'
+
+const SOLVERS_INFO_SWR_CONFIG: SWRConfiguration = {
+  refreshInterval: ms`1day`,
+  refreshWhenHidden: false,
+  refreshWhenOffline: false,
+  revalidateOnFocus: false,
+}
+
+export function useCmsSolversInfo() {
+  const { data } = useSWR<CmsSolversInfo, Error, string>('/solvers', getSolversInfo, SOLVERS_INFO_SWR_CONFIG)
+
+  return data || []
+}

--- a/libs/core/src/cms/hooks/useCmsSolversInfo.ts
+++ b/libs/core/src/cms/hooks/useCmsSolversInfo.ts
@@ -5,7 +5,7 @@ import { CmsSolversInfo } from '../types'
 import { getSolversInfo } from '../utils'
 
 const SOLVERS_INFO_SWR_CONFIG: SWRConfiguration = {
-  refreshInterval: ms`1day`,
+  refreshInterval: ms`1hour`,
   refreshWhenHidden: false,
   refreshWhenOffline: false,
   revalidateOnFocus: false,

--- a/libs/core/src/cms/hooks/useSolversInfo.ts
+++ b/libs/core/src/cms/hooks/useSolversInfo.ts
@@ -4,10 +4,20 @@ import { useMemo } from 'react'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import { solversInfoAtom } from '../state'
-import { SolversInfo } from '../types'
+import { SolverInfo } from '../types'
 
-export function useSolversInfo(chainId: SupportedChainId): SolversInfo {
+export function useSolversInfo(chainId: SupportedChainId): Record<string, SolverInfo> {
   const allSolversInfo = useAtomValue(solversInfoAtom)
 
-  return useMemo(() => allSolversInfo.filter((info) => info.chainIds.includes(chainId)), [chainId, allSolversInfo])
+  return useMemo(
+    () =>
+      allSolversInfo.reduce<Record<string, SolverInfo>>((acc, info) => {
+        if (info.chainIds.includes(chainId)) {
+          acc[info.solverId] = info
+        }
+
+        return acc
+      }, {}),
+    [chainId, allSolversInfo]
+  )
 }

--- a/libs/core/src/cms/hooks/useSolversInfo.ts
+++ b/libs/core/src/cms/hooks/useSolversInfo.ts
@@ -1,0 +1,13 @@
+import { useAtomValue } from 'jotai'
+import { useMemo } from 'react'
+
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import { solversInfoAtom } from '../state'
+import { SolversInfo } from '../types'
+
+export function useSolversInfo(chainId: SupportedChainId): SolversInfo {
+  const allSolversInfo = useAtomValue(solversInfoAtom)
+
+  return useMemo(() => allSolversInfo.filter((info) => info.chainIds.includes(chainId)), [chainId, allSolversInfo])
+}

--- a/libs/core/src/cms/index.ts
+++ b/libs/core/src/cms/index.ts
@@ -1,15 +1,5 @@
-import { CmsClient } from '@cowprotocol/cms'
-
-export const CMS_BASE_URL =
-  process.env.REACT_APP_CMS_BASE_URL || process.env.NEXT_PUBLIC_CMS_BASE_URL || 'https://cms.cow.fi/api'
-
-let cmsClient: ReturnType<typeof CmsClient> | undefined
-
-export function getCmsClient() {
-  if (!cmsClient) {
-    cmsClient = CmsClient({
-      url: CMS_BASE_URL,
-    })
-  }
-  return cmsClient
-}
+export * from './hooks'
+export * from './types'
+export * from './state'
+export * from './utils'
+export * from './updaters'

--- a/libs/core/src/cms/state/index.ts
+++ b/libs/core/src/cms/state/index.ts
@@ -1,5 +1,5 @@
-import { atom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
 
 import { SolversInfo } from '../types'
 
-export const solversInfoAtom = atom<SolversInfo>([])
+export const solversInfoAtom = atomWithStorage<SolversInfo>('solversInfoAtom:v0', [])

--- a/libs/core/src/cms/state/index.ts
+++ b/libs/core/src/cms/state/index.ts
@@ -1,0 +1,5 @@
+import { atom } from 'jotai'
+
+import { SolversInfo } from '../types'
+
+export const solversInfoAtom = atom<SolversInfo>([])

--- a/libs/core/src/cms/types.ts
+++ b/libs/core/src/cms/types.ts
@@ -1,0 +1,13 @@
+import { components } from '@cowprotocol/cms'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
+export type CmsSolversInfo = components['schemas']['SolverListResponseDataItem'][]
+
+export type SolversInfo = SolverInfo[]
+
+export type SolverInfo = {
+  solverId: string
+  displayName: string
+  chainIds: SupportedChainId[]
+  image?: string
+}

--- a/libs/core/src/cms/updaters/SolversInfoUpdater.ts
+++ b/libs/core/src/cms/updaters/SolversInfoUpdater.ts
@@ -1,7 +1,8 @@
 import { useSetAtom } from 'jotai'
-import { solversInfoAtom } from '../state'
 import { useEffect } from 'react'
+
 import { useCmsSolversInfo } from '../hooks'
+import { solversInfoAtom } from '../state'
 import { mapCmsSolversInfoToSolversInfo } from '../utils'
 
 export function SolversInfoUpdater() {

--- a/libs/core/src/cms/updaters/SolversInfoUpdater.ts
+++ b/libs/core/src/cms/updaters/SolversInfoUpdater.ts
@@ -1,0 +1,19 @@
+import { useSetAtom } from 'jotai'
+import { solversInfoAtom } from '../state'
+import { useEffect } from 'react'
+import { useCmsSolversInfo } from '../hooks'
+import { mapCmsSolversInfoToSolversInfo } from '../utils'
+
+export function SolversInfoUpdater() {
+  const setSolversInfo = useSetAtom(solversInfoAtom)
+
+  const cmsSolversInfo = useCmsSolversInfo()
+
+  useEffect(() => {
+    const solversInfo = mapCmsSolversInfoToSolversInfo(cmsSolversInfo)
+
+    solversInfo && setSolversInfo(solversInfo)
+  }, [cmsSolversInfo])
+
+  return null
+}

--- a/libs/core/src/cms/updaters/index.ts
+++ b/libs/core/src/cms/updaters/index.ts
@@ -1,0 +1,1 @@
+export * from './SolversInfoUpdater'

--- a/libs/core/src/cms/utils/getCmsClient.ts
+++ b/libs/core/src/cms/utils/getCmsClient.ts
@@ -1,0 +1,15 @@
+import { CmsClient } from '@cowprotocol/cms'
+
+export const CMS_BASE_URL =
+  process.env.REACT_APP_CMS_BASE_URL || process.env.NEXT_PUBLIC_CMS_BASE_URL || 'https://cms.cow.fi/api'
+
+let cmsClient: ReturnType<typeof CmsClient> | undefined
+
+export function getCmsClient() {
+  if (!cmsClient) {
+    cmsClient = CmsClient({
+      url: CMS_BASE_URL,
+    })
+  }
+  return cmsClient
+}

--- a/libs/core/src/cms/utils/getSolversInfo.ts
+++ b/libs/core/src/cms/utils/getSolversInfo.ts
@@ -22,7 +22,7 @@ export async function getSolversInfo(): Promise<CmsSolversInfo> {
           // },
           populate: {
             networks: { fields: ['chainId'] },
-            image: { fields: ['data'] },
+            image: { fields: ['url'] },
           },
           fields: ['displayName', 'solverId'],
         },

--- a/libs/core/src/cms/utils/getSolversInfo.ts
+++ b/libs/core/src/cms/utils/getSolversInfo.ts
@@ -1,0 +1,41 @@
+import { components } from '@cowprotocol/cms'
+
+import qs from 'qs'
+
+import { CmsSolversInfo } from '../types'
+import { getCmsClient } from '../utils'
+
+const cmsClient = getCmsClient()
+
+export async function getSolversInfo(): Promise<CmsSolversInfo> {
+  return cmsClient
+    .GET('/solvers', {
+      params: {
+        query: {
+          // TODO: if we ever want to filter the query per chain, uncomment this
+          // filters: {
+          //   networks: {
+          //     chainId: {
+          //       $eq: chainId,
+          //     },
+          //   },
+          // },
+          populate: {
+            networks: { fields: ['chainId'] },
+            image: { fields: ['data'] },
+          },
+          fields: ['displayName', 'solverId'],
+        },
+      },
+      querySerializer,
+    })
+    .then((res: { data: components['schemas']['SolverListResponse'] }) => res.data?.data)
+    .catch((error: Error) => {
+      console.error('Failed to fetch solvers', error)
+      return []
+    })
+}
+
+const querySerializer = (params: any) => {
+  return qs.stringify(params, { encodeValuesOnly: true, arrayFormat: 'brackets' })
+}

--- a/libs/core/src/cms/utils/getSolversInfo.ts
+++ b/libs/core/src/cms/utils/getSolversInfo.ts
@@ -12,14 +12,15 @@ export async function getSolversInfo(): Promise<CmsSolversInfo> {
     .GET('/solvers', {
       params: {
         query: {
-          // TODO: if we ever want to filter the query per chain, uncomment this
-          // filters: {
-          //   networks: {
-          //     chainId: {
-          //       $eq: chainId,
-          //     },
-          //   },
-          // },
+          filters: {
+            // TODO: if we ever want to filter the query per chain, uncomment this
+            //   networks: {
+            //     chainId: {
+            //       $eq: chainId,
+            //     },
+            //   },
+            active: { $eq: true },
+          },
           populate: {
             networks: { fields: ['chainId'] },
             image: { fields: ['url'] },

--- a/libs/core/src/cms/utils/getSolversInfo.ts
+++ b/libs/core/src/cms/utils/getSolversInfo.ts
@@ -25,6 +25,7 @@ export async function getSolversInfo(): Promise<CmsSolversInfo> {
             image: { fields: ['url'] },
           },
           fields: ['displayName', 'solverId'],
+          pagination: { pageSize: 100 },
         },
       },
       querySerializer,

--- a/libs/core/src/cms/utils/index.ts
+++ b/libs/core/src/cms/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './getCmsClient'
+export * from './getSolversInfo'
+export * from './mapCmsSolversInfoToSolversInfo'

--- a/libs/core/src/cms/utils/mapCmsSolversInfoToSolversInfo.ts
+++ b/libs/core/src/cms/utils/mapCmsSolversInfoToSolversInfo.ts
@@ -1,0 +1,25 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import { CmsSolversInfo, SolversInfo } from '../types'
+
+export function mapCmsSolversInfoToSolversInfo(cmsSolversInfo: CmsSolversInfo): SolversInfo {
+  return cmsSolversInfo.reduce((acc, info) => {
+    if (info?.attributes) {
+      const { solverId, displayName, image, networks } = info.attributes
+
+      const chainIds = networks?.data?.reduce(
+        (acc, network) => (network?.attributes?.chainId ? [...acc, network?.attributes?.chainId] : acc),
+        [] as SupportedChainId[]
+      )
+
+      // Ignore any that doesn't have a chainId set
+      if (!chainIds) {
+        return acc
+      }
+
+      acc.push({ solverId, displayName, image: image?.data?.attributes?.url, chainIds })
+    }
+
+    return acc
+  }, [] as SolversInfo)
+}

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@babel/runtime": "^7.17.0",
     "@coinbase/wallet-sdk": "^3.3.0",
     "@cowprotocol/app-data": "^2.1.0",
-    "@cowprotocol/cms": "^0.3.1",
+    "@cowprotocol/cms": "^0.5.0",
     "@cowprotocol/contracts": "^1.3.1",
     "@cowprotocol/cow-runner-game": "^0.2.9",
     "@cowprotocol/cow-sdk": "^5.4.1-RC.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2386,10 +2386,10 @@
     json-stringify-deterministic "^1.0.8"
     multiformats "^9.6.4"
 
-"@cowprotocol/cms@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cms/-/cms-0.3.1.tgz#8e5f77be1a97f9c083ce30a744402689802b4c3e"
-  integrity sha512-jslJwDdmn29ygB+iXnDG+5W9XCCUkexkcWV46EvKzrX8i3T7feUb/Hmgc+OiU59avWp9yMw2l1qrZ+sEPIwiPw==
+"@cowprotocol/cms@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cms/-/cms-0.5.0.tgz#e3dc8ea604806ec3c550454f8150a729c202d5ae"
+  integrity sha512-5rhF05rriJUQjmtgSETkWyerXAQRB80MlZpmjjF4QFX26a9DOqmW50cRD+o4VukytvbwekOUfGjHhseQKzq4Sw==
   dependencies:
     openapi-fetch "^0.9.3"
 


### PR DESCRIPTION
# Summary

Load solvers info from CMS

![image (2)](https://github.com/user-attachments/assets/2bcd13e5-d1fc-4193-8d57-d1996fc5c0c4)

- Solver display name
- Solver image
- Total number of solvers
- Fixed solver ranking sorting (it was inverted)

# To Test

1. Place order
2. Wait for order to execute
* Total number of solvers should match the chain (mainnet: 24, gchain: 11, arb1: 13, sepolia: 3)
* Depending on the solver, there might be custom images