### PR TITLE
chore(feature-flags): remove isNotificationsFeedEnabled

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/index.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react'
 
 import { useNativeCurrencyAmount } from '@cowprotocol/balances-and-allowances'
 import { NATIVE_CURRENCIES } from '@cowprotocol/common-const'
-import { useFeatureFlags } from '@cowprotocol/common-hooks'
 import { TokenAmount } from '@cowprotocol/ui'
 import { useWalletInfo } from '@cowprotocol/wallet'
 
@@ -35,7 +34,7 @@ export function AccountElement({ className, standaloneMode, pendingActivities }:
   const toggleAccountModal = useToggleAccountModal()
   const nativeTokenSymbol = NATIVE_CURRENCIES[chainId].symbol
   const isUpToLarge = useMediaQuery(upToLarge)
-  const { isNotificationsFeedEnabled } = useFeatureFlags()
+
 
   const unreadNotifications = useUnreadNotifications()
   const unreadNotificationsCount = Object.keys(unreadNotifications).length
@@ -51,7 +50,7 @@ export function AccountElement({ className, standaloneMode, pendingActivities }:
           </BalanceText>
         )}
         <Web3Status pendingActivities={pendingActivities} onClick={() => account && toggleAccountModal()} />
-        {account && isNotificationsFeedEnabled && (
+        {account && (
           <NotificationBell
             unreadCount={unreadNotificationsCount}
             onClick={() => {


### PR DESCRIPTION
# Summary

Remove `isNotificationsFeedEnabled` feature flag.
It has been enabled for awhile, we won't turn it off.

# To Test

Notifications feed should be enabled