### PR TITLE
feat: add tooltip and change message

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/TransactionSettings/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/TransactionSettings/index.tsx
@@ -102,9 +102,15 @@ const SlippageEmojiContainer = styled.span`
   }
 `
 
-const SmartSlippageInfo = styled.span`
-  color: #f3841e;
+const SmartSlippageInfo = styled.div`
+  color: var(${UI.COLOR_GREEN});
   font-size: 13px;
+  text-align: right;
+  width: 100%;
+  padding-right: 0.2rem;
+  display: flex;
+  justify-content: flex-end;
+  padding-bottom: 0.35rem;
 `
 
 const Wrapper = styled.div`
@@ -350,7 +356,15 @@ export function TransactionSettings() {
           {isSmartSlippageApplied && (
             <RowBetween>
               <SmartSlippageInfo>
-                The best slippage value is selected for the fastest order execution!
+                <span>Dynamic</span>
+                <HelpTooltip
+                  text={
+                    <Trans>
+                      Based on recent volatility observed for this token pair. Its recommended to leave the default to
+                      account for price changes
+                    </Trans>
+                  }
+                />
               </SmartSlippageInfo>
             </RowBetween>
           )}

--- a/apps/cowswap-frontend/src/modules/swap/updaters/SmartSlippageUpdater.ts
+++ b/apps/cowswap-frontend/src/modules/swap/updaters/SmartSlippageUpdater.ts
@@ -36,7 +36,7 @@ export function SmartSlippageUpdater() {
       ? null
       : [chainId, sellTokenAddress, buyTokenAddress],
     async ([chainId, sellTokenAddress, buyTokenAddress]) => {
-      const url = `${BFF_BASE_URL}/chains/${chainId}/markets/${sellTokenAddress}-${buyTokenAddress}/defaultSlippageTolerance`
+      const url = `${BFF_BASE_URL}/${chainId}/markets/${sellTokenAddress}-${buyTokenAddress}/slippageTolerance`
 
       const response: SlippageApiResponse = await fetch(url).then((res) => res.json())
 

--- a/libs/common-utils/src/tooltips.ts
+++ b/libs/common-utils/src/tooltips.ts
@@ -5,7 +5,7 @@ import { formatPercent } from './amountFormat'
 export function getMinimumReceivedTooltip(allowedSlippage: Percent, isExactIn: boolean): string {
   return `${
     isExactIn ? "Minimum tokens you'll receive." : "Maximum tokens you'll sell."
-  } This accounts for the current price and your chosen slippage (${formatPercent(
+  } This accounts for the current price and the slippage tolerance (${formatPercent(
     allowedSlippage
-  )}%). If the price moves beyond your slippage, you won't trade but also you won't pay any fees or gas.`
+  )}%). If the price moves beyond the slippage tolerance, you won't trade but also you won't pay any fees or gas.`
 }


### PR DESCRIPTION
# Summary

Changes the text for the smart slippage and adds a tooltip

![image](https://github.com/user-attachments/assets/f82d01b5-6a0e-43ff-aa9b-105f23813689)

![image](https://github.com/user-attachments/assets/b7bb68f2-90e4-4287-88bc-f304fa08f108)

## Implementation details
This PR will use BFF for estimating the slippage tolerance. Specifically uses this: https://github.com/cowprotocol/bff/pull/84

This implementation has been deployed to BARN, so it should have #84 applied:
https://bff.barn.cow.fi/1/markets/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2-0x2260fac5e5542a773aa44fbcfedf7c193bc2c599/slippageTolerance


# Test
Select different markets, and check how it change the default slippage suggested by the app.

Make sure the trades go trough even for illiquid markets.


It might be helpful to check coingecko to understand why sometimes is the number higher, like in AAVE token (1.84%)

<img width="1100" alt="image" src="https://github.com/user-attachments/assets/30bcf6c8-a872-46b8-9115-bc5bb40157c3">

<img width="1356" alt="image" src="https://github.com/user-attachments/assets/b792e6a0-e73f-4a49-a353-f89ad36276ad">


<img width="1711" alt="image" src="https://github.com/user-attachments/assets/d3a44729-89c7-45c9-a915-709bf7012676">


<img width="1429" alt="image" src="https://github.com/user-attachments/assets/8e74610c-164b-4df5-84c5-41c38498dd2d">


<img width="929" alt="image" src="https://github.com/user-attachments/assets/fdf7d3ac-b401-486d-bcaa-fd7ac0025f8b">
