### PR TITLE
fix(progress-bar-v2): reset countdown every time not in 'active' state

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
@@ -190,8 +190,8 @@ function useCountdownStartUpdater(
     if (!countdown && countdown !== 0 && backendApiStatus === 'active') {
       // Start countdown when it becomes active
       setCountdown(orderId, PROGRESS_BAR_TIMER_DURATION)
-    } else if (backendApiStatus === 'scheduled' || backendApiStatus === 'open') {
-      // If for some reason it went back to start, reset it
+    } else if (backendApiStatus !== 'active' && countdown) {
+      // Every time backend status is not `active` and countdown is set, reset the countdown
       setCountdown(orderId, null)
     }
   }, [backendApiStatus, setCountdown, countdown, orderId])


### PR DESCRIPTION
# Summary

To avoid situations where countdown reaches 0 only once and follow up cycles end up going straight away to `delayed` step, this change resets it every time the backend state is not `active`.

# To Test

1. No recipe for triggering this as it's dependant on failure states (failed to execute, failed to solve)