### PR TITLE
fix: account for a bad CMS request

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBarV2/index.tsx
@@ -839,7 +839,8 @@ function FinishedStep(props: OrderProgressBarV2Props) {
             {solvers.length > 1 && (
               <p>
                 <b>
-                  {solvers.length} out of {totalSolvers} solvers
+                  {solvers.length}
+                  {totalSolvers ? ` out of ${totalSolvers}` : ''} solvers
                 </b>{' '}
                 submitted a solution
               </p>


### PR DESCRIPTION
# Summary

If the CMS calls fail, we might not know the number of solvers in a network
![image](https://github.com/user-attachments/assets/420baf04-6145-4e26-bfa4-7e357251755e)

This PR accounts for that. 

## Test
Block requests to CMS.

Asserts the message is still readable
