### PR TITLE
fix: loading effect fixes for widget and daos page

### DIFF
--- a/apps/cow-fi/app/(main)/widget/page.tsx
+++ b/apps/cow-fi/app/(main)/widget/page.tsx
@@ -269,7 +269,7 @@ export default function Page() {
                     {isPng ? (
                       <img src={dao.icon} alt={dao.title} style={{ maxWidth: '100%' }} loading="lazy" />
                     ) : (
-                      <LazySVG src={dao.icon} loader={<div style={{ fontSize: '20px' }}>Loading SVG...</div>} />
+                      <LazySVG src={dao.icon} />
                     )}
                   </TopicImage>
                 </TopicCard>

--- a/apps/cow-fi/app/(main)/widget/page.tsx
+++ b/apps/cow-fi/app/(main)/widget/page.tsx
@@ -269,7 +269,7 @@ export default function Page() {
                     {isPng ? (
                       <img src={dao.icon} alt={dao.title} style={{ maxWidth: '100%' }} loading="lazy" />
                     ) : (
-                      <LazySVG src={dao.icon} />
+                      <LazySVG src={dao.icon} loader={<div style={{ fontSize: '20px' }}>Loading SVG...</div>} />
                     )}
                   </TopicImage>
                 </TopicCard>

--- a/apps/cow-fi/components/DaosPageComponent.tsx
+++ b/apps/cow-fi/components/DaosPageComponent.tsx
@@ -64,7 +64,7 @@ export function DaosPageComponent() {
               ({ icon, title, volume }, index) =>
                 volume && (
                   <li key={index}>
-                    <LazySVG src={icon} title={title} />
+                    <LazySVG src={icon} title={title} height={40} />
                     <small>with</small>
                     <strong>{volume}</strong>
                   </li>

--- a/apps/cow-fi/components/LazySVG.tsx
+++ b/apps/cow-fi/components/LazySVG.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import SVG, { Props as SVGProps } from 'react-inlinesvg'
+import styled, { keyframes } from 'styled-components/macro'
 
 interface LazySVGProps extends Omit<SVGProps, 'loader'> {
   src: string
@@ -7,9 +8,26 @@ interface LazySVGProps extends Omit<SVGProps, 'loader'> {
   rootMargin?: string
 }
 
+const spin = keyframes`
+  to {
+    transform: rotate(360deg);
+  }
+`
+
+// Styled component for the loader
+const Spinner = styled.div`
+  width: 40px;
+  height: 40px;
+  border: 4px solid transparent;
+  border-top: 4px solid #9c8d8d;
+  margin: 0 auto;
+  border-radius: 50%;
+  animation: ${spin} 1s linear infinite;
+`
+
 const LazySVG: React.FC<LazySVGProps> = ({
   src,
-  loader = <div>Loading SVG...</div>,
+  loader = <Spinner />,
   rootMargin = '100px',
   width,
   height,

--- a/apps/cow-fi/styles/styled.ts
+++ b/apps/cow-fi/styles/styled.ts
@@ -367,6 +367,7 @@ export const TopicImage = styled.div<{
   left: ${({ left }) => (typeof left === 'number' ? `${left}px` : left || 'initial')};
   right: ${({ right }) => (typeof right === 'number' ? `${right}px` : right || 'initial')};
   bottom: ${({ bottom }) => (typeof bottom === 'number' ? `${bottom}px` : bottom || 'initial')};
+  line-height: normal;
 
   ${Media.upToLarge()} {
     order: ${({ orderReverseTablet }) => (orderReverseTablet ? -1 : 'initial')};
@@ -1191,6 +1192,7 @@ export const TrustedBy = styled.div`
     flex-flow: row nowrap;
     align-items: center;
     justify-content: center;
+    line-height: normal;
     height: 100%;
     width: 100%;
     font-size: 2.6rem;

--- a/apps/cow-fi/styles/styled.ts
+++ b/apps/cow-fi/styles/styled.ts
@@ -392,6 +392,9 @@ export const TopicImage = styled.div<{
     width: inherit;
     color: inherit;
     max-width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
 
   svg,


### PR DESCRIPTION
# Summary

Fixes #5065

This PR resolves the loading effect issues on the `/widgets` and `/daos` pages under cowfi. The primary issue was the line height of the loading text, which caused it to appear cramped. 

Additionally, I noticed that the icons in the “trusted by” section on the cow.fi/daos page were missing, and I have included a fix for that as well. (Please check here: https://tinyurl.com/2avu2hyy)

Attached below are the screenshots showing the fixes. 

![image](https://github.com/user-attachments/assets/1eb3985b-5bb3-40c4-ab1e-ceebb92fdab3)

![image](https://github.com/user-attachments/assets/222e5a51-4fb9-439d-bece-e8d940a52bad)

![image](https://github.com/user-attachments/assets/61c3115d-73e8-49c8-a626-f7921e862b49)

I opted for a minimal approach to implement these changes without modifying the widely used LazySVG component.