### PR TITLE
feat: allow adding networks without invalidating local-storage

### DIFF
--- a/apps/cowswap-frontend/src/modules/hooksStore/state/customHookDappsAtom.ts
+++ b/apps/cowswap-frontend/src/modules/hooksStore/state/customHookDappsAtom.ts
@@ -18,7 +18,7 @@ type CustomHooksState = {
 
 const EMPTY_STATE: CustomHooksState = { pre: {}, post: {} }
 
-const customHookDappsInner = atomWithStorage<Record<SupportedChainId, CustomHooksState>>(
+const customHookDappsInner = atomWithStorage<Record<SupportedChainId, CustomHooksState | undefined>>(
   'customHookDappsAtom:v1',
   mapSupportedNetworks(EMPTY_STATE),
   getJotaiIsolatedStorage(),
@@ -48,7 +48,7 @@ export const upsertCustomHookDappAtom = atom(null, (get, set, isPreHook: boolean
     [chainId]: {
       ...state[chainId],
       [isPreHook ? 'pre' : 'post']: {
-        ...state[chainId][isPreHook ? 'pre' : 'post'],
+        ...(state[chainId] && state[chainId][isPreHook ? 'pre' : 'post']),
         [dapp.url]: dapp,
       },
     },
@@ -60,8 +60,12 @@ export const removeCustomHookDappAtom = atom(null, (get, set, dapp: HookDappIfra
   const state = get(customHookDappsInner)
   const currentState = { ...state[chainId] }
 
-  delete currentState.pre[dapp.url]
-  delete currentState.post[dapp.url]
+  if (currentState.pre) {
+    delete currentState.pre[dapp.url]
+  }
+  if (currentState.post) {
+    delete currentState.post[dapp.url]
+  }
 
   set(customHookDappsInner, {
     ...state,

--- a/apps/cowswap-frontend/src/modules/hooksStore/state/hookDetailsAtom.ts
+++ b/apps/cowswap-frontend/src/modules/hooksStore/state/hookDetailsAtom.ts
@@ -12,7 +12,7 @@ export type HooksStoreState = {
 }
 
 type StatePerAccount = Record<string, HooksStoreState>
-type StatePerNetwork = Record<SupportedChainId, StatePerAccount>
+type StatePerNetwork = Record<SupportedChainId, StatePerAccount | undefined>
 
 const EMPTY_STATE: HooksStoreState = {
   preHooks: [],
@@ -29,7 +29,7 @@ export const hooksAtom = atom((get) => {
   const { chainId, account = '' } = get(walletInfoAtom)
   const state = get(hooksAtomInner)
 
-  return state[chainId][account] || EMPTY_STATE
+  return (state[chainId] && state[chainId][account]) || EMPTY_STATE
 })
 
 export const setHooksAtom = atom(null, (get, set, update: SetStateAction<HooksStoreState>) => {
@@ -40,7 +40,8 @@ export const setHooksAtom = atom(null, (get, set, update: SetStateAction<HooksSt
       ...state,
       [chainId]: {
         ...state[chainId],
-        [account]: typeof update === 'function' ? update(state[chainId][account] || EMPTY_STATE) : update,
+        [account]:
+          typeof update === 'function' ? update((state[chainId] && state[chainId][account]) || EMPTY_STATE) : update,
       },
     }
   })

--- a/apps/cowswap-frontend/src/modules/hooksStore/state/hookDetailsAtom.ts
+++ b/apps/cowswap-frontend/src/modules/hooksStore/state/hookDetailsAtom.ts
@@ -5,6 +5,7 @@ import { getJotaiIsolatedStorage } from '@cowprotocol/core'
 import { mapSupportedNetworks, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { CowHookDetails } from '@cowprotocol/hook-dapp-lib'
 import { walletInfoAtom } from '@cowprotocol/wallet'
+import { PersistentStateByChain } from '@cowprotocol/types'
 
 export type HooksStoreState = {
   preHooks: CowHookDetails[]
@@ -12,7 +13,7 @@ export type HooksStoreState = {
 }
 
 type StatePerAccount = Record<string, HooksStoreState>
-type StatePerNetwork = Record<SupportedChainId, StatePerAccount | undefined>
+type StatePerNetwork = PersistentStateByChain<StatePerAccount>
 
 const EMPTY_STATE: HooksStoreState = {
   preHooks: [],
@@ -28,20 +29,22 @@ const hooksAtomInner = atomWithStorage<StatePerNetwork>(
 export const hooksAtom = atom((get) => {
   const { chainId, account = '' } = get(walletInfoAtom)
   const state = get(hooksAtomInner)
+  const stateForChain = state[chainId] || {}
 
-  return (state[chainId] && state[chainId][account]) || EMPTY_STATE
+  return stateForChain[account] || EMPTY_STATE
 })
 
 export const setHooksAtom = atom(null, (get, set, update: SetStateAction<HooksStoreState>) => {
   const { chainId, account = '' } = get(walletInfoAtom)
 
   set(hooksAtomInner, (state) => {
+    const stateForChain = state[chainId] || {}
+
     return {
       ...state,
       [chainId]: {
         ...state[chainId],
-        [account]:
-          typeof update === 'function' ? update((state[chainId] && state[chainId][account]) || EMPTY_STATE) : update,
+        [account]: typeof update === 'function' ? update(stateForChain[account] || EMPTY_STATE) : update,
       },
     }
   })

--- a/apps/cowswap-frontend/src/modules/permit/state/permittableTokensAtom.ts
+++ b/apps/cowswap-frontend/src/modules/permit/state/permittableTokensAtom.ts
@@ -16,10 +16,10 @@ type PermittableTokens = Record<string, PermitInfo>
  * Contains the permit info for every token checked locally
  */
 
-export const permittableTokensAtom = atomWithStorage<Record<SupportedChainId, PermittableTokens>>(
+export const permittableTokensAtom = atomWithStorage<Record<SupportedChainId, PermittableTokens | undefined>>(
   'permittableTokens:v3',
   mapSupportedNetworks({}),
-  getJotaiMergerStorage()
+  getJotaiMergerStorage(),
 )
 
 /**
@@ -30,8 +30,12 @@ export const addPermitInfoForTokenAtom = atom(
   (get, set, { chainId, tokenAddress, permitInfo }: AddPermitTokenParams) => {
     const permittableTokens = { ...get(permittableTokensAtom) }
 
+    if (!permittableTokens[chainId]) {
+      permittableTokens[chainId] = {}
+    }
+
     permittableTokens[chainId][tokenAddress.toLowerCase()] = permitInfo
 
     set(permittableTokensAtom, permittableTokens)
-  }
+  },
 )

--- a/apps/cowswap-frontend/src/modules/permit/state/permittableTokensAtom.ts
+++ b/apps/cowswap-frontend/src/modules/permit/state/permittableTokensAtom.ts
@@ -6,6 +6,7 @@ import { mapSupportedNetworks, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { PermitInfo } from '@cowprotocol/permit-utils'
 
 import { AddPermitTokenParams } from '../types'
+import { PersistentStateByChain } from '@cowprotocol/types'
 
 type PermittableTokens = Record<string, PermitInfo>
 
@@ -16,7 +17,7 @@ type PermittableTokens = Record<string, PermitInfo>
  * Contains the permit info for every token checked locally
  */
 
-export const permittableTokensAtom = atomWithStorage<Record<SupportedChainId, PermittableTokens | undefined>>(
+export const permittableTokensAtom = atomWithStorage<PersistentStateByChain<PermittableTokens>>(
   'permittableTokens:v3',
   mapSupportedNetworks({}),
   getJotaiMergerStorage(),
@@ -29,12 +30,12 @@ export const addPermitInfoForTokenAtom = atom(
   null,
   (get, set, { chainId, tokenAddress, permitInfo }: AddPermitTokenParams) => {
     const permittableTokens = { ...get(permittableTokensAtom) }
+    const permittableTokensForChain = permittableTokens[chainId] || {}
 
-    if (!permittableTokens[chainId]) {
-      permittableTokens[chainId] = {}
+    permittableTokens[chainId] = {
+      ...permittableTokensForChain,
+      [tokenAddress.toLowerCase()]: permitInfo,
     }
-
-    permittableTokens[chainId][tokenAddress.toLowerCase()] = permitInfo
 
     set(permittableTokensAtom, permittableTokens)
   },

--- a/apps/cowswap-frontend/src/modules/tradeSlippage/state/slippageValueAndTypeAtom.ts
+++ b/apps/cowswap-frontend/src/modules/tradeSlippage/state/slippageValueAndTypeAtom.ts
@@ -7,8 +7,9 @@ import { mapSupportedNetworks, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { walletInfoAtom } from '@cowprotocol/wallet'
 
 import { isEoaEthFlowAtom } from 'modules/trade'
+import { PersistentStateByChain } from '@cowprotocol/types'
 
-type SlippageBpsPerNetwork = Record<SupportedChainId, number | undefined>
+type SlippageBpsPerNetwork = PersistentStateByChain<number>
 
 type SlippageType = 'smart' | 'default' | 'user'
 

--- a/apps/cowswap-frontend/src/modules/tradeSlippage/state/slippageValueAndTypeAtom.ts
+++ b/apps/cowswap-frontend/src/modules/tradeSlippage/state/slippageValueAndTypeAtom.ts
@@ -8,16 +8,19 @@ import { walletInfoAtom } from '@cowprotocol/wallet'
 
 import { isEoaEthFlowAtom } from 'modules/trade'
 
-type SlippageBpsPerNetwork = Record<SupportedChainId, number | null>
+type SlippageBpsPerNetwork = Record<SupportedChainId, number | undefined>
 
 type SlippageType = 'smart' | 'default' | 'user'
 
 const normalTradeSlippageAtom = atomWithStorage<SlippageBpsPerNetwork>(
   'swapSlippageAtom:v0',
-  mapSupportedNetworks(null),
+  mapSupportedNetworks(undefined),
 )
 
-const ethFlowSlippageAtom = atomWithStorage<SlippageBpsPerNetwork>('ethFlowSlippageAtom:v0', mapSupportedNetworks(null))
+const ethFlowSlippageAtom = atomWithStorage<SlippageBpsPerNetwork>(
+  'ethFlowSlippageAtom:v0',
+  mapSupportedNetworks(undefined),
+)
 
 export const smartTradeSlippageAtom = atom<number | null>(null)
 

--- a/apps/cowswap-frontend/src/modules/usdAmount/services/fetchCurrencyUsdPrice.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/services/fetchCurrencyUsdPrice.ts
@@ -7,13 +7,13 @@ import { getCowProtocolUsdPrice } from '../apis/getCowProtocolUsdPrice'
 import { DEFILLAMA_PLATFORMS, DEFILLAMA_RATE_LIMIT_TIMEOUT, getDefillamaUsdPrice } from '../apis/getDefillamaUsdPrice'
 
 type UnknownCurrencies = { [address: string]: true }
-type UnknownCurrenciesMap = Record<SupportedChainId, UnknownCurrencies>
+type UnknownCurrenciesMap = Record<SupportedChainId, UnknownCurrencies | undefined>
 
 let coingeckoRateLimitHitTimestamp: null | number = null
 let defillamaRateLimitHitTimestamp: null | number = null
 
-const coingeckoUnknownCurrencies: Record<SupportedChainId, UnknownCurrencies> = mapSupportedNetworks({})
-const defillamaUnknownCurrencies: Record<SupportedChainId, UnknownCurrencies> = mapSupportedNetworks({})
+const coingeckoUnknownCurrencies: Record<SupportedChainId, UnknownCurrencies | undefined> = mapSupportedNetworks({})
+const defillamaUnknownCurrencies: Record<SupportedChainId, UnknownCurrencies | undefined> = mapSupportedNetworks({})
 
 function getShouldSkipCoingecko(currency: Token): boolean {
   return getShouldSkipPriceSource(
@@ -21,7 +21,7 @@ function getShouldSkipCoingecko(currency: Token): boolean {
     COINGECKO_PLATFORMS,
     coingeckoUnknownCurrencies,
     coingeckoRateLimitHitTimestamp,
-    COINGECKO_RATE_LIMIT_TIMEOUT
+    COINGECKO_RATE_LIMIT_TIMEOUT,
   )
 }
 
@@ -31,7 +31,7 @@ function getShouldSkipDefillama(currency: Token): boolean {
     DEFILLAMA_PLATFORMS,
     defillamaUnknownCurrencies,
     defillamaRateLimitHitTimestamp,
-    DEFILLAMA_RATE_LIMIT_TIMEOUT
+    DEFILLAMA_RATE_LIMIT_TIMEOUT,
   )
 }
 
@@ -40,13 +40,13 @@ function getShouldSkipPriceSource(
   platforms: Record<SupportedChainId, string | null>,
   unknownCurrenciesMap: UnknownCurrenciesMap,
   rateLimitTimestamp: null | number,
-  timeout: number
+  timeout: number,
 ): boolean {
   const chainId = currency.chainId as SupportedChainId
 
   if (!platforms[chainId]) return true
 
-  if (unknownCurrenciesMap[chainId][currency.address.toLowerCase()]) return true
+  if (unknownCurrenciesMap[chainId] && unknownCurrenciesMap[chainId][currency.address.toLowerCase()]) return true
 
   return !!rateLimitTimestamp && Date.now() - rateLimitTimestamp < timeout
 }
@@ -58,7 +58,7 @@ function getShouldSkipPriceSource(
  */
 export function fetchCurrencyUsdPrice(
   currency: Token,
-  getUsdcPrice: () => Promise<Fraction | null>
+  getUsdcPrice: () => Promise<Fraction | null>,
 ): Promise<Fraction | null> {
   const shouldSkipCoingecko = getShouldSkipCoingecko(currency)
   const shouldSkipDefillama = getShouldSkipDefillama(currency)
@@ -81,19 +81,19 @@ export function fetchCurrencyUsdPrice(
   // No coingecko. Try Defillama, then cow
   if (shouldSkipCoingecko) {
     return getDefillamaUsdPrice(currency).catch(
-      handleErrorFactory(currency, defillamaRateLimitHitTimestamp, defillamaUnknownCurrencies, getCowPrice)
+      handleErrorFactory(currency, defillamaRateLimitHitTimestamp, defillamaUnknownCurrencies, getCowPrice),
     )
   }
   // No Defillama. Try coingecko, then cow
   if (shouldSkipDefillama) {
     return getCoingeckoUsdPrice(currency).catch(
-      handleErrorFactory(currency, coingeckoRateLimitHitTimestamp, coingeckoUnknownCurrencies, getCowPrice)
+      handleErrorFactory(currency, coingeckoRateLimitHitTimestamp, coingeckoUnknownCurrencies, getCowPrice),
     )
   }
   // Both coingecko and defillama available. Try coingecko, then defillama, then cow
   return getCoingeckoUsdPrice(currency)
     .catch(
-      handleErrorFactory(currency, coingeckoRateLimitHitTimestamp, coingeckoUnknownCurrencies, getDefillamaUsdPrice)
+      handleErrorFactory(currency, coingeckoRateLimitHitTimestamp, coingeckoUnknownCurrencies, getDefillamaUsdPrice),
     )
     .catch(handleErrorFactory(currency, defillamaRateLimitHitTimestamp, defillamaUnknownCurrencies, getCowPrice))
 }
@@ -102,14 +102,22 @@ function handleErrorFactory(
   currency: Token,
   rateLimitTimestamp: null | number,
   unknownCurrenciesMap: UnknownCurrenciesMap,
-  fetchPriceFallback: (currency: Token) => Promise<Fraction | null>
+  fetchPriceFallback: (currency: Token) => Promise<Fraction | null>,
 ): ((reason: any) => Fraction | PromiseLike<Fraction | null> | null) | null | undefined {
   return (error) => {
     if (error instanceof RateLimitError) {
       rateLimitTimestamp = Date.now()
     } else if (error instanceof UnknownCurrencyError) {
       // Mark currency as unknown
-      unknownCurrenciesMap[currency.chainId as SupportedChainId][currency.address.toLowerCase()] = true
+      const chainId = currency.chainId as SupportedChainId
+      const unknownCurrenciesForChain = unknownCurrenciesMap[chainId]
+      const addressToLowercase = currency.address.toLowerCase()
+
+      if (unknownCurrenciesForChain === undefined) {
+        unknownCurrenciesMap[chainId] = { [addressToLowercase]: true }
+      } else {
+        unknownCurrenciesForChain[addressToLowercase] = true
+      }
     } else {
     }
 

--- a/apps/explorer/src/api/tenderly/tenderlyApi.ts
+++ b/apps/explorer/src/api/tenderly/tenderlyApi.ts
@@ -22,15 +22,15 @@ import { SPECIAL_ADDRESSES } from '../../explorer/const'
 export const ALIAS_TRADER_NAME = 'Trader'
 const COW_PROTOCOL_CONTRACT_NAME = 'GPv2Settlement'
 
-const API_BASE_URLs: Record<SupportedChainId, string> = mapSupportedNetworks(
-  (_networkId: SupportedChainId): string => `${TENDERLY_API_URL}/${_networkId}`
+const API_BASE_URLs: Record<SupportedChainId, string | undefined> = mapSupportedNetworks(
+  (_networkId: SupportedChainId): string => `${TENDERLY_API_URL}/${_networkId}`,
 )
 
 function _getApiBaseUrl(networkId: SupportedChainId): string {
   const baseUrl = API_BASE_URLs[networkId]
 
   if (!baseUrl) {
-    throw new Error('Unsupported Network. The tenderly API is not available in the SupportedChainId ' + networkId)
+    throw new Error('Unsupported Network. The tenderly API is not available or configured for chain id ' + networkId)
   } else {
     return baseUrl
   }
@@ -65,7 +65,7 @@ export async function getTransactionContracts(networkId: SupportedChainId, txHas
 
 export async function getTradesAndTransfers(
   networkId: SupportedChainId,
-  txHash: string
+  txHash: string,
 ): Promise<TxTradesAndTransfers> {
   const trace = await _fetchTrace(networkId, txHash)
 
@@ -132,7 +132,7 @@ export async function getTradesAccount(
   networkId: SupportedChainId,
   txHash: string,
   trades: Array<Trade>,
-  transfers: Array<Transfer>
+  transfers: Array<Transfer>,
 ): Promise<Map<string, Account>> {
   const contracts = await _fetchTradesAccounts(networkId, txHash)
 
@@ -146,7 +146,7 @@ export async function getTradesAccount(
 export function accountAddressesInvolved(
   contracts: Contract[],
   trades: Array<Trade>,
-  transfers: Array<Transfer>
+  transfers: Array<Transfer>,
 ): Map<string, Account> {
   const result = new Map()
 

--- a/apps/explorer/src/state/erc20/atoms.ts
+++ b/apps/explorer/src/state/erc20/atoms.ts
@@ -4,8 +4,9 @@ import { atomWithStorage } from 'jotai/utils'
 import { SupportedChainId, mapSupportedNetworks } from '@cowprotocol/cow-sdk'
 
 import { TokenErc20 } from '@gnosis.pm/dex-js'
+import { PersistentStateByChain } from '@cowprotocol/types'
 
-export type TokensLoadedFromChain = Record<SupportedChainId, Record<string, TokenErc20> | undefined>
+export type TokensLoadedFromChain = PersistentStateByChain<Record<string, TokenErc20>>
 
 const DEFAULT_TOKENS_LOADED_FROM_CHAIN: TokensLoadedFromChain = mapSupportedNetworks({})
 

--- a/apps/explorer/src/state/erc20/atoms.ts
+++ b/apps/explorer/src/state/erc20/atoms.ts
@@ -5,13 +5,13 @@ import { SupportedChainId, mapSupportedNetworks } from '@cowprotocol/cow-sdk'
 
 import { TokenErc20 } from '@gnosis.pm/dex-js'
 
-export type TokensLoadedFromChain = Record<SupportedChainId, Record<string, TokenErc20>>
+export type TokensLoadedFromChain = Record<SupportedChainId, Record<string, TokenErc20> | undefined>
 
 const DEFAULT_TOKENS_LOADED_FROM_CHAIN: TokensLoadedFromChain = mapSupportedNetworks({})
 
 export const tokensLoadedFromChainAtom = atomWithStorage<TokensLoadedFromChain>(
   'tokensLoadedFromChain:v0',
-  DEFAULT_TOKENS_LOADED_FROM_CHAIN
+  DEFAULT_TOKENS_LOADED_FROM_CHAIN,
 )
 
 type AddLoadedTokens = {
@@ -32,7 +32,7 @@ export const addLoadedTokensToChainAtom = atom(null, (get, set, { chainId, token
       }
       return acc
     },
-    { ...chainTokens }
+    { ...chainTokens },
   )
 
   set(tokensLoadedFromChainAtom, { ...current, [chainId]: updatedChainTokens })

--- a/libs/balances-and-allowances/src/state/balancesAtom.ts
+++ b/libs/balances-and-allowances/src/state/balancesAtom.ts
@@ -5,7 +5,7 @@ import { mapSupportedNetworks, SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import { Erc20MulticallState } from '../types'
 
-type BalancesCache = Record<SupportedChainId, Record<string, string>>
+type BalancesCache = Record<SupportedChainId, Record<string, string> | undefined>
 
 export interface BalancesState extends Erc20MulticallState {}
 

--- a/libs/balances-and-allowances/src/state/balancesAtom.ts
+++ b/libs/balances-and-allowances/src/state/balancesAtom.ts
@@ -4,8 +4,9 @@ import { getJotaiMergerStorage } from '@cowprotocol/core'
 import { mapSupportedNetworks, SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import { Erc20MulticallState } from '../types'
+import { PersistentStateByChain } from '@cowprotocol/types'
 
-type BalancesCache = Record<SupportedChainId, Record<string, string> | undefined>
+type BalancesCache = PersistentStateByChain<Record<string, string>>
 
 export interface BalancesState extends Erc20MulticallState {}
 

--- a/libs/balances-and-allowances/src/updaters/BalancesCacheUpdater.tsx
+++ b/libs/balances-and-allowances/src/updaters/BalancesCacheUpdater.tsx
@@ -34,7 +34,7 @@ export function BalancesCacheUpdater({ chainId, account }: { chainId: SupportedC
         {} as Record<string, string>,
       )
 
-      const currentCache = state[chainId]
+      const currentCache = state[chainId] || {}
       // Remove zero balances from the current cache
       const updatedCache = Object.keys(currentCache).reduce(
         (acc, tokenAddress) => {

--- a/libs/tokens/src/hooks/tokens/unsupported/useUnsupportedTokens.ts
+++ b/libs/tokens/src/hooks/tokens/unsupported/useUnsupportedTokens.ts
@@ -1,7 +1,8 @@
 import { useAtomValue } from 'jotai'
 
 import { currentUnsupportedTokensAtom } from '../../../state/tokens/unsupportedTokensAtom'
+import { UnsupportedTokensState } from '@cowprotocol/tokens'
 
-export function useUnsupportedTokens() {
-  return useAtomValue(currentUnsupportedTokensAtom)
+export function useUnsupportedTokens(): UnsupportedTokensState {
+  return useAtomValue(currentUnsupportedTokensAtom) || {}
 }

--- a/libs/tokens/src/state/tokenLists/tokenListsActionsAtom.ts
+++ b/libs/tokens/src/state/tokenLists/tokenListsActionsAtom.ts
@@ -36,6 +36,7 @@ export const upsertListsAtom = atom(null, (get, set, chainId: SupportedChainId, 
 export const addListAtom = atom(null, (get, set, state: ListState) => {
   const { chainId, widgetAppCode } = get(environmentAtom)
   const userAddedTokenLists = get(userAddedListsSourcesAtom)
+  const userAddedTokenListsForChain = userAddedTokenLists[chainId] || []
 
   state.isEnabled = true
 
@@ -45,7 +46,7 @@ export const addListAtom = atom(null, (get, set, state: ListState) => {
 
   set(userAddedListsSourcesAtom, {
     ...userAddedTokenLists,
-    [chainId]: userAddedTokenLists[chainId].concat({
+    [chainId]: userAddedTokenListsForChain.concat({
       widgetAppCode: state.widgetAppCode,
       priority: state.priority,
       source: state.source,
@@ -58,10 +59,11 @@ export const addListAtom = atom(null, (get, set, state: ListState) => {
 export const removeListAtom = atom(null, (get, set, source: string) => {
   const { chainId } = get(environmentAtom)
   const userAddedTokenLists = get(userAddedListsSourcesAtom)
+  const userAddedTokenListsForChain = userAddedTokenLists[chainId] || []
 
   set(userAddedListsSourcesAtom, {
     ...userAddedTokenLists,
-    [chainId]: userAddedTokenLists[chainId].filter((item) => item.source !== source),
+    [chainId]: userAddedTokenListsForChain.filter((item) => item.source !== source),
   })
 
   const stateCopy = { ...get(listsStatesByChainAtom) }

--- a/libs/tokens/src/state/tokenLists/tokenListsStateAtom.ts
+++ b/libs/tokens/src/state/tokenLists/tokenListsStateAtom.ts
@@ -46,14 +46,15 @@ export const userAddedListsSourcesAtom = atomWithStorage<ListsSourcesByNetwork>(
 export const allListsSourcesAtom = atom((get) => {
   const { chainId, useCuratedListOnly, isYieldEnabled } = get(environmentAtom)
   const userAddedTokenLists = get(userAddedListsSourcesAtom)
+  const userAddedTokenListsForChain = userAddedTokenLists[chainId] || []
 
   const lpLists = isYieldEnabled ? LP_TOKEN_LISTS : []
 
   if (useCuratedListOnly) {
-    return [get(curatedListSourceAtom), ...lpLists, ...userAddedTokenLists[chainId]]
+    return [get(curatedListSourceAtom), ...lpLists, ...userAddedTokenListsForChain]
   }
 
-  return [...DEFAULT_TOKENS_LISTS[chainId], ...lpLists, ...(userAddedTokenLists[chainId] || [])]
+  return [...(DEFAULT_TOKENS_LISTS[chainId] || []), ...lpLists, ...userAddedTokenListsForChain]
 })
 
 // Lists states
@@ -78,13 +79,14 @@ export const listsStatesMapAtom = atom((get) => {
   const allTokenListsInfo = get(listsStatesByChainAtom)
   const virtualListsState = get(virtualListsStateAtom)
   const userAddedTokenLists = get(userAddedListsSourcesAtom)
+  const useeAddedTokenListsForChain = userAddedTokenLists[chainId] || []
 
   const currentNetworkLists = {
     ...allTokenListsInfo[chainId],
     ...virtualListsState,
   }
 
-  const userAddedListSources = userAddedTokenLists[chainId].reduce<{ [key: string]: boolean }>((acc, list) => {
+  const userAddedListSources = useeAddedTokenListsForChain.reduce<{ [key: string]: boolean }>((acc, list) => {
     acc[list.source] = true
     return acc
   }, {})

--- a/libs/tokens/src/state/tokens/allTokensAtom.ts
+++ b/libs/tokens/src/state/tokens/allTokensAtom.ts
@@ -79,7 +79,7 @@ export const activeTokensAtom = atom<TokenWithLogo[]>((get) => {
     {
       [nativeToken.address.toLowerCase()]: nativeToken as TokenInfo,
       ...tokensMap.activeTokens,
-      ...lowerCaseTokensMap(userAddedTokens[chainId]),
+      ...lowerCaseTokensMap(userAddedTokens[chainId] || {}),
       ...lowerCaseTokensMap(favoriteTokensState[chainId]),
       ...(enableLpTokensByDefault
         ? Object.keys(tokensMap.inactiveTokens).reduce<TokensMap>((acc, key) => {

--- a/libs/tokens/src/state/tokens/unsupportedTokensAtom.ts
+++ b/libs/tokens/src/state/tokens/unsupportedTokensAtom.ts
@@ -7,10 +7,10 @@ import { mapSupportedNetworks, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { UnsupportedTokensState } from '../../types'
 import { environmentAtom } from '../environmentAtom'
 
-export const unsupportedTokensAtom = atomWithStorage<Record<SupportedChainId, UnsupportedTokensState>>(
+export const unsupportedTokensAtom = atomWithStorage<Record<SupportedChainId, UnsupportedTokensState | undefined>>(
   'unsupportedTokensAtom:v2',
   mapSupportedNetworks({}),
-  getJotaiMergerStorage()
+  getJotaiMergerStorage(),
 )
 
 export const currentUnsupportedTokensAtom = atom((get) => {
@@ -22,8 +22,9 @@ export const currentUnsupportedTokensAtom = atom((get) => {
 export const addUnsupportedTokenAtom = atom(null, (get, set, chainId: SupportedChainId, tokenAddress: string) => {
   const tokenId = tokenAddress.toLowerCase()
   const tokenList = get(unsupportedTokensAtom)
+  const tokenListForChain = tokenList[chainId] || {}
 
-  if (!tokenList[chainId][tokenId]) {
+  if (!tokenListForChain[tokenId]) {
     const update: UnsupportedTokensState = {
       ...tokenList[chainId],
       [tokenId]: { dateAdded: Date.now() },
@@ -39,11 +40,12 @@ export const addUnsupportedTokenAtom = atom(null, (get, set, chainId: SupportedC
 export const removeUnsupportedTokensAtom = atom(null, (get, set, tokenAddresses: Array<string>) => {
   const { chainId } = get(environmentAtom)
   const tokenList = { ...get(unsupportedTokensAtom) }
+  const tokenListForChain = tokenList[chainId] || {}
 
   tokenAddresses.forEach((tokenAddress) => {
     const tokenId = tokenAddress.toLowerCase()
 
-    delete tokenList[chainId][tokenId]
+    delete tokenListForChain[tokenId]
   })
 
   set(unsupportedTokensAtom, tokenList)

--- a/libs/tokens/src/state/tokens/unsupportedTokensAtom.ts
+++ b/libs/tokens/src/state/tokens/unsupportedTokensAtom.ts
@@ -6,8 +6,9 @@ import { mapSupportedNetworks, SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import { UnsupportedTokensState } from '../../types'
 import { environmentAtom } from '../environmentAtom'
+import { PersistentStateByChain } from '@cowprotocol/types'
 
-export const unsupportedTokensAtom = atomWithStorage<Record<SupportedChainId, UnsupportedTokensState | undefined>>(
+export const unsupportedTokensAtom = atomWithStorage<PersistentStateByChain<UnsupportedTokensState>>(
   'unsupportedTokensAtom:v2',
   mapSupportedNetworks({}),
   getJotaiMergerStorage(),

--- a/libs/tokens/src/state/tokens/userAddedTokensAtom.ts
+++ b/libs/tokens/src/state/tokens/userAddedTokensAtom.ts
@@ -8,8 +8,9 @@ import { Token } from '@uniswap/sdk-core'
 
 import { TokensMap } from '../../types'
 import { environmentAtom } from '../environmentAtom'
+import { PersistentStateByChain } from '@cowprotocol/types'
 
-export const userAddedTokensAtom = atomWithStorage<Record<SupportedChainId, TokensMap | undefined>>(
+export const userAddedTokensAtom = atomWithStorage<PersistentStateByChain<TokensMap>>(
   'userAddedTokensAtom:v1',
   mapSupportedNetworks({}),
   getJotaiMergerStorage(),

--- a/libs/tokens/src/state/tokens/userAddedTokensAtom.ts
+++ b/libs/tokens/src/state/tokens/userAddedTokensAtom.ts
@@ -9,17 +9,18 @@ import { Token } from '@uniswap/sdk-core'
 import { TokensMap } from '../../types'
 import { environmentAtom } from '../environmentAtom'
 
-export const userAddedTokensAtom = atomWithStorage<Record<SupportedChainId, TokensMap>>(
+export const userAddedTokensAtom = atomWithStorage<Record<SupportedChainId, TokensMap | undefined>>(
   'userAddedTokensAtom:v1',
   mapSupportedNetworks({}),
-  getJotaiMergerStorage()
+  getJotaiMergerStorage(),
 )
 
 export const userAddedTokensListAtom = atom((get) => {
   const { chainId } = get(environmentAtom)
   const userAddedTokensState = get(userAddedTokensAtom)
+  const userAddedTokenStateForChain = userAddedTokensState[chainId] || {}
 
-  return Object.values(userAddedTokensState[chainId]).map((token) => TokenWithLogo.fromToken(token, token.logoURI))
+  return Object.values(userAddedTokenStateForChain).map((token) => TokenWithLogo.fromToken(token, token.logoURI))
 })
 
 export const addUserTokenAtom = atom(null, (get, set, tokens: TokenWithLogo[]) => {

--- a/libs/tokens/src/types.ts
+++ b/libs/tokens/src/types.ts
@@ -19,7 +19,7 @@ export type ListSourceConfig = {
   source: string
 }
 
-export type ListsSourcesByNetwork = Record<SupportedChainId, Array<ListSourceConfig>>
+export type ListsSourcesByNetwork = Record<SupportedChainId, Array<ListSourceConfig> | undefined>
 
 export type TokensMap = { [address: string]: TokenInfo }
 

--- a/libs/tokens/src/types.ts
+++ b/libs/tokens/src/types.ts
@@ -1,5 +1,5 @@
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { LpTokenProvider, TokenInfo } from '@cowprotocol/types'
+import { LpTokenProvider, PersistentStateByChain, TokenInfo } from '@cowprotocol/types'
 import type { TokenList as UniTokenList } from '@uniswap/token-lists'
 
 export enum TokenListCategory {
@@ -19,7 +19,7 @@ export type ListSourceConfig = {
   source: string
 }
 
-export type ListsSourcesByNetwork = Record<SupportedChainId, Array<ListSourceConfig> | undefined>
+export type ListsSourcesByNetwork = PersistentStateByChain<Array<ListSourceConfig>>
 
 export type TokensMap = { [address: string]: TokenInfo }
 
@@ -34,4 +34,4 @@ export interface ListState extends Pick<ListSourceConfig, 'source' | 'priority' 
 
 export type TokenListsState = { [source: string]: ListState }
 
-export type TokenListsByChainState = Record<SupportedChainId, TokenListsState | undefined>
+export type TokenListsByChainState = PersistentStateByChain<TokenListsState>

--- a/libs/tokens/src/updaters/TokensListsUpdater/index.ts
+++ b/libs/tokens/src/updaters/TokensListsUpdater/index.ts
@@ -16,11 +16,12 @@ import { environmentAtom, updateEnvironmentAtom } from '../../state/environmentA
 import { upsertListsAtom } from '../../state/tokenLists/tokenListsActionsAtom'
 import { allListsSourcesAtom, tokenListsUpdatingAtom } from '../../state/tokenLists/tokenListsStateAtom'
 import { ListState } from '../../types'
+import { PersistentStateByChain } from '@cowprotocol/types'
 
 const LAST_UPDATE_TIME_DEFAULT = 0
 
 const { atom: lastUpdateTimeAtom, updateAtom: updateLastUpdateTimeAtom } = atomWithPartialUpdate(
-  atomWithStorage<Record<SupportedChainId, number | undefined>>(
+  atomWithStorage<PersistentStateByChain<number>>(
     'tokens:lastUpdateTimeAtom:v4',
     mapSupportedNetworks(LAST_UPDATE_TIME_DEFAULT),
     getJotaiMergerStorage(),

--- a/libs/tokens/src/updaters/TokensListsUpdater/index.ts
+++ b/libs/tokens/src/updaters/TokensListsUpdater/index.ts
@@ -17,10 +17,12 @@ import { upsertListsAtom } from '../../state/tokenLists/tokenListsActionsAtom'
 import { allListsSourcesAtom, tokenListsUpdatingAtom } from '../../state/tokenLists/tokenListsStateAtom'
 import { ListState } from '../../types'
 
+const LAST_UPDATE_TIME_DEFAULT = 0
+
 const { atom: lastUpdateTimeAtom, updateAtom: updateLastUpdateTimeAtom } = atomWithPartialUpdate(
-  atomWithStorage<Record<SupportedChainId, number>>(
+  atomWithStorage<Record<SupportedChainId, number | undefined>>(
     'tokens:lastUpdateTimeAtom:v4',
-    mapSupportedNetworks(0),
+    mapSupportedNetworks(LAST_UPDATE_TIME_DEFAULT),
     getJotaiMergerStorage(),
   ),
 )
@@ -70,7 +72,7 @@ export function TokensListsUpdater({
   const { data: listsStates, isLoading } = useSWR<ListState[] | null>(
     ['TokensListsUpdater', allTokensLists, chainId, lastUpdateTimeState],
     () => {
-      if (!getIsTimeToUpdate(lastUpdateTimeState[chainId])) return null
+      if (!getIsTimeToUpdate(lastUpdateTimeState[chainId] || LAST_UPDATE_TIME_DEFAULT)) return null
 
       return Promise.allSettled(allTokensLists.map(fetchTokenList)).then(getFulfilledResults)
     },

--- a/libs/types/src/common.ts
+++ b/libs/types/src/common.ts
@@ -1,3 +1,5 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
 export type Command = () => void
 
 export type StatefulValue<T> = [T, (value: T) => void]
@@ -35,3 +37,15 @@ export enum LpTokenProvider {
   SUSHI = 'SUSHI',
   PANCAKE = 'PANCAKE',
 }
+
+/**
+ * This helper type allows to define a state that is persisted by chain.
+ *
+ * For a lot of constants in the project we use Record<SupportedChainId, T> to model them, so when we add new chains, we will get a compile time error until we update the new value for the added chain.
+ * This patter is fine for this configuration constants.
+ *
+ * However, we can't use the same pattern for modeling persisted state (in local storage for example).
+ * The reason is that when a user recovers a persisted value from an older version where a chain didn't exist, it will return `undefined` when we try to access the value for the new chain.
+ * The type won't be correct, and typescript will make us assume that the value is always defined leading to hard to debug runtime errors.
+ */
+export type PersistentStateByChain<T> = Record<SupportedChainId, T | undefined>


### PR DESCRIPTION
# Summary

Make CoW Swap more resilient for run-time errors when we introduce new networks.

## Motivation
Every addition of a new chain makes us increase the version all the local storages that have some state per network.
This is because a lot of state is model as `Record<SupportedChainId, MyState>>`, because `SupportedChainId` type is changes with the addition of a network, we need to version the local storage key.

This makes all users to loose their state or settings.

What is worse is that, updating the version is something super easy to forget to do, and if you forget to do it for one of the states it will easily lead to a hard crash of the app that is:
- hard to debug
- hard to notice (only users with old states will have the issue)

The error comes from assuming the type of the deserialised state is the one defined in the app, which contains a state for a newly added chain, however because the object was serialised in the past, the state for that chain is undefined. 

Typescript will be unable to detect at compile time if you forgot to handle the undefined case. This will lead to run-time errors.

## Solution
Basically assume that the state can be undefined for all states that follow the pattern `Record<SupportedChainId, MyState>`. 

Because this pattern is very common, and we have a lot of persisted states by network, I defined a new helper type which makes the definition of the state simpler.

`type PersistentStateByChain<T> = Record<SupportedChainId, T | undefined>`



This way, we can turn this state:
`Record<SupportedChainId, CustomHooksState>>` 

into: 
`PersistentStateByChain<CustomHooksState>>`

And it will already assume that some chain might be un-initialised



# Test
This PR doesn't change any logic. So everything should work as before. 

Its a bit sensitive PR because it touches the state logic of many critical parts of the app, such as balances, token lists, etc
So probably good to test all flows.

If we want to stress test this PR, we could go to the local storage and delete the KEY for one chain we have. 
For example:

- For example, go to you local storage, and replace the content of `allTokenListsInfoAtom:v4` with `{}`
- You can try also to delete only one network instead of all of them, and see how it doesn't crash to use other networks, nor doesn't crash for the deleted network. 
   - For example, for key `hooksStoreAtom:v3` we can leave only mainnet `{"1":{}}`