### PR TITLE
feat(volumeFee): add volume fee for Safe

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/TradeRateDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/TradeRateDetails/index.tsx
@@ -3,7 +3,7 @@ import React, { useState, useCallback } from 'react'
 import { useInjectedWidgetParams } from 'modules/injectedWidget'
 import { TradeTotalCostsDetails, PartnerFeeRow } from 'modules/trade'
 import { useUsdAmount } from 'modules/usdAmount'
-import { useVolumeFee } from 'modules/volumeFee'
+import { useVolumeFee, useVolumeFeeTooltip } from 'modules/volumeFee'
 
 import { RateInfoParams } from 'common/pure/RateInfo'
 
@@ -18,6 +18,7 @@ export function TradeRateDetails({ rateInfoParams }: TradeRateDetailsProps) {
   const widgetParams = useInjectedWidgetParams()
   const volumeFee = useVolumeFee()
   const partnerFeeAmount = useLimitOrderPartnerFeeAmount()
+  const volumeFeeTooltip = useVolumeFeeTooltip()
   const partnerFeeUsd = useUsdAmount(partnerFeeAmount).value
   const partnerFeeBps = volumeFee?.bps
 
@@ -33,6 +34,7 @@ export function TradeRateDetails({ rateInfoParams }: TradeRateDetailsProps) {
       partnerFeeAmount={partnerFeeAmount}
       partnerFeeBps={partnerFeeBps}
       widgetContent={widgetParams.content}
+      volumeFeeTooltip={volumeFeeTooltip}
     />
   )
 

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeBasicConfirmDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeBasicConfirmDetails/index.tsx
@@ -8,6 +8,7 @@ import { Nullish } from 'types'
 
 import { useInjectedWidgetParams } from 'modules/injectedWidget'
 import { useUsdAmount } from 'modules/usdAmount'
+import { useVolumeFeeTooltip } from 'modules/volumeFee'
 
 import { RateInfoParams } from 'common/pure/RateInfo'
 
@@ -64,6 +65,7 @@ export function TradeBasicConfirmDetails(props: Props) {
   } = props
   const isInvertedState = useState(false)
   const widgetParams = useInjectedWidgetParams()
+  const volumeFeeTooltip = useVolumeFeeTooltip()
   const { amountAfterFees, amountAfterSlippage } = getOrderTypeReceiveAmounts(receiveAmountInfo)
   const { networkCostsSuffix, networkCostsTooltipSuffix } = labelsAndTooltips || {}
 
@@ -109,6 +111,7 @@ export function TradeBasicConfirmDetails(props: Props) {
         alwaysRow={alwaysRow}
         networkCostsSuffix={networkCostsSuffix}
         networkCostsTooltipSuffix={networkCostsTooltipSuffix}
+        volumeFeeTooltip={volumeFeeTooltip}
       />
 
       <ReviewOrderModalAmountRow

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeFeesAndCosts/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeFeesAndCosts/index.tsx
@@ -16,6 +16,7 @@ interface TradeFeesAndCostsProps {
   networkCostsTooltipSuffix?: ReactNode
   withTimelineDot?: boolean
   alwaysRow?: boolean
+  volumeFeeTooltip?: string
 }
 
 export function TradeFeesAndCosts(props: TradeFeesAndCostsProps) {
@@ -26,6 +27,7 @@ export function TradeFeesAndCosts(props: TradeFeesAndCostsProps) {
     networkCostsTooltipSuffix,
     withTimelineDot = true,
     alwaysRow,
+    volumeFeeTooltip,
   } = props
 
   const networkFeeAmount = receiveAmountInfo && getOrderTypeReceiveAmounts(receiveAmountInfo).networkFeeAmount
@@ -46,6 +48,7 @@ export function TradeFeesAndCosts(props: TradeFeesAndCostsProps) {
         partnerFeeAmount={partnerFeeAmount}
         partnerFeeBps={partnerFeeBps}
         widgetContent={widgetParams.content}
+        volumeFeeTooltip={volumeFeeTooltip}
       />
 
       {/*Network cost*/}

--- a/apps/cowswap-frontend/src/modules/trade/pure/PartnerFeeRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/PartnerFeeRow/index.tsx
@@ -16,6 +16,7 @@ interface PartnerFeeRowProps {
   withTimelineDot: boolean
   alwaysRow?: boolean
   widgetContent?: CowSwapWidgetContent
+  volumeFeeTooltip?: string
 }
 
 export function PartnerFeeRow({
@@ -25,6 +26,7 @@ export function PartnerFeeRow({
   withTimelineDot,
   alwaysRow,
   widgetContent,
+  volumeFeeTooltip,
 }: PartnerFeeRowProps) {
   const feeAsPercent = partnerFeeBps ? formatPercent(bpsToPercent(partnerFeeBps)) : null
   const minPartnerFeeAmount = FractionUtils.amountToAtLeastOneWei(partnerFeeAmount)
@@ -38,8 +40,8 @@ export function PartnerFeeRow({
           fiatAmount={partnerFeeUsd}
           alwaysRow={alwaysRow}
           tooltip={
-            widgetContent?.feeTooltipMarkdown ? (
-              <WidgetMarkdownContent>{widgetContent.feeTooltipMarkdown}</WidgetMarkdownContent>
+            volumeFeeTooltip ? (
+              <WidgetMarkdownContent>{volumeFeeTooltip}</WidgetMarkdownContent>
             ) : (
               <>
                 This fee helps pay for maintenance & improvements to the trade experience.

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/TradeRateDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/TradeRateDetails/index.tsx
@@ -15,6 +15,7 @@ import {
 import { useTradeQuote } from 'modules/tradeQuote'
 import { useIsSlippageModified, useTradeSlippage } from 'modules/tradeSlippage'
 import { useUsdAmount } from 'modules/usdAmount'
+import { useVolumeFeeTooltip } from 'modules/volumeFee'
 
 import { NetworkCostsSuffix } from 'common/pure/NetworkCostsSuffix'
 import { RateInfoParams } from 'common/pure/RateInfo'
@@ -50,6 +51,7 @@ export function TradeRateDetails({ rateInfoParams, deadline, isTradePriceUpdatin
   }, [costsExceedFeeRaw, inputCurrency])
 
   const widgetParams = useInjectedWidgetParams()
+  const volumeFeeTooltip = useVolumeFeeTooltip()
   const networkFeeAmountUsd = useUsdAmount(networkFeeAmount).value
 
   const toggleAccordion = useCallback(() => {
@@ -88,6 +90,7 @@ export function TradeRateDetails({ rateInfoParams, deadline, isTradePriceUpdatin
         withTimelineDot={false}
         networkCostsSuffix={shouldPayGas ? <NetworkCostsSuffix /> : null}
         networkCostsTooltipSuffix={<NetworkCostsTooltipSuffix />}
+        volumeFeeTooltip={volumeFeeTooltip}
         alwaysRow
       />
       {slippage && (

--- a/apps/cowswap-frontend/src/modules/volumeFee/hooks/useVolumeFeeTooltip.ts
+++ b/apps/cowswap-frontend/src/modules/volumeFee/hooks/useVolumeFeeTooltip.ts
@@ -4,7 +4,7 @@ import { useInjectedWidgetParams } from '../../injectedWidget'
 import { safeAppFeeAtom } from '../state/safeAppFeeAtom'
 
 const SAFE_FEE_TOOLTIP =
-  'The [tiered widget fee](https://help.safe.global/en/articles/178530-how-does-the-widget-fee-work-for-native-swaps) incurred here is charged by CoW Protocol for the operation of this widget. The fee is automatically calculated into this quote. Part of the fee will contribute to a license fee that supports the Safe Community. Neither the Safe Ecosystem Foundation nor Safe{Wallet} operate the CoW Swap Widget and/or CoW Swap'
+  'The [Safe App Fee](https://help.safe.global/en/articles/178530-how-does-the-widget-fee-work-for-native-swaps) incurred here is charged by the Safe Foundation for the display of the app within their Safe Store. The fee is automatically calculated in this quote. Part of the fees will contribute to the CoW DAO treasury that supports the CoW Community.'
 
 export function useVolumeFeeTooltip() {
   const safeAppFee = useAtomValue(safeAppFeeAtom)

--- a/apps/cowswap-frontend/src/modules/volumeFee/hooks/useVolumeFeeTooltip.ts
+++ b/apps/cowswap-frontend/src/modules/volumeFee/hooks/useVolumeFeeTooltip.ts
@@ -4,7 +4,7 @@ import { useInjectedWidgetParams } from '../../injectedWidget'
 import { safeAppFeeAtom } from '../state/safeAppFeeAtom'
 
 const SAFE_FEE_TOOLTIP =
-  'The [Safe App Fee](https://help.safe.global/en/articles/178530-how-does-the-widget-fee-work-for-native-swaps) incurred here is charged by the Safe Foundation for the display of the app within their Safe Store. The fee is automatically calculated in this quote. Part of the fees will contribute to the CoW DAO treasury that supports the CoW Community.'
+  'The Safe App License Fee incurred here is charged by the Safe Foundation for the display of the app within their Safe Store. The fee is automatically calculated in this quote. Part of the fees will contribute to the CoW DAO treasury that supports the CoW Community.'
 
 export function useVolumeFeeTooltip() {
   const safeAppFee = useAtomValue(safeAppFeeAtom)

--- a/apps/cowswap-frontend/src/modules/volumeFee/hooks/useVolumeFeeTooltip.ts
+++ b/apps/cowswap-frontend/src/modules/volumeFee/hooks/useVolumeFeeTooltip.ts
@@ -1,0 +1,16 @@
+import { useAtomValue } from 'jotai'
+
+import { useInjectedWidgetParams } from '../../injectedWidget'
+import { safeAppFeeAtom } from '../state/safeAppFeeAtom'
+
+const SAFE_FEE_TOOLTIP =
+  'The [tiered widget fee](https://help.safe.global/en/articles/178530-how-does-the-widget-fee-work-for-native-swaps) incurred here is charged by CoW Protocol for the operation of this widget. The fee is automatically calculated into this quote. Part of the fee will contribute to a license fee that supports the Safe Community. Neither the Safe Ecosystem Foundation nor Safe{Wallet} operate the CoW Swap Widget and/or CoW Swap'
+
+export function useVolumeFeeTooltip() {
+  const safeAppFee = useAtomValue(safeAppFeeAtom)
+  const widgetParams = useInjectedWidgetParams()
+
+  if (safeAppFee) return SAFE_FEE_TOOLTIP
+
+  return widgetParams.content?.feeTooltipMarkdown
+}

--- a/apps/cowswap-frontend/src/modules/volumeFee/index.ts
+++ b/apps/cowswap-frontend/src/modules/volumeFee/index.ts
@@ -1,3 +1,4 @@
 export { useVolumeFee } from './hooks/useVolumeFee'
+export { useVolumeFeeTooltip } from './hooks/useVolumeFeeTooltip'
 export { volumeFeeAtom } from './state/volumeFeeAtom'
 export * from './types'

--- a/apps/cowswap-frontend/src/modules/volumeFee/state/safeAppFeeAtom.ts
+++ b/apps/cowswap-frontend/src/modules/volumeFee/state/safeAppFeeAtom.ts
@@ -1,7 +1,7 @@
 import { atom } from 'jotai'
 
-import { OrderKind } from '@cowprotocol/cow-sdk'
-import { walletDetailsAtom } from '@cowprotocol/wallet'
+import { OrderKind, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { walletDetailsAtom, walletInfoAtom } from '@cowprotocol/wallet'
 
 import { featureFlagsAtom } from '../../../common/state/featureFlagsState'
 import { derivedTradeStateAtom } from '../../trade'
@@ -15,11 +15,13 @@ const SAFE_FEE_BPS = 10
  * https://github.com/safe-global/safe-wallet-web/blob/0818e713fa0f9bb7a6472e34a05888896ffc3835/src/features/swap/helpers/fee.ts
  */
 export const safeAppFeeAtom = atom<VolumeFee | null>((get) => {
+  const { chainId } = get(walletInfoAtom)
   const { isSafeApp } = get(walletDetailsAtom)
   const { isSafeAppFeeEnabled } = get(featureFlagsAtom)
   const { inputCurrencyFiatAmount, outputCurrencyFiatAmount, orderKind } = get(derivedTradeStateAtom) || {}
+  const isBaseNetwork = chainId === SupportedChainId.BASE
 
-  if (!isSafeApp || !isSafeAppFeeEnabled) return null
+  if (!isSafeApp || !isSafeAppFeeEnabled || isBaseNetwork) return null
 
   const fiatCurrencyValue = orderKind === OrderKind.SELL ? inputCurrencyFiatAmount : outputCurrencyFiatAmount
   const fiatAmount = fiatCurrencyValue ? +fiatCurrencyValue.toExact() : null

--- a/apps/cowswap-frontend/src/modules/volumeFee/state/safeAppFeeAtom.ts
+++ b/apps/cowswap-frontend/src/modules/volumeFee/state/safeAppFeeAtom.ts
@@ -1,0 +1,66 @@
+import { atom } from 'jotai'
+
+import { STABLECOINS } from '@cowprotocol/common-const'
+import { getCurrencyAddress } from '@cowprotocol/common-utils'
+import { OrderKind } from '@cowprotocol/cow-sdk'
+import { walletDetailsAtom, walletInfoAtom } from '@cowprotocol/wallet'
+
+import { derivedTradeStateAtom } from '../../trade'
+import { VolumeFee } from '../types'
+
+const SAFE_FEE_RECIPIENT = '0x63695Eee2c3141BDE314C5a6f89B98E62808d716'
+
+const FEE_TIERS = {
+  TIER_1: 100_000, // 0 - 100k
+  TIER_2: 1_000_000, // 100k - 1m
+}
+
+const FEE_PERCENTAGE_BPS = {
+  REGULAR: {
+    TIER_1: 35,
+    TIER_2: 20,
+    TIER_3: 10,
+  },
+  STABLE: {
+    TIER_1: 10,
+    TIER_2: 7,
+    TIER_3: 5,
+  },
+}
+
+/**
+ * https://help.safe.global/en/articles/178530-how-does-the-widget-fee-work-for-native-swaps
+ * https://github.com/safe-global/safe-wallet-web/blob/0818e713fa0f9bb7a6472e34a05888896ffc3835/src/features/swap/helpers/fee.ts
+ */
+export const safeAppFeeAtom = atom<VolumeFee | null>((get) => {
+  const { chainId } = get(walletInfoAtom)
+  const { isSafeApp } = get(walletDetailsAtom)
+  const { inputCurrency, outputCurrency, inputCurrencyFiatAmount, outputCurrencyFiatAmount, orderKind } =
+    get(derivedTradeStateAtom) || {}
+
+  if (!isSafeApp) return null
+
+  const fiatCurrencyValue = orderKind === OrderKind.SELL ? inputCurrencyFiatAmount : outputCurrencyFiatAmount
+  const fiatAmount = fiatCurrencyValue ? +fiatCurrencyValue.quotient.toString() : null
+
+  if (typeof fiatAmount !== 'number') return null
+
+  const stablecoins = STABLECOINS[chainId]
+  const isInputStableCoin = !!inputCurrency && stablecoins.has(getCurrencyAddress(inputCurrency).toLowerCase())
+  const isOutputStableCoin = !!outputCurrency && stablecoins.has(getCurrencyAddress(outputCurrency).toLowerCase())
+  const isStableCoinTrade = isInputStableCoin && isOutputStableCoin
+
+  const bps = (() => {
+    if (fiatAmount < FEE_TIERS.TIER_1) {
+      return isStableCoinTrade ? FEE_PERCENTAGE_BPS.STABLE.TIER_1 : FEE_PERCENTAGE_BPS.REGULAR.TIER_1
+    }
+
+    if (fiatAmount < FEE_TIERS.TIER_2) {
+      return isStableCoinTrade ? FEE_PERCENTAGE_BPS.STABLE.TIER_2 : FEE_PERCENTAGE_BPS.REGULAR.TIER_2
+    }
+
+    return isStableCoinTrade ? FEE_PERCENTAGE_BPS.STABLE.TIER_3 : FEE_PERCENTAGE_BPS.REGULAR.TIER_3
+  })()
+
+  return { bps, recipient: SAFE_FEE_RECIPIENT }
+})

--- a/apps/cowswap-frontend/src/modules/volumeFee/state/safeAppFeeAtom.ts
+++ b/apps/cowswap-frontend/src/modules/volumeFee/state/safeAppFeeAtom.ts
@@ -5,6 +5,7 @@ import { getCurrencyAddress } from '@cowprotocol/common-utils'
 import { OrderKind } from '@cowprotocol/cow-sdk'
 import { walletDetailsAtom, walletInfoAtom } from '@cowprotocol/wallet'
 
+import { featureFlagsAtom } from '../../../common/state/featureFlagsState'
 import { derivedTradeStateAtom } from '../../trade'
 import { VolumeFee } from '../types'
 
@@ -35,10 +36,11 @@ const FEE_PERCENTAGE_BPS = {
 export const safeAppFeeAtom = atom<VolumeFee | null>((get) => {
   const { chainId } = get(walletInfoAtom)
   const { isSafeApp } = get(walletDetailsAtom)
+  const { isSafeAppFeeEnabled } = get(featureFlagsAtom)
   const { inputCurrency, outputCurrency, inputCurrencyFiatAmount, outputCurrencyFiatAmount, orderKind } =
     get(derivedTradeStateAtom) || {}
 
-  if (!isSafeApp) return null
+  if (!isSafeApp || !isSafeAppFeeEnabled) return null
 
   const fiatCurrencyValue = orderKind === OrderKind.SELL ? inputCurrencyFiatAmount : outputCurrencyFiatAmount
   const fiatAmount = fiatCurrencyValue ? +fiatCurrencyValue.toExact() : null

--- a/apps/cowswap-frontend/src/modules/volumeFee/state/safeAppFeeAtom.ts
+++ b/apps/cowswap-frontend/src/modules/volumeFee/state/safeAppFeeAtom.ts
@@ -1,5 +1,7 @@
 import { atom } from 'jotai'
 
+import { STABLECOINS } from '@cowprotocol/common-const'
+import { getCurrencyAddress } from '@cowprotocol/common-utils'
 import { OrderKind, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { walletDetailsAtom, walletInfoAtom } from '@cowprotocol/wallet'
 
@@ -8,7 +10,24 @@ import { derivedTradeStateAtom } from '../../trade'
 import { VolumeFee } from '../types'
 
 const SAFE_FEE_RECIPIENT = '0x63695Eee2c3141BDE314C5a6f89B98E62808d716'
-const SAFE_FEE_BPS = 10
+
+const FEE_TIERS = {
+  TIER_1: 100_000, // 0 - 100k
+  TIER_2: 1_000_000, // 100k - 1m
+}
+
+const FEE_PERCENTAGE_BPS = {
+  REGULAR: {
+    TIER_1: 10,
+    TIER_2: 10,
+    TIER_3: 10,
+  },
+  STABLE: {
+    TIER_1: 10,
+    TIER_2: 7,
+    TIER_3: 5,
+  },
+}
 
 /**
  * https://help.safe.global/en/articles/178530-how-does-the-widget-fee-work-for-native-swaps
@@ -18,7 +37,8 @@ export const safeAppFeeAtom = atom<VolumeFee | null>((get) => {
   const { chainId } = get(walletInfoAtom)
   const { isSafeApp } = get(walletDetailsAtom)
   const { isSafeAppFeeEnabled } = get(featureFlagsAtom)
-  const { inputCurrencyFiatAmount, outputCurrencyFiatAmount, orderKind } = get(derivedTradeStateAtom) || {}
+  const { inputCurrency, outputCurrency, inputCurrencyFiatAmount, outputCurrencyFiatAmount, orderKind } =
+    get(derivedTradeStateAtom) || {}
   const isBaseNetwork = chainId === SupportedChainId.BASE
 
   if (!isSafeApp || !isSafeAppFeeEnabled || isBaseNetwork) return null
@@ -28,5 +48,22 @@ export const safeAppFeeAtom = atom<VolumeFee | null>((get) => {
 
   if (typeof fiatAmount !== 'number') return null
 
-  return { bps: SAFE_FEE_BPS, recipient: SAFE_FEE_RECIPIENT }
+  const stablecoins = STABLECOINS[chainId]
+  const isInputStableCoin = !!inputCurrency && stablecoins.has(getCurrencyAddress(inputCurrency).toLowerCase())
+  const isOutputStableCoin = !!outputCurrency && stablecoins.has(getCurrencyAddress(outputCurrency).toLowerCase())
+  const isStableCoinTrade = isInputStableCoin && isOutputStableCoin
+
+  const bps = (() => {
+    if (fiatAmount < FEE_TIERS.TIER_1) {
+      return isStableCoinTrade ? FEE_PERCENTAGE_BPS.STABLE.TIER_1 : FEE_PERCENTAGE_BPS.REGULAR.TIER_1
+    }
+
+    if (fiatAmount < FEE_TIERS.TIER_2) {
+      return isStableCoinTrade ? FEE_PERCENTAGE_BPS.STABLE.TIER_2 : FEE_PERCENTAGE_BPS.REGULAR.TIER_2
+    }
+
+    return isStableCoinTrade ? FEE_PERCENTAGE_BPS.STABLE.TIER_3 : FEE_PERCENTAGE_BPS.REGULAR.TIER_3
+  })()
+
+  return { bps, recipient: SAFE_FEE_RECIPIENT }
 })

--- a/apps/cowswap-frontend/src/modules/volumeFee/state/safeAppFeeAtom.ts
+++ b/apps/cowswap-frontend/src/modules/volumeFee/state/safeAppFeeAtom.ts
@@ -1,44 +1,23 @@
 import { atom } from 'jotai'
 
-import { STABLECOINS } from '@cowprotocol/common-const'
-import { getCurrencyAddress } from '@cowprotocol/common-utils'
 import { OrderKind } from '@cowprotocol/cow-sdk'
-import { walletDetailsAtom, walletInfoAtom } from '@cowprotocol/wallet'
+import { walletDetailsAtom } from '@cowprotocol/wallet'
 
 import { featureFlagsAtom } from '../../../common/state/featureFlagsState'
 import { derivedTradeStateAtom } from '../../trade'
 import { VolumeFee } from '../types'
 
 const SAFE_FEE_RECIPIENT = '0x63695Eee2c3141BDE314C5a6f89B98E62808d716'
-
-const FEE_TIERS = {
-  TIER_1: 100_000, // 0 - 100k
-  TIER_2: 1_000_000, // 100k - 1m
-}
-
-const FEE_PERCENTAGE_BPS = {
-  REGULAR: {
-    TIER_1: 35,
-    TIER_2: 20,
-    TIER_3: 10,
-  },
-  STABLE: {
-    TIER_1: 10,
-    TIER_2: 7,
-    TIER_3: 5,
-  },
-}
+const SAFE_FEE_BPS = 10
 
 /**
  * https://help.safe.global/en/articles/178530-how-does-the-widget-fee-work-for-native-swaps
  * https://github.com/safe-global/safe-wallet-web/blob/0818e713fa0f9bb7a6472e34a05888896ffc3835/src/features/swap/helpers/fee.ts
  */
 export const safeAppFeeAtom = atom<VolumeFee | null>((get) => {
-  const { chainId } = get(walletInfoAtom)
   const { isSafeApp } = get(walletDetailsAtom)
   const { isSafeAppFeeEnabled } = get(featureFlagsAtom)
-  const { inputCurrency, outputCurrency, inputCurrencyFiatAmount, outputCurrencyFiatAmount, orderKind } =
-    get(derivedTradeStateAtom) || {}
+  const { inputCurrencyFiatAmount, outputCurrencyFiatAmount, orderKind } = get(derivedTradeStateAtom) || {}
 
   if (!isSafeApp || !isSafeAppFeeEnabled) return null
 
@@ -47,22 +26,5 @@ export const safeAppFeeAtom = atom<VolumeFee | null>((get) => {
 
   if (typeof fiatAmount !== 'number') return null
 
-  const stablecoins = STABLECOINS[chainId]
-  const isInputStableCoin = !!inputCurrency && stablecoins.has(getCurrencyAddress(inputCurrency).toLowerCase())
-  const isOutputStableCoin = !!outputCurrency && stablecoins.has(getCurrencyAddress(outputCurrency).toLowerCase())
-  const isStableCoinTrade = isInputStableCoin && isOutputStableCoin
-
-  const bps = (() => {
-    if (fiatAmount < FEE_TIERS.TIER_1) {
-      return isStableCoinTrade ? FEE_PERCENTAGE_BPS.STABLE.TIER_1 : FEE_PERCENTAGE_BPS.REGULAR.TIER_1
-    }
-
-    if (fiatAmount < FEE_TIERS.TIER_2) {
-      return isStableCoinTrade ? FEE_PERCENTAGE_BPS.STABLE.TIER_2 : FEE_PERCENTAGE_BPS.REGULAR.TIER_2
-    }
-
-    return isStableCoinTrade ? FEE_PERCENTAGE_BPS.STABLE.TIER_3 : FEE_PERCENTAGE_BPS.REGULAR.TIER_3
-  })()
-
-  return { bps, recipient: SAFE_FEE_RECIPIENT }
+  return { bps: SAFE_FEE_BPS, recipient: SAFE_FEE_RECIPIENT }
 })

--- a/apps/cowswap-frontend/src/modules/volumeFee/state/safeAppFeeAtom.ts
+++ b/apps/cowswap-frontend/src/modules/volumeFee/state/safeAppFeeAtom.ts
@@ -41,7 +41,7 @@ export const safeAppFeeAtom = atom<VolumeFee | null>((get) => {
   if (!isSafeApp) return null
 
   const fiatCurrencyValue = orderKind === OrderKind.SELL ? inputCurrencyFiatAmount : outputCurrencyFiatAmount
-  const fiatAmount = fiatCurrencyValue ? +fiatCurrencyValue.quotient.toString() : null
+  const fiatAmount = fiatCurrencyValue ? +fiatCurrencyValue.toExact() : null
 
   if (typeof fiatAmount !== 'number') return null
 

--- a/apps/cowswap-frontend/src/modules/volumeFee/state/volumeFeeAtom.ts
+++ b/apps/cowswap-frontend/src/modules/volumeFee/state/volumeFeeAtom.ts
@@ -8,15 +8,17 @@ import { tradeTypeAtom } from 'modules/trade'
 import { TradeType } from 'modules/trade/types/TradeType'
 
 import { cowSwapFeeAtom } from './cowswapFeeAtom'
+import { safeAppFeeAtom } from './safeAppFeeAtom'
 
 import { VolumeFee } from '../types'
 
 export const volumeFeeAtom = atom<VolumeFee | undefined>((get) => {
   const cowSwapFee = get(cowSwapFeeAtom)
   const widgetPartnerFee = get(widgetPartnerFeeAtom)
+  const safeAppFee = get(safeAppFeeAtom)
 
   // CoW Swap Fee won't be enabled when in Widget mode, thus it takes precedence here
-  return cowSwapFee || widgetPartnerFee
+  return safeAppFee || cowSwapFee || widgetPartnerFee
 })
 
 const widgetPartnerFeeAtom = atom<VolumeFee | undefined>((get) => {

--- a/libs/ui/src/pure/InfoTooltip/index.tsx
+++ b/libs/ui/src/pure/InfoTooltip/index.tsx
@@ -34,6 +34,10 @@ const StyledTooltipContainer = styled(TooltipContainer)`
   border: 0;
   box-shadow: none;
   background: transparent;
+
+  > p {
+    margin: 0;
+  }
 `
 
 export interface InfoTooltipProps {

--- a/libs/ui/src/pure/Tooltip/index.tsx
+++ b/libs/ui/src/pure/Tooltip/index.tsx
@@ -63,7 +63,7 @@ export function HoverTooltip(props: HoverTooltipProps) {
       setShow(true)
       onOpen?.()
     },
-    [onOpen]
+    [onOpen],
   )
 
   // Close the tooltip
@@ -113,7 +113,7 @@ export function HoverTooltip(props: HoverTooltipProps) {
         open(e)
       }
     },
-    [close, open, show]
+    [close, open, show],
   )
 
   // Hide tooltip when scrolling

--- a/libs/wallet/src/api/state.ts
+++ b/libs/wallet/src/api/state.ts
@@ -19,6 +19,7 @@ export const walletDetailsAtom = atom<WalletDetails>({
 
   // Feature Support
   allowsOffchainSigning: false,
+  isSafeApp: false,
 })
 
 export const gnosisSafeInfoAtom = atom<GnosisSafeInfo | undefined>(undefined)

--- a/libs/wallet/src/api/types.ts
+++ b/libs/wallet/src/api/types.ts
@@ -27,12 +27,16 @@ export interface WalletDetails {
   walletName?: string
   icon?: string
   isSupportedWallet: boolean
+  isSafeApp: boolean
 
   // Feature Support
   allowsOffchainSigning: boolean
 }
 
-export type GnosisSafeInfo = Pick<SafeInfoResponse, 'address' | 'threshold' | 'owners' | 'nonce' > & { isReadOnly?: boolean, chainId: number }
+export type GnosisSafeInfo = Pick<SafeInfoResponse, 'address' | 'threshold' | 'owners' | 'nonce'> & {
+  isReadOnly?: boolean
+  chainId: number
+}
 
 export enum WalletType {
   SAFE,

--- a/libs/wallet/src/web3-react/updater.ts
+++ b/libs/wallet/src/web3-react/updater.ts
@@ -11,7 +11,7 @@ import ms from 'ms.macro'
 
 import { useIsSmartContractWallet } from './hooks/useIsSmartContractWallet'
 import { useSafeAppsSdk } from './hooks/useSafeAppsSdk'
-import { useWalletMetaData } from './hooks/useWalletMetadata'
+import { useIsSafeApp, useWalletMetaData } from './hooks/useWalletMetadata'
 
 import { gnosisSafeInfoAtom, walletDetailsAtom, walletInfoAtom } from '../api/state'
 import { GnosisSafeInfo, WalletDetails, WalletInfo } from '../api/types'
@@ -50,6 +50,7 @@ function _useWalletDetails(account?: string, standaloneMode?: boolean): WalletDe
   const { ENSName: ensName } = useENSName(account ?? undefined)
   const isSmartContractWallet = useIsSmartContractWallet()
   const { walletName, icon } = useWalletMetaData(standaloneMode)
+  const isSafeApp = useIsSafeApp()
 
   return useMemo(() => {
     return {
@@ -62,8 +63,9 @@ function _useWalletDetails(account?: string, standaloneMode?: boolean): WalletDe
       // TODO: For now, all SC wallets use pre-sign instead of offchain signing
       // In the future, once the API adds EIP-1271 support, we can allow some SC wallets to use offchain signing
       allowsOffchainSigning: !isSmartContractWallet,
+      isSafeApp,
     }
-  }, [isSmartContractWallet, walletName, icon, ensName])
+  }, [isSmartContractWallet, isSafeApp, walletName, icon, ensName])
 }
 
 function _useSafeInfo(walletInfo: WalletInfo): GnosisSafeInfo | undefined {


### PR DESCRIPTION
# Summary

Reference: https://help.safe.global/en/articles/178530-how-does-the-widget-fee-work-for-native-swaps

Basically, CoW Swap should work the same with https://app.safe.global/swap when it is open in Safe Apps.
I literally copy-pasted the logic from Safe frontend.
The only thing that might be different is stablecoins list. We have [our own list](https://github.com/cowprotocol/cowswap/blob/4cf0c91a300d6fcdc026364e74c45e5b2f729f2b/libs/common-const/src/tokens.ts#L488), our list at least matches mainnet (USDC/USDT/DAI).

<img width="582" alt="image" src="https://github.com/user-attachments/assets/4f31aca0-7abe-4230-b03b-7d1bfa205f1b">

# To Test

Volume fee should work exactly the same with https://app.safe.global/swap
