### PR TITLE
feat: fix custom hook alert title and trim slash from url

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/ExternalSourceAlert/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ExternalSourceAlert/index.tsx
@@ -16,7 +16,7 @@ export function ExternalSourceAlert({ className, onChange, title, children }: Ex
   return (
     <styledEl.Contents className={className}>
       <AlertTriangle size={48} strokeWidth={1} />
-      <h3>{title}</h3>
+      <styledEl.Title>{title}</styledEl.Title>
       {children}
 
       <styledEl.AcceptanceBox>

--- a/apps/cowswap-frontend/src/common/pure/ExternalSourceAlert/styled.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ExternalSourceAlert/styled.tsx
@@ -14,22 +14,19 @@ export const Contents = styled.div`
   color: var(${UI.COLOR_DANGER_TEXT});
   background: var(${UI.COLOR_DANGER_BG});
 
-  h3 {
-    font-size: 24px;
-    text-align: center;
-    margin: 16px 0;
-    font-weight: bold;
-  }
-
-  p {
-    margin: 6px 0;
-  }
-
   > svg > path,
   > svg > line {
     stroke: var(${UI.COLOR_DANGER_TEXT});
     stroke-width: 2px;
   }
+`
+
+export const Title = styled.h4`
+  font-size: 24px;
+  text-align: center;
+  margin: 16px 0;
+  font-weight: bold;
+  width: 100%;
 `
 
 export const AcceptanceBox = styled.label`

--- a/apps/cowswap-frontend/src/modules/hooksStore/pure/AddCustomHookForm/index.tsx
+++ b/apps/cowswap-frontend/src/modules/hooksStore/pure/AddCustomHookForm/index.tsx
@@ -82,7 +82,7 @@ export function AddCustomHookForm({ addHookDapp, children, isPreHook, walletType
             type="text"
             placeholder="Enter a hook dapp URL"
             value={input}
-            onChange={(e) => setInput(e.target.value?.trim())}
+            onChange={(e) => setInput(e.target.value?.trim().replace(/\/+$/, ''))}
           />
 
           {/* Validation and Error Messages */}

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
@@ -326,6 +326,7 @@ export function SwapWidget({ topContent, bottomContent }: SwapWidgetProps) {
             iconSize={24}
             orientation={BannerOrientation.Horizontal}
             backDropBlur
+            margin="10px auto auto"
           >
             Funds stuck? <Link to={cowShedLink}>Recover your funds</Link>
           </InlineBanner>


### PR DESCRIPTION
# Summary

- Addresses https://github.com/cowprotocol/cowswap/issues/5078
- Partly addresses https://github.com/cowprotocol/cowswap/issues/5116 (doesn't change the message)


https://github.com/user-attachments/assets/80a2d418-c771-4e0f-ab2c-14fb95c50390

<img width="519" alt="Screenshot 2024-11-20 at 17 35 11" src="https://github.com/user-attachments/assets/5544fa9e-3f12-4d07-bab8-c91344f702ba">

## To test:
- Add custom post hook
- Paste url `https://cow-hooks-dapps-create-vesting.vercel.app/`
- Should automatically trim the last '/' from the url to `https://cow-hooks-dapps-create-vesting.vercel.app`