### PR TITLE
fix(limit-orders): update price and amounts when tokens changed

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/updaters/SetupLimitOrderAmountsFromUrlUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/updaters/SetupLimitOrderAmountsFromUrlUpdater.tsx
@@ -27,11 +27,9 @@ export function SetupLimitOrderAmountsFromUrlUpdater() {
    * So, we reset isRateFromUrl flag when at least one of the tokens is changed
    */
   useEffect(() => {
-    if (!tokensPair || !prevTokensPair) return
+    if (!tokensPair || !prevTokensPair || tokensPair === prevTokensPair) return
 
-    if (tokensPair !== prevTokensPair) {
-      updateRateState({ isRateFromUrl: false })
-    }
+    updateRateState({ isRateFromUrl: false })
   }, [tokensPair, prevTokensPair, updateRateState])
 
   const params = useMemo(() => {

--- a/apps/cowswap-frontend/src/modules/limitOrders/updaters/SetupLimitOrderAmountsFromUrlUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/updaters/SetupLimitOrderAmountsFromUrlUpdater.tsx
@@ -1,15 +1,38 @@
-import { useMemo } from 'react'
+import { useSetAtom } from 'jotai/index'
+import { useEffect, useMemo } from 'react'
 
+import { usePrevious } from '@cowprotocol/common-hooks'
 import { Price } from '@uniswap/sdk-core'
 
 import { useSetupTradeAmountsFromUrl } from 'modules/trade'
 
 import { TradeAmounts } from 'common/types'
 
+import { useLimitOrdersRawState } from '../hooks/useLimitOrdersRawState'
 import { useUpdateActiveRate } from '../hooks/useUpdateActiveRate'
+import { updateLimitRateAtom } from '../state/limitRateAtom'
 
 export function SetupLimitOrderAmountsFromUrlUpdater() {
   const updateRate = useUpdateActiveRate()
+  const updateRateState = useSetAtom(updateLimitRateAtom)
+
+  const { inputCurrencyId, outputCurrencyId } = useLimitOrdersRawState()
+  const tokensPair = `${inputCurrencyId || ''}${outputCurrencyId || ''}`
+  const prevTokensPair = usePrevious(tokensPair)
+
+  /**
+   * In useUpdateActiveRate() we have a logic which depends on isRateFromUrl flag
+   * Mainly, it serves for keeping amounts static after coming from another trade widget
+   * But we should not prevent amounts and price update when we change tokens
+   * So, we reset isRateFromUrl flag when at least one of the tokens is changed
+   */
+  useEffect(() => {
+    if (!tokensPair || !prevTokensPair) return
+
+    if (tokensPair !== prevTokensPair) {
+      updateRateState({ isRateFromUrl: false })
+    }
+  }, [tokensPair, prevTokensPair, updateRateState])
 
   const params = useMemo(() => {
     return {


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Price-is-wrong-when-change-a-token-using-token-selector-1858da5f04ca802c99e1caa36375b7d5

This problem more likely comes from #4668 fix. At least I can reproduce it on prod now.
In useUpdateActiveRate() we have a logic which depends on `isRateFromUrl` flag.
Mainly, it serves for keeping amounts static after coming from another trade widget.
But we should not prevent amounts and price update when we change tokens.
So, we reset `isRateFromUrl` flag when at least one of the tokens is changed.

# To Test

1. Open swap widget in Sepolia, setup selling WETH to USDC
2. Go to limit orders
3. Change one of the tokens. You can do it in 3 ways: a) using token selector b) switching tokens places c) changing tokens in URL

- [ ] AR: you will see >999% after "is worth"
- [ ] ER: price and amounts are recalculated correctly
