### PR TITLE
fix(token-lists): remove old token lists from cache

### DIFF
--- a/apps/cowswap-frontend/public/emergency.js
+++ b/apps/cowswap-frontend/public/emergency.js
@@ -20,7 +20,12 @@ if (window.location.pathname !== '/') {
  */
 ;(function () {
   const key = 'allTokenListsInfoAtom:v5'
-  const tokenLists = JSON.parse(localStorage.getItem(key) || '[]')
+  const storageValue = localStorage.getItem(key)
+
+  // Exit early if the storage value is not set
+  if (!storageValue) return
+
+  const tokenLists = JSON.parse(storageValue)
 
   const listsToSkip = new RegExp(
     'CoingeckoTokensList\\.json$|' +


### PR DESCRIPTION
# Summary

This PR removes old token lists from localStorage with the key `allTokenListsInfoAtom:v5`

# To Test

1. Load into your localStorage the above key from staging/prod
2. Open the page console and filter by `service`
3. Reload the page
* Should print logs like these:
![image](https://github.com/user-attachments/assets/37638c43-d0b6-46a4-a8c2-d691f0657d02)

4. Check the loaded token lists
* Should only contain the new lists from [here](https://github.com/cowprotocol/cowswap/blob/fix/remove-old-token-lists-from-cache/libs/tokens/src/const/tokensList.json) and whatever else you had loaded previously, that's not in the exclusion list:
![image](https://github.com/user-attachments/assets/fab57cd4-0c6a-4908-95dc-0bab1c661349)
![image](https://github.com/user-attachments/assets/26792281-915f-4300-960d-36e012353721)
