### PR TITLE
feat: warn about unsigned orders, and hide not relevant orders

### DIFF
--- a/apps/explorer/src/components/orders/DetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/index.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { ExplorerDataType, getExplorerLink } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { Command } from '@cowprotocol/types'
-import { Media } from '@cowprotocol/ui'
+import { Icon, Media, UI } from '@cowprotocol/ui'
 import { TruncatedText } from '@cowprotocol/ui/pure/TruncatedText'
 
 import { faFill, faGroupArrowsRotate, faHistory, faProjectDiagram } from '@fortawesome/free-solid-svg-icons'
@@ -31,6 +31,7 @@ import { Order } from 'api/operator'
 import { getUiOrderType } from 'utils/getUiOrderType'
 
 import { OrderHooksDetails } from '../OrderHooksDetails'
+import { UnsignedOrderWarning } from '../UnsignedOrderWarning'
 
 const tooltip = {
   orderID: 'A unique identifier ID for this order.',
@@ -87,6 +88,8 @@ const tooltip = {
 }
 
 export const Wrapper = styled.div`
+  --cow-color-alert: ${({ theme }): string => theme.alert2};
+
   display: flex;
   flex-direction: row;
 
@@ -124,6 +127,10 @@ export const LinkButton = styled(LinkWithPrefixNetwork)`
   svg {
     margin-right: 0.5rem;
   }
+`
+
+const WarningRow = styled.tr`
+  background-color: ${({ theme }): string => theme.background};
 `
 
 export type Props = {
@@ -167,12 +174,20 @@ export function DetailsTable(props: Props): React.ReactNode | null {
   }
 
   const onCopy = (label: string): void => clickOnOrderDetails('Copy', label)
+  const isSigning = status === 'signing'
 
   return (
     <SimpleTable
       columnViewMobile
       body={
         <>
+          {isSigning && (
+            <WarningRow>
+              <td colSpan={2}>
+                <UnsignedOrderWarning />
+              </td>
+            </WarningRow>
+          )}
           <tr>
             <td>
               <span>
@@ -195,6 +210,12 @@ export function DetailsTable(props: Props): React.ReactNode | null {
             </td>
             <td>
               <Wrapper>
+                {isSigning && (
+                  <>
+                    <Icon image="ALERT" color={UI.COLOR_ALERT} />
+                    &nbsp;
+                  </>
+                )}
                 <RowWithCopyButton
                   textToCopy={owner}
                   onCopy={(): void => onCopy('ownerAddress')}

--- a/apps/explorer/src/components/orders/OrdersUserDetailsTable/ToggleFilter.tsx
+++ b/apps/explorer/src/components/orders/OrdersUserDetailsTable/ToggleFilter.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import styled from 'styled-components'
+
+interface BadgeProps {
+  checked: boolean
+  onChange: () => void
+  label: string
+  count: number
+}
+
+const Wrapper = styled.div<{ checked: boolean }>`
+  display: inline-block;
+  padding: 5px 10px;
+  border-radius: 20px;
+  background-color: ${({ checked }) => (checked ? '#007bff' : '#e0e0e0')};
+  color: ${({ checked }) => (checked ? '#fff' : '#000')};
+  cursor: pointer;
+  user-select: none;
+  font-size: 11px;
+`
+
+const Label = styled.span`
+  margin-right: 10px;
+`
+
+const Count = styled.span`
+  font-weight: bold;
+`
+
+export const ToggleFilter: React.FC<BadgeProps> = ({ checked, onChange, label, count }) => {
+  return (
+    <Wrapper checked={checked} onClick={onChange}>
+      <Label>{label}</Label>
+      <Count>{count}</Count>
+    </Wrapper>
+  )
+}

--- a/apps/explorer/src/components/orders/OrdersUserDetailsTable/ToggleFilter.tsx
+++ b/apps/explorer/src/components/orders/OrdersUserDetailsTable/ToggleFilter.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import styled from 'styled-components'
+
+import styled from 'styled-components/macro'
 
 interface BadgeProps {
   checked: boolean

--- a/apps/explorer/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -69,6 +69,15 @@ const FilterRow = styled.tr`
   }
 `
 
+const NoOrdersContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  padding: 2rem;
+`
+
 const RowOrder: React.FC<RowProps> = ({ order, isPriceInverted, showCanceledAndExpired, showPreSigning }) => {
   const { creationDate, buyToken, buyAmount, sellToken, sellAmount, kind, partiallyFilled, uid, filledPercentage } =
     order
@@ -228,10 +237,10 @@ const OrdersUserDetailsTable: React.FC<Props> = (props) => {
               />
             ))
           ) : (
-            <>
+            <NoOrdersContainer>
               <p>No orders found.</p>
               <p>You can toggle the filters to show the {orders.length} hidden orders.</p>
-            </>
+            </NoOrdersContainer>
           )}
         </>
       }

