### PR TITLE
fix: do not show header controls when progress bar is shown

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/Header/styled.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Header/styled.tsx
@@ -1,4 +1,4 @@
-import { UI, Media, RowFixed } from '@cowprotocol/ui'
+import { Media, RowFixed, UI } from '@cowprotocol/ui'
 
 import styled, { css } from 'styled-components/macro'
 
@@ -18,7 +18,7 @@ export const HeaderControls = styled.div`
     position: sticky;
     bottom: 0;
     left: 0;
-    z-index: 101;
+    z-index: 10;
     background: var(${UI.COLOR_PAPER});
     padding: 5px 10px;
     flex-flow: row-reverse;
@@ -47,8 +47,8 @@ export const LogoImage = styled.div<{ isMobileMenuOpen?: boolean }>`
 
   ${Media.upToLarge()} {
     ${({ isMobileMenuOpen }) =>
-      isMobileMenuOpen &&
-      css`
+    isMobileMenuOpen &&
+    css`
         height: 34px;
         width: auto;
       `}


### PR DESCRIPTION
# Summary

Fixes https://github.com/cowprotocol/cowswap/pull/4811#issuecomment-2299206850

![image](https://github.com/user-attachments/assets/42efb774-7794-424f-91a4-c815fc5ec0b8)

Now you _must_ close it in order to see the rest of the info, like on desktop view

# To Test

1. On mobile, place order
2. Close progress bar
3. Open account modal
4. Click on `show progress`
* Progress bar is displayed
* Pending button is hidden