### PR TITLE
fix(volume-fee): do not add fee for USDC.e on arb

### DIFF
--- a/libs/common-const/src/tokens.ts
+++ b/libs/common-const/src/tokens.ts
@@ -175,6 +175,15 @@ const USDE_ARBITRUM_ONE = new TokenWithLogo(
   'USDe',
 )
 
+const USDCE_ARBITRUM_ONE = new TokenWithLogo(
+  cowprotocolTokenLogoUrl('0xff970a61a04b1ca14834a43f5de4533ebddb5cc8', SupportedChainId.ARBITRUM_ONE),
+  SupportedChainId.ARBITRUM_ONE,
+  '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8',
+  6,
+  'USDC',
+  'USD Coin (Arb1)',
+)
+
 const USDM_ARBITRUM_ONE = new TokenWithLogo(
   cowprotocolTokenLogoUrl('0x59d9356e565ab3a36dd77763fc0d87feaf85508c', SupportedChainId.ARBITRUM_ONE),
   SupportedChainId.ARBITRUM_ONE,
@@ -352,6 +361,7 @@ const ARBITRUM_ONE_STABLECOINS = [
   USDT_ARBITRUM_ONE.address,
   USDE_ARBITRUM_ONE.address,
   USDM_ARBITRUM_ONE.address,
+  USDCE_ARBITRUM_ONE.address,
   FRAX_ARBITRUM_ONE.address,
   MIM_ARBITRUM_ONE.address,
 ].map((t) => t.toLowerCase())


### PR DESCRIPTION
# Summary

Fixes #5114

Added USDC.e (https://arbiscan.io/address/0xff970a61a04b1ca14834a43f5de4533ebddb5cc8) to the stablecoins list on Arbitrum (stablecoins are not taxed by volume-fee)

Docs update: https://github.com/cowprotocol/docs/pull/431

# To Test

1. Set USDC.e/USDT swap on Arbitrum
2. Expand price details
- [ ] Fee FREE should be displayed
