### PR TITLE
fix(smart-slippage): replace volatity with trade size on tooltips

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeSlippage/containers/HighSuggestedSlippageWarning/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeSlippage/containers/HighSuggestedSlippageWarning/index.tsx
@@ -32,7 +32,7 @@ export function HighSuggestedSlippageWarning(props: HighSuggestedSlippageWarning
       Slippage adjusted to {`${slippageBps / 100}`}% to ensure quick execution
       <InfoTooltip
         size={24}
-        content="CoW Swap dynamically adjusts your slippage tolerance based on current volatility. You can set a custom slippage using the settings icon above."
+        content="CoW Swap dynamically adjusts your slippage tolerance based on current gas prices and trade size. You can set a custom slippage using the settings icon above."
       />
     </StyledInlineBanner>
   )

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/TransactionSettings/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/TransactionSettings/index.tsx
@@ -279,8 +279,8 @@ export function TransactionSettings({ deadlineState }: TransactionSettingsProps)
                 <HelpTooltip
                   text={
                     <Trans>
-                      CoW Swap has dynamically selected this slippage amount to account for current gas prices and
-                      volatility. Changes may result in slower execution.
+                      CoW Swap has dynamically selected this slippage amount to account for current gas prices and trade
+                      size. Changes may result in slower execution.
                     </Trans>
                   }
                 />

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/pure/Row/RowSlippageContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/pure/Row/RowSlippageContent/index.tsx
@@ -11,7 +11,7 @@ import styled from 'styled-components/macro'
 import { getNativeSlippageTooltip, getNonNativeSlippageTooltip } from 'common/utils/tradeSettingsTooltips'
 
 import { settingsTabStateAtom } from '../../../state/settingsTabState'
-import { StyledRowBetween, TextWrapper, StyledInfoIcon, TransactionText, RowStyleProps } from '../styled'
+import { RowStyleProps, StyledInfoIcon, StyledRowBetween, TextWrapper, TransactionText } from '../styled'
 
 const DefaultSlippage = styled.span`
   display: inline-flex;
@@ -30,7 +30,7 @@ const DefaultSlippage = styled.span`
 `
 
 const SUGGESTED_SLIPPAGE_TOOLTIP =
-  'This is the recommended slippage tolerance based on current gas prices & volatility. A lower amount may result in slower execution.'
+  'This is the recommended slippage tolerance based on current gas prices & trade size. A lower amount may result in slower execution.'
 
 export interface RowSlippageContentProps {
   chainId: SupportedChainId


### PR DESCRIPTION
# Summary

Based on suggestions from the test session, this change replaces `volatility` with `[gas prices and] trade size`.

# To Test

1. With the smart slippage feature flag on, check the tooltips