### PR TITLE
fix: price error handling

### DIFF
--- a/apps/cowswap-frontend/src/common/updaters/orders/SpotPricesUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/SpotPricesUpdater.ts
@@ -104,7 +104,7 @@ export function SpotPricesUpdater(): null {
           price,
         })
       } catch (e) {
-        console.debug(
+        console.error(
           `[SpotPricesUpdater] Failed to calculate spot price for ${inputCurrency.address} and ${outputCurrency.address}`,
           inputPrice.price.numerator.toString(),
           inputPrice.price.denominator.toString(),

--- a/apps/cowswap-frontend/src/common/updaters/orders/SpotPricesUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/SpotPricesUpdater.ts
@@ -104,9 +104,12 @@ export function SpotPricesUpdater(): null {
           price,
         })
       } catch (e) {
-        console.error(
-          `Failed to update spot prices for ${inputCurrency.address} and ${outputCurrency.address}`,
-          { inputPrice, outputPrice },
+        console.debug(
+          `[SpotPricesUpdater] Failed to calculate spot price for ${inputCurrency.address} and ${outputCurrency.address}`,
+          inputPrice.price.numerator.toString(),
+          inputPrice.price.denominator.toString(),
+          outputPrice.price.numerator.toString(),
+          outputPrice.price.denominator.toString(),
           e,
         )
       }

--- a/apps/cowswap-frontend/src/legacy/state/orders/utils.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/utils.ts
@@ -319,7 +319,7 @@ export function getEstimatedExecutionPrice(
 
   // When fee > amount, return 0 price
   if (!remainingSellAmount.greaterThan(ZERO_FRACTION)) {
-    return new Price(inputToken, outputToken, '0', '0')
+    return new Price(inputToken, outputToken, '0', '1')
   }
 
   const feeWithMargin = feeAmount.add(feeAmount.multiply(EXECUTION_PRICE_FEE_COEFFICIENT))
@@ -355,7 +355,7 @@ export function getEstimatedExecutionPrice(
 
     // Just in case when the denominator is <= 0 after subtracting the fee
     if (!denominator.greaterThan(ZERO_FRACTION)) {
-      return new Price(inputToken, outputToken, '0', '0')
+      return new Price(inputToken, outputToken, '0', '1')
     }
 
     /**

--- a/apps/cowswap-frontend/src/legacy/state/orders/utils.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/utils.ts
@@ -319,7 +319,7 @@ export function getEstimatedExecutionPrice(
 
   // When fee > amount, return 0 price
   if (!remainingSellAmount.greaterThan(ZERO_FRACTION)) {
-    return new Price(inputToken, outputToken, '0', '1')
+    return new Price(inputToken, outputToken, '1', '0')
   }
 
   const feeWithMargin = feeAmount.add(feeAmount.multiply(EXECUTION_PRICE_FEE_COEFFICIENT))
@@ -355,7 +355,9 @@ export function getEstimatedExecutionPrice(
 
     // Just in case when the denominator is <= 0 after subtracting the fee
     if (!denominator.greaterThan(ZERO_FRACTION)) {
-      return new Price(inputToken, outputToken, '0', '1')
+      // numerator and denominator are inverted!!!
+      // https://github.com/Uniswap/sdk-core/blob/9997e88/src/entities/fractions/price.ts#L26
+      return new Price(inputToken, outputToken, '1', '0')
     }
 
     /**

--- a/apps/cowswap-frontend/src/modules/limitOrders/updaters/ExecutionPriceUpdater/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/updaters/ExecutionPriceUpdater/index.tsx
@@ -29,10 +29,8 @@ export function ExecutionPriceUpdater() {
         return FractionUtils.toPrice(marketRate, inputToken, outputToken)
       }
     } catch (e) {
-      console.debug(
-        `Failed to parse the market price for`,
-        inputToken?.address,
-        outputToken?.address,
+      console.error(
+        `[ExecutionPriceUpdater] Failed to parse the market price for ${inputToken?.address} and ${outputToken?.address}`,
         marketRate?.numerator.toString(),
         marketRate?.denominator.toString(),
         e,

--- a/apps/cowswap-frontend/src/modules/limitOrders/updaters/ExecutionPriceUpdater/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/updaters/ExecutionPriceUpdater/index.tsx
@@ -9,7 +9,7 @@ import { useLimitOrdersDerivedState } from 'modules/limitOrders/hooks/useLimitOr
 import { executionPriceAtom } from 'modules/limitOrders/state/executionPriceAtom'
 import { limitRateAtom } from 'modules/limitOrders/state/limitRateAtom'
 
-import { useSafeEffect } from 'common/hooks/useSafeMemo'
+import { useSafeEffect, useSafeMemo } from 'common/hooks/useSafeMemo'
 
 import { limitOrdersSettingsAtom } from '../../state/limitOrdersSettingsAtom'
 
@@ -23,12 +23,23 @@ export function ExecutionPriceUpdater() {
   const inputToken = inputCurrencyAmount?.currency && getWrappedToken(inputCurrencyAmount.currency)
   const outputToken = outputCurrencyAmount?.currency && getWrappedToken(outputCurrencyAmount.currency)
 
-  const marketPrice =
-    marketRate &&
-    !marketRate.equalTo('0') &&
-    inputToken &&
-    outputToken &&
-    FractionUtils.toPrice(marketRate, inputToken, outputToken)
+  const marketPrice = useSafeMemo(() => {
+    try {
+      if (marketRate && !marketRate.equalTo('0') && inputToken && outputToken) {
+        return FractionUtils.toPrice(marketRate, inputToken, outputToken)
+      }
+    } catch (e) {
+      console.debug(
+        `Failed to parse the market price for`,
+        inputToken?.address,
+        outputToken?.address,
+        marketRate?.numerator.toString(),
+        marketRate?.denominator.toString(),
+        e,
+      )
+    }
+    return null
+  }, [marketRate, inputToken, outputToken])
 
   const fee = feeAmount?.quotient.toString()
 

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
@@ -340,7 +340,7 @@ export function OrderRow({
       return '-'
     }
 
-    if (prices && estimatedExecutionPrice) {
+    if (estimatedExecutionPrice && !estimatedExecutionPrice.equalTo(ZERO_FRACTION)) {
       return (
         <styledEl.ExecuteCellWrapper>
           {!isUnfillable &&

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/OrderRow/index.tsx
@@ -497,7 +497,7 @@ export function OrderRow({
       if (nextScheduledOrder) {
         // For scheduled orders, use the execution price if available, otherwise use the estimated price from props
         const nextOrderExecutionPrice =
-          nextScheduledOrder.executionData.executedPrice || prices?.estimatedExecutionPrice
+          nextScheduledOrder.executionData.executedPrice || estimatedExecutionPrice
         const nextOrderPriceDiffs = nextOrderExecutionPrice
           ? calculatePriceDifference({
             referencePrice: spotPrice,

--- a/libs/common-utils/src/fractionUtils.test.ts
+++ b/libs/common-utils/src/fractionUtils.test.ts
@@ -76,5 +76,11 @@ describe('Fraction utils', () => {
       expect(JSBI.toNumber(simplified.numerator)).toBe(1)
       expect(JSBI.toNumber(simplified.denominator)).toBe(3)
     })
+    it('should avoid division by 0', () => {
+      const fraction = new Fraction(JSBI.BigInt(0), JSBI.BigInt(0))
+      const simplified = FractionUtils.simplify(fraction)
+      expect(JSBI.toNumber(simplified.numerator)).toBe(0)
+      expect(JSBI.toNumber(simplified.denominator)).toBe(1)
+    })
   })
 })

--- a/libs/common-utils/src/fractionUtils.ts
+++ b/libs/common-utils/src/fractionUtils.ts
@@ -193,6 +193,11 @@ function reduce(fraction: Fraction): Fraction {
   let numerator = fraction.numerator
   let denominator = fraction.denominator
   let rest: JSBI
+
+  if (JSBI.equal(denominator, ZERO)) {
+    return new Fraction(JSBI.BigInt(0), JSBI.BigInt(1))
+  }
+
   while (JSBI.notEqual(denominator, ZERO)) {
     rest = JSBI.remainder(numerator, denominator)
     numerator = denominator


### PR DESCRIPTION
# Summary

Add a simple error handling for SpotPrice and ExecutionPrice updaters

Depends on https://github.com/cowprotocol/cowswap/pull/5326 (merged)

~Shouldn't be needed after the changes above, but great to have anyway just to prevent app crashes.~

Edit: There are important fixes now in the addition to the error handling

# To Test

1. Play around with prices, mostly on LIMIT orders
* Should not crash
* Should show market prices as expected