--- a/apps/explorer/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -163,8 +163,6 @@ const OrdersUserDetailsTable: React.FC<Props> = (props) => {
   const allOrdersAreHidden =
     orders?.length === (showPreSigning ? 0 : preSigningCount) + (showCanceledAndExpired ? 0 : canceledAndExpiredCount)
 
-  console.log('allOrdersAreHidden', { allOrdersAreHidden, preSigningCount, canceledAndExpiredCount })
-
   const invertLimitPrice = (): void => {
     setIsPriceInverted((previousValue) => !previousValue)
   }

--- a/apps/explorer/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -17,13 +17,17 @@ import { useNetworkId } from 'state/network'
 import styled from 'styled-components/macro'
 import { FormatAmountPrecision, formattedAmount } from 'utils'
 
-import { Order } from 'api/operator'
+import { Order, OrderStatus } from 'api/operator'
 import { getLimitPrice } from 'utils/getLimitPrice'
 
 import { OrderSurplusDisplayStyledByRow } from './OrderSurplusTooltipStyledByRow'
 
 import { SimpleTable, SimpleTableProps } from '../../common/SimpleTable'
 import { StatusLabel } from '../StatusLabel'
+import { ToggleFilter } from './ToggleFilter'
+import { UnsignedOrderWarning } from '../UnsignedOrderWarning'
+
+const EXPIRED_CANCELED_STATES: OrderStatus[] = ['cancelled', 'cancelling', 'expired']
 
 const tooltip = {
   orderID: 'A unique identifier ID for this order.',
@@ -46,9 +50,26 @@ export type Props = SimpleTableProps & {
 interface RowProps {
   order: Order
   isPriceInverted: boolean
+
+  // TODO: Filter by state using the API. Not available for now, so filtering in the client
+  showCanceledAndExpired: boolean
+  showPreSigning: boolean
 }
 
-const RowOrder: React.FC<RowProps> = ({ order, isPriceInverted }) => {
+const FilterRow = styled.tr`
+  background-color: ${({ theme }) => theme.background};
+
+  th {
+    text-align: right;
+    padding-right: 10px;
+
+    & > * {
+      margin-left: 10px;
+    }
+  }
+`
+
+const RowOrder: React.FC<RowProps> = ({ order, isPriceInverted, showCanceledAndExpired, showPreSigning }) => {
   const { creationDate, buyToken, buyAmount, sellToken, sellAmount, kind, partiallyFilled, uid, filledPercentage } =
     order
   const [_isPriceInverted, setIsPriceInverted] = useState(isPriceInverted)
@@ -66,6 +87,10 @@ const RowOrder: React.FC<RowProps> = ({ order, isPriceInverted }) => {
   const renderSpinnerWhenNoValue = (textValue: string): React.ReactNode | void => {
     if (textValue === '-') return <Spinner spin size="1x" />
   }
+
+  // Hide the row if the order is canceled, expired or pre-signing
+  if (!showCanceledAndExpired && EXPIRED_CANCELED_STATES.includes(order.status)) return null
+  if (!showPreSigning && order.status === 'signing') return null
 
   return (
     <tr key={uid}>
@@ -118,6 +143,18 @@ const RowOrder: React.FC<RowProps> = ({ order, isPriceInverted }) => {
 const OrdersUserDetailsTable: React.FC<Props> = (props) => {
   const { orders, messageWhenEmpty } = props
   const [isPriceInverted, setIsPriceInverted] = useState(false)
+  const [showCanceledAndExpired, setShowCanceledAndExpired] = useState(false)
+  const [showPreSigning, setShowPreSigning] = useState(false)
+
+  const canceledAndExpiredCount = orders
+    ? orders.filter((order) => EXPIRED_CANCELED_STATES.includes(order.status)).length
+    : 0
+  const preSigningCount = orders ? orders.filter((order) => order.status === 'signing').length : 0
+  const showFilter = canceledAndExpiredCount > 0 || preSigningCount > 0
+  const allOrdersAreHidden =
+    orders?.length === (showPreSigning ? 0 : preSigningCount) + (showCanceledAndExpired ? 0 : canceledAndExpiredCount)
+
+  console.log('allOrdersAreHidden', { allOrdersAreHidden, preSigningCount, canceledAndExpiredCount })
 
   const invertLimitPrice = (): void => {
     setIsPriceInverted((previousValue) => !previousValue)
@@ -130,30 +167,72 @@ const OrdersUserDetailsTable: React.FC<Props> = (props) => {
   return (
     <SimpleTable
       header={
-        <tr>
-          <th>
-            <span>
-              Order ID <HelpTooltip tooltip={tooltip.orderID} />
-            </span>
-          </th>
-          <th>Type</th>
-          <th>Sell amount</th>
-          <th>Buy amount</th>
-          <th>
-            <span>
-              Limit price <Icon icon={faExchangeAlt} onClick={invertLimitPrice} />
-            </span>
-          </th>
-          <th>Surplus</th>
-          <th>Created</th>
-          <th>Status</th>
-        </tr>
+        <>
+          {showFilter && (
+            <FilterRow>
+              <th colSpan={8}>
+                {canceledAndExpiredCount > 0 && (
+                  <ToggleFilter
+                    checked={showCanceledAndExpired}
+                    onChange={() => setShowCanceledAndExpired((previousValue) => !previousValue)}
+                    label={(showCanceledAndExpired ? 'Hide' : 'Show') + ' canceled/expired'}
+                    count={canceledAndExpiredCount}
+                  />
+                )}
+                {preSigningCount > 0 && (
+                  <>
+                    <ToggleFilter
+                      checked={showPreSigning}
+                      onChange={() => setShowPreSigning((previousValue) => !previousValue)}
+                      label={(showPreSigning ? 'Hide' : 'Show') + ' unsigned'}
+                      count={preSigningCount}
+                    />
+                    {showPreSigning && <UnsignedOrderWarning />}
+                  </>
+                )}
+              </th>
+            </FilterRow>
+          )}
+          {!allOrdersAreHidden && (
+            <tr>
+              <th>
+                <span>
+                  Order ID <HelpTooltip tooltip={tooltip.orderID} />
+                </span>
+              </th>
+              <th>Type</th>
+              <th>Sell amount</th>
+              <th>Buy amount</th>
+              <th>
+                <span>
+                  Limit price <Icon icon={faExchangeAlt} onClick={invertLimitPrice} />
+                </span>
+              </th>
+              <th>Surplus</th>
+              <th>Created</th>
+              <th>Status</th>
+            </tr>
+          )}
+        </>
       }
       body={
         <>
-          {orders.map((item) => (
-            <RowOrder key={item.uid} order={item} isPriceInverted={isPriceInverted} />
-          ))}
+          {!allOrdersAreHidden ? (
+            orders.map((item) => (
+              <RowOrder
+                key={item.uid}
+                order={item}
+                isPriceInverted={isPriceInverted}
+                showCanceledAndExpired={showCanceledAndExpired}
+                showPreSigning={showPreSigning}
+              />
+            ))
+          ) : (
+            <>
+              <p>No orders found.</p>
+              <p>You can toggle the filters to show the {orders.length} hidden orders.</p>
+            </>
+          )}
         </>
       }
     />

--- a/apps/explorer/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -21,10 +21,10 @@ import { Order, OrderStatus } from 'api/operator'
 import { getLimitPrice } from 'utils/getLimitPrice'
 
 import { OrderSurplusDisplayStyledByRow } from './OrderSurplusTooltipStyledByRow'
+import { ToggleFilter } from './ToggleFilter'
 
 import { SimpleTable, SimpleTableProps } from '../../common/SimpleTable'
 import { StatusLabel } from '../StatusLabel'
-import { ToggleFilter } from './ToggleFilter'
 import { UnsignedOrderWarning } from '../UnsignedOrderWarning'
 
 const EXPIRED_CANCELED_STATES: OrderStatus[] = ['cancelled', 'cancelling', 'expired']

--- a/apps/explorer/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -164,8 +164,8 @@ const OrdersUserDetailsTable: React.FC<Props> = (props) => {
   const [showCanceledAndExpired, setShowCanceledAndExpired] = useState(false)
   const [showPreSigning, setShowPreSigning] = useState(false)
 
-  const canceledAndExpiredCount = orders ? orders.filter(isExpiredOrCanceled).length : 0
-  const preSigningCount = orders ? orders.filter((order) => order.status === 'signing').length : 0
+  const canceledAndExpiredCount = orders?.filter(isExpiredOrCanceled).length || 0
+  const preSigningCount = orders?.filter((order) => order.status === 'signing').length || 0
   const showFilter = canceledAndExpiredCount > 0 || preSigningCount > 0
   const allOrdersAreHidden =
     orders?.length === (showPreSigning ? 0 : preSigningCount) + (showCanceledAndExpired ? 0 : canceledAndExpiredCount)

--- a/apps/explorer/src/components/orders/UnsignedOrderWarning/index.tsx
+++ b/apps/explorer/src/components/orders/UnsignedOrderWarning/index.tsx
@@ -1,5 +1,6 @@
 import { BannerOrientation, InlineBanner } from '@cowprotocol/ui'
-import styled from 'styled-components'
+
+import styled from 'styled-components/macro'
 
 const StyledInlineBanner = styled(InlineBanner)`
   --cow-color-danger-text: ${({ theme }): string => theme.alert2};

--- a/apps/explorer/src/components/orders/UnsignedOrderWarning/index.tsx
+++ b/apps/explorer/src/components/orders/UnsignedOrderWarning/index.tsx
@@ -1,0 +1,14 @@
+import { BannerOrientation, InlineBanner } from '@cowprotocol/ui'
+import styled from 'styled-components'
+
+const StyledInlineBanner = styled(InlineBanner)`
+  --cow-color-danger-text: ${({ theme }): string => theme.alert2};
+`
+
+export const UnsignedOrderWarning: React.FC = () => {
+  return (
+    <StyledInlineBanner orientation={BannerOrientation.Horizontal} bannerType="danger" padding="0">
+      An unsigned order is not necessarily placed by the owner's account. Please be cautious.
+    </StyledInlineBanner>
+  )
+}


### PR DESCRIPTION
# Summary

This PR tries to address several issues related to the explorer. Primarily its displaying a warning for unsigned orders, so users know that the owner can be faked and anyone could have placed the order. Also, it makes some improvements to make the order table result more relevant for users.

## Explorer shows not relevant orders
Some accounts have a lot of expired and canceled orders.  When you go over your history, these orders are usually not super relevant to you. 

Because for now the API don't allow any filtering by the status of the order, I applied a filter in the client.

Test with `0x79063d9173C09887d536924E2F6eADbaBAc099f5` account: https://explorer-dev-git-hide-canceled-expired-cowswap.vercel.app/address/0x79063d9173C09887d536924E2F6eADbaBAc099f5

You should only be able to see the relevant orders:
<img width="1520" alt="image" src="https://github.com/user-attachments/assets/896f405c-3ae4-4c8b-b61e-9a8d6d443891" />

Notice the filter on top of the table. It allows you to show the hidden orders.

<img width="859" alt="image" src="https://github.com/user-attachments/assets/8d165562-9363-41de-add5-94be8222b797" />


Toggle the filter to show canceled or expired orders:

<img width="1555" alt="image" src="https://github.com/user-attachments/assets/3f192bc1-b0e7-4e10-9e44-adbdaa138e79" />


## Handle empty pages
This PR will also handle pages, where all orders are filtered client side.

You can test with `0x6810e776880c02933d47db1b9fc05908e5386b96` account. All orders are hidden: https://explorer-dev-git-hide-canceled-expired-cowswap.vercel.app/address/0x6810e776880c02933d47db1b9fc05908e5386b96

<img width="1452" alt="image" src="https://github.com/user-attachments/assets/893ea5ad-30f7-45ea-a4d6-aa0142667759" />

But you can reveal the orders:

<img width="1513" alt="image" src="https://github.com/user-attachments/assets/50c6d73a-69bf-46ad-beed-955f14fb7c8f" />


## Hide pre-sign orders

Similarly to canceled or expired, if the page has at least one order in the state of `presign`, we will hide it.

You can test `0x5be9a4959308A0D0c7bC0870E319314d8D957dBB` account. You can see how most of the orders are hidden, because from the 20 orders, only one is shown: https://explorer-dev-git-hide-canceled-expired-cowswap.vercel.app/address/0x5be9a4959308A0D0c7bC0870E319314d8D957dBB

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/d795cb84-6960-4ba6-b462-1475451a0614" />

10 are canceled or expired, and we can see them as I showed before. 9 are unsigned.

If you show the unsigned, it will show a warning to make sure users don't trust the owner:

<img width="1461" alt="image" src="https://github.com/user-attachments/assets/d053969f-8520-4b85-a8cb-957df7f124f0" />


## Show warning for the details
The warning to not trust the owner until an order is signed is added to the details to.

Try to open `0xe16f5e497eed1a90d570542a365ad0791e42a23f1960acac4274312ba64e707a5be9a4959308a0d0c7bc0870e319314d8d957dbb6769acd3` order: https://explorer-dev-git-hide-canceled-expired-cowswap.vercel.app/orders/0xe16f5e497eed1a90d570542a365ad0791e42a23f1960acac4274312ba64e707a5be9a4959308a0d0c7bc0870e319314d8d957dbb6769acd3?tab=overview

<img width="1539" alt="image" src="https://github.com/user-attachments/assets/c6e0a6ce-b60b-4c3b-a475-b7e223925aaa" />

