### PR TITLE
fix(progress-bar-v2): previous backend status

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/atoms.ts
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/atoms.ts
@@ -6,7 +6,7 @@ import {
   OrderProgressBarState,
   OrderProgressBarStepName,
   OrdersProgressBarCountdown,
-  OrdersProgressBarState
+  OrdersProgressBarState,
 } from './types'
 
 /**
@@ -127,7 +127,9 @@ export const updateOrderProgressBarBackendInfo = atom(
       return
     }
 
+    singleOrderState.previousBackendApiStatus = currentBackendApiStatus
     singleOrderState.backendApiStatus = backendApiStatus
+
     // Only update solver competition if changed and not falsy
     if (solverCompetitionChanged && solverCompetition) {
       singleOrderState.solverCompetition = solverCompetition

--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/types.ts
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/types.ts
@@ -4,6 +4,7 @@ import type { CompetitionOrderStatus } from '@cowprotocol/cow-sdk'
 export type OrderProgressBarState = {
   countdown?: number | null
   backendApiStatus?: CompetitionOrderStatus.type
+  previousBackendApiStatus?: CompetitionOrderStatus.type
   solverCompetition?: CompetitionOrderStatus['value']
   progressBarStepName?: OrderProgressBarStepName
   previousStepName?: OrderProgressBarStepName

--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
@@ -78,6 +78,7 @@ export function useOrderProgressBarV2Props(
   const {
     countdown,
     backendApiStatus,
+    previousBackendApiStatus,
     solverCompetition: apiSolverCompetition,
     progressBarStepName,
     previousStepName,
@@ -102,6 +103,7 @@ export function useOrderProgressBarV2Props(
     isConfirmed,
     countdown,
     backendApiStatus,
+    previousBackendApiStatus,
     lastTimeChangedSteps,
     previousStepName
   )
@@ -215,6 +217,7 @@ function useProgressBarStepNameUpdater(
   isConfirmed: boolean,
   countdown: OrderProgressBarState['countdown'],
   backendApiStatus: OrderProgressBarState['backendApiStatus'],
+  previousBackendApiStatus: OrderProgressBarState['previousBackendApiStatus'],
   lastTimeChangedSteps: OrderProgressBarState['lastTimeChangedSteps'],
   previousStepName: OrderProgressBarState['previousStepName']
 ) {
@@ -229,6 +232,7 @@ function useProgressBarStepNameUpdater(
     isConfirmed,
     countdown,
     backendApiStatus,
+    previousBackendApiStatus,
     previousStepName
   )
 
@@ -276,6 +280,7 @@ function getProgressBarStepName(
   isConfirmed: boolean,
   countdown: OrderProgressBarState['countdown'],
   backendApiStatus: OrderProgressBarState['backendApiStatus'],
+  previousBackendApiStatus: OrderProgressBarState['previousBackendApiStatus'],
   previousStepName: OrderProgressBarState['previousStepName']
 ): OrderProgressBarStepName {
   if (isExpired) {
@@ -291,7 +296,7 @@ function getProgressBarStepName(
     // already traded
     return 'finished'
   } else if (
-    previousStepName === 'executing' &&
+    previousBackendApiStatus === 'executing' &&
     (backendApiStatus === 'active' || backendApiStatus === 'open' || backendApiStatus === 'scheduled')
   ) {
     // moved back from executing to active


### PR DESCRIPTION
# Summary

To accommodate potential race condition issues, this change stores previous backend api status in the state and uses it when checking for the state change leading to `submissionFailure`.

# To Test

1. Place order better on arb1 as block times are super short there
2. Wait for an order in `executing` stage go back to `solving`
* It should go to `submissionFailure` step after `executing` and before `solving`