### PR TITLE
chore: fix hooks store registry import

### DIFF
--- a/libs/hook-dapp-lib/src/index.ts
+++ b/libs/hook-dapp-lib/src/index.ts
@@ -3,5 +3,5 @@ export * from './hookDappIframeTransport'
 export * from './types'
 export * from './consts'
 export * from './utils'
-import * as hookDappsRegistry from './hookDappsRegistry.json'
+import hookDappsRegistry from './hookDappsRegistry.json'
 export { hookDappsRegistry }


### PR DESCRIPTION
# Summary

`hookDappsRegistry` was imported as JS module and had `default` property

![image](https://github.com/user-attachments/assets/e441474f-7918-48f6-b171-1daddbac0b18)
