### PR TITLE
Allow change network standalone widget

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/index.tsx
@@ -19,7 +19,7 @@ import { Web3Status } from 'modules/wallet/containers/Web3Status'
 
 import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetworkUnsupported'
 
-import { BalanceText, Wrapper } from './styled'
+import { BalanceText, Wrapper, LeftGroup } from './styled'
 
 import { NetworkSelector } from '../NetworkSelector'
 
@@ -54,25 +54,28 @@ export function AccountElement({ className, pendingActivities }: AccountElementP
 
   return (
     <>
-      <Wrapper className={className} active={!!account}>
-        {showEthBalance && (
-          <BalanceText>
-            <TokenAmount amount={userEthBalance} tokenSymbol={{ symbol: nativeTokenSymbol }} />
-          </BalanceText>
-        )}
+      <Wrapper className={className}>
+        <LeftGroup active={!!account}>
+          {showEthBalance && (
+            <BalanceText>
+              <TokenAmount amount={userEthBalance} tokenSymbol={{ symbol: nativeTokenSymbol }} />
+            </BalanceText>
+          )}
+          <Web3Status pendingActivities={pendingActivities} onClick={() => account && toggleAccountModal()} />
+          {account && (
+            <NotificationBell
+              unreadCount={unreadNotificationsCount}
+              onClick={() => {
+                clickNotifications(
+                  unreadNotificationsCount === 0 ? 'click-bell' : 'click-bell-with-pending-notifications',
+                )
+                setSidebarOpen(true)
+              }}
+            />
+          )}
+        </LeftGroup>
+
         {!hideNetworkSelector && <NetworkSelector />}
-        <Web3Status pendingActivities={pendingActivities} onClick={() => account && toggleAccountModal()} />
-        {account && (
-          <NotificationBell
-            unreadCount={unreadNotificationsCount}
-            onClick={() => {
-              clickNotifications(
-                unreadNotificationsCount === 0 ? 'click-bell' : 'click-bell-with-pending-notifications',
-              )
-              setSidebarOpen(true)
-            }}
-          />
-        )}
       </Wrapper>
 
       {ReactDOM.createPortal(

--- a/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/index.tsx
@@ -7,8 +7,6 @@ import { useWalletInfo } from '@cowprotocol/wallet'
 
 import ReactDOM from 'react-dom'
 
-
-
 import { upToLarge, useMediaQuery } from 'legacy/hooks/useMediaQuery'
 
 import { useToggleAccountModal } from 'modules/account'
@@ -21,20 +19,27 @@ import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetwo
 
 import { BalanceText, Wrapper } from './styled'
 
+import { NetworkSelector } from '../NetworkSelector'
+
 interface AccountElementProps {
   pendingActivities: string[]
   standaloneMode?: boolean
   className?: string
+  hideNetworkSelector?: boolean
 }
 
-export function AccountElement({ className, standaloneMode, pendingActivities }: AccountElementProps) {
+export function AccountElement({
+  className,
+  standaloneMode,
+  pendingActivities,
+  hideNetworkSelector,
+}: AccountElementProps) {
   const { account, chainId } = useWalletInfo()
   const isChainIdUnsupported = useIsProviderNetworkUnsupported()
   const userEthBalance = useNativeCurrencyAmount(chainId, account)
   const toggleAccountModal = useToggleAccountModal()
   const nativeTokenSymbol = NATIVE_CURRENCIES[chainId].symbol
   const isUpToLarge = useMediaQuery(upToLarge)
-
 
   const unreadNotifications = useUnreadNotifications()
   const unreadNotificationsCount = Object.keys(unreadNotifications).length
@@ -44,18 +49,25 @@ export function AccountElement({ className, standaloneMode, pendingActivities }:
   return (
     <>
       <Wrapper className={className} active={!!account}>
-        {standaloneMode !== false && account && !isChainIdUnsupported && userEthBalance && chainId && !isUpToLarge && (
-          <BalanceText>
-            <TokenAmount amount={userEthBalance} tokenSymbol={{ symbol: nativeTokenSymbol }} />
-          </BalanceText>
-        )}
+        {!!hideNetworkSelector &&
+          standaloneMode !== false &&
+          account &&
+          !isChainIdUnsupported &&
+          userEthBalance &&
+          chainId &&
+          !isUpToLarge && (
+            <BalanceText>
+              <TokenAmount amount={userEthBalance} tokenSymbol={{ symbol: nativeTokenSymbol }} />
+            </BalanceText>
+          )}
+        {!hideNetworkSelector && <NetworkSelector />}
         <Web3Status pendingActivities={pendingActivities} onClick={() => account && toggleAccountModal()} />
         {account && (
           <NotificationBell
             unreadCount={unreadNotificationsCount}
             onClick={() => {
               clickNotifications(
-                unreadNotificationsCount === 0 ? 'click-bell' : 'click-bell-with-pending-notifications'
+                unreadNotificationsCount === 0 ? 'click-bell' : 'click-bell-with-pending-notifications',
               )
               setSidebarOpen(true)
             }}
@@ -65,7 +77,7 @@ export function AccountElement({ className, standaloneMode, pendingActivities }:
 
       {ReactDOM.createPortal(
         <NotificationSidebar isOpen={isSidebarOpen} onClose={() => setSidebarOpen(false)} />,
-        document.body
+        document.body,
       )}
     </>
   )

--- a/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/styled.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/styled.tsx
@@ -25,29 +25,27 @@ export const BalanceText = styled(Text)`
   }
 `
 
-export const Wrapper = styled.div<{ active: boolean }>`
+export const Wrapper = styled.div`
   display: flex;
-  flex-direction: row;
   align-items: center;
-  white-space: nowrap;
-  cursor: pointer;
+  gap: 16px;
+  position: relative;
+  width: 100%;
+  flex-direction: row-reverse;
+
+  ${Media.upToMedium()} {
+    flex-direction: row;
+    justify-content: space-between;
+    width: 100%;
+  }
+`
+
+export const LeftGroup = styled.div<{ active: boolean }>`
+  display: flex;
+  align-items: center;
   background: ${({ active }) => (active ? `var(${UI.COLOR_PAPER_DARKER})` : `var(${UI.COLOR_PAPER})`)};
   border-radius: 28px;
   border: none;
   transition: border var(${UI.ANIMATION_DURATION}) ease-in-out;
   pointer-events: auto;
-  width: auto;
-  height: 100%;
-
-  ${Media.upToMedium()} {
-    height: 100%;
-  }
-
-  ${({ theme }) =>
-    theme.isInjectedWidgetMode &&
-    `
-    background-color: transparent;
-    margin: 0 20px 0 auto!important;
-    border: 0!important;
-  `}
 `

--- a/apps/cowswap-frontend/src/legacy/components/Header/styled.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Header/styled.tsx
@@ -31,6 +31,7 @@ export const HeaderElement = styled.div`
   align-items: center;
   gap: 0;
   height: 100%;
+  width: 100%;
 `
 
 export const LogoImage = styled.div<{ isMobileMenuOpen?: boolean }>`
@@ -47,8 +48,8 @@ export const LogoImage = styled.div<{ isMobileMenuOpen?: boolean }>`
 
   ${Media.upToLarge()} {
     ${({ isMobileMenuOpen }) =>
-    isMobileMenuOpen &&
-    css`
+      isMobileMenuOpen &&
+      css`
         height: 34px;
         width: auto;
       `}

--- a/apps/cowswap-frontend/src/modules/application/containers/App/index.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/App/index.tsx
@@ -12,7 +12,6 @@ import { ThemeProvider } from 'theme'
 
 import ErrorBoundary from 'legacy/components/ErrorBoundary'
 import { AccountElement } from 'legacy/components/Header/AccountElement'
-import { NetworkSelector } from 'legacy/components/Header/NetworkSelector'
 import { HeaderControls, HeaderElement } from 'legacy/components/Header/styled'
 import { URLWarning } from 'legacy/components/Header/URLWarning'
 import TopLevelModals from 'legacy/components/TopLevelModals'
@@ -20,7 +19,6 @@ import { useDarkModeManager } from 'legacy/state/user/hooks'
 
 import { OrdersPanel } from 'modules/account'
 import { useAnalyticsReporterCowSwap } from 'modules/analytics'
-import { useInjectedWidgetParams } from 'modules/injectedWidget'
 import { parameterizeTradeRoute, useTradeRouteContext } from 'modules/trade'
 import { useInitializeUtm } from 'modules/utm'
 
@@ -54,7 +52,7 @@ export function App() {
   useAnalyticsReporterCowSwap()
   useInitializeUtm()
 
-  const { isYieldEnabled, } = useFeatureFlags()
+  const { isYieldEnabled } = useFeatureFlags()
   // TODO: load them from feature flags when we want to enable again
   const isChristmasEnabled = false
   const isHalloweenEnabled = false
@@ -96,7 +94,6 @@ export function App() {
     ]
   }, [tradeContext, menuItems])
 
-  const { hideNetworkSelector } = useInjectedWidgetParams()
   const { pendingActivity } = useCategorizeRecentActivity()
   const isMobile = useMediaQuery(Media.upToMedium(false))
   const customTheme = useMemo(() => {
@@ -111,7 +108,6 @@ export function App() {
 
   const persistentAdditionalContent = (
     <HeaderControls>
-      {!hideNetworkSelector && <NetworkSelector />}
       <HeaderElement>
         <AccountElement pendingActivities={pendingActivity} />
       </HeaderElement>

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
@@ -161,13 +161,7 @@ export function TradeWidgetForm(props: TradeWidgetProps) {
       <styledEl.ContainerBox>
         <styledEl.Header>
           {isAlternativeOrderModalVisible ? <div></div> : <TradeWidgetLinks isDropdown={showDropdown} />}
-          {isInjectedWidgetMode && standaloneMode && (
-            <AccountElement
-              standaloneMode
-              pendingActivities={pendingActivity}
-              hideNetworkSelector={hideNetworkSelector}
-            />
-          )}
+          {isInjectedWidgetMode && standaloneMode && <AccountElement pendingActivities={pendingActivity} />}
 
           {shouldShowMyOrdersButton && (
             <ButtonOutlined margin={'0 16px 0 auto'} onClick={handleMyOrdersClick}>

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
@@ -45,7 +45,7 @@ const scrollToMyOrders = () => {
 
 export function TradeWidgetForm(props: TradeWidgetProps) {
   const isInjectedWidgetMode = isInjectedWidget()
-  const { standaloneMode, hideOrdersTable, hideNetworkSelector } = useInjectedWidgetParams()
+  const { standaloneMode, hideOrdersTable } = useInjectedWidgetParams()
   const isMobile = useMediaQuery(Media.upToSmall(false))
 
   const isAlternativeOrderModalVisible = useIsAlternativeOrderModalVisible()

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
@@ -45,7 +45,7 @@ const scrollToMyOrders = () => {
 
 export function TradeWidgetForm(props: TradeWidgetProps) {
   const isInjectedWidgetMode = isInjectedWidget()
-  const { standaloneMode, hideOrdersTable } = useInjectedWidgetParams()
+  const { standaloneMode, hideOrdersTable, hideNetworkSelector } = useInjectedWidgetParams()
   const isMobile = useMediaQuery(Media.upToSmall(false))
 
   const isAlternativeOrderModalVisible = useIsAlternativeOrderModalVisible()
@@ -162,7 +162,11 @@ export function TradeWidgetForm(props: TradeWidgetProps) {
         <styledEl.Header>
           {isAlternativeOrderModalVisible ? <div></div> : <TradeWidgetLinks isDropdown={showDropdown} />}
           {isInjectedWidgetMode && standaloneMode && (
-            <AccountElement standaloneMode pendingActivities={pendingActivity} />
+            <AccountElement
+              standaloneMode
+              pendingActivities={pendingActivity}
+              hideNetworkSelector={hideNetworkSelector}
+            />
           )}
 
           {shouldShowMyOrdersButton && (

--- a/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
@@ -43,6 +43,7 @@ export function useWidgetParams(configuratorState: ConfiguratorState): CowSwapWi
       standaloneMode,
       disableToastMessages,
       disableProgressBar,
+      hideNetworkSelector,
       hideBridgeInfo,
       hideOrdersTable,
     } = configuratorState
@@ -90,6 +91,7 @@ export function useWidgetParams(configuratorState: ConfiguratorState): CowSwapWi
       standaloneMode,
       disableToastMessages,
       disableProgressBar,
+      hideNetworkSelector,
 
       partnerFee:
         partnerFeeBps > 0

--- a/apps/widget-configurator/src/app/configurator/index.tsx
+++ b/apps/widget-configurator/src/app/configurator/index.tsx
@@ -145,6 +145,9 @@ export function Configurator({ title }: { title: string }) {
   const [disableProgressBar, setDisableProgressBar] = useState<boolean>(false)
   const toggleDisableProgressBar = useCallback(() => setDisableProgressBar((curr) => !curr), [])
 
+  const [hideNetworkSelector, setHideNetworkSelector] = useState<boolean>(true)
+  const toggleHideNetworkSelector = useCallback(() => setHideNetworkSelector((curr) => !curr), [])
+
   const [hideBridgeInfo, setHideBridgeInfo] = useState<boolean | undefined>(false)
   const toggleHideBridgeInfo = useCallback(() => setHideBridgeInfo((curr) => !curr), [])
 
@@ -184,6 +187,7 @@ export function Configurator({ title }: { title: string }) {
     standaloneMode,
     disableToastMessages,
     disableProgressBar,
+    hideNetworkSelector,
     hideBridgeInfo,
     hideOrdersTable,
   }
@@ -332,6 +336,20 @@ export function Configurator({ title }: { title: string }) {
           >
             <FormControlLabel value="false" control={<Radio />} label="Self-contain in Widget" />
             <FormControlLabel value="true" control={<Radio />} label="Dapp mode" />
+          </RadioGroup>
+        </FormControl>
+
+        <FormControl component="fieldset">
+          <FormLabel component="legend">Network selector:</FormLabel>
+          <RadioGroup
+            row
+            aria-label="mode"
+            name="mode"
+            value={hideNetworkSelector}
+            onChange={toggleHideNetworkSelector}
+          >
+            <FormControlLabel value="false" control={<Radio />} label="Show network selector" />
+            <FormControlLabel value="true" control={<Radio />} label="Hide network selector" />
           </RadioGroup>
         </FormControl>
 

--- a/apps/widget-configurator/src/app/configurator/types.ts
+++ b/apps/widget-configurator/src/app/configurator/types.ts
@@ -35,4 +35,5 @@ export interface ConfiguratorState {
   disableProgressBar: boolean
   hideBridgeInfo: boolean | undefined
   hideOrdersTable: boolean | undefined
+  hideNetworkSelector: boolean | undefined
 }


### PR DESCRIPTION
# Summary

Fixes #4870 

The widget is currently not showing the network selector. For dapp mode, is not a big deal, because the connection is handled by the dapp, and therefore, the responsibility of the network is there too.

However, in standalone mode, there's not currently a way to change network.




https://github.com/user-attachments/assets/9e0ff2c2-6631-4685-a6a8-885526cf6b98

This PR does 2 things:

## Adds the setting in the configurator

<img width="560" alt="image" src="https://github.com/user-attachments/assets/e4f2249a-783e-468c-b78f-4b210b118b8f" />


## Replaces the ETH balance by the network selector
ETH can be seen already in the network selector, and we are short on space. Plus we are a "gassless" exchange, you shouldn't need Ether a lot :) 

So I took the space of the ETH to show the network:
<img width="618" alt="image" src="https://github.com/user-attachments/assets/afc6ecbf-855f-4668-b046-ad103e3dc3a3" />
