### PR TITLE
fix(widget): remove irrelevant change trade params events

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/hooks/useNotifyWidgetTrade.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useNotifyWidgetTrade.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 
 import { getCurrencyAddress } from '@cowprotocol/common-utils'
 import { AtomsAndUnits, CowWidgetEvents, OnTradeParamsPayload } from '@cowprotocol/events'
@@ -15,17 +15,23 @@ import { TradeDerivedState } from '../types/TradeDerivedState'
 
 export function useNotifyWidgetTrade() {
   const state = useDerivedTradeState()
-  const isFirstLoad = useRef(true)
 
   useEffect(() => {
-    if (isFirstLoad.current && !!state) {
-      isFirstLoad.current = false
+    if (!state) return
+
+    /**
+     * There is no way to select both empty sell and buy currencies in the widget UI.
+     * The only way when it is possible is when the widget integrator set the state, but in this case it doesn't make sense to notify them.
+     *
+     * In practice, the state has both currencies empty only at the beginning, when the widget is not ready to trade.
+     * So we skip the notification in this case.
+     */
+    const stateIsNotReady = !state.inputCurrency && !state.outputCurrency
+
+    if (!state.tradeType || stateIsNotReady) {
       return
     }
 
-    if (!state?.tradeType) {
-      return
-    }
     WIDGET_EVENT_EMITTER.emit(
       CowWidgetEvents.ON_CHANGE_TRADE_PARAMS,
       getTradeParamsEventPayload(state.tradeType, state),


### PR DESCRIPTION
# Summary

Fixes #4879

`derivedTradeStateAtom` initially returns a default state (DEFAULT_TRADE_DERIVED_STATE) which may cause race condition.
How it works:
1. You set some assets in Swap (/1/swap/COW/USDC)
2. You navigate from Swap to Limit orders (/1/limit/COW/USDC)
3. By default `limitOrdersDerivedStateAtom` is empty (has DEFAULT_TRADE_DERIVED_STATE value)
4. `useNotifyWidgetTrade()` sends this empty state to the integrator side
5. At the same time, `useFillLimitOrdersDerivedState()` fills `limitOrdersDerivedStateAtom` with values (COW/USDC)
6. Integrator received (ON_CHANGE_TRADE_PARAMS) an empty state from step 3, and updates widget params with them (navigate to /1/limit/_/_)
7. `useNotifyWidgetTrade()` reacts on changes from step 5 and here we go in a loop

**To avoid that I added skipping of the step 3.**
There is no way to select both empty sell and buy currencies in the widget UI.
The only way when it is possible is when the widget integrator set the state, but in this case it doesn't make sense to notify them.

# To Test

1. See #4879. I've tested with Safe swaps
2. Switch between Swap/Limit/TWAP. Try specifying some assets before navigating
