### PR TITLE
feat: improve orders table when hidden orders

### DIFF
--- a/apps/explorer/src/components/common/Tabs/Tabs.tsx
+++ b/apps/explorer/src/components/common/Tabs/Tabs.tsx
@@ -42,7 +42,7 @@ export interface Props {
   readonly tabTheme: TabTheme
   readonly selectedTab?: TabId
   readonly extra?: TabBarExtraContent
-  readonly extraPosition?: 'top' | 'bottom'
+  readonly extraPosition?: 'top' | 'bottom' | 'both'
   readonly updateSelectedTab?: (activeId: TabId) => void
 }
 
@@ -129,10 +129,10 @@ const Tabs: React.FC<Props> = (props) => {
             tabTheme={tabTheme}
           />
         ))}
-        {extraPosition === 'top' && <ExtraContent extra={tabBarExtraContent} />}
+        {['top', 'both'].includes(extraPosition) && <ExtraContent extra={tabBarExtraContent} />}
       </TabList>
       <TabContent tabItems={tabItems} activeTab={selectedTab} />
-      {extraPosition === 'bottom' && <ExtraContent extra={tabBarExtraContent} />}
+      {['bottom', 'both'].includes(extraPosition) && <ExtraContent extra={tabBarExtraContent} />}
     </Wrapper>
   )
 }

--- a/apps/explorer/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -279,14 +279,16 @@ const OrdersUserDetailsTable: React.FC<Props> = (props) => {
             <HiddenOrdersLegend>
               <td colSpan={8}>
                 <p>
-                  Showing {orders.length - hiddenOrdersCount} out of {orders.length}&nbsp; orders for the current page.
+                  Showing {orders.length - hiddenOrdersCount} out of {orders.length} orders for the current page.
                 </p>
                 <p>
                   {hiddenOrdersCount} orders are hidden, you can make them visible using the filters above
-                  {tableState.hasNextPage && (
+                  {tableState.hasNextPage ? (
                     <span>
                       , or go to&nbsp;<a onClick={handleNextPage}>next page</a>&nbsp;for more orders.
                     </span>
+                  ) : (
+                    '.'
                   )}
                 </p>
               </td>

--- a/apps/explorer/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -72,48 +72,47 @@ interface RowProps {
 const FilterRow = styled.tr`
   background-color: ${({ theme }) => theme.background};
 
-  th {
+  @media (max-width: 1155px) {
+    div:first-child {
+      max-width: 90vw;
+    }
+  }
+
+  td {
+    padding: 2rem;
     text-align: right;
     padding-right: 10px;
-
+    max-width: 100%;
     & > * {
       margin-left: 10px;
     }
   }
+
+  p {
+    word-wrap: break-word;
+    white-space: normal;
+  }
 `
 
-const NoOrdersContainer = styled.div`
+const Filters = styled.div`
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
   justify-content: center;
-  flex-direction: column;
-  padding: 2rem;
+  flex-wrap: wrap;
+  flex-direction: row;
+  gap: 1rem;
 `
 
-const HiddenOrdersLegend = styled.tr`
+const HiddenOrdersLegend = styled.div`
   p {
     text-align: center;
   }
 
-  &:hover,
-  td:hover {
-    background-color: ${({ theme }) => theme.paper};
-    color: ${({ theme }) => theme.textSecondary1};
+  a {
+    text-decoration: underline;
   }
 
-  td {
-    padding: 0;
-    font-size: 1.2rem;
-    color: ${({ theme }) => theme.textSecondary1};
-
-    a {
-      text-decoration: underline;
-    }
-
-    a:hover {
-      color: ${({ theme }) => theme.textSecondary2};
-    }
+  a:hover {
+    color: ${({ theme }) => theme.textSecondary2};
   }
 `
 
@@ -215,31 +214,6 @@ const OrdersUserDetailsTable: React.FC<Props> = (props) => {
     <SimpleTable
       header={
         <>
-          {showFilter && (
-            <FilterRow>
-              <th colSpan={8}>
-                {canceledAndExpiredCount > 0 && (
-                  <ToggleFilter
-                    checked={showCanceledAndExpired}
-                    onChange={() => setShowCanceledAndExpired((previousValue) => !previousValue)}
-                    label={(showCanceledAndExpired ? 'Hide' : 'Show') + ' canceled/expired'}
-                    count={canceledAndExpiredCount}
-                  />
-                )}
-                {preSigningCount > 0 && (
-                  <>
-                    <ToggleFilter
-                      checked={showPreSigning}
-                      onChange={() => setShowPreSigning((previousValue) => !previousValue)}
-                      label={(showPreSigning ? 'Hide' : 'Show') + ' unsigned'}
-                      count={preSigningCount}
-                    />
-                    {showPreSigning && <UnsignedOrderWarning />}
-                  </>
-                )}
-              </th>
-            </FilterRow>
-          )}
           {!areOrdersAllHidden && (
             <tr>
               <th>
@@ -260,6 +234,15 @@ const OrdersUserDetailsTable: React.FC<Props> = (props) => {
               <th>Status</th>
             </tr>
           )}
+          {showPreSigning && (
+            <FilterRow>
+              <td colSpan={8}>
+                <div>
+                  <UnsignedOrderWarning />
+                </div>
+              </td>
+            </FilterRow>
+          )}
         </>
       }
       body={
@@ -275,24 +258,50 @@ const OrdersUserDetailsTable: React.FC<Props> = (props) => {
               />
             ))}
 
-          {hiddenOrdersCount > 0 && (
-            <HiddenOrdersLegend>
+          {showFilter && (
+            <FilterRow>
               <td colSpan={8}>
-                <p>
-                  Showing {orders.length - hiddenOrdersCount} out of {orders.length} orders for the current page.
-                </p>
-                <p>
-                  {hiddenOrdersCount} orders are hidden, you can make them visible using the filters above
-                  {tableState.hasNextPage ? (
-                    <span>
-                      , or go to&nbsp;<a onClick={handleNextPage}>next page</a>&nbsp;for more orders.
-                    </span>
-                  ) : (
-                    '.'
+                <div>
+                  {hiddenOrdersCount > 0 && (
+                    <HiddenOrdersLegend>
+                      <p>
+                        Showing {orders.length - hiddenOrdersCount} out of {orders.length} orders for the current page.
+                      </p>
+                      <p>
+                        {hiddenOrdersCount} orders are hidden, you can make them visible using the filters below
+                        {tableState.hasNextPage ? (
+                          <span>
+                            , or go to&nbsp;<a onClick={handleNextPage}>next page</a>&nbsp;for more orders.
+                          </span>
+                        ) : (
+                          '.'
+                        )}
+                      </p>
+                    </HiddenOrdersLegend>
                   )}
-                </p>
+                  <Filters>
+                    {canceledAndExpiredCount > 0 && (
+                      <ToggleFilter
+                        checked={showCanceledAndExpired}
+                        onChange={() => setShowCanceledAndExpired((previousValue) => !previousValue)}
+                        label={(showCanceledAndExpired ? 'Hide' : 'Show') + ' canceled/expired'}
+                        count={canceledAndExpiredCount}
+                      />
+                    )}
+                    {preSigningCount > 0 && (
+                      <>
+                        <ToggleFilter
+                          checked={showPreSigning}
+                          onChange={() => setShowPreSigning((previousValue) => !previousValue)}
+                          label={(showPreSigning ? 'Hide' : 'Show') + ' unsigned'}
+                          count={preSigningCount}
+                        />
+                      </>
+                    )}
+                  </Filters>
+                </div>
               </td>
-            </HiddenOrdersLegend>
+            </FilterRow>
           )}
         </>
       }

--- a/apps/explorer/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -262,23 +262,28 @@ const OrdersUserDetailsTable: React.FC<Props> = (props) => {
             <FilterRow>
               <td colSpan={8}>
                 <div>
-                  {hiddenOrdersCount > 0 && (
-                    <HiddenOrdersLegend>
-                      <p>
-                        Showing {orders.length - hiddenOrdersCount} out of {orders.length} orders for the current page.
-                      </p>
-                      <p>
-                        {hiddenOrdersCount} orders are hidden, you can make them visible using the filters below
-                        {tableState.hasNextPage ? (
-                          <span>
-                            , or go to&nbsp;<a onClick={handleNextPage}>next page</a>&nbsp;for more orders.
-                          </span>
-                        ) : (
-                          '.'
-                        )}
-                      </p>
-                    </HiddenOrdersLegend>
-                  )}
+                  <HiddenOrdersLegend>
+                    {hiddenOrdersCount > 0 ? (
+                      <>
+                        <p>
+                          Showing {orders.length - hiddenOrdersCount} out of {orders.length} orders for the current
+                          page.
+                        </p>
+                        <p>
+                          {hiddenOrdersCount} orders are hidden, you can make them visible using the filters below
+                          {tableState.hasNextPage ? (
+                            <span>
+                              , or go to&nbsp;<a onClick={handleNextPage}>next page</a>&nbsp;for more orders.
+                            </span>
+                          ) : (
+                            '.'
+                          )}
+                        </p>
+                      </>
+                    ) : (
+                      <p>Showing all {orders.length} orders for the current page.</p>
+                    )}
+                  </HiddenOrdersLegend>
                   <Filters>
                     {canceledAndExpiredCount > 0 && (
                       <ToggleFilter

--- a/apps/explorer/src/components/orders/OrdersUserDetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/OrdersUserDetailsTable/index.tsx
@@ -26,7 +26,7 @@ import { ToggleFilter } from './ToggleFilter'
 import { SimpleTable, SimpleTableProps } from '../../common/SimpleTable'
 import { StatusLabel } from '../StatusLabel'
 import { UnsignedOrderWarning } from '../UnsignedOrderWarning'
-import { TableState } from 'explorer/components/TokensTableWidget/useTable'
+import { TableState } from '../../../explorer/components/TokensTableWidget/useTable'
 import { Command } from '@cowprotocol/types'
 
 const EXPIRED_CANCELED_STATES: OrderStatus[] = ['cancelled', 'cancelling', 'expired']

--- a/apps/explorer/src/explorer/components/OrdersTableWidget/OrdersTableWithData.tsx
+++ b/apps/explorer/src/explorer/components/OrdersTableWidget/OrdersTableWithData.tsx
@@ -12,6 +12,8 @@ export const OrdersTableWithData: React.FC = () => {
   const {
     data: orders,
     addressAccountParams: { ownerAddress, networkId },
+    tableState,
+    handleNextPage,
   } = useContext(OrdersTableContext)
   const isFirstRender = useFirstRender()
   const [isFirstLoading, setIsFirstLoading] = useState(true)
@@ -46,6 +48,8 @@ export const OrdersTableWithData: React.FC = () => {
   ) : (
     <OrdersTable
       orders={orders}
+      tableState={tableState}
+      handleNextPage={handleNextPage}
       messageWhenEmpty={
         <EmptyOrdersMessage
           isLoading={searchInAnotherNetworkState}

--- a/apps/explorer/src/explorer/components/OrdersTableWidget/index.tsx
+++ b/apps/explorer/src/explorer/components/OrdersTableWidget/index.tsx
@@ -91,7 +91,7 @@ const OrdersTableWidget: React.FC<Props> = ({ ownerAddress, networkId }) => {
     >
       <ConnectionStatus />
       {error && <Notification type={error.type} message={error.message} />}
-      <StyledExplorerTabs tabItems={tabItems(isLoading)} extra={ExtraComponentNode} />
+      <StyledExplorerTabs tabItems={tabItems(isLoading)} extra={ExtraComponentNode} extraPosition="both" />
     </OrdersTableContext.Provider>
   )
 }

--- a/apps/explorer/src/explorer/components/common/ExplorerTabs/ExplorerTabs.tsx
+++ b/apps/explorer/src/explorer/components/common/ExplorerTabs/ExplorerTabs.tsx
@@ -5,11 +5,7 @@ import { Media } from '@cowprotocol/ui'
 import styled from 'styled-components/macro'
 import { DARK_COLOURS } from 'theme'
 
-import Tabs, {
-  getTabTheme,
-  Props as TabsProps,
-  IndicatorTabSize,
-} from '../../../../components/common/Tabs/Tabs'
+import Tabs, { getTabTheme, Props as TabsProps, IndicatorTabSize } from '../../../../components/common/Tabs/Tabs'
 
 const StyledTabs = styled.div`
   display: flex;
@@ -56,7 +52,7 @@ const tabCustomThemeConfig = getTabTheme({
   indicatorTabSize: IndicatorTabSize.big,
 })
 
-type ExplorerTabsProps = Omit<TabsProps, 'tabTheme'> & { extraPosition?: 'top' | 'bottom' }
+type ExplorerTabsProps = Omit<TabsProps, 'tabTheme'> & { extraPosition?: 'top' | 'bottom' | 'both' }
 
 const ExplorerTabs: React.FC<ExplorerTabsProps> = (props) => {
   return (


### PR DESCRIPTION
# Summary

This PR adds 2 things:
- Another pagination control in the bottom of the table. After all, makes sense to not scroll up to go to next page
- Makes it more cleat that the page is complete, and there's more pages later


It is not very clear in this table that 19 orders are hidden and I can navigate to next pages. Basically, it looks like there's no more than 1 order.

<img width="1458" alt="image" src="https://github.com/user-attachments/assets/acf0448d-bdc1-4655-ac09-689f98b57ae1" />


This PR shows the same account like this:

![image](https://github.com/user-attachments/assets/a3cc1870-df45-43e1-9e25-85b9c1d79d0e)




You can unhide orders, and the message will update
![image](https://github.com/user-attachments/assets/0e4a5b39-1d35-45cb-90de-bd935b662d59)


You can click on next page to navigate.

In last page, you don't see the next page link

<img width="1460" alt="image" src="https://github.com/user-attachments/assets/cdeebbde-3697-42ff-96e1-975b518f03a9" />


# To Test

Search for your orders in the explorer, for example for the account `0x5be9a4959308A0D0c7bC0870E319314d8D957dBB`

- Notice the two paginators
- Check the cases described above