### PR TITLE
fix: display Metamask warning only for extension/mobile wallets

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/MetamaskTransactionWarning/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/MetamaskTransactionWarning/index.tsx
@@ -3,6 +3,7 @@ import { getIsNativeToken } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { InlineBanner } from '@cowprotocol/ui'
 import { useIsMetamaskBrowserExtensionWallet, useWalletDetails } from '@cowprotocol/wallet'
+import { useWalletProvider } from '@cowprotocol/wallet-provider'
 import { Currency } from '@uniswap/sdk-core'
 
 import SVG from 'react-inlinesvg'
@@ -25,9 +26,11 @@ const NetworkInfo = styled.div`
 export function MetamaskTransactionWarning({ sellToken }: { sellToken: Currency }) {
   const walletDetails = useWalletDetails()
   const isMetamaskBrowserExtension = useIsMetamaskBrowserExtensionWallet()
+
+  const isMetamaskMobileInjectedBrowser = useIsMetamaskMobileInjectedWallet()
   const isMetamaskViaWalletConnect = walletDetails.walletName === METAMASK_WALLET_NAME
 
-  const isMetamask = isMetamaskBrowserExtension || isMetamaskViaWalletConnect
+  const isMetamask = isMetamaskBrowserExtension || isMetamaskViaWalletConnect || isMetamaskMobileInjectedBrowser
   const isNativeSellToken = getIsNativeToken(sellToken)
 
   if (!isMetamask || !isNativeSellToken) return null
@@ -43,4 +46,15 @@ export function MetamaskTransactionWarning({ sellToken }: { sellToken: Currency 
       </NetworkInfo>
     </Banner>
   )
+}
+
+/**
+ * This is hacky way to detect if the wallet is metamask mobile injected wallet
+ * Many injected wallet browsers emulate isMetaMask, but only metamask mobile has _metamask
+ */
+function useIsMetamaskMobileInjectedWallet(): boolean {
+  const walletProvider = useWalletProvider()
+  const rawProvider = walletProvider?.provider as any
+
+  return Boolean(rawProvider?.isMetaMask && rawProvider._metamask)
 }

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/MetamaskTransactionWarning/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/MetamaskTransactionWarning/index.tsx
@@ -2,11 +2,13 @@ import { CHAIN_INFO } from '@cowprotocol/common-const'
 import { getIsNativeToken } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { InlineBanner } from '@cowprotocol/ui'
-import { useWalletProvider } from '@cowprotocol/wallet-provider'
+import { useIsMetamaskBrowserExtensionWallet, useWalletDetails } from '@cowprotocol/wallet'
 import { Currency } from '@uniswap/sdk-core'
 
 import SVG from 'react-inlinesvg'
 import styled from 'styled-components/macro'
+
+const METAMASK_WALLET_NAME = 'MetaMask Wallet'
 
 const Banner = styled(InlineBanner)`
   font-size: 14px;
