### PR TITLE
fix: estimated execution price

### DIFF
--- a/apps/cowswap-frontend/src/common/updaters/orders/SpotPricesUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/SpotPricesUpdater.ts
@@ -105,8 +105,11 @@ export function SpotPricesUpdater(): null {
         })
       } catch (e) {
         console.error(
-          `Failed to update spot prices for ${inputCurrency.address} and ${outputCurrency.address}`,
-          { inputPrice, outputPrice },
+          `[SpotPricesUpdater] Failed to calculate spot price for ${inputCurrency.address} and ${outputCurrency.address}`,
+          inputPrice.price.numerator.toString(),
+          inputPrice.price.denominator.toString(),
+          outputPrice.price.numerator.toString(),
+          outputPrice.price.denominator.toString(),
           e,
         )
       }

--- a/apps/cowswap-frontend/src/common/updaters/orders/UnfillableOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/UnfillableOrdersUpdater.ts
@@ -181,6 +181,7 @@ export function UnfillableOrdersUpdater(): null {
 async function _getOrderPrice(chainId: ChainId, order: Order, strategy: PriceStrategy) {
   let baseToken, quoteToken
 
+  // TODO: consider a fixed amount in case of partial fills
   const amount = getRemainderAmount(order.kind, order)
 
   // Don't quote if there's nothing left to match in this order

--- a/apps/cowswap-frontend/src/legacy/state/orders/utils.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/utils.ts
@@ -288,20 +288,27 @@ export function getEstimatedExecutionPrice(
     sellAmount = getRemainderAmountsWithoutSurplus(order).sellAmount
     partiallyFillable = order.partiallyFillable
   } else {
+    if (!inputAmount || !outputAmount || !kind || inputAmount.equalTo(0) || outputAmount.equalTo(0)) {
+      return null
+    }
     // Always the full amount
-    sellAmount = inputAmount!.quotient.toString()
+    sellAmount = inputAmount.quotient.toString()
 
-    inputToken = getWrappedToken(inputAmount!.currency)
-    outputToken = getWrappedToken(outputAmount!.currency)
+    inputToken = getWrappedToken(inputAmount.currency)
+    outputToken = getWrappedToken(outputAmount.currency)
 
     limitPrice = getOrderLimitPriceWithPartnerFee({
       inputToken,
       outputToken,
       sellAmount,
-      buyAmount: outputAmount!.quotient.toString(),
+      buyAmount: outputAmount.quotient.toString(),
       kind: kind as OrderKind,
       fullAppData,
     })
+  }
+
+  if (!limitPrice) {
+    return null
   }
 
   const feeAmount = CurrencyAmount.fromRawAmount(inputToken, fee)

--- a/apps/cowswap-frontend/src/legacy/state/orders/utils.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/utils.ts
@@ -319,7 +319,7 @@ export function getEstimatedExecutionPrice(
 
   // When fee > amount, return 0 price
   if (!remainingSellAmount.greaterThan(ZERO_FRACTION)) {
-    return new Price(inputToken, outputToken, '0', '0')
+    return new Price(inputToken, outputToken, '1', '0')
   }
 
   const feeWithMargin = feeAmount.add(feeAmount.multiply(EXECUTION_PRICE_FEE_COEFFICIENT))
@@ -355,7 +355,9 @@ export function getEstimatedExecutionPrice(
 
     // Just in case when the denominator is <= 0 after subtracting the fee
     if (!denominator.greaterThan(ZERO_FRACTION)) {
-      return new Price(inputToken, outputToken, '0', '0')
+      // numerator and denominator are inverted!!!
+      // https://github.com/Uniswap/sdk-core/blob/9997e88/src/entities/fractions/price.ts#L26
+      return new Price(inputToken, outputToken, '1', '0')
     }
 
     /**

--- a/apps/cowswap-frontend/src/legacy/state/orders/utils.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/utils.ts
@@ -191,7 +191,7 @@ export function getOrderMarketPrice(order: Order, quotedAmount: string, feeAmoun
  * 5% to level out the fee amount changes
  */
 const EXECUTION_PRICE_FEE_COEFFICIENT = new Percent(5, 100)
-const FEE_AMOUNT_MULTIPLIER = 50
+const FEE_AMOUNT_MULTIPLIER = 1_000
 
 /**
  * Calculates the estimated execution price based on order params, before the order is placed

--- a/apps/cowswap-frontend/src/legacy/state/orders/utils.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/utils.ts
@@ -358,8 +358,12 @@ export function getEstimatedExecutionPrice(
     })
   }
 
+  // // Make the fill price a bit worse to account for the fee
+  const newFillPrice =
+    extrapolatePriceBasedOnFeeAmount(feeAmount, remainingSellAmount, fillPrice, inputToken, outputToken) || fillPrice
+
   // Pick the MAX between FEP and FP
-  return fillPrice.greaterThan(feasibleExecutionPrice) ? fillPrice : feasibleExecutionPrice
+  return newFillPrice.greaterThan(feasibleExecutionPrice) ? newFillPrice : feasibleExecutionPrice
 }
 
 /**

--- a/apps/cowswap-frontend/src/legacy/state/orders/utils.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/utils.ts
@@ -13,12 +13,12 @@ import { decodeAppData } from 'modules/appData/utils/decodeAppData'
 import { getIsComposableCowParentOrder } from 'utils/orderUtils/getIsComposableCowParentOrder'
 import { getOrderSurplus } from 'utils/orderUtils/getOrderSurplus'
 import { getUiOrderType } from 'utils/orderUtils/getUiOrderType'
+import { ParsedOrder } from 'utils/orderUtils/parseOrder'
 
 import { Order, updateOrder, UpdateOrderParams as UpdateOrderParamsAction } from './actions'
 import { OUT_OF_MARKET_PRICE_DELTA_PERCENTAGE } from './consts'
 import { UpdateOrderParams } from './hooks'
 
-import { ParsedOrder } from '../../../utils/orderUtils/parseOrder'
 import { AppDispatch } from '../index'
 import { serializeToken } from '../user/hooks'
 

--- a/apps/cowswap-frontend/src/modules/limitOrders/updaters/ExecutionPriceUpdater/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/updaters/ExecutionPriceUpdater/index.tsx
@@ -24,7 +24,11 @@ export function ExecutionPriceUpdater() {
   const outputToken = outputCurrencyAmount?.currency && getWrappedToken(outputCurrencyAmount.currency)
 
   const marketPrice =
-    marketRate && inputToken && outputToken && FractionUtils.toPrice(marketRate, inputToken, outputToken)
+    marketRate &&
+    !marketRate.equalTo('0') &&
+    inputToken &&
+    outputToken &&
+    FractionUtils.toPrice(marketRate, inputToken, outputToken)
 
   const fee = feeAmount?.quotient.toString()
 

--- a/apps/cowswap-frontend/src/modules/limitOrders/updaters/ExecutionPriceUpdater/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/updaters/ExecutionPriceUpdater/index.tsx
@@ -45,6 +45,12 @@ export function ExecutionPriceUpdater() {
     )
 
   useSafeEffect(() => {
+    // Reset execution price when input or output token changes
+    setExecutionPrice(null)
+  }, [inputToken, outputToken, setExecutionPrice])
+
+  useSafeEffect(() => {
+    // Set execution price when price is calculated and it's valid
     price && price.greaterThan(0) && setExecutionPrice(price)
   }, [price, setExecutionPrice])
 

--- a/apps/cowswap-frontend/src/modules/limitOrders/updaters/ExecutionPriceUpdater/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/updaters/ExecutionPriceUpdater/index.tsx
@@ -31,6 +31,8 @@ export function ExecutionPriceUpdater() {
   const price =
     marketPrice &&
     fee &&
+    inputCurrencyAmount &&
+    outputCurrencyAmount &&
     getEstimatedExecutionPrice(
       undefined,
       marketPrice,

--- a/apps/cowswap-frontend/src/modules/limitOrders/updaters/ExecutionPriceUpdater/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/updaters/ExecutionPriceUpdater/index.tsx
@@ -11,9 +11,12 @@ import { limitRateAtom } from 'modules/limitOrders/state/limitRateAtom'
 
 import { useSafeEffect } from 'common/hooks/useSafeMemo'
 
+import { limitOrdersSettingsAtom } from '../../state/limitOrdersSettingsAtom'
+
 export function ExecutionPriceUpdater() {
   const { marketRate, feeAmount } = useAtomValue(limitRateAtom)
   const { inputCurrencyAmount, outputCurrencyAmount, orderKind } = useLimitOrdersDerivedState()
+  const { partialFillsEnabled } = useAtomValue(limitOrdersSettingsAtom)
   const setExecutionPrice = useSetAtom(executionPriceAtom)
   const { fullAppData } = useAppData() || {}
 
@@ -36,6 +39,7 @@ export function ExecutionPriceUpdater() {
       outputCurrencyAmount,
       orderKind,
       fullAppData,
+      partialFillsEnabled,
     )
 
   useSafeEffect(() => {

--- a/apps/cowswap-frontend/src/modules/limitOrders/updaters/ExecutionPriceUpdater/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/updaters/ExecutionPriceUpdater/index.tsx
@@ -1,27 +1,45 @@
 import { useAtomValue, useSetAtom } from 'jotai'
-import { useEffect } from 'react'
 
+import { FractionUtils, getWrappedToken } from '@cowprotocol/common-utils'
+
+import { getEstimatedExecutionPrice } from 'legacy/state/orders/utils'
+
+import { useAppData } from 'modules/appData'
 import { useLimitOrdersDerivedState } from 'modules/limitOrders/hooks/useLimitOrdersDerivedState'
 import { executionPriceAtom } from 'modules/limitOrders/state/executionPriceAtom'
 import { limitRateAtom } from 'modules/limitOrders/state/limitRateAtom'
 
-import { calculateExecutionPrice } from 'utils/orderUtils/calculateExecutionPrice'
+import { useSafeEffect } from 'common/hooks/useSafeMemo'
 
 export function ExecutionPriceUpdater() {
   const { marketRate, feeAmount } = useAtomValue(limitRateAtom)
   const { inputCurrencyAmount, outputCurrencyAmount, orderKind } = useLimitOrdersDerivedState()
   const setExecutionPrice = useSetAtom(executionPriceAtom)
+  const { fullAppData } = useAppData() || {}
 
-  const price = calculateExecutionPrice({
-    inputCurrencyAmount,
-    outputCurrencyAmount,
-    feeAmount,
-    marketRate,
-    orderKind,
-  })
+  const inputToken = inputCurrencyAmount?.currency && getWrappedToken(inputCurrencyAmount.currency)
+  const outputToken = outputCurrencyAmount?.currency && getWrappedToken(outputCurrencyAmount.currency)
 
-  useEffect(() => {
-    setExecutionPrice(price)
+  const marketPrice =
+    marketRate && inputToken && outputToken && FractionUtils.toPrice(marketRate, inputToken, outputToken)
+
+  const fee = feeAmount?.quotient.toString()
+
+  const price =
+    marketPrice &&
+    fee &&
+    getEstimatedExecutionPrice(
+      undefined,
+      marketPrice,
+      fee,
+      inputCurrencyAmount,
+      outputCurrencyAmount,
+      orderKind,
+      fullAppData,
+    )
+
+  useSafeEffect(() => {
+    price && price.greaterThan(0) && setExecutionPrice(price)
   }, [price, setExecutionPrice])
 
   return null

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
@@ -41,6 +41,7 @@ import { OrderContextMenu } from './OrderContextMenu'
 import { WarningTooltip } from './OrderWarning'
 import * as styledEl from './styled'
 
+import { getEstimatedExecutionPrice } from '../../../../../legacy/state/orders/utils'
 import { OrderParams } from '../../../utils/getOrderParams'
 import { OrderStatusBox } from '../../OrderStatusBox'
 import { CheckboxCheckmark, TableRow, TableRowCheckbox, TableRowCheckboxWrapper } from '../styled'
@@ -113,7 +114,10 @@ export function OrderRow({
   const { creationTime, expirationTime, status } = order
   const { filledPercentDisplay, executedPrice } = order.executionData
   const { inputCurrencyAmount, outputCurrencyAmount } = rateInfoParams
-  const { estimatedExecutionPrice, feeAmount } = prices || {}
+  const { feeAmount } = prices || {}
+  const estimatedExecutionPrice = useSafeMemo(() => {
+    return spotPrice && feeAmount && getEstimatedExecutionPrice(order, spotPrice, feeAmount.quotient.toString())
+  }, [spotPrice, feeAmount, order])
   const isSafeWallet = useIsSafeWallet()
 
   const showCancellationModal = useMemo(() => {

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
@@ -340,7 +340,7 @@ export function OrderRow({
       return '-'
     }
 
-    if (prices && estimatedExecutionPrice) {
+    if (estimatedExecutionPrice && !estimatedExecutionPrice.equalTo(ZERO_FRACTION)) {
       return (
         <styledEl.ExecuteCellWrapper>
           {!isUnfillable &&
@@ -497,7 +497,7 @@ export function OrderRow({
       if (nextScheduledOrder) {
         // For scheduled orders, use the execution price if available, otherwise use the estimated price from props
         const nextOrderExecutionPrice =
-          nextScheduledOrder.executionData.executedPrice || prices?.estimatedExecutionPrice
+          nextScheduledOrder.executionData.executedPrice || estimatedExecutionPrice
         const nextOrderPriceDiffs = nextOrderExecutionPrice
           ? calculatePriceDifference({
             referencePrice: spotPrice,

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
@@ -16,6 +16,7 @@ import SVG from 'react-inlinesvg'
 import { Nullish } from 'types'
 
 import { OrderStatus } from 'legacy/state/orders/actions'
+import { getEstimatedExecutionPrice } from 'legacy/state/orders/utils'
 
 import { PendingOrderPrices } from 'modules/orders/state/pendingOrdersPricesAtom'
 import { getIsEthFlowOrder } from 'modules/swap/containers/EthFlowStepper'
@@ -42,7 +43,6 @@ import { OrderContextMenu } from './OrderContextMenu'
 import { WarningTooltip } from './OrderWarning'
 import * as styledEl from './styled'
 
-import { getEstimatedExecutionPrice } from '../../../../../legacy/state/orders/utils'
 import { OrderParams } from '../../../utils/getOrderParams'
 import { OrderStatusBox } from '../../OrderStatusBox'
 import { CheckboxCheckmark, TableRow, TableRowCheckbox, TableRowCheckboxWrapper } from '../styled'

--- a/apps/cowswap-frontend/src/utils/orderUtils/calculateExecutionPrice.ts
+++ b/apps/cowswap-frontend/src/utils/orderUtils/calculateExecutionPrice.ts
@@ -20,7 +20,7 @@ export interface ExecutionPriceParams {
  */
 export function convertAmountToCurrency(
   amount: CurrencyAmount<Currency>,
-  targetCurrency: Currency
+  targetCurrency: Currency,
 ): CurrencyAmount<Currency> {
   const { numerator, denominator } = amount
 
@@ -34,12 +34,12 @@ export function convertAmountToCurrency(
   const decimalsDiff = Math.abs(inputDecimals - outputDecimals)
   const decimalsDiffAmount = rawToTokenAmount(1, decimalsDiff)
 
-  const fixedNumenator =
+  const fixedNumerator =
     inputDecimals < outputDecimals
       ? JSBI.multiply(numerator, decimalsDiffAmount)
       : JSBI.divide(numerator, decimalsDiffAmount)
 
-  return CurrencyAmount.fromFractionalAmount(targetCurrency, fixedNumenator, denominator)
+  return CurrencyAmount.fromFractionalAmount(targetCurrency, fixedNumerator, denominator)
 }
 
 export function calculateExecutionPrice(params: ExecutionPriceParams): Price<Currency, Currency> | null {
@@ -62,7 +62,7 @@ export function calculateExecutionPrice(params: ExecutionPriceParams): Price<Cur
     baseAmount: inputCurrencyAmount,
     quoteAmount: convertAmountToCurrency(
       inputCurrencyAmount.subtract(feeAmount).multiply(marketRateFixed),
-      outputCurrencyAmount.currency
+      outputCurrencyAmount.currency,
     ),
   })
   const marketPrice = isInverted ? marketPriceRaw.invert() : marketPriceRaw

--- a/libs/common-utils/src/fractionUtils.test.ts
+++ b/libs/common-utils/src/fractionUtils.test.ts
@@ -76,5 +76,11 @@ describe('Fraction utils', () => {
       expect(JSBI.toNumber(simplified.numerator)).toBe(1)
       expect(JSBI.toNumber(simplified.denominator)).toBe(3)
     })
+    it('should avoid division by 0', () => {
+      const fraction = new Fraction(JSBI.BigInt(0), JSBI.BigInt(0))
+      const simplified = FractionUtils.simplify(fraction)
+      expect(JSBI.toNumber(simplified.numerator)).toBe(0)
+      expect(JSBI.toNumber(simplified.denominator)).toBe(1)
+    })
   })
 })

