### PR TITLE
chore: remove xmas/halowren feature flags

### DIFF
--- a/apps/cowswap-frontend/src/modules/application/containers/App/index.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/App/index.tsx
@@ -1,8 +1,7 @@
 import { lazy, PropsWithChildren, Suspense, useMemo } from 'react'
 
 import { ACTIVE_CUSTOM_THEME, CustomTheme } from '@cowprotocol/common-const'
-import { useMediaQuery } from '@cowprotocol/common-hooks'
-import { useFeatureFlags } from '@cowprotocol/common-hooks'
+import { useFeatureFlags, useMediaQuery } from '@cowprotocol/common-hooks'
 import { isInjectedWidget } from '@cowprotocol/common-utils'
 import { Color, Footer, GlobalCoWDAOStyles, Media, MenuBar } from '@cowprotocol/ui'
 
@@ -55,7 +54,10 @@ export function App() {
   useAnalyticsReporterCowSwap()
   useInitializeUtm()
 
-  const { isYieldEnabled, isChristmasEnabled, isHalloweenEnabled } = useFeatureFlags()
+  const { isYieldEnabled, } = useFeatureFlags()
+  // TODO: load them from feature flags when we want to enable again
+  const isChristmasEnabled = false
+  const isHalloweenEnabled = false
 
   const isInjectedWidgetMode = isInjectedWidget()
   const menuItems = useMenuItems()

--- a/apps/cowswap-frontend/src/modules/sounds/utils/sound.ts
+++ b/apps/cowswap-frontend/src/modules/sounds/utils/sound.ts
@@ -7,8 +7,6 @@ import { cowSwapStore } from 'legacy/state'
 
 import { injectedWidgetParamsAtom } from 'modules/injectedWidget/state/injectedWidgetParamsAtom'
 
-import { featureFlagsAtom } from 'common/state/featureFlagsState'
-
 type SoundType = 'SEND' | 'SUCCESS' | 'ERROR'
 type Sounds = Record<SoundType, string>
 type WidgetSounds = keyof NonNullable<CowSwapWidgetAppParams['sounds']>
@@ -47,7 +45,12 @@ function isDarkMode(): boolean {
 }
 
 function getThemeBasedSound(type: SoundType): string {
-  const featureFlags = jotaiStore.get(featureFlagsAtom) as Record<string, boolean>
+  // TODO: load featureFlags when enabling again
+  // const featureFlags = jotaiStore.get(featureFlagsAtom) as Record<string, boolean>
+  // const { isChristmasEnabled, isHalloweenEnabled } = featureFlags
+  const isChristmasEnabled = false
+  const isHalloweenEnabled = false
+
   const defaultSound = DEFAULT_COW_SOUNDS[type]
   const themedOptions = THEMED_SOUNDS[type]
 
@@ -62,13 +65,13 @@ function getThemeBasedSound(type: SoundType): string {
     return defaultSound
   }
 
-  if (ACTIVE_CUSTOM_THEME === CustomTheme.CHRISTMAS && featureFlags.isChristmasEnabled && themedOptions.winterSound) {
+  if (ACTIVE_CUSTOM_THEME === CustomTheme.CHRISTMAS && isChristmasEnabled && themedOptions.winterSound) {
     return themedOptions.winterSound
   }
 
   if (
     ACTIVE_CUSTOM_THEME === CustomTheme.HALLOWEEN &&
-    featureFlags.isHalloweenEnabled &&
+    isHalloweenEnabled &&
     themedOptions.halloweenSound &&
     isDarkMode()
   ) {


### PR DESCRIPTION
# Summary

Only preventing the flags from being loaded from Launch Darkly.
All the functionality is still there.

# To Test

1. Turn flags on and off
* Should not have any effect