### PR TITLE
fix(volume-fee): control safe app fees for stablecoins with ff

### DIFF
--- a/apps/cowswap-frontend/src/modules/volumeFee/state/safeAppFeeAtom.ts
+++ b/apps/cowswap-frontend/src/modules/volumeFee/state/safeAppFeeAtom.ts
@@ -38,7 +38,7 @@ const FEE_PERCENTAGE_BPS = {
 export const safeAppFeeAtom = atom<VolumeFee | null>((get) => {
   const { chainId } = get(walletInfoAtom)
   const { isSafeApp } = get(walletDetailsAtom)
-  const { isSafeAppFeeEnabled } = get(featureFlagsAtom)
+  const { isSafeAppFeeEnabled, isSafeAppStableCoinsFeeEnabled } = get(featureFlagsAtom)
   const { inputCurrency, outputCurrency, inputCurrencyFiatAmount, outputCurrencyFiatAmount, orderKind } =
     get(derivedTradeStateAtom) || {}
 
@@ -53,6 +53,8 @@ export const safeAppFeeAtom = atom<VolumeFee | null>((get) => {
   const isInputStableCoin = !!inputCurrency && stablecoins.has(getCurrencyAddress(inputCurrency).toLowerCase())
   const isOutputStableCoin = !!outputCurrency && stablecoins.has(getCurrencyAddress(outputCurrency).toLowerCase())
   const isStableCoinTrade = isInputStableCoin && isOutputStableCoin
+
+  if (isStableCoinTrade && !isSafeAppStableCoinsFeeEnabled) return null
 
   const bps = (() => {
     if (fiatAmount < FEE_TIERS.TIER_1) {

--- a/libs/common-const/src/tokens.ts
+++ b/libs/common-const/src/tokens.ts
@@ -322,6 +322,14 @@ export const USDC_SEPOLIA = new TokenWithLogo(
   'USDC',
   'USDC (test)',
 )
+export const USDT_SEPOLIA = new TokenWithLogo(
+  USDT.logoURI,
+  SupportedChainId.SEPOLIA,
+  '0x58eb19ef91e8a6327fed391b51ae1887b833cc91',
+  6,
+  'USDT',
+  'Tether USD',
+)
 
 export const USDC: Record<SupportedChainId, TokenWithLogo> = {
   [SupportedChainId.MAINNET]: USDC_MAINNET,
@@ -483,15 +491,21 @@ const BASE_STABLECOINS = [
   CGUSD_BASE.address,
   USD_PLUS_BASE.address,
   EUSD_BASE.address,
+  USDT_BASE.address,
 ].map((t) => t.toLowerCase())
+
+// Not used for fees
+const SEPOLIA_STABLECOINS = [USDC_SEPOLIA.address, USDT_SEPOLIA.address].map((t) => t.toLowerCase())
 
 export const STABLECOINS: Record<ChainId, Set<string>> = {
   [SupportedChainId.MAINNET]: new Set(MAINNET_STABLECOINS),
   [SupportedChainId.GNOSIS_CHAIN]: new Set(GNOSIS_CHAIN_STABLECOINS),
   [SupportedChainId.ARBITRUM_ONE]: new Set(ARBITRUM_ONE_STABLECOINS),
-  [SupportedChainId.SEPOLIA]: new Set([USDC_SEPOLIA.address]),
+  [SupportedChainId.SEPOLIA]: new Set(SEPOLIA_STABLECOINS),
   [SupportedChainId.BASE]: new Set(BASE_STABLECOINS),
 }
+
+console.debug('STABLECOINS', STABLECOINS)
 
 /**
  * Addresses related to COW vesting for Locked GNO


### PR DESCRIPTION
# Summary

When `isSafeAppStableCoinsFeeEnabled` featureflag is off, then Safe Apps fee for stable-stable trades should not be added, otherwise should work as in #5139