### PR TITLE
fix(twap): cache fb handler verification for 10min

### DIFF
--- a/apps/cowswap-frontend/src/modules/twap/services/verifyExtensibleFallback.ts
+++ b/apps/cowswap-frontend/src/modules/twap/services/verifyExtensibleFallback.ts
@@ -25,12 +25,14 @@ export async function verifyExtensibleFallback(
   try {
     const domainVerifier = await signatureVerifierContract.callStatic.domainVerifiers(safeAddress, domainSeparator)
 
+    console.log('FALLBACK HANDLER CHECKED, domainVerifier: ', domainVerifier)
     if (domainVerifier.toLowerCase() === composableCowContractAddress.toLowerCase()) {
       return ExtensibleFallbackVerification.HAS_DOMAIN_VERIFIER
     }
 
     return ExtensibleFallbackVerification.HAS_EXTENSIBLE_FALLBACK
-  } catch {
+  } catch (e) {
+    console.log('FALLBACK HANDLER CHECKED, error: ', e)
     return ExtensibleFallbackVerification.HAS_NOTHING
   }
 }

--- a/apps/cowswap-frontend/src/modules/twap/updaters/FallbackHandlerVerificationUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/updaters/FallbackHandlerVerificationUpdater.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 
 import { useWalletInfo } from '@cowprotocol/wallet'
 
+import ms from 'ms.macro'
 import { useAsyncMemo } from 'use-async-memo'
 
 import { useExtensibleFallbackContext } from '../hooks/useExtensibleFallbackContext'
@@ -10,26 +11,33 @@ import { useFallbackHandlerVerification } from '../hooks/useFallbackHandlerVerif
 import { ExtensibleFallbackVerification, verifyExtensibleFallback } from '../services/verifyExtensibleFallback'
 import { updateFallbackHandlerVerificationAtom } from '../state/fallbackHandlerVerificationAtom'
 
+const FB_CACHE_TIME = ms`10m`
+const FB_UPDATE_TIME_KEY = 'fallbackHandlerUpdateTime'
+
 export function FallbackHandlerVerificationUpdater() {
   const { account } = useWalletInfo()
   const update = useSetAtom(updateFallbackHandlerVerificationAtom)
   const verification = useFallbackHandlerVerification()
   const isFallbackHandlerRequired = verification !== ExtensibleFallbackVerification.HAS_DOMAIN_VERIFIER
 
+  const fallbackHandlerUpdateTime = localStorage.getItem(FB_UPDATE_TIME_KEY)
+  const isCacheOutdated = !fallbackHandlerUpdateTime || Date.now() - +fallbackHandlerUpdateTime > FB_CACHE_TIME
+
   const extensibleFallbackContext = useExtensibleFallbackContext()
   const fallbackHandlerVerification = useAsyncMemo(
     () =>
-      extensibleFallbackContext && isFallbackHandlerRequired
+      extensibleFallbackContext && (isFallbackHandlerRequired || isCacheOutdated)
         ? verifyExtensibleFallback(extensibleFallbackContext)
         : null,
-    [isFallbackHandlerRequired, extensibleFallbackContext],
-    null
+    [isFallbackHandlerRequired, isCacheOutdated, extensibleFallbackContext],
+    null,
   )
 
   useEffect(() => {
     if (!account || fallbackHandlerVerification === null) return
 
     update({ [account]: fallbackHandlerVerification })
+    localStorage.setItem(FB_UPDATE_TIME_KEY, Date.now().toString())
   }, [fallbackHandlerVerification, update, account])
 
   return null


### PR DESCRIPTION
# Summary

Related to #2949 

Since Safe fallback handler might be changed any time, we should not cache the fb verification result for ever.
In this PR I added cache life time - 10 minutes.

# To Test

1. Open a Safe with no CowSwapFallbackHandler
2. Create a TWAP along with changing FB
- [ ] within the next 10 minutes there should not be "FALLBACK HANDLER CHECKED" in console logs
- [ ] after 10 mins (might need a page reload) there should be "FALLBACK HANDLER CHECKED" in console logs
