### PR TITLE
Fix Arrow Background Animation & Add Opacity Control

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/ArrowBackground/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ArrowBackground/index.tsx
@@ -5,7 +5,7 @@ import { UI } from '@cowprotocol/ui'
 
 import styled from 'styled-components/macro'
 
-const ArrowBackgroundWrapper = styled.div`
+const ArrowBackgroundWrapper = styled.div<{ $maxOpacity: number }>`
   position: absolute;
   top: 0;
   left: 0;
@@ -14,7 +14,15 @@ const ArrowBackgroundWrapper = styled.div`
   pointer-events: none;
   visibility: hidden;
   opacity: 0;
-  transition: opacity 0.3s ease-in-out;
+  transition: opacity 1s ease-in-out;
+
+  &.visible {
+    visibility: visible;
+  }
+
+  &.show {
+    opacity: ${({ $maxOpacity }) => $maxOpacity};
+  }
 `
 
 const MIN_FONT_SIZE = 18
@@ -26,6 +34,7 @@ const Arrow = styled.div<{ delay: number; color: string; fontSize: number }>`
   color: ${({ color }) => color};
   animation: float 2s infinite linear;
   animation-delay: ${({ delay }) => delay}s;
+  opacity: 0;
 
   @keyframes float {
     0% {
@@ -33,12 +42,15 @@ const Arrow = styled.div<{ delay: number; color: string; fontSize: number }>`
       opacity: 0;
     }
     10% {
+      transform: translateY(80%);
       opacity: 0.3;
     }
     50% {
+      transform: translateY(0);
       opacity: 0.3;
     }
     90% {
+      transform: translateY(-80%);
       opacity: 0.2;
     }
     100% {
@@ -51,11 +63,13 @@ const Arrow = styled.div<{ delay: number; color: string; fontSize: number }>`
 export interface ArrowBackgroundProps {
   count?: number
   color?: string
+  className?: string
+  maxOpacity?: number
 }
 
 export const ArrowBackground = memo(
   forwardRef<HTMLDivElement, ArrowBackgroundProps>(
-    ({ count = 36, color = `var(${UI.COLOR_COWAMM_LIGHT_GREEN})` }, ref) => {
+    ({ count = 36, color = `var(${UI.COLOR_COWAMM_LIGHT_GREEN})`, className = '', maxOpacity = 0.25 }, ref) => {
       const arrows = useMemo(() => {
         return Array.from({ length: count }, (_, index) => ({
           delay: (index / count) * 4,
@@ -66,7 +80,7 @@ export const ArrowBackground = memo(
       }, [count])
 
       return (
-        <ArrowBackgroundWrapper ref={ref}>
+        <ArrowBackgroundWrapper ref={ref} className={className} $maxOpacity={maxOpacity}>
           {arrows.map((arrow, index) => (
             <Arrow
               key={index}

--- a/apps/cowswap-frontend/src/common/pure/LimitOrdersPromoBanner/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/LimitOrdersPromoBanner/index.tsx
@@ -1,9 +1,14 @@
+import { useState, useEffect } from 'react'
+
 import iconCompleted from '@cowprotocol/assets/cow-swap/check.svg'
 import { Command } from '@cowprotocol/types'
+import { UI } from '@cowprotocol/ui'
 
 import SVG from 'react-inlinesvg'
 
 import * as styledEl from './styled'
+
+import { ArrowBackground } from '../ArrowBackground'
 
 interface LimitOrdersPromoBannerProps {
   onCtaClick: Command
@@ -25,8 +30,37 @@ export function LimitOrdersPromoBanner({
   onDismiss,
   isLimitOrdersTab = false,
 }: LimitOrdersPromoBannerProps) {
+  const [isHovered, setIsHovered] = useState(false)
+  const [arrowRef, setArrowRef] = useState<HTMLDivElement | null>(null)
+  const [arrowsReady, setArrowsReady] = useState(false)
+
+  useEffect(() => {
+    // First make arrows visible but transparent
+    setArrowsReady(true)
+
+    // Wait for animations to be ready before showing
+    const timer = setTimeout(() => {
+      if (arrowRef) {
+        arrowRef.classList.add('show')
+      }
+    }, 1000)
+
+    return () => {
+      if (timer) {
+        clearTimeout(timer)
+      }
+    }
+  }, [arrowRef])
+
   return (
     <styledEl.BannerWrapper>
+      <ArrowBackground
+        ref={setArrowRef}
+        count={20}
+        color={`var(${UI.COLOR_SUCCESS})`}
+        className={arrowsReady ? 'visible' : ''}
+        maxOpacity={0.3}
+      />
       <styledEl.CloseButton size={24} onClick={onDismiss} />
       <styledEl.TitleSection>
         <h3>Level Up Your Trading with Smarter Limit Orders!</h3>
@@ -45,7 +79,14 @@ export function LimitOrdersPromoBanner({
       </styledEl.List>
 
       <styledEl.ControlSection>
-        <styledEl.CTAButton onClick={onCtaClick}>Place your limit order!</styledEl.CTAButton>
+        <styledEl.CTAButton
+          onClick={onCtaClick}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+        >
+          <styledEl.ButtonText $hover={isHovered}>Place your limit order!</styledEl.ButtonText>
+          <styledEl.Shimmer />
+        </styledEl.CTAButton>
         {!isLimitOrdersTab && <styledEl.DismissLink onClick={onDismiss}>Maybe next time</styledEl.DismissLink>}
       </styledEl.ControlSection>
     </styledEl.BannerWrapper>

--- a/apps/cowswap-frontend/src/common/pure/LimitOrdersPromoBanner/styled.ts
+++ b/apps/cowswap-frontend/src/common/pure/LimitOrdersPromoBanner/styled.ts
@@ -1,7 +1,33 @@
 import { UI, Media } from '@cowprotocol/ui'
 
 import { X } from 'react-feather'
-import styled from 'styled-components/macro'
+import styled, { css, keyframes } from 'styled-components/macro'
+
+const springEasing = `linear(
+  0, 0.002, 0.01 0.9%, 0.038 1.8%, 0.156, 0.312 5.8%, 0.789 11.1%, 1.015 14.2%,
+  1.096, 1.157, 1.199, 1.224 20.3%, 1.231, 1.231, 1.226, 1.214 24.6%,
+  1.176 26.9%, 1.057 32.6%, 1.007 35.5%, 0.984, 0.968, 0.956, 0.949 42%,
+  0.946 44.1%, 0.95 46.5%, 0.998 57.2%, 1.007, 1.011 63.3%, 1.012 68.3%,
+  0.998 84%, 1
+)`
+
+const wipe = keyframes`
+  0% {
+    mask-position: 200% center;
+  }
+  100% {
+    mask-position: 0% center;
+  }
+`
+
+const text = keyframes`
+  0% {
+    background-position: 100% center;
+  }    
+  100% {
+    background-position: -100% center;
+  }    
+`
 
 export const BannerWrapper = styled.div`
   position: relative;
@@ -11,6 +37,7 @@ export const BannerWrapper = styled.div`
   background: var(${UI.COLOR_PAPER_DARKER});
   margin: 10px 0;
   color: var(${UI.COLOR_TEXT});
+  overflow: hidden;
 `
 
 export const CloseButton = styled(X)`
@@ -102,20 +129,118 @@ export const ControlSection = styled.div`
   color: inherit;
 `
 
+interface ButtonTextProps {
+  $hover?: boolean
+}
+
+export const ButtonText = styled.span<ButtonTextProps>`
+  position: relative;
+  z-index: 1;
+  color: var(--button-text);
+
+  ${(props) =>
+    props.$hover &&
+    css`
+      color: transparent;
+      background-clip: text;
+      -webkit-background-clip: text;
+      background-color: var(--button-text);
+      background-image: linear-gradient(
+        120deg,
+        var(--button-text) 0%,
+        var(--button-text) 45%,
+        color-mix(in srgb, var(--button-darker) 90%, transparent) 50%,
+        var(--button-text) 55%,
+        var(--button-text) 100%
+      );
+      background-repeat: no-repeat;
+      background-size: 200% 100%;
+      background-position: 100% center;
+      animation: ${text} 0.66s ease-in-out 1 both;
+    `}
+`
+
+export const Shimmer = styled.span`
+  position: absolute;
+  inset: -40px;
+  border-radius: inherit;
+  mix-blend-mode: color-dodge;
+  mix-blend-mode: plus-lighter;
+  pointer-events: none;
+
+  &::before,
+  &::after {
+    transition: all 0.5s ease;
+    content: '';
+    border-radius: inherit;
+    position: absolute;
+    inset: 40px;
+  }
+
+  &::before {
+    box-shadow:
+      0 0 3px 2px color-mix(in srgb, var(--button-lighter) 95%, transparent),
+      0 0 7px 4px color-mix(in srgb, var(--button-lighter) 80%, transparent),
+      0 0 13px 8px color-mix(in srgb, var(--button-lighter) 60%, transparent),
+      0 0 22px 6px color-mix(in srgb, var(--button-lighter) 40%, transparent);
+    z-index: -1;
+    opacity: 0.4;
+  }
+
+  &::after {
+    box-shadow:
+      inset 0 0 0 1px color-mix(in srgb, var(--button-lighter) 95%, transparent),
+      inset 0 0 3px 1px color-mix(in srgb, var(--button-lighter) 80%, transparent),
+      inset 0 0 9px 1px color-mix(in srgb, var(--button-lighter) 70%, transparent);
+    z-index: 2;
+    opacity: 0.35;
+  }
+
+  mask-image: linear-gradient(90deg, transparent 15%, black 45%, black 55%, transparent 85%);
+  mask-size: 200% 200%;
+  mask-position: center;
+  animation: ${wipe} 3s linear infinite both -0.5s;
+`
+
 export const CTAButton = styled.button`
+  --shimmer-hue-1: 213deg;
+  --shimmer-hue-2: 248deg;
+  --button-base: var(${UI.COLOR_PRIMARY});
+  --button-darker: var(${UI.COLOR_PRIMARY_DARKER});
+  --button-lighter: ${({ theme }) => (theme.darkMode ? `var(${UI.COLOR_WHITE})` : `var(${UI.COLOR_PRIMARY_LIGHTER})`)};
+  --button-text: var(${UI.COLOR_BUTTON_TEXT});
+  --spring-duration: 1.33s;
+
   width: 100%;
-  padding: 16px;
-  border-radius: 12px;
+  padding: 0.8em 1.4em;
+  border-radius: 0.66em;
   border: none;
-  background: var(${UI.COLOR_PRIMARY});
-  color: var(${UI.COLOR_BUTTON_TEXT});
-  font-size: 21px;
+  outline: none;
+  background-image: linear-gradient(315deg, var(--button-darker) 0%, var(--button-base) 47%, var(--button-darker) 100%);
+  color: var(--button-text);
+  font-size: 1.2em;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease-in-out;
+  position: relative;
+  isolation: isolate;
+  box-shadow: 0 2px 3px 1px color-mix(in srgb, var(--button-base) 50%, transparent);
+  scale: 1;
+  transition: all var(--spring-duration) ${springEasing};
+  text-transform: unset;
 
-  &:hover {
-    background: var(${UI.COLOR_PRIMARY_LIGHTER});
+  &:hover:not(:active) {
+    scale: 1.03;
+    transition-duration: calc(var(--spring-duration) * 0.5);
+  }
+
+  &:active {
+    scale: 1.02;
+    transition-duration: calc(var(--spring-duration) * 0.5);
+  }
+
+  &:focus ${Shimmer}, &:active ${Shimmer} {
+    animation-play-state: paused !important;
+    mask-image: none !important;
   }
 `
 

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/index.tsx
@@ -14,7 +14,7 @@ export function TradeWidget(props: TradeWidgetProps) {
     tradeQuoteStateOverride,
     enableSmartSlippage,
   } = params
-  const modals = TradeWidgetModals({confirmModal, genericModal, selectTokenWidget: slots.selectTokenWidget})
+  const modals = TradeWidgetModals({ confirmModal, genericModal, selectTokenWidget: slots.selectTokenWidget })
 
   return (
     <>


### PR DESCRIPTION
# Fix Arrow Background Animation & Add Opacity Control

## 🔄 Changes
Fixed the arrow background animation in the Limit Orders promo banner to ensure smooth transitions and prevent "stuck" arrows on initialization. Also added customizable opacity control.


https://github.com/user-attachments/assets/9b0d0b65-c02d-4567-aae4-d4bddd71970a


https://github.com/user-attachments/assets/63f301aa-e22f-4446-adfd-1237fc403010



## Technical Details
* Refactored animation initialization to ensure arrows are moving before becoming visible
* Added `maxOpacity` prop to `ArrowBackground` component for customizable visibility
* Improved transition timing using CSS classes instead of direct style manipulation
* Extended animation delay to ensure proper initialization
* Added smoother transition curve for opacity changes (1s ease-in-out)

## 🎯 Testing Steps
1. Open the app and verify the Limit Orders promo banner appears
2. Check that arrows fade in smoothly without any "stuck" or static arrows
3. Verify arrows are already in motion when they become visible
4. Test different opacity values:
   ```tsx
   <ArrowBackground maxOpacity={0.3} /> // Should be more visible
   <ArrowBackground maxOpacity={0.1} /> // Should be more subtle
   ```
5. Test rapid mounting/unmounting of the banner to ensure cleanup works properly

 

**After:** Smooth fade-in with all arrows already in motion, consistent opacity transitions.

## 🧪 Test Environment
* Open any page with the Limit Orders promo banner
* Try different screen sizes to ensure animations work consistently
* Test on different browsers (Chrome, Firefox, Safari)

## 📝 Additional Notes
* Default opacity remains at 0.25 for backward compatibility
* Animation timing can be adjusted if needed through the transition duration
* No breaking changes - new prop is optional