### PR TITLE
fix: don't request network switching at page load

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
@@ -40,7 +40,7 @@ export function useSetupTradeState(): void {
   const urlChainId = tradeStateFromUrl?.chainId
   const prevTradeStateFromUrl = usePrevious(tradeStateFromUrl)
 
-  const currentChainId = !urlChainId ? prevProviderChainId || SupportedChainId.MAINNET : urlChainId
+  const currentChainId = !urlChainId ? prevProviderChainId || providerChainId || SupportedChainId.MAINNET : urlChainId
 
   const isAlternativeModalVisible = useIsAlternativeOrderModalVisible()
 


### PR DESCRIPTION
# Summary

Since the recent fix about widget flickering, `tradeStateFromUrl` became nullable (it is null at the very beginning).
Because of that, the value of `currentChainId` sets to `SupportedChainId.MAINNET` and it triggers network switching.

# To Test

1. Connect Metamask with Sepolia
2. Refresh page
3. AR: it requests network switching to Mainnet
4. ER: no network switching request
