### PR TITLE
feat: allow 1 year max deadline

### DIFF
--- a/apps/cowswap-frontend/src/common/constants/common.ts
+++ b/apps/cowswap-frontend/src/common/constants/common.ts
@@ -5,7 +5,7 @@ import ms from 'ms.macro'
 
 export const HIGH_FEE_WARNING_PERCENTAGE = new Percent(1, 10)
 
-export const MAX_ORDER_DEADLINE = ms`182d` + ms`12h` // 6 months, matching backend's https://github.com/cowprotocol/infrastructure/blob/901ed8e2fe3ea57956585f107bdd7539c2e7d3d1/services/Pulumi.yaml#L15
+export const MAX_ORDER_DEADLINE = ms`1y` // https://github.com/cowprotocol/infrastructure/blob/staging/services/Pulumi.yaml#L7
 
 // Use a 150K gas as a fallback if there's issue calculating the gas estimation (fixes some issues with some nodes failing to calculate gas costs for SC wallets)
 export const GAS_LIMIT_DEFAULT = BigNumber.from('150000')

--- a/apps/cowswap-frontend/src/modules/limitOrders/pure/DeadlineSelector/deadlines.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/pure/DeadlineSelector/deadlines.ts
@@ -21,7 +21,7 @@ export const LIMIT_ORDERS_DEADLINES: LimitOrderDeadline[] = [
   { title: '3 Days', value: ms`3d` },
   defaultLimitOrderDeadline,
   { title: '1 Month', value: ms`30d` },
-  { title: '6 Months (max)', value: MAX_CUSTOM_DEADLINE },
+  { title: '1 Year (max)', value: MAX_CUSTOM_DEADLINE },
 ]
 
 /**


### PR DESCRIPTION
# Summary

Before this PR, we allowed a maximum deadline of 6 month for limit orders

This PR increases it to 1 year:

<img width="1713" alt="image" src="https://github.com/user-attachments/assets/e48da0e5-241a-4faa-83f6-732d29825e2e" />


## Test
Place orders of more than 6 months deadline, up to a year