### PR TITLE
feat(hooks-store): add sell/buy amounts to hook-dapp context

### DIFF
--- a/apps/cowswap-frontend/src/modules/hooksStore/hooks/useSetupHooksStoreOrderParams.ts
+++ b/apps/cowswap-frontend/src/modules/hooksStore/hooks/useSetupHooksStoreOrderParams.ts
@@ -16,6 +16,8 @@ export function useSetupHooksStoreOrderParams() {
 
     setOrderParams({
       validTo: orderParams.validTo,
+      sellAmount: orderParams.inputAmount.quotient.toString(),
+      buyAmount: orderParams.outputAmount.quotient.toString(),
       sellTokenAddress: getCurrencyAddress(orderParams.inputAmount.currency),
       buyTokenAddress: getCurrencyAddress(orderParams.outputAmount.currency),
     })

--- a/libs/hook-dapp-lib/src/types.ts
+++ b/libs/hook-dapp-lib/src/types.ts
@@ -44,6 +44,8 @@ export interface HookDappOrderParams {
   validTo: number
   sellTokenAddress: string
   buyTokenAddress: string
+  sellAmount: string
+  buyAmount: string
 }
 
 export interface HookDappContext {


### PR DESCRIPTION
# Summary

Just extended the hook-dapp context with order sell/buy amounts

# Test

No need to test