--- a/libs/common-utils/src/fractionUtils.ts
+++ b/libs/common-utils/src/fractionUtils.ts
@@ -193,6 +193,11 @@ function reduce(fraction: Fraction): Fraction {
   let numerator = fraction.numerator
   let denominator = fraction.denominator
   let rest: JSBI
+
+  if (JSBI.equal(denominator, ZERO)) {
+    return new Fraction(JSBI.BigInt(0), JSBI.BigInt(1))
+  }
+
   while (JSBI.notEqual(denominator, ZERO)) {
     rest = JSBI.remainder(numerator, denominator)
     numerator = denominator


### PR DESCRIPTION
# Summary

Overhaul estimated fill price in the form (and a bit in the table)

- Unified calculation in the single method

Overloaded `getEstimatedExecutionPrice` to be used in the `ExecutionPriceUpdater`
It now can also take order parameters without having an existing order

- Taking into account order flag `partially fillable`

Now it'll use a fixed sell amount to make estimation stable regardless of order size
The amount is currently set to ~50x~ 1000x `feeAmount`
From there, we use the chosen limit price (already discounted for potential fees) to derive the buy amount
Lastly, the `feeAmount` is deduced from the calculated sell amount, to give us the new estimated price

If the order is fill or kill OR the amount calculated above is bigger than actual sell amount, use the old way considering the whole sell amount

- Adding the fee to market price as well

One last adjustment, is to use the same method above to add the fee to the market price as well
We know we cannot execute exactly at the spot price because we need to take fees into account
So the same ~50x~ 1000x the fee strategy is applied to the spot price in case the limit price is below market.

# To Test

1. Play around with limit orders `fill or kill` and partially fillable
2. Verify the values on the open orders table
3. If the order is partially fillable, higher amounts shouldn't impact estimated fill price (when amount > 50x fee)

# TODO

- [ ] update unit tests
- [ ] add unit tests for overloaded variation