### PR TITLE
fix: fix order filled condition for permit check

### DIFF
--- a/apps/cowswap-frontend/src/modules/ordersTable/utils/getOrderParams.ts
+++ b/apps/cowswap-frontend/src/modules/ordersTable/utils/getOrderParams.ts
@@ -47,7 +47,7 @@ export function getOrderParams(
     sellAmount,
     balance,
     // If the order has been filled at least once, we should not consider the permit amount
-    allowance: isOrderAtLeastOnceFilled ? getBiggerAmount(allowance, permitAmount) : allowance,
+    allowance: !isOrderAtLeastOnceFilled ? getBiggerAmount(allowance, permitAmount) : allowance,
   })
 
   return {


### PR DESCRIPTION
# Summary

The bug was introduced in #5207

In the code we have a comment:
```
// If the order has been filled at least once, we should not consider the permit amount
```

But the code didn't satisfy it

# To Test

Check this account with impersonator: https://explorer.cow.fi/base/orders/0xb5ada1af24500813ff0f7956c0b80d52354c790d811fd1acbc8a38006c2db74f958b275d4d2132da3d651df4d6e446e307544c5767727b30?tab=overview
