### PR TITLE
feat: enable hooks using settings

### DIFF
--- a/apps/cowswap-frontend/src/common/constants/routes.ts
+++ b/apps/cowswap-frontend/src/common/constants/routes.ts
@@ -54,7 +54,6 @@ export const HOOKS_STORE_MENU_ITEM = {
   route: Routes.HOOKS,
   label: 'Hooks',
   description: 'Powerful tool to generate pre/post interaction for CoW Protocol',
-  badge: 'New',
 }
 
 export const YIELD_MENU_ITEM = {

--- a/apps/cowswap-frontend/src/common/hooks/useMenuItems.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useMenuItems.ts
@@ -4,15 +4,16 @@ import { useFeatureFlags } from '@cowprotocol/common-hooks'
 import { isLocal } from '@cowprotocol/common-utils'
 
 import { HOOKS_STORE_MENU_ITEM, MENU_ITEMS, YIELD_MENU_ITEM } from '../constants/routes'
+import { useHooksEnabled } from 'legacy/state/user/hooks'
 
 export function useMenuItems() {
-  const { isHooksStoreEnabled } = useFeatureFlags()
+  const isHooksEnabled = useHooksEnabled()
   const { isYieldEnabled } = useFeatureFlags()
 
   return useMemo(() => {
     const items = [...MENU_ITEMS]
 
-    if (isHooksStoreEnabled || isLocal) {
+    if (isHooksEnabled) {
       items.push(HOOKS_STORE_MENU_ITEM)
     }
 
@@ -21,5 +22,5 @@ export function useMenuItems() {
     }
 
     return items
-  }, [isHooksStoreEnabled, isYieldEnabled])
+  }, [isHooksEnabled, isYieldEnabled])
 }

--- a/apps/cowswap-frontend/src/legacy/state/user/hooks.tsx
+++ b/apps/cowswap-frontend/src/legacy/state/user/hooks.tsx
@@ -8,7 +8,13 @@ import { Currency } from '@uniswap/sdk-core'
 
 import { shallowEqual } from 'react-redux'
 
-import { updateRecipientToggleVisible, updateUserDarkMode, updateUserDeadline, updateUserLocale } from './reducer'
+import {
+  updateHooksEnabled,
+  updateRecipientToggleVisible,
+  updateUserDarkMode,
+  updateUserDeadline,
+  updateUserLocale,
+} from './reducer'
 import { SerializedToken } from './types'
 
 import { useAppDispatch, useAppSelector } from '../hooks'
@@ -81,6 +87,21 @@ export function useRecipientToggleManager(): [boolean, (value: boolean) => void]
   )
 
   return [isVisible, toggleVisibility]
