### PR TITLE
Feat/limit UI upgrade 11

### DIFF
--- a/apps/cowswap-frontend/src/modules/ordersTable/containers/OrdersTableWidget/hooks/useOrdersTableList.ts
+++ b/apps/cowswap-frontend/src/modules/ordersTable/containers/OrdersTableWidget/hooks/useOrdersTableList.ts
@@ -68,14 +68,14 @@ export function useOrdersTableList(
           setIsOrderUnfillable({ chainId, id: order.id, isUnfillable })
         }
 
-        // Only add to unfillable if the order is both pending and unfillable
-        if (isPending && isUnfillable) {
-          acc.unfillable.push(item)
-        }
-
         // Add to signing if in presignature pending state
         if (isSigning) {
           acc.signing.push(item)
+        }
+
+        // Add to unfillable only if pending, unfillable, and not in signing state
+        if (isPending && isUnfillable && !isSigning) {
+          acc.unfillable.push(item)
         }
 
         // Add to pending or history based on status

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrderStatusBox/getOrderStatusTitleAndColor.ts
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrderStatusBox/getOrderStatusTitleAndColor.ts
@@ -53,21 +53,21 @@ export function getOrderStatusTitleAndColor(order: ParsedOrder): { title: string
     }
   }
 
-  // Handle unfillable orders
-  if (order.isUnfillable) {
-    return {
-      title: 'Unfillable',
-      color: `var(${UI.COLOR_DANGER_TEXT})`,
-      background: `var(${UI.COLOR_DANGER_BG})`,
-    }
-  }
-
   // Handle signing state
   if (order.status === OrderStatus.PRESIGNATURE_PENDING) {
     return {
       title: orderStatusTitleMap[OrderStatus.PRESIGNATURE_PENDING],
       color: `var(${UI.COLOR_ALERT_TEXT})`,
       background: `var(${UI.COLOR_ALERT_BG})`,
+    }
+  }
+
+  // Handle unfillable orders
+  if (order.isUnfillable) {
+    return {
+      title: 'Unfillable',
+      color: `var(${UI.COLOR_DANGER_TEXT})`,
+      background: `var(${UI.COLOR_DANGER_BG})`,
     }
   }
 

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
@@ -536,6 +536,9 @@ export function OrderRow({
       {/* Add empty cell for child TWAP orders */}
       {isTwapTable && isChild && <styledEl.CellElement />}
 
+      {/* Add empty cell for signing orders */}
+      {order.status === OrderStatus.PRESIGNATURE_PENDING && <styledEl.CellElement />}
+
       {/* Action content menu */}
       <styledEl.CellElement>
         <OrderContextMenu

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
@@ -125,7 +125,8 @@ export function OrderRow({
   const withAllowanceWarning = hasEnoughAllowance === false
   const withWarning =
     (hasEnoughBalance === false || withAllowanceWarning) &&
-    // show the warning only for pending and scheduled orders
+    // show the warning only for pending and scheduled orders, but not for presignature pending
+    status !== OrderStatus.PRESIGNATURE_PENDING &&
     (status === OrderStatus.PENDING || status === OrderStatus.SCHEDULED)
   const isOrderScheduled = order.status === OrderStatus.SCHEDULED
 

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
@@ -537,8 +537,8 @@ export function OrderRow({
       {/* Add empty cell for child TWAP orders */}
       {isTwapTable && isChild && <styledEl.CellElement />}
 
-      {/* Add empty cell for signing orders */}
-      {order.status === OrderStatus.PRESIGNATURE_PENDING && <styledEl.CellElement />}
+      {/* Add empty cell for signing orders - only for TWAP */}
+      {isTwapTable && order.status === OrderStatus.PRESIGNATURE_PENDING && <styledEl.CellElement />}
 
       {/* Action content menu */}
       <styledEl.CellElement>


### PR DESCRIPTION
# Summary

- LIMIT: Add to unfillable only if pending, unfillable, and not in signing state
- LIMIT: Show the warning only for pending and scheduled orders, but not for presignature pending
- LIMIT: Add empty cell for signing orders - only for TWAP