### PR TITLE
fix: display usd value for tokens with small prices

### DIFF
--- a/apps/cowswap-frontend/src/modules/usdAmount/state/usdTokenPricesAtom.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/state/usdTokenPricesAtom.ts
@@ -28,7 +28,7 @@ export const usdTokenPricesAtom = atom((get) => {
   }, {})
 })
 
-const ONE_USDC_ATOM = new Fraction(1, 1_000_000)
+const MINIMAL_PRICE_VALUE = new Fraction(1, 1_000_000_000)
 
 function calculatePrice(currency: Token, price: Fraction | null): Price<Token, Token> | null {
   if (!price) {
@@ -37,8 +37,8 @@ function calculatePrice(currency: Token, price: Fraction | null): Price<Token, T
 
   const usdcToken = USDC[currency.chainId as SupportedChainId]
 
-  if (price.lessThan(ONE_USDC_ATOM)) {
-    // Less than 1 atom of USDC, cannot create a Price instance
+  if (price.lessThan(MINIMAL_PRICE_VALUE)) {
+    console.error('Price is too small, cannot create a Price instance', currency.address, currency, price)
     return null
   }
 


### PR DESCRIPTION
# Summary

USD value is not displayed for TITANX (address 0xf19308f923582a6f7c465e5ce7a9dc1bec6665b1) token because it's USD price value is too small.
@alfetopito [added](https://github.com/cowprotocol/cowswap/pull/3111) a threshold in this case, I just increased it from 1000000 up to 1000000000.

<img width="549" alt="image" src="https://github.com/user-attachments/assets/76988763-5ecc-456f-8df6-0c1c5465015b">


# To Test

1. Setup WETH/TITANX(0xf19308f923582a6f7c465e5ce7a9dc1bec6665b1) trade in Mainnet
- [ ] ER: USD value for the buy amount should be displayed