### PR TITLE
fix: hide 'show progress' when progress bar is disabled

### DIFF
--- a/apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
@@ -22,6 +22,7 @@ import { ActivityStatus } from 'legacy/hooks/useRecentActivity'
 import { OrderStatus } from 'legacy/state/orders/actions'
 
 import { useToggleAccountModal } from 'modules/account'
+import { useInjectedWidgetParams } from 'modules/injectedWidget'
 import { EthFlowStepper } from 'modules/swap/containers/EthFlowStepper'
 
 import { useCancelOrder } from 'common/hooks/useCancelOrder'
@@ -193,7 +194,9 @@ export function ActivityDetails(props: {
 
   const isSwap = order && getUiOrderType(order) === UiOrderType.SWAP
 
-  const showProgressBar = activityState === 'open' && isSwap && order
+  const { disableProgressBar } = useInjectedWidgetParams()
+
+  const showProgressBar = activityState === 'open' && isSwap && order && !disableProgressBar
   const showCancellationModal = order ? getShowCancellationModal(order) : null
 
   const { surplusFiatValue, showFiatValue, surplusToken, surplusAmount } = useGetSurplusData(order)

--- a/apps/cowswap-frontend/src/modules/account/containers/Transaction/StatusDetails.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/Transaction/StatusDetails.tsx
@@ -131,7 +131,6 @@ export function StatusDetails(props: StatusDetailsProps) {
           <CancelButton onClick={showCancellationModal} />
         </StatusLabelBelow>
       )}
-      {/* TODO: Probably not the right component, just placeholder for now */}
       {showProgressBar && <span onClick={showProgressBar}>Show progress</span>}
       {hasCancellationHash && cancellationTxLink && (
         <CancelTxLink href={cancellationTxLink} target="_blank" title="Cancellation transaction">


### PR DESCRIPTION
# Summary

Do not show button `show progress` when progress bar is disabled

# To Test

1. Using the widget, place an order
2. Disable progress bar
3. Open activity modal
* Should not have `show progress` for the pending order