### PR TITLE
fix(twap): fix orders fetching

### DIFF
--- a/apps/cowswap-frontend/src/api/cowProtocol/hooks.ts
+++ b/apps/cowswap-frontend/src/api/cowProtocol/hooks.ts
@@ -8,6 +8,8 @@ import { useSWROrdersRequest } from 'modules/orders/hooks/useSWROrdersRequest'
 
 import { getOrders } from './api'
 
+const emptyOrders: EnrichedOrder[] = []
+
 export function useOrdersFromOrderBook(): EnrichedOrder[] {
   const { chainId } = useWalletInfo()
 
@@ -17,8 +19,8 @@ export function useOrdersFromOrderBook(): EnrichedOrder[] {
   const { data: currentEnvOrders } = useSWR(
     requestParams && chainId ? ['orders', requestParams, chainId] : null,
     ([, params, _chainId]) => getOrders(params, { chainId: _chainId }),
-    { refreshInterval: ORDER_BOOK_API_UPDATE_INTERVAL }
+    { refreshInterval: ORDER_BOOK_API_UPDATE_INTERVAL, fallbackData: emptyOrders },
   )
 
-  return currentEnvOrders || []
+  return currentEnvOrders
 }


### PR DESCRIPTION
# Summary

Since the recent update of React to v19 we started getting app freezing.
It's reproducible only on prod/staging enviroment! (because of the `useSWRProdOrders()` logic hook, it depends on `isBarnBackendEnv`).

The main cause of the problem is in `useOrdersFromOrderBook()` hook. It was returning a new istance of array every time which causes infinite re-renderings.
It actually was a problem even before React version update, it has been worsening app performance but didn't cause app freezing.

**I also checked other parts of the code-base and haven't found similar problems.**

# To Test

You can test it only on staging.
You just need to open twap page with no connected wallet.
