### PR TITLE
fix: price lock

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useUpdateActiveRate.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useUpdateActiveRate.ts
@@ -53,6 +53,7 @@ export function useUpdateActiveRate(): UpdateRateCallback {
           activeRate,
           amount: isSell ? inputCurrencyAmount : outputCurrencyAmount,
           orderKind,
+          isPriceUpdate: true,
         })
       }
 

--- a/apps/cowswap-frontend/src/utils/orderUtils/calculateRateForAmount.ts
+++ b/apps/cowswap-frontend/src/utils/orderUtils/calculateRateForAmount.ts
@@ -1,0 +1,24 @@
+import { Currency, CurrencyAmount, Price } from '@uniswap/sdk-core'
+
+export function calculateRateForAmount(
+  isBuyAmountChange: boolean,
+  amount: CurrencyAmount<Currency> | null,
+  inputCurrencyAmount: CurrencyAmount<Currency> | null,
+  outputCurrencyAmount: CurrencyAmount<Currency> | null,
+): Price<Currency, Currency> | null {
+  if (!amount) {
+    return null
+  }
+
+  if (isBuyAmountChange) {
+    return (
+      inputCurrencyAmount &&
+      new Price(inputCurrencyAmount.currency, amount.currency, inputCurrencyAmount.quotient, amount.quotient)
+    )
+  } else {
+    return (
+      outputCurrencyAmount &&
+      new Price(amount.currency, outputCurrencyAmount.currency, amount.quotient, outputCurrencyAmount.quotient)
+    )
+  }
+}


### PR DESCRIPTION
# Summary

Price locking/unlocking should work again as expected

I broke the unlocking in this PR https://github.com/cowprotocol/cowswap/pull/5304, although I could swear it was working when I tested...
Well, I was mistaken.

# To Test

1. Play around with prices and amounts while the price is locked
* Should behave like prod
2. Play around with prices and amounts while the price is unlocked
* Price should be updated when amounts are changed
* Opposite amount should be updated when price is edited