### PR TITLE
feat: allow to use same tokens for hooks

### DIFF
--- a/apps/cowswap-frontend/src/api/cowProtocol/api.ts
+++ b/apps/cowswap-frontend/src/api/cowProtocol/api.ts
@@ -37,7 +37,6 @@ import { ApiErrorCodes } from './errors/OperatorError'
 import QuoteApiError, { mapOperatorErrorToQuoteError, QuoteApiErrorDetails } from './errors/QuoteError'
 import { getIsOrderBookTypedError } from './getIsOrderBookTypedError'
 
-
 function getProfileUrl(): Partial<Record<ChainId, string>> {
   if (isLocal || isDev || isPr || isBarn) {
     return {
@@ -157,16 +156,16 @@ function _getAppDataQuoteParams(params: FeeQuoteParams) {
 export async function getQuote(params: FeeQuoteParams): Promise<OrderQuoteResponse> {
   const { chainId } = params
   const quoteParams = _mapNewToLegacyParams(params)
-  const { sellToken, buyToken } = quoteParams
+  // const { sellToken, buyToken } = quoteParams
 
-  if (sellToken === buyToken) {
-    return Promise.reject(
-      mapOperatorErrorToQuoteError({
-        errorType: ApiErrorCodes.SameBuyAndSellToken,
-        description: QuoteApiErrorDetails.SameBuyAndSellToken,
-      }),
-    )
-  }
+  // if (sellToken === buyToken) {
+  //   return Promise.reject(
+  //     mapOperatorErrorToQuoteError({
+  //       errorType: ApiErrorCodes.SameBuyAndSellToken,
+  //       description: QuoteApiErrorDetails.SameBuyAndSellToken,
+  //     }),
+  //   )
+  // }
 
   return orderBookApi.getQuote(quoteParams, { chainId }).catch((error) => {
     if (getIsOrderBookTypedError(error)) {

--- a/apps/cowswap-frontend/src/legacy/hooks/useRefetchPriceCallback.tsx
+++ b/apps/cowswap-frontend/src/legacy/hooks/useRefetchPriceCallback.tsx
@@ -109,6 +109,7 @@ function handleQuoteError({ quoteData, error, addUnsupportedToken }: HandleQuote
 
     // Some other error getting the quote ocurred
     console.error('Error quoting price/fee: ' + error)
+    console.error(error)
     return 'fetch-quote-error'
   }
 }

--- a/apps/cowswap-frontend/src/legacy/utils/price.ts
+++ b/apps/cowswap-frontend/src/legacy/utils/price.ts
@@ -44,7 +44,7 @@ export async function getBestQuote({
       console.warn(
         '[GP PRICE::API] getBestQuote - error using COWSWAP price strategy, reason: [',
         err,
-        '] - trying back up price sources...'
+        '] - trying back up price sources...',
       )
       // ATTEMPT LEGACY CALL
       return getBestQuote({

--- a/apps/cowswap-frontend/src/modules/advancedOrders/containers/AdvancedOrdersWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/advancedOrders/containers/AdvancedOrdersWidget/index.tsx
@@ -68,7 +68,7 @@ export function AdvancedOrdersWidget({
     orderKind,
     isUnlocked,
   } = useAdvancedOrdersDerivedState()
-  const actions = useAdvancedOrdersActions()
+  const actions = useAdvancedOrdersActions({ allowSameToken: false })
   const { isLoading: isTradePriceUpdating } = useTradeQuote()
   const { showRecipient } = useAtomValue(advancedOrdersSettingsAtom)
   const priceImpact = useTradePriceImpact()
@@ -124,6 +124,7 @@ export function AdvancedOrdersWidget({
     isTradePriceUpdating,
     priceImpact,
     disablePriceImpact,
+    allowSameToken: false,
   }
 
   return (

--- a/apps/cowswap-frontend/src/modules/advancedOrders/hooks/useAdvancedOrdersActions.ts
+++ b/apps/cowswap-frontend/src/modules/advancedOrders/hooks/useAdvancedOrdersActions.ts
@@ -12,10 +12,10 @@ import { useAdvancedOrdersDerivedState } from './useAdvancedOrdersDerivedState'
 import { useUpdateAdvancedOrdersRawState } from './useAdvancedOrdersRawState'
 
 // TODO: this should be also unified for each trade widget (swap, limit, advanced)
-export function useAdvancedOrdersActions() {
+export function useAdvancedOrdersActions({ allowSameToken }: { allowSameToken: boolean }) {
   const { inputCurrency } = useAdvancedOrdersDerivedState()
 
-  const naviageOnCurrencySelection = useNavigateOnCurrencySelection()
+  const naviageOnCurrencySelection = useNavigateOnCurrencySelection({ allowSameToken })
   const updateCurrencyAmount = useUpdateCurrencyAmount()
   const resetTradeQuote = useResetTradeQuote()
 
@@ -33,7 +33,7 @@ export function useAdvancedOrdersActions() {
       naviageOnCurrencySelection(field, currency)
       resetTradeQuote()
     },
-    [naviageOnCurrencySelection, updateCurrencyAmount, resetTradeQuote]
+    [naviageOnCurrencySelection, updateCurrencyAmount, resetTradeQuote],
   )
 
   const onUserInput = useCallback(
@@ -45,14 +45,14 @@ export function useAdvancedOrdersActions() {
         field,
       })
     },
-    [inputCurrency, updateCurrencyAmount]
+    [inputCurrency, updateCurrencyAmount],
   )
 
   const onChangeRecipient = useCallback(
     (recipient: string | null) => {
       updateAdvancedOrdersState({ recipient })
     },
-    [updateAdvancedOrdersState]
+    [updateAdvancedOrdersState],
   )
 
   const onSwitchTokensDefault = useSwitchTokensPlaces({
@@ -71,6 +71,6 @@ export function useAdvancedOrdersActions() {
       onChangeRecipient,
       onSwitchTokens,
     }),
-    [onCurrencySelection, onUserInput, onChangeRecipient, onSwitchTokens]
+    [onCurrencySelection, onUserInput, onChangeRecipient, onSwitchTokens],
   )
 }

--- a/apps/cowswap-frontend/src/modules/hooksStore/containers/HooksStoreWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/hooksStore/containers/HooksStoreWidget/index.tsx
@@ -66,7 +66,7 @@ export function HooksStoreWidget() {
   }, [chainId, isChainIdUnsupported, onDismiss])
 
   useSetupHooksStoreOrderParams()
-  useSetRecipientOverride()
+  useSetRecipientOverride({ allowSameToken: true })
 
   const isHookSelectionOpen = !!(selectedHookPosition || hookToEdit)
   const hideSwapWidget = isHookSelectionOpen || isRescueWidgetOpen
@@ -114,7 +114,7 @@ export function HooksStoreWidget() {
   return (
     <>
       <TradeWidgetWrapper visible$={!hideSwapWidget}>
-        <SwapWidget topContent={TopContent} bottomContent={BottomContent} />
+        <SwapWidget topContent={TopContent} bottomContent={BottomContent} allowSameToken />
       </TradeWidgetWrapper>
       <IframeDappsManifestUpdater />
       {isHookSelectionOpen && (

--- a/apps/cowswap-frontend/src/modules/hooksStore/hooks/useSetRecipientOverride.ts
+++ b/apps/cowswap-frontend/src/modules/hooksStore/hooks/useSetRecipientOverride.ts
@@ -5,8 +5,8 @@ import { useIsHooksTradeType, useIsNativeIn } from 'modules/trade'
 
 import { usePostHooksRecipientOverride } from './usePostHooksRecipientOverride'
 
-export function useSetRecipientOverride() {
-  const { onChangeRecipient } = useSwapActionHandlers()
+export function useSetRecipientOverride({ allowSameToken }: { allowSameToken: boolean }): void {
+  const { onChangeRecipient } = useSwapActionHandlers({ allowSameToken })
   const hookRecipientOverride = usePostHooksRecipientOverride()
   const isHooksTradeType = useIsHooksTradeType()
   const isNativeIn = useIsNativeIn()

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWarnings/index.tsx
@@ -99,7 +99,7 @@ export function LimitOrdersWarnings(props: LimitOrdersWarningsProps) {
 
       {/*// TODO: must be replaced by <NotificationBanner>*/}
       {showHighFeeWarning && <SmallVolumeWarningBanner feeAmount={feeAmount} feePercentage={feePercentage} />}
-      {showNativeSellWarning && <SellNativeWarningBanner />}
+      {showNativeSellWarning && <SellNativeWarningBanner allowSameToken={false} />}
     </Wrapper>
   ) : null
 }

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWidget/hooks/useLimitOrdersWidgetActions.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWidget/hooks/useLimitOrdersWidgetActions.ts
@@ -16,7 +16,7 @@ import { useIsWrapOrUnwrap } from 'modules/trade/hooks/useIsWrapOrUnwrap'
 import { useOnCurrencySelection } from 'modules/trade/hooks/useOnCurrencySelection'
 import { useSwitchTokensPlaces } from 'modules/trade/hooks/useSwitchTokensPlaces'
 
-export function useLimitOrdersWidgetActions(): TradeWidgetActions {
+export function useLimitOrdersWidgetActions({ allowSameToken }: { allowSameToken: boolean }): TradeWidgetActions {
   const { inputCurrency, outputCurrency, orderKind } = useLimitOrdersDerivedState()
   const { activeRate } = useAtomValue(limitRateAtom)
   const isWrapOrUnwrap = useIsWrapOrUnwrap()
@@ -24,7 +24,7 @@ export function useLimitOrdersWidgetActions(): TradeWidgetActions {
 
   const updateLimitOrdersState = useUpdateLimitOrdersRawState()
 
-  const onCurrencySelection = useOnCurrencySelection()
+  const onCurrencySelection = useOnCurrencySelection({ allowSameToken })
 
   const onUserInput = useCallback(
     (field: Field, typedValue: string) => {
@@ -42,7 +42,7 @@ export function useLimitOrdersWidgetActions(): TradeWidgetActions {
         orderKind: isWrapOrUnwrap || field === Field.INPUT ? OrderKind.SELL : OrderKind.BUY,
       })
     },
-    [updateCurrencyAmount, isWrapOrUnwrap, inputCurrency, outputCurrency, activeRate]
+    [updateCurrencyAmount, isWrapOrUnwrap, inputCurrency, outputCurrency, activeRate],
   )
 
   const onSwitchTokens = useSwitchTokensPlaces({
@@ -51,11 +51,11 @@ export function useLimitOrdersWidgetActions(): TradeWidgetActions {
 
   const onChangeRecipient = useCallback(
     (recipient: string | null) => updateLimitOrdersState({ recipient }),
-    [updateLimitOrdersState]
+    [updateLimitOrdersState],
   )
 
   return useMemo(
     () => ({ onUserInput, onSwitchTokens, onChangeRecipient, onCurrencySelection }),
-    [onUserInput, onSwitchTokens, onChangeRecipient, onCurrencySelection]
+    [onUserInput, onSwitchTokens, onChangeRecipient, onCurrencySelection],
   )
 }

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -75,7 +75,7 @@ export function LimitOrdersWidget() {
   const { feeAmount } = useAtomValue(limitRateAtom)
   const { isLoading: isRateLoading } = useTradeQuote()
   const rateInfoParams = useRateInfoParams(inputCurrencyAmount, outputCurrencyAmount)
-  const widgetActions = useLimitOrdersWidgetActions()
+  const widgetActions = useLimitOrdersWidgetActions({ allowSameToken: false })
   const isWrapOrUnwrap = useIsWrapOrUnwrap()
 
   const { showRecipient: showRecipientSetting } = settingsState
@@ -228,6 +228,7 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
     disablePriceImpact: localFormValidation === LimitOrdersFormState.FeeExceedsFrom,
     disableQuotePolling: isConfirmOpen,
     hideTradeWarnings: !!localFormValidation,
+    allowSameToken: false,
   }
 
   return (

--- a/apps/cowswap-frontend/src/modules/swap/containers/EthFlow/hooks/useEthFlowActions.ts
+++ b/apps/cowswap-frontend/src/modules/swap/containers/EthFlow/hooks/useEthFlowActions.ts
@@ -30,13 +30,13 @@ export interface EthFlowActions {
   directSwap(): void
 }
 
-export function useEthFlowActions(callbacks: EthFlowActionCallbacks): EthFlowActions {
+export function useEthFlowActions(callbacks: EthFlowActionCallbacks, allowSameToken: boolean): EthFlowActions {
   const { chainId } = useWalletInfo()
   const { trade } = useDerivedSwapInfo()
 
   const updateEthFlowContext = useSetAtom(updateEthFlowContextAtom)
 
-  const { onCurrencySelection } = useSwapActionHandlers()
+  const { onCurrencySelection } = useSwapActionHandlers({ allowSameToken })
   const { onOpen: openSwapConfirmModal } = useTradeConfirmActions()
 
   return useMemo(() => {

--- a/apps/cowswap-frontend/src/modules/swap/containers/EthFlow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/EthFlow/index.tsx
@@ -25,13 +25,13 @@ import { useEthFlowActions } from './hooks/useEthFlowActions'
 import useRemainingNativeTxsAndCosts from './hooks/useRemainingNativeTxsAndCosts'
 import { useSetupEthFlow } from './hooks/useSetupEthFlow'
 
-
 export interface EthFlowProps {
   nativeInput?: CurrencyAmount<Currency>
   hasEnoughWrappedBalanceForSwap: boolean
   wrapCallback: WrapUnwrapCallback | null
   directSwapCallback: HandleSwapCallback
   onDismiss: Command
+  allowSameToken: boolean
 }
 
 export function EthFlowModal({
@@ -40,6 +40,7 @@ export function EthFlowModal({
   wrapCallback,
   directSwapCallback,
   hasEnoughWrappedBalanceForSwap,
+  allowSameToken,
 }: EthFlowProps) {
   const { chainId } = useWalletInfo()
   const native = useNativeCurrency()
@@ -48,14 +49,17 @@ export function EthFlowModal({
 
   const ethFlowContext = useAtomValue(ethFlowContextAtom)
   const approveCallback = useTradeApproveCallback(
-    (nativeInput && currencyAmountToTokenAmount(nativeInput)) || undefined
+    (nativeInput && currencyAmountToTokenAmount(nativeInput)) || undefined,
   )
-  const ethFlowActions = useEthFlowActions({
-    wrap: wrapCallback,
-    approve: approveCallback,
-    dismiss: onDismiss,
-    directSwap: directSwapCallback,
-  })
+  const ethFlowActions = useEthFlowActions(
+    {
+      wrap: wrapCallback,
+      approve: approveCallback,
+      dismiss: onDismiss,
+      directSwap: directSwapCallback,
+    },
+    allowSameToken,
+  )
 
   const approveActivity = useSingleActivityDescriptor({ chainId, id: ethFlowContext.approve.txHash || undefined })
   const wrapActivity = useSingleActivityDescriptor({ chainId, id: ethFlowContext.wrap.txHash || undefined })
@@ -86,7 +90,7 @@ export function EthFlowModal({
     approvalState,
     approveActivity,
     wrapActivity,
-    onDismiss
+    onDismiss,
   })
 
   return (

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapUpdaters/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapUpdaters/index.tsx
@@ -6,7 +6,7 @@ import { useTradeSlippage, useIsSmartSlippageApplied } from 'modules/tradeSlippa
 import { SwapAmountsFromUrlUpdater } from '../../updaters/SwapAmountsFromUrlUpdater'
 import { SwapDerivedStateUpdater } from '../../updaters/SwapDerivedStateUpdater'
 
-export function SwapUpdaters() {
+export function SwapUpdaters({ allowSameToken }: { allowSameToken: boolean }) {
   const slippage = useTradeSlippage()
   const isSmartSlippageApplied = useIsSmartSlippageApplied()
 
@@ -18,7 +18,7 @@ export function SwapUpdaters() {
         isSmartSlippage={isSmartSlippageApplied}
       />
       <SwapDerivedStateUpdater />
-      <SwapAmountsFromUrlUpdater />
+      <SwapAmountsFromUrlUpdater allowSameToken={allowSameToken} />
     </>
   )
 }

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
@@ -54,16 +54,17 @@ import { ConfirmSwapModalSetup } from '../ConfirmSwapModalSetup'
 export interface SwapWidgetProps {
   topContent?: ReactNode
   bottomContent?: ReactNode
+  allowSameToken?: boolean
 }
 
-export function SwapWidget({ topContent, bottomContent }: SwapWidgetProps) {
+export function SwapWidget({ topContent, bottomContent, allowSameToken = false }: SwapWidgetProps) {
   const { chainId } = useWalletInfo()
   const { currencies, trade } = useDerivedSwapInfo()
   const slippage = useTradeSlippage()
   const parsedAmounts = useSwapCurrenciesAmounts()
   const { isSupportedWallet } = useWalletDetails()
   const isSwapUnsupported = useIsTradeUnsupported(currencies.INPUT, currencies.OUTPUT)
-  const swapActions = useSwapActionHandlers()
+  const swapActions = useSwapActionHandlers({ allowSameToken })
   const swapState = useSwapState()
   const { independentField, recipient } = swapState
   const showRecipientControls = useShowRecipientControls(recipient)
@@ -169,6 +170,7 @@ export function SwapWidget({ topContent, bottomContent }: SwapWidgetProps) {
       openNativeWrapModal,
     },
     swapActions,
+    allowSameToken,
   )
 
   const tradeUrlParams = useTradeRouteContext()
@@ -181,6 +183,7 @@ export function SwapWidget({ topContent, bottomContent }: SwapWidgetProps) {
     wrapCallback: swapButtonContext.onWrapOrUnwrap,
     directSwapCallback: swapButtonContext.handleSwap,
     hasEnoughWrappedBalanceForSwap: swapButtonContext.hasEnoughWrappedBalanceForSwap,
+    allowSameToken,
   }
 
   const swapModalsProps: SwapModalsProps = {
@@ -255,6 +258,7 @@ export function SwapWidget({ topContent, bottomContent }: SwapWidgetProps) {
     priceImpact: priceImpactParams,
     disableQuotePolling: true,
     tradeQuoteStateOverride,
+    allowSameToken,
   }
 
   useSetLocalTimeOffset(getQuoteTimeOffset(swapButtonContext.quoteDeadlineParams))

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useSetupSwapAmountsFromUrl.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useSetupSwapAmountsFromUrl.ts
@@ -25,11 +25,11 @@ import { useSwapActionHandlers } from './useSwapState'
  *
  * In case when both sellAmount and buyAmount specified, buyAmount will be ignored
  */
-export function useSetupSwapAmountsFromUrl() {
+export function useSetupSwapAmountsFromUrl({ allowSameToken }: { allowSameToken: boolean }): void {
   const { search, pathname } = useLocation()
   const navigate = useNavigate()
   const params = useMemo(() => new URLSearchParams(search), [search])
-  const { onUserInput } = useSwapActionHandlers()
+  const { onUserInput } = useSwapActionHandlers({ allowSameToken })
 
   const cleanParams = useCallback(() => {
     const queryParams = new URLSearchParams(search)

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useSwapButtonContext.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useSwapButtonContext.ts
@@ -38,7 +38,11 @@ export interface SwapButtonInput {
   openNativeWrapModal(): void
 }
 
-export function useSwapButtonContext(input: SwapButtonInput, actions: TradeWidgetActions): SwapButtonsContext {
+export function useSwapButtonContext(
+  input: SwapButtonInput,
+  actions: TradeWidgetActions,
+  allowSameToken: boolean,
+): SwapButtonsContext {
   const { feeWarningAccepted, impactWarningAccepted, openNativeWrapModal } = input
 
   const { account, chainId } = useWalletInfo()
@@ -52,7 +56,7 @@ export function useSwapButtonContext(input: SwapButtonInput, actions: TradeWidge
     inputError: swapInputError,
   } = useDerivedSwapInfo()
   const toggleWalletModal = useToggleWalletModal()
-  const { onCurrencySelection } = useSwapActionHandlers()
+  const { onCurrencySelection } = useSwapActionHandlers({ allowSameToken })
   const isBestQuoteLoading = useIsBestQuoteLoading()
   const tradeConfirmActions = useTradeConfirmActions()
   const { standaloneMode } = useInjectedWidgetParams()

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useSwapState.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useSwapState.tsx
@@ -60,10 +60,10 @@ interface DerivedSwapInfo {
   trade: TradeGp | undefined
 }
 
-export function useSwapActionHandlers(): TradeWidgetActions {
+export function useSwapActionHandlers({ allowSameToken }: { allowSameToken: boolean }): TradeWidgetActions {
   const { chainId } = useWalletInfo()
   const dispatch = useAppDispatch()
-  const onCurrencySelection = useNavigateOnCurrencySelection()
+  const onCurrencySelection = useNavigateOnCurrencySelection({ allowSameToken })
   const navigate = useTradeNavigate()
   const swapState = useSwapState()
 

--- a/apps/cowswap-frontend/src/modules/swap/updaters/SwapAmountsFromUrlUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/updaters/SwapAmountsFromUrlUpdater.tsx
@@ -1,6 +1,6 @@
 import { useSetupSwapAmountsFromUrl } from '../hooks/useSetupSwapAmountsFromUrl'
 
-export function SwapAmountsFromUrlUpdater() {
-  useSetupSwapAmountsFromUrl()
+export function SwapAmountsFromUrlUpdater({ allowSameToken }: { allowSameToken: boolean }) {
+  useSetupSwapAmountsFromUrl({ allowSameToken })
   return null
 }

--- a/apps/cowswap-frontend/src/modules/trade/containers/SellNativeWarningBanner/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/SellNativeWarningBanner/index.tsx
@@ -9,10 +9,10 @@ import { useDerivedTradeState } from '../../hooks/useDerivedTradeState'
 import { useNavigateOnCurrencySelection } from '../../hooks/useNavigateOnCurrencySelection'
 import { useWrappedToken } from '../../hooks/useWrappedToken'
 
-export function SellNativeWarningBanner() {
+export function SellNativeWarningBanner({ allowSameToken }: { allowSameToken: boolean }) {
   const native = useNativeCurrency()
   const wrapped = useWrappedToken()
-  const navigateOnCurrencySelection = useNavigateOnCurrencySelection()
+  const navigateOnCurrencySelection = useNavigateOnCurrencySelection({ allowSameToken })
 
   const state = useDerivedTradeState()
 

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
@@ -52,7 +52,7 @@ export function TradeWidgetForm(props: TradeWidgetProps) {
   const { pendingActivity } = useCategorizeRecentActivity()
   const isWrapOrUnwrap = useIsWrapOrUnwrap()
 
-  const { slots, actions, params, disableOutput, allowSameToken } = props
+  const { slots, actions, params, disableOutput } = props
   const { settingsWidget, lockScreen, topContent, middleContent, bottomContent, outerContent } = slots
 
   const { onCurrencySelection, onUserInput, onSwitchTokens, onChangeRecipient } = actions

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
@@ -52,7 +52,7 @@ export function TradeWidgetForm(props: TradeWidgetProps) {
   const { pendingActivity } = useCategorizeRecentActivity()
   const isWrapOrUnwrap = useIsWrapOrUnwrap()
 
-  const { slots, actions, params, disableOutput } = props
+  const { slots, actions, params, disableOutput, allowSameToken } = props
   const { settingsWidget, lockScreen, topContent, middleContent, bottomContent, outerContent } = slots
 
   const { onCurrencySelection, onUserInput, onSwitchTokens, onChangeRecipient } = actions

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetUpdaters.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetUpdaters.tsx
@@ -21,6 +21,7 @@ interface TradeWidgetUpdatersProps {
   children: ReactNode
   tradeQuoteStateOverride?: TradeQuoteState | null
   onChangeRecipient: (recipient: string | null) => void
+  allowSameToken: boolean
 }
 
 export function TradeWidgetUpdaters({
@@ -30,6 +31,7 @@ export function TradeWidgetUpdaters({
   enableSmartSlippage,
   onChangeRecipient,
   children,
+  allowSameToken,
 }: TradeWidgetUpdatersProps) {
   const { chainId, account } = useWalletInfo()
   const updateQuoteState = useUpdateTradeQuote()
@@ -51,7 +53,7 @@ export function TradeWidgetUpdaters({
       {!disableQuotePolling && <TradeQuoteUpdater />}
       <PriceImpactUpdater />
       <TradeFormValidationUpdater />
-      <CommonTradeUpdater />
+      <CommonTradeUpdater allowSameToken={allowSameToken} />
       {enableSmartSlippage && <SmartSlippageUpdater />}
       {disableNativeSelling && <DisableNativeTokenSellingUpdater />}
       {children}

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/index.tsx
@@ -13,8 +13,9 @@ export function TradeWidget(props: TradeWidgetProps) {
     disableNativeSelling = false,
     tradeQuoteStateOverride,
     enableSmartSlippage,
+    allowSameToken,
   } = params
-  const modals = TradeWidgetModals({confirmModal, genericModal, selectTokenWidget: slots.selectTokenWidget})
+  const modals = TradeWidgetModals({ confirmModal, genericModal, selectTokenWidget: slots.selectTokenWidget })
 
   return (
     <>
@@ -25,6 +26,7 @@ export function TradeWidget(props: TradeWidgetProps) {
           tradeQuoteStateOverride={tradeQuoteStateOverride}
           enableSmartSlippage={enableSmartSlippage}
           onChangeRecipient={props.actions.onChangeRecipient}
+          allowSameToken={allowSameToken}
         >
           {slots.updaters}
         </TradeWidgetUpdaters>

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/types.ts
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/types.ts
@@ -31,6 +31,7 @@ interface TradeWidgetParams {
   isMarketOrderWidget?: boolean
   displayTokenName?: boolean
   customSelectTokenButton?: ReactNode
+  allowSameToken: boolean
 }
 
 export interface TradeWidgetSlots {

--- a/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
@@ -19,7 +19,7 @@ import { useTradeState } from '../useTradeState'
 const INITIAL_CHAIN_ID_FROM_URL = getRawCurrentChainIdFromUrl()
 const EMPTY_TOKEN_ID = '_'
 
-export function useSetupTradeState(): void {
+export function useSetupTradeState({ allowSameToken }: { allowSameToken: boolean }): void {
   useSetupTradeStateFromUrl()
   const { chainId: providerChainId, account } = useWalletInfo()
   const prevProviderChainId = usePrevious(providerChainId)
@@ -130,7 +130,8 @@ export function useSetupTradeState(): void {
 
     const tokensAreEmpty = !inputCurrencyId && !outputCurrencyId
 
-    const sameTokens =
+    const sameTokensError =
+      !allowSameToken &&
       inputCurrencyId !== EMPTY_TOKEN_ID &&
       (inputCurrencyId || outputCurrencyId) &&
       inputCurrencyId?.toLowerCase() === outputCurrencyId?.toLowerCase()
@@ -155,10 +156,10 @@ export function useSetupTradeState(): void {
       return
     }
 
-    if (sameTokens || tokensAreEmpty || onlyChainIdIsChanged) {
+    if (sameTokensError || tokensAreEmpty || onlyChainIdIsChanged) {
       tradeNavigate(currentChainId, defaultState)
 
-      if (sameTokens) {
+      if (sameTokensError) {
         console.debug('[TRADE STATE]', 'Url contains invalid tokens, resetting')
       } else if (tokensAreEmpty) {
         console.debug('[TRADE STATE]', 'Url does not contain both tokens, resetting')

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useNavigateOnCurrencySelection.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useNavigateOnCurrencySelection.ts
@@ -40,7 +40,11 @@ function useResolveCurrencyAddressOrSymbol(): (currency: Currency | null) => str
  * if there are more than one token with the same symbol
  * @see useResetStateWithSymbolDuplication.ts
  */
-export function useNavigateOnCurrencySelection(): CurrencySelectionCallback {
+export function useNavigateOnCurrencySelection({
+  allowSameToken,
+}: {
+  allowSameToken: boolean
+}): CurrencySelectionCallback {
   const { chainId } = useWalletInfo()
   const { state } = useTradeState()
   const navigate = useTradeNavigate()
@@ -60,7 +64,7 @@ export function useNavigateOnCurrencySelection(): CurrencySelectionCallback {
       navigate(
         chainId,
         // Just invert tokens when user selected the same token
-        areCurrenciesTheSame
+        areCurrenciesTheSame && !allowSameToken
           ? { inputCurrencyId: outputCurrencyId, outputCurrencyId: inputCurrencyId }
           : {
               inputCurrencyId: targetInputCurrencyId,

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useOnCurrencySelection.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useOnCurrencySelection.ts
@@ -11,9 +11,13 @@ import { useNavigateOnCurrencySelection } from 'modules/trade/hooks/useNavigateO
 
 import { convertAmountToCurrency } from 'utils/orderUtils/calculateExecutionPrice'
 
-export function useOnCurrencySelection(): (field: Field, currency: Currency | null) => void {
+export function useOnCurrencySelection({
+  allowSameToken,
+}: {
+  allowSameToken: boolean
+}): (field: Field, currency: Currency | null) => void {
   const { inputCurrencyAmount, outputCurrencyAmount } = useLimitOrdersDerivedState()
-  const navigateOnCurrencySelection = useNavigateOnCurrencySelection()
+  const navigateOnCurrencySelection = useNavigateOnCurrencySelection({ allowSameToken })
   const updateLimitOrdersState = useUpdateLimitOrdersRawState()
 
   return useCallback(
@@ -44,6 +48,6 @@ export function useOnCurrencySelection(): (field: Field, currency: Currency | nu
 
       return navigateOnCurrencySelection(field, currency)
     },
-    [navigateOnCurrencySelection, updateLimitOrdersState, inputCurrencyAmount, outputCurrencyAmount]
+    [navigateOnCurrencySelection, updateLimitOrdersState, inputCurrencyAmount, outputCurrencyAmount],
   )
 }

--- a/apps/cowswap-frontend/src/modules/trade/updaters/CommonTradeUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/updaters/CommonTradeUpdater.tsx
@@ -2,8 +2,8 @@ import { useSetupTradeState } from '../hooks/setupTradeState/useSetupTradeState'
 import { useNotifyWidgetTrade } from '../hooks/useNotifyWidgetTrade'
 import { useSetupTradeTypeInfo } from '../hooks/useSetupTradeTypeInfo'
 
-export function CommonTradeUpdater() {
-  useSetupTradeState()
+export function CommonTradeUpdater(props: { allowSameToken: boolean }): null {
+  useSetupTradeState(props)
   useNotifyWidgetTrade()
   useSetupTradeTypeInfo()
 

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/index.tsx
@@ -79,7 +79,7 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
         }
 
         if (primaryFormValidation === TradeFormValidation.SellNativeToken) {
-          return <SellNativeWarningBanner />
+          return <SellNativeWarningBanner allowSameToken={false} />
         }
 
         if (localFormValidation === TwapFormState.SELL_AMOUNT_TOO_SMALL) {

--- a/apps/cowswap-frontend/src/modules/yield/containers/YieldWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/yield/containers/YieldWidget/index.tsx
@@ -41,6 +41,7 @@ import { TargetPoolPreviewInfo } from '../../pure/TargetPoolPreviewInfo'
 import { TradeButtons } from '../TradeButtons'
 import { Warnings } from '../Warnings'
 import { YieldConfirmModal } from '../YieldConfirmModal'
+import { a } from '@react-spring/web'
 
 const YIELD_BULLET_LIST_CONTENT: BulletListItem[] = [
   { content: 'Maximize your yield on existing LP positions' },
@@ -206,6 +207,7 @@ export function YieldWidget() {
     priceImpact,
     disableQuotePolling: isConfirmOpen,
     customSelectTokenButton: SelectAPoolButton,
+    allowSameToken: false,
   }
 
   return (

--- a/apps/cowswap-frontend/src/modules/yield/hooks/useYieldWidgetActions.ts
+++ b/apps/cowswap-frontend/src/modules/yield/hooks/useYieldWidgetActions.ts
@@ -14,7 +14,7 @@ import { useYieldDerivedState } from './useYieldDerivedState'
 export function useYieldWidgetActions(): TradeWidgetActions {
   const { inputCurrency, outputCurrency, orderKind } = useYieldDerivedState()
   const updateYieldState = useUpdateYieldRawState()
-  const onCurrencySelection = useOnCurrencySelection()
+  const onCurrencySelection = useOnCurrencySelection({ allowSameToken: false })
   const updateCurrencyAmount = useUpdateCurrencyAmount()
 
   const onUserInput = useCallback(

--- a/apps/cowswap-frontend/src/pages/Hooks/index.tsx
+++ b/apps/cowswap-frontend/src/pages/Hooks/index.tsx
@@ -4,7 +4,7 @@ import { SwapUpdaters } from 'modules/swap'
 export function HooksPage() {
   return (
     <>
-      <SwapUpdaters />
+      <SwapUpdaters allowSameToken={true} />
       <HooksStoreWidget />
     </>
   )

--- a/apps/cowswap-frontend/src/pages/Swap/index.tsx
+++ b/apps/cowswap-frontend/src/pages/Swap/index.tsx
@@ -1,4 +1,3 @@
-
 import { WRAPPED_NATIVE_CURRENCIES as WETH } from '@cowprotocol/common-const'
 import { useWalletInfo } from '@cowprotocol/wallet'
 
@@ -19,7 +18,7 @@ export function SwapPage() {
 
   return (
     <>
-      <SwapUpdaters />
+      <SwapUpdaters allowSameToken={false} />
       <SwapWidget />
     </>
   )


### PR DESCRIPTION
# Summary

🧪 Experiment to allow to select the same token for the sell and buy when we use hooks.
This allows to use CoW Swap as a gas network.

SWAP (and all other swap flows) remains the same.

<img width="1449" alt="image" src="https://github.com/user-attachments/assets/25a6fc6e-4ef8-471b-b928-174bb79ff0a4">

However hooks flow, allow to select the same sell/buy token
<img width="1434" alt="image" src="https://github.com/user-attachments/assets/a76f5fe9-9321-4182-a398-e1d75ea25455">



WIP: quotes are broken, not only in the backend, also in the frontend. 


## Blocked
The backend sends still a 40X when the sell token and buy token matches
<img width="1445" alt="Screenshot at Nov 06 18-27-47" src="https://github.com/user-attachments/assets/8a118b3e-2a79-46e3-bcf6-35f7e559f916">
