### PR TITLE
feat(token-lists): add balancer token list to arb1

### DIFF
--- a/libs/tokens/src/const/tokensList.json
+++ b/libs/tokens/src/const/tokensList.json
@@ -100,6 +100,10 @@
     {
       "priority": 4,
       "source": "https://curvefi.github.io/curve-assets/arbitrum.json"
+    },
+    {
+      "priority": 5,
+      "source": "https://raw.githubusercontent.com/balancer/tokenlists/refs/heads/main/generated/balancer.tokenlist.json"
     }
   ],
   "11155111": [


### PR DESCRIPTION
# Summary

To have more tokens available on arb1, this change adds Balancer token list.
It's disabled by default to reduce performance impact.

# To Test

1. Connect to arb1
2. Check the loaded token lists
* It should have balancer
![image](https://github.com/user-attachments/assets/2ba2f9af-9960-4e6d-b710-0732ef623cbf)

3. Check other chains
* It should not have balancer