### PR TITLE
Failed to import token list error message handled

### DIFF
--- a/apps/cowswap-frontend/src/modules/tokensList/containers/ManageLists/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/containers/ManageLists/index.tsx
@@ -20,10 +20,11 @@ interface ListSearchState {
 export interface ManageListsProps {
   lists: ListState[]
   listSearchResponse: ListSearchResponse
+  isListUrlValid: boolean
 }
 
 export function ManageLists(props: ManageListsProps) {
-  const { lists, listSearchResponse } = props
+  const { lists, listSearchResponse, isListUrlValid } = props
 
   const activeTokenListsIds = useListsEnabledState()
   const addListImport = useAddListImport()
@@ -34,6 +35,9 @@ export function ManageLists(props: ManageListsProps) {
 
   return (
     <styledEl.Wrapper>
+      {isListUrlValid && !listToImport?.list && !loading && (
+        <styledEl.InputError>Error importing token list</styledEl.InputError>
+      )}
       {loading && (
         <styledEl.LoaderWrapper>
           <Loader />

--- a/apps/cowswap-frontend/src/modules/tokensList/containers/ManageLists/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/containers/ManageLists/index.tsx
@@ -20,7 +20,7 @@ interface ListSearchState {
 export interface ManageListsProps {
   lists: ListState[]
   listSearchResponse: ListSearchResponse
-  isListUrlValid: boolean
+  isListUrlValid?: boolean
 }
 
 export function ManageLists(props: ManageListsProps) {

--- a/apps/cowswap-frontend/src/modules/tokensList/containers/ManageLists/styled.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/containers/ManageLists/styled.ts
@@ -18,3 +18,10 @@ export const LoaderWrapper = styled.div`
 export const ImportListsContainer = styled.div`
   border-bottom: 1px solid var(${UI.COLOR_BORDER});
 `
+
+export const InputError = styled.div`
+  padding: 20px;
+  color: var(${UI.COLOR_DANGER});
+  font-weight: 500;
+  border-bottom: 1px solid var(${UI.COLOR_BORDER});
+`

--- a/apps/cowswap-frontend/src/modules/tokensList/containers/ManageLists/styled.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/containers/ManageLists/styled.ts
@@ -8,6 +8,7 @@ export const Wrapper = styled(CommonListContainer)``
 
 export const ListsContainer = styled.div`
   padding-bottom: 20px;
+  border-top: 1px solid var(${UI.COLOR_BORDER});
 `
 
 export const LoaderWrapper = styled.div`
@@ -16,12 +17,11 @@ export const LoaderWrapper = styled.div`
 `
 
 export const ImportListsContainer = styled.div`
-  border-bottom: 1px solid var(${UI.COLOR_BORDER});
+  border-top: 1px solid var(${UI.COLOR_BORDER});
 `
 
 export const InputError = styled.div`
-  padding: 20px;
+  padding: 0 20px 20px;
   color: var(${UI.COLOR_DANGER});
   font-weight: 500;
-  border-bottom: 1px solid var(${UI.COLOR_BORDER});
 `

--- a/apps/cowswap-frontend/src/modules/tokensList/containers/ManageListsAndTokens/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/containers/ManageListsAndTokens/index.tsx
@@ -38,7 +38,7 @@ export function ManageListsAndTokens(props: ManageListsAndTokensProps) {
   }, [tokenInput])
 
   const isListUrlValid = useMemo(() => {
-    if (!listInput) return true
+    if (!listInput) return false
 
     return uriToHttp(listInput).length > 0 || Boolean(parseENSAddress(listInput))
   }, [listInput])
@@ -75,11 +75,11 @@ export function ManageListsAndTokens(props: ManageListsAndTokensProps) {
           onChange={(e) => setInputValue(e.target.value)}
           placeholder={isListsTab ? listsInputPlaceholder : tokensInputPlaceholder}
         />
-        {!isListUrlValid && <styledEl.InputError>Enter valid list location</styledEl.InputError>}
+        {!isListUrlValid && listInput && <styledEl.InputError>Enter valid list location</styledEl.InputError>}
         {!isTokenAddressValid && <styledEl.InputError>Enter valid token address</styledEl.InputError>}
       </styledEl.PrimaryInputBox>
       {currentTab === 'lists' ? (
-        <ManageLists listSearchResponse={listSearchResponse} lists={lists} />
+        <ManageLists listSearchResponse={listSearchResponse} lists={lists} isListUrlValid={isListUrlValid} />
       ) : (
         <ManageTokens tokenSearchResponse={tokenSearchResponse} tokens={customTokens} />
       )}

--- a/apps/cowswap-frontend/src/modules/tokensList/containers/ManageListsAndTokens/styled.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/containers/ManageListsAndTokens/styled.ts
@@ -43,7 +43,6 @@ export const Tab = styled.button<{ active$: boolean }>`
 export const PrimaryInputBox = styled.div`
   margin: 10px 0 0 0;
   padding: 0 20px 20px 20px;
-  border-bottom: 1px solid var(${UI.COLOR_PAPER_DARKEST});
 `
 
 export const PrimaryInput = styled.input`

--- a/libs/tokens/src/hooks/lists/useSearchList.ts
+++ b/libs/tokens/src/hooks/lists/useSearchList.ts
@@ -36,7 +36,10 @@ export function useSearchList(input: string | null): ListSearchResponse {
 
       return fetchTokenList({ source: input })
     },
-    {}
+    {
+      errorRetryCount: 0,
+      revalidateOnFocus: false,
+    },
   )
 
   return existingList ? { source: 'existing', response: existingList } : { source: 'external', response }


### PR DESCRIPTION
# Summary

Fixes #4915 

The popup currently does not display an error message when a user enters a token list URL that fails to load.

This PR resolves the issue by managing the error within the `ManageLists` component through the introduction of a new prop, `isListUrlValid`.

The solution is intentionally designed to minimize changes to the existing business logic and component structure, so it might not fully align with the requested UI (an error message without a top border).

Screenshots and a video demonstrating the changes are attached.

![image](https://github.com/user-attachments/assets/23218b8b-75b1-4366-a25d-46b7e18a8f57)

https://github.com/user-attachments/assets/9a6cc5ec-1540-401d-85ce-1ef79780ebf7