### PR TITLE
chore: fix e2e tests after limit orders upgrade

### DIFF
--- a/apps/cowswap-frontend-e2e/src/e2e/limit-orders.test.ts
+++ b/apps/cowswap-frontend-e2e/src/e2e/limit-orders.test.ts
@@ -30,8 +30,6 @@ describe('Limit orders', () => {
 
     navigate('')
 
-    cy.pickToken('USDC', 'output')
-
     getInputToken().type(inputAmount.toString())
     cy.get('#rate-limit-amount-input').should('be.enabled').clear().type(rate.toString(), { force: true })
     getOutputToken().should('have.value', outputAmount.toString())
@@ -59,7 +57,7 @@ describe('Limit orders', () => {
     })
 
     it('should not accept buyAmount when there is no buy token', () => {
-      navigate(`?buyAmount=0.1`)
+      navigate(`/${SELL_TOKEN}?buyAmount=0.1`)
       getOutputToken().should('have.value', '')
     })
 
@@ -69,9 +67,9 @@ describe('Limit orders', () => {
       getOutputToken().should('have.value', '0.2')
     })
 
-    it('should ignore invalid sellAmount and buyAmount url params', () => {
-      navigate(`/${SELL_TOKEN}/${BUY_TOKEN}?sellAmount=rwe&buyAmount=aaa`)
-      getInputToken().should('have.value', '')
+    it('sell amount should be 1 by default', () => {
+      navigate(`/${SELL_TOKEN}/${BUY_TOKEN}`)
+      getInputToken().should('have.value', '1')
       getOutputToken().should('have.value', '')
     })
   })

--- a/apps/cowswap-frontend-e2e/src/e2e/swapMod.test.ts
+++ b/apps/cowswap-frontend-e2e/src/e2e/swapMod.test.ts
@@ -10,7 +10,7 @@ describe('Swap (mod)', () => {
     cy.get('#input-currency-input .token-amount-input').should('not.have.value')
     cy.get('#input-currency-input .token-symbol-container').should('contain.text', 'WETH')
     cy.get('#output-currency-input .token-amount-input').should('not.have.value')
-    cy.get('#output-currency-input .token-symbol-container').should('contain.text', 'Select a token')
+    cy.get('#output-currency-input .token-symbol-container').should('contain.text', 'USDC')
   })
 
   it('can enter an amount into input', () => {
@@ -64,7 +64,7 @@ describe('Swap (mod)', () => {
     cy.swapEnterInputAmount(ETH, '0.5', true)
     cy.swapSelectOutput(COW)
     cy.get('#output-currency-input .token-amount-input').should('not.equal', '')
-    cy.get('#swap-button > button').should('contain.text', 'Swap').click()
+    cy.get('#swap-button > button').should('contain.text', 'Swap').click({ timeout: 10000 })
     cy.get('#trade-confirmation > button').should('contain', 'Confirm Swap')
   })
 


### PR DESCRIPTION
# Summary

Just fixed failed tests after the recent changes:
1. Now default buy token is USDC
2. Now default sell amount is 1
