### PR TITLE
feat: once moved out of initial, do not go back to it

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
@@ -302,6 +302,13 @@ function getProgressBarStepName(
   } else if (backendApiStatus === 'active' && countdown === 0) {
     // solving, but took longer than stipulated countdown
     return 'delayed'
+  } else if (
+    (backendApiStatus === 'open' || backendApiStatus === 'scheduled') &&
+    previousStepName &&
+    previousStepName !== 'initial'
+  ) {
+    // once moved out of initial state, never go back to it
+    return 'delayed'
   } else if (backendApiStatus) {
     // straight mapping API status to progress bar steps
     return BACKEND_TYPE_TO_PROGRESS_BAR_STEP_NAME[backendApiStatus]


### PR DESCRIPTION
# Summary

If we previously have a state that was NOT initial, and attempt to get back to it, move to delayed instead

# To Test

1. Tricky. Place several orders on arb1 and hope for the best, I guess.