### PR TITLE
fix(cowfi): fix pages crashes

### DIFF
--- a/apps/cow-fi/app/(learn)/learn/articles/[[...pageIndex]]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/articles/[[...pageIndex]]/page.tsx
@@ -2,6 +2,7 @@
 
 import { Article, getArticles, getCategories } from '../../../../../services/cms'
 import { ArticlesPageComponents } from '@/components/ArticlesPageComponents'
+import { redirect } from 'next/navigation'
 
 const ITEMS_PER_PAGE = 24
 
@@ -28,7 +29,14 @@ export async function generateStaticParams() {
 
 export default async function Page({ params }: Props) {
   const pageParam = (await params)?.pageIndex
-  const page = pageParam && pageParam.length > 0 ? parseInt(pageParam[0], 10) : 1
+  const paramsAreSet = Boolean(pageParam && pageParam.length > 0)
+  const pageIndexIsValid = Boolean(pageParam && /^\d+$/.test(pageParam))
+
+  if (paramsAreSet && !pageIndexIsValid) {
+    return redirect('/learn/articles')
+  }
+
+  const page = pageParam && pageIndexIsValid ? parseInt(pageParam, 10) : 1
 
   const articlesResponse = (await getArticles({ page, pageSize: ITEMS_PER_PAGE })) as ArticlesResponse
 

--- a/apps/cow-fi/app/(main)/tokens/[tokenId]/page.tsx
+++ b/apps/cow-fi/app/(main)/tokens/[tokenId]/page.tsx
@@ -9,6 +9,7 @@ import { TokenPageComponent } from '@/components/TokenPageComponent'
 import type { Metadata } from 'next'
 import type { TokenDetails } from '../../../../types'
 import { getPageMetadata } from '@/util/getPageMetadata'
+import { redirect } from 'next/navigation'
 
 type Props = {
   params: Promise<{ tokenId: string }>
@@ -35,6 +36,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const token = await getTokenDetails(tokenId)
 
+  if (!token) return {}
+
   return getPageMetadata(getTokenMetaData(token))
 }
 
@@ -50,6 +53,8 @@ export default async function Page({ params }: Props) {
   if (!tokenId) return null
 
   const token = await getTokenDetails(tokenId)
+
+  if (!token) return redirect('/tokens')
 
   return <TokenPageComponent token={token} />
 }

--- a/apps/cow-fi/services/tokens/index.ts
+++ b/apps/cow-fi/services/tokens/index.ts
@@ -48,10 +48,10 @@ export async function getTokensInfo(): Promise<TokenInfo[]> {
  *
  * @returns token details for the given token id
  */
-export async function getTokenDetails(coingeckoId: string): Promise<TokenDetails> {
+export async function getTokenDetails(coingeckoId: string): Promise<TokenDetails | undefined> {
   const id = coingeckoId.toLowerCase()
   const tokensRaw = await _getAllTokensData()
-  return tokensRaw.find(({ id: _id }) => _id === id) as TokenDetails
+  return tokensRaw.find(({ id: _id }) => _id === id) as TokenDetails | undefined
 }
 
 function _getDescriptionFilePaths(): string[] {


### PR DESCRIPTION
# Summary

Continuing the cow.fi costs issue investigation I got a responce from Vercel support where they siad that there are some errors which may cause costs increases.
I don't think this s a key of the problem, because there are very few of the errors.
Anyway, we should fix there errors, there are two of them:
1. /learn/articles/tally-recipe-for-cow-swaps
2. /tokens/metaverse-index

Some people open links which are invalid (/learn/articles/tally-recipe-for-cow-swaps -> /learn/tally-recipe-for-cow-swaps) and (/tokens/metaverse-index doesn't even exist) which causes the app errors.

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/75241a9e-363f-4ec3-88d8-41f9f8ed9063" />


# To Test

1. Open /learn/articles/tally-recipe-for-cow-swaps
- [ ] should redirect to /learn/articles

3. Open /tokens/metaverse-index
- [ ] should redirect to /tokens