### PR TITLE
fix: amount locking

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/RateInput/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/RateInput/index.tsx
@@ -224,7 +224,7 @@ export function RateInput() {
             rateImpact={rateImpact}
             toggleIcon={
               <HoverTooltip
-                content="When enabled, the limit price stays fixed when changing the BUY amount. When disabled, the limit price will update based on the BUY amount changes."
+                content="When locked, the limit price stays fixed when changing the amounts. When unlocked, the limit price will update based on the amount changes."
                 wrapInContainer
                 placement="top-start"
               >

--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useUpdateCurrencyAmount.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useUpdateCurrencyAmount.ts
@@ -1,4 +1,3 @@
-import { useAtomValue, useSetAtom } from 'jotai'
 import { useCallback } from 'react'
 
 import { FractionUtils, isSellOrder } from '@cowprotocol/common-utils'
@@ -12,8 +11,6 @@ import { Field } from 'legacy/state/types'
 import { useLimitOrdersDerivedState } from 'modules/limitOrders/hooks/useLimitOrdersDerivedState'
 import { useUpdateLimitOrdersRawState } from 'modules/limitOrders/hooks/useLimitOrdersRawState'
 import { LimitOrdersRawState } from 'modules/limitOrders/state/limitOrdersRawStateAtom'
-import { limitOrdersSettingsAtom } from 'modules/limitOrders/state/limitOrdersSettingsAtom'
-import { updateLimitRateAtom } from 'modules/limitOrders/state/limitRateAtom'
 
 import { calculateAmountForRate } from 'utils/orderUtils/calculateAmountForRate'
 
@@ -25,9 +22,7 @@ type CurrencyAmountProps = {
 
 export function useUpdateCurrencyAmount() {
   const updateLimitOrdersState = useUpdateLimitOrdersRawState()
-  const { inputCurrency, outputCurrency, inputCurrencyAmount: currentInputAmount } = useLimitOrdersDerivedState()
-  const { limitPriceLocked } = useAtomValue(limitOrdersSettingsAtom)
-  const updateLimitRateState = useSetAtom(updateLimitRateAtom)
+  const { inputCurrency, outputCurrency } = useLimitOrdersDerivedState()
 
   return useCallback(
     (params: CurrencyAmountProps) => {
@@ -57,6 +52,6 @@ export function useUpdateCurrencyAmount() {
 
       updateLimitOrdersState(update)
     },
-    [inputCurrency, outputCurrency, updateLimitOrdersState, limitPriceLocked, updateLimitRateState, currentInputAmount],
+    [inputCurrency, outputCurrency, updateLimitOrdersState],
   )
 }

--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useUpdateCurrencyAmount.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useUpdateCurrencyAmount.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react'
 
 import { FractionUtils, isSellOrder } from '@cowprotocol/common-utils'
 import { OrderKind } from '@cowprotocol/cow-sdk'
-import { Currency, CurrencyAmount, Fraction, Price } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount, Fraction } from '@uniswap/sdk-core'
 
 import { Writeable } from 'types'
 
@@ -33,38 +33,7 @@ export function useUpdateCurrencyAmount() {
     (params: CurrencyAmountProps) => {
       const { activeRate, amount, orderKind } = params
       const field = isSellOrder(orderKind) ? Field.INPUT : Field.OUTPUT
-      const isBuyAmountChange = field === Field.OUTPUT
 
-      if (isBuyAmountChange) {
-        const update: Partial<Writeable<LimitOrdersRawState>> = {
-          orderKind,
-          outputCurrencyAmount: FractionUtils.serializeFractionToJSON(amount),
-        }
-
-        updateLimitOrdersState(update)
-
-        // If price is unlocked, update the rate based on the new amounts
-        if (!limitPriceLocked) {
-          // Calculate and update the new rate
-          if (amount && currentInputAmount) {
-            const newRate = new Price(
-              currentInputAmount.currency,
-              amount.currency,
-              currentInputAmount.quotient,
-              amount.quotient,
-            )
-            updateLimitRateState({
-              activeRate: FractionUtils.fractionLikeToFraction(newRate),
-              isTypedValue: false,
-              isRateFromUrl: false,
-              isAlternativeOrderRate: false,
-            })
-          }
-        }
-        return
-      }
-
-      // Normal flow for SELL amount changes
       const calculatedAmount = calculateAmountForRate({
         activeRate,
         amount,

--- a/apps/cowswap-frontend/src/modules/limitOrders/state/limitOrdersSettingsAtom.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/state/limitOrdersSettingsAtom.ts
@@ -29,7 +29,7 @@ export const defaultLimitOrdersSettings: LimitOrdersSettingsState = {
   deadlineMilliseconds: defaultLimitOrderDeadline.value,
   customDeadlineTimestamp: null,
   limitPricePosition: 'bottom',
-  limitPriceLocked: false,
+  limitPriceLocked: true,
   ordersTableOnLeft: false,
   isUsdValuesMode: false,
 }


### PR DESCRIPTION
# Summary

- Fixes buy amount behaviour on limit form for locked/unlocked price
- Sets price locking ON by default (same as prod currently)

Sell behaviour should also work as usual, as well as limit price changes.

In summary:

- Edit sell amount:
  - Price locked (default, same as prod): update buy amount
  - Price unlocked: update price
- Edit buy amount:
  - Price locked (default, same as prod): update sell amount
  - Price unlocked: update price
- Edit price:
  - Price locked or unlocked: update the field opposite to the last edited one

# To Test

1. Test all 6 scenarios defined above