### PR TITLE
feat(market-price): use spot price for LIMIT market price button

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/updaters/QuoteObserverUpdater/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/updaters/QuoteObserverUpdater/index.tsx
@@ -4,14 +4,13 @@ import { useEffect, useMemo } from 'react'
 import { FractionUtils, getWrappedToken } from '@cowprotocol/common-utils'
 import { Fraction, Token } from '@uniswap/sdk-core'
 
-import { updateLimitRateAtom } from 'modules/limitOrders/state/limitRateAtom'
-import { useDerivedTradeState } from 'modules/trade/hooks/useDerivedTradeState'
-import { useTradeQuote } from 'modules/tradeQuote'
-import { useUsdPrice } from 'modules/usdAmount/hooks/useUsdPrice'
 import { Nullish } from 'types'
 
+import { updateLimitRateAtom } from 'modules/limitOrders/state/limitRateAtom'
+import { useDerivedTradeState } from 'modules/trade/hooks/useDerivedTradeState'
+import { useUsdPrice } from 'modules/usdAmount/hooks/useUsdPrice'
+
 export function QuoteObserverUpdater() {
-  const { response } = useTradeQuote()
   const state = useDerivedTradeState()
 
   const updateLimitRateState = useSetAtom(updateLimitRateAtom)
@@ -26,7 +25,9 @@ export function QuoteObserverUpdater() {
 
   useEffect(() => {
     updateLimitRateState({ marketRate: price, isLoadingMarketRate: isLoading })
-  }, [price, isLoading])
+  }, [price, isLoading, updateLimitRateState])
+
+  return null
 }
 
 function useSpotPrice(


### PR DESCRIPTION
# Summary

Depends on https://github.com/cowprotocol/cowswap/pull/5297

Using spot price (from BFF USD estimations) to populate the `market price` button in the limit orders form.

It's easier to see in the new design, but since it's independent from the changes there I'm piping into develop to add there later.

## ⚠️ Notes

- Before this change, we were adding a 0.1% slippage to the current market price to make it more likely to match
  This is being removed to match _exactly_ what's shown in the table
- The previous value was size dependent, based on the result from the quote. Now this is _purely_ the spot price
- As a bonus, the market price loading is back! (Don't know since when, but it was not being set at all)

# To Test

1. Open LIMIT
2. Pick pair of tokens
3. Place order (out of market just to have it pending)
4. For the same pair, check the proposed market price in the form
* Should match exactly what's shown in the table

