### PR TITLE
fix(explorer): display hook details of unknown hook-dapp

### DIFF
--- a/apps/explorer/src/components/orders/OrderHooksDetails/HookItem/index.tsx
+++ b/apps/explorer/src/components/orders/OrderHooksDetails/HookItem/index.tsx
@@ -11,42 +11,49 @@ export function HookItem({ item, number }: { item: HookToDappMatch; number: numb
 
   return (
     <Item>
-      {item.dapp ? (
-        <Wrapper>
-          <p>
-            #{number} - <img src={item.dapp.image} alt={item.dapp.name} /> <strong>{item.dapp.name}</strong>{' '}
-            <ToggleButton onClick={toggleDetails}>{showDetails ? '[-] Show less' : '[+] Show more'}</ToggleButton>
-          </p>
-
-          {showDetails && (
-            <Details>
-              <p>
-                <i>Version:</i> {item.dapp.version}
-              </p>
-              <p>
-                <i>Description:</i> {item.dapp.descriptionShort}
-              </p>
-              <p>
-                <i>Website: </i>
-                <a href={item.dapp.website} target="_blank" rel="noopener noreferrer">
-                  {item.dapp.website}
-                </a>
-              </p>
-              <p>
-                <i>Call Data:</i> {item.hook.callData}
-              </p>
-              <p>
-                <i>Gas Limit:</i> {item.hook.gasLimit}
-              </p>
-              <p>
-                <i>Target:</i> {item.hook.target}
-              </p>
-            </Details>
+      <Wrapper>
+        <p>
+          #{number} -{' '}
+          {item.dapp ? (
+            <>
+              <img src={item.dapp.image} alt={item.dapp.name} /> <strong>{item.dapp.name}</strong>{' '}
+            </>
+          ) : (
+            'Unknown hook dapp'
           )}
-        </Wrapper>
-      ) : (
-        <div>Unknown hook dapp</div>
-      )}
+          <ToggleButton onClick={toggleDetails}>{showDetails ? '[-] Show less' : '[+] Show more'}</ToggleButton>
+        </p>
+
+        {showDetails && (
+          <Details>
+            {item.dapp && (
+              <>
+                <p>
+                  <i>Version:</i> {item.dapp.version}
+                </p>
+                <p>
+                  <i>Description:</i> {item.dapp.descriptionShort}
+                </p>
+                <p>
+                  <i>Website: </i>
+                  <a href={item.dapp.website} target="_blank" rel="noopener noreferrer">
+                    {item.dapp.website}
+                  </a>
+                </p>
+              </>
+            )}
+            <p>
+              <i>Call Data:</i> {item.hook.callData}
+            </p>
+            <p>
+              <i>Gas Limit:</i> {item.hook.gasLimit}
+            </p>
+            <p>
+              <i>Target:</i> {item.hook.target}
+            </p>
+          </Details>
+        )}
+      </Wrapper>
     </Item>
   )
 }


### PR DESCRIPTION
# Summary

Fixes #4979

Example: http://localhost:4200/gc/orders/0x1a8188e91fc0c2a6b27e8e124b140303b9c106e97fab262a0b26732b6cde921bfb3c7eb936caa12b5a884d612393969a557d430767069044?tab=overview

<img width="1435" alt="image" src="https://github.com/user-attachments/assets/813c7ad9-fcaf-445c-9303-0184311c01e6">

