### PR TITLE
fix: fix text by mocking quick-lru

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,6 +1,7 @@
 import { config } from 'dotenv'
 import 'jest-styled-components' // include style rules in snapshots
 import fetchMock from 'jest-fetch-mock' // Mocks `fetch` calls in unittests
+import QuickLRU from 'quick-lru'
 
 import { Readable } from 'stream'
 import { TextDecoder, TextEncoder } from 'util'
@@ -19,3 +20,10 @@ fetchMock.dontMock()
 jest.mock('react-markdown', () => () => null)
 
 jest.mock('lottie-react', () => () => null)
+
+jest.mock('quick-lru', () => {
+  return {
+    __esModule: true,
+    default: QuickLRU,
+  }
+})


### PR DESCRIPTION
# Summary

Tests are broken cause jest import don't like commonjs modules, so I mocked to apply a transformation