### PR TITLE
fix(libs): fix import error on multiple libs

### DIFF
--- a/libs/events/package.json
+++ b/libs/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/events",
-  "version": "1.4.0",
+  "version": "1.4.1-RC.0",
   "type": "commonjs",
   "description": "CoW Swap events",
   "main": "index.js",
@@ -20,6 +20,6 @@
     "dex"
   ],
   "dependencies": {
-    "@cowprotocol/types": "^1.1.0"
+    "@cowprotocol/types": "^1.1.1-RC.0"
   }
 }

--- a/libs/events/package.json
+++ b/libs/events/package.json
@@ -19,5 +19,7 @@
     "cowswap",
     "dex"
   ],
-  "dependencies": {}
+  "dependencies": {
+    "@cowprotocol/types": "^1.1.0"
+  }
 }

--- a/libs/events/src/types/orders.ts
+++ b/libs/events/src/types/orders.ts
@@ -1,5 +1,5 @@
-import { SupportedChainId, EnrichedOrder, OrderKind } from '@cowprotocol/cow-sdk'
-import { TokenInfo, UiOrderType } from '@cowprotocol/types'
+import type { EnrichedOrder, OrderKind, SupportedChainId } from '@cowprotocol/cow-sdk'
+import type { TokenInfo, UiOrderType } from '@cowprotocol/types'
 
 type BaseOrderPayload = {
   chainId: SupportedChainId

--- a/libs/events/vite.config.ts
+++ b/libs/events/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig(({ mode }) => {
       dts({
         entryRoot: 'src',
         tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
+        pathsToAliases: false,
       }),
       react(),
       viteTsConfigPaths({

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/types",
-  "version": "1.1.0",
+  "version": "1.1.1-RC.0",
   "type": "commonjs",
   "description": "CoW Swap events",
   "main": "index.js",

--- a/libs/types/src/hooks.ts
+++ b/libs/types/src/hooks.ts
@@ -1,8 +1,8 @@
 import { ReactNode } from 'react'
 
-import { latest } from '@cowprotocol/app-data'
-import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
+import type { latest } from '@cowprotocol/app-data'
+import type { SupportedChainId } from '@cowprotocol/cow-sdk'
+import type { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
 import { Command } from './common'
 

--- a/libs/types/vite.config.ts
+++ b/libs/types/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig(({ mode }) => {
       dts({
         entryRoot: 'src',
         tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
+        pathsToAliases: false,
       }),
       react(),
       viteTsConfigPaths({

--- a/libs/widget-lib/package.json
+++ b/libs/widget-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/widget-lib",
-  "version": "0.14.0",
+  "version": "0.14.1-RC.0",
   "type": "commonjs",
   "description": "CoW Swap Widget Library. Allows you to easily embed a CoW Swap widget on your website.",
   "main": "index.js",
@@ -21,6 +21,6 @@
     "widget-lib"
   ],
   "dependencies": {
-    "@cowprotocol/events": "^1.3.0"
+    "@cowprotocol/events": "^1.4.1-RC.0"
   }
 }

--- a/libs/widget-lib/vite.config.ts
+++ b/libs/widget-lib/vite.config.ts
@@ -32,8 +32,8 @@ export default defineConfig(({ command }) => {
       dts({
         entryRoot: 'src',
         tsconfigPath: joinPathFragments(__dirname, 'tsconfig.lib.json'),
+        pathsToAliases: false,
       }),
-
       viteTsConfigPaths({
         root: '../../../',
       }),

--- a/libs/widget-react/package.json
+++ b/libs/widget-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/widget-react",
-  "version": "0.10.1",
+  "version": "0.10.2-RC.0",
   "type": "commonjs",
   "description": "CoW Swap Widget Library. Allows you to easily embed a CoW Swap widget on your React application.",
   "main": "index.js",
@@ -22,6 +22,6 @@
     "react"
   ],
   "dependencies": {
-    "@cowprotocol/widget-lib": "^0.14.0"
+    "@cowprotocol/widget-lib": "^0.14.1-RC.0"
   }
 }

--- a/libs/widget-react/src/lib/CowSwapWidget.tsx
+++ b/libs/widget-react/src/lib/CowSwapWidget.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type { CowEventListeners } from '@cowprotocol/events'
-import { Command } from '@cowprotocol/types'
+import type { Command } from '@cowprotocol/types'
 import {
   CowSwapWidgetHandler,
   CowSwapWidgetParams,

--- a/libs/widget-react/vite.config.ts
+++ b/libs/widget-react/vite.config.ts
@@ -5,23 +5,6 @@ import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
 import viteTsConfigPaths from 'vite-tsconfig-paths'
 
-import { writeFileSync } from 'fs'
-import { join } from 'path'
-
-// Workaround to generate the declaration file for the bundle in a way that does not replace the import of the widget-lib with a local path
-// If you know a better way to do this, please let me know
-function generateBundleDeclarationFile(outDir: string) {
-  return {
-    name: 'generate-bundle-declaration-file',
-    writeBundle() {
-      const content = `export * from './lib/CowSwapWidget';\nexport * from '@cowprotocol/widget-lib';`
-      const outputPath = join(outDir, 'index.d.ts')
-      writeFileSync(outputPath, content)
-      console.log(`Generated declaration file at: ${outputPath}`)
-    },
-  }
-}
-
 export default defineConfig({
   cacheDir: '../../../node_modules/.vite/widget-react',
 
@@ -29,12 +12,12 @@ export default defineConfig({
     dts({
       entryRoot: 'src',
       tsconfigPath: joinPathFragments(__dirname, 'tsconfig.lib.json'),
+      pathsToAliases: false,
     }),
     react(),
     viteTsConfigPaths({
       root: '../../../',
     }),
-    generateBundleDeclarationFile('dist/libs/widget-react'),
   ],
 
   // Uncomment this if you are using workers.


### PR DESCRIPTION
# Summary

Fixes https://github.com/cowprotocol/cowswap/issues/4833

Short summary: this change, among other things, makes use of `https://www.npmjs.com/package/vite-plugin-dts` property `pathsToAliases` to disable the local path aliasing for given libs.
Before this change, the paths were converted to local path in the exported libs, resulting in errors when those were consumed.

Additionally, added missing dependencies to the individual lib package.json files and imported/exported types with the `type` keyword.

# To Test

1. Test the app and the widget
* Should work as before