### PR TITLE
feat: default limit sell input

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/state/limitOrdersRawStateAtom.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/state/limitOrdersRawStateAtom.ts
@@ -1,17 +1,16 @@
 import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 
-import { atomWithPartialUpdate, getRawCurrentChainIdFromUrl } from '@cowprotocol/common-utils'
+import { atomWithPartialUpdate } from '@cowprotocol/common-utils'
 import { getJotaiIsolatedStorage } from '@cowprotocol/core'
 import { OrderKind, SupportedChainId } from '@cowprotocol/cow-sdk'
-import { parseUnits } from '@ethersproject/units'
 
 import {
   alternativeOrderAtomSetterFactory,
   alternativeOrderReadWriteAtomFactory,
 } from 'modules/trade/state/alternativeOrder'
 import { DEFAULT_TRADE_DERIVED_STATE, TradeDerivedState } from 'modules/trade/types/TradeDerivedState'
-import { ExtendedTradeRawState, getDefaultCurrencies, getDefaultTradeRawState } from 'modules/trade/types/TradeRawState'
+import { ExtendedTradeRawState, getDefaultTradeRawState } from 'modules/trade/types/TradeRawState'
 
 export interface LimitOrdersDerivedState extends TradeDerivedState {
   readonly isUnlocked: boolean
@@ -22,13 +21,9 @@ export interface LimitOrdersRawState extends ExtendedTradeRawState {
 }
 
 export function getDefaultLimitOrdersState(chainId: SupportedChainId | null, isUnlocked = false): LimitOrdersRawState {
-  const defaultState = getDefaultTradeRawState(chainId)
-  const { inputCurrency } = getDefaultCurrencies(chainId)
-  const inputCurrencyAmount = inputCurrency ? parseUnits('1', inputCurrency.decimals).toString() : null // defaults to selling 1 unit of input currency
-
   return {
-    ...defaultState,
-    inputCurrencyAmount,
+    ...getDefaultTradeRawState(chainId),
+    inputCurrencyAmount: null,
     outputCurrencyAmount: null,
     orderKind: OrderKind.SELL,
     isUnlocked,
@@ -39,7 +34,7 @@ export function getDefaultLimitOrdersState(chainId: SupportedChainId | null, isU
 
 const regularRawStateAtom = atomWithStorage<LimitOrdersRawState>(
   'limit-orders-atom:v4',
-  getDefaultLimitOrdersState(getRawCurrentChainIdFromUrl()),
+  getDefaultLimitOrdersState(null),
   getJotaiIsolatedStorage(),
 )
 
@@ -52,9 +47,7 @@ const regularDerivedStateAtom = atom<LimitOrdersDerivedState>({
 
 // Alternative state for recreating/editing existing orders
 
-const alternativeRawStateAtom = atom<LimitOrdersRawState>(
-  getDefaultLimitOrdersState(getRawCurrentChainIdFromUrl(), true),
-)
+const alternativeRawStateAtom = atom<LimitOrdersRawState>(getDefaultLimitOrdersState(null, true))
 
 const { updateAtom: alternativeUpdateRawStateAtom } = atomWithPartialUpdate(alternativeRawStateAtom)
 

--- a/apps/cowswap-frontend/src/modules/limitOrders/state/limitOrdersRawStateAtom.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/state/limitOrdersRawStateAtom.ts
@@ -1,7 +1,7 @@
 import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 
-import { atomWithPartialUpdate } from '@cowprotocol/common-utils'
+import { atomWithPartialUpdate, getRawCurrentChainIdFromUrl } from '@cowprotocol/common-utils'
 import { getJotaiIsolatedStorage } from '@cowprotocol/core'
 import { OrderKind, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { parseUnits } from '@ethersproject/units'
@@ -39,7 +39,7 @@ export function getDefaultLimitOrdersState(chainId: SupportedChainId | null, isU
 
 const regularRawStateAtom = atomWithStorage<LimitOrdersRawState>(
   'limit-orders-atom:v4',
-  getDefaultLimitOrdersState(null),
+  getDefaultLimitOrdersState(getRawCurrentChainIdFromUrl()),
   getJotaiIsolatedStorage(),
 )
 
@@ -52,7 +52,9 @@ const regularDerivedStateAtom = atom<LimitOrdersDerivedState>({
 
 // Alternative state for recreating/editing existing orders
 
-const alternativeRawStateAtom = atom<LimitOrdersRawState>(getDefaultLimitOrdersState(null, true))
+const alternativeRawStateAtom = atom<LimitOrdersRawState>(
+  getDefaultLimitOrdersState(getRawCurrentChainIdFromUrl(), true),
+)
 
 const { updateAtom: alternativeUpdateRawStateAtom } = atomWithPartialUpdate(alternativeRawStateAtom)
 

--- a/apps/cowswap-frontend/src/modules/limitOrders/state/limitOrdersRawStateAtom.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/state/limitOrdersRawStateAtom.ts
@@ -4,13 +4,14 @@ import { atomWithStorage } from 'jotai/utils'
 import { atomWithPartialUpdate } from '@cowprotocol/common-utils'
 import { getJotaiIsolatedStorage } from '@cowprotocol/core'
 import { OrderKind, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { parseUnits } from '@ethersproject/units'
 
 import {
   alternativeOrderAtomSetterFactory,
   alternativeOrderReadWriteAtomFactory,
 } from 'modules/trade/state/alternativeOrder'
 import { DEFAULT_TRADE_DERIVED_STATE, TradeDerivedState } from 'modules/trade/types/TradeDerivedState'
-import { ExtendedTradeRawState, getDefaultTradeRawState } from 'modules/trade/types/TradeRawState'
+import { ExtendedTradeRawState, getDefaultCurrencies, getDefaultTradeRawState } from 'modules/trade/types/TradeRawState'
 
 export interface LimitOrdersDerivedState extends TradeDerivedState {
   readonly isUnlocked: boolean
@@ -21,9 +22,13 @@ export interface LimitOrdersRawState extends ExtendedTradeRawState {
 }
 
 export function getDefaultLimitOrdersState(chainId: SupportedChainId | null, isUnlocked = false): LimitOrdersRawState {
+  const defaultState = getDefaultTradeRawState(chainId)
+  const { inputCurrency } = getDefaultCurrencies(chainId)
+  const inputCurrencyAmount = inputCurrency ? parseUnits('1', inputCurrency.decimals).toString() : null // defaults to selling 1 unit of input currency
+
   return {
-    ...getDefaultTradeRawState(chainId),
-    inputCurrencyAmount: null,
+    ...defaultState,
+    inputCurrencyAmount,
     outputCurrencyAmount: null,
     orderKind: OrderKind.SELL,
     isUnlocked,
@@ -35,7 +40,7 @@ export function getDefaultLimitOrdersState(chainId: SupportedChainId | null, isU
 const regularRawStateAtom = atomWithStorage<LimitOrdersRawState>(
   'limit-orders-atom:v4',
   getDefaultLimitOrdersState(null),
-  getJotaiIsolatedStorage()
+  getJotaiIsolatedStorage(),
 )
 
 const { updateAtom: regularUpdateRawStateAtom } = atomWithPartialUpdate(regularRawStateAtom)
@@ -60,7 +65,7 @@ const alternativeDerivedStateAtom = atom<LimitOrdersDerivedState>({
 
 export const limitOrdersRawStateAtom = alternativeOrderReadWriteAtomFactory<LimitOrdersRawState>(
   regularRawStateAtom,
-  alternativeRawStateAtom
+  alternativeRawStateAtom,
 )
 
 export const updateLimitOrdersRawStateAtom = atom(
@@ -68,10 +73,10 @@ export const updateLimitOrdersRawStateAtom = atom(
   alternativeOrderAtomSetterFactory<
     null, // pass null to indicate there is no getter
     Partial<LimitOrdersRawState>
-  >(regularUpdateRawStateAtom, alternativeUpdateRawStateAtom)
+  >(regularUpdateRawStateAtom, alternativeUpdateRawStateAtom),
 )
 
 export const limitOrdersDerivedStateAtom = alternativeOrderReadWriteAtomFactory<LimitOrdersDerivedState>(
   regularDerivedStateAtom,
-  alternativeDerivedStateAtom
+  alternativeDerivedStateAtom,
 )

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useSetupTradeAmountsFromUrl.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useSetupTradeAmountsFromUrl.ts
@@ -38,7 +38,8 @@ export function useSetupTradeAmountsFromUrl({ onAmountsUpdate, onlySell }: Setup
   const params = useMemo(() => new URLSearchParams(search), [search])
   const { updateState } = useTradeState()
   const state = useDerivedTradeState()
-  const { inputCurrency, outputCurrency } = state || {}
+  const { inputCurrency, outputCurrency, inputCurrencyAmount, outputCurrencyAmount } = state || {}
+  const isAtLeastOneAmountIsSet = Boolean(inputCurrencyAmount || outputCurrencyAmount)
 
   const cleanParams = useCallback(() => {
     if (!search) return
@@ -82,6 +83,12 @@ export function useSetupTradeAmountsFromUrl({ onAmountsUpdate, onlySell }: Setup
 
     const hasUpdates = Object.keys(update).length > 0
 
+    // When both sell and buy amount are not set
+    // Then set 1 unit to sell by default
+    if (!isAtLeastOneAmountIsSet && !update.inputCurrencyAmount && inputCurrency) {
+      update.inputCurrencyAmount = FractionUtils.serializeFractionToJSON(tryParseCurrencyAmount('1', inputCurrency))
+    }
+
     if (hasUpdates) {
       // Clean params only when an update was applied or currencies are loaded
       if (inputCurrency || outputCurrency) {
@@ -95,5 +102,5 @@ export function useSetupTradeAmountsFromUrl({ onAmountsUpdate, onlySell }: Setup
       }
     }
     // Trigger only when URL or assets are changed
-  }, [params, inputCurrency, outputCurrency, onlySell])
+  }, [params, inputCurrency, outputCurrency, onlySell, isAtLeastOneAmountIsSet])
 }

--- a/apps/cowswap-frontend/src/modules/trade/types/TradeRawState.ts
+++ b/apps/cowswap-frontend/src/modules/trade/types/TradeRawState.ts
@@ -1,4 +1,4 @@
-import { USDC, WRAPPED_NATIVE_CURRENCIES as WETH } from '@cowprotocol/common-const'
+import { TokenWithLogo, USDC, WRAPPED_NATIVE_CURRENCIES as WETH } from '@cowprotocol/common-const'
 import { OrderKind, SupportedChainId } from '@cowprotocol/cow-sdk'
 
 export interface TradeUrlParams {
@@ -25,12 +25,25 @@ export interface ExtendedTradeRawState extends TradeRawState {
 }
 
 export type TradeCurrenciesIds = Pick<TradeRawState, 'inputCurrencyId' | 'outputCurrencyId'>
+export type TradeCurrencies = {
+  inputCurrency: TokenWithLogo | null
+  outputCurrency: TokenWithLogo | null
+}
+
+export function getDefaultCurrencies(chainId: SupportedChainId | null): TradeCurrencies {
+  return {
+    inputCurrency: chainId ? WETH[chainId] || null : null,
+    outputCurrency: chainId ? USDC[chainId] || null : null,
+  }
+}
 
 export function getDefaultTradeRawState(chainId: SupportedChainId | null): TradeRawState {
+  const { inputCurrency, outputCurrency } = getDefaultCurrencies(chainId)
+
   return {
     chainId,
-    inputCurrencyId: chainId ? WETH[chainId]?.symbol || null : null,
-    outputCurrencyId: chainId ? USDC[chainId].symbol || null : null,
+    inputCurrencyId: inputCurrency?.symbol || null,
+    outputCurrencyId: outputCurrency?.symbol || null,
     recipient: null,
     recipientAddress: null,
   }


### PR DESCRIPTION
# Summary

1 unit of token should be default amount for sell token in Limit orders / Twap / Yield widgets
