### PR TITLE
feat: limit UI upgrade 2 - USD precision

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useConvertUsdToTokenValue.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useConvertUsdToTokenValue.ts
@@ -1,7 +1,7 @@
-import { TokenWithLogo, USDC } from '@cowprotocol/common-const'
+import { USDC } from '@cowprotocol/common-const'
 import { getWrappedToken, tryParseCurrencyAmount } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
+import { Currency } from '@uniswap/sdk-core'
 
 import { useUsdPrice } from 'modules/usdAmount'
 
@@ -15,19 +15,11 @@ export function useConvertUsdToTokenValue(
       const usdcToken = USDC[currencyUsdcPrice.currency.chainId as SupportedChainId]
       const usdAmount = tryParseCurrencyAmount(typedValue, usdcToken)
 
-      const tokenAmount = currencyUsdcPrice.price.invert().quote(hackyAdjustAmountDust(usdAmount))
+      const tokenAmount = currencyUsdcPrice.price.invert().quote(usdAmount)
 
       return tokenAmount.toExact()
     }
 
     return typedValue
   }
-}
-
-/**
- * TODO: this is a hacky way to adjust the amount to avoid dust
- * For some reason, when you enter for example $366, price.quote() returns 365,9999999999
- */
-function hackyAdjustAmountDust(amount: CurrencyAmount<TokenWithLogo>): typeof amount {
-  return amount.add(tryParseCurrencyAmount('0.000001', amount.currency))
 }

--- a/apps/cowswap-frontend/src/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
+++ b/apps/cowswap-frontend/src/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
@@ -106,7 +106,7 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
   const convertUsdToTokenValue = useConvertUsdToTokenValue(currency)
 
   const onUserInputDispatch = useCallback(
-    (typedValue: string) => {
+    (typedValue: string, currencyValue?: string) => {
       // Always pass through empty string to allow clearing
       if (typedValue === '') {
         setTypedValue('')
@@ -114,8 +114,9 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
         return
       }
 
-      const value = convertUsdToTokenValue(typedValue, isUsdValuesMode)
       setTypedValue(typedValue)
+      // Avoid converting from USD if currencyValue is already provided
+      const value = currencyValue || convertUsdToTokenValue(typedValue, isUsdValuesMode)
       onUserInput(field, value)
     },
     [onUserInput, field, convertUsdToTokenValue, isUsdValuesMode],
@@ -129,7 +130,7 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps) {
     const value = isUsdValuesMode ? maxBalanceUsdAmount : maxBalance
 
     if (value) {
-      onUserInputDispatch(value.toExact())
+      onUserInputDispatch(value.toExact(), isUsdValuesMode ? maxBalance.toExact() : undefined)
       setMaxSellTokensAnalytics()
     }
   }, [maxBalance, onUserInputDispatch, isUsdValuesMode, maxBalanceUsdAmount])

--- a/apps/cowswap-frontend/src/modules/limitOrders/pure/DeadlineSelector/deadlines.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/pure/DeadlineSelector/deadlines.ts
@@ -18,7 +18,7 @@ export enum LimitOrderDeadlinePreset {
   ONE_DAY = '1 Day',
   THREE_DAYS = '3 Days',
   ONE_MONTH = '1 Month',
-  SIX_MONTHS = '6 Months (max)',
+  SIX_MONTHS = '1 Year (max)',
 }
 
 const DEADLINE_VALUES: Record<LimitOrderDeadlinePreset, number> = {

--- a/libs/common-utils/src/amountFormat/index.ts
+++ b/libs/common-utils/src/amountFormat/index.ts
@@ -1,11 +1,9 @@
-
-
 import {
   AMOUNT_PRECISION,
   FIAT_PRECISION,
+  INTL_NUMBER_FORMAT,
   PERCENTAGE_PRECISION,
   ZERO_FRACTION,
-  INTL_NUMBER_FORMAT,
 } from '@cowprotocol/common-const'
 import { Currency, CurrencyAmount, Percent, Rounding } from '@uniswap/sdk-core'
 
@@ -33,7 +31,7 @@ export function formatPercent(percent: Nullish<Percent>): string {
 export function formatAmountWithPrecision(
   amount: Nullish<FractionLike>,
   precision: number,
-  numberFormat = INTL_NUMBER_FORMAT
+  numberFormat = INTL_NUMBER_FORMAT,
 ): string {
   if (!amount) return ''
 
@@ -59,7 +57,7 @@ export function formatAmountWithPrecision(
   // Apply the language formatting for the amount
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat
   const formattedQuotient = numberFormat.format(
-    BigInt(trimTrailingZeros(adjustedQuotient.toString(), decimalsSeparator))
+    BigInt(trimTrailingZeros(adjustedQuotient.toString(), decimalsSeparator)),
   )
 
   // Remove trailing zeros
@@ -80,7 +78,7 @@ export function formatAmountWithPrecision(
 export function formatInputAmount(
   amount: Nullish<FractionLike>,
   balance: Nullish<CurrencyAmount<Currency>> = null,
-  isIndependentField = false
+  isIndependentField = false,
 ): string {
   if (!amount) return ''
 
@@ -92,7 +90,7 @@ export function formatInputAmount(
   }
 
   const precision = getPrecisionForAmount(amount)
-  const result = amount.toFixed(precision)
+  const result = amount.toFixed(precision, undefined, Rounding.ROUND_HALF_UP)
 
   return trimTrailingZeros(+result === 0 ? amount.toSignificant(AMOUNT_PRECISION) : result)
 }


### PR DESCRIPTION
# Summary

- Fix max precision bug with USD amounts
- Attempt fixing issues with precision

# To Test

1. On limit, turn on global USD
2. On a sell token which you have balance, click on max
3. Place a `fill or kill` order
* Should NOT show insufficient balance
* Should use ALL available balance

* USD amounts should be a bit less finicky (better with rounding)