### PR TITLE
fix(swap): disable partial fills

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/const/common.ts
+++ b/apps/cowswap-frontend/src/modules/trade/const/common.ts
@@ -1,0 +1,10 @@
+import { UiOrderType } from '@cowprotocol/types'
+
+import { TradeType } from '../types'
+
+export const TradeTypeToUiOrderType: Record<TradeType, UiOrderType> = {
+  [TradeType.SWAP]: UiOrderType.SWAP,
+  [TradeType.LIMIT_ORDER]: UiOrderType.LIMIT,
+  [TradeType.ADVANCED_ORDERS]: UiOrderType.TWAP,
+  [TradeType.YIELD]: UiOrderType.YIELD,
+}

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useNotifyWidgetTrade.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useNotifyWidgetTrade.ts
@@ -2,13 +2,14 @@ import { useEffect, useRef } from 'react'
 
 import { getCurrencyAddress } from '@cowprotocol/common-utils'
 import { AtomsAndUnits, CowWidgetEvents, OnTradeParamsPayload } from '@cowprotocol/events'
-import { TokenInfo, UiOrderType } from '@cowprotocol/types'
+import { TokenInfo } from '@cowprotocol/types'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
 import { WIDGET_EVENT_EMITTER } from 'widgetEventEmitter'
 
 import { useDerivedTradeState } from './useDerivedTradeState'
 
+import { TradeTypeToUiOrderType } from '../const/common'
 import { TradeType } from '../types'
 import { TradeDerivedState } from '../types/TradeDerivedState'
 
@@ -30,13 +31,6 @@ export function useNotifyWidgetTrade() {
       getTradeParamsEventPayload(state.tradeType, state),
     )
   }, [state])
-}
-
-const TradeTypeToUiOrderType: Record<TradeType, UiOrderType> = {
-  [TradeType.SWAP]: UiOrderType.SWAP,
-  [TradeType.LIMIT_ORDER]: UiOrderType.LIMIT,
-  [TradeType.ADVANCED_ORDERS]: UiOrderType.TWAP,
-  [TradeType.YIELD]: UiOrderType.YIELD,
 }
 
 function getTradeParamsEventPayload(tradeType: TradeType, state: TradeDerivedState): OnTradeParamsPayload {

--- a/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowContext.ts
@@ -1,5 +1,5 @@
 import { TokenWithLogo } from '@cowprotocol/common-const'
-import { COW_PROTOCOL_VAULT_RELAYER_ADDRESS, OrderClass, OrderKind, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { COW_PROTOCOL_VAULT_RELAYER_ADDRESS, OrderClass, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { UiOrderType } from '@cowprotocol/types'
 import { useIsSafeWallet, useWalletDetails, useWalletInfo } from '@cowprotocol/wallet'
 import { useWalletProvider } from '@cowprotocol/wallet-provider'
@@ -57,7 +57,13 @@ export function useTradeFlowContext({ deadline }: TradeFlowParams): TradeFlowCon
     checkAllowanceAddress,
   })
 
-  const { inputCurrency: sellToken, outputCurrency: buyToken, recipient, recipientAddress } = derivedTradeState || {}
+  const {
+    inputCurrency: sellToken,
+    outputCurrency: buyToken,
+    recipient,
+    recipientAddress,
+    orderKind,
+  } = derivedTradeState || {}
   const quoteParams = tradeQuote?.quoteParams
   const quoteResponse = tradeQuote?.response
   const localQuoteTimestamp = tradeQuote?.localQuoteTimestamp
@@ -77,6 +83,7 @@ export function useTradeFlowContext({ deadline }: TradeFlowParams): TradeFlowCon
         quoteParams &&
         quoteResponse &&
         localQuoteTimestamp &&
+        orderKind &&
         settlementContract
         ? [
             account,
@@ -104,6 +111,7 @@ export function useTradeFlowContext({ deadline }: TradeFlowParams): TradeFlowCon
             tradeConfirmActions,
             typedHooks,
             deadline,
+            orderKind,
           ]
         : null,
       ([
@@ -132,6 +140,7 @@ export function useTradeFlowContext({ deadline }: TradeFlowParams): TradeFlowCon
         tradeConfirmActions,
         typedHooks,
         deadline,
+        orderKind,
       ]) => {
         return {
           context: {
@@ -164,7 +173,7 @@ export function useTradeFlowContext({ deadline }: TradeFlowParams): TradeFlowCon
             account,
             chainId,
             signer: provider.getSigner(),
-            kind: OrderKind.SELL,
+            kind: orderKind,
             inputAmount,
             outputAmount,
             sellAmountBeforeFee,

--- a/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowContext.ts
@@ -181,7 +181,7 @@ export function useTradeFlowContext({ deadline }: TradeFlowParams): TradeFlowCon
             allowsOffchainSigning,
             appData,
             class: OrderClass.MARKET,
-            partiallyFillable: true,
+            partiallyFillable: false, // SWAP orders are always fill or kill - for now
             quoteId: quoteResponse.id,
             isSafeWallet,
           },


### PR DESCRIPTION
# Summary

With the recent refactoring I changed false to true:
https://github.com/cowprotocol/cowswap/blob/99c4c42aec60a734a37926935be5dca6cd4cf11c/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowContext.ts#L184

# To Test

Market orders should always be fill or kill
