### PR TITLE
fix(smart-slippage): fix smart slip tooltip and feature flag

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/TransactionSettings/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/TransactionSettings/index.tsx
@@ -335,7 +335,7 @@ export function TransactionSettings() {
                 // <Trans>Your transaction will revert if the price changes unfavorably by more than this percentage.</Trans>
                 isEoaEthFlow
                   ? getNativeSlippageTooltip(chainId, [nativeCurrency.symbol, getWrappedToken(nativeCurrency).symbol])
-                  : getNonNativeSlippageTooltip(true)
+                  : getNonNativeSlippageTooltip({ isDynamic: !!smartSlippage, isSettingsModal: true })
               }
             />
           </RowFixed>

--- a/apps/cowswap-frontend/src/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
@@ -39,6 +39,7 @@ import { useSwapState } from '../../hooks/useSwapState'
 import { NetworkCostsTooltipSuffix } from '../../pure/NetworkCostsTooltipSuffix'
 import { getNativeSlippageTooltip, getNonNativeSlippageTooltip } from '../../pure/Row/RowSlippageContent'
 import { RowDeadline } from '../Row/RowDeadline'
+import { useSmartSwapSlippage } from '../../hooks/useSwapSlippage'
 
 const CONFIRM_TITLE = 'Swap'
 
