### PR TITLE
fix(explorer): make sure txHash always has the 0x prefix

### DIFF
--- a/apps/explorer/src/explorer/pages/TransactionDetails.tsx
+++ b/apps/explorer/src/explorer/pages/TransactionDetails.tsx
@@ -17,12 +17,14 @@ const TransactionDetails = () => {
     return <RedirectToSearch from="tx" />
   }
 
+  const txHashWithOx = !txHash || txHash.startsWith('0x') ? txHash : `0x${txHash}`
+
   return (
     <Wrapper>
       <Helmet>
         <title>Transaction Details - {APP_TITLE}</title>
       </Helmet>
-      {txHash && <TransactionsTableWidget txHash={txHash} networkId={networkId} />}
+      {txHashWithOx && <TransactionsTableWidget txHash={txHashWithOx} networkId={networkId} />}
     </Wrapper>
   )
 }


### PR DESCRIPTION
# Summary

Make sure txHash on transaction view always has the 0x prefix

# To Test

1. Search for a transaction hash without the `0x` prefix
* Should load as usual
* Link to etherscan should work