### PR TITLE
feat: disable wrapping eth

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/containers/EthFlow/EthFlowBanner.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/EthFlow/EthFlowBanner.tsx
@@ -4,6 +4,7 @@ import { Command } from '@cowprotocol/types'
 
 import { EthFlowBannerContent } from 'modules/swap/pure/EthFlow/EthFlowBanner'
 import { useIsNativeIn } from 'modules/trade/hooks/useIsNativeInOrOut'
+import { useIsWrapDisabled } from 'modules/trade/hooks/useIsWrapDisabled'
 import { useWrappedToken } from 'modules/trade/hooks/useWrappedToken'
 
 import useNativeCurrency from 'lib/hooks/useNativeCurrency'
@@ -26,8 +27,9 @@ export function EthFlowBanner({ hasEnoughWrappedBalance, ...props }: EthFlowBann
     return setShowBanner((state) => !state)
   }
 
-  // dont render if it isn't a native token swap
-  if (!isNativeIn) return null
+  // Don't render if it isn't a native token or the wrap is disabled
+  const isWrapDisabled = useIsWrapDisabled()
+  if (!isNativeIn || isWrapDisabled) return null
 
   return (
     <EthFlowBannerContent

--- a/apps/cowswap-frontend/src/modules/swap/helpers/getSwapButtonState.ts
+++ b/apps/cowswap-frontend/src/modules/swap/helpers/getSwapButtonState.ts
@@ -32,6 +32,7 @@ export enum SwapButtonState {
   SellNativeInHooks = 'SellNativeInHooks',
 
   WrapAndSwap = 'WrapAndSwap',
+  WrapDisable = 'WrapDisable',
 }
 
 export interface SwapButtonStateParams {

--- a/apps/cowswap-frontend/src/modules/swap/pure/SwapButtons/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/SwapButtons/index.tsx
@@ -55,6 +55,15 @@ const swapButtonStateMap: { [key in SwapButtonState]: (props: SwapButtonsContext
       </Text>
     </ButtonError>
   ),
+
+  [SwapButtonState.WrapDisable]: () => (
+    <ButtonError buttonSize={ButtonSize.BIG} disabled={true}>
+      <Text fontSize={20} fontWeight={500}>
+        <Trans>Temporary disabled</Trans>
+      </Text>
+    </ButtonError>
+  ),
+
   [SwapButtonState.SwapWithWrappedToken]: (props: SwapButtonsContext) => (
     <ButtonError buttonSize={ButtonSize.BIG} onClick={props.onEthFlow}>
       <styledEl.SwapButtonBox>

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useIsWrapDisabled.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useIsWrapDisabled.ts
@@ -1,0 +1,6 @@
+import { useFeatureFlags } from '@cowprotocol/common-hooks'
+
+export function useIsWrapDisabled(): boolean {
+  const { isWrapDisabled = true } = useFeatureFlags()
+  return isWrapDisabled
+}

--- a/apps/cowswap-frontend/src/modules/trade/pure/WrapDisabledWarning/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/WrapDisabledWarning/index.tsx
@@ -1,0 +1,10 @@
+import { WarningCard } from 'common/pure/WarningCard'
+
+export function WrapDisabledWarning({ nativeCurrency }: { nativeCurrency: string }) {
+  return (
+    <WarningCard>
+      Wrapping {nativeCurrency} is temporarily disabled, but will be back very soon! In the meantime, you can still
+      trade {nativeCurrency} directly
+    </WarningCard>
+  )
+}

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormButtonContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormButtonContext.ts
@@ -5,15 +5,16 @@ import { useWalletDetails } from '@cowprotocol/wallet'
 import { useToggleWalletModal } from 'legacy/state/application/hooks'
 
 import { useInjectedWidgetParams } from 'modules/injectedWidget'
-import { useWrapNativeFlow } from 'modules/trade'
+import { useIsSellNative, useWrapNativeFlow } from 'modules/trade'
 import { useDerivedTradeState } from 'modules/trade/hooks/useDerivedTradeState'
 import { useTradeQuote } from 'modules/tradeQuote'
 
 import { TradeFormButtonContext } from '../types'
+import { useIsWrapDisabled } from 'modules/trade/hooks/useIsWrapDisabled'
 
 export function useTradeFormButtonContext(
   defaultText: string,
-  confirmTrade: () => void
+  confirmTrade: () => void,
 ): TradeFormButtonContext | null {
   const derivedState = useDerivedTradeState()
   const wrapNativeFlow = useWrapNativeFlow()
@@ -21,6 +22,7 @@ export function useTradeFormButtonContext(
   const quote = useTradeQuote()
   const toggleWalletModal = useToggleWalletModal()
   const { standaloneMode } = useInjectedWidgetParams()
+  const isWrapDisabled = useIsWrapDisabled()
 
   return useMemo(() => {
     if (!derivedState) return null
@@ -34,6 +36,7 @@ export function useTradeFormButtonContext(
       wrapNativeFlow,
       connectWallet: toggleWalletModal,
       widgetStandaloneMode: standaloneMode,
+      isWrapDisabled,
     }
   }, [
     defaultText,

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormValidationContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormValidationContext.ts
@@ -14,6 +14,7 @@ import { useApproveState } from 'common/hooks/useApproveState'
 
 import { TradeType } from '../../trade'
 import { TradeFormValidationCommonContext } from '../types'
+import { useIsWrapDisabled } from 'modules/trade/hooks/useIsWrapDisabled'
 
 export function useTradeFormValidationContext(): TradeFormValidationCommonContext | null {
   const { account } = useWalletInfo()
@@ -34,6 +35,7 @@ export function useTradeFormValidationContext(): TradeFormValidationCommonContex
   const isSafeReadonlyUser = gnosisSafeInfo?.isReadOnly === true
 
   const isPermitSupported = useTokenSupportsPermit(inputCurrency, tradeType)
+  const isWrapDisabled = useIsWrapDisabled()
 
   const isInsufficientBalanceOrderAllowed = tradeType === TradeType.LIMIT_ORDER
 
@@ -49,6 +51,7 @@ export function useTradeFormValidationContext(): TradeFormValidationCommonContex
     tradeQuote,
     isPermitSupported,
     isInsufficientBalanceOrderAllowed,
+    isWrapDisabled,
   }
 
   return useMemo(() => {

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
@@ -58,6 +58,13 @@ const unsupportedTokenButton = (context: TradeFormButtonContext) => {
 }
 
 export const tradeButtonsMap: Record<TradeFormValidation, ButtonErrorConfig | ButtonCallback> = {
+  [TradeFormValidation.WrapDisabled]: () => {
+    return (
+      <TradeFormBlankButton disabled={true}>
+        <Trans>Temporary disabled</Trans>
+      </TradeFormBlankButton>
+    )
+  },
   [TradeFormValidation.WrapUnwrapFlow]: (context) => {
     const isNativeIn = !!context.derivedState.inputCurrency && getIsNativeToken(context.derivedState.inputCurrency)
 

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
@@ -14,6 +14,7 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
     approvalState,
     isBundlingSupported,
     isWrapUnwrap,
+    isWrapDisabled,
     isSupportedWallet,
     isSafeReadonlyUser,
     isSwapUnsupported,
@@ -29,7 +30,7 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
     ? BigInt(inputCurrencyBalance.quotient.toString()) > BigInt(0)
     : false
   const canPlaceOrderWithoutBalance = isBalanceGreaterThan1Atom && isInsufficientBalanceOrderAllowed && !isWrapUnwrap
-  const isNativeIn = inputCurrency && getIsNativeToken(inputCurrency) && !isWrapUnwrap
+  const isNativeIn = inputCurrency && getIsNativeToken(inputCurrency)
 
   const approvalRequired =
     !isPermitSupported && (approvalState === ApprovalState.NOT_APPROVED || approvalState === ApprovalState.PENDING)
@@ -56,7 +57,11 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
     return TradeFormValidation.CurrencyNotSet
   }
 
-  if (isNativeIn) {
+  if (isNativeIn && isWrapDisabled) {
+    return TradeFormValidation.WrapDisabled
+  }
+
+  if (isNativeIn && !isWrapUnwrap) {
     return TradeFormValidation.SellNativeToken
   }
 

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/types.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/types.ts
@@ -6,6 +6,9 @@ import { TradeQuoteState } from 'modules/tradeQuote'
 import { ApprovalState } from 'common/hooks/useApproveState'
 
 export enum TradeFormValidation {
+  // Wrap is disabled
+  WrapDisabled,
+
   // Wrap/unwrap
   WrapUnwrapFlow,
 
@@ -52,6 +55,7 @@ export interface TradeFormValidationCommonContext {
   isSafeReadonlyUser: boolean
   isPermitSupported: boolean
   isInsufficientBalanceOrderAllowed: boolean
+  isWrapDisabled: boolean
 }
 
 export interface TradeFormValidationContext extends TradeFormValidationCommonContext {}


### PR DESCRIPTION
# Summary

This PR disables the wrapping native tokens (i.e. wrap Ether).

- Disables the wrap ether button and changes the text
- Shows a warning with a explainer
- Disables the classic flow, which also allow to wrap
- It does this for Swap and Limit Orders
- Adds a feature flag so we can enable/disable the flow

It allows to unwrap ether, though.

NOTE: I added the label DONT MERGE because Its very likely this doesn't need to be deployed to production as latest tests show we are not affected by the Metamask bug with our current production version. 


https://github.com/user-attachments/assets/58feca01-f5dd-43c5-a024-9add123ccb0a



# To Test
Try to wrap. Make sure you fail to do so!