@@ -87,6 +88,7 @@ export function ConfirmSwapModalSetup(props: ConfirmSwapModalSetupProps) {
   const buttonText = useSwapConfirmButtonText(slippageAdjustedSellAmount)
 
   const isSmartSlippageApplied = useIsSmartSlippageApplied()
+  const smartSlippage = useSmartSwapSlippage()
 
   const labelsAndTooltips = useMemo(
     () => ({
@@ -96,7 +98,7 @@ export function ConfirmSwapModalSetup(props: ConfirmSwapModalSetupProps) {
           : undefined,
       slippageTooltip: isEoaEthFlow
         ? getNativeSlippageTooltip(chainId, [nativeCurrency.symbol])
-        : getNonNativeSlippageTooltip(),
+        : getNonNativeSlippageTooltip({ isDynamic: !!smartSlippage }),
       expectReceiveLabel: isExactIn ? 'Expected to receive' : 'Expected to sell',
       minReceivedLabel: isExactIn ? 'Minimum receive' : 'Maximum sent',
       minReceivedTooltip: getMinimumReceivedTooltip(allowedSlippage, isExactIn),

--- a/apps/cowswap-frontend/src/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/ConfirmSwapModalSetup/index.tsx
@@ -35,11 +35,11 @@ import { useIsEoaEthFlow } from '../../hooks/useIsEoaEthFlow'
 import { useNavigateToNewOrderCallback } from '../../hooks/useNavigateToNewOrderCallback'
 import { useShouldPayGas } from '../../hooks/useShouldPayGas'
 import { useSwapConfirmButtonText } from '../../hooks/useSwapConfirmButtonText'
+import { useSmartSwapSlippage } from '../../hooks/useSwapSlippage'
 import { useSwapState } from '../../hooks/useSwapState'
 import { NetworkCostsTooltipSuffix } from '../../pure/NetworkCostsTooltipSuffix'
 import { getNativeSlippageTooltip, getNonNativeSlippageTooltip } from '../../pure/Row/RowSlippageContent'
 import { RowDeadline } from '../Row/RowDeadline'
-import { useSmartSwapSlippage } from '../../hooks/useSwapSlippage'
 
 const CONFIRM_TITLE = 'Swap'
 

--- a/apps/cowswap-frontend/src/modules/swap/pure/Row/RowSlippageContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/Row/RowSlippageContent/index.tsx
@@ -53,19 +53,30 @@ export const getNativeSlippageTooltip = (chainId: SupportedChainId, symbols: (st
     robust MEV protection, consider wrapping your {symbols?.[0] || 'native currency'} before trading.
   </Trans>
 )
-export const getNonNativeSlippageTooltip = (isSettingsModal?: boolean) => (
+
+export const getNonNativeSlippageTooltip = (params?: { isDynamic?: boolean; isSettingsModal?: boolean }) => (
   <Trans>
-    CoW Swap dynamically adjusts your slippage tolerance to ensure your trade executes quickly while still getting the
-    best price.{' '}
-    {isSettingsModal ? (
+    {params?.isDynamic ? (
       <>
-        To override this, enter your desired slippage amount.
-        <br />
-        <br />
-        Either way, your slippage is protected from MEV!
+        CoW Swap dynamically adjusts your slippage tolerance to ensure your trade executes quickly while still getting
+        the best price.{' '}
+        {params?.isSettingsModal ? (
+          <>
+            To override this, enter your desired slippage amount.
+            <br />
+            <br />
+            Either way, your slippage is protected from MEV!
+          </>
+        ) : (
+          <>
+            <br />
+            <br />
+            Trades are protected from MEV, so your slippage can't be exploited!
+          </>
+        )}
       </>
     ) : (
-      "Trades are protected from MEV, so your slippage can't be exploited!"
+      <>CoW Swap trades are protected from MEV, so your slippage can't be exploited!</>
     )}
   </Trans>
 )

--- a/apps/cowswap-frontend/src/modules/swap/pure/Row/RowSlippageContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/Row/RowSlippageContent/index.tsx
@@ -124,7 +124,10 @@ export function RowSlippageContent(props: RowSlippageContentProps) {
   } = props
 
   const tooltipContent =
-    slippageTooltip || (isEoaEthFlow ? getNativeSlippageTooltip(chainId, symbols) : getNonNativeSlippageTooltip())
+    slippageTooltip ||
+    (isEoaEthFlow
+      ? getNativeSlippageTooltip(chainId, symbols)
+      : getNonNativeSlippageTooltip({ isDynamic: !!smartSlippage }))
 
   // In case the user happened to set the same slippage as the suggestion, do not show the suggestion
   const suggestedEqualToUserSlippage = smartSlippage && smartSlippage === displaySlippage

--- a/apps/cowswap-frontend/src/modules/swap/updaters/SmartSlippageUpdater/calculateBpsFromFeeMultiplier.ts
+++ b/apps/cowswap-frontend/src/modules/swap/updaters/SmartSlippageUpdater/calculateBpsFromFeeMultiplier.ts
@@ -8,7 +8,7 @@ export function calculateBpsFromFeeMultiplier(
   isSell: boolean | undefined,
   multiplierPercentage: number,
 ): number | undefined {
-  if (!sellAmount || !feeAmount || isSell === undefined || multiplierPercentage <= 0) {
+  if (!sellAmount || !feeAmount || isSell === undefined || !multiplierPercentage || multiplierPercentage <= 0) {
     return undefined
   }
 

--- a/apps/cowswap-frontend/src/modules/swap/updaters/SmartSlippageUpdater/useSmartSlippageFromFeeMultiplier.ts
+++ b/apps/cowswap-frontend/src/modules/swap/updaters/SmartSlippageUpdater/useSmartSlippageFromFeeMultiplier.ts
@@ -6,7 +6,6 @@ import { useReceiveAmountInfo } from 'modules/trade'
 
 import { calculateBpsFromFeeMultiplier } from './calculateBpsFromFeeMultiplier'
 
-
 /**
  * Calculates smart slippage in bps, based on quoted fee
  *
@@ -19,7 +18,7 @@ export function useSmartSlippageFromFeeMultiplier(): number | undefined {
   const sellAmount = isSell ? afterNetworkCosts?.sellAmount : beforeNetworkCosts?.sellAmount
   const feeAmount = costs?.networkFee?.amountInSellCurrency
 
-  const { smartSlippageFeeMultiplierPercentage = 50 } = useFeatureFlags()
+  const { smartSlippageFeeMultiplierPercentage } = useFeatureFlags()
 
   return useMemo(
     () => calculateBpsFromFeeMultiplier(sellAmount, feeAmount, isSell, smartSlippageFeeMultiplierPercentage),


### PR DESCRIPTION
# Summary

Fixes #5001

Show non-dynamic slippage tooltips when feature flag is off.
This also helped me identify an issue with the feature flag that was essentially never turning off.

# To Test

1. With the flag on, check the tooltips
* Should be the dynamic version
2. With the flag off (set to 0 OR having lauchdarkly requests blocked), check the tooltips
* Should be the non-dynamic version
* There should be no suggested slippage