### PR TITLE
feat: re-enable surplus modal pop up

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/CancelButton/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/CancelButton/index.tsx
@@ -1,6 +1,7 @@
 import { PropsWithChildren } from 'react'
 
 import { Command } from '@cowprotocol/types'
+import { UI } from '@cowprotocol/ui'
 
 import { LinkStyledButton } from 'theme'
 
@@ -11,7 +12,7 @@ export type CancelButtonProps = {
 
 export function CancelButton({ onClick, children, className }: CancelButtonProps) {
   return (
-    <LinkStyledButton onClick={onClick} className={className}>
+    <LinkStyledButton onClick={onClick} className={className} color={`var(${UI.COLOR_DANGER})`}>
       {children || 'Cancel order'}
     </LinkStyledButton>
   )

--- a/apps/cowswap-frontend/src/common/pure/Modal/styled.tsx
+++ b/apps/cowswap-frontend/src/common/pure/Modal/styled.tsx
@@ -117,6 +117,7 @@ export const StyledDialogContent = styled(({ ...rest }) => <AnimatedDialogConten
           border-radius: 20px;
           border-bottom-left-radius: 0;
           border-bottom-right-radius: 0;
+          padding: 0 0 58px;
         `}
       `}
     }

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.cosmos.tsx
@@ -41,6 +41,7 @@ const defaultProps: OrderProgressBarV2Props = {
     showFiatValue: true,
     showSurplus: true,
   },
+  isProgressBarSetup: true
 }
 
 const Wrapper = styled.div`

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
@@ -57,17 +57,18 @@ const IS_DEBUG_MODE = false
 const DEBUG_FORCE_SHOW_SURPLUS = false
 
 export type OrderProgressBarV2Props = {
-  stepName: OrderProgressBarStepName
+  stepName?: OrderProgressBarStepName
   chainId: SupportedChainId
   countdown?: number | null | undefined
   solverCompetition?: SolverCompetition[]
-  totalSolvers: number
+  totalSolvers?: number
   order?: Order
   debugMode?: boolean
   showCancellationModal: Command | null
   surplusData?: SurplusData
   receiverEnsName?: string
   navigateToNewOrder?: Command
+  isProgressBarSetup: boolean
 }
 
 const STEPS = [
@@ -203,7 +204,7 @@ const trackLearnMoreClick = (stepName: string) => {
 }
 
 export function OrderProgressBarV2(props: OrderProgressBarV2Props) {
-  const { stepName, debugMode = IS_DEBUG_MODE } = props
+  const { stepName = 'initial', debugMode = IS_DEBUG_MODE } = props
   const [debugStep, setDebugStep] = useState<OrderProgressBarStepName>(stepName)
   const currentStep = debugMode ? debugStep : stepName
   console.log('OrderProgressBarV2 - currentStep:', currentStep)

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/styled.ts
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/styled.ts
@@ -393,6 +393,7 @@ export const CowImage = styled.div`
     width: 100%;
     align-items: center;
     justify-content: center;
