### PR TITLE
fix(explorer): get token logo url from known token lists

### DIFF
--- a/apps/explorer/src/components/common/TokenDisplay/index.tsx
+++ b/apps/explorer/src/components/common/TokenDisplay/index.tsx
@@ -48,7 +48,7 @@ export function TokenDisplay(props: Readonly<Props>): React.ReactNode {
 
   return (
     <Wrapper>
-      <StyledImg address={imageAddress} />
+      <StyledImg address={imageAddress} network={network} />
       {isNativeToken(erc20.address) ? (
         // There's nowhere to link when it's a native token, so, only display the symbol
         <NativeWrapper>{erc20.symbol}</NativeWrapper>


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C04DV3TL1MH/p1727332936250749

The code which is responsible for token logos displaying is super legacy.
It mainly gets logos for Trust wallet repo.
But in Explorer we already have many token lists loaded (CoWSwap, Coingecko, etc.) and it's obvious we should rely on them first.

<img width="544" alt="image" src="https://github.com/user-attachments/assets/dfbf4d58-4b3e-4b85-bf2b-f16248ea3a44">

# To Test

1. Open http://localhost:4200/orders/0xfa41f84ccd12b6d0fddc52a82090554101502f4586e86ad4a4d3050f67e34c8a42d9e44eed903a0ee477c9c04d1d1730c5e8727266f4937f?tab=overview (with the corresponding domain of course)
- [ ] Osaka token logo should be displayed
- [ ] There are no excessive requests to token lists in network (comparing to prod version)