### PR TITLE
fix(widget): ignore selected eip6963 provider when in widget

### DIFF
--- a/apps/cowswap-frontend/src/cow-react/index.tsx
+++ b/apps/cowswap-frontend/src/cow-react/index.tsx
@@ -70,8 +70,13 @@ function Main() {
 
 function Web3ProviderInstance({ children }: { children: ReactNode }) {
   const selectedWallet = useAppSelector((state) => state.user.selectedWallet)
+  const { standaloneMode } = useInjectedWidgetParams()
 
-  return <Web3Provider selectedWallet={selectedWallet}>{children}</Web3Provider>
+  return (
+    <Web3Provider standaloneMode={standaloneMode} selectedWallet={selectedWallet}>
+      {children}
+    </Web3Provider>
+  )
 }
 
 function Toasts() {

--- a/libs/wallet/src/web3-react/Web3Provider/hooks/useEagerlyConnect.ts
+++ b/libs/wallet/src/web3-react/Web3Provider/hooks/useEagerlyConnect.ts
@@ -27,7 +27,7 @@ async function connect(connector: Connector) {
   }
 }
 
-export function useEagerlyConnect(selectedWallet: ConnectionType | undefined) {
+export function useEagerlyConnect(selectedWallet: ConnectionType | undefined, standaloneMode?: boolean) {
   const [tryConnectEip6963Provider, setTryConnectEip6963Provider] = useState(false)
   const eagerlyConnectInitRef = useRef(false)
   const selectedEip6963ProviderInfo = useSelectedEip6963ProviderInfo()
@@ -75,6 +75,8 @@ export function useEagerlyConnect(selectedWallet: ConnectionType | undefined) {
    * Activate the selected eip6963 provider
    */
   useEffect(() => {
+    // Ignore remembered eip6963 provider if the app is in widget dapp mode
+    if (isInjectedWidget() && !standaloneMode) return
     if (!selectedWallet || !tryConnectEip6963Provider) return
 
     const connection = getWeb3ReactConnection(selectedWallet)
@@ -90,5 +92,5 @@ export function useEagerlyConnect(selectedWallet: ConnectionType | undefined) {
       setTryConnectEip6963Provider(false)
       connect(connector)
     }
-  }, [selectedEip6963ProviderInfo, selectedWallet, setEip6963Provider, tryConnectEip6963Provider])
+  }, [standaloneMode, selectedEip6963ProviderInfo, selectedWallet, setEip6963Provider, tryConnectEip6963Provider])
 }

--- a/libs/wallet/src/web3-react/Web3Provider/index.tsx
+++ b/libs/wallet/src/web3-react/Web3Provider/index.tsx
@@ -13,10 +13,11 @@ import { Web3ReactConnection } from '../types'
 interface Web3ProviderProps {
   children: ReactNode
   selectedWallet: ConnectionType | undefined
+  standaloneMode?: boolean
 }
 
-export function Web3Provider({ children, selectedWallet }: Web3ProviderProps) {
-  useEagerlyConnect(selectedWallet)
+export function Web3Provider({ children, selectedWallet, standaloneMode }: Web3ProviderProps) {
+  useEagerlyConnect(selectedWallet, standaloneMode)
 
   const connections = useOrderedConnections(selectedWallet)
   const connectors: [Connector, Web3ReactHooks][] = connections
@@ -25,7 +26,7 @@ export function Web3Provider({ children, selectedWallet }: Web3ProviderProps) {
 
   const key = useMemo(
     () => connections.map(({ type }: Web3ReactConnection) => getConnectionName(type)).join('-'),
-    [connections]
+    [connections],
   )
 
   return (


### PR DESCRIPTION
# Summary

Fixes #5006

THe problem in the fact that we remember eip6963 provider in CoW Swap and give it more prio than widget provider.
For dapp mode in widget we should always use widget provider.

# To Test

1. Open CoW Swap, connect to some eip6963 wallet
2. Open widget-configurator, use dapp mode and connect to a wallet
3. Change network in the wallet that was connected to widget-configurator

- [ ] AR: widget content didn't update network
- [ ] ER: widget content updated network corresponding to the widget-configurator

If you instead of the 1st step disconnect a wallet in CoW Swap, then everything should work well
