### PR TITLE
feat: remove outdated token lists

### DIFF
--- a/apps/widget-configurator/src/app/configurator/consts.ts
+++ b/apps/widget-configurator/src/app/configurator/consts.ts
@@ -22,28 +22,12 @@ export const TRADE_MODES = [TradeType.SWAP, TradeType.LIMIT, TradeType.ADVANCED,
 // Sourced from https://tokenlists.org/
 export const DEFAULT_TOKEN_LISTS: TokenListItem[] = [
   { url: 'https://files.cow.fi/tokens/CowSwap.json', enabled: true },
-  { url: 'https://files.cow.fi/tokens/CoinGecko.json', enabled: true },
-  { url: 'https://tokens.1inch.eth.link', enabled: false },
-  { url: 'https://tokenlist.aave.eth.link', enabled: false },
-  { url: 'https://datafi.theagora.eth.link', enabled: false },
-  { url: 'https://defi.cmc.eth.link', enabled: false },
-  { url: 'https://stablecoin.cmc.eth.link', enabled: false },
-  { url: 'https://erc20.cmc.eth.link', enabled: false },
-  {
-    url: 'https://raw.githubusercontent.com/compound-finance/token-list/master/compound.tokenlist.json',
-    enabled: false,
-  },
-  { url: 'https://tokenlist.dharma.eth.link', enabled: false },
+  { url: 'https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/CoinGecko.1.json', enabled: true },
   { url: 'https://www.gemini.com/uniswap/manifest.json', enabled: false },
   { url: 'https://messari.io/tokenlist/messari-verified', enabled: false },
-  { url: 'https://uniswap.mycryptoapi.com', enabled: false },
   { url: 'https://static.optimism.io/optimism.tokenlist.json', enabled: false },
   { url: 'https://app.tryroll.com/tokens.json', enabled: false },
-  { url: 'https://raw.githubusercontent.com/SetProtocol/uniswap-tokenlist/main/set.tokenlist.json', enabled: false },
-  { url: 'https://synths.snx.eth.link', enabled: false },
-  { url: 'https://testnet.tokenlist.eth.link', enabled: false },
   { url: 'https://ipfs.io/ipns/tokens.uniswap.org', enabled: false },
-  { url: 'https://wrapped.tokensoft.eth.link', enabled: false },
 ]
 // TODO: Move default palette to a new lib that only exposes the palette colors.
 // This way it can be consumed by both the configurator and the widget.

--- a/libs/tokens/src/const/tokensList.json
+++ b/libs/tokens/src/const/tokensList.json
@@ -92,6 +92,10 @@
     {
       "priority": 4,
       "source": "https://curvefi.github.io/curve-assets/base.json"
+    },
+    {
+      "priority": 5,
+      "source": "https://static.optimism.io/optimism.tokenlist.json"
     }
   ]
 }

--- a/libs/tokens/src/const/tokensList.json
+++ b/libs/tokens/src/const/tokensList.json
@@ -88,6 +88,10 @@
       "priority": 3,
       "enabledByDefault": true,
       "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/Uniswap.8453.json"
+    },
+    {
+      "priority": 4,
+      "source": "https://curvefi.github.io/curve-assets/base.json"
     }
   ]
 }

--- a/libs/tokens/src/const/tokensList.json
+++ b/libs/tokens/src/const/tokensList.json
@@ -12,42 +12,6 @@
     },
     {
       "priority": 3,
-      "source": "https://raw.githubusercontent.com/compound-finance/token-list/master/compound.tokenlist.json"
-    },
-    {
-      "priority": 4,
-      "source": "tokenlist.aave.eth"
-    },
-    {
-      "priority": 5,
-      "source": "synths.snx.eth"
-    },
-    {
-      "priority": 6,
-      "source": "wrapped.tokensoft.eth"
-    },
-    {
-      "priority": 7,
-      "source": "https://raw.githubusercontent.com/SetProtocol/uniswap-tokenlist/main/set.tokenlist.json"
-    },
-    {
-      "priority": 8,
-      "source": "https://raw.githubusercontent.com/opynfinance/opyn-tokenlist/master/opyn-squeeth-tokenlist.json"
-    },
-    {
-      "priority": 9,
-      "source": "https://app.tryroll.com/tokens.json"
-    },
-    {
-      "priority": 10,
-      "source": "defi.cmc.eth"
-    },
-    {
-      "priority": 11,
-      "source": "stablecoin.cmc.eth"
-    },
-    {
-      "priority": 12,
       "source": "https://curvefi.github.io/curve-assets/ethereum.json"
     }
   ],


### PR DESCRIPTION
# Summary

Remove outdated token lists

All of the lists being removed haven't been updated in years. Probably where never updated.

# To Test

1. Open app on mainnet
2. Check loaded lists
* Should contain only: CoW Swap, Coingecko (500) and Curve (disabled by default)

1. Open the widget configurator
2. Check the suggested lists
* Should contain less options