### PR TITLE
feat: add default list for tokens in base

### DIFF
--- a/libs/tokens/src/const/tokensList.json
+++ b/libs/tokens/src/const/tokensList.json
@@ -121,7 +121,8 @@
     },
     {
       "priority": 2,
-      "source": "https://tokens.coingecko.com/base/all.json"
+      "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/CoinGecko.8453.json",
+      "enabledByDefault": true
     }
   ]
 }


### PR DESCRIPTION
# Summary

Follow up on https://github.com/cowprotocol/token-lists/pull/756

This PR adds a new default list for Base chain with the top 500 tokens

<img width="1680" alt="image" src="https://github.com/user-attachments/assets/fc83c6c6-175a-41b4-82d6-d491a2a94afe">

<img width="1023" alt="image" src="https://github.com/user-attachments/assets/5d254b21-bf24-473d-90ed-9b6fc15e4a74">


# To Test

- Connect to safe
- Check there's plenty of tokens now
- Check that coinbase and coswap list are enabled

