### PR TITLE
feat: remove cowamm banner loading and add menu item Tag

### DIFF
--- a/apps/cowswap-frontend/src/modules/application/containers/App/index.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/App/index.tsx
@@ -24,7 +24,6 @@ import { useInitializeUtm } from 'modules/utm'
 import { InvalidLocalTimeWarning } from 'common/containers/InvalidLocalTimeWarning'
 import { useCategorizeRecentActivity } from 'common/hooks/useCategorizeRecentActivity'
 import { useMenuItems } from 'common/hooks/useMenuItems'
-import { CoWAmmBanner } from 'common/pure/CoWAMMBanner'
 import { LoadingApp } from 'common/pure/LoadingApp'
 import { CoWDAOFonts } from 'common/styles/CoWDAOFonts'
 import RedirectAnySwapAffectedUsers from 'pages/error/AnySwapAffectedUsers/RedirectAnySwapAffectedUsers'
@@ -62,7 +61,7 @@ export function App() {
         onClick: toggleDarkMode,
       },
     ],
-    [darkMode, toggleDarkMode]
+    [darkMode, toggleDarkMode],
   )
 
   const tradeContext = useTradeRouteContext()
@@ -127,9 +126,6 @@ export function App() {
               additionalContent={null} // On desktop renders inside the menu bar, on mobile renders inside the mobile menu
             />
           )}
-
-          {/* CoW AMM banner */}
-          {!isInjectedWidgetMode && <CoWAmmBanner />}
 
           <styledEl.BodyWrapper>
             <TopLevelModals />

--- a/apps/cowswap-frontend/src/modules/application/containers/App/menuConsts.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/App/menuConsts.tsx
@@ -41,6 +41,7 @@ export const NAV_ITEMS: MenuItem[] = [
   },
   {
     label: 'More',
+    tag: 'New',
     children: [
       {
         href: 'https://cow.fi/cow-protocol',
@@ -51,6 +52,7 @@ export const NAV_ITEMS: MenuItem[] = [
         href: 'https://cow.fi/cow-amm',
         label: 'CoW AMM',
         external: true,
+        tag: 'New',
       },
       {
         href: Routes.PLAY_COWRUNNER,

--- a/libs/ui/src/pure/MenuBar/index.tsx
+++ b/libs/ui/src/pure/MenuBar/index.tsx
@@ -30,6 +30,7 @@ import {
   RightAligned,
   RootNavItem,
   StyledDropdownContentItem,
+  TagLabel,
 } from './styled'
 
 import { Color } from '../../consts'
@@ -98,6 +99,7 @@ export interface MenuItem {
   hasDivider?: boolean
   utmContent?: string
   utmSource?: string
+  tag?: string
 }
 
 interface DropdownMenuItem {
@@ -118,10 +120,12 @@ interface DropdownMenuItem {
   hasDivider?: boolean
   utmContent?: string
   utmSource?: string
+  tag?: string
 }
 
 interface DropdownMenuContent {
   title: string | undefined
+  tag?: string
   items?: DropdownMenuItem[]
 }
 
@@ -169,7 +173,7 @@ const NavItem = ({
   return item.children ? (
     <GenericDropdown
       isOpen={openDropdown === item.label}
-      content={{ title: item.label, items: item.children }}
+      content={{ title: item.label, tag: item.tag, items: item.children }} // Pass tag here
       onTrigger={handleToggle}
       interaction="click" // Ensure it's 'click' for both mobile and desktop
       mobileMode={mobileMode}
@@ -409,6 +413,7 @@ const GenericDropdown: React.FC<DropdownProps> = ({
     <DropdownMenu {...interactionProps} mobileMode={mobileMode}>
       <RootNavItem as="button" aria-haspopup="true" aria-expanded={isOpen} isOpen={isOpen} mobileMode={mobileMode}>
         <span>{content.title}</span>
+        {content.tag && <TagLabel>{content.tag}</TagLabel>}
         {content.items && <SVG src={IMG_ICON_CARRET_DOWN} />}
       </RootNavItem>
       {isOpen && (
@@ -477,7 +482,10 @@ const DropdownContentWrapper: React.FC<DropdownContentWrapperProps> = ({
           <>
             {item.icon && <DropdownContentItemIcon src={item.icon} alt="" />}
             <DropdownContentItemText>
-              <DropdownContentItemTitle>{item.label}</DropdownContentItemTitle>
+              <DropdownContentItemTitle>
+                {item.label}
+                {item.tag && <TagLabel>{item.tag}</TagLabel>}
+              </DropdownContentItemTitle>
               {item.description && <DropdownContentItemDescription>{item.description}</DropdownContentItemDescription>}
             </DropdownContentItemText>
             {item.children && <SVG src={IMG_ICON_CARRET_DOWN} />}

--- a/libs/ui/src/pure/MenuBar/styled.ts
+++ b/libs/ui/src/pure/MenuBar/styled.ts
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components/macro'
 
 import { Color, Font } from '../../consts'
+import { UI } from '../../enum'
 import { CowSwapTheme } from '../../types'
 import { ProductLogoWrapper } from '../ProductLogo'
 
@@ -488,6 +489,8 @@ export const DropdownContentItemText = styled.div`
 `
 
 export const DropdownContentItemTitle = styled.span`
+  display: flex;
+  gap: 5px;
   font-weight: bold;
   font-size: 18px;
   line-height: 1.2;
@@ -693,4 +696,18 @@ export const GlobalSettingsButton = styled.button<{ mobileMode?: boolean }>`
       color: var(--activeFill);
     }
   }
+`
+
+export const TagLabel = styled.span`
+  display: inline-block;
+  padding: 4px 8px;
+  background: var(${UI.COLOR_ALERT_BG});
+  color: var(${UI.COLOR_ALERT_TEXT});
+  font-size: 10px;
+  letter-spacing: 0.2px;
+  text-transform: uppercase;
+  font-weight: bold;
+  border-radius: 9px;
+  margin: auto 0;
+  position: relative;
 `


### PR DESCRIPTION
# Summary

- Removes loading of the existing CoW AMM banner
- Adds support for tags in the root/dropdown menu items
- Adds 'New' tag for 'More' and 'CoW AMM' items

<img width="335" alt="Screenshot 2024-10-16 at 15 25 11" src="https://github.com/user-attachments/assets/d2d1dae0-7c4c-4f6c-b037-ac21d77ba373">
<img width="360" alt="Screenshot 2024-10-16 at 15 25 03" src="https://github.com/user-attachments/assets/b0c4b7bf-4466-4437-8752-92f14bfc1205">
