### PR TITLE
fix: type guard to make sure provider is a JsonRpcProvider

### DIFF
--- a/apps/cowswap-frontend/src/common/utils/assertProviderNetwork.ts
+++ b/apps/cowswap-frontend/src/common/utils/assertProviderNetwork.ts
@@ -1,0 +1,23 @@
+import { getChainIdImmediately } from '@cowprotocol/common-utils'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { JsonRpcProvider, Provider } from '@ethersproject/providers'
+
+export async function assertProviderNetwork(
+  chainId: SupportedChainId,
+  provider: JsonRpcProvider | Provider,
+  description: string,
+): Promise<SupportedChainId> {
+  const ethereumProvider = (provider as unknown as { provider: typeof window.ethereum }).provider
+
+  // Do assert only for Metamask
+  if (!ethereumProvider || !ethereumProvider.isMetaMask || ethereumProvider.isRabby) return chainId
+
+  const network = await getChainIdImmediately(provider)
+  if (network !== chainId) {
+    throw new Error(
+      `Wallet chainId differs from order params chainId. Wallet: ${network}, App: ${chainId}. Action: ${description}`,
+    )
+  }
+
+  return network
+}

--- a/apps/cowswap-frontend/src/common/utils/assertProviderNetwork.ts
+++ b/apps/cowswap-frontend/src/common/utils/assertProviderNetwork.ts
@@ -15,7 +15,7 @@ export async function assertProviderNetwork(
   const network = await getChainIdImmediately(provider)
   if (network !== chainId) {
     throw new Error(
-      `Wallet chainId differs from order params chainId. Wallet: ${network}, App: ${chainId}. Action: ${description}`,
+      `Wallet chainId differs from app chainId. Wallet: ${network}, App: ${chainId}. Action: ${description}`,
     )
   }
 

--- a/apps/cowswap-frontend/src/legacy/hooks/useWrapCallback.ts
+++ b/apps/cowswap-frontend/src/legacy/hooks/useWrapCallback.ts
@@ -10,7 +10,7 @@ import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { Command } from '@cowprotocol/types'
 import { BigNumber } from '@ethersproject/bignumber'
 import { Contract } from '@ethersproject/contracts'
-import { JsonRpcProvider, TransactionResponse } from '@ethersproject/providers'
+import { TransactionResponse } from '@ethersproject/providers'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
 import { useTransactionAdder } from 'legacy/state/enhancedTransactions/hooks'
@@ -114,7 +114,7 @@ async function wrapContractCall(
   const estimatedGas = await wethContract.estimateGas.deposit({ value: amountHex }).catch(_handleGasEstimateError)
   const gasLimit = calculateGasMargin(estimatedGas)
 
-  const network = await getChainIdImmediately(wethContract.provider as JsonRpcProvider)
+  const network = await getChainIdImmediately(wethContract.provider)
   if (network !== chainId) {
     throw new Error(`Wallet chainId differs from app chainId. Wallet: ${network}, App: ${chainId}`)
   }
@@ -134,7 +134,7 @@ async function unwrapContractCall(
 
   const tx = await wethContract.populateTransaction.withdraw(amountHex, { gasLimit })
 
-  const network = await getChainIdImmediately(wethContract.provider as JsonRpcProvider)
+  const network = await getChainIdImmediately(wethContract.provider)
   if (network !== chainId) {
     throw new Error(`Wallet chainId differs from app chainId. Wallet: ${network}, App: ${chainId}`)
   }

--- a/apps/cowswap-frontend/src/legacy/hooks/useWrapCallback.ts
+++ b/apps/cowswap-frontend/src/legacy/hooks/useWrapCallback.ts
@@ -2,7 +2,6 @@ import { getChainCurrencySymbols, RADIX_HEX } from '@cowprotocol/common-const'
 import {
   calculateGasMargin,
   formatTokenAmount,
-  getChainIdImmediately,
   getIsNativeToken,
   isRejectRequestProviderError,
 } from '@cowprotocol/common-utils'
@@ -16,6 +15,8 @@ import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import { useTransactionAdder } from 'legacy/state/enhancedTransactions/hooks'
 
 import { wrapAnalytics } from 'modules/analytics'
+
+import { assertProviderNetwork } from 'common/utils/assertProviderNetwork'
 
 // Use a 180K gas as a fallback if there's issue calculating the gas estimation (fixes some issues with some nodes failing to calculate gas costs for SC wallets)
 const WRAP_UNWRAP_GAS_LIMIT_DEFAULT = BigNumber.from('180000')
@@ -114,10 +115,7 @@ async function wrapContractCall(
   const estimatedGas = await wethContract.estimateGas.deposit({ value: amountHex }).catch(_handleGasEstimateError)
   const gasLimit = calculateGasMargin(estimatedGas)
 
-  const network = await getChainIdImmediately(wethContract.provider)
-  if (network !== chainId) {
-    throw new Error(`Wallet chainId differs from app chainId. Wallet: ${network}, App: ${chainId}`)
-  }
+  const network = await assertProviderNetwork(chainId, wethContract.provider, 'wrap')
 
   const tx = await wethContract.populateTransaction.deposit({ value: amountHex, gasLimit })
 
@@ -134,10 +132,7 @@ async function unwrapContractCall(
 
   const tx = await wethContract.populateTransaction.withdraw(amountHex, { gasLimit })
 
-  const network = await getChainIdImmediately(wethContract.provider)
-  if (network !== chainId) {
-    throw new Error(`Wallet chainId differs from app chainId. Wallet: ${network}, App: ${chainId}`)
-  }
+  const network = await assertProviderNetwork(chainId, wethContract.provider, 'unwrap')
 
   return wethContract.signer.sendTransaction({ ...tx, chainId: network })
 }

--- a/apps/cowswap-frontend/src/modules/swap/services/ethFlow/steps/signEthFlowOrderStep.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/ethFlow/steps/signEthFlowOrderStep.ts
@@ -1,5 +1,5 @@
 import { CoWSwapEthFlow } from '@cowprotocol/abis'
-import { calculateGasMargin, getChainIdImmediately } from '@cowprotocol/common-utils'
+import { calculateGasMargin } from '@cowprotocol/common-utils'
 import { OrderClass, SigningScheme, UnsignedOrder } from '@cowprotocol/cow-sdk'
 import { ContractTransaction } from '@ethersproject/contracts'
 import { NativeCurrency } from '@uniswap/sdk-core'
@@ -10,6 +10,7 @@ import { getSignOrderParams, mapUnsignedOrderToOrder, PostOrderParams } from 'le
 import { logTradeFlow, logTradeFlowError } from 'modules/trade/utils/logger'
 
 import { GAS_LIMIT_DEFAULT } from 'common/constants/common'
+import { assertProviderNetwork } from 'common/utils/assertProviderNetwork'
 
 type EthFlowOrderParams = Omit<PostOrderParams, 'sellToken'> & {
   sellToken: NativeCurrency
@@ -44,12 +45,7 @@ export async function signEthFlowOrderStep(
     throw new Error('[EthFlow::SignEthFlowOrderStep] No quoteId passed')
   }
 
-  const network = await getChainIdImmediately(ethFlowContract.provider)
-  if (network !== orderParams.chainId) {
-    throw new Error(
-      `Wallet chainId differs from order params chainId. Wallet: ${network}, Order: ${orderParams.chainId}`,
-    )
-  }
+  const network = await assertProviderNetwork(orderParams.chainId, ethFlowContract.provider, 'eth-flow')
 
   const ethOrderParams: EthFlowCreateOrderParams = {
     ...order,

--- a/apps/cowswap-frontend/src/modules/swap/services/ethFlow/steps/signEthFlowOrderStep.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/ethFlow/steps/signEthFlowOrderStep.ts
@@ -2,7 +2,6 @@ import { CoWSwapEthFlow } from '@cowprotocol/abis'
 import { calculateGasMargin, getChainIdImmediately } from '@cowprotocol/common-utils'
 import { OrderClass, SigningScheme, UnsignedOrder } from '@cowprotocol/cow-sdk'
 import { ContractTransaction } from '@ethersproject/contracts'
-import { JsonRpcProvider } from '@ethersproject/providers'
 import { NativeCurrency } from '@uniswap/sdk-core'
 
 import { Order } from 'legacy/state/orders/actions'
@@ -45,7 +44,7 @@ export async function signEthFlowOrderStep(
     throw new Error('[EthFlow::SignEthFlowOrderStep] No quoteId passed')
   }
 
-  const network = await getChainIdImmediately(ethFlowContract.provider as JsonRpcProvider)
+  const network = await getChainIdImmediately(ethFlowContract.provider)
   if (network !== orderParams.chainId) {
     throw new Error(
       `Wallet chainId differs from order params chainId. Wallet: ${network}, Order: ${orderParams.chainId}`,

--- a/apps/cowswap-frontend/src/react-app-env.d.ts
+++ b/apps/cowswap-frontend/src/react-app-env.d.ts
@@ -14,6 +14,7 @@ interface Window {
     // value that is populated and returns true by the Coinbase Wallet mobile dapp browser
     isCoinbaseWallet?: true
     isMetaMask?: true
+    isRabby?: true
     autoRefreshOnNetworkChange?: boolean
     autoConnect?: boolean
     setSelectedProvider: (any) => void

--- a/libs/common-utils/src/getChainIdImmediately.ts
+++ b/libs/common-utils/src/getChainIdImmediately.ts
@@ -1,6 +1,11 @@
-import { JsonRpcProvider } from '@ethersproject/providers'
+import { JsonRpcProvider, Provider } from '@ethersproject/providers'
 
-export async function getChainIdImmediately(provider: JsonRpcProvider): Promise<number | undefined> {
+export async function getChainIdImmediately(provider: JsonRpcProvider | Provider): Promise<number | undefined> {
+  if (!isJsonRpcProvider(provider)) {
+    console.error('Provider is not a JsonRpcProvider')
+    return undefined
+  }
+
   try {
     const chainId = await provider.send('eth_chainId', [])
 
@@ -9,4 +14,8 @@ export async function getChainIdImmediately(provider: JsonRpcProvider): Promise<
     console.error('Failed to get chainId from provider', error)
     return undefined
   }
+}
+
+function isJsonRpcProvider(provider: JsonRpcProvider | Provider): provider is JsonRpcProvider {
+  return (provider as JsonRpcProvider).send !== undefined
 }

--- a/libs/wallet/src/web3-react/connectors/TrezorConnector/index.ts
+++ b/libs/wallet/src/web3-react/connectors/TrezorConnector/index.ts
@@ -143,7 +143,7 @@ export class TrezorConnector extends Connector {
 
     this.customProvider = customProvider
 
-    const chainId = await customProvider.send('eth_chainId', [])
+    const chainId = +(await customProvider.send('eth_chainId', []))
 
     trezorConnect.on('DEVICE_EVENT', (event) => {
       if (event.type === 'device-disconnect') {

--- a/libs/wallet/src/web3-react/connectors/TrezorConnector/sendTransactionHandler.ts
+++ b/libs/wallet/src/web3-react/connectors/TrezorConnector/sendTransactionHandler.ts
@@ -14,7 +14,7 @@ export async function sendTransactionHandler(
   provider: JsonRpcProvider,
   trezorConnect: TrezorConnect,
 ) {
-  const chainId = await provider.send('eth_chainId', [])
+  const chainId = +(await provider.send('eth_chainId', []))
   const nonce = await provider.send('eth_getTransactionCount', [account, 'latest'])
 
   const originalTx = params[0]


### PR DESCRIPTION
# Summary

Added a type guard to make sure provider is a JsonRpcProvider.
No functional changes expected.

# To Test

1. Wrap, unwrap and place ethflow
* All should work