### PR TITLE
fix(twap): display relevant price after slippage

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/RateInfo/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/RateInfo/index.tsx
@@ -196,6 +196,8 @@ export function RateInfo({
 
     const [quoteCurrencyAddress, inputCurrencyAddress] = [getAddress(quoteCurrency), getAddress(inputCurrency)]
 
+    if (!quoteCurrencyAddress || !inputCurrencyAddress) return
+
     setCurrentIsInverted(quoteCurrencyAddress !== inputCurrencyAddress)
 
     if (setSmartQuoteSelectionOnce) {

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWidget/index.tsx
@@ -15,6 +15,7 @@ import { useGetTradeFormValidation } from 'modules/tradeFormValidation'
 import { useTradeQuote } from 'modules/tradeQuote'
 import { TwapFormState } from 'modules/twap/pure/PrimaryActionButton/getTwapFormState'
 
+import { usePrice } from 'common/hooks/usePrice'
 import { useRateInfoParams } from 'common/hooks/useRateInfoParams'
 
 import * as styledEl from './styled'
@@ -62,7 +63,10 @@ export function TwapFormWidget() {
 
   const receiveAmountInfo = useReceiveAmountInfo()
 
-  const limitPrice = receiveAmountInfo?.quotePrice
+  const limitPriceAfterSlippage = usePrice(
+    receiveAmountInfo?.afterSlippage.sellAmount,
+    receiveAmountInfo?.afterSlippage.buyAmount
+  )
 
   const deadlineState = {
     deadline,
@@ -133,9 +137,9 @@ export function TwapFormWidget() {
         upDownArrowsLeftAlign={true}
         prefixComponent={
           <em>
-            {limitPrice ? (
+            {limitPriceAfterSlippage ? (
               <styledEl.ExecutionPriceStyled
-                executionPrice={limitPrice}
+                executionPrice={limitPriceAfterSlippage}
                 isInverted={isInverted}
                 hideFiat
                 hideSeparator


### PR DESCRIPTION
# Summary

Fixes #4799

There was a bug with displaying the price protection value (introduced after adding partner fee).

<img width="484" alt="image" src="https://github.com/user-attachments/assets/0bc1735f-4765-4123-9dfc-41c4232ba5b1">


# To Test

See #4799