+    max-height: 100%;
   }
 
   > svg {
@@ -413,10 +414,6 @@ export const TokenPairTitle = styled.span`
   padding: 0 6px;
   word-break: break-word;
   line-height: 1;
-
-  ${Media.upToSmall()} {
-    display: none;
-  }
 `
 
 export const TokenImages = styled.div`
@@ -463,6 +460,7 @@ export const FinishedTagLine = styled.div`
 
   ${Media.upToSmall()} {
     flex: 0 0 auto;
+    height: auto;
   }
 `
 
@@ -859,6 +857,7 @@ export const FinishedImageContent = styled.div`
 
   ${Media.upToSmall()} {
     width: 100%;
+    max-height: 290px;
   }
 `
 

--- a/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/SurplusModal.tsx
+++ b/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/SurplusModal.tsx
@@ -58,8 +58,6 @@ export const Wrapper = styled.div`
       background: var(${UI.COLOR_SUCCESS_BG});
       color: var(${UI.COLOR_SUCCESS_TEXT});
       border-radius: 50%;
-      width: var(--size);
-      height: var(--size);
       object-fit: contain;
       margin: 0 10px 0 0;
       padding: 6px;

--- a/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/index.cosmos.tsx
@@ -19,9 +19,11 @@ const defaultProps = {
     ...activityDerivedStateMock,
     order,
   },
-  showCancellationModal: () => {
-    alert('Cancellation triggered!!')
-  },
+  orderProgressBarV2Props: {
+    chainId: SupportedChainId.MAINNET, isProgressBarSetup: false, showCancellationModal: () => {
+      alert('Cancellation triggered!!')
+    }
+  }
 }
 
 const Wrapper = styled.div`

--- a/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/index.tsx
@@ -9,7 +9,7 @@ import { ActivityStatus } from 'legacy/hooks/useRecentActivity'
 
 import { ActivityDerivedState } from 'modules/account/containers/Transaction'
 import { GnosisSafeTxDetails } from 'modules/account/containers/Transaction/ActivityDetails'
-import { cowAnalytics, Category } from 'modules/analytics'
+import { Category, cowAnalytics } from 'modules/analytics'
 import { NavigateToNewOrderCallback } from 'modules/swap/containers/ConfirmSwapModalSetup'
 import { EthFlowStepper } from 'modules/swap/containers/EthFlowStepper'
 import { WatchAssetInWallet } from 'modules/wallet/containers/WatchAssetInWallet'
@@ -69,43 +69,7 @@ export function TransactionSubmittedContent({
 
   const isPresignaturePending = activityDerivedState?.isPresignaturePending
   const showSafeSigningInfo = isPresignaturePending && activityDerivedState && !!activityDerivedState.gnosisSafeInfo
-  const showProgressBar =
-    !showSafeSigningInfo && !isPresignaturePending && activityDerivedState && isProgressBarSetup
-
-  const trackCancelClick = () => {
-    cowAnalytics.sendEvent({
-      category: Category.PROGRESS_BAR,
-      action: 'Click Cancel Order',
-    })
-  }
-
-  const trackCloseClick = () => {
-    cowAnalytics.sendEvent({
-      category: Category.PROGRESS_BAR,
-      action: 'Click Close',
-    })
-  }
-
-  const trackBackClick = () => {
-    cowAnalytics.sendEvent({
-      category: Category.PROGRESS_BAR,
-      action: 'Click Back Arrow Button',
-    })
-  }
-
-  const trackDisplayLinkClick = () => {
-    cowAnalytics.sendEvent({
-      category: Category.PROGRESS_BAR,
-      action: 'Click Transaction Link',
-    })
-  }
-
-  const trackWatchAssetClick = () => {
-    cowAnalytics.sendEvent({
-      category: Category.PROGRESS_BAR,
-      action: 'Click Watch Asset',
-    })
-  }
+  const showProgressBar = !showSafeSigningInfo && !isPresignaturePending && activityDerivedState && isProgressBarSetup
 
   return (
     <styledEl.Wrapper>
@@ -147,7 +111,7 @@ export function TransactionSubmittedContent({
 
             {(activityDerivedState?.status === (ActivityStatus.CONFIRMED || ActivityStatus.EXPIRED) ||
               (activityDerivedState?.status === ActivityStatus.PENDING && !isProgressBarSetup)) && (
-                <styledEl.ButtonCustom
+              <styledEl.ButtonCustom
                 onClick={() => {
                   onDismiss()
                   trackCloseClick()
@@ -155,10 +119,45 @@ export function TransactionSubmittedContent({
               >
                 Close
               </styledEl.ButtonCustom>
-              )}
+            )}
           </styledEl.ButtonGroup>
         </>
       </styledEl.Section>
     </styledEl.Wrapper>
   )
+}
+
+const trackCancelClick = () => {
+  cowAnalytics.sendEvent({
+    category: Category.PROGRESS_BAR,
+    action: 'Click Cancel Order',
+  })
+}
+
+const trackCloseClick = () => {
+  cowAnalytics.sendEvent({
+    category: Category.PROGRESS_BAR,
+    action: 'Click Close',
+  })
+}
+
+const trackBackClick = () => {
+  cowAnalytics.sendEvent({
+    category: Category.PROGRESS_BAR,
+    action: 'Click Back Arrow Button',
+  })
+}
+
+const trackDisplayLinkClick = () => {
+  cowAnalytics.sendEvent({
+    category: Category.PROGRESS_BAR,
+    action: 'Click Transaction Link',
+  })
+}
+
+const trackWatchAssetClick = () => {
+  cowAnalytics.sendEvent({
+    category: Category.PROGRESS_BAR,
+    action: 'Click Watch Asset',
+  })
 }

--- a/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/index.tsx
@@ -1,5 +1,4 @@
 import { SupportedChainId as ChainId } from '@cowprotocol/cow-sdk'
-import { Command } from '@cowprotocol/types'
 import { BackButton } from '@cowprotocol/ui'
 import { Currency } from '@uniswap/sdk-core'
 
@@ -47,8 +46,7 @@ export interface TransactionSubmittedContentProps {
   chainId: ChainId
   activityDerivedState: ActivityDerivedState | null
   currencyToAdd?: Nullish<Currency>
-  orderProgressBarV2Props?: OrderProgressBarV2Props | null
-  showCancellationModal: Command | null
+  orderProgressBarV2Props: OrderProgressBarV2Props
   navigateToNewOrderCallback?: NavigateToNewOrderCallback
 }
 
@@ -59,10 +57,10 @@ export function TransactionSubmittedContent({
   currencyToAdd,
   activityDerivedState,
   orderProgressBarV2Props,
-  showCancellationModal,
   navigateToNewOrderCallback,
 }: TransactionSubmittedContentProps) {
   const { order, isOrder, isCreating, isPending } = activityDerivedState || {}
+  const { isProgressBarSetup, showCancellationModal } = orderProgressBarV2Props
   const showCancellationButton = isOrder && (isCreating || isPending) && showCancellationModal
 
   if (!chainId) {
@@ -72,7 +70,7 @@ export function TransactionSubmittedContent({
   const isPresignaturePending = activityDerivedState?.isPresignaturePending
   const showSafeSigningInfo = isPresignaturePending && activityDerivedState && !!activityDerivedState.gnosisSafeInfo
   const showProgressBar =
-    !showSafeSigningInfo && !isPresignaturePending && activityDerivedState && orderProgressBarV2Props
+    !showSafeSigningInfo && !isPresignaturePending && activityDerivedState && isProgressBarSetup
 
   const trackCancelClick = () => {
     cowAnalytics.sendEvent({
@@ -134,10 +132,10 @@ export function TransactionSubmittedContent({
           </styledEl.ActionsWrapper>
         </styledEl.Header>
         <>
-          {!orderProgressBarV2Props && <styledEl.Title>{getTitleStatus(activityDerivedState)}</styledEl.Title>}
+          {!isProgressBarSetup && <styledEl.Title>{getTitleStatus(activityDerivedState)}</styledEl.Title>}
           {showSafeSigningInfo && <GnosisSafeTxDetails chainId={chainId} activityDerivedState={activityDerivedState} />}
           <EthFlowStepper order={order} showProgressBar={!!showProgressBar} />
-          {activityDerivedState && showProgressBar && orderProgressBarV2Props && (
+          {activityDerivedState && showProgressBar && isProgressBarSetup && (
             <OrderProgressBarV2
               {...orderProgressBarV2Props}
               order={order}
@@ -148,8 +146,8 @@ export function TransactionSubmittedContent({
             <WatchAssetInWallet shortLabel currency={currencyToAdd} onClick={trackWatchAssetClick} />
 
             {(activityDerivedState?.status === (ActivityStatus.CONFIRMED || ActivityStatus.EXPIRED) ||
-              (activityDerivedState?.status === ActivityStatus.PENDING && !orderProgressBarV2Props)) && (
-              <styledEl.ButtonCustom
+              (activityDerivedState?.status === ActivityStatus.PENDING && !isProgressBarSetup)) && (
+                <styledEl.ButtonCustom
                 onClick={() => {
                   onDismiss()
                   trackCloseClick()
@@ -157,7 +155,7 @@ export function TransactionSubmittedContent({
               >
                 Close
               </styledEl.ButtonCustom>
-            )}
+              )}
           </styledEl.ButtonGroup>
         </>
       </styledEl.Section>

--- a/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/styled.tsx
+++ b/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/styled.tsx
@@ -82,6 +82,10 @@ export const Header = styled.div`
   width: 100%;
   padding: 16px 0;
   z-index: 20;
