### PR TITLE
fix(token-list): increase token symbol validation length

### DIFF
--- a/libs/tokens/src/utils/validateTokenList.ts
+++ b/libs/tokens/src/utils/validateTokenList.ts
@@ -8,7 +8,7 @@ const SYMBOL_AND_NAME_VALIDATION = [
     const: '',
   },
   {
-    pattern: '^[^\\n]+$',
+    pattern: '^[\\w\\d\\-\\+_\\.\\s]+$',
   },
 ]
 

--- a/libs/tokens/src/utils/validateTokenList.ts
+++ b/libs/tokens/src/utils/validateTokenList.ts
@@ -3,6 +3,37 @@ import type { TokenList } from '@uniswap/token-lists'
 
 import type { Ajv, ValidateFunction } from 'ajv'
 
+const SYMBOL_AND_NAME_VALIDATION = [
+  {
+    const: '',
+  },
+  {
+    pattern: '^[^\\n]+$',
+  },
+]
+
+const patchValidationSchema = (schema: any) => ({
+  ...schema,
+  definitions: {
+    ...schema.definitions,
+    TokenInfo: {
+      ...schema.definitions.TokenInfo,
+      properties: {
+        ...schema.definitions.TokenInfo.properties,
+        symbol: {
+          ...schema.definitions.TokenInfo.properties.symbol,
+          maxLength: 80,
+          anyOf: SYMBOL_AND_NAME_VALIDATION,
+        },
+        name: {
+          ...schema.definitions.TokenInfo.properties.name,
+          maxLength: 100,
+          anyOf: SYMBOL_AND_NAME_VALIDATION,
+        },
+      },
+    },
+  },
+})
 enum ValidationSchema {
   LIST = 'list',
   TOKENS = 'tokens',
@@ -11,15 +42,15 @@ enum ValidationSchema {
 const validator = new Promise<Ajv>((resolve) => {
   Promise.all([import('ajv'), import('@uniswap/token-lists/src/tokenlist.schema.json')]).then(([ajv, schema]) => {
     const validator = new ajv.default({ allErrors: true })
-      .addSchema(schema, ValidationSchema.LIST)
+      .addSchema(patchValidationSchema(schema), ValidationSchema.LIST)
       // Adds a meta scheme of Pick<TokenList, 'tokens'>
       .addSchema(
         {
-          ...schema,
+          ...patchValidationSchema(schema),
           $id: schema.$id + '#tokens',
           required: ['tokens'],
         },
-        ValidationSchema.TOKENS
+        ValidationSchema.TOKENS,
       )
     resolve(validator)
   })


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C05QVFJUX9R/p1726893122604539

We currently use [Uniswap token lists validation schema](https://github.com/Uniswap/token-lists/blob/main/src/tokenlist.schema.json) and it's strct enough.
In order to support new requirements I changed the validation schema:
 - TokenInfo.symbol max length not 80 and pattern is `^[\w\d\-\+_\.\s]+$`
 - TokenInfo.name max length not 100 and pattern is `^[\w\d\-\+_\.\s]+$`

# To Test

https://raw.githubusercontent.com/cowmarketing/cowidget-custom-token-lists/refs/heads/main/pendle_pt.json - should be added into CoW Swap with no valdiation errors
