### PR TITLE
fix: add cow-shed page

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useNavigate.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useNavigate.ts
@@ -18,6 +18,14 @@ export function useNavigate(): NavigateFunction {
         ...options,
       })
     },
-    [navigate, isWidget]
+    [navigate, isWidget],
   )
+}
+
+export function useNavigateBack(): () => void {
+  const navigate = useNavigateOriginal()
+
+  return useCallback(() => {
+    navigate(-1)
+  }, [navigate])
 }

--- a/apps/cowswap-frontend/src/modules/application/containers/App/RoutesApp.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/App/RoutesApp.tsx
@@ -21,10 +21,10 @@ import Account, { AccountOverview } from 'pages/Account'
 import AdvancedOrdersPage from 'pages/AdvancedOrders'
 import AnySwapAffectedUsers from 'pages/error/AnySwapAffectedUsers'
 import { HooksPage } from 'pages/Hooks'
+import { CowShed } from 'pages/Hooks/cowShed'
 import LimitOrderPage from 'pages/LimitOrders'
 import { SwapPage } from 'pages/Swap'
 import YieldPage from 'pages/Yield'
-import { CowShed } from 'pages/Hooks/cowShed'
 
 // Async routes
 const NotFound = lazy(() => import(/* webpackChunkName: "not_found" */ 'pages/error/NotFound'))

