### PR TITLE
chore: use eth flow new contracts

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useCancelOrder/useGetOnChainCancellation.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useCancelOrder/useGetOnChainCancellation.ts
@@ -15,7 +15,9 @@ import { getIsComposableCowParentOrder } from 'utils/orderUtils/getIsComposableC
 import { getIsTheLastTwapPart } from 'utils/orderUtils/getIsTheLastTwapPart'
 
 export function useGetOnChainCancellation(): (order: Order) => Promise<OnChainCancellation> {
-  const { contract: ethFlowContract, chainId: ethFlowChainId } = useEthFlowContract()
+  const {
+    result: { contract: ethFlowContract, chainId: ethFlowChainId },
+  } = useEthFlowContract()
   const { contract: settlementContract, chainId: settlementChainId } = useGP2SettlementContract()
   const cancelTwapOrder = useCancelTwapOrder()
 

--- a/apps/cowswap-frontend/src/common/hooks/useCancelOrder/useSendOnChainCancellation.test.tsx
+++ b/apps/cowswap-frontend/src/common/hooks/useCancelOrder/useSendOnChainCancellation.test.tsx
@@ -82,15 +82,18 @@ describe('useSendOnChainCancellation() + useGetOnChainCancellation()', () => {
     ethFlowInvalidationMock.mockResolvedValue({ hash: ethFlowCancellationTxHash })
 
     mockUseEthFlowContract.mockReturnValue({
-      contract: {
-        estimateGas: {
-          invalidateOrder: () => Promise.resolve(BigNumber.from(100)),
-        },
-        invalidateOrder: ethFlowInvalidationMock,
-      } as any,
-      chainId,
-      error: null,
-      loading: false,
+      result: {
+        contract: {
+          estimateGas: {
+            invalidateOrder: () => Promise.resolve(BigNumber.from(100)),
+          },
+          invalidateOrder: ethFlowInvalidationMock,
+        } as any,
+        chainId,
+        error: null,
+        loading: false,
+      },
+      useNewEthFlowContracts: false,
     })
 
     settlementInvalidationMock.mockResolvedValue({ hash: settlementCancellationTxHash })

--- a/apps/cowswap-frontend/src/common/hooks/useContract.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useContract.ts
@@ -14,9 +14,11 @@ import {
 } from '@cowprotocol/abis'
 import {
   COWSWAP_ETHFLOW_CONTRACT_ADDRESS,
+  OLD_COWSWAP_ETHFLOW_CONTRACT_ADDRESS,
   V_COW_CONTRACT_ADDRESS,
   WRAPPED_NATIVE_CURRENCIES,
 } from '@cowprotocol/common-const'
+import { useFeatureFlags } from '@cowprotocol/common-hooks'
 import { getContract, isEns, isProd, isStaging } from '@cowprotocol/common-utils'
 import { COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { useWalletInfo } from '@cowprotocol/wallet'
@@ -29,7 +31,6 @@ const WETH_CONTRACT_ADDRESS_MAP = Object.fromEntries(
 )
 
 const contractEnv = isProd || isStaging || isEns ? 'prod' : 'barn'
-export const COWSWAP_ETHFLOW_CONTRACT_ADDRESS_MAP = COWSWAP_ETHFLOW_CONTRACT_ADDRESS[contractEnv]
 
 export type UseContractResult<T extends Contract = Contract> = {
   contract: T | null
@@ -103,7 +104,12 @@ export function useWethContract(withSignerIfPossible?: boolean) {
 }
 
 export function useEthFlowContract(): UseContractResult<CoWSwapEthFlow> {
-  return useContract<CoWSwapEthFlow>(COWSWAP_ETHFLOW_CONTRACT_ADDRESS_MAP, CoWSwapEthFlowAbi, true)
+  const { useNewEthFlowContracts = false } = useFeatureFlags()
+  const contractAddresses = useNewEthFlowContracts
+    ? COWSWAP_ETHFLOW_CONTRACT_ADDRESS[contractEnv]
+    : OLD_COWSWAP_ETHFLOW_CONTRACT_ADDRESS[contractEnv]
+
+  return useContract<CoWSwapEthFlow>(contractAddresses, CoWSwapEthFlowAbi, true)
 }
 
 export function useGP2SettlementContract(): UseContractResult<GPv2Settlement> {

--- a/apps/cowswap-frontend/src/common/hooks/useContract.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useContract.ts
@@ -17,7 +17,6 @@ import {
   V_COW_CONTRACT_ADDRESS,
   WRAPPED_NATIVE_CURRENCIES,
 } from '@cowprotocol/common-const'
-import { useFeatureFlags } from '@cowprotocol/common-hooks'
 import { getContract } from '@cowprotocol/common-utils'
 import { isEns, isProd, isStaging } from '@cowprotocol/common-utils'
 import { COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS, SupportedChainId } from '@cowprotocol/cow-sdk'
@@ -107,7 +106,8 @@ export function useEthFlowContract(): {
   result: UseContractResult<CoWSwapEthFlow>
   useNewEthFlowContracts: boolean
 } {
-  const { useNewEthFlowContracts = false } = useFeatureFlags()
+  // const { useNewEthFlowContracts = false } = useFeatureFlags()
+  const useNewEthFlowContracts = true
   const contractAddress = getEthFlowContractAddresses(ethFlowEnv, useNewEthFlowContracts)
 
   return {

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useCheckEthFlowOrderExists.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useCheckEthFlowOrderExists.ts
@@ -13,7 +13,9 @@ export interface EthFlowOrderExistsCallback {
 
 export function useCheckEthFlowOrderExists(): EthFlowOrderExistsCallback {
   const ethFlowInFlightOrderIds = useAtomValue(ethFlowInFlightOrderIdsAtom)
-  const { contract: ethFlowContract } = useEthFlowContract()
+  const {
+    result: { contract: ethFlowContract },
+  } = useEthFlowContract()
 
   return useCallback(
     async (orderId: string, orderDigest: string) => {

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useEthFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useEthFlowContext.ts
@@ -16,7 +16,10 @@ import { EthFlowContext } from '../services/types'
 import { addInFlightOrderIdAtom } from '../state/EthFlow/ethFlowInFlightOrderIdsAtom'
 
 export function useEthFlowContext(): EthFlowContext | null {
-  const { contract: ethFlowContract, chainId: ethFlowChainId } = useEthFlowContract()
+  const {
+    result: { contract: ethFlowContract, chainId: ethFlowChainId },
+    useNewEthFlowContracts,
+  } = useEthFlowContract()
   const { currenciesIds } = useDerivedSwapInfo()
   const { quote } = useGetQuoteAndStatus({
     token: currenciesIds.INPUT,
@@ -34,12 +37,31 @@ export function useEthFlowContext(): EthFlowContext | null {
   return (
     useSWR(
       appData && ethFlowContract
-        ? [quote, ethFlowContract, addTransaction, checkEthFlowOrderExists, addInFlightOrderId, uploadAppData, appData]
+        ? [
+            quote,
+            ethFlowContract,
+            useNewEthFlowContracts,
+            addTransaction,
+            checkEthFlowOrderExists,
+            addInFlightOrderId,
+            uploadAppData,
+            appData,
+          ]
         : null,
-      ([quote, contract, addTransaction, checkEthFlowOrderExists, addInFlightOrderId, uploadAppData, appData]) => {
+      ([
+        quote,
+        contract,
+        useNewEthFlowContracts,
+        addTransaction,
+        checkEthFlowOrderExists,
+        addInFlightOrderId,
+        uploadAppData,
+        appData,
+      ]) => {
         return {
           quote,
           contract,
+          useNewEthFlowContracts,
           addTransaction,
           checkEthFlowOrderExists,
           addInFlightOrderId,

--- a/apps/cowswap-frontend/src/modules/swap/services/ethFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/ethFlow/index.ts
@@ -1,5 +1,5 @@
+import { getEthFlowContractAddresses } from '@cowprotocol/common-const'
 import { reportPlaceOrderWithExpiredQuote } from '@cowprotocol/common-utils'
-import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { UiOrderType } from '@cowprotocol/types'
 import { Percent } from '@uniswap/sdk-core'
 
@@ -16,7 +16,7 @@ import { tradeFlowAnalytics } from 'modules/trade/utils/tradeFlowAnalytics'
 import { TradeFlowContext } from 'modules/tradeFlow'
 import { isQuoteExpired } from 'modules/tradeQuote'
 
-import { COWSWAP_ETHFLOW_CONTRACT_ADDRESS_MAP } from 'common/hooks/useContract'
+import { ethFlowEnv } from 'common/hooks/useContract'
 
 import { calculateUniqueOrderId } from './steps/calculateUniqueOrderId'
 
@@ -34,8 +34,16 @@ export async function ethFlow(
     orderParams: orderParamsOriginal,
     typedHooks,
   } = tradeContext
-  const { contract, appData, uploadAppData, addTransaction, checkEthFlowOrderExists, addInFlightOrderId, quote } =
-    ethFlowContext
+  const {
+    contract,
+    useNewEthFlowContracts,
+    appData,
+    uploadAppData,
+    addTransaction,
+    checkEthFlowOrderExists,
+    addInFlightOrderId,
+    quote,
+  } = ethFlowContext
 
   const { chainId, inputAmount, outputAmount } = context
   const tradeAmounts = { inputAmount, outputAmount }
@@ -72,7 +80,7 @@ export async function ethFlow(
       throw new Error('Quote expired. Please refresh.')
     }
 
-    if (contract.address !== COWSWAP_ETHFLOW_CONTRACT_ADDRESS_MAP[chainId as SupportedChainId]) {
+    if (contract.address !== getEthFlowContractAddresses(ethFlowEnv, useNewEthFlowContracts, chainId)) {
       throw new Error('EthFlow contract address mismatch. Please refresh the page and try again.')
     }
 

--- a/apps/cowswap-frontend/src/modules/swap/services/types.ts
+++ b/apps/cowswap-frontend/src/modules/swap/services/types.ts
@@ -9,6 +9,7 @@ import { EthFlowOrderExistsCallback } from '../hooks/useCheckEthFlowOrderExists'
 
 export type EthFlowContext = {
   contract: CoWSwapEthFlow
+  useNewEthFlowContracts: boolean
   addTransaction: ReturnType<typeof useTransactionAdder>
   checkEthFlowOrderExists: EthFlowOrderExistsCallback
   addInFlightOrderId: (orderId: string) => void

--- a/libs/common-const/src/common.ts
+++ b/libs/common-const/src/common.ts
@@ -41,7 +41,12 @@ export const APP_TITLE = 'CoW Swap | The smartest way to trade cryptocurrencies'
 
 type Env = 'barn' | 'prod'
 
-export const COWSWAP_ETHFLOW_CONTRACT_ADDRESS: Record<Env, Record<SupportedChainId, string>> = {
+export const COWSWAP_ETHFLOW_CONTRACT_ADDRESS: Record<Env, string> = {
+  prod: '0xba3cb449bd2b4adddbc894d8697f5170800eadec',
+  barn: '0x04501b9b1d52e67f6862d157e00d13419d2d6e95',
+}
+
+export const OLD_COWSWAP_ETHFLOW_CONTRACT_ADDRESS: Record<Env, Record<SupportedChainId, string>> = {
   prod: mapSupportedNetworks((chain) => EthFlowProd[chain].address),
   barn: mapSupportedNetworks((chain) => EthFlowBarn[chain].address),
 }

--- a/libs/common-const/src/common.ts
+++ b/libs/common-const/src/common.ts
@@ -41,14 +41,37 @@ export const APP_TITLE = 'CoW Swap | The smartest way to trade cryptocurrencies'
 
 type Env = 'barn' | 'prod'
 
-export const COWSWAP_ETHFLOW_CONTRACT_ADDRESS: Record<Env, string> = {
+const NEW_COWSWAP_ETHFLOW_CONTRACT_ADDRESS: Record<Env, string> = {
   prod: '0xba3cb449bd2b4adddbc894d8697f5170800eadec',
   barn: '0x04501b9b1d52e67f6862d157e00d13419d2d6e95',
 }
 
-export const OLD_COWSWAP_ETHFLOW_CONTRACT_ADDRESS: Record<Env, Record<SupportedChainId, string>> = {
+const OLD_COWSWAP_ETHFLOW_CONTRACT_ADDRESS: Record<Env, Record<SupportedChainId, string>> = {
   prod: mapSupportedNetworks((chain) => EthFlowProd[chain].address),
   barn: mapSupportedNetworks((chain) => EthFlowBarn[chain].address),
+}
+
+export function getEthFlowContractAddresses(
+  env: Env,
+  useNewEthFlowContracts: boolean,
+  chainId: SupportedChainId,
+): string
+export function getEthFlowContractAddresses(
+  env: Env,
+  useNewEthFlowContracts: boolean,
+): string | Record<SupportedChainId, string>
+
+export function getEthFlowContractAddresses(
+  env: Env,
+  useNewEthFlowContracts: boolean,
+  chainId?: SupportedChainId,
+): string | Record<SupportedChainId, string> {
+  if (useNewEthFlowContracts) {
+    return NEW_COWSWAP_ETHFLOW_CONTRACT_ADDRESS[env]
+  }
+
+  const contractAddressesByChainId = OLD_COWSWAP_ETHFLOW_CONTRACT_ADDRESS[env]
+  return chainId ? contractAddressesByChainId[chainId] : contractAddressesByChainId
 }
 
 export const V_COW_CONTRACT_ADDRESS: Record<SupportedChainId, string | null> = {


### PR DESCRIPTION
# Summary

This PR is just to facilitate testing https://github.com/cowprotocol/cowswap/pull/5334 for when the flag is ON. 

It is just to make it easier for the backend to test it. This way the original allows us to test both scenarios, but I expect it to leave the default as `false` (old contracts), and this PR is `true` always (new contracts)