### PR TITLE
fix(progress-bar-v2): add Safe signing back

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/index.tsx
@@ -12,7 +12,7 @@ import { DisplayLink } from 'legacy/components/TransactionConfirmationModal/Disp
 import { ActivityStatus } from 'legacy/hooks/useRecentActivity'
 
 import { ActivityDerivedState } from 'modules/account/containers/Transaction'
-// import { GnosisSafeTxDetails } from 'modules/account/containers/Transaction/ActivityDetails'
+import { GnosisSafeTxDetails } from 'modules/account/containers/Transaction/ActivityDetails'
 import { NavigateToNewOrderCallback } from 'modules/swap/containers/ConfirmSwapModalSetup'
 import { EthFlowStepper } from 'modules/swap/containers/EthFlowStepper'
 import { WatchAssetInWallet } from 'modules/wallet/containers/WatchAssetInWallet'
@@ -98,6 +98,7 @@ export function TransactionSubmittedContent({
               </Text>
             </>
           )}
+          {showSafeSigningInfo && <GnosisSafeTxDetails chainId={chainId} activityDerivedState={activityDerivedState} />}
           <EthFlowStepper order={order} extend={!!orderProgressBarV2Props} />
           {activityDerivedState && showProgressBar && orderProgressBarV2Props && (
             <OrderProgressBarV2


### PR DESCRIPTION
# Summary

Safe signing added on https://github.com/cowprotocol/cowswap/pull/4755 got lost during a merge.

Adding it back:
![image](https://github.com/user-attachments/assets/a4f203b3-830d-4cfa-874f-df1ca81db0ac)


# To Test

1. Place order with Safe
* Signing steps should be displayed when needed.