+}
+
+export function useHooksEnabled(): boolean {
+  return useAppSelector((state) => state.user.hooksEnabled)
+}
+
+export function useHooksEnabledManager(): [boolean, Command] {
+  const dispatch = useAppDispatch()
+  const hooksEnabled = useHooksEnabled()
+
+  const toggleHooksEnabled = useCallback(() => {
+    dispatch(updateHooksEnabled({ hooksEnabled: !hooksEnabled }))
+  }, [hooksEnabled, dispatch])
+
+  return [hooksEnabled, toggleHooksEnabled]
 }
 
 export function useUserTransactionTTL(): [number, (slippage: number) => void] {

--- a/apps/cowswap-frontend/src/legacy/state/user/reducer.ts
+++ b/apps/cowswap-frontend/src/legacy/state/user/reducer.ts
@@ -17,6 +17,7 @@ export interface UserState {
 
   // TODO: mod, shouldn't be here
   recipientToggleVisible: boolean
+  hooksEnabled: boolean
 
   // deadline set by user in minutes, used in all txns
   userDeadline: number
@@ -28,6 +29,7 @@ export const initialState: UserState = {
   userDarkMode: null,
   // TODO: mod, shouldn't be here
   recipientToggleVisible: false,
+  hooksEnabled: false,
   userLocale: null,
   userDeadline: DEFAULT_DEADLINE_FROM_NOW,
 }
@@ -41,6 +43,9 @@ const userSlice = createSlice({
     },
     updateUserDarkMode(state, action) {
       state.userDarkMode = action.payload.userDarkMode
+    },
+    updateHooksEnabled(state, action) {
+      state.hooksEnabled = action.payload.hooksEnabled
     },
     updateMatchesDarkMode(state, action) {
       state.matchesDarkMode = action.payload.matchesDarkMode
@@ -61,6 +66,7 @@ export const {
   updateSelectedWallet,
   updateMatchesDarkMode,
   updateUserDarkMode,
+  updateHooksEnabled,
   updateUserDeadline,
   updateUserLocale,
   updateRecipientToggleVisible,

--- a/apps/cowswap-frontend/src/modules/analytics/events.ts
+++ b/apps/cowswap-frontend/src/modules/analytics/events.ts
@@ -93,6 +93,14 @@ export function toggleRecipientAddressAnalytics(enable: boolean) {
   })
 }
 
+export function toggleHooksEnabledAnalytics(enable: boolean) {
+  cowAnalytics.sendEvent({
+    category: Category.HOOKS,
+    action: 'Toggle Hooks Enabled',
+    label: enable ? 'Enabled' : 'Disabled',
+  })
+}
+
 export function searchByAddressAnalytics(isAddressSearch: string) {
   cowAnalytics.sendEvent({
     category: Category.CURRENCY_SELECT,

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
@@ -10,7 +10,7 @@ import { NetworkAlert } from 'legacy/components/NetworkAlert/NetworkAlert'
 import { useModalIsOpen } from 'legacy/state/application/hooks'
 import { ApplicationModal } from 'legacy/state/application/reducer'
 import { Field } from 'legacy/state/types'
-import { useRecipientToggleManager, useUserTransactionTTL } from 'legacy/state/user/hooks'
+import { useHooksEnabledManager, useRecipientToggleManager, useUserTransactionTTL } from 'legacy/state/user/hooks'
 
 import { useCurrencyAmountBalanceCombined } from 'modules/combinedBalances'
 import { useInjectedWidgetParams } from 'modules/injectedWidget'
@@ -75,6 +75,7 @@ export function SwapWidget({ topContent, bottomContent }: SwapWidgetProps) {
   const tradeQuoteStateOverride = useTradeQuoteStateFromLegacy()
   const receiveAmountInfo = useReceiveAmountInfo()
   const recipientToggleState = useRecipientToggleManager()
+  const hooksEnabledState = useHooksEnabledManager()
   const deadlineState = useUserTransactionTTL()
 
   const isTradePriceUpdating = useTradePricesUpdate()
@@ -213,7 +214,13 @@ export function SwapWidget({ topContent, bottomContent }: SwapWidgetProps) {
   )
 
   const slots: TradeWidgetSlots = {
-    settingsWidget: <SettingsTab recipientToggleState={recipientToggleState} deadlineState={deadlineState} />,
+    settingsWidget: (
+      <SettingsTab
+        recipientToggleState={recipientToggleState}
+        hooksEnabledState={hooksEnabledState}
+        deadlineState={deadlineState}
+      />
+    ),
 
     topContent,
     bottomContent: useCallback(

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/SettingsTab/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/SettingsTab/index.tsx
@@ -12,7 +12,7 @@ import { ThemedText } from 'theme'
 import { AutoColumn } from 'legacy/components/Column'
 import { Toggle } from 'legacy/components/Toggle'
 
-import { toggleRecipientAddressAnalytics } from 'modules/analytics'
+import { toggleHooksEnabledAnalytics, toggleRecipientAddressAnalytics } from 'modules/analytics'
 import { SettingsIcon } from 'modules/trade/pure/Settings'
 
 import * as styledEl from './styled'
@@ -23,10 +23,11 @@ import { TransactionSettings } from '../TransactionSettings'
 interface SettingsTabProps {
   className?: string
   recipientToggleState: StatefulValue<boolean>
+  hooksEnabledState?: StatefulValue<boolean>
   deadlineState: StatefulValue<number>
 }
 
-export function SettingsTab({ className, recipientToggleState, deadlineState }: SettingsTabProps) {
+export function SettingsTab({ className, recipientToggleState, hooksEnabledState, deadlineState }: SettingsTabProps) {
   const menuButtonRef = useRef<HTMLButtonElement>(null)
 
   const [recipientToggleVisible, toggleRecipientVisibilityAux] = recipientToggleState
@@ -37,6 +38,18 @@ export function SettingsTab({ className, recipientToggleState, deadlineState }: 
       toggleRecipientVisibilityAux(isVisible)
     },
     [toggleRecipientVisibilityAux, recipientToggleVisible],
+  )
+
+  const [hooksEnabled, toggleHooksEnabledAux] = hooksEnabledState || [undefined, undefined]
+  const toggleHooksEnabled = useCallback(
+    (value?: boolean) => {
+      if (hooksEnabled === undefined || toggleHooksEnabledAux === undefined) return
+
+      const isEnabled = value ?? !hooksEnabled
+      toggleHooksEnabledAnalytics(isEnabled)
+      toggleHooksEnabledAux(isEnabled)
+    },
+    [toggleRecipientVisibilityAux, hooksEnabled],
   )
 
   return (
@@ -75,6 +88,18 @@ export function SettingsTab({ className, recipientToggleState, deadlineState }: 
                   toggle={toggleRecipientVisibility}
                 />
               </RowBetween>
+
+              {hooksEnabled !== undefined && (
+                <RowBetween>
+                  <RowFixed>
+                    <ThemedText.Black fontWeight={400} fontSize={14}>
+                      <Trans>Enable Hooks</Trans>
+                    </ThemedText.Black>
+                    <HelpTooltip text={<Trans>🧪 Add deFI interactions before and after your trade</Trans>} />
+                  </RowFixed>
+                  <Toggle id="toggle-hooks-mode-button" isActive={hooksEnabled} toggle={toggleHooksEnabled} />
+                </RowBetween>
+              )}
             </AutoColumn>
           </styledEl.MenuFlyout>
         </styledEl.StyledMenu>

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/SettingsTab/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/SettingsTab/index.tsx
@@ -19,6 +19,7 @@ import * as styledEl from './styled'
 
 import { settingsTabStateAtom } from '../../state/settingsTabState'
 import { TransactionSettings } from '../TransactionSettings'
+import { isInjectedWidget } from '@cowprotocol/common-utils'
 
 interface SettingsTabProps {
   className?: string
@@ -40,10 +41,10 @@ export function SettingsTab({ className, recipientToggleState, hooksEnabledState
     [toggleRecipientVisibilityAux, recipientToggleVisible],
   )
 
-  const [hooksEnabled, toggleHooksEnabledAux] = hooksEnabledState || [undefined, undefined]
+  const [hooksEnabled, toggleHooksEnabledAux] = hooksEnabledState || [null, null]
   const toggleHooksEnabled = useCallback(
     (value?: boolean) => {
-      if (hooksEnabled === undefined || toggleHooksEnabledAux === undefined) return
+      if (hooksEnabled === null || toggleHooksEnabledAux === null) return
 
       const isEnabled = value ?? !hooksEnabled
       toggleHooksEnabledAnalytics(isEnabled)
@@ -89,7 +90,7 @@ export function SettingsTab({ className, recipientToggleState, hooksEnabledState
                 />
               </RowBetween>
 
-              {hooksEnabled !== undefined && (
+              {!isInjectedWidget() && hooksEnabled !== null && (
                 <RowBetween>
                   <RowFixed>
                     <ThemedText.Black fontWeight={400} fontSize={14}>

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/SettingsTab/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/SettingsTab/index.tsx
@@ -95,7 +95,7 @@ export function SettingsTab({ className, recipientToggleState, hooksEnabledState
                     <ThemedText.Black fontWeight={400} fontSize={14}>
                       <Trans>Enable Hooks</Trans>
                     </ThemedText.Black>
-                    <HelpTooltip text={<Trans>🧪 Add deFI interactions before and after your trade</Trans>} />
+                    <HelpTooltip text={<Trans>🧪 Add DeFI interactions before and after your trade</Trans>} />
                   </RowFixed>
                   <Toggle id="toggle-hooks-mode-button" isActive={hooksEnabled} toggle={toggleHooksEnabled} />
                 </RowBetween>

--- a/apps/cowswap-frontend/src/modules/yield/containers/YieldWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/yield/containers/YieldWidget/index.tsx
@@ -35,6 +35,7 @@ import {
   useYieldSettings,
   useYieldUnlockState,
 } from '../../hooks/useYieldSettings'
+
 import { useYieldWidgetActions } from '../../hooks/useYieldWidgetActions'
 import { PoolApyPreview } from '../../pure/PoolApyPreview'
 import { TargetPoolPreviewInfo } from '../../pure/TargetPoolPreviewInfo'


### PR DESCRIPTION
# Summary

This PR allows to enable the hooks using a user setting

For simplicity I only added it in SWAP tab's setting. I think is enough for this transitory state while is not enabled by default. 

# Test

go to SWAP
<img width="615" alt="image" src="https://github.com/user-attachments/assets/fa6e01e4-48e6-42d0-a9bf-89caa1cd581e">


See the new setting
<img width="787" alt="image" src="https://github.com/user-attachments/assets/39b0bcb6-bed0-45b0-81e0-61f5c8e97132">

and the tooltip
<img width="919" alt="image" src="https://github.com/user-attachments/assets/fc006ae0-4f9c-4002-b9b6-d858acd737ab">


Enable it and check that you see the new tab:

<img width="892" alt="image" src="https://github.com/user-attachments/assets/02e38c28-db7c-4db2-969d-b2c1cc742866">


