### PR TITLE
fix: spot prices display edge cases

### DIFF
--- a/apps/cowswap-frontend/src/common/updaters/orders/SpotPricesUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/SpotPricesUpdater.ts
@@ -87,9 +87,7 @@ export function SpotPricesUpdater(): null {
         return
       }
 
-      const inputFraction = FractionUtils.fractionLikeToFraction(inputPrice.price)
-      const outputFraction = FractionUtils.fractionLikeToFraction(outputPrice.price)
-      const fraction = inputFraction.divide(outputFraction)
+      const fraction = inputPrice.price.asFraction.divide(outputPrice.price.asFraction)
 
       if (!fraction) {
         return

--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useGetInitialPrice.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useGetInitialPrice.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-import { FractionUtils, getWrappedToken } from '@cowprotocol/common-utils'
+import { getWrappedToken } from '@cowprotocol/common-utils'
 import { Fraction } from '@uniswap/sdk-core'
 
 import { useAsyncMemo } from 'use-async-memo'
@@ -32,9 +32,8 @@ export function useGetInitialPrice(): { price: Fraction | null; isLoading: boole
       if (!inputUsdPrice?.price || !outputUsdPrice?.price) {
         return null
       }
-      const inputFraction = FractionUtils.fractionLikeToFraction(inputUsdPrice.price)
-      const outputFraction = FractionUtils.fractionLikeToFraction(outputUsdPrice.price)
-      return inputFraction.divide(outputFraction)
+
+      return inputUsdPrice.price.asFraction.divide(outputUsdPrice.price.asFraction)
     },
     [inputUsdPrice?.price, outputUsdPrice?.price],
     null,

--- a/apps/cowswap-frontend/src/modules/limitOrders/updaters/QuoteObserverUpdater/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/updaters/QuoteObserverUpdater/index.tsx
@@ -1,7 +1,7 @@
 import { useSetAtom } from 'jotai'
 import { useEffect, useMemo } from 'react'
 
-import { FractionUtils, getWrappedToken } from '@cowprotocol/common-utils'
+import { getWrappedToken } from '@cowprotocol/common-utils'
 import { Fraction, Token } from '@uniswap/sdk-core'
 
 import { Nullish } from 'types'
@@ -46,10 +46,8 @@ function useSpotPrice(
     if (!inputUsdPrice?.price || !outputUsdPrice?.price) {
       return { price: null, isLoading }
     }
-    const inputFraction = FractionUtils.fractionLikeToFraction(inputUsdPrice.price)
-    const outputFraction = FractionUtils.fractionLikeToFraction(outputUsdPrice.price)
 
-    const price = inputFraction.divide(outputFraction)
+    const price = inputUsdPrice.price.asFraction.divide(outputUsdPrice.price.asFraction)
 
     return { price, isLoading }
   }, [inputUsdPrice?.price, inputUsdPrice?.isLoading, outputUsdPrice?.price, outputUsdPrice?.isLoading])


### PR DESCRIPTION
# Summary

Fix issue when sometimes spot/market prices are not loaded

# To Test

1. Load the app in the Safe https://app.safe.global/apps/open?safe=sep:0x8FAb71C0d4272698A3B2d1F3Ed5FC3c1B9b3E531
2. Check limit orders
* Market prices should load 
![image](https://github.com/user-attachments/assets/e6870c08-dca7-41da-911f-efcfa80dad1e)
