### PR TITLE
fix(hooks): support native currency rescuing from proxy

### DIFF
--- a/apps/cowswap-frontend/src/modules/hooksStore/containers/HooksStoreWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/hooksStore/containers/HooksStoreWidget/index.tsx
@@ -6,7 +6,7 @@ import { BannerOrientation, DismissableInlineBanner } from '@cowprotocol/ui'
 import { useIsSmartContractWallet, useWalletInfo } from '@cowprotocol/wallet'
 
 import { SwapWidget } from 'modules/swap'
-import { useIsSellNative } from 'modules/trade'
+import { useIsSellNative, useIsWrapOrUnwrap } from 'modules/trade'
 
 import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetworkUnsupported'
 
@@ -32,6 +32,7 @@ export function HooksStoreWidget() {
 
   const isNativeSell = useIsSellNative()
   const isChainIdUnsupported = useIsProviderNetworkUnsupported()
+  const isWrapOrUnwrap = useIsWrapOrUnwrap()
 
   const walletType = useIsSmartContractWallet()
     ? HookDappWalletCompatibility.SMART_CONTRACT
@@ -79,6 +80,8 @@ export function HooksStoreWidget() {
   )
 
   const TopContent = shouldNotUseHooks ? (
+    HooksTop
+  ) : isWrapOrUnwrap ? (
     HooksTop
   ) : (
     <>

--- a/apps/cowswap-frontend/src/modules/hooksStore/containers/HooksStoreWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/hooksStore/containers/HooksStoreWidget/index.tsx
@@ -72,13 +72,17 @@ export function HooksStoreWidget() {
 
   const shouldNotUseHooks = isNativeSell || isChainIdUnsupported
 
-  const TopContent = shouldNotUseHooks ? null : (
+  const HooksTop = (
+    <HooksTopActions>
+      <RescueFundsToggle onClick={() => setRescueWidgetOpen(true)}>Rescue funds</RescueFundsToggle>
+    </HooksTopActions>
+  )
+
+  const TopContent = shouldNotUseHooks ? (
+    HooksTop
+  ) : (
     <>
-      {!isRescueWidgetOpen && account && (
-        <HooksTopActions>
-          <RescueFundsToggle onClick={() => setRescueWidgetOpen(true)}>Rescue funds</RescueFundsToggle>
-        </HooksTopActions>
-      )}
+      {!isRescueWidgetOpen && account && HooksTop}
       <DismissableInlineBanner
         orientation={BannerOrientation.Horizontal}
         customIcon={ICON_HOOK}

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
@@ -178,7 +178,7 @@ export function TradeWidgetForm(props: TradeWidgetProps) {
           lockScreen
         ) : (
           <>
-            {!isWrapOrUnwrap && topContent}
+            {topContent}
             <div>
               <CurrencyInputPanel
                 id="input-currency-input"

--- a/libs/balances-and-allowances/src/hooks/useNativeTokenBalance.ts
+++ b/libs/balances-and-allowances/src/hooks/useNativeTokenBalance.ts
@@ -3,11 +3,14 @@ import { useWalletProvider } from '@cowprotocol/wallet-provider'
 import { BigNumber } from '@ethersproject/bignumber'
 
 import ms from 'ms.macro'
-import useSWR, { SWRResponse } from 'swr'
+import useSWR, { SWRConfiguration, SWRResponse } from 'swr'
 
 const SWR_CONFIG = { refreshInterval: ms`11s` }
 
-export function useNativeTokenBalance(account: string | undefined): SWRResponse<BigNumber> {
+export function useNativeTokenBalance(
+  account: string | undefined,
+  swrConfig: SWRConfiguration = SWR_CONFIG,
+): SWRResponse<BigNumber> {
   const provider = useWalletProvider()
 
   return useSWR(
@@ -17,6 +20,6 @@ export function useNativeTokenBalance(account: string | undefined): SWRResponse<
 
       return contract.callStatic.getEthBalance(_account)
     },
-    SWR_CONFIG
+    swrConfig,
   )
 }


### PR DESCRIPTION
# Summary

Fixes #5034

<img width="520" alt="image" src="https://github.com/user-attachments/assets/aaf30639-026a-4b8f-a56b-aa91581ec409">

# To Test

1. Send some ETH to your Shed proxy
2. Rescue the funds from Proxy using CoWSwap UI
- [ ] ER: all native tokens are transfered from Proxy to your account
