### PR TITLE
fix: allow any safe-like apps

### DIFF
--- a/libs/wallet/src/web3-react/connection/safe.tsx
+++ b/libs/wallet/src/web3-react/connection/safe.tsx
@@ -7,19 +7,7 @@ import { Web3ReactConnection } from '../types'
 
 const [web3GnosisSafe, web3GnosisSafeHooks] = initializeConnector<AsyncConnector>(
   (actions) =>
-    new AsyncConnector(
-      () =>
-        import('@web3-react/gnosis-safe').then(
-          (m) =>
-            new m.GnosisSafe({
-              actions,
-              options: {
-                allowedDomains: [/app\.safe\.global$/, /(.+\.)?coinshift\.global$/, /localhost:5173$/],
-              },
-            }),
-        ),
-      actions,
-    ),
+    new AsyncConnector(() => import('@web3-react/gnosis-safe').then((m) => new m.GnosisSafe({ actions })), actions),
 )
 export const gnosisSafeConnection: Web3ReactConnection = {
   connector: web3GnosisSafe,


### PR DESCRIPTION
# Summary

Context: https://cowservices.slack.com/archives/C03DVQREAH0/p1734609531567519

This is a revert of https://github.com/cowprotocol/cowswap/pull/4931

# To Test

Need to run Safe app locally and specify `baseUrl` to this PR preview link, so I will test it by myself
