### PR TITLE
feat: use new uni and coingecko token lists

### DIFF
--- a/apps/explorer/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 
+import { Command } from '@cowprotocol/types'
 import { TruncatedText } from '@cowprotocol/ui/pure/TruncatedText'
 
 import { faExchangeAlt } from '@fortawesome/free-solid-svg-icons'
@@ -23,11 +24,10 @@ import { getLimitPrice } from 'utils/getLimitPrice'
 import { OrderSurplusDisplayStyledByRow } from './OrderSurplusTooltipStyledByRow'
 import { ToggleFilter } from './ToggleFilter'
 
+import { TableState } from '../../../explorer/components/TokensTableWidget/useTable'
 import { SimpleTable, SimpleTableProps } from '../../common/SimpleTable'
 import { StatusLabel } from '../StatusLabel'
 import { UnsignedOrderWarning } from '../UnsignedOrderWarning'
-import { TableState } from '../../../explorer/components/TokensTableWidget/useTable'
-import { Command } from '@cowprotocol/types'
 
 const EXPIRED_CANCELED_STATES: OrderStatus[] = ['cancelled', 'cancelling', 'expired']
 
@@ -37,7 +37,7 @@ function isExpiredOrCanceled(order: Order): boolean {
   if (!executedSellAmount.isZero() || !executedBuyAmount.isZero()) return false
 
   // Otherwise, return if the order is expired or canceled
-  return EXPIRED_CANCELED_STATES.includes(order.status)
+  return EXPIRED_CANCELED_STATES.includes(status)
 }
 
 const tooltip = {

--- a/libs/tokens/src/const/tokensList.json
+++ b/libs/tokens/src/const/tokensList.json
@@ -8,7 +8,7 @@
     {
       "priority": 2,
       "enabledByDefault": true,
-      "source": "https://files.cow.fi/tokens/CoinGecko.json"
+      "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/CoinGecko.1.json"
     },
     {
       "priority": 3,
@@ -65,12 +65,12 @@
     {
       "priority": 3,
       "enabledByDefault": true,
-      "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/GnosisUniswapTokensList.json"
+      "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/Uniswap.100.json"
     },
     {
       "priority": 4,
       "enabledByDefault": true,
-      "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/GnosisCoingeckoTokensList.json"
+      "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/CoinGecko.100.json"
     },
     {
       "priority": 5,
@@ -86,12 +86,12 @@
     {
       "priority": 2,
       "enabledByDefault": true,
-      "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/ArbitrumOneUniswapTokensList.json"
+      "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/Uniswap.42161.json"
     },
     {
       "priority": 3,
       "enabledByDefault": true,
-      "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/ArbitrumOneCoingeckoTokensList.json"
+      "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/CoinGecko.42161.json"
     },
     {
       "priority": 4,
@@ -119,6 +119,11 @@
       "priority": 2,
       "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/CoinGecko.8453.json",
       "enabledByDefault": true
+    },
+    {
+      "priority": 3,
+      "enabledByDefault": true,
+      "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/Uniswap.8453.json"
     }
   ]
 }

--- a/libs/tokens/src/const/tokensLists.ts
+++ b/libs/tokens/src/const/tokensLists.ts
@@ -10,6 +10,3 @@ export const LP_TOKEN_LISTS = lpTokensList as Array<ListSourceConfig>
 export const DEFAULT_TOKENS_LISTS: ListsSourcesByNetwork = mapSupportedNetworks((chainId) => tokensList[chainId])
 
 export const UNISWAP_TOKENS_LIST = 'https://ipfs.io/ipns/tokens.uniswap.org'
-
-export const GNOSIS_UNISWAP_TOKENS_LIST =
-  'https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/GnosisUniswapTokensList.json'

--- a/libs/tokens/src/state/tokenLists/tokenListsStateAtom.ts
+++ b/libs/tokens/src/state/tokenLists/tokenListsStateAtom.ts
@@ -4,12 +4,7 @@ import { atomWithStorage } from 'jotai/utils'
 import { getJotaiMergerStorage } from '@cowprotocol/core'
 import { mapSupportedNetworks, SupportedChainId } from '@cowprotocol/cow-sdk'
 
-import {
-  DEFAULT_TOKENS_LISTS,
-  GNOSIS_UNISWAP_TOKENS_LIST,
-  LP_TOKEN_LISTS,
-  UNISWAP_TOKENS_LIST,
-} from '../../const/tokensLists'
+import { DEFAULT_TOKENS_LISTS, LP_TOKEN_LISTS, UNISWAP_TOKENS_LIST } from '../../const/tokensLists'
 import {
   ListSourceConfig,
   ListsSourcesByNetwork,
@@ -21,9 +16,12 @@ import { environmentAtom } from '../environmentAtom'
 
 const UNISWAP_TOKEN_LIST_URL: Record<SupportedChainId, string> = {
   [SupportedChainId.MAINNET]: UNISWAP_TOKENS_LIST,
-  [SupportedChainId.GNOSIS_CHAIN]: GNOSIS_UNISWAP_TOKENS_LIST,
-  [SupportedChainId.ARBITRUM_ONE]: UNISWAP_TOKENS_LIST,
-  [SupportedChainId.BASE]: UNISWAP_TOKENS_LIST,
+  [SupportedChainId.GNOSIS_CHAIN]:
+    'https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/Uniswap.100.json',
+  [SupportedChainId.ARBITRUM_ONE]:
+    'https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/Uniswap.42161.json',
+  [SupportedChainId.BASE]:
+    'https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/Uniswap.8453.json',
   [SupportedChainId.SEPOLIA]: UNISWAP_TOKENS_LIST,
 }
 


### PR DESCRIPTION
# Summary

New token lists for Uniswap and Coingecko in all chains (where applicable)

# To Test

1. Load the app (make sure browser cache is disabled)
2. Manage the token lists
* You should see something similar to this on every chain
![image](https://github.com/user-attachments/assets/d3c12b63-612a-45c2-aa91-5bf04817ad4a)
* Except on Sepolia, since it's Sepolia and mainnet, that doesn't have a Uniswap subset and it's not enabled by default