### PR TITLE
fix(twap): don't crash when slippage is 100

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeBasicConfirmDetails/LimitPriceRow.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeBasicConfirmDetails/LimitPriceRow.tsx
@@ -24,7 +24,13 @@ export function LimitPriceRow(props: Props) {
     <RateWrapper onClick={() => setIsInverted((curr) => !curr)}>
       <ConfirmDetailsItem withTimelineDot={true} label={limitPriceLabel} tooltip={limitPriceTooltip}>
         {price ? (
-          <ExecutionPrice executionPrice={price} isInverted={isInverted} showBaseCurrency separatorSymbol="=" />
+          <ExecutionPrice
+            executionPrice={price}
+            isInverted={isInverted}
+            hideFiat
+            showBaseCurrency
+            separatorSymbol="="
+          />
         ) : (
           '-'
         )}

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeBasicConfirmDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeBasicConfirmDetails/index.tsx
@@ -1,5 +1,6 @@
 import { Dispatch, ReactNode, SetStateAction, useMemo } from 'react'
 
+import { FractionUtils } from '@cowprotocol/common-utils'
 import { PercentDisplay } from '@cowprotocol/ui'
 import { CowSwapWidgetAppParams } from '@cowprotocol/widget-lib'
 import { Percent, Price } from '@uniswap/sdk-core'
@@ -83,8 +84,12 @@ export function TradeBasicConfirmDetails(props: Props) {
   const limitPrice = useMemo(() => {
     const { afterNetworkCosts, afterSlippage } = receiveAmountInfo
 
+    const quoteAmount = FractionUtils.amountToAtLeastOneWei(afterSlippage.buyAmount)
+
+    if (!quoteAmount) return null
+
     return new Price({
-      quoteAmount: afterSlippage.buyAmount,
+      quoteAmount,
       baseAmount: afterNetworkCosts.sellAmount,
     })
   }, [receiveAmountInfo])

--- a/apps/cowswap-frontend/src/modules/trade/pure/PartnerFeeRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/PartnerFeeRow/index.tsx
@@ -1,4 +1,4 @@
-import { bpsToPercent, formatPercent } from '@cowprotocol/common-utils'
+import { bpsToPercent, formatPercent, FractionUtils } from '@cowprotocol/common-utils'
 import { CowSwapWidgetContent } from '@cowprotocol/widget-lib'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
@@ -27,9 +27,7 @@ export function PartnerFeeRow({
   widgetContent,
 }: PartnerFeeRowProps) {
   const feeAsPercent = partnerFeeBps ? formatPercent(bpsToPercent(partnerFeeBps)) : null
-  const minPartnerFeeAmount = partnerFeeAmount?.equalTo(0)
-    ? CurrencyAmount.fromRawAmount(partnerFeeAmount.currency, 1)
-    : partnerFeeAmount
+  const minPartnerFeeAmount = FractionUtils.amountToAtLeastOneWei(partnerFeeAmount)
 
   return (
     <>

--- a/apps/cowswap-frontend/src/modules/twap/utils/twapOrderToStruct.ts
+++ b/apps/cowswap-frontend/src/modules/twap/utils/twapOrderToStruct.ts
@@ -11,7 +11,7 @@ export function twapOrderToStruct(order: TWAPOrder): TWAPOrderStruct {
     buyToken: getCurrencyAddress(buyToken),
     receiver: order.receiver,
     partSellAmount: order.sellAmount.divide(order.numOfParts).quotient.toString(),
-    minPartLimit: minPartLimit.quotient.toString(),
+    minPartLimit: minPartLimit!.quotient.toString(),
     t0: order.startTime,
     n: order.numOfParts,
     t: order.timeInterval,

--- a/libs/common-utils/src/fractionUtils.ts
+++ b/libs/common-utils/src/fractionUtils.ts
@@ -164,7 +164,9 @@ export class FractionUtils {
    *
    * @param amount
    */
-  static amountToAtLeastOneWei(amount: CurrencyAmount<Token>): CurrencyAmount<Token> {
-    return JSBI.EQ(amount.quotient, 0) ? CurrencyAmount.fromRawAmount(amount.currency, 1) : amount
+  static amountToAtLeastOneWei<T extends Currency>(amount: Nullish<CurrencyAmount<T>>): Nullish<CurrencyAmount<T>> {
+    if (!amount) return null
+
+    return amount.equalTo(0) ? CurrencyAmount.fromRawAmount(amount.currency, 1) : amount
   }
 }


### PR DESCRIPTION
# Summary

Fixes #4830

When price protection is 100% in TWAP we can't calculate the limit price (because we can't divide on zero).
To avoid crashing, we have to check buyAmount after slippage and if it equals zero, then don't calculate and display the limit price.

<img width="490" alt="image" src="https://github.com/user-attachments/assets/886f2a36-23d5-4500-9029-ec5f311a4404">


# To Test

See #4830
