### PR TITLE
ci: deploy some apps preview only when PR has label

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,21 @@ In case of problems with the service worker cache you force a reset using
 
 `emergency.js` is not cached by browser and loaded before all.
 
+## Vercel preview build
+
+Since this repo includes multiple apps, we do not want to build all of them on each PR because it causes long build queues in Vercel.  
+Some apps (see the list bellow) are not required to be built on each PR so we run them only a PR is labeled with a specific label.  
+This label is defined in the project settings on Vercel in `Settings`/`Git`/`Ignored Build Step` script.  
+For example, the label for the widget-configurator is `preview-widget-cfg`:
+```
+node tools/scripts/ignore-build-step.js --app=preview-widget-cfg
+```
+
+List of applications and their labels:
+- widget-configurator: `preview-widget-cfg`
+- cosmos: `preview-cosmos`
+- sdk-tools: `preview-sdk-tools`
+
 # 📚 Technical Documentation
 
 1. [Oveall Architecture](docs/architecture-overview.md)

--- a/tools/scripts/ignore-build-step.js
+++ b/tools/scripts/ignore-build-step.js
@@ -1,0 +1,74 @@
+const owner = process.env.VERCEL_GIT_REPO_OWNER
+const repo = process.env.VERCEL_GIT_REPO_SLUG
+const pullRequestId = process.env.VERCEL_GIT_PULL_REQUEST_ID
+const commitRef = process.env.VERCEL_GIT_COMMIT_REF
+
+const APP_ARGV = '--app='
+const appName = (() => {
+  const argv = process.argv.find((arg) => arg.startsWith(APP_ARGV))
+  return argv ? argv.slice(APP_ARGV.length) : undefined
+})()
+
+const PREVIEW_IGNORE_BRANCHES = ['main', 'configuration', 'release-please--branches--main']
+
+/**
+ * Skip the build if:
+ *  - The branch is in the list of branches to ignore
+ *  - The app preview is configured to be deployed manually, and label is not present in the PR
+ */
+async function shouldSkipBuild() {
+  if (PREVIEW_IGNORE_BRANCHES.includes(commitRef)) {
+    console.log(`Skipping build for branch ${commitRef}.`)
+    return true
+  }
+
+  if (!pullRequestId) {
+    console.log('No PR ID found. Proceeding with build.')
+    return false
+  }
+
+  if (!appName) {
+    console.log(`No appName label: ${appName}, found. Proceeding with build.`)
+    return false
+  }
+
+  const url = `https://api.github.com/repos/${owner}/${repo}/issues/${pullRequestId}/labels`
+
+  try {
+    const response = await fetch(url)
+
+    if (!response.ok) {
+      console.error('Failed to fetch PR labels:', response.statusText)
+      return false // Proceed with the build in case of an error
+    }
+
+    const labels = await response.json()
+    console.log(
+      'PR Labels:',
+      labels.map((label) => label.name),
+    )
+    const hasAppLabel = labels.some((label) => label.name === appName)
+
+    if (hasAppLabel) {
+      console.log(`Found label: ${appName}. Proceeding with build.`)
+    } else {
+      console.log(`Label ${appName} not found. Skipping build.`)
+    }
+
+    // Skip the build if the PR doesn't have the app label
+    return !hasAppLabel
+  } catch (error) {
+    console.error('Error fetching PR labels:', error)
+    return false // Proceed with the build in case of an error
+  }
+}
+
+shouldSkipBuild().then((skip) => {
+  if (skip) {
+    console.log('Skipping build.')
+    process.exit(0)
+  } else {
+    console.log('Proceeding with build.')
+    process.exit(1)
+  }
+})


### PR DESCRIPTION
# Summary

Since this repo includes multiple apps, we do not want to build all of them on each PR because it causes long build queues in Vercel.  
Some apps (see the list bellow) are not required to be built on each PR so we run them only a PR is labeled with a specific label.  
This label is defined in the project settings on Vercel in `Settings`/`Git`/`Ignored Build Step` script.  
For example, the label for the widget-configurator is `preview-widget-cfg`:
```
node tools/scripts/ignore-build-step.js --app=preview-widget-cfg
```

List of applications and their labels:
- widget-configurator: `preview-widget-cfg`
- cosmos: `preview-cosmos`
- sdk-tools: `preview-sdk-tools`

In addition, I expanded the list of branches that should not be deployed in preview.
Before this fix only `configuration` branch was excluded, now:
```
['main', 'configuration', 'release-please--branches--main']
```

> This PR is a demo of the new feature.
As you can see, `widget-configurator` is buit when `cosmos` and `sdk-tools` are skipped