### PR TITLE
Feat/limit UI upgrade 12

### DIFF
--- a/apps/cowswap-frontend/src/modules/ordersTable/containers/OrdersTableWidget/hooks/useOrdersTableList.ts
+++ b/apps/cowswap-frontend/src/modules/ordersTable/containers/OrdersTableWidget/hooks/useOrdersTableList.ts
@@ -36,10 +36,12 @@ export function useOrdersTableList(
 ): OrdersTableList {
   const setIsOrderUnfillable = useSetIsOrderUnfillable()
 
+  // First, group and sort all orders
   const allSortedOrders = useMemo(() => {
     return groupOrdersTable(allOrders).sort(ordersSorter)
   }, [allOrders])
 
+  // Then, categorize orders into their respective lists
   return useMemo(() => {
     const { pending, history, unfillable, signing, all } = allSortedOrders.reduce(
       (acc, item) => {
@@ -96,6 +98,7 @@ export function useOrdersTableList(
       },
     )
 
+    // Return sliced lists to respect ORDERS_LIMIT
     return {
       pending: pending.slice(0, ORDERS_LIMIT),
       history: history.slice(0, ORDERS_LIMIT),

--- a/apps/cowswap-frontend/src/modules/ordersTable/containers/OrdersTableWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/containers/OrdersTableWidget/index.tsx
@@ -160,11 +160,20 @@ export function OrdersTableWidget({
   const { currentTabId, currentPageNumber } = useMemo(() => {
     const params = parseOrdersTableUrl(location.search)
 
+    // If we're on the signing tab but there are no signing orders,
+    // default to the all orders tab
+    if (params.tabId === 'signing' && !ordersList.signing.length) {
+      return {
+        currentTabId: ALL_ORDERS_TAB.id,
+        currentPageNumber: params.pageNumber || 1,
+      }
+    }
+
     return {
       currentTabId: params.tabId || ALL_ORDERS_TAB.id,
       currentPageNumber: params.pageNumber || 1,
     }
-  }, [location.search])
+  }, [location.search, ordersList.signing.length])
 
   const orders = useMemo(() => {
     return getOrdersListByIndex(ordersList, currentTabId)

--- a/apps/cowswap-frontend/src/modules/ordersTable/containers/OrdersTableWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/containers/OrdersTableWidget/index.tsx
@@ -160,9 +160,12 @@ export function OrdersTableWidget({
   const { currentTabId, currentPageNumber } = useMemo(() => {
     const params = parseOrdersTableUrl(location.search)
 
-    // If we're on the signing tab but there are no signing orders,
+    // If we're on a tab that becomes empty (signing or unfillable),
     // default to the all orders tab
-    if (params.tabId === 'signing' && !ordersList.signing.length) {
+    if (
+      (params.tabId === 'signing' && !ordersList.signing.length) ||
+      (params.tabId === 'unfillable' && !ordersList.unfillable.length)
+    ) {
       return {
         currentTabId: ALL_ORDERS_TAB.id,
         currentPageNumber: params.pageNumber || 1,
@@ -173,7 +176,7 @@ export function OrdersTableWidget({
       currentTabId: params.tabId || ALL_ORDERS_TAB.id,
       currentPageNumber: params.pageNumber || 1,
     }
-  }, [location.search, ordersList.signing.length])
+  }, [location.search, ordersList.signing.length, ordersList.unfillable.length])
 
   const orders = useMemo(() => {
     return getOrdersListByIndex(ordersList, currentTabId)


### PR DESCRIPTION
# Summary

fix: auto-switch to 'all orders' tab when signing/unfillable tabs become empty

When an order transitions out of the 'signing' or 'unfillable' state, and there are no more orders in that state, the UI now automatically switches to the 'all orders' tab. This behavior is consistent for both LIMIT and TWAP orders.