### PR TITLE
fix(cow-fi): add utm content to mevblocker menu item

### DIFF
--- a/libs/ui/src/pure/MenuBar/index.tsx
+++ b/libs/ui/src/pure/MenuBar/index.tsx
@@ -80,6 +80,7 @@ const DAO_NAV_ITEMS: MenuItem[] = [
     hoverColor: '#F2CD16',
     hoverBgColor: '#EC4612',
     external: true,
+    utmContent: 'menubar-dao-nav-mevblocker',
   },
 ]
 
@@ -557,6 +558,14 @@ const appendUtmParams = (
   isExternal: boolean,
   label: string | undefined,
 ) => {
+  console.log('SSSS', {
+    href,
+    utmSource,
+    utmContent,
+    rootDomain,
+    isExternal,
+    label,
+  })
   const defaultUtm = {
     utmSource: rootDomain,
     utmMedium: 'web',


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C0361CDG8GP/p1733749781104509

<img width="732" alt="image" src="https://github.com/user-attachments/assets/1d8606b0-7eda-49a2-a884-69261d141006">

# To Test

The "MEV Blocker" menu item in header should have utm_content=menubar-dao-nav-mevblocker
