### PR TITLE
feat: do not show amounts on finished step

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
@@ -367,6 +367,8 @@ const RenderProgressTopSection: React.FC<{
   showCancellationModal: Command | null
   surplusData?: SurplusData
 }> = ({ stepName, order, countdown, surplusData }) => {
+  const hideIntent = stepName === 'finished' || stepName === 'cancellationFailed'
+
   const { randomImage, randomBenefit } = useMemo(
     () => ({
       randomImage: SURPLUS_IMAGES[getRandomInt(0, SURPLUS_IMAGES.length - 1)],
@@ -595,7 +597,7 @@ const RenderProgressTopSection: React.FC<{
           {content}
         </motion.div>
       </AnimatePresence>
-      <OrderIntent order={order} />
+      {!hideIntent && <OrderIntent order={order} />}
     </styledEl.ProgressTopSection>
   )
 }


### PR DESCRIPTION
# Summary

![image](https://github.com/user-attachments/assets/061eefe9-5b1f-44f6-949b-7d8508f536d4)

# To Test

1. Place order and observe finished screen
* Should not have amounts at the top like previous screens