### PR TITLE
fix(explorer): do not crash when appData is not parsed

### DIFF
--- a/apps/explorer/src/components/orders/OrderHooksDetails/index.tsx
+++ b/apps/explorer/src/components/orders/OrderHooksDetails/index.tsx
@@ -17,7 +17,7 @@ interface OrderHooksDetailsProps {
 export function OrderHooksDetails({ appData, fullAppData, children }: OrderHooksDetailsProps) {
   const { appDataDoc } = useAppData(appData, fullAppData)
 
-  if (!appDataDoc) return null
+  if (!appDataDoc?.metadata) return null
 
   const metadata = appDataDoc.metadata as latest.Metadata
 


### PR DESCRIPTION
# Summary

Order example: https://explorer.cow.fi/orders/0x1fc821545e8df229e80418060afbe15d01d1ab1c5dc2b7337c3016a6869aaf31aad621bfbb284bb82c47d77429585baf986e98bb670d2593?tab=overview

![image](https://github.com/user-attachments/assets/03167a19-62ed-4b63-958a-d987de554ff4)
