### PR TITLE
chore: fix failed e2e test

### DIFF
--- a/apps/cowswap-frontend-e2e/src/e2e/swap.test.ts
+++ b/apps/cowswap-frontend-e2e/src/e2e/swap.test.ts
@@ -68,7 +68,7 @@ describe('Swap (custom)', () => {
     })
 
     it('should accept buyAmount url param', () => {
-      cy.visit(`/#/${CHAIN_ID}/swap/${SELL_TOKEN}/${BUY_TOKEN}?buyAmount=0.5`)
+      cy.visit(`/#/${CHAIN_ID}/swap/${SELL_TOKEN}/${BUY_TOKEN}?buyAmount=0.5&orderKind=buy`)
       cy.get('#output-currency-input .token-amount-input').should('have.value', '0.5')
     })
 


### PR DESCRIPTION
# Summary

The case on the picture bellow is always failed.
It's actually has wrong URL setup. If you want to specify only `buyAmount` you have to set `orderKind` parameter as well. 

<img width="740" alt="image" src="https://github.com/user-attachments/assets/eaff9385-495e-480b-bd32-fd90da7aac12" />

# Test

All e2e tests should be green
