### PR TITLE
fix(wallet): connect eagerly only once

### DIFF
--- a/libs/wallet/src/web3-react/Web3Provider/hooks/useEagerlyConnect.ts
+++ b/libs/wallet/src/web3-react/Web3Provider/hooks/useEagerlyConnect.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { getCurrentChainIdFromUrl, isInjectedWidget } from '@cowprotocol/common-utils'
 import { jotaiStore } from '@cowprotocol/core'
@@ -29,10 +29,14 @@ async function connect(connector: Connector) {
 
 export function useEagerlyConnect(selectedWallet: ConnectionType | undefined) {
   const [tryConnectEip6963Provider, setTryConnectEip6963Provider] = useState(false)
+  const eagerlyConnectInitRef = useRef(false)
   const selectedEip6963ProviderInfo = useSelectedEip6963ProviderInfo()
   const setEip6963Provider = useSetEip6963Provider()
 
   useEffect(() => {
+    // Initialize EagerlyConnect once
+    if (eagerlyConnectInitRef.current) return
+
     const isIframe = window.top !== window.self
 
     // autoConnect is set to true in the e2e tests
@@ -62,6 +66,8 @@ export function useEagerlyConnect(selectedWallet: ConnectionType | undefined) {
 
       connect(connection.connector)
     }
+
+    eagerlyConnectInitRef.current = true
     // The dependency list is empty so this is only run once on mount
   }, [selectedWallet])
 


### PR DESCRIPTION
# Summary

Fixes #4753

`useEagerlyConnect()` hook is supposed to be called only once on app start.
But, due to `selectedWallet` dependency it is called again after disconnect+connect.
To prevent this I added a boolean reference.

# To Test

See #4753
