### PR TITLE
fix: remove Kleros token list because it's too big

### DIFF
--- a/apps/widget-configurator/src/app/configurator/consts.ts
+++ b/apps/widget-configurator/src/app/configurator/consts.ts
@@ -35,7 +35,6 @@ export const DEFAULT_TOKEN_LISTS: TokenListItem[] = [
   },
   { url: 'https://tokenlist.dharma.eth.link', enabled: false },
   { url: 'https://www.gemini.com/uniswap/manifest.json', enabled: false },
-  { url: 'https://t2crtokens.eth.link', enabled: false },
   { url: 'https://messari.io/tokenlist/messari-verified', enabled: false },
   { url: 'https://uniswap.mycryptoapi.com', enabled: false },
   { url: 'https://static.optimism.io/optimism.tokenlist.json', enabled: false },

--- a/libs/tokens/src/const/tokensList.json
+++ b/libs/tokens/src/const/tokensList.json
@@ -48,10 +48,6 @@
     },
     {
       "priority": 12,
-      "source": "t2crtokens.eth"
-    },
-    {
-      "priority": 13,
       "source": "https://curvefi.github.io/curve-assets/ethereum.json"
     }
   ],

--- a/libs/tokens/src/state/tokenLists/tokenListsStateAtom.ts
+++ b/libs/tokens/src/state/tokenLists/tokenListsStateAtom.ts
@@ -59,7 +59,7 @@ export const allListsSourcesAtom = atom((get) => {
 
 // Lists states
 export const listsStatesByChainAtom = atomWithStorage<TokenListsByChainState>(
-  'allTokenListsInfoAtom:v4',
+  'allTokenListsInfoAtom:v5',
   mapSupportedNetworks({}),
   getJotaiMergerStorage(),
 )


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C0361CDG8GP/p1734421577955559

Before:
```
allTokenListsInfoAtom:v4 5279.48046875 KB
```

After:
```
allTokenListsInfoAtom:v5 2361.544921875 KB
```

# To Test

Change network many times, the app should not crash
