### PR TITLE
chore: remove isCowSwapFeeEnabled feature flag

### DIFF
--- a/apps/cowswap-frontend/src/modules/volumeFee/state/cowswapFeeAtom.ts
+++ b/apps/cowswap-frontend/src/modules/volumeFee/state/cowswapFeeAtom.ts
@@ -37,10 +37,6 @@ export const cowSwapFeeAtom = atom((get) => {
   // Don't user it when the currencies are not set
   if (!inputCurrency || !outputCurrency) return null
 
-  // TODO: remove this feature flag in another PR
-  // Don't use it when isCowSwapFeeEnabled is not enabled
-  if (!featureFlags.isCowSwapFeeEnabled) return null
-
   // Don't use it when on arb1 and shouldn't apply fee based on percentage
   if (chainId === SupportedChainId.ARBITRUM_ONE && !shouldApplyFee(account, featureFlags.arb1CowSwapFeePercentage))
     return null

--- a/apps/cowswap-frontend/src/modules/volumeFee/state/volumeFeeAtom.ts
+++ b/apps/cowswap-frontend/src/modules/volumeFee/state/volumeFeeAtom.ts
@@ -7,22 +7,16 @@ import { injectedWidgetPartnerFeeAtom } from 'modules/injectedWidget'
 import { tradeTypeAtom } from 'modules/trade'
 import { TradeType } from 'modules/trade/types/TradeType'
 
-import { featureFlagsAtom } from 'common/state/featureFlagsState'
-
 import { cowSwapFeeAtom } from './cowswapFeeAtom'
 
 import { VolumeFee } from '../types'
 
 export const volumeFeeAtom = atom<VolumeFee | undefined>((get) => {
-  const featureFlags = get(featureFlagsAtom)
   const cowSwapFee = get(cowSwapFeeAtom)
   const widgetPartnerFee = get(widgetPartnerFeeAtom)
 
-  if (featureFlags.isCowSwapFeeEnabled) {
-    return cowSwapFee || widgetPartnerFee
-  }
-
-  return widgetPartnerFee
+  // CoW Swap Fee won't be enabled when in Widget mode, thus it takes precedence here
+  return cowSwapFee || widgetPartnerFee
 })
 
 const widgetPartnerFeeAtom = atom<VolumeFee | undefined>((get) => {


### PR DESCRIPTION
# Summary

Remove `isCowSwapFeeEnabled` feature flag

Fee is not a permanent part of Gnosis Chain

# To Test

1. On Gnosis chain, setup a trade with non-stable tokens
* There should be a fee displayed
2. Pick a stable pair
* There should be no fee
3. Repeat on other chains (except Arb1)
* There should be no fee
4. Connect to Gnosis chain in the widget configurator
5. Set a partner fee
* That fee/recipient should be used instead of the protocol one