--- a/apps/cowswap-frontend/src/modules/hooksStore/containers/HooksStoreWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/hooksStore/containers/HooksStoreWidget/index.tsx
@@ -24,7 +24,7 @@ type HookPosition = 'pre' | 'post'
 console.log(ICON_HOOK)
 
 export function HooksStoreWidget() {
-  const { account, chainId } = useWalletInfo()
+  const { chainId } = useWalletInfo()
   const [selectedHookPosition, setSelectedHookPosition] = useState<HookPosition | null>(null)
   const [hookToEdit, setHookToEdit] = useState<string | undefined>(undefined)
 

--- a/apps/cowswap-frontend/src/modules/hooksStore/containers/HooksStoreWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/hooksStore/containers/HooksStoreWidget/index.tsx
@@ -64,7 +64,6 @@ export function HooksStoreWidget() {
 
   const TopContent = shouldNotUseHooks ? undefined : isWrapOrUnwrap ? undefined : (
     <>
-      {account}
       <DismissableInlineBanner
         orientation={BannerOrientation.Horizontal}
         customIcon={ICON_HOOK}

--- a/apps/cowswap-frontend/src/modules/hooksStore/containers/RescueFundsFromProxy/index.tsx
+++ b/apps/cowswap-frontend/src/modules/hooksStore/containers/RescueFundsFromProxy/index.tsx
@@ -102,7 +102,7 @@ export function RescueFundsFromProxy({ onDismiss }: { onDismiss: Command }) {
     onSelectToken(selectedTokenAddress, undefined, undefined, setSelectedCurrency)
   }, [onSelectToken, selectedTokenAddress, setSelectedCurrency])
 
-  const etherscanLink = proxyAddress ? getEtherscanLink(chainId, 'address', proxyAddress) : undefined
+  const explorerLink = proxyAddress ? getEtherscanLink(chainId, 'address', proxyAddress) : undefined
 
   return (
     <Wrapper>
@@ -140,10 +140,10 @@ export function RescueFundsFromProxy({ onDismiss }: { onDismiss: Command }) {
               <strong>How do I unstuck my funds in CoW Shed?</strong>
               <ol>
                 <li>
-                  {etherscanLink ? (
-                    <ExternalLink href={etherscanLink}>Check in Etherscan</ExternalLink>
+                  {explorerLink ? (
+                    <ExternalLink href={explorerLink}>Check in the block explorer</ExternalLink>
                   ) : (
-                    'Check in Etherscan'
+                    'Check in block explorer'
                   )}{' '}
                   if your own CoW Shed has any token
                 </li>
@@ -153,8 +153,8 @@ export function RescueFundsFromProxy({ onDismiss }: { onDismiss: Command }) {
             </InlineBanner>
             <ProxyInfo>
               <h4>Proxy account:</h4>
-              {etherscanLink && (
-                <ExternalLink href={etherscanLink}>
+              {explorerLink && (
+                <ExternalLink href={explorerLink}>
                   <span>{proxyAddress} ↗</span>
                 </ExternalLink>
               )}

--- a/apps/cowswap-frontend/src/modules/hooksStore/containers/RescueFundsFromProxy/index.tsx
+++ b/apps/cowswap-frontend/src/modules/hooksStore/containers/RescueFundsFromProxy/index.tsx
@@ -25,7 +25,7 @@ import { useTokenContract } from 'common/hooks/useContract'
 import { CurrencySelectButton } from 'common/pure/CurrencySelectButton'
 import { NewModal } from 'common/pure/NewModal'
 
-import { Content, ProxyInfo, Wrapper } from './styled'
+import { Content, ProxyInfo, Wrapper, Title } from './styled'
 import { useRescueFundsFromProxy } from './useRescueFundsFromProxy'
 
 const BALANCE_UPDATE_INTERVAL = ms`5s`
@@ -131,7 +131,7 @@ export function RescueFundsFromProxy({ onDismiss }: { onDismiss: Command }) {
               an intermediary account who will do the trading on your behalf.
             </p>
 
-            <h3>Rescue funds</h3>
+            <Title>Rescue funds</Title>
             <p>
               Because this contract holds the funds temporarily, it's possible the funds are stuck in some edge cases.
               This tool will help you recover your funds.

--- a/apps/cowswap-frontend/src/modules/hooksStore/containers/RescueFundsFromProxy/styled.tsx
+++ b/apps/cowswap-frontend/src/modules/hooksStore/containers/RescueFundsFromProxy/styled.tsx
@@ -9,12 +9,6 @@ export const Wrapper = styled.div`
   margin: 0 auto;
   position: relative;
 
-  h3 {
-    font-size: 24px;
-    font-weight: 600;
-    margin: 10px 0;
-  }
-
   p {
     padding: 0.8rem 0 0.8rem 0;
   }
@@ -66,4 +60,10 @@ export const Content = styled.div`
   p {
     text-align: center;
   }
+`
+
+export const Title = styled.div`
+  font-size: 24px;
+  font-weight: 600;
+  margin: 10px 0;
 `

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
@@ -3,15 +3,18 @@ import { ReactNode, useCallback, useMemo, useState } from 'react'
 // import { useCurrencyAmountBalance } from '@cowprotocol/balances-and-allowances'
 import { NATIVE_CURRENCIES, TokenWithLogo } from '@cowprotocol/common-const'
 import { useIsTradeUnsupported } from '@cowprotocol/tokens'
+import { InlineBanner } from '@cowprotocol/ui'
 import { useWalletDetails, useWalletInfo } from '@cowprotocol/wallet'
 import { TradeType } from '@cowprotocol/widget-lib'
+
+import { Link } from 'react-router-dom'
 
 import { NetworkAlert } from 'legacy/components/NetworkAlert/NetworkAlert'
 import { useModalIsOpen } from 'legacy/state/application/hooks'
 import { ApplicationModal } from 'legacy/state/application/reducer'
 import { Field } from 'legacy/state/types'
 import { useHooksEnabledManager, useRecipientToggleManager, useUserTransactionTTL } from 'legacy/state/user/hooks'
-import { Routes } from 'common/constants/routes'
+
 
 import { useCurrencyAmountBalanceCombined } from 'modules/combinedBalances'
 import { useInjectedWidgetParams } from 'modules/injectedWidget'
@@ -46,6 +49,7 @@ import { useTradeSlippage } from 'modules/tradeSlippage'
 import { SettingsTab, TradeRateDetails, useHighFeeWarning } from 'modules/tradeWidgetAddons'
 import { useTradeUsdAmounts } from 'modules/usdAmount'
 
+import { Routes } from 'common/constants/routes'
 import { useSetLocalTimeOffset } from 'common/containers/InvalidLocalTimeWarning/localTimeOffsetState'
 import { useRateInfoParams } from 'common/hooks/useRateInfoParams'
 import { CurrencyInfo } from 'common/pure/CurrencyInputPanel/types'
@@ -54,8 +58,6 @@ import { SWAP_QUOTE_CHECK_INTERVAL } from 'common/updaters/FeesUpdater'
 import { useDerivedSwapInfo, useSwapActionHandlers, useSwapState } from '../../hooks/useSwapState'
 import { useTradeQuoteStateFromLegacy } from '../../hooks/useTradeQuoteStateFromLegacy'
 import { ConfirmSwapModalSetup } from '../ConfirmSwapModalSetup'
-import { InlineBanner } from '@cowprotocol/ui'
-import { Link } from 'react-router-dom'
 
 export interface SwapWidgetProps {
   topContent?: ReactNode

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
@@ -63,7 +63,7 @@ export interface SwapWidgetProps {
 }
 
 export function SwapWidget({ topContent, bottomContent }: SwapWidgetProps) {
-  const { chainId } = useWalletInfo()
+  const { chainId, account } = useWalletInfo()
   const { currencies, trade } = useDerivedSwapInfo()
   const slippage = useTradeSlippage()
   const parsedAmounts = useSwapCurrenciesAmounts()
@@ -317,7 +317,7 @@ export function SwapWidget({ topContent, bottomContent }: SwapWidgetProps) {
         />
 
         {!isHookTradeType && <NetworkAlert />}
-        {isHookTradeType && (
+        {isHookTradeType && !!account && (
           <InlineBanner>
             CoW Shed: <Link to={cowShedLink}>Recover funds</Link>
           </InlineBanner>

--- a/apps/cowswap-frontend/src/pages/Hooks/cowShed.tsx
+++ b/apps/cowswap-frontend/src/pages/Hooks/cowShed.tsx
@@ -1,6 +1,7 @@
+import { RescueFundsFromProxy } from 'modules/hooksStore/containers/RescueFundsFromProxy'
+
 import { useNavigateBack } from 'common/hooks/useNavigate'
 
-import { RescueFundsFromProxy } from 'modules/hooksStore/containers/RescueFundsFromProxy'
 
 export function CowShed() {
   const navigateBack = useNavigateBack()

--- a/apps/cowswap-frontend/src/pages/Hooks/cowShed.tsx
+++ b/apps/cowswap-frontend/src/pages/Hooks/cowShed.tsx
@@ -1,12 +1,13 @@
+import { useNavigateBack } from 'common/hooks/useNavigate'
+
 import { RescueFundsFromProxy } from 'modules/hooksStore/containers/RescueFundsFromProxy'
-import { useNavigate } from 'react-router-dom'
 
 export function CowShed() {
-  const navigate = useNavigate()
+  const navigateBack = useNavigateBack()
 
   return (
     <>
-      <RescueFundsFromProxy onDismiss={() => navigate(-1)} />
+      <RescueFundsFromProxy onDismiss={navigateBack} />
     </>
   )
 }


### PR DESCRIPTION
# Summary

This PR removes ther recue funds link from the top and move it to a banner on the top. It also hides the bridging banner that SWAP has (for bridging tokens in Gnosis Chain for example)

It also moves the content of cow-shed to a new page.

This page tries to give more context to the user on what cow-shed is, what his address, why would they want to need to rescue funds, and how do they do it


![image](https://github.com/user-attachments/assets/d18d53d3-95a1-4877-b334-b53cb21f407a)


![image](https://github.com/user-attachments/assets/e068b831-c77a-427d-8d97-02f3d564a636)
