### PR TITLE
feat(progress-bar-v2): increase min display to 5s and override on finished

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
@@ -38,7 +38,7 @@ export type UseOrderProgressBarV2Result = Pick<OrderProgressBarState, 'countdown
   totalSolvers: number
 }
 
-const MINIMUM_STEP_DISPLAY_TIME = ms`2s`
+const MINIMUM_STEP_DISPLAY_TIME = ms`5s`
 export const PROGRESS_BAR_TIMER_DURATION = 15 // in seconds
 
 /**
@@ -216,7 +216,11 @@ function useProgressBarStepNameUpdater(
 
     const timeSinceLastChange = lastTimeChangedSteps ? Date.now() - lastTimeChangedSteps : 0
 
-    if (lastTimeChangedSteps === undefined || timeSinceLastChange >= MINIMUM_STEP_DISPLAY_TIME) {
+    if (
+      lastTimeChangedSteps === undefined ||
+      timeSinceLastChange >= MINIMUM_STEP_DISPLAY_TIME ||
+      stepName === 'finished'
+    ) {
       updateStepName(stepName)
 
       // schedule update for temporary steps


### PR DESCRIPTION
# Summary

- Increase min display time from 2s to 5s
- Override state immediately when finished

# To Test

1. Easier to observe on arb1, place order
* Immediately after getting the traded notification it should jump to the finished screen, regardless of how long the screen was displayed before