### PR TITLE
Faster TWAPs with smaller parts

### DIFF
--- a/apps/cowswap-frontend/src/modules/twap/const.ts
+++ b/apps/cowswap-frontend/src/modules/twap/const.ts
@@ -38,14 +38,14 @@ export const TWAP_PENDING_STATUSES = [TwapOrderStatus.WaitSigning, TwapOrderStat
 export const TWAP_FINAL_STATUSES = [TwapOrderStatus.Fulfilled, TwapOrderStatus.Expired, TwapOrderStatus.Cancelled]
 
 export const MINIMUM_PART_SELL_AMOUNT_FIAT: Record<SupportedChainId, CurrencyAmount<Currency>> = {
-  [SupportedChainId.MAINNET]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.MAINNET], 1_000e6), // 1k
-  [SupportedChainId.GNOSIS_CHAIN]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.GNOSIS_CHAIN], 5e6), // 5
-  [SupportedChainId.ARBITRUM_ONE]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.ARBITRUM_ONE], 5e6), // 5
-  [SupportedChainId.BASE]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.BASE], 5e6), // 5
+  [SupportedChainId.MAINNET]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.MAINNET], 1_000e6), // $1k
+  [SupportedChainId.GNOSIS_CHAIN]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.GNOSIS_CHAIN], 1e5), // $0.1
+  [SupportedChainId.ARBITRUM_ONE]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.ARBITRUM_ONE], 1e6), // $1
+  [SupportedChainId.BASE]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.BASE], 1e6), // $1
   [SupportedChainId.SEPOLIA]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.SEPOLIA], 100e18), // 100
 }
 
-export const MINIMUM_PART_TIME = ms`5min` / 1000 // in seconds
+export const MINIMUM_PART_TIME = 15 // 15s
 export const MAX_PART_TIME = MAX_ORDER_DEADLINE / 1000 // in seconds
 
 export const DEFAULT_TWAP_EXECUTION_INFO: TwapOrderExecutionInfo = {

--- a/apps/cowswap-frontend/src/modules/twap/state/twapOrderAtom.ts
+++ b/apps/cowswap-frontend/src/modules/twap/state/twapOrderAtom.ts
@@ -3,6 +3,8 @@ import { atom } from 'jotai'
 import { walletInfoAtom } from '@cowprotocol/wallet'
 import { CurrencyAmount, Token } from '@uniswap/sdk-core'
 
+import ms from 'ms.macro'
+
 import { advancedOrdersDerivedStateAtom } from 'modules/advancedOrders'
 import { getAppData } from 'modules/appData'
 import { appDataInfoAtom } from 'modules/appData/state/atoms'
@@ -12,6 +14,8 @@ import { twapOrdersSettingsAtom } from './twapOrdersSettingsAtom'
 
 import { TWAPOrder } from '../types'
 import { customDeadlineToSeconds } from '../utils/deadlinePartsDisplay'
+
+const MINIMUM_SPAN = ms`30min` / 1000
 
 export const twapDeadlineAtom = atom<number>((get) => {
   const { isCustomDeadline, customDeadline, deadline } = get(twapOrdersSettingsAtom)
@@ -38,6 +42,8 @@ export const twapOrderAtom = atom<TWAPOrder | null>((get) => {
 
   const { sellAmount, buyAmount } = receiveAmountInfo.afterSlippage
 
+  const span = timeInterval < MINIMUM_SPAN ? MINIMUM_SPAN : 0
+
   return {
     sellAmount: sellAmount as CurrencyAmount<Token>,
     buyAmount: buyAmount as CurrencyAmount<Token>,
@@ -45,7 +51,7 @@ export const twapOrderAtom = atom<TWAPOrder | null>((get) => {
     numOfParts: numberOfPartsValue,
     startTime: 0, // Will be set to a block timestamp value from CurrentBlockTimestampFactory
     timeInterval,
-    span: 0,
+    span,
     appData: appDataInfo?.appDataKeccak256 || getAppData().appDataKeccak256,
   }
 })


### PR DESCRIPTION
# Twap reduce restrictions

Experimental PR to reduce drastically the restrictions for TWAP orders. 

## Relax Time 
I allow here, for dramatic porpoises, to place a order every 15s (before 300s --> 5min )

## Relax order size
Additionally, I reduced the minum trade size for Gnosis Chain, Base and Arbitrum.
  * Gnosis: $5 ---> $0.10
  * Arbitrum, Base: 5$ ---> 1$

## Allow more time to execute the orders
Before this PR discrete orders expire when the next part epoc starts.

This PR suggests a minimum of 30min in which orders are open. This way, it leaves more time for orders to execute. 

This way, you can send orders every 15s, but they will be batched in the same block if they are active concurrently OPEN. 
There could be other potential logic for the duration, I just used 30min as it is the default SWAP deadline.

## My test
I was able to place the order
<img width="966" alt="Screenshot at Jan 22 22-32-06" src="https://github.com/user-attachments/assets/1229dc9c-9b8a-4802-b360-8178b018c42f" />

It created this weird effect and the order expired before executing. Watch-tower didn't even place the order!

https://github.com/user-attachments/assets/8e52ff3d-032a-42be-a845-fb8b5532b2ed



## This shows some issues 
However, this shows how the order's table show some wrong data.
- The countdown for expiration starts to go down as I place the order (before the TX gets mined). I believe this is wrong. The expiration is given in time (60seconds in this case) after mining time. While signing the clock shouldn't be ticking.
- The orders table is confusing (to see the 60s left, and then 30min expiration)
- The creation time says 30min, but is not true, the order should be created in a few seconds (unless my TWAP creation is wrong)
- Watch Tower didn't place the orders fast enough. I would expect it to be quick --> after order mining it should 


# Follow ups
We should
- Fix the UI issues above
- Double check why watchtower didn't even place the order. place the orders
- Relax the time, but maybe 15seconds is too much!
- Double check the new amounts make sense
- Battle test the new logic for the minimum deadline of 30min
- Test is ok for the UI to have more than one TWAP part OPEN (before, only one was open)