### PR TITLE
fix(swap): take slippage into account for buy orders

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowContext.ts
@@ -36,10 +36,9 @@ export function useTradeFlowContext({ deadline }: TradeFlowParams): TradeFlowCon
   const uiOrderType = tradeType ? TradeTypeToUiOrderType[tradeType] : null
 
   const sellCurrency = derivedTradeState?.inputCurrency
-  const inputAmount = receiveAmountInfo?.afterNetworkCosts.sellAmount
+  const inputAmount = receiveAmountInfo?.afterSlippage.sellAmount
   const outputAmount = receiveAmountInfo?.afterSlippage.buyAmount
   const sellAmountBeforeFee = receiveAmountInfo?.afterNetworkCosts.sellAmount
-  const inputAmountWithSlippage = receiveAmountInfo?.afterSlippage.sellAmount
   const networkFee = receiveAmountInfo?.costs.networkFee.amountInSellCurrency
 
   const permitInfo = usePermitInfo(sellCurrency, tradeType)
@@ -56,7 +55,7 @@ export function useTradeFlowContext({ deadline }: TradeFlowParams): TradeFlowCon
   const checkAllowanceAddress = COW_PROTOCOL_VAULT_RELAYER_ADDRESS[chainId || SupportedChainId.MAINNET]
   const { enoughAllowance } = useEnoughBalanceAndAllowance({
     account,
-    amount: inputAmountWithSlippage,
+    amount: inputAmount,
     checkAllowanceAddress,
   })
 
@@ -75,7 +74,6 @@ export function useTradeFlowContext({ deadline }: TradeFlowParams): TradeFlowCon
     useSWR(
       inputAmount &&
         outputAmount &&
-        inputAmountWithSlippage &&
         sellAmountBeforeFee &&
         networkFee &&
         sellToken &&
@@ -103,7 +101,6 @@ export function useTradeFlowContext({ deadline }: TradeFlowParams): TradeFlowCon
             enoughAllowance,
             generatePermitHook,
             inputAmount,
-            inputAmountWithSlippage,
             networkFee,
             outputAmount,
             permitInfo,
@@ -134,7 +131,6 @@ export function useTradeFlowContext({ deadline }: TradeFlowParams): TradeFlowCon
         enoughAllowance,
         generatePermitHook,
         inputAmount,
-        inputAmountWithSlippage,
         networkFee,
         outputAmount,
         permitInfo,
@@ -155,7 +151,7 @@ export function useTradeFlowContext({ deadline }: TradeFlowParams): TradeFlowCon
             chainId,
             inputAmount,
             outputAmount,
-            inputAmountWithSlippage,
+            inputAmountWithSlippage: inputAmount,
           },
           flags: {
             allowsOffchainSigning,

--- a/apps/cowswap-frontend/src/modules/tradeFlow/services/safeBundleFlow/safeBundleEthFlow.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/services/safeBundleFlow/safeBundleEthFlow.ts
@@ -39,7 +39,7 @@ export async function safeBundleEthFlow(
 
   const { spender, settlementContract, safeAppsSdk, needsApproval, wrappedNativeContract } = safeBundleContext
 
-  const { inputAmountWithSlippage, chainId, inputAmount, outputAmount } = context
+  const { chainId, inputAmount, outputAmount } = context
 
   const orderParams: PostOrderParams = {
     ...tradeContext.orderParams,
@@ -49,7 +49,7 @@ export async function safeBundleEthFlow(
   const { account, recipientAddressOrName, kind } = orderParams
 
   tradeFlowAnalytics.wrapApproveAndPresign(swapFlowAnalyticsContext)
-  const nativeAmountInWei = inputAmountWithSlippage.quotient.toString()
+  const nativeAmountInWei = inputAmount.quotient.toString()
   const tradeAmounts = { inputAmount, outputAmount }
 
   tradeConfirmActions.onSign(tradeAmounts)
@@ -72,7 +72,7 @@ export async function safeBundleEthFlow(
       const approveTx = await buildApproveTx({
         erc20Contract: wrappedNativeContract as unknown as Erc20,
         spender,
-        amountToApprove: inputAmountWithSlippage,
+        amountToApprove: inputAmount,
       })
 
       txs.push({

--- a/apps/cowswap-frontend/src/modules/tradeFlow/types/TradeFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/types/TradeFlowContext.ts
@@ -23,7 +23,6 @@ export interface TradeFlowContext {
     chainId: number
     inputAmount: CurrencyAmount<Currency>
     outputAmount: CurrencyAmount<Currency>
-    inputAmountWithSlippage: CurrencyAmount<Currency>
   }
   flags: {
     allowsOffchainSigning: boolean


### PR DESCRIPTION
# Summary

Fixes #5066

Did a mistake in the recent refactoring (#4950).

`const inputAmount = receiveAmountInfo?.afterNetworkCosts.sellAmount` -> `const inputAmount = receiveAmountInfo?.afterSlippage.sellAmount`

# To Test

See #5066.
Please, check ETH-flow as well.
