### PR TITLE
fix: add Base to CoW Protocol FAQ on cow.fi

### DIFF
--- a/apps/cow-fi/data/cow-protocol/const.tsx
+++ b/apps/cow-fi/data/cow-protocol/const.tsx
@@ -402,7 +402,7 @@ export const FAQ_DATA = [
   },
   {
     question: 'What chains does CoW Protocol currently support?',
-    answer: 'CoW Protocol is currently deployed on Ethereum, Gnosis Chain, and Arbitrum One.',
+    answer: 'CoW Protocol is currently deployed on Ethereum, Gnosis Chain, Arbitrum One and Base.',
   },
   {
     question: 'How do I get support?',


### PR DESCRIPTION
# Summary

Add `Base` to the list of supported networks on CoW Protocol FAQ on cow.fi

![image](https://github.com/user-attachments/assets/97558289-6f1f-4ffc-be42-af14394d651a)

# To Test

1. Open cow.fi
2. Go to CoW Protocol's FAQ
3. Look for `What chains does CoW Protocol currently support?`
* Should include `Base`