### PR TITLE
fix(ui): get rid of flickering in HelpTooltip

### DIFF
--- a/libs/ui/src/pure/HelpTooltip/index.tsx
+++ b/libs/ui/src/pure/HelpTooltip/index.tsx
@@ -49,17 +49,12 @@ export interface HelpTooltipProps extends Omit<HoverTooltipProps, 'QuestionMark'
 
 export function HelpTooltip({ text, Icon, className, ...props }: HelpTooltipProps) {
   const tooltip = renderTooltip(text, props)
-
   const content = <div>{tooltip}</div>
-
-  const HelpIcon = () => Icon || DefaultQuestionIcon
 
   return (
     <HelpTooltipContainer className={className}>
       <HoverTooltip {...props} content={content} wrapInContainer>
-        <QuestionTooltipIconWrapper>
-          <HelpIcon />
-        </QuestionTooltipIconWrapper>
+        <QuestionTooltipIconWrapper>{Icon || DefaultQuestionIcon}</QuestionTooltipIconWrapper>
       </HoverTooltip>
     </HelpTooltipContainer>
   )


### PR DESCRIPTION
# Summary

Fixes a part of https://www.notion.so/cownation/Flickering-1778da5f04ca8060b4d2cd7b87de2ba1

It fixes only help tooltip icons (you can see them in settings)

![image](https://github.com/user-attachments/assets/c73b2d8b-8fb8-4254-80b2-b411119cf6dd)

# To Test

1. Open limit orders
2. Setup some trade
3. Open settings
4. Wait till the next price update
- [ ] AR: help tooltip icons are flickering
- [ ] ER: no  flickering
