### PR TITLE
fix(progress-bar-v2): adjust cancellation failed banner when combined with ethflow

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/styled.ts
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/styled.ts
@@ -754,6 +754,7 @@ export const CancellationFailedBanner = styled.div`
   background-color: var(${UI.COLOR_DANGER_BG});
   color: var(${UI.COLOR_DANGER_TEXT});
   padding: 10px;
+  margin-top: 10px;
   border-radius: 16px;
   text-align: center;
   font-size: 15px;

--- a/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/TransactionSubmittedContent/index.tsx
@@ -14,6 +14,7 @@ import { NavigateToNewOrderCallback } from 'modules/swap/containers/ConfirmSwapM
 import { EthFlowStepper } from 'modules/swap/containers/EthFlowStepper'
 import { WatchAssetInWallet } from 'modules/wallet/containers/WatchAssetInWallet'
 
+
 import * as styledEl from './styled'
 
 // import { SurplusModal } from './SurplusModal'
@@ -60,7 +61,7 @@ export function TransactionSubmittedContent({
   navigateToNewOrderCallback,
 }: TransactionSubmittedContentProps) {
   const { order, isOrder, isCreating, isPending } = activityDerivedState || {}
-  const { isProgressBarSetup, showCancellationModal } = orderProgressBarV2Props
+  const { isProgressBarSetup, showCancellationModal, stepName } = orderProgressBarV2Props
   const showCancellationButton = isOrder && (isCreating || isPending) && showCancellationModal
 
   if (!chainId) {
@@ -70,6 +71,7 @@ export function TransactionSubmittedContent({
   const isPresignaturePending = activityDerivedState?.isPresignaturePending
   const showSafeSigningInfo = isPresignaturePending && activityDerivedState && !!activityDerivedState.gnosisSafeInfo
   const showProgressBar = !showSafeSigningInfo && !isPresignaturePending && activityDerivedState && isProgressBarSetup
+  const cancellationFailed = stepName === 'cancellationFailed'
 
   return (
     <styledEl.Wrapper>
@@ -98,7 +100,7 @@ export function TransactionSubmittedContent({
         <>
           {!isProgressBarSetup && <styledEl.Title>{getTitleStatus(activityDerivedState)}</styledEl.Title>}
           {showSafeSigningInfo && <GnosisSafeTxDetails chainId={chainId} activityDerivedState={activityDerivedState} />}
-          <EthFlowStepper order={order} showProgressBar={!!showProgressBar} />
+          <EthFlowStepper order={order} showProgressBar={!!showProgressBar && !cancellationFailed} />
           {activityDerivedState && showProgressBar && isProgressBarSetup && (
             <OrderProgressBarV2
               {...orderProgressBarV2Props}
@@ -111,15 +113,15 @@ export function TransactionSubmittedContent({
 
             {(activityDerivedState?.status === (ActivityStatus.CONFIRMED || ActivityStatus.EXPIRED) ||
               (activityDerivedState?.status === ActivityStatus.PENDING && !isProgressBarSetup)) && (
-              <styledEl.ButtonCustom
-                onClick={() => {
-                  onDismiss()
-                  trackCloseClick()
-                }}
-              >
-                Close
-              </styledEl.ButtonCustom>
-            )}
+                <styledEl.ButtonCustom
+                  onClick={() => {
+                    onDismiss()
+                    trackCloseClick()
+                  }}
+                >
+                  Close
+                </styledEl.ButtonCustom>
+              )}
           </styledEl.ButtonGroup>
         </>
       </styledEl.Section>


### PR DESCRIPTION
# Summary

Fix css on cancellation failed banner when combined with ethflow

With banner

![Screenshot 2024-08-26 at 14 45 36](https://github.com/user-attachments/assets/496b9650-09fd-4e17-9401-b1e96c3a417d)

Without banner

![Screenshot 2024-08-26 at 14 47 00](https://github.com/user-attachments/assets/ba707e79-9829-4d98-b617-0f1566c2a4bb)


# To Test

1. Place ethflow order
2. Cancel it 
3. Hope cancellation fails
* Cancellation failed banner should be displayed