+
+  ${Media.upToSmall()} {
+    background: var(${UI.COLOR_PAPER});
+  }
 `
 
 export const ActionsWrapper = styled.div`
@@ -113,6 +117,10 @@ export const Section = styled.div`
   justify-content: flex-start;
   display: flex;
   flex-flow: column wrap;
+
+  ${Media.upToSmall()} {
+    padding: 0 16px 78px;
+  }
 
   ${TransactionInnerDetail} {
     margin: 0 auto;

--- a/apps/cowswap-frontend/src/legacy/components/TopLevelModals/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/TopLevelModals/index.tsx
@@ -3,11 +3,14 @@ import { useAtomValue } from 'jotai'
 import { useModalIsOpen, useToggleModal } from 'legacy/state/application/hooks'
 import { ApplicationModal } from 'legacy/state/application/reducer'
 
+import { SurplusModalSetup } from 'modules/swap/containers/SurplusModalSetup'
+
 import { CancellationModal } from 'common/containers/CancellationModal'
 import { ConfirmationModal } from 'common/containers/ConfirmationModal'
 import { MultipleOrdersCancellationModal } from 'common/containers/MultipleOrdersCancellationModal'
 import { cancellationModalContextAtom } from 'common/hooks/useCancelOrder/state'
 import { confirmationModalContextAtom } from 'common/hooks/useConfirmationRequest'
+
 
 export default function TopLevelModals() {
   const cancelModalOpen = useModalIsOpen(ApplicationModal.CANCELLATION)
@@ -29,6 +32,7 @@ export default function TopLevelModals() {
       />
       <CancellationModal isOpen={cancelModalOpen} onDismiss={onDismissCancellationModal || cancelModalToggle} />
       <MultipleOrdersCancellationModal isOpen={multipleCancelModalOpen} onDismiss={multipleCancelModalToggle} />
+      <SurplusModalSetup />
     </>
   )
 }

--- a/apps/cowswap-frontend/src/legacy/hooks/useActivityDerivedState.ts
+++ b/apps/cowswap-frontend/src/legacy/hooks/useActivityDerivedState.ts
@@ -18,12 +18,16 @@ export function useActivityDerivedState({
   activity,
 }: {
   chainId: number | undefined
-  activity: ActivityDescriptors
+  activity: ActivityDescriptors | undefined
 }): ActivityDerivedState | null {
   const allTransactions = useAllTransactions()
   const gnosisSafeInfo = useGnosisSafeInfo()
 
   const orderCreationTxInfo: OrderCreationTxInfo | undefined = useMemo(() => {
+    if (!activity) {
+      return undefined
+    }
+
     const isOrder = activity.type === ActivityType.ORDER
     const order = isOrder ? (activity.activity as Order) : undefined
 
@@ -43,10 +47,13 @@ export function useActivityDerivedState({
   }, [allTransactions, activity])
 
   // Get some derived information about the activity. It helps to simplify the rendering of the subcomponents
-  return useMemo(
-    () => getActivityDerivedState({ chainId, activityData: activity, gnosisSafeInfo, orderCreationTxInfo }),
-    [chainId, activity, gnosisSafeInfo, orderCreationTxInfo]
-  )
+  return useMemo(() => {
+    if (!activity) {
+      return null
+    }
+
+    return getActivityDerivedState({ chainId, activityData: activity, gnosisSafeInfo, orderCreationTxInfo })
+  }, [chainId, activity, gnosisSafeInfo, orderCreationTxInfo])
 }
 
 export function getActivityDerivedState(props: {

--- a/apps/cowswap-frontend/src/modules/account/containers/OrdersPanel/index.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/OrdersPanel/index.tsx
@@ -47,6 +47,10 @@ const SideBar = styled.div`
     border-radius: ${({ theme }) => (theme.isInjectedWidgetMode ? '24px' : '0')};
     z-index: 10;
   }
