### PR TITLE
fix: use quote partiallyFillable flag

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowContext.ts
@@ -181,7 +181,7 @@ export function useTradeFlowContext({ deadline }: TradeFlowParams): TradeFlowCon
             allowsOffchainSigning,
             appData,
             class: OrderClass.MARKET,
-            partiallyFillable: true,
+            partiallyFillable: quoteResponse.quote.partiallyFillable,
             quoteId: quoteResponse.id,
             isSafeWallet,
           },


### PR DESCRIPTION
# Summary

Since the big refactor, all SWAPs are hardcoded to send `partiallyFillable` orders https://github.com/cowprotocol/cowswap/blob/99c4c42aec60a734a37926935be5dca6cd4cf11c/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowContext.ts#L184

# To Test

1. On SWAP, go to the signing step
2. Check the 