### PR TITLE
chore: fix typo on CoW protocol token page

### DIFF
--- a/apps/cow-fi/data/descriptions/cow-protocol.md
+++ b/apps/cow-fi/data/descriptions/cow-protocol.md
@@ -12,4 +12,4 @@
 
 <h3>Where can you swap or trade CoW Protocol (COW)?</h3>
 
-<p>Moo-ving your assets is easier than ever with CoW Swap, the trading interface built on top of the CoW Protocol. This Meta DEX aggregator allows you to buy and sell tokens in a way that is gasless, peer-to-peer, and provides MEV protection. So if you're ready to join the herd, gallop over to <a href="https://swap.cow.fi/" rel="noopener" target="_blank">CowSwap</a>. Here, you'll find that it aggregates all the DEXes where the COW token is swappable. Join the herd and let's move DeFi forward, one moo at a time!</p>
+<p>Moo-ving your assets is easier than ever with CoW Swap, the trading interface built on top of the CoW Protocol. This Meta DEX aggregator allows you to buy and sell tokens in a way that is gasless, peer-to-peer, and provides MEV protection. So if you're ready to join the herd, gallop over to <a href="https://swap.cow.fi/" rel="noopener" target="_blank">CoW Swap</a>. Here, you'll find that it aggregates all the DEXes where the COW token is swappable. Join the herd and let's move DeFi forward, one moo at a time!</p>


### PR DESCRIPTION
# Summary
 Fixes #4391 

# To Test

1. Open [/tokens/cow-protocol](https://cowfi-git-elena-zh-patch-1-cowswap.vercel.app/tokens/cow-protocol) page
2. Check CoW Swap link in 'Where can you swap or trade CoW Protocol (COW)?' section
![image](https://github.com/user-attachments/assets/039dc142-d502-4eab-a0d6-5b4fe88c6b0d)
