### PR TITLE
feat(hooks-store): update custom hook-dapps manifests periodically

### DIFF
--- a/apps/cowswap-frontend/src/modules/hooksStore/containers/HookDappContainer/index.tsx
+++ b/apps/cowswap-frontend/src/modules/hooksStore/containers/HookDappContainer/index.tsx
@@ -77,6 +77,7 @@ export function HookDappContainer({ dapp, isPreHook, onDismiss, hookToEdit }: Ho
     tradeNavigate,
     inputCurrencyId,
     outputCurrencyId,
+    isDarkMode,
   ])
 
   const dappProps = useMemo(() => ({ context, dapp, isPreHook }), [context, dapp, isPreHook])

--- a/apps/cowswap-frontend/src/modules/hooksStore/containers/HooksStoreWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/hooksStore/containers/HooksStoreWidget/index.tsx
@@ -10,6 +10,7 @@ import { useIsSellNative } from 'modules/trade'
 
 import { useSetRecipientOverride } from '../../hooks/useSetRecipientOverride'
 import { useSetupHooksStoreOrderParams } from '../../hooks/useSetupHooksStoreOrderParams'
+import { IframeDappsManifestUpdater } from '../../updaters/iframeDappsManifestUpdater'
 import { HookRegistryList } from '../HookRegistryList'
 import { PostHookButton } from '../PostHookButton'
 import { PreHookButton } from '../PreHookButton'
@@ -81,6 +82,7 @@ export function HooksStoreWidget() {
       <TradeWidgetWrapper visible$={!isHookSelectionOpen}>
         <SwapWidget topContent={TopContent} bottomContent={BottomContent} />
       </TradeWidgetWrapper>
+      <IframeDappsManifestUpdater />
       {isHookSelectionOpen && (
         <HookRegistryList onDismiss={onDismiss} hookToEdit={hookToEdit} isPreHook={selectedHookPosition === 'pre'} />
       )}

--- a/apps/cowswap-frontend/src/modules/hooksStore/hooks/useAddCustomHookDapp.ts
+++ b/apps/cowswap-frontend/src/modules/hooksStore/hooks/useAddCustomHookDapp.ts
@@ -1,11 +1,11 @@
 import { useSetAtom } from 'jotai'
 import { useCallback } from 'react'
 
-import { addCustomHookDappAtom } from '../state/customHookDappsAtom'
+import { upsertCustomHookDappAtom } from '../state/customHookDappsAtom'
 import { HookDappIframe } from '../types/hooks'
 
 export function useAddCustomHookDapp(isPreHook: boolean) {
-  const setState = useSetAtom(addCustomHookDappAtom)
+  const setState = useSetAtom(upsertCustomHookDappAtom)
 
   return useCallback(
     (dapp: HookDappIframe) => {

--- a/apps/cowswap-frontend/src/modules/hooksStore/pure/AddCustomHookForm/CustomDappLoader/index.tsx
+++ b/apps/cowswap-frontend/src/modules/hooksStore/pure/AddCustomHookForm/CustomDappLoader/index.tsx
@@ -6,12 +6,6 @@ import { useWalletInfo } from '@cowprotocol/wallet'
 import { HookDappIframe } from '../../../types/hooks'
 import { validateHookDappManifest } from '../../../validateHookDappManifest'
 
-type HookDappBaseInfo = Omit<HookDappBase, 'type' | 'conditions'>
-
-const MANDATORY_DAPP_FIELDS: (keyof HookDappBaseInfo)[] = ['id', 'name', 'image', 'version', 'website']
-
-const isHex = (val: string) => Boolean(val.match(/^[0-9a-f]+$/i))
-
 interface ExternalDappLoaderProps {
   input: string
   isPreHook: boolean

--- a/apps/cowswap-frontend/src/modules/hooksStore/state/customHookDappsAtom.ts
+++ b/apps/cowswap-frontend/src/modules/hooksStore/state/customHookDappsAtom.ts
@@ -39,7 +39,7 @@ export const customPostHookDappsAtom = atom((get) => {
   return Object.values(get(customHookDappsAtom).post) as HookDappIframe[]
 })
 
-export const addCustomHookDappAtom = atom(null, (get, set, isPreHook: boolean, dapp: HookDappIframe) => {
+export const upsertCustomHookDappAtom = atom(null, (get, set, isPreHook: boolean, dapp: HookDappIframe) => {
   const { chainId } = get(walletInfoAtom)
   const state = get(customHookDappsInner)
 

--- a/apps/cowswap-frontend/src/modules/hooksStore/updaters/iframeDappsManifestUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/hooksStore/updaters/iframeDappsManifestUpdater.tsx
@@ -1,0 +1,81 @@
+import { useSetAtom } from 'jotai'
+import { useAtomValue } from 'jotai/index'
+import { useCallback, useEffect, useMemo } from 'react'
+
+import { HookDappBase, HookDappType } from '@cowprotocol/hook-dapp-lib'
+import { useWalletInfo } from '@cowprotocol/wallet'
+
+import ms from 'ms.macro'
+
+import { customHookDappsAtom, upsertCustomHookDappAtom } from '../state/customHookDappsAtom'
+import { validateHookDappManifest } from '../validateHookDappManifest'
+
+const UPDATE_TIME_KEY = 'HOOK_DAPPS_UPDATE_TIME'
+const HOOK_DAPPS_UPDATE_INTERVAL = ms`6h`
+
+const getLastUpdateTimestamp = () => {
+  const lastUpdate = localStorage.getItem(UPDATE_TIME_KEY)
+  return lastUpdate ? +lastUpdate : null
+}
+
+export function IframeDappsManifestUpdater() {
+  const hooksState = useAtomValue(customHookDappsAtom)
+  const upsertCustomHookDapp = useSetAtom(upsertCustomHookDappAtom)
+  const { chainId } = useWalletInfo()
+
+  const [preHooks, postHooks] = useMemo(
+    () => [Object.values(hooksState.pre), Object.values(hooksState.post)],
+    [hooksState],
+  )
+
+  const fetchAndUpdateHookDapp = useCallback(
+    (url: string, isPreHook: boolean) => {
+      return fetch(`${url}/manifest.json`)
+        .then((res) => res.json())
+        .then((data) => {
+          const dapp = data.cow_hook_dapp as HookDappBase
+
+          // Don't pass parameters that are not needed for validation
+          // In order to skip validation of the already added hook-dapp
+          const validationError = validateHookDappManifest(
+            data.cow_hook_dapp as HookDappBase,
+            undefined,
+            undefined,
+            undefined,
+          )
+
+          if (validationError) {
+            console.error('Cannot update iframe hook dapp:', validationError)
+          } else {
+            upsertCustomHookDapp(isPreHook, {
+              ...dapp,
+              type: HookDappType.IFRAME,
+              url,
+            })
+          }
+        })
+    },
+    [chainId, upsertCustomHookDapp],
+  )
+
+  /**
+   * Update iframe hook dapps not more often than every 6 hours
+   */
+  useEffect(() => {
+    if (!preHooks.length && !postHooks.length) return
+
+    const lastUpdate = getLastUpdateTimestamp()
+    const shouldUpdate = !lastUpdate || lastUpdate + HOOK_DAPPS_UPDATE_INTERVAL < Date.now()
+
+    if (!shouldUpdate) return
+
+    console.debug('Updating iframe hook dapps...', { preHooks, postHooks })
+
+    localStorage.setItem(UPDATE_TIME_KEY, Date.now().toString())
+
+    preHooks.forEach((hook) => fetchAndUpdateHookDapp(hook.url, true))
+    postHooks.forEach((hook) => fetchAndUpdateHookDapp(hook.url, false))
+  }, [preHooks, postHooks, fetchAndUpdateHookDapp])
+
+  return null
+}

--- a/apps/cowswap-frontend/src/modules/hooksStore/validateHookDappManifest.tsx
+++ b/apps/cowswap-frontend/src/modules/hooksStore/validateHookDappManifest.tsx
@@ -1,0 +1,55 @@
+import { ReactElement } from 'react'
+
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { HOOK_DAPP_ID_LENGTH, HookDappBase, HookDappWalletCompatibility } from '@cowprotocol/hook-dapp-lib'
+
+type HookDappBaseInfo = Omit<HookDappBase, 'type' | 'conditions'>
+
+const MANDATORY_DAPP_FIELDS: (keyof HookDappBaseInfo)[] = ['id', 'name', 'image', 'version', 'website']
+
+const isHex = (val: string) => Boolean(val.match(/^[0-9a-f]+$/i))
+
+export function validateHookDappManifest(
+  data: HookDappBase,
+  chainId: SupportedChainId | undefined,
+  isPreHook: boolean | undefined,
+  isSmartContractWallet: boolean | undefined,
+): ReactElement | string | null {
+  const { conditions = {}, ...dapp } = data
+
+  if (dapp) {
+    const emptyFields = MANDATORY_DAPP_FIELDS.filter((field) => typeof dapp[field] === 'undefined')
+
+    if (emptyFields.length > 0) {
+      return `${emptyFields.join(',')} fields are no set.`
+    } else {
+      if (
+        isSmartContractWallet === true &&
+        conditions.walletCompatibility &&
+        !conditions.walletCompatibility.includes(HookDappWalletCompatibility.SMART_CONTRACT)
+      ) {
+        return 'The app does not support smart-contract wallets.'
+      } else if (!isHex(dapp.id) || dapp.id.length !== HOOK_DAPP_ID_LENGTH) {
+        return <p>Hook dapp id must be a hex with length 64.</p>
+      } else if (chainId && conditions.supportedNetworks && !conditions.supportedNetworks.includes(chainId)) {
+        return <p>This app/hook doesn't support current network (chainId={chainId}).</p>
+      } else if (conditions.position === 'post' && isPreHook === true) {
+        return (
+          <p>
+            This app/hook can only be used as a <strong>post-hook</strong> and cannot be added as a pre-hook.
+          </p>
+        )
+      } else if (conditions.position === 'pre' && isPreHook === false) {
+        return (
+          <p>
+            This app/hook can only be used as a <strong>pre-hook</strong> and cannot be added as a post-hook.
+          </p>
+        )
+      }
+    }
+  } else {
+    return 'Manifest does not contain "cow_hook_dapp" property.'
+  }
+
+  return null
+}


### PR DESCRIPTION
# Summary

In [this PR](https://github.com/cowprotocol/cowswap/pull/4910), I added a functionality to import custom hook-dapps using iframes.
This mechanism fetches manifest.json and save it content into localStorage.
As @yvesfracari noticed, the saved info never gets updated.
To fix that I added `IframeDappsManifestUpdater` which tries to update all custom hook-dapps, but not often than 6 hours.

# To Test

1. Add a custom hook-dapp (see the mentioned PR above)
2. Change something in its manifest (for example image)
3. Remove `HOOK_DAPPS_UPDATE_TIME` from localStorage
4. Update the page
- [ ] the image of the hook-dapp should be updated in CoW Swap
