### PR TITLE
fix: rate loading on chain change

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useSafeMemo.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useSafeMemo.ts
@@ -4,7 +4,7 @@ import { CurrencyAmount, NativeCurrency, Percent, Price, Token } from '@uniswap/
 
 export function useSafeDeps(deps: unknown[]): unknown[] {
   return deps.map((dep) => {
-    if (dep instanceof NativeCurrency) return dep.symbol || '' + dep.chainId
+    if (dep instanceof NativeCurrency) return (dep.symbol || '') + dep.chainId
     if (dep instanceof Token) return dep.address.toLowerCase() + dep.chainId
     if (dep instanceof CurrencyAmount) return dep.toExact() + dep.currency.symbol + dep.currency.chainId
     if (dep instanceof Percent) return dep.toFixed(6)

--- a/apps/cowswap-frontend/src/common/hooks/useSafeMemo.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useSafeMemo.ts
@@ -4,11 +4,19 @@ import { CurrencyAmount, NativeCurrency, Percent, Price, Token } from '@uniswap/
 
 export function useSafeDeps(deps: unknown[]): unknown[] {
   return deps.map((dep) => {
-    if (dep instanceof NativeCurrency) return dep.symbol
-    if (dep instanceof Token) return dep.address.toLowerCase()
+    if (dep instanceof NativeCurrency) return dep.symbol || '' + dep.chainId
+    if (dep instanceof Token) return dep.address.toLowerCase() + dep.chainId
     if (dep instanceof CurrencyAmount) return dep.toExact() + dep.currency.symbol + dep.currency.chainId
     if (dep instanceof Percent) return dep.toFixed(6)
-    if (dep instanceof Price) return dep.toFixed(12) + dep.baseCurrency.symbol + dep.quoteCurrency.symbol
+    if (dep instanceof Price)
+      return (
+        dep.numerator.toString() +
+        dep.denominator.toString() +
+        dep.baseCurrency.symbol +
+        dep.quoteCurrency.symbol +
+        dep.baseCurrency.chainId +
+        dep.quoteCurrency.chainId
+      )
 
     return dep
   })

--- a/apps/cowswap-frontend/src/modules/limitOrders/updaters/InitialPriceUpdater/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/updaters/InitialPriceUpdater/index.tsx
@@ -12,7 +12,7 @@ import { limitRateAtom, LimitRateState, updateLimitRateAtom } from '../../state/
 
 // Fetch and update initial price for the selected token pair
 export function InitialPriceUpdater() {
-  const { inputCurrencyId, outputCurrencyId } = useLimitOrdersRawState()
+  const { inputCurrencyId, outputCurrencyId, chainId } = useLimitOrdersRawState()
   const { isTypedValue } = useAtomValue(limitRateAtom)
   const updateLimitRateState = useSetAtom(updateLimitRateAtom)
   const updateRate = useUpdateActiveRate()
@@ -54,7 +54,7 @@ export function InitialPriceUpdater() {
   // Reset initial price set flag when any token was changed
   useLayoutEffect(() => {
     setIsInitialPriceSet(false)
-  }, [inputCurrencyId, outputCurrencyId])
+  }, [inputCurrencyId, outputCurrencyId, chainId])
 
   return null
 }

--- a/apps/cowswap-frontend/src/modules/limitOrders/updaters/InitialPriceUpdater/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/updaters/InitialPriceUpdater/index.tsx
@@ -51,7 +51,7 @@ export function InitialPriceUpdater() {
     updateLimitRateState({ isLoading })
   }, [isInitialPriceSet, updateLimitRateState, updateRate, price, isLoading, prevPrice])
 
-  // Reset initial price set flag when any token was changed
+  // Reset initial price set flag when any token or chain was changed
   useLayoutEffect(() => {
     setIsInitialPriceSet(false)
   }, [inputCurrencyId, outputCurrencyId, chainId])


### PR DESCRIPTION
# Summary

Fixes issue https://www.notion.so/cownation/Recalculate-price-when-change-a-network-1828da5f04ca80069c9bdf01e8e0b483?pvs=4

Price is now recalculated when network changes but tokens are the same

# To Test

1. Load LIMIT on mainnet
2. Change to sepolia
* Price should be updated