### PR TITLE
Add Create LlamaPay Vesting iframe hook

### DIFF
--- a/apps/cowswap-frontend/src/modules/hooksStore/hookRegistry.tsx
+++ b/apps/cowswap-frontend/src/modules/hooksStore/hookRegistry.tsx
@@ -24,4 +24,5 @@ export const ALL_HOOK_DAPPS = [
     component: (props) => <AirdropHookApp {...props} />,
   },
   hookDappsRegistry.CLAIM_LLAMAPAY_VESTING,
+  hookDappsRegistry.CREATE_LLAMAPAY_VESTING
 ] as HookDapp[]

--- a/libs/hook-dapp-lib/src/hookDappsRegistry.json
+++ b/libs/hook-dapp-lib/src/hookDappsRegistry.json
@@ -63,5 +63,22 @@
     "conditions": {
       "supportedNetworks": [1, 100, 42161]
     }
+  },
+  "CREATE_LLAMAPAY_VESTING": {
+    "id": "a316488cecc23fde8c39d3e748e0cb12bd4d18305826d36576d4bba74bd97baf",
+    "type": "IFRAME",
+    "name": "Create LlamaPay Vesting Hook",
+    "descriptionShort": "Create a LlamaPay vesting contract",
+    "description": "This hook allows you to easily set up vesting contracts with LlamaPay. Enter the recipient’s address or ENS name, then choose how much to transfer: the token buy will be automatically detected by the hook and the contracts will be linked to your LlamaPay dashboard for seamless tracking.",
+    "version": "0.1.0",
+    "website": "https://llamapay.io/vesting",
+    "image": "https://cow-hooks-dapps-create-vesting.vercel.app/llama-pay-icon.png",
+    "walletCompatibility": ["EOA"],
+    "url": "https://cow-hooks-dapps-create-vesting.vercel.app",
+    "conditions": {
+      "position": "post",
+      "smartContractWalletSupported": false,
+      "supportedNetworks": [1, 100, 42161]
+    }
   }
 }


### PR DESCRIPTION
# Summary

Add Create Vesting Hook

![image](https://github.com/user-attachments/assets/ed91ba9d-124e-445d-ba01-6ba22f69cd37)
![image](https://github.com/user-attachments/assets/92d4fc62-0747-4ddc-a54a-e74f74f5013a)


# To Test

1. Access /#/100/swap/hooks/WXDAI

2. Connect your wallet and switch to a chain with deployed LlamaPay vesting factory (Mainnet, Gnosis or Arbitrum)

3. Fill some swap order 

4. In Hooks > Add Post-Hook Action, the Create Vesting Hook should appear in the "All hooks" section

5. Fill the form data and add the post-hook

# Issues that are still being fixed:

- Tenderly simulations are currently not working
- If you try to manually input a vesting amount that is larger than your balance, the encoding will fail