### PR TITLE
fix(widget): do not display Christmas background

### DIFF
--- a/apps/cowswap-frontend/src/common/constants/common.ts
+++ b/apps/cowswap-frontend/src/common/constants/common.ts
@@ -9,3 +9,5 @@ export const MAX_ORDER_DEADLINE = ms`1y` // https://github.com/cowprotocol/infra
 
 // Use a 150K gas as a fallback if there's issue calculating the gas estimation (fixes some issues with some nodes failing to calculate gas costs for SC wallets)
 export const GAS_LIMIT_DEFAULT = BigNumber.from('150000')
+
+export const APP_HEADER_ELEMENT_ID = 'cowswap-app-header'

--- a/apps/cowswap-frontend/src/cow-react/index.tsx
+++ b/apps/cowswap-frontend/src/cow-react/index.tsx
@@ -27,6 +27,7 @@ import { Updaters } from 'modules/application/containers/App/Updaters'
 import { WithLDProvider } from 'modules/application/containers/WithLDProvider'
 import { useInjectedWidgetParams } from 'modules/injectedWidget'
 
+import { APP_HEADER_ELEMENT_ID } from '../common/constants/common'
 import { WalletUnsupportedNetworkBanner } from '../common/containers/WalletUnsupportedNetworkBanner'
 import { BlockNumberProvider } from '../common/hooks/useBlockNumber'
 
@@ -85,7 +86,7 @@ function Web3ProviderInstance({ children }: { children: ReactNode }) {
 function Toasts() {
   const { disableToastMessages = false } = useInjectedWidgetParams()
 
-  return <SnackbarsWidget hidden={disableToastMessages} />
+  return <SnackbarsWidget hidden={disableToastMessages} anchorElementId={APP_HEADER_ELEMENT_ID} />
 }
 
 const container = document.getElementById('root')

--- a/apps/cowswap-frontend/src/modules/application/containers/App/index.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/App/index.tsx
@@ -25,6 +25,7 @@ import { useInjectedWidgetParams } from 'modules/injectedWidget'
 import { parameterizeTradeRoute, useTradeRouteContext } from 'modules/trade'
 import { useInitializeUtm } from 'modules/utm'
 
+import { APP_HEADER_ELEMENT_ID } from 'common/constants/common'
 import { CoWAmmBanner } from 'common/containers/CoWAmmBanner'
 import { InvalidLocalTimeWarning } from 'common/containers/InvalidLocalTimeWarning'
 import { useCategorizeRecentActivity } from 'common/hooks/useCategorizeRecentActivity'
@@ -133,6 +134,7 @@ export function App() {
           {!isInjectedWidgetMode && (
             // TODO: Move hard-coded colors to theme
             <MenuBar
+              id={APP_HEADER_ELEMENT_ID}
               navItems={navItems}
               productVariant={PRODUCT_VARIANT}
               customTheme={customTheme}

--- a/apps/cowswap-frontend/src/modules/application/containers/App/styled.ts
+++ b/apps/cowswap-frontend/src/modules/application/containers/App/styled.ts
@@ -84,6 +84,7 @@ export const BodyWrapper = styled.div<{ customTheme?: CowSwapTheme }>`
 
     ${({ customTheme, theme }) =>
       isChristmasTheme(customTheme) &&
+      !theme.isInjectedWidgetMode &&
       `
         background-image: url(${theme.darkMode ? IMAGE_BACKGROUND_DARK_CHRISTMAS_MEDIUM : IMAGE_BACKGROUND_LIGHT_CHRISTMAS_MEDIUM});
       `}
@@ -101,6 +102,7 @@ export const BodyWrapper = styled.div<{ customTheme?: CowSwapTheme }>`
 
     ${({ customTheme, theme }) =>
       isChristmasTheme(customTheme) &&
+      !theme.isInjectedWidgetMode &&
       `
         background-image: url(${theme.darkMode ? IMAGE_BACKGROUND_DARK_CHRISTMAS_SMALL : IMAGE_BACKGROUND_LIGHT_CHRISTMAS_SMALL});
       `}

--- a/libs/snackbars/src/hooks/useAnchorPosition.ts
+++ b/libs/snackbars/src/hooks/useAnchorPosition.ts
@@ -1,0 +1,36 @@
+import { useLayoutEffect, useState } from 'react'
+
+export function useAnchorPosition(elementId: string | undefined) {
+  const [top, setOffsetTop] = useState(0)
+  const [height, setOffsetHeight] = useState(0)
+
+  useLayoutEffect(() => {
+    if (!elementId) return
+
+    const updatePosition = () => {
+      const element = document.getElementById(elementId)
+
+      if (element) {
+        const { top, height } = element.getBoundingClientRect()
+        setOffsetTop(top)
+        setOffsetHeight(height)
+      } else {
+        setTimeout(updatePosition, 100)
+      }
+    }
+
+    updatePosition()
+
+    const resizeObserver = new ResizeObserver(updatePosition)
+    resizeObserver.observe(document.body)
+
+    window.addEventListener('scroll', updatePosition)
+
+    return () => {
+      window.removeEventListener('scroll', updatePosition)
+      resizeObserver.disconnect()
+    }
+  }, [elementId])
+
+  return { top, height }
+}

--- a/libs/ui/src/pure/MenuBar/index.tsx
+++ b/libs/ui/src/pure/MenuBar/index.tsx
@@ -666,6 +666,7 @@ function _onDropdownItemClickFactory(item: MenuItem, postClick?: () => void) {
 }
 
 interface MenuBarProps {
+  id?: string
   navItems: MenuItem[]
   productVariant: ProductVariant
   LinkComponent: LinkComponentType
@@ -695,6 +696,7 @@ interface MenuBarProps {
 
 export const MenuBar = (props: MenuBarProps) => {
   const {
+    id,
     navItems,
     productVariant,
     persistentAdditionalContent,
@@ -775,6 +777,7 @@ export const MenuBar = (props: MenuBarProps) => {
 
   return (
     <MenuBarWrapper
+      id={id}
       ref={menuRef}
       bgColorLight={bgColorLight}
       bgColorDark={bgColorDark}


### PR DESCRIPTION
# Summary

Fixes #5247, #5242

After adding Christmas theme we have broken the widget background in small resolutions.

<img width="636" alt="image" src="https://github.com/user-attachments/assets/efd69a21-bc24-46a7-b8d3-3eba14c19386" />

# To Test

1. Open a widget configurator
2. Make your window size smaller 
- [ ] AR: the Christmas background is displayed
- [ ] ER: the Christmas background is NOT displayed