### PR TITLE
feat(progress-bar-v2): show solver description if set

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
@@ -26,7 +26,7 @@ import type { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { OrderKind } from '@cowprotocol/cow-sdk'
 import { TokenLogo } from '@cowprotocol/tokens'
 import { Command } from '@cowprotocol/types'
-import { ExternalLink, HoverTooltip, ProductLogo, ProductVariant, TokenAmount, UI } from '@cowprotocol/ui'
+import { ExternalLink, InfoTooltip, ProductLogo, ProductVariant, TokenAmount, UI } from '@cowprotocol/ui'
 import { CurrencyAmount } from '@uniswap/sdk-core'
 
 import Lottie from 'lottie-react'
@@ -734,13 +734,10 @@ function FinishedStep({
                             height="24"
                           />
                         </styledEl.SolverLogo>
-                        {solver.description ? (
-                          <HoverTooltip content={solver.description}>
-                            <styledEl.SolverName>{solver.displayName || solver.solver}</styledEl.SolverName>
-                          </HoverTooltip>
-                        ) : (
-                          <styledEl.SolverName>{solver.displayName || solver.solver}</styledEl.SolverName>
-                        )}
+                        <styledEl.SolverName>
+                          {solver.displayName || solver.solver}
+                          {solver.description && <span><InfoTooltip content={solver.description} /></span>}
+                        </styledEl.SolverName>
                       </styledEl.SolverInfo>
                     </styledEl.SolverTableCell>
                     <styledEl.SolverTableCell>

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import PROGRESS_BAR_BAD_NEWS from '@cowprotocol/assets/cow-swap/progressbar-bad-news.svg'
 import PROGRESSBAR_COW_SURPLUS_1 from '@cowprotocol/assets/cow-swap/progressbar-finished-image-1.svg'
@@ -26,7 +26,7 @@ import type { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { OrderKind } from '@cowprotocol/cow-sdk'
 import { TokenLogo } from '@cowprotocol/tokens'
 import { Command } from '@cowprotocol/types'
-import { ExternalLink, ProductLogo, ProductVariant, TokenAmount, UI } from '@cowprotocol/ui'
+import { ExternalLink, HoverTooltip, ProductLogo, ProductVariant, TokenAmount, UI } from '@cowprotocol/ui'
 import { CurrencyAmount } from '@uniswap/sdk-core'
 
 import Lottie from 'lottie-react'
@@ -46,7 +46,7 @@ import { AMM_LOGOS } from 'legacy/components/AMMsLogo'
 import { Order } from 'legacy/state/orders/actions'
 import { useIsDarkMode } from 'legacy/state/user/hooks'
 
-import { cowAnalytics, Category } from 'modules/analytics'
+import { Category, cowAnalytics } from 'modules/analytics'
 
 import { OrderProgressBarStepName, SolverCompetition } from 'common/hooks/orderProgressBarV2'
 import { SurplusData } from 'common/hooks/useGetSurplusFiatValue'
@@ -734,7 +734,13 @@ function FinishedStep({
                             height="24"
                           />
                         </styledEl.SolverLogo>
-                        <styledEl.SolverName>{solver.displayName || solver.solver}</styledEl.SolverName>
+                        {solver.description ? (
+                          <HoverTooltip content={solver.description}>
+                            <styledEl.SolverName>{solver.displayName || solver.solver}</styledEl.SolverName>
+                          </HoverTooltip>
+                        ) : (
+                          <styledEl.SolverName>{solver.displayName || solver.solver}</styledEl.SolverName>
+                        )}
                       </styledEl.SolverInfo>
                     </styledEl.SolverTableCell>
                     <styledEl.SolverTableCell>

--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/styled.ts
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/styled.ts
@@ -1,5 +1,5 @@
 import IMAGE_STAR_SHINE from '@cowprotocol/assets/cow-swap/star-shine.svg'
-import { LinkStyledButton, Font, Media, UI } from '@cowprotocol/ui'
+import { Font, LinkStyledButton, Media, UI } from '@cowprotocol/ui'
 
 import styled, { css, keyframes } from 'styled-components/macro'
 
@@ -9,12 +9,12 @@ const BLUE_COLOR = '#65d9ff'
 
 const slideAnimation = (direction: 'up' | 'down', status: string, isDarkMode: boolean) => keyframes`
   from {
-    transform: translateY(${direction === 'up' ? '20px' : '-20px'}); 
-    opacity: 0; 
+    transform: translateY(${direction === 'up' ? '20px' : '-20px'});
+    opacity: 0;
   }
-  to { 
-    transform: translateY(0); 
-    opacity: ${getOpacity(status, isDarkMode)}; 
+  to {
+    transform: translateY(0);
+    opacity: ${getOpacity(status, isDarkMode)};
   }
 `
 
@@ -634,6 +634,12 @@ export const SolverName = styled.span`
   flex-grow: 1;
   color: inherit;
   text-transform: capitalize;
+  display: flex;
+  align-items: center;
+
+  > span {
+    margin-left: 4px;
+  }
 `
 
 export const TrophyIcon = styled.span`

--- a/libs/core/src/cms/types.ts
+++ b/libs/core/src/cms/types.ts
@@ -9,6 +9,7 @@ export type SolverInfo = {
   solverId: string
   displayName: string
   solverNetworks: SolverNetwork[]
+  description?: string
   image?: string
 }
 

--- a/libs/core/src/cms/utils/getSolversInfo.ts
+++ b/libs/core/src/cms/utils/getSolversInfo.ts
@@ -26,7 +26,7 @@ export async function getSolversInfo(): Promise<CmsSolversInfo> {
             },
             image: { fields: ['url'] },
           },
-          fields: ['displayName', 'solverId'],
+          fields: ['displayName', 'solverId', 'description'],
           pagination: { pageSize: 100 },
         },
       },

--- a/libs/core/src/cms/utils/mapCmsSolversInfoToSolversInfo.ts
+++ b/libs/core/src/cms/utils/mapCmsSolversInfoToSolversInfo.ts
@@ -3,7 +3,7 @@ import { CmsSolversInfo, SolverNetwork, SolversInfo } from '../types'
 export function mapCmsSolversInfoToSolversInfo(cmsSolversInfo: CmsSolversInfo): SolversInfo {
   return cmsSolversInfo.reduce<SolversInfo>((acc, info) => {
     if (info?.attributes) {
-      const { solverId, displayName, image, solver_networks } = info.attributes
+      const { solverId, displayName, image, solver_networks, description } = info.attributes
 
       const solverNetworks = solver_networks?.data?.reduce<SolverNetwork[]>((acc, entry) => {
         if (entry.attributes) {
@@ -29,7 +29,7 @@ export function mapCmsSolversInfoToSolversInfo(cmsSolversInfo: CmsSolversInfo): 
         return acc
       }
 
-      acc.push({ solverId, displayName, image: image?.data?.attributes?.url, solverNetworks })
+      acc.push({ solverId, displayName, description, image: image?.data?.attributes?.url, solverNetworks })
     }
 
     return acc


### PR DESCRIPTION
# Summary

Show solver description from CMS on a tooltip

![image](https://github.com/user-attachments/assets/b7589274-6947-40a5-afbd-61a265acb462)

In this example, all the `<name> API` were set to `Operated by GnosisDAO`

# To Test

1. Place order on arb1/mainnet
2. Wait for it to trade
3. Hover over the solvers (if present): 0x, 1inch, Paraswap and Balancer
* Should contain `Operated by GnosisDAO` tooltip