### PR TITLE
feat(explorer): add search bar in order view

### DIFF
--- a/apps/explorer/src/explorer/pages/Order.tsx
+++ b/apps/explorer/src/explorer/pages/Order.tsx
@@ -1,27 +1,20 @@
 import { Helmet } from 'react-helmet'
 import styled from 'styled-components/macro'
 
-import { Wrapper as WrapperMod } from './styled'
+import { Wrapper as WrapperMod, StyledSearch } from './styled'
 
 import RedirectToSearch from '../../components/RedirectToSearch'
 import { useOrderIdParam } from '../../hooks/useSanitizeOrderIdAndUpdateUrl'
 import { isAnOrderId } from '../../utils'
-import { Search } from '../components/common/Search'
 import { OrderWidget } from '../components/OrderWidget'
 import { APP_TITLE } from '../const'
 
 const Wrapper = styled(WrapperMod)`
   max-width: 140rem;
-  padding: 1.6rem;
 
   > h1 {
     padding: 2.4rem 0 0.75rem;
   }
-`
-
-const StyledSearch = styled(Search)`
-  width: 100%;
-  max-width: 60rem;
 `
 
 const Order = () => {

--- a/apps/explorer/src/explorer/pages/Order.tsx
+++ b/apps/explorer/src/explorer/pages/Order.tsx
@@ -6,15 +6,22 @@ import { Wrapper as WrapperMod } from './styled'
 import RedirectToSearch from '../../components/RedirectToSearch'
 import { useOrderIdParam } from '../../hooks/useSanitizeOrderIdAndUpdateUrl'
 import { isAnOrderId } from '../../utils'
+import { Search } from '../components/common/Search'
 import { OrderWidget } from '../components/OrderWidget'
 import { APP_TITLE } from '../const'
 
 const Wrapper = styled(WrapperMod)`
   max-width: 140rem;
+  padding: 1.6rem;
 
   > h1 {
     padding: 2.4rem 0 0.75rem;
   }
+`
+
+const StyledSearch = styled(Search)`
+  width: 100%;
+  max-width: 60rem;
 `
 
 const Order = () => {
@@ -29,6 +36,7 @@ const Order = () => {
       <Helmet>
         <title>Order Details - {APP_TITLE}</title>
       </Helmet>
+      <StyledSearch />
       <OrderWidget />
     </Wrapper>
   )

--- a/apps/explorer/src/explorer/pages/TransactionDetails.tsx
+++ b/apps/explorer/src/explorer/pages/TransactionDetails.tsx
@@ -1,7 +1,7 @@
 import { Helmet } from 'react-helmet'
 import { useParams } from 'react-router'
 
-import { Wrapper } from './styled'
+import { Wrapper, StyledSearch } from './styled'
 
 import RedirectToSearch from '../../components/RedirectToSearch'
 import { useNetworkId } from '../../state/network'
@@ -24,6 +24,7 @@ const TransactionDetails = () => {
       <Helmet>
         <title>Transaction Details - {APP_TITLE}</title>
       </Helmet>
+      <StyledSearch />
       {txHashWithOx && <TransactionsTableWidget txHash={txHashWithOx} networkId={networkId} />}
     </Wrapper>
   )

--- a/apps/explorer/src/explorer/pages/UserDetails.tsx
+++ b/apps/explorer/src/explorer/pages/UserDetails.tsx
@@ -4,7 +4,7 @@ import { Helmet } from 'react-helmet'
 import { useParams } from 'react-router'
 import styled from 'styled-components/macro'
 
-import { TitleAddress, Wrapper as WrapperMod, FlexContainerVar } from './styled'
+import { TitleAddress, Wrapper as WrapperMod, FlexContainerVar, StyledSearch } from './styled'
 
 import { BlockExplorerLink } from '../../components/common/BlockExplorerLink'
 import CowLoading from '../../components/common/CowLoading'
@@ -30,6 +30,7 @@ const UserDetails: React.FC = () => {
       <Helmet>
         <title>User Details - {APP_TITLE}</title>
       </Helmet>
+      <StyledSearch />
       {addressAccount ? (
         <>
           <FlexContainerVar>

--- a/apps/explorer/src/explorer/pages/styled.tsx
+++ b/apps/explorer/src/explorer/pages/styled.tsx
@@ -108,7 +108,7 @@ export const ContentCard = styled.div`
 `
 
 export const StyledSearch = styled(Search)`
-  width: 100%;
+  width: calc(100% - 3.2rem);
   max-width: 60rem;
 
   ${Media.upToMedium()} {

--- a/apps/explorer/src/explorer/pages/styled.tsx
+++ b/apps/explorer/src/explorer/pages/styled.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
 import { RowWithCopyButton } from '../../components/common/RowWithCopyButton'
+import { Search } from '../components/common/Search'
 
 export const Wrapper = styled.div`
   padding: 1.6rem;
@@ -103,5 +104,14 @@ export const ContentCard = styled.div`
   p {
     line-height: ${({ theme }): string => theme.fontLineHeight};
     overflow-wrap: break-word;
+  }
+`
+
+export const StyledSearch = styled(Search)`
+  width: 100%;
+  max-width: 60rem;
+
+  ${Media.upToMedium()} {
+    margin: 1.6rem;
   }
 `


### PR DESCRIPTION
# Summary

Adding a search bar in order view s.t. users don't have to go back to homepage to look up other orders!
I used `max-width: 60rem`, `padding: 1.6rem` & styled component for consistency with this repo's convention and compatibility.

- Full-screen view
![image](https://github.com/user-attachments/assets/21fa05ef-fd07-4e6a-a4fe-698dc96d917a)
- Mobile view
![image](https://github.com/user-attachments/assets/2080cd17-e7fa-4c15-b736-196cda02477c)
- When order id doesn't exist
![image](https://github.com/user-attachments/assets/d337439b-6280-473c-a59d-4ff1ac214650)


# To Test

1. UI components are responsive in different views

- [x] In any view, the search bar should have paddings on all sides
- [x] In narrower views, the search bar will become shorter but eventually the width stops shortening

2. The search bar can work/search 

- [x] Insert diff order ids and hit enter should be directed to diff order views

3.  The search bar won't show up when there's already a search bar at `Search not found` page

- [x] Insert invalid order id to make sure there's no a second search bar