### PR TITLE
feat(widget): add maxHeight parameter for the widget

### DIFF
--- a/apps/widget-configurator/src/app/configurator/index.tsx
+++ b/apps/widget-configurator/src/app/configurator/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { ChangeEvent, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 
 import { useAvailableChains } from '@cowprotocol/common-hooks'
 import { CowWidgetEventListeners } from '@cowprotocol/events'
@@ -20,6 +20,7 @@ import List from '@mui/material/List'
 import ListItemButton from '@mui/material/ListItemButton'
 import ListItemIcon from '@mui/material/ListItemIcon'
 import ListItemText from '@mui/material/ListItemText'
+import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import { useWeb3ModalAccount, useWeb3ModalTheme } from '@web3modal/ethers5/react'
 
@@ -53,6 +54,7 @@ import { ConfiguratorState, TokenListItem } from './types'
 import { ColorModeContext } from '../../theme/ColorModeContext'
 import { connectWalletToConfiguratorGA } from '../analytics'
 import { EmbedDialog } from '../embedDialog'
+import Button from '@mui/material/Button'
 
 declare global {
   interface Window {
@@ -129,6 +131,9 @@ export function Configurator({ title }: { title: string }) {
   const [customImages] = customImagesState
   const [customSounds] = customSoundsState
 
+  const [rawParams, setRawParams] = useState<string | undefined>()
+  const [isWidgetDisplayed, setIsWidgetDisplayed] = useState(true)
+
   const paletteManager = useColorPaletteManager(mode)
   const { colorPalette, defaultPalette } = paletteManager
 
@@ -183,6 +188,15 @@ export function Configurator({ title }: { title: string }) {
     hideOrdersTable,
   }
 
+  const rawParamsObject = useMemo(() => {
+    if (!rawParams) return undefined
+    try {
+      return JSON.parse(rawParams)
+    } catch {
+      return undefined
+    }
+  }, [rawParams])
+
   const computedParams = useWidgetParams(state)
   const params = useMemo(
     () => ({
@@ -190,10 +204,17 @@ export function Configurator({ title }: { title: string }) {
       images: customImages,
       sounds: customSounds,
       customTokens,
+      ...rawParamsObject,
       ...window.cowSwapWidgetParams,
     }),
     [computedParams, customImages, customSounds, customTokens],
   )
+
+  const updateWidget = useCallback(() => {
+    setIsWidgetDisplayed(false)
+
+    setTimeout(() => setIsWidgetDisplayed(true), 100)
+  }, [])
 
   useEffect(() => {
     setThemeMode(mode)
@@ -338,6 +359,20 @@ export function Configurator({ title }: { title: string }) {
           </RadioGroup>
         </FormControl>
 
+        <TextField
+          fullWidth
+          margin="dense"
+          id="rawParams"
+          label="Raw JSON params"
+          value={rawParams}
+          onChange={(e) => setRawParams(e.target.value)}
+          size="medium"
+        />
+
+        <Button sx={{ width: '100%' }} variant="contained" onClick={updateWidget}>
+          Update widget
+        </Button>
+
         {isDrawerOpen && (
           <Fab
             size="small"
@@ -381,11 +416,13 @@ export function Configurator({ title }: { title: string }) {
               open={dialogOpen}
               handleClose={handleDialogClose}
             />
-            <CowSwapWidget
-              params={params}
-              provider={!IS_IFRAME && !standaloneMode ? provider : undefined}
-              listeners={listeners}
-            />
+            {isWidgetDisplayed && (
+              <CowSwapWidget
+                params={params}
+                provider={!IS_IFRAME && !standaloneMode ? provider : undefined}
+                listeners={listeners}
+              />
+            )}
           </>
         )}
       </Box>

--- a/apps/widget-configurator/src/app/configurator/index.tsx
+++ b/apps/widget-configurator/src/app/configurator/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { ChangeEvent, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 
 import { useAvailableChains } from '@cowprotocol/common-hooks'
 import { CowWidgetEventListeners } from '@cowprotocol/events'
@@ -13,6 +13,7 @@ import KeyboardDoubleArrowLeftIcon from '@mui/icons-material/KeyboardDoubleArrow
 import LanguageIcon from '@mui/icons-material/Language'
 import { FormControl, FormControlLabel, FormLabel, IconButton, Radio, RadioGroup, Snackbar } from '@mui/material'
 import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
 import Divider from '@mui/material/Divider'
 import Drawer from '@mui/material/Drawer'
 import Fab from '@mui/material/Fab'
@@ -54,7 +55,6 @@ import { ConfiguratorState, TokenListItem } from './types'
 import { ColorModeContext } from '../../theme/ColorModeContext'
 import { connectWalletToConfiguratorGA } from '../analytics'
 import { EmbedDialog } from '../embedDialog'
-import Button from '@mui/material/Button'
 
 declare global {
   interface Window {
@@ -207,7 +207,7 @@ export function Configurator({ title }: { title: string }) {
       ...rawParamsObject,
       ...window.cowSwapWidgetParams,
     }),
-    [computedParams, customImages, customSounds, customTokens],
+    [computedParams, customImages, customSounds, customTokens, rawParamsObject],
   )
 
   const updateWidget = useCallback(() => {

--- a/libs/widget-lib/package.json
+++ b/libs/widget-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/widget-lib",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "type": "commonjs",
   "description": "CoW Swap Widget Library. Allows you to easily embed a CoW Swap widget on your website.",
   "main": "index.js",

--- a/libs/widget-lib/src/cowSwapWidget.ts
+++ b/libs/widget-lib/src/cowSwapWidget.ts
@@ -64,7 +64,7 @@ export function createCowSwapWidget(container: HTMLElement, props: CowSwapWidget
   windowListeners.push(sendAppCodeOnActivation(iframeWindow, params.appCode))
 
   // 4. Handle widget height changes
-  windowListeners.push(...listenToHeightChanges(iframe, params.height))
+  windowListeners.push(...listenToHeightChanges(iframe, params.height, params.maxHeight))
 
   // 5. Intercept deeplinks navigation in the iframe
   windowListeners.push(interceptDeepLinks())
@@ -223,14 +223,19 @@ function interceptDeepLinks() {
  *
  * @param iframe - The HTMLIFrameElement of the widget.
  * @param defaultHeight - Default height for the widget.
+ * @param maxHeight - Maximum height for the widget.
  */
-function listenToHeightChanges(iframe: HTMLIFrameElement, defaultHeight = DEFAULT_HEIGHT): WindowListener[] {
+function listenToHeightChanges(
+  iframe: HTMLIFrameElement,
+  defaultHeight = DEFAULT_HEIGHT,
+  maxHeight = `${document.body.offsetHeight}px`,
+): WindowListener[] {
   return [
     widgetIframeTransport.listenToMessageFromWindow(window, WidgetMethodsEmit.UPDATE_HEIGHT, (data) => {
       iframe.style.height = data.height ? `${data.height + HEIGHT_THRESHOLD}px` : defaultHeight
     }),
     widgetIframeTransport.listenToMessageFromWindow(window, WidgetMethodsEmit.SET_FULL_HEIGHT, ({ isUpToSmall }) => {
-      iframe.style.height = isUpToSmall ? defaultHeight : `${document.body.offsetHeight}px`
+      iframe.style.height = isUpToSmall ? defaultHeight : maxHeight
     }),
   ]
 }

--- a/libs/widget-lib/src/cowSwapWidget.ts
+++ b/libs/widget-lib/src/cowSwapWidget.ts
@@ -228,14 +228,16 @@ function interceptDeepLinks() {
 function listenToHeightChanges(
   iframe: HTMLIFrameElement,
   defaultHeight = DEFAULT_HEIGHT,
-  maxHeight = `${document.body.offsetHeight}px`,
+  maxHeight?: number,
 ): WindowListener[] {
   return [
     widgetIframeTransport.listenToMessageFromWindow(window, WidgetMethodsEmit.UPDATE_HEIGHT, (data) => {
-      iframe.style.height = data.height ? `${data.height + HEIGHT_THRESHOLD}px` : defaultHeight
+      const newHeight = data.height ? data.height + HEIGHT_THRESHOLD : undefined
+
+      iframe.style.height = newHeight ? `${maxHeight ? Math.min(newHeight, maxHeight) : newHeight}px` : defaultHeight
     }),
     widgetIframeTransport.listenToMessageFromWindow(window, WidgetMethodsEmit.SET_FULL_HEIGHT, ({ isUpToSmall }) => {
-      iframe.style.height = isUpToSmall ? defaultHeight : maxHeight
+      iframe.style.height = isUpToSmall ? defaultHeight : `${maxHeight || document.body.offsetHeight}px`
     }),
   ]
 }

--- a/libs/widget-lib/src/types.ts
+++ b/libs/widget-lib/src/types.ts
@@ -205,6 +205,11 @@ export interface CowSwapWidgetParams {
   height?: string
 
   /**
+   * The maximum height of the widget in pixels. Default: body.offsetHeight
+   */
+  maxHeight?: string
+
+  /**
    * Network ID.
    */
   chainId?: SupportedChainId

--- a/libs/widget-lib/src/types.ts
+++ b/libs/widget-lib/src/types.ts
@@ -207,7 +207,7 @@ export interface CowSwapWidgetParams {
   /**
    * The maximum height of the widget in pixels. Default: body.offsetHeight
    */
-  maxHeight?: string
+  maxHeight?: number
 
   /**
    * Network ID.


### PR DESCRIPTION
# Summary

https://www.titanxhub.com/swap - if you click "connect wallet" in the widget here, you will see that the modal is displayed not correctly.
It happens because we always take `document.body.offsetHeight` as a max height for the widget.
In order to handle that, I've added a new parameter - `maxHeight`.

# To Test

1. Scroll widget configurator settings to the bottom (see the pic bellow)
2. Input `{"maxHeight": 200}` in "Raw JSON params" field
3. Click "Update widget"
- [ ] Widget height should be limited up to 200px

<img width="289" alt="image" src="https://github.com/user-attachments/assets/5e9d7ff4-c33f-42cc-85c6-bc0af8e30def">

