### PR TITLE
fix(usd-rate-input): keep track of usd toggle in the rate input on limit form

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/RateInput/atoms.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/RateInput/atoms.ts
@@ -1,0 +1,9 @@
+import { atomWithDefault } from 'jotai/utils'
+
+import { limitOrdersSettingsAtom } from '../../state/limitOrdersSettingsAtom'
+
+/**
+ * Flag local to the RateInput component to determine if the USD rate mode is enabled
+ * Can be overridden by the global isUsdValuesMode flag from limitOrdersSettingsAtom
+ */
+export const isLocalUsdRateModeAtom = atomWithDefault((get) => get(limitOrdersSettingsAtom).isUsdValuesMode)

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/RateInput/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/RateInput/index.tsx
@@ -28,10 +28,10 @@ import { useConvertUsdToTokenValue } from 'common/hooks/useConvertUsdToTokenValu
 import { ExecutionPrice } from 'common/pure/ExecutionPrice'
 import { getQuoteCurrency, getQuoteCurrencyByStableCoin } from 'common/services/getQuoteCurrency'
 
+import { isLocalUsdRateModeAtom } from './atoms'
 import { useExecutionPriceUsdValue } from './hooks/useExecutionPriceUsdValue'
 import { useRateDisplayedValue } from './hooks/useRateDisplayedValue'
 import * as styledEl from './styled'
-import { isLocalUsdRateModeAtom } from './atoms'
 
 export function RateInput() {
   const { chainId } = useWalletInfo()
@@ -155,7 +155,7 @@ export function RateInput() {
       // When already in token mode, toggle between tokens
       updateLimitRateState({ isInverted: !isInverted, isTypedValue: false })
     }
-  }, [isInverted, updateLimitRateState, isUsdRateMode])
+  }, [isInverted, updateLimitRateState, isUsdRateMode, setIsUsdRateMode])
 
   // Handle toggle price lock
   const handleTogglePriceLock = useCallback(

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/RateInput/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/RateInput/index.tsx
@@ -1,4 +1,4 @@
-import { useAtomValue, useSetAtom } from 'jotai'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import LockedIcon from '@cowprotocol/assets/images/icon-locked.svg'
@@ -31,6 +31,7 @@ import { getQuoteCurrency, getQuoteCurrencyByStableCoin } from 'common/services/
 import { useExecutionPriceUsdValue } from './hooks/useExecutionPriceUsdValue'
 import { useRateDisplayedValue } from './hooks/useRateDisplayedValue'
 import * as styledEl from './styled'
+import { isLocalUsdRateModeAtom } from './atoms'
 
 export function RateInput() {
   const { chainId } = useWalletInfo()
@@ -40,14 +41,14 @@ export function RateInput() {
   const updateRate = useUpdateActiveRate()
   const updateLimitRateState = useSetAtom(updateLimitRateAtom)
   const executionPrice = useAtomValue(executionPriceAtom)
-  const { limitPriceLocked, isUsdValuesMode, partialFillsEnabled } = useAtomValue(limitOrdersSettingsAtom)
+  const { limitPriceLocked, partialFillsEnabled } = useAtomValue(limitOrdersSettingsAtom)
   const updateLimitOrdersSettings = useSetAtom(updateLimitOrdersSettingsAtom)
 
   const executionPriceUsdValue = useExecutionPriceUsdValue(executionPrice)
 
   const [isQuoteCurrencySet, setIsQuoteCurrencySet] = useState(false)
   const [typedTrailingZeros, setTypedTrailingZeros] = useState('')
-  const [isUsdRateMode, setIsUsdRateMode] = useState(isUsdValuesMode)
+  const [isUsdRateMode, setIsUsdRateMode] = useAtom(isLocalUsdRateModeAtom)
 
   // Limit order state
   const { inputCurrency, outputCurrency, inputCurrencyAmount, outputCurrencyAmount } = useLimitOrdersDerivedState()
@@ -212,11 +213,6 @@ export function RateInput() {
   useEffect(() => {
     setIsQuoteCurrencySet(false)
   }, [inputCurrency, outputCurrency])
-
-  // Depend rate USD mode on settings
-  useEffect(() => {
-    setIsUsdRateMode(isUsdValuesMode)
-  }, [isUsdValuesMode])
 
   return (
     <>

--- a/apps/cowswap-frontend/src/modules/zeroApproval/hooks/useShouldZeroApprove/useShouldZeroApprove.ts
+++ b/apps/cowswap-frontend/src/modules/zeroApproval/hooks/useShouldZeroApprove/useShouldZeroApprove.ts
@@ -47,7 +47,7 @@ export function useShouldZeroApprove(amountToApprove: Nullish<CurrencyAmount<Cur
     return () => {
       isStale = true
     }
-  }, [tokenContract, spender, amountToApprove, approvalState])
+  }, [tokenContract, spender, amountToApprove, approvalState, shouldZeroApprove])
 
   return shouldZeroApprove
 }


### PR DESCRIPTION
# Summary

Fixes #5386 

# To Test

1. On limit orders form, toggle the USD input mode
2. Change currencies
* Selection should remain
3. Pick as sell a token that needs approval and it's not permittable (like WETH)
4. Approve token
* Selection should remain