### PR TITLE
feat: add FractionUtils.simplify

### DIFF
--- a/libs/common-utils/src/fractionUtils.test.ts
+++ b/libs/common-utils/src/fractionUtils.test.ts
@@ -1,3 +1,5 @@
+import { Fraction } from '@uniswap/sdk-core'
+
 import JSBI from 'jsbi'
 
 import { FractionUtils } from './fractionUtils'
@@ -40,6 +42,39 @@ describe('Fraction utils', () => {
       const fraction = FractionUtils.fromNumber(1e-5)
       expect(JSBI.toNumber(fraction.numerator)).toBe(1)
       expect(JSBI.toNumber(fraction.denominator)).toBe(100000)
+    })
+  })
+
+  describe('simplify', () => {
+    it('should simplify a small fraction', () => {
+      const fraction = FractionUtils.fromNumber(15)
+      const simplified = FractionUtils.simplify(fraction)
+      expect(JSBI.toNumber(simplified.numerator)).toBe(15)
+      expect(JSBI.toNumber(simplified.denominator)).toBe(1)
+    })
+    it('should simplify a large fraction with zeros', () => {
+      const fraction = new Fraction(JSBI.BigInt(3000000), JSBI.BigInt(2000000))
+      const simplified = FractionUtils.simplify(fraction)
+      expect(JSBI.toNumber(simplified.numerator)).toBe(3)
+      expect(JSBI.toNumber(simplified.denominator)).toBe(2)
+    })
+    it('should not simplify a fraction with large denominator already in the simplest form', () => {
+      const fraction = new Fraction(JSBI.BigInt(1), JSBI.BigInt(1000000))
+      const simplified = FractionUtils.simplify(fraction)
+      expect(JSBI.toNumber(simplified.numerator)).toBe(1)
+      expect(JSBI.toNumber(simplified.denominator)).toBe(1000000)
+    })
+    it('should not simplify a fraction with a large numerator already in the simplest form', () => {
+      const fraction = new Fraction(JSBI.BigInt(1000000), JSBI.BigInt(1))
+      const simplified = FractionUtils.simplify(fraction)
+      expect(JSBI.toNumber(simplified.numerator)).toBe(1000000)
+      expect(JSBI.toNumber(simplified.denominator)).toBe(1)
+    })
+    it('should simplify a fraction with zeros and that can be further simplified', () => {
+      const fraction = new Fraction(JSBI.BigInt(3000000), JSBI.BigInt(9000000))
+      const simplified = FractionUtils.simplify(fraction)
+      expect(JSBI.toNumber(simplified.numerator)).toBe(1)
+      expect(JSBI.toNumber(simplified.denominator)).toBe(3)
     })
   })
 })

--- a/libs/common-utils/src/fractionUtils.ts
+++ b/libs/common-utils/src/fractionUtils.ts
@@ -180,6 +180,8 @@ export class FractionUtils {
   }
 }
 
+const ZERO = JSBI.BigInt(0)
+
 /**
  * Use GCD to reduce the fraction to the smallest possible
  *
@@ -188,15 +190,15 @@ export class FractionUtils {
  * @param fraction
  */
 function reduce(fraction: Fraction): Fraction {
-  let a = fraction.numerator
-  let b = fraction.denominator
-  let c: JSBI
-  while (JSBI.notEqual(b, JSBI.BigInt(0))) {
-    c = JSBI.remainder(a, b)
-    a = b
-    b = c
+  let numerator = fraction.numerator
+  let denominator = fraction.denominator
+  let rest: JSBI
+  while (JSBI.notEqual(denominator, ZERO)) {
+    rest = JSBI.remainder(numerator, denominator)
+    numerator = denominator
+    denominator = rest
   }
-  return new Fraction(JSBI.divide(fraction.numerator, a), JSBI.divide(fraction.denominator, a))
+  return new Fraction(JSBI.divide(fraction.numerator, numerator), JSBI.divide(fraction.denominator, numerator))
 }
 
 /**

--- a/libs/common-utils/src/fractionUtils.ts
+++ b/libs/common-utils/src/fractionUtils.ts
@@ -107,11 +107,16 @@ export class FractionUtils {
    * @returns
    */
   static fromPrice(price: Price<Currency, Currency>): Fraction {
-    return FractionUtils.adjustDecimalsAtoms(
-      new Fraction(price.numerator, price.denominator),
+    // Simplify the input fraction
+    const simplifiedPrice = FractionUtils.simplify(price)
+    // Adjust the fraction to consider the decimals
+    const decimalAdjustedFraction = FractionUtils.adjustDecimalsAtoms(
+      new Fraction(simplifiedPrice.numerator, simplifiedPrice.denominator),
       price.quoteCurrency.decimals,
       price.baseCurrency.decimals,
     )
+    // Simplify the output fraction
+    return FractionUtils.simplify(decimalAdjustedFraction)
   }
 
   /**
@@ -169,4 +174,43 @@ export class FractionUtils {
 
     return amount.equalTo(0) ? CurrencyAmount.fromRawAmount(amount.currency, 1) : amount
   }
+
+  static simplify(fraction: Fraction): Fraction {
+    return reduce(trimZeros(fraction))
+  }
+}
+
+/**
+ * Use GCD to reduce the fraction to the smallest possible
+ *
+ * From https://stackoverflow.com/a/65927538
+ *
+ * @param fraction
+ */
+function reduce(fraction: Fraction): Fraction {
+  let a = fraction.numerator
+  let b = fraction.denominator
+  let c: JSBI
+  while (JSBI.notEqual(b, JSBI.BigInt(0))) {
+    c = JSBI.remainder(a, b)
+    a = b
+    b = c
+  }
+  return new Fraction(JSBI.divide(fraction.numerator, a), JSBI.divide(fraction.denominator, a))
+}
+
+/**
+ * Remove trailing zeros from a fraction
+ * @param fraction
+ */
+function trimZeros(fraction: Fraction): Fraction {
+  const numerator = fraction.numerator.toString()
+  const denominator = fraction.denominator.toString()
+
+  const numeratorZeros = numerator.match(/0+$/)?.[0].length || 0
+  const denominatorZeros = denominator.match(/0+$/)?.[0].length || 0
+
+  const zeros = Math.min(numeratorZeros, denominatorZeros)
+
+  return new Fraction(numerator.slice(0, numerator.length - zeros), denominator.slice(0, denominator.length - zeros))
 }


### PR DESCRIPTION
# Summary

Fix for several crashes happening recently when dealing with prices

The underlying fraction numerator/denominator can become quite large numbers due to the decimals padding.
That leads to the fraction operations crashing behind the scenes.
However, fractions can be simplified and still maintain the same precision.
This PR does that: add a `FractionUtils.simplify` static method

# To Test

1. Play around with prices, orders etc
* Should not crash

Also, added unit tests for the new method