### PR TITLE
fix: reset trade completely if default token is duplicated

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useResetStateWithSymbolDuplication.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useResetStateWithSymbolDuplication.ts
@@ -9,7 +9,7 @@ import { getDefaultTradeRawState, TradeRawState } from '../../types/TradeRawStat
 import { useTradeNavigate } from '../useTradeNavigate'
 
 const alertMessage = (
-  doubledSymbol: string
+  doubledSymbol: string,
 ) => t`There is more than one token in the list of tokens with the symbol: ${doubledSymbol}.
 Please select the token you need from the UI or use the address of the token instead of the symbol`
 
@@ -45,8 +45,8 @@ export function useResetStateWithSymbolDuplication(state: TradeRawState | null):
 
       const defaultState = getDefaultTradeRawState(chainId)
       navigate(chainId, {
-        inputCurrencyId: defaultState.inputCurrencyId,
-        outputCurrencyId: defaultState.outputCurrencyId,
+        inputCurrencyId: defaultState.inputCurrencyId === inputCurrencyId ? '' : defaultState.inputCurrencyId,
+        outputCurrencyId: defaultState.outputCurrencyId === outputCurrencyId ? '' : defaultState.outputCurrencyId,
       })
     }
 


### PR DESCRIPTION
# Summary

By default we use token symbols in URL.
But in some cases we can have more than one token with the same symbol.
In this case if we meet a symbol of that token we do:
 - Display "There is more than one token in the list of tokens with the symbol..." alert
 - Reset the widget state to default assets
It works perfectly with everything but WETH :) Because WETH is a default asset and here we go in a trouble.
To avoid that now we check if the token with duplicated symbol is WETH, then we completely clean up the widget assets state.

Fixes #4323 

# To Test

1. Open /11155111/swap/WTH (Sepolia)
2. Add 0x7b79995e5f793A07Bc00c21412e50Ecae098E7f9 (symbol=WETH) as a custom token and choose it as buy token
3. You should see "There is more than one token in the list of tokens with the symbol..." alert
- [ ] AR: the widget becomes frozen, you cannot pick any token
- [ ] ER: the widget should reset assets and then you can pick any token to trade