### PR TITLE
fix(safe-app): remove approval+order placement bundling recommendation

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWarnings/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWarnings/index.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 
-import { CowSwapSafeAppLink, InlineBanner } from '@cowprotocol/ui'
-import { useIsSafeViaWc } from '@cowprotocol/wallet'
+import { InlineBanner } from '@cowprotocol/ui'
 
-import { useInjectedWidgetParams } from 'modules/injectedWidget'
 import { TradeFormValidation, useGetTradeFormValidation } from 'modules/tradeFormValidation'
 import { HighSuggestedSlippageWarning } from 'modules/tradeSlippage'
 import { useShouldZeroApprove } from 'modules/zeroApproval'
@@ -18,23 +16,18 @@ interface TradeWarningsProps {
 }
 
 export function TradeWarnings({ isTradePriceUpdating, enableSmartSlippage }: TradeWarningsProps) {
-  const { banners: widgetBanners } = useInjectedWidgetParams()
   const primaryFormValidation = useGetTradeFormValidation()
   const receiveAmountInfo = useReceiveAmountInfo()
   const inputAmountWithSlippage = receiveAmountInfo?.afterSlippage.sellAmount
   const shouldZeroApprove = useShouldZeroApprove(inputAmountWithSlippage)
-  const isSafeViaWc = useIsSafeViaWc()
 
   const showBundleTxApprovalBanner = primaryFormValidation === TradeFormValidation.ApproveAndSwap
-  const showSafeWcBundlingBanner =
-    isSafeViaWc && primaryFormValidation === TradeFormValidation.ApproveRequired && !widgetBanners?.hideSafeWebAppBanner
 
   return (
     <>
       {shouldZeroApprove && <ZeroApprovalWarning currency={inputAmountWithSlippage?.currency} />}
       <NoImpactWarning />
       {showBundleTxApprovalBanner && <BundleTxApprovalBanner />}
-      {showSafeWcBundlingBanner && <BundleTxSafeWcBanner />}
       {enableSmartSlippage && <HighSuggestedSlippageWarning isTradePriceUpdating={isTradePriceUpdating} />}
     </>
   )
@@ -47,18 +40,6 @@ function BundleTxApprovalBanner() {
       <p>
         For your convenience, token approval and order placement will be bundled into a single transaction, streamlining
         your experience!
-      </p>
-    </InlineBanner>
-  )
-}
-
-function BundleTxSafeWcBanner() {
-  return (
-    <InlineBanner bannerType="information" iconSize={32}>
-      <strong>Use Safe web app</strong>
-      <p>
-        Use the Safe web app for streamlined trading: token approval and orders bundled in one go! Only available in the{' '}
-        <CowSwapSafeAppLink />
       </p>
     </InlineBanner>
   )

--- a/libs/widget-lib/src/types.ts
+++ b/libs/widget-lib/src/types.ts
@@ -169,20 +169,6 @@ export interface CowSwapWidgetImages {
   emptyOrders?: string | null
 }
 
-export interface CowSwapWidgetBanners {
-  /**
-   * Banner text: "Use Safe web app..."
-   *
-   * Conditions for displaying the banner:
-   *  - Safe-like app is connected to CoW Swap via WalletConnect
-   *  - Selling native token via Swap
-   *  - Sell token needs approval
-   *
-   *  If the flag is set to true, the banner will not be displayed
-   */
-  hideSafeWebAppBanner?: boolean
-}
-
 export interface CowSwapWidgetContent {
   feeLabel?: string
   feeTooltipMarkdown?: string
@@ -327,11 +313,6 @@ export interface CowSwapWidgetParams {
    * Sounds configuration for the app.
    */
   sounds?: CowSwapWidgetSounds
-
-  /**
-   * Flags to control the display of banners in the widget.
-   */
-  banners?: CowSwapWidgetBanners
 
   /**
    * In case when widget does not support some tokens, you can provide a list of tokens to be used in the widget


### PR DESCRIPTION
# Summary

Remove bundling recommendation for approval+order placement

# To Test

1. Connect with Safe via WC
2. On SWAP, Pick as sell a token that needs approval
* Should no longer see the banner
3. Repeat with LIMIT orders
* Same result
4. Repeat with Safe app and EOA/another wallet
* Should not show any banner, as before