### PR TITLE
feat: allow all final states to override minimum display time

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
@@ -245,7 +245,10 @@ function useProgressBarStepNameUpdater(
     if (
       lastTimeChangedSteps === undefined ||
       timeSinceLastChange >= MINIMUM_STEP_DISPLAY_TIME ||
-      stepName === 'finished'
+      stepName === 'finished' ||
+      stepName === 'cancellationFailed' ||
+      stepName === 'cancelled' ||
+      stepName === 'expired'
     ) {
       updateStepName(stepName)
 


### PR DESCRIPTION
# Summary

Follow up to https://github.com/cowprotocol/cowswap/pull/4804

Allow all finished states to override minimum display time of 5s per screen.

# To Test

1. Place order
2. Cancel/expire it
* Should change to final screen right away instead of waiting for 5s