### PR TITLE
fix(limit-orders): do not crash when sell amount is giant

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/NumericalInput/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/NumericalInput/index.tsx
@@ -102,7 +102,7 @@ export const Input = React.memo(function InnerInput({
       pattern="^[0-9]*[.,]?[0-9]*$"
       placeholder={placeholder || '0.0'}
       minLength={1}
-      maxLength={79}
+      maxLength={32}
       spellCheck="false"
     />
   )

--- a/apps/cowswap-frontend/src/modules/limitOrders/updaters/QuoteObserverUpdater/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/updaters/QuoteObserverUpdater/index.tsx
@@ -35,7 +35,14 @@ export function QuoteObserverUpdater() {
     const price = FractionUtils.fractionLikeToFraction(new Price({ baseAmount: sellAmount, quoteAmount: buyAmount }))
     const marketRate = price.subtract(price.multiply(LIMIT_ORDERS_PRICE_SLIPPAGE.divide(100)))
 
-    updateLimitRateState({ marketRate, feeAmount })
+    const biggestDecimal = Math.max(sellAmount.currency.decimals, buyAmount.currency.decimals)
+    /**
+     * In case when inputted sell amount is enormously big and the price is very small
+     * App crashes with "Invariant failed"
+     */
+    const isPriceInvalid = +marketRate.toFixed(biggestDecimal) === 0
+
+    updateLimitRateState({ marketRate: isPriceInvalid ? null : marketRate, feeAmount })
   }, [response, inputCurrency, outputCurrency, updateLimitRateState])
 
   return null


### PR DESCRIPTION
# Summary

Fixes #5110

1. Added a condition in order to avoid price calculation when sell amount is enormuosly big to avoid app crashing
2. Limited amount input with 32 chars (it was 79 since 2020)

# To Test

See #5110