+
+  ${Media.upToSmall()} {
+    padding: 0 0 58px;
+  }
 `
 
 const SidebarBackground = styled.div`

--- a/apps/cowswap-frontend/src/modules/account/containers/Transaction/StatusDetails.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/Transaction/StatusDetails.tsx
@@ -7,7 +7,7 @@ import { ExplorerDataType, getExplorerLink } from '@cowprotocol/common-utils'
 import { getSafeWebUrl } from '@cowprotocol/core'
 import { Command } from '@cowprotocol/types'
 
-import { ExternalLink as LinkIconFeather, Info } from 'react-feather'
+import { Info, ExternalLink as LinkIconFeather } from 'react-feather'
 import SVG from 'react-inlinesvg'
 
 import { getActivityState } from 'legacy/hooks/useActivityDerivedState'
@@ -52,10 +52,11 @@ export type StatusDetailsProps = {
   chainId: number
   activityDerivedState: ActivityDerivedState
   showCancellationModal: Command | null
+  showProgressBar: Command | null
 }
 
 export function StatusDetails(props: StatusDetailsProps) {
-  const { chainId, activityDerivedState, showCancellationModal } = props
+  const { chainId, activityDerivedState, showCancellationModal, showProgressBar } = props
 
   const {
     status,
@@ -130,6 +131,8 @@ export function StatusDetails(props: StatusDetailsProps) {
           <CancelButton onClick={showCancellationModal} />
         </StatusLabelBelow>
       )}
+      {/* TODO: Probably not the right component, just placeholder for now */}
+      {showProgressBar && <CancelButton onClick={showProgressBar}>Show progress</CancelButton>}
       {hasCancellationHash && cancellationTxLink && (
         <CancelTxLink href={cancellationTxLink} target="_blank" title="Cancellation transaction">
           <LinkIconFeather size={16} />

--- a/apps/cowswap-frontend/src/modules/account/containers/Transaction/StatusDetails.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/Transaction/StatusDetails.tsx
@@ -132,7 +132,7 @@ export function StatusDetails(props: StatusDetailsProps) {
         </StatusLabelBelow>
       )}
       {/* TODO: Probably not the right component, just placeholder for now */}
-      {showProgressBar && <CancelButton onClick={showProgressBar}>Show progress</CancelButton>}
+      {showProgressBar && <span onClick={showProgressBar}>Show progress</span>}
       {hasCancellationHash && cancellationTxLink && (
         <CancelTxLink href={cancellationTxLink} target="_blank" title="Cancellation transaction">
           <LinkIconFeather size={16} />

--- a/apps/cowswap-frontend/src/modules/account/containers/Transaction/styled.ts
+++ b/apps/cowswap-frontend/src/modules/account/containers/Transaction/styled.ts
@@ -5,7 +5,6 @@ import { UI } from '@cowprotocol/ui'
 
 import { transparentize } from 'color2k'
 import styled, { css, keyframes } from 'styled-components/macro'
-import { LinkStyledButton } from 'theme'
 
 import { RateWrapper } from 'common/pure/RateInfo'
 
@@ -41,7 +40,7 @@ export const Summary = styled.div`
   flex-flow: row wrap;
   width: 100%;
   padding: 22px;
-  grid-template-columns: 80px auto min-content;
+  grid-template-columns: 80px auto max-content;
   grid-template-rows: max-content;
   color: inherit;
 
@@ -199,9 +198,31 @@ export const StatusLabelWrapper = styled.div<{ withCancellationHash$: boolean }>
   align-items: center;
   margin: 0 0 auto auto;
 
+  gap: 4px;
+  font-size: 14px;
+  font-weight: 500;
+  > span,
+  > button {
+    cursor: pointer;
+    font-size: inherit;
+    padding: 0;
+  }
+  > span {
+    color: inherit;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+  > button {
+    appearance: none;
+    border: none;
+    background: none;
+  }
+
   ${Media.upToSmall()} {
     margin: 16px auto 0;
     width: 100%;
+    gap: 20px;
   }
 `
 
@@ -294,12 +315,6 @@ export const StatusLabelBelow = styled.div<{ isCancelling?: boolean }>`
   line-height: 1.1;
   margin: 7px auto 0;
   color: ${({ isCancelling }) => (isCancelling ? `var(${UI.COLOR_TEXT})` : 'inherit')};
-
-  > ${LinkStyledButton} {
-    margin: 2px 0;
-    opacity: 1;
-    color: inherit;
-  }
 `
 
 export const OldTransactionState = styled(ExternalLink)<{ pending: boolean; success?: boolean }>`

--- a/apps/cowswap-frontend/src/modules/swap/containers/SurplusModalSetup/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SurplusModalSetup/index.tsx
@@ -23,7 +23,7 @@ export function SurplusModalSetup() {
   const { surplusData, isProgressBarSetup, activityDerivedState } = progressBarV2Props
   const { showSurplus } = surplusData
 
-  const { isOpen: isConfirmationModalOpen } = useTradeConfirmState()
+  const { isOpen: isConfirmationModalOpen, transactionHash } = useTradeConfirmState()
 
   const onDismiss = useCallback(() => {
     orderId && removeOrderId(orderId)
@@ -33,12 +33,23 @@ export function SurplusModalSetup() {
 
   useEffect(() => {
     // If we should NOT show the screen, remove the orderId from the queue
-    if (((showSurplus === false && order?.status === 'fulfilled') || isConfirmationModalOpen) && orderId) {
+    if (
+      orderId &&
+      // Remove when there's no relevant surplus and the order is filled
+      ((showSurplus === false && order?.status === 'fulfilled') ||
+        // OR when the confirmation is open and the current order is already in display
+        (isConfirmationModalOpen && transactionHash === orderId))
+    ) {
       removeOrderId(orderId)
     }
   }, [orderId, order?.status, removeOrderId, showSurplus, isConfirmationModalOpen])
 
-  const isOpen = !!orderId && !isConfirmationModalOpen && (showSurplus === true || isProgressBarSetup)
+  const isOpen =
+    !!orderId &&
+    // Open when confirmation modal is closed OR the order we are trying to show is not the one in display
+    (!isConfirmationModalOpen || transactionHash !== orderId) &&
+    // Open when we want to show surplus or when the progress bar is active
+    (showSurplus === true || isProgressBarSetup)
 
   if (!orderId) {
     return null

--- a/apps/cowswap-frontend/src/modules/swap/containers/SurplusModalSetup/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SurplusModalSetup/index.tsx
@@ -40,6 +40,10 @@ export function SurplusModalSetup() {
 
   const isOpen = !!orderId && !isConfirmationModalOpen && (showSurplus === true || isProgressBarSetup)
 
+  if (!orderId) {
+    return null
+  }
+
   return (
     <CowModal isOpen={isOpen} onDismiss={onDismiss} maxHeight={90} maxWidth={470}>
       <TransactionSubmittedContent

--- a/apps/cowswap-frontend/src/modules/swap/containers/SurplusModalSetup/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SurplusModalSetup/index.tsx
@@ -20,8 +20,7 @@ export function SurplusModalSetup() {
   const order = useOrder({ id: orderId, chainId })
 
   const progressBarV2Props = useSetupAdditionalProgressBarProps(chainId, order)
-  const { surplusData, isProgressBarSetup, activityDerivedState } = progressBarV2Props
-  const { showSurplus } = surplusData
+  const { isProgressBarSetup, activityDerivedState } = progressBarV2Props
 
   const { isOpen: isConfirmationModalOpen, transactionHash } = useTradeConfirmState()
 
@@ -35,8 +34,8 @@ export function SurplusModalSetup() {
     !!orderId &&
     // Open when confirmation modal is closed OR the order we are trying to show is not the one in display
     (!isConfirmationModalOpen || (!!transactionHash && transactionHash !== orderId)) &&
-    // Open when we want to show surplus or when the progress bar is active
-    (showSurplus === true || isProgressBarSetup)
+    // Open when the progress bar is active
+    isProgressBarSetup
 
   useEffect(() => {
     // If we should NOT show the screen, remove the orderId from the queue
@@ -44,14 +43,13 @@ export function SurplusModalSetup() {
       orderId &&
       // Don't remove it while the modal is open
       !isOpen &&
-      // Remove when there's no relevant surplus and the order is filled
-      ((showSurplus === false && order?.status === 'fulfilled') ||
-        // OR when the confirmation is open and the current order is already in display
-        (isConfirmationModalOpen && transactionHash === orderId))
+      // Remove when the confirmation is open and the current order is already in display
+      isConfirmationModalOpen &&
+      transactionHash === orderId
     ) {
       removeOrderId(orderId)
     }
-  }, [orderId, isOpen, order?.status, removeOrderId, showSurplus, isConfirmationModalOpen])
+  }, [orderId, isOpen, order?.status, removeOrderId, isConfirmationModalOpen])
 
   if (!orderId) {
     return null

--- a/apps/cowswap-frontend/src/modules/swap/containers/SurplusModalSetup/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SurplusModalSetup/index.tsx
@@ -31,10 +31,19 @@ export function SurplusModalSetup() {
 
   const navigateToNewOrderCallback = useNavigateToNewOrderCallback()
 
+  const isOpen =
+    !!orderId &&
+    // Open when confirmation modal is closed OR the order we are trying to show is not the one in display
+    (!isConfirmationModalOpen || (!!transactionHash && transactionHash !== orderId)) &&
+    // Open when we want to show surplus or when the progress bar is active
+    (showSurplus === true || isProgressBarSetup)
+
   useEffect(() => {
     // If we should NOT show the screen, remove the orderId from the queue
     if (
       orderId &&
+      // Don't remove it while the modal is open
+      !isOpen &&
       // Remove when there's no relevant surplus and the order is filled
       ((showSurplus === false && order?.status === 'fulfilled') ||
         // OR when the confirmation is open and the current order is already in display
@@ -42,14 +51,7 @@ export function SurplusModalSetup() {
     ) {
       removeOrderId(orderId)
     }
-  }, [orderId, order?.status, removeOrderId, showSurplus, isConfirmationModalOpen])
-
-  const isOpen =
-    !!orderId &&
-    // Open when confirmation modal is closed OR the order we are trying to show is not the one in display
-    (!isConfirmationModalOpen || transactionHash !== orderId) &&
-    // Open when we want to show surplus or when the progress bar is active
-    (showSurplus === true || isProgressBarSetup)
+  }, [orderId, isOpen, order?.status, removeOrderId, showSurplus, isConfirmationModalOpen])
 
   if (!orderId) {
     return null

--- a/apps/cowswap-frontend/src/modules/swap/containers/SurplusModalSetup/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SurplusModalSetup/index.tsx
@@ -4,33 +4,42 @@ import { useWalletInfo } from '@cowprotocol/wallet'
 
 import { useOrder } from 'legacy/state/orders/hooks'
 
-import { useGetSurplusData } from 'common/hooks/useGetSurplusFiatValue'
 import { CowModal } from 'common/pure/Modal'
+import { OrderProgressBarV2 } from 'common/pure/OrderProgressBarV2'
 import * as styledEl from 'common/pure/TransactionSubmittedContent/styled'
-import { SurplusModal } from 'common/pure/TransactionSubmittedContent/SurplusModal'
 
+import { useTradeConfirmState } from '../../../trade'
 import { useOrderIdForSurplusModal, useRemoveOrderFromSurplusQueue } from '../../state/surplusModal'
+import { useNavigateToNewOrderCallback, useSetupAdditionalProgressBarProps } from '../ConfirmSwapModalSetup'
 
+// TODO: rename?
 export function SurplusModalSetup() {
   const orderId = useOrderIdForSurplusModal()
   const removeOrderId = useRemoveOrderFromSurplusQueue()
 
   const { chainId } = useWalletInfo()
   const order = useOrder({ id: orderId, chainId })
-  const { showSurplus } = useGetSurplusData(order)
+
+  const progressBarV2Props = useSetupAdditionalProgressBarProps(chainId, order)
+  const { surplusData, isProgressBarSetup } = progressBarV2Props
+  const { showSurplus } = surplusData
+
+  const { isOpen: isConfirmationModalOpen } = useTradeConfirmState()
 
   const onDismiss = useCallback(() => {
     orderId && removeOrderId(orderId)
   }, [orderId, removeOrderId])
 
+  const navigateToNewOrderCallback = useNavigateToNewOrderCallback()
+
   useEffect(() => {
-    // If we should NOT show the surplus, remove the orderId from the queue
-    if (showSurplus === false && orderId) {
+    // If we should NOT show the screen, remove the orderId from the queue
+    if (((showSurplus === false && order?.status === 'fulfilled') || isConfirmationModalOpen) && orderId) {
       removeOrderId(orderId)
     }
-  }, [orderId, removeOrderId, showSurplus])
+  }, [orderId, order?.status, removeOrderId, showSurplus, isConfirmationModalOpen])
 
-  const isOpen = !!orderId && showSurplus === true
+  const isOpen = !!orderId && !isConfirmationModalOpen && (showSurplus === true || isProgressBarSetup)
 
   return (
     <CowModal isOpen={isOpen} onDismiss={onDismiss} maxHeight={90} maxWidth={470}>
@@ -39,7 +48,9 @@ export function SurplusModalSetup() {
           <styledEl.Header>
             <styledEl.CloseIconWrapper onClick={onDismiss} />
           </styledEl.Header>
-          <SurplusModal order={order} />
+          {isProgressBarSetup && (
+            <OrderProgressBarV2 {...progressBarV2Props} order={order} navigateToNewOrder={navigateToNewOrderCallback(chainId, order, onDismiss)} />
+          )}
         </styledEl.Section>
       </styledEl.Wrapper>
     </CowModal>

--- a/apps/cowswap-frontend/src/modules/swap/containers/SurplusModalSetup/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SurplusModalSetup/index.tsx
@@ -5,8 +5,7 @@ import { useWalletInfo } from '@cowprotocol/wallet'
 import { useOrder } from 'legacy/state/orders/hooks'
 
 import { CowModal } from 'common/pure/Modal'
-import { OrderProgressBarV2 } from 'common/pure/OrderProgressBarV2'
-import * as styledEl from 'common/pure/TransactionSubmittedContent/styled'
+import { TransactionSubmittedContent } from 'common/pure/TransactionSubmittedContent'
 
 import { useTradeConfirmState } from '../../../trade'
 import { useOrderIdForSurplusModal, useRemoveOrderFromSurplusQueue } from '../../state/surplusModal'
@@ -21,7 +20,7 @@ export function SurplusModalSetup() {
   const order = useOrder({ id: orderId, chainId })
 
   const progressBarV2Props = useSetupAdditionalProgressBarProps(chainId, order)
-  const { surplusData, isProgressBarSetup } = progressBarV2Props
+  const { surplusData, isProgressBarSetup, activityDerivedState } = progressBarV2Props
   const { showSurplus } = surplusData
 
   const { isOpen: isConfirmationModalOpen } = useTradeConfirmState()
@@ -43,16 +42,14 @@ export function SurplusModalSetup() {
 
   return (
     <CowModal isOpen={isOpen} onDismiss={onDismiss} maxHeight={90} maxWidth={470}>
-      <styledEl.Wrapper>
-        <styledEl.Section>
-          <styledEl.Header>
-            <styledEl.CloseIconWrapper onClick={onDismiss} />
-          </styledEl.Header>
-          {isProgressBarSetup && (
-            <OrderProgressBarV2 {...progressBarV2Props} order={order} navigateToNewOrder={navigateToNewOrderCallback(chainId, order, onDismiss)} />
-          )}
-        </styledEl.Section>
-      </styledEl.Wrapper>
+      <TransactionSubmittedContent
+        onDismiss={onDismiss}
+        chainId={chainId}
+        hash={orderId}
+        activityDerivedState={activityDerivedState}
+        orderProgressBarV2Props={progressBarV2Props}
+        navigateToNewOrderCallback={navigateToNewOrderCallback}
+      />
     </CowModal>
   )
 }

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapModals/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapModals/index.tsx
@@ -2,19 +2,16 @@ import React from 'react'
 
 import { genericPropsChecker } from '@cowprotocol/common-utils'
 
-import { SurplusModalSetup } from '../SurplusModalSetup'
-
 export interface SwapModalsProps {
   showNativeWrapModal: boolean
   showCowSubsidyModal: boolean
 }
 
-export const SwapModals = React.memo(function ({ showNativeWrapModal }: SwapModalsProps) {
+export const SwapModals = React.memo(function (_props: SwapModalsProps) {
   return (
     <>
       {/* TODO: Re-enable modal once subsidy is back  */}
       {/*<CowSubsidyModal isOpen={showCowSubsidyModal} onDismiss={closeModals} /> */}
-      {!showNativeWrapModal && <SurplusModalSetup />}
     </>
   )
 }, genericPropsChecker)

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapModals/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapModals/index.tsx
@@ -2,18 +2,19 @@ import React from 'react'
 
 import { genericPropsChecker } from '@cowprotocol/common-utils'
 
+import { SurplusModalSetup } from '../SurplusModalSetup'
+
 export interface SwapModalsProps {
   showNativeWrapModal: boolean
   showCowSubsidyModal: boolean
 }
 
-export const SwapModals = React.memo(function (_props: SwapModalsProps) {
+export const SwapModals = React.memo(function ({ showNativeWrapModal }: SwapModalsProps) {
   return (
     <>
       {/* TODO: Re-enable modal once subsidy is back  */}
       {/*<CowSubsidyModal isOpen={showCowSubsidyModal} onDismiss={closeModals} /> */}
-      {/* TODO: Re-enable modal for displaying when progress bar is closed */}
-      {/*{!showNativeWrapModal && <SurplusModalSetup />}*/}
+      {!showNativeWrapModal && <SurplusModalSetup />}
     </>
   )
 }, genericPropsChecker)

--- a/apps/cowswap-frontend/src/theme/components.tsx
+++ b/apps/cowswap-frontend/src/theme/components.tsx
@@ -16,12 +16,12 @@ export const CloseIcon = styled(X)<{ onClick: Command }>`
 `
 
 // A button that triggers some onClick result, but looks like a link.
-export const LinkStyledButton = styled.button<{ disabled?: boolean; bg?: boolean; isCopied?: boolean }>`
+export const LinkStyledButton = styled.button<{ disabled?: boolean; bg?: boolean; isCopied?: boolean; color?: string }>`
   border: none;
   text-decoration: none;
   background: none;
   cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
-  color: inherit;
+  color: ${({ color }) => color || 'inherit'};
   font-weight: 500;
   opacity: ${({ disabled }) => (disabled ? 0.7 : 1)};
 


### PR DESCRIPTION
# Summary

- Re-enable surplus modal pop-up when progress bar is closed
- Remove progress bar from activity modal
- Add button to bring progress bar back/focus on running progress bar

# To Test

1. Place order, don't close modal
2. Open activity modal
* There should be an ugly `show progress` button
3. Click on `show progress`
* Should close the activity modal and existing progress bar should be running
4. Close progress bar
5. Open activity modal
6. Click on `show progress`
* Should close activity modal and show progress bar in another pop-up modal
* Everything in this modal should work like regular modal (cancel button, expired link, etc)
7. Place order with high slippage (50%) for making sure there'll be surplus
8. Close progress bar and wait for it to trade
* When traded, progress bar should pop-up in a new modal in the last step

Additionally, do a full regression test on progress bar up to here, as with the refactoring some things might have been broken.