@@ -21,9 +23,11 @@ const NetworkInfo = styled.div`
 `
 
 export function MetamaskTransactionWarning({ sellToken }: { sellToken: Currency }) {
-  const provider = useWalletProvider()
-  const ethereumProvider = (provider as unknown as { provider: typeof window.ethereum })?.provider
-  const isMetamask = !!ethereumProvider?.isMetaMask && !ethereumProvider.isRabby
+  const walletDetails = useWalletDetails()
+  const isMetamaskBrowserExtension = useIsMetamaskBrowserExtensionWallet()
+  const isMetamaskViaWalletConnect = walletDetails.walletName === METAMASK_WALLET_NAME
+
+  const isMetamask = isMetamaskBrowserExtension || isMetamaskViaWalletConnect
   const isNativeSellToken = getIsNativeToken(sellToken)
 
   if (!isMetamask || !isNativeSellToken) return null

--- a/apps/cowswap-frontend/src/modules/wallet/containers/ConnectWalletOptions.tsx
+++ b/apps/cowswap-frontend/src/modules/wallet/containers/ConnectWalletOptions.tsx
@@ -1,5 +1,6 @@
 import { useTheme } from '@cowprotocol/common-hooks'
 import { isMobile, isInjectedWidget } from '@cowprotocol/common-utils'
+import { EIP6963ProviderDetail } from '@cowprotocol/types'
 import {
   CoinbaseWalletOption,
   InjectedOption as DefaultInjectedOption,
@@ -12,11 +13,9 @@ import {
   Eip6963Option,
   COINBASE_WALLET_RDNS,
   getIsInjectedMobileBrowser,
-  EIP6963ProviderDetail,
 } from '@cowprotocol/wallet'
 
 import { useSelectedWallet } from 'legacy/state/user/hooks'
-
 
 export function ConnectWalletOptions({ tryActivation }: { tryActivation: TryActivation }) {
   const selectedWallet = useSelectedWallet()
@@ -35,7 +34,11 @@ export function ConnectWalletOptions({ tryActivation }: { tryActivation: TryActi
   const walletConnectionV2Option =
     ((!isInjectedMobileBrowser || isWidget) && <WalletConnectV2Option {...connectionProps} />) ?? null
   const trezorOption = (!isInjectedMobileBrowser && !isMobile && <TrezorOption {...connectionProps} />) ?? null
-  const injectedOption = (getIsInjected() && <InjectedOptions connectionProps={connectionProps} multiInjectedProviders={multiInjectedProviders} />) ?? null
+  const injectedOption =
+    (getIsInjected() && (
+      <InjectedOptions connectionProps={connectionProps} multiInjectedProviders={multiInjectedProviders} />
+    )) ??
+    null
 
   return (
     <>

--- a/libs/iframe-transport/src/iframeRpcProvider/iframeRpcProviderEvents.ts
+++ b/libs/iframe-transport/src/iframeRpcProvider/iframeRpcProviderEvents.ts
@@ -1,5 +1,5 @@
 import { IframeTransport } from '../IframeTransport'
-import { JsonRpcRequestMessage, JsonRpcResponse } from '../types'
+import { EIP6963ProviderInfo, JsonRpcRequestMessage, JsonRpcResponse, ProviderWcMetadata } from '../types'
 
 export interface ProviderRpcRequestPayload {
   rpcRequest: JsonRpcRequestMessage
@@ -13,16 +13,25 @@ export interface ProviderOnEventPayload {
   params: unknown
 }
 
+export interface ProviderMetaInfoPayload {
+  providerEip6963Info?: EIP6963ProviderInfo
+  providerWcMetadata?: ProviderWcMetadata
+}
+
 export enum IframeRpcProviderEvents {
   PROVIDER_RPC_REQUEST = 'PROVIDER_RPC_REQUEST',
   PROVIDER_RPC_RESPONSE = 'PROVIDER_RPC_RESPONSE',
   PROVIDER_ON_EVENT = 'PROVIDER_ON_EVENT',
+  SEND_PROVIDER_META_INFO = 'SEND_PROVIDER_META_INFO',
+  REQUEST_PROVIDER_META_INFO = 'REQUEST_PROVIDER_META_INFO',
 }
 
 export interface IframeEventsPayloadMap {
   [IframeRpcProviderEvents.PROVIDER_RPC_REQUEST]: ProviderRpcRequestPayload
   [IframeRpcProviderEvents.PROVIDER_RPC_RESPONSE]: ProviderRpcResponsePayload
   [IframeRpcProviderEvents.PROVIDER_ON_EVENT]: ProviderOnEventPayload
+  [IframeRpcProviderEvents.SEND_PROVIDER_META_INFO]: ProviderMetaInfoPayload
+  [IframeRpcProviderEvents.REQUEST_PROVIDER_META_INFO]: null
 }
 
 export const iframeRpcProviderTransport = new IframeTransport<IframeEventsPayloadMap>(

--- a/libs/iframe-transport/src/iframeRpcProvider/utils.ts
+++ b/libs/iframe-transport/src/iframeRpcProvider/utils.ts
@@ -1,0 +1,16 @@
+import type { EIP6963ProviderDetail } from '@cowprotocol/types'
+
+import { EIP6963ProviderInfo, ProviderWcMetadata } from '../types'
+
+export function getProviderWcMetadata(provider: any): ProviderWcMetadata | undefined {
+  if (!provider.isWalletConnect) return
+
+  return provider?.session?.peer?.metadata
+}
+
+export function getEip6963ProviderInfo(
+  provider: unknown,
+  eip6963Providers: EIP6963ProviderDetail[],
+): EIP6963ProviderInfo | undefined {
+  return eip6963Providers.find((p) => p.provider === provider)?.info
+}

--- a/libs/iframe-transport/src/types.ts
+++ b/libs/iframe-transport/src/types.ts
@@ -58,3 +58,22 @@ export interface EthereumProvider {
 }
 
 export type WindowListener = (event: MessageEvent<unknown>) => void
+
+export interface ProviderWcMetadata {
+  name: string
+  description: string
+  url: string
+  icons: string[]
+  verifyUrl?: string
+  redirect?: {
+    native?: string
+    universal?: string
+  }
+}
+
+export interface EIP6963ProviderInfo {
+  uuid: string
+  name: string
+  icon: string
+  rdns: string
+}

--- a/libs/types/src/eip6963-types.ts
+++ b/libs/types/src/eip6963-types.ts
@@ -1,6 +1,6 @@
-import type { Command } from '@cowprotocol/types'
 import type { RequestArguments } from '@web3-react/types'
 
+import type { Command } from './common'
 import type EventEmitter from 'eventemitter3'
 
 export interface EIP6963ProviderInfo {

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -1,1 +1,2 @@
 export * from './common'
+export * from './eip6963-types'

--- a/libs/wallet/src/api/hooks.ts
+++ b/libs/wallet/src/api/hooks.ts
@@ -8,7 +8,7 @@ import {
 } from './state/multiInjectedProvidersAtom'
 import { ConnectionType, GnosisSafeInfo, WalletDetails, WalletInfo } from './types'
 
-import { RABBY_RDNS, WATCH_ASSET_SUPPORED_WALLETS } from '../constants'
+import { METAMASK_RDNS, RABBY_RDNS, WATCH_ASSET_SUPPORED_WALLETS } from '../constants'
 import { useConnectionType } from '../web3-react/hooks/useConnectionType'
 import { useIsSafeApp } from '../web3-react/hooks/useWalletMetadata'
 
@@ -68,4 +68,15 @@ export function useIsRabbyWallet(): boolean {
   if (!info || connectionType !== ConnectionType.INJECTED) return false
 
   return RABBY_RDNS === info.info.rdns
+}
+
+export function useIsMetamaskBrowserExtensionWallet(): boolean {
+  const connectionType = useConnectionType()
+  const info = useSelectedEip6963ProviderInfo()
+
+  if (connectionType === ConnectionType.METAMASK) return true
+
+  if (!info || connectionType !== ConnectionType.INJECTED) return false
+
+  return METAMASK_RDNS === info.info.rdns
 }

--- a/libs/wallet/src/api/state/multiInjectedProvidersAtom.ts
+++ b/libs/wallet/src/api/state/multiInjectedProvidersAtom.ts
@@ -2,8 +2,7 @@ import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 
 import { getJotaiIsolatedStorage, jotaiStore } from '@cowprotocol/core'
-
-import { EIP6963AnnounceProviderEvent, EIP6963ProviderDetail } from '../eip6963-types'
+import { EIP6963AnnounceProviderEvent, EIP6963ProviderDetail } from '@cowprotocol/types'
 
 export const multiInjectedProvidersAtom = atom<EIP6963ProviderDetail[]>([])
 
@@ -11,7 +10,7 @@ export const multiInjectedProvidersAtom = atom<EIP6963ProviderDetail[]>([])
 export const selectedEip6963ProviderRdnsAtom = atomWithStorage<string | null>(
   'selectedEip6963ProviderAtom:v0',
   null,
-  getJotaiIsolatedStorage()
+  getJotaiIsolatedStorage(),
 )
 
 export const selectedEip6963ProviderAtom = atom((get) => {

--- a/libs/wallet/src/api/types.ts
+++ b/libs/wallet/src/api/types.ts
@@ -1,8 +1,6 @@
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { SafeInfoResponse } from '@safe-global/api-kit'
 
-export * from './eip6963-types'
-
 export enum ConnectionType {
   NETWORK = 'NETWORK',
   INJECTED = 'INJECTED',

--- a/libs/wallet/src/web3-react/connection/injectedOptions.tsx
+++ b/libs/wallet/src/web3-react/connection/injectedOptions.tsx
@@ -1,11 +1,13 @@
 import { useCallback } from 'react'
 
+import { EIP1193Provider, EIP6963ProviderDetail } from '@cowprotocol/types'
+
 import { injectedWalletConnection } from './injectedWallet'
 
 import { default as InjectedImage, default as InjectedImageDark } from '../../api/assets/arrow-right.svg'
 import { useSelectedEip6963ProviderRdns, useSetEip6963Provider } from '../../api/hooks'
 import { ConnectWalletOption } from '../../api/pure/ConnectWalletOption'
-import { ConnectionType, type EIP1193Provider, EIP6963ProviderDetail } from '../../api/types'
+import { ConnectionType } from '../../api/types'
 import { getConnectionName } from '../../api/utils/connection'
 import { useIsActiveConnection } from '../hooks/useIsActiveConnection'
 import { ConnectionOptionProps, TryActivation } from '../types'

--- a/libs/wallet/src/web3-react/connectors/Injected/index.tsx
+++ b/libs/wallet/src/web3-react/connectors/Injected/index.tsx
@@ -1,9 +1,8 @@
 import { isInjectedWidget, isRejectRequestProviderError } from '@cowprotocol/common-utils'
 import { WidgetEthereumProvider } from '@cowprotocol/iframe-transport'
 import { Command } from '@cowprotocol/types'
+import type { EIP1193Provider } from '@cowprotocol/types'
 import { Actions, AddEthereumChainParameter, Connector, ProviderConnectInfo, ProviderRpcError } from '@web3-react/types'
-
-import type { EIP1193Provider } from '../../../api/eip6963-types'
 
 interface injectedWalletConstructorArgs {
   actions: Actions


### PR DESCRIPTION
# Summary

Fixes #5369

1. Do not display the banner for wallets who expose `isMetamask = true` and only display it for Metamask browser extension
2. Display the wallet for Metamask mobile wallet via WC (tested only with IOS wallet)

# To Test

See above
