### PR TITLE
feat: fix pagination for fills

### DIFF
--- a/apps/explorer/src/components/orders/OrderDetails/FillsTableWithData.tsx
+++ b/apps/explorer/src/components/orders/OrderDetails/FillsTableWithData.tsx
@@ -18,7 +18,7 @@ type Props = {
 }
 
 export const FillsTableWithData: React.FC<Props> = ({ areTokensLoaded, order, isPriceInverted, invertPrice }) => {
-  const { trades, tableState } = useContext(FillsTableContext)
+  const { data: trades, tableState } = useContext(FillsTableContext)
   const isFirstRender = useFirstRender()
 
   return isFirstRender || !areTokensLoaded ? (

--- a/apps/explorer/src/components/orders/OrderDetails/context/FillsTableContext.tsx
+++ b/apps/explorer/src/components/orders/OrderDetails/context/FillsTableContext.tsx
@@ -5,7 +5,7 @@ import { Trade } from 'api/operator'
 import { TableState, TableStateSetters } from '../../../../explorer/components/TokensTableWidget/useTable'
 
 type CommonState = {
-  trades: Trade[]
+  data: Trade[]
   isLoading: boolean
   tableState: TableState
 } & TableStateSetters

--- a/apps/explorer/src/components/orders/OrderDetails/index.tsx
+++ b/apps/explorer/src/components/orders/OrderDetails/index.tsx
@@ -177,7 +177,7 @@ export const OrderDetails: React.FC<Props> = (props) => {
 
   const ExtraComponentNode: React.ReactNode = (
     <WrapperExtraComponents>
-      <>{tabViewSelected === TabView.FILLS && <TablePagination context={FillsTableContext} />}</>
+      {tabViewSelected === TabView.FILLS && <TablePagination context={FillsTableContext} />}
     </WrapperExtraComponents>
   )
 

--- a/apps/explorer/src/components/orders/OrderDetails/index.tsx
+++ b/apps/explorer/src/components/orders/OrderDetails/index.tsx
@@ -72,7 +72,7 @@ export type Props = {
 
 export enum TabView {
   OVERVIEW = 1,
-  FILLS,
+  FILLS = 2,
 }
 
 const DEFAULT_TAB = TabView[1]
@@ -177,7 +177,7 @@ export const OrderDetails: React.FC<Props> = (props) => {
 
   const ExtraComponentNode: React.ReactNode = (
     <WrapperExtraComponents>
-      {tabViewSelected === TabView.FILLS && <TablePagination context={FillsTableContext} />}
+      <>{tabViewSelected === TabView.FILLS && <TablePagination context={FillsTableContext} />}</>
     </WrapperExtraComponents>
   )
 
@@ -225,7 +225,7 @@ export const OrderDetails: React.FC<Props> = (props) => {
       ))}
       <FillsTableContext.Provider
         value={{
-          trades,
+          data: trades,
           isLoading: areTradesLoading,
           tableState,
           setPageSize,


### PR DESCRIPTION
# Summary

Fixes the pagination for fills


Before 
https://explorer-dev-git-add-double-pagination-cowswap.vercel.app/orders/0xc0688a39e9ce5ee01c49786867357811c3fcf86e27eefb072e80c9417d731bf3a53a13a80d72a855481de5211e7654fabdfe352664fd9408?tab=fills

<img width="1431" alt="image" src="https://github.com/user-attachments/assets/6bc06a13-97fc-4729-9be2-5b37d5fb2509" />


After
<img width="1487" alt="Screenshot at Dec 18 12-39-17" src="https://github.com/user-attachments/assets/170b51fe-250b-4793-a5a4-86af04360396" />


# Test
test for order `0xc0688a39e9ce5ee01c49786867357811c3fcf86e27eefb072e80c9417d731bf3a53a13a80d72a855481de5211e7654fabdfe352664fd9408` 