### PR TITLE
feat(protocol-fees): arb1 protocol fee

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
+++ b/apps/cowswap-frontend/src/common/hooks/orderProgressBarV2/useOrderProgressBarV2Props.ts
@@ -61,7 +61,7 @@ export function useOrderProgressBarV2Props(chainId: SupportedChainId, order: Ord
   const showCancellationModal = useMemo(
     // Sort of duplicate cancellation logic since ethflow on creating state don't have progress bar props
     () => progressBarV2Props?.showCancellationModal || (order && getCancellation ? getCancellation(order) : null),
-    [progressBarV2Props?.showCancellationModal, order, getCancellation]
+    [progressBarV2Props?.showCancellationModal, order, getCancellation],
   )
   const surplusData = useGetSurplusData(order)
   const receiverEnsName = useENS(order?.receiver).name || undefined
@@ -87,7 +87,7 @@ export function useOrderProgressBarV2Props(chainId: SupportedChainId, order: Ord
 }
 
 function useOrderBaseProgressBarV2Props(
-  params: UseOrderProgressBarPropsParams
+  params: UseOrderProgressBarPropsParams,
 ): UseOrderProgressBarV2Result | undefined {
   const { activityDerivedState, chainId } = params
 
@@ -129,7 +129,7 @@ function useOrderBaseProgressBarV2Props(
   const solversInfo = useSolversInfo(chainId)
   const totalSolvers = Object.keys(solversInfo).length
 
-  const doNotQuery = getDoNotQueryStatusEndpoint(order, apiSolverCompetition, disableProgressBar)
+  const doNotQuery = getDoNotQueryStatusEndpoint(order, apiSolverCompetition, !!disableProgressBar)
 
   // Local updaters of the respective atom
   useBackendApiStatusUpdater(chainId, orderId, doNotQuery)
@@ -145,7 +145,7 @@ function useOrderBaseProgressBarV2Props(
     backendApiStatus,
     previousBackendApiStatus,
     lastTimeChangedSteps,
-    previousStepName
+    previousStepName,
   )
   useCancellingOrderUpdater(orderId, isCancelling)
   useCountdownStartUpdater(orderId, countdown, backendApiStatus)
@@ -156,7 +156,7 @@ function useOrderBaseProgressBarV2Props(
         ?.map((entry) => mergeSolverData(entry, solversInfo))
         // Reverse it since backend returns the solutions ranked ascending. Winner is the last one.
         .reverse(),
-    [apiSolverCompetition, solversInfo]
+    [apiSolverCompetition, solversInfo],
   )
 
   return useMemo(() => {
@@ -184,7 +184,7 @@ function useOrderBaseProgressBarV2Props(
 function getDoNotQueryStatusEndpoint(
   order: Order | undefined,
   apiSolverCompetition: CompetitionOrderStatus['value'] | undefined,
-  disableProgressBar: boolean
+  disableProgressBar: boolean,
 ) {
   return (
     !!(
@@ -224,7 +224,7 @@ function useSetExecutingOrderProgressBarStepNameCallback() {
 function useCountdownStartUpdater(
   orderId: string,
   countdown: OrderProgressBarState['countdown'],
-  backendApiStatus: OrderProgressBarState['backendApiStatus']
+  backendApiStatus: OrderProgressBarState['backendApiStatus'],
 ) {
   const setCountdown = useSetExecutingOrderCountdownCallback()
 
@@ -259,7 +259,7 @@ function useProgressBarStepNameUpdater(
   backendApiStatus: OrderProgressBarState['backendApiStatus'],
   previousBackendApiStatus: OrderProgressBarState['previousBackendApiStatus'],
   lastTimeChangedSteps: OrderProgressBarState['lastTimeChangedSteps'],
-  previousStepName: OrderProgressBarState['previousStepName']
+  previousStepName: OrderProgressBarState['previousStepName'],
 ) {
   const setProgressBarStepName = useSetExecutingOrderProgressBarStepNameCallback()
 
@@ -273,7 +273,7 @@ function useProgressBarStepNameUpdater(
     countdown,
     backendApiStatus,
     previousBackendApiStatus,
-    previousStepName
+    previousStepName,
   )
 
   // Update state with new step name
@@ -321,7 +321,7 @@ function getProgressBarStepName(
   countdown: OrderProgressBarState['countdown'],
   backendApiStatus: OrderProgressBarState['backendApiStatus'],
   previousBackendApiStatus: OrderProgressBarState['previousBackendApiStatus'],
-  previousStepName: OrderProgressBarState['previousStepName']
+  previousStepName: OrderProgressBarState['previousStepName'],
 ): OrderProgressBarStepName {
   if (isExpired) {
     return 'expired'
@@ -391,7 +391,7 @@ function usePendingOrderStatus(chainId: SupportedChainId, orderId: string, doNot
   return useSWR(
     chainId && orderId && !doNotQuery ? ['getOrderCompetitionStatus', chainId, orderId] : null,
     async ([, _chainId, _orderId]) => getOrderCompetitionStatus(_chainId, _orderId),
-    doNotQuery ? SWR_NO_REFRESH_OPTIONS : POOLING_SWR_OPTIONS
+    doNotQuery ? SWR_NO_REFRESH_OPTIONS : POOLING_SWR_OPTIONS,
   ).data
 }
 
@@ -404,7 +404,7 @@ function usePendingOrderStatus(chainId: SupportedChainId, orderId: string, doNot
  */
 function mergeSolverData(
   solverCompetition: ApiSolverCompetition,
-  solversInfo: Record<string, SolverInfo>
+  solversInfo: Record<string, SolverInfo>,
 ): SolverCompetition {
   // Backend has the prefix `-solve` on some solvers. We should discard that for now.
   // In the future this prefix will be removed.

--- a/apps/cowswap-frontend/src/common/state/featureFlagsState.ts
+++ b/apps/cowswap-frontend/src/common/state/featureFlagsState.ts
@@ -1,3 +1,3 @@
 import { atom } from 'jotai'
 
-export const featureFlagsAtom = atom<Record<string, boolean>>({})
+export const featureFlagsAtom = atom<Record<string, boolean | number>>({})

--- a/apps/cowswap-frontend/src/modules/volumeFee/state/cowswapFeeAtom.ts
+++ b/apps/cowswap-frontend/src/modules/volumeFee/state/cowswapFeeAtom.ts
@@ -37,6 +37,7 @@ export const cowSwapFeeAtom = atom((get) => {
   // Don't user it when the currencies are not set
   if (!inputCurrency || !outputCurrency) return null
 
+  // TODO: remove this feature flag in another PR
   // Don't use it when isCowSwapFeeEnabled is not enabled
   if (!featureFlags.isCowSwapFeeEnabled) return null
 

--- a/apps/cowswap-frontend/src/modules/volumeFee/state/cowswapFeeAtom.ts
+++ b/apps/cowswap-frontend/src/modules/volumeFee/state/cowswapFeeAtom.ts
@@ -54,6 +54,12 @@ export const cowSwapFeeAtom = atom((get) => {
 })
 
 function shouldApplyFee(account: string | undefined, percentage: number | boolean | undefined): boolean {
+  // Early exit for 100%, meaning should be enabled for everyone
+  if (percentage === 100) {
+    return true
+  }
+
+  // Falsy conditions
   if (typeof percentage !== 'number' || !account || percentage < 0 || percentage > 100) {
     return false
   }

--- a/apps/cowswap-frontend/src/modules/volumeFee/state/cowswapFeeAtom.ts
+++ b/apps/cowswap-frontend/src/modules/volumeFee/state/cowswapFeeAtom.ts
@@ -1,19 +1,23 @@
 import { atom } from 'jotai'
 
-import { GNOSIS_CHAIN_STABLECOINS } from '@cowprotocol/common-const'
+import { STABLECOINS } from '@cowprotocol/common-const'
 import { getCurrencyAddress, isInjectedWidget } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { walletInfoAtom } from '@cowprotocol/wallet'
 
 import { derivedTradeStateAtom } from 'modules/trade'
 
+import { featureFlagsAtom } from 'common/state/featureFlagsState'
+
 import { VolumeFee } from '../types'
 
 const COWSWAP_VOLUME_FEES: Record<SupportedChainId, VolumeFee | null> = {
   [SupportedChainId.MAINNET]: null,
   [SupportedChainId.SEPOLIA]: null,
-  [SupportedChainId.ARBITRUM_ONE]: null,
-  // Only Gnosis chain
+  [SupportedChainId.ARBITRUM_ONE]: {
+    bps: 10, // 0.1%
+    recipient: '0x451100Ffc88884bde4ce87adC8bB6c7Df7fACccd', // Arb1 Protocol fee safe
+  },
   [SupportedChainId.GNOSIS_CHAIN]: {
     bps: 10, // 0.1%
     recipient: '0x6b3214fD11dc91De14718DeE98Ef59bCbFcfB432', // Gnosis Chain Protocol fee safe
@@ -21,21 +25,38 @@ const COWSWAP_VOLUME_FEES: Record<SupportedChainId, VolumeFee | null> = {
 }
 
 export const cowSwapFeeAtom = atom((get) => {
-  const { chainId } = get(walletInfoAtom)
+  const { chainId, account } = get(walletInfoAtom)
   const tradeState = get(derivedTradeStateAtom)
+  const featureFlags = get(featureFlagsAtom)
 
   const { inputCurrency, outputCurrency } = tradeState || {}
 
-  // No widget mode
+  // Don't use it in the widget
   if (isInjectedWidget()) return null
 
+  // Don't user it when the currencies are not set
   if (!inputCurrency || !outputCurrency) return null
 
-  const isInputTokenStable = GNOSIS_CHAIN_STABLECOINS.includes(getCurrencyAddress(inputCurrency).toLowerCase())
-  const isOutputTokenStable = GNOSIS_CHAIN_STABLECOINS.includes(getCurrencyAddress(outputCurrency).toLowerCase())
+  // Don't use it when isCowSwapFeeEnabled is not enabled
+  if (!featureFlags.isCowSwapFeeEnabled) return null
+
+  // Don't use it when on arb1 and shouldn't apply fee based on percentage
+  if (chainId === SupportedChainId.ARBITRUM_ONE && !shouldApplyFee(account, featureFlags.arb1CowSwapFeePercentage))
+    return null
+
+  const isInputTokenStable = STABLECOINS[chainId].includes(getCurrencyAddress(inputCurrency).toLowerCase())
+  const isOutputTokenStable = STABLECOINS[chainId].includes(getCurrencyAddress(outputCurrency).toLowerCase())
 
   // No stable-stable trades
   if (isInputTokenStable && isOutputTokenStable) return null
 
   return COWSWAP_VOLUME_FEES[chainId]
 })
+
+function shouldApplyFee(account: string | undefined, percentage: number | boolean | undefined): boolean {
+  if (typeof percentage !== 'number' || !account || percentage < 0 || percentage > 100) {
+    return false
+  }
+
+  return BigInt(account) % 100n < percentage
+}

--- a/apps/cowswap-frontend/src/modules/volumeFee/state/cowswapFeeAtom.ts
+++ b/apps/cowswap-frontend/src/modules/volumeFee/state/cowswapFeeAtom.ts
@@ -45,8 +45,8 @@ export const cowSwapFeeAtom = atom((get) => {
   if (chainId === SupportedChainId.ARBITRUM_ONE && !shouldApplyFee(account, featureFlags.arb1CowSwapFeePercentage))
     return null
 
-  const isInputTokenStable = STABLECOINS[chainId].includes(getCurrencyAddress(inputCurrency).toLowerCase())
-  const isOutputTokenStable = STABLECOINS[chainId].includes(getCurrencyAddress(outputCurrency).toLowerCase())
+  const isInputTokenStable = STABLECOINS[chainId].has(getCurrencyAddress(inputCurrency).toLowerCase())
+  const isOutputTokenStable = STABLECOINS[chainId].has(getCurrencyAddress(outputCurrency).toLowerCase())
 
   // No stable-stable trades
   if (isInputTokenStable && isOutputTokenStable) return null

--- a/libs/common-const/src/tokens.ts
+++ b/libs/common-const/src/tokens.ts
@@ -167,7 +167,7 @@ export const GNO_ARBITRUM_ONE = new TokenWithLogo(
 )
 
 const USDE_ARBITRUM_ONE = new TokenWithLogo(
-  '', // TODO: add logo, and add it to default token list
+  cowprotocolTokenLogoUrl('0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34', SupportedChainId.ARBITRUM_ONE),
   SupportedChainId.ARBITRUM_ONE,
   '0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34',
   18,
@@ -176,7 +176,7 @@ const USDE_ARBITRUM_ONE = new TokenWithLogo(
 )
 
 const USDM_ARBITRUM_ONE = new TokenWithLogo(
-  '', // TODO: add logo, and add it to default token list
+  cowprotocolTokenLogoUrl('0x59d9356e565ab3a36dd77763fc0d87feaf85508c', SupportedChainId.ARBITRUM_ONE),
   SupportedChainId.ARBITRUM_ONE,
   '0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C',
   18,
@@ -185,7 +185,7 @@ const USDM_ARBITRUM_ONE = new TokenWithLogo(
 )
 
 const FRAX_ARBITRUM_ONE = new TokenWithLogo(
-  '', // TODO: add logo, and add it to default token list
+  cowprotocolTokenLogoUrl('0x17fc002b466eec40dae837fc4be5c67993ddbd6f', SupportedChainId.ARBITRUM_ONE),
   SupportedChainId.ARBITRUM_ONE,
   '0x17FC002b466eEc40DaE837Fc4bE5c67993ddBd6F',
   18,
@@ -194,7 +194,7 @@ const FRAX_ARBITRUM_ONE = new TokenWithLogo(
 )
 
 const MIM_ARBITRUM_ONE = new TokenWithLogo(
-  '', // TODO: add logo, and add it to default token list
+  cowprotocolTokenLogoUrl('0x99d8a9c45b2eca8864373a26d1459e3dff1e17f3', SupportedChainId.ARBITRUM_ONE),
   SupportedChainId.ARBITRUM_ONE,
   '0xFEa7a6a0B346362BF88A9e4A88416B77a57D6c2A',
   18,

--- a/libs/common-const/src/tokens.ts
+++ b/libs/common-const/src/tokens.ts
@@ -12,7 +12,7 @@ export const USDT = new TokenWithLogo(
   '0xdAC17F958D2ee523a2206206994597C13D831ec7',
   6,
   'USDT',
-  'Tether USD'
+  'Tether USD',
 )
 export const WBTC = new TokenWithLogo(
   cowprotocolTokenLogoUrl('0x2260fac5e5542a773aa44fbcfedf7c193bc2c599', SupportedChainId.MAINNET),
@@ -20,7 +20,7 @@ export const WBTC = new TokenWithLogo(
   '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
   8,
   'WBTC',
-  'Wrapped BTC'
+  'Wrapped BTC',
 )
 
 export const USDC_MAINNET = new TokenWithLogo(
@@ -29,7 +29,7 @@ export const USDC_MAINNET = new TokenWithLogo(
   '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
   6,
   'USDC',
-  'USD Coin'
+  'USD Coin',
 )
 
 export const DAI = new TokenWithLogo(
@@ -38,7 +38,7 @@ export const DAI = new TokenWithLogo(
   '0x6B175474E89094C44Da98b954EedeAC495271d0F',
   18,
   'DAI',
-  'Dai Stablecoin'
+  'Dai Stablecoin',
 )
 
 const GNO_MAINNET = new TokenWithLogo(
@@ -47,7 +47,7 @@ const GNO_MAINNET = new TokenWithLogo(
   '0x6810e776880c02933d47db1b9fc05908e5386b96',
   18,
   'GNO',
-  'Gnosis'
+  'Gnosis',
 )
 
 // Gnosis chain
@@ -59,7 +59,7 @@ export const USDT_GNOSIS_CHAIN = new TokenWithLogo(
   '0x4ECaBa5870353805a9F068101A40E0f32ed605C6',
   6,
   'USDT',
-  'Tether USD'
+  'Tether USD',
 )
 export const USDC_GNOSIS_CHAIN = new TokenWithLogo(
   USDC_MAINNET.logoURI,
@@ -67,7 +67,7 @@ export const USDC_GNOSIS_CHAIN = new TokenWithLogo(
   '0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83',
   6,
   'USDC',
-  'USD Coin (old)'
+  'USD Coin (old)',
 )
 export const USDCe_GNOSIS_CHAIN = new TokenWithLogo(
   USDC_MAINNET.logoURI,
@@ -75,7 +75,7 @@ export const USDCe_GNOSIS_CHAIN = new TokenWithLogo(
   '0x2a22f9c3b484c3629090feed35f17ff8f88f76f0',
   6,
   'USDC.e',
-  'USD Coin'
+  'USD Coin',
 )
 export const WBTC_GNOSIS_CHAIN = new TokenWithLogo(
   WBTC.logoURI,
@@ -83,7 +83,7 @@ export const WBTC_GNOSIS_CHAIN = new TokenWithLogo(
   '0x8e5bbbb09ed1ebde8674cda39a0c169401db4252',
   8,
   'WBTC',
-  'Wrapped BTC'
+  'Wrapped BTC',
 )
 export const WETH_GNOSIS_CHAIN = new TokenWithLogo(
   WETH_MAINNET.logoURI,
@@ -91,7 +91,7 @@ export const WETH_GNOSIS_CHAIN = new TokenWithLogo(
   '0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1',
   18,
   'WETH',
-  'Wrapped Ether on Gnosis Chain'
+  'Wrapped Ether on Gnosis Chain',
 )
 export const GNO_GNOSIS_CHAIN = new TokenWithLogo(
   GNO_MAINNET.logoURI,
@@ -99,7 +99,7 @@ export const GNO_GNOSIS_CHAIN = new TokenWithLogo(
   '0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb',
   18,
   'GNO',
-  'Gnosis Token'
+  'Gnosis Token',
 )
 
 export const EURE_GNOSIS_CHAIN = new TokenWithLogo(
@@ -108,7 +108,7 @@ export const EURE_GNOSIS_CHAIN = new TokenWithLogo(
   '0xcb444e90d8198415266c6a2724b7900fb12fc56e',
   18,
   'EURe',
-  'Monerium EUR emoney'
+  'Monerium EUR emoney',
 )
 
 // Arbitrum
@@ -119,7 +119,7 @@ export const USDT_ARBITRUM_ONE = new TokenWithLogo(
   '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
   6,
   'USDT',
-  'Tether USD'
+  'Tether USD',
 )
 export const WBTC_ARBITRUM_ONE = new TokenWithLogo(
   WBTC.logoURI,
@@ -127,7 +127,7 @@ export const WBTC_ARBITRUM_ONE = new TokenWithLogo(
   '0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f',
   8,
   'WBTC',
-  'Wrapped BTC'
+  'Wrapped BTC',
 )
 
 export const USDC_ARBITRUM_ONE = new TokenWithLogo(
@@ -136,7 +136,7 @@ export const USDC_ARBITRUM_ONE = new TokenWithLogo(
   '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
   6,
   'USDC',
-  'USD Coin'
+  'USD Coin',
 )
 
 export const DAI_ARBITRUM_ONE = new TokenWithLogo(
@@ -145,7 +145,7 @@ export const DAI_ARBITRUM_ONE = new TokenWithLogo(
   '0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1',
   18,
   'DAI',
-  'Dai Stablecoin'
+  'Dai Stablecoin',
 )
 
 export const ARB_ARBITRUM_ONE = new TokenWithLogo(
@@ -154,7 +154,7 @@ export const ARB_ARBITRUM_ONE = new TokenWithLogo(
   '0x912ce59144191c1204e64559fe8253a0e49e6548',
   18,
   'ARB',
-  'Arbitrum'
+  'Arbitrum',
 )
 
 export const GNO_ARBITRUM_ONE = new TokenWithLogo(
@@ -163,7 +163,43 @@ export const GNO_ARBITRUM_ONE = new TokenWithLogo(
   '0xa0b862F60edEf4452F25B4160F177db44DeB6Cf1',
   18,
   'GNO',
-  'Gnosis Token'
+  'Gnosis Token',
+)
+
+const USDE_ARBITRUM_ONE = new TokenWithLogo(
+  '', // TODO: add logo, and add it to default token list
+  SupportedChainId.ARBITRUM_ONE,
+  '0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34',
+  18,
+  'USDe',
+  'USDe',
+)
+
+const USDM_ARBITRUM_ONE = new TokenWithLogo(
+  '', // TODO: add logo, and add it to default token list
+  SupportedChainId.ARBITRUM_ONE,
+  '0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C',
+  18,
+  'USDM',
+  'Mountain Protocol USD',
+)
+
+const FRAX_ARBITRUM_ONE = new TokenWithLogo(
+  '', // TODO: add logo, and add it to default token list
+  SupportedChainId.ARBITRUM_ONE,
+  '0x17FC002b466eEc40DaE837Fc4bE5c67993ddBd6F',
+  18,
+  'FRAX',
+  'Frax',
+)
+
+const MIM_ARBITRUM_ONE = new TokenWithLogo(
+  '', // TODO: add logo, and add it to default token list
+  SupportedChainId.ARBITRUM_ONE,
+  '0xFEa7a6a0B346362BF88A9e4A88416B77a57D6c2A',
+  18,
+  'MIM',
+  'Magic Internet Money',
 )
 
 // Sepolia
@@ -174,7 +210,7 @@ const GNO_SEPOLIA = new TokenWithLogo(
   '0xd3f3d46FeBCD4CdAa2B83799b7A5CdcB69d135De',
   18,
   'GNO',
-  'GNO (test)'
+  'GNO (test)',
 )
 
 // Sepolia
@@ -184,7 +220,7 @@ export const USDC_SEPOLIA = new TokenWithLogo(
   '0xbe72E441BF55620febc26715db68d3494213D8Cb',
   18,
   'USDC',
-  'USDC (test)'
+  'USDC (test)',
 )
 
 export const USDC: Record<SupportedChainId, TokenWithLogo> = {
@@ -212,7 +248,7 @@ const V_COW_TOKEN_MAINNET = new TokenWithLogo(
   V_COW_CONTRACT_ADDRESS[SupportedChainId.MAINNET] || '',
   18,
   'vCOW',
-  'CoW Protocol Virtual Token'
+  'CoW Protocol Virtual Token',
 )
 
 const V_COW_TOKEN_XDAI = new TokenWithLogo(
@@ -221,7 +257,7 @@ const V_COW_TOKEN_XDAI = new TokenWithLogo(
   V_COW_CONTRACT_ADDRESS[SupportedChainId.GNOSIS_CHAIN] || '',
   18,
   'vCOW',
-  'CoW Protocol Virtual Token'
+  'CoW Protocol Virtual Token',
 )
 
 const V_COW_TOKEN_SEPOLIA = new TokenWithLogo(
@@ -230,7 +266,7 @@ const V_COW_TOKEN_SEPOLIA = new TokenWithLogo(
   V_COW_CONTRACT_ADDRESS[SupportedChainId.SEPOLIA] || '',
   18,
   'vCOW',
-  'CoW Protocol Virtual Token'
+  'CoW Protocol Virtual Token',
 )
 
 // TODO: V_COW not present in all chains, make sure code using it can handle that
@@ -250,7 +286,7 @@ const COW_TOKEN_MAINNET = new TokenWithLogo(
   COW_CONTRACT_ADDRESS[SupportedChainId.MAINNET] || '',
   18,
   'COW',
-  'CoW Protocol Token'
+  'CoW Protocol Token',
 )
 
 const COW_TOKEN_XDAI = new TokenWithLogo(
@@ -259,7 +295,7 @@ const COW_TOKEN_XDAI = new TokenWithLogo(
   COW_CONTRACT_ADDRESS[SupportedChainId.GNOSIS_CHAIN] || '',
   18,
   'COW',
-  'CoW Protocol Token'
+  'CoW Protocol Token',
 )
 
 export const COW_TOKEN_ARBITRUM = new TokenWithLogo(
@@ -268,7 +304,7 @@ export const COW_TOKEN_ARBITRUM = new TokenWithLogo(
   COW_CONTRACT_ADDRESS[SupportedChainId.ARBITRUM_ONE] || '',
   18,
   'COW',
-  'CoW Protocol Token'
+  'CoW Protocol Token',
 )
 
 const COW_TOKEN_SEPOLIA = new TokenWithLogo(
@@ -277,7 +313,7 @@ const COW_TOKEN_SEPOLIA = new TokenWithLogo(
   COW_CONTRACT_ADDRESS[SupportedChainId.SEPOLIA] || '',
   18,
   'COW',
-  'CoW Protocol Token'
+  'CoW Protocol Token',
 )
 
 export const COW: Record<SupportedChainId, TokenWithLogo> = {
@@ -309,6 +345,23 @@ export const GNOSIS_CHAIN_STABLECOINS = [
   USDCe_GNOSIS_CHAIN.address,
   USDT_GNOSIS_CHAIN.address,
 ].map((t) => t.toLowerCase())
+
+export const ARBITRUM_ONE_STABLECOINS = [
+  USDC_ARBITRUM_ONE.address,
+  DAI_ARBITRUM_ONE.address,
+  USDT_ARBITRUM_ONE.address,
+  USDE_ARBITRUM_ONE.address,
+  USDM_ARBITRUM_ONE.address,
+  FRAX_ARBITRUM_ONE.address,
+  MIM_ARBITRUM_ONE.address,
+].map((t) => t.toLowerCase())
+
+export const STABLECOINS: Record<ChainId, string[]> = {
+  [SupportedChainId.MAINNET]: [],
+  [SupportedChainId.GNOSIS_CHAIN]: GNOSIS_CHAIN_STABLECOINS,
+  [SupportedChainId.ARBITRUM_ONE]: ARBITRUM_ONE_STABLECOINS,
+  [SupportedChainId.SEPOLIA]: [],
+}
 
 /**
  * Addresses related to COW vesting for Locked GNO

--- a/libs/common-const/src/tokens.ts
+++ b/libs/common-const/src/tokens.ts
@@ -356,11 +356,11 @@ const ARBITRUM_ONE_STABLECOINS = [
   MIM_ARBITRUM_ONE.address,
 ].map((t) => t.toLowerCase())
 
-export const STABLECOINS: Record<ChainId, string[]> = {
-  [SupportedChainId.MAINNET]: [],
-  [SupportedChainId.GNOSIS_CHAIN]: GNOSIS_CHAIN_STABLECOINS,
-  [SupportedChainId.ARBITRUM_ONE]: ARBITRUM_ONE_STABLECOINS,
-  [SupportedChainId.SEPOLIA]: [],
+export const STABLECOINS: Record<ChainId, Set<string>> = {
+  [SupportedChainId.MAINNET]: new Set(),
+  [SupportedChainId.GNOSIS_CHAIN]: new Set(GNOSIS_CHAIN_STABLECOINS),
+  [SupportedChainId.ARBITRUM_ONE]: new Set(ARBITRUM_ONE_STABLECOINS),
+  [SupportedChainId.SEPOLIA]: new Set(),
 }
 
 /**

--- a/libs/common-const/src/tokens.ts
+++ b/libs/common-const/src/tokens.ts
@@ -335,7 +335,7 @@ const GBPE_GNOSIS_CHAIN_ADDRESS = '0x5cb9073902f2035222b9749f8fb0c9bfe5527108'
 
 // NOTE: whenever this list is updated, make sure to update the docs section regarding the volume fees
 // https://github.com/cowprotocol/docs/blob/main/docs/governance/fees/fees.md?plain=1#L40
-export const GNOSIS_CHAIN_STABLECOINS = [
+const GNOSIS_CHAIN_STABLECOINS = [
   SDAI_GNOSIS_CHAIN_ADDRESS,
   NATIVE_CURRENCIES[SupportedChainId.GNOSIS_CHAIN].address, //xDAI
   WRAPPED_NATIVE_CURRENCIES[SupportedChainId.GNOSIS_CHAIN].address, //wxDAI
@@ -346,7 +346,7 @@ export const GNOSIS_CHAIN_STABLECOINS = [
   USDT_GNOSIS_CHAIN.address,
 ].map((t) => t.toLowerCase())
 
-export const ARBITRUM_ONE_STABLECOINS = [
+const ARBITRUM_ONE_STABLECOINS = [
   USDC_ARBITRUM_ONE.address,
   DAI_ARBITRUM_ONE.address,
   USDT_ARBITRUM_ONE.address,


### PR DESCRIPTION
# Summary

Adds support for enabling Arb1 protocol fees for non-stable coins, based on % from feature flag.

This allows for gradual rollout, based on connected account.

Similar to Gchain fees, it's set to 0.1% on non stable to stable trades.

# To Test

1. Connect on arb1,
2. Make sure the feature flag `arb1CowSwapFeePercentage` is set to a value > 0.
3. Pick a non stable pair
* Fee should be set for whatever percentage of accounts (default is 50%)
4. Pick a stable pair (any of USDC,DAI,USDT,USDE,USDM,FRAX,MIM)
* Fee should not be displayed
5. Change the percentage on launch darkly to 100% 
![image](https://github.com/user-attachments/assets/4ec21fc0-3c2f-4a8b-bd3b-b5c8337ed4a1)
* Fee should be displayed for all accounts

6. Check Gnosis chain
* Fee should be displayed for all accounts (except on stable pairs)
7. Check Mainnet
* There should be no fee for any account or pair
