### PR TITLE
feat: reorder ranking and order

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
@@ -53,7 +53,7 @@ import { SurplusData } from 'common/hooks/useGetSurplusFiatValue'
 import { getIsCustomRecipient } from 'utils/orderUtils/getIsCustomRecipient'
 
 import * as styledEl from './styled'
-const IS_DEBUG_MODE = false
+const IS_DEBUG_MODE = true
 const DEBUG_FORCE_SHOW_SURPLUS = false
 
 export type OrderProgressBarV2Props = {
@@ -654,7 +654,7 @@ function FinishedStep({
       </styledEl.ProgressTopSection>
 
       <styledEl.ConclusionContent>
-        <styledEl.TransactionStatus flexFlow="column" margin={'0 auto 14px'}>
+        <styledEl.TransactionStatus flexFlow="column" margin={'0 auto 24px'}>
           <Lottie
             animationData={isDarkMode ? LOTTIE_GREEN_CHECKMARK_DARK : LOTTIE_GREEN_CHECKMARK}
             loop={false}
@@ -663,6 +663,48 @@ function FinishedStep({
           />
           Transaction completed!
         </styledEl.TransactionStatus>
+
+        {order?.apiAdditionalInfo?.executedSellAmount && (
+          <styledEl.SoldAmount>
+            You sold <TokenLogo token={order.inputToken} size={20} />
+            <b>
+              <TokenAmount
+                amount={CurrencyAmount.fromRawAmount(order.inputToken, order.apiAdditionalInfo.executedSellAmount)}
+                tokenSymbol={order.inputToken}
+              />
+            </b>
+          </styledEl.SoldAmount>
+        )}
+
+        {order?.apiAdditionalInfo?.executedBuyAmount && (
+          <styledEl.ReceivedAmount>
+            {!isCustomRecipient && 'You received '}
+            <TokenLogo token={order.outputToken} size={20} />
+            <b>
+              <TokenAmount
+                amount={CurrencyAmount.fromRawAmount(order.outputToken, order.apiAdditionalInfo.executedBuyAmount)}
+                tokenSymbol={order.outputToken}
+              />
+            </b>{' '}
+            {isCustomRecipient && receiver && (
+              <>
+                was sent to
+                <ExternalLink href={getExplorerLink(chainId, receiver, ExplorerDataType.ADDRESS)}>
+                  {receiverEnsName || shortenAddress(receiver)} ↗
+                </ExternalLink>
+              </>
+            )}
+          </styledEl.ReceivedAmount>
+        )}
+        {shouldShowSurplus ? (
+          <styledEl.ExtraAmount>
+            {getSurplusText(isSell, isCustomRecipient)}
+            <i>
+              +<TokenAmount amount={surplusAmount} tokenSymbol={surplusAmount?.currency} />
+            </i>{' '}
+            {surplusFiatValue && +surplusFiatValue.toFixed(2) > 0 && <>(~${surplusFiatValue.toFixed(2)})</>}
+          </styledEl.ExtraAmount>
+        ) : null}
 
         {solvers?.length && (
           <styledEl.SolverRankings>
@@ -724,35 +766,6 @@ function FinishedStep({
             )}
           </styledEl.SolverRankings>
         )}
-        {order?.apiAdditionalInfo?.executedBuyAmount && (
-          <styledEl.ReceivedAmount>
-            {!isCustomRecipient && 'You received '}
-            <TokenLogo token={order.outputToken} size={16} />
-            <b>
-              <TokenAmount
-                amount={CurrencyAmount.fromRawAmount(order.outputToken, order.apiAdditionalInfo.executedBuyAmount)}
-                tokenSymbol={order.outputToken}
-              />
-            </b>{' '}
-            {isCustomRecipient && receiver && (
-              <>
-                was sent to
-                <ExternalLink href={getExplorerLink(chainId, receiver, ExplorerDataType.ADDRESS)}>
-                  {receiverEnsName || shortenAddress(receiver)} ↗
-                </ExternalLink>
-              </>
-            )}
-          </styledEl.ReceivedAmount>
-        )}
-        {shouldShowSurplus ? (
-          <styledEl.ExtraAmount>
-            {getSurplusText(isSell, isCustomRecipient)}
-            <i>
-              +<TokenAmount amount={surplusAmount} tokenSymbol={surplusAmount?.currency} />
-            </i>{' '}
-            {surplusFiatValue && +surplusFiatValue.toFixed(2) > 0 && <>(~${surplusFiatValue.toFixed(2)})</>}
-          </styledEl.ExtraAmount>
-        ) : null}
       </styledEl.ConclusionContent>
     </styledEl.FinishedStepContainer>
   )

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
@@ -53,7 +53,7 @@ import { SurplusData } from 'common/hooks/useGetSurplusFiatValue'
 import { getIsCustomRecipient } from 'utils/orderUtils/getIsCustomRecipient'
 
 import * as styledEl from './styled'
-const IS_DEBUG_MODE = true
+const IS_DEBUG_MODE = false
 const DEBUG_FORCE_SHOW_SURPLUS = false
 
 export type OrderProgressBarV2Props = {

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/styled.ts
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/styled.ts
@@ -559,10 +559,12 @@ export const SolverRankings = styled.div`
   justify-content: center;
   align-items: center;
   width: 100%;
+  margin: 52px auto 0;
 
   > h3 {
+    font-size: 17px;
     font-weight: 600;
-    margin: 20px auto 0;
+    margin: 0;
   }
 
   > p {
@@ -684,9 +686,9 @@ export const ReceivedAmount = styled.span`
   justify-content: center;
   width: 100%;
   gap: 4px;
-  font-size: 14px;
+  font-size: 15px;
   font-weight: normal;
-  margin: 20px auto 0;
+  margin: 0 auto 10px;
   color: var(${UI.COLOR_TEXT_OPACITY_70});
 
   > b {
@@ -694,14 +696,16 @@ export const ReceivedAmount = styled.span`
   }
 `
 
+export const SoldAmount = styled(ReceivedAmount)``
+
 export const ExtraAmount = styled.p`
   display: flex;
   align-items: center;
   justify-content: center;
   width: 100%;
   color: var(${UI.COLOR_TEXT_OPACITY_70});
-  font-size: 14px;
-  margin: 4px auto 0;
+  font-size: 15px;
+  margin: 0 auto;
   gap: 4px;
 
   > i {


### PR DESCRIPTION
# Summary

- Changes the order of showing solver ranking table and sell/buy/surplus amounts

<img width="546" alt="Screenshot 2024-08-20 at 17 29 47" src="https://github.com/user-attachments/assets/78bae35d-594d-4945-9d25-f70c8346d7b7">
