### PR TITLE
fix: exclude USDT from permittable in Arbitrum

### DIFF
--- a/apps/cowswap-frontend/src/modules/permit/hooks/usePreGeneratedPermitInfoForToken.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/usePreGeneratedPermitInfoForToken.ts
@@ -1,5 +1,8 @@
 import { useMemo } from 'react'
 
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { PERMIT_TOKENS_BLACKLIST } from '@cowprotocol/permit-utils'
+
 import { Nullish } from 'types'
 
 import { usePreGeneratedPermitInfo } from './usePreGeneratedPermitInfo'
@@ -9,21 +12,24 @@ import { IsTokenPermittableResult } from '../types'
 /**
  * Fetch pre-generated permit info for a single token
  */
-export function usePreGeneratedPermitInfoForToken(token: Nullish<{ address: string }>): {
+export function usePreGeneratedPermitInfoForToken(token: Nullish<{ address: string; chainId: number }>): {
   permitInfo: IsTokenPermittableResult
   isLoading: boolean
 } {
   const { allPermitInfo, isLoading } = usePreGeneratedPermitInfo()
 
   const address = token?.address.toLowerCase()
+  const isBlackListed = Boolean(
+    token && address && PERMIT_TOKENS_BLACKLIST[token.chainId as SupportedChainId]?.includes(address.toLowerCase()),
+  )
 
-  const permitInfo = address ? allPermitInfo[address] : undefined
+  const permitInfo = address && !isBlackListed ? allPermitInfo[address] : undefined
 
   return useMemo(
     () => ({
       permitInfo,
       isLoading,
     }),
-    [permitInfo, isLoading]
+    [permitInfo, isLoading],
   )
 }

--- a/apps/cowswap-frontend/src/modules/permit/state/permitCacheAtom.ts
+++ b/apps/cowswap-frontend/src/modules/permit/state/permitCacheAtom.ts
@@ -14,14 +14,14 @@ import {
  * Should never change once it has been created.
  * Used exclusively for quote requests
  */
-export const staticPermitCacheAtom = atomWithStorage<PermitCache>('staticPermitCache:v3', {})
+export const staticPermitCacheAtom = atomWithStorage<PermitCache>('staticPermitCache:v4', {})
 
 /**
  * Atom that stores permit data for user permit requests.
  * Should be updated whenever the permit nonce is updated.
  * Used exclusively for order requests
  */
-export const userPermitCacheAtom = atomWithStorage<PermitCache>('userPermitCache:v1', {})
+export const userPermitCacheAtom = atomWithStorage<PermitCache>('userPermitCache:v2', {})
 
 /**
  * Atom to add/update permit cache data

--- a/libs/permit-utils/src/const.ts
+++ b/libs/permit-utils/src/const.ts
@@ -1,3 +1,4 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { MaxUint256 } from '@ethersproject/constants'
 import { Wallet } from '@ethersproject/wallet'
 
@@ -16,3 +17,14 @@ export const DEFAULT_PERMIT_GAS_LIMIT = '80000'
 export const DEFAULT_PERMIT_VALUE = MaxUint256.toString()
 
 export const DEFAULT_PERMIT_DURATION = ms`5 years`
+
+export const TOKEN_PERMIT_BLACKLISTED_ERROR = 'Token is blacklisted for permit'
+
+/**
+ * Tokens that are known to not support permit
+ */
+export const PERMIT_TOKENS_BLACKLIST: Partial<Record<SupportedChainId, string[]>> = {
+  [SupportedChainId.ARBITRUM_ONE]: [
+    '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9', // USDT
+  ],
+}

--- a/libs/permit-utils/src/index.ts
+++ b/libs/permit-utils/src/index.ts
@@ -5,5 +5,6 @@ export { generatePermitHook } from './lib/generatePermitHook'
 export { getPermitUtilsInstance } from './lib/getPermitUtilsInstance'
 export { getTokenPermitInfo } from './lib/getTokenPermitInfo'
 export { isSupportedPermitInfo } from './utils/isSupportedPermitInfo'
+export { PERMIT_TOKENS_BLACKLIST, TOKEN_PERMIT_BLACKLISTED_ERROR } from './const'
 
 export type { GetTokenPermitIntoResult, PermitHookData, PermitHookParams, PermitInfo, PermitType } from './types'

--- a/libs/permit-utils/src/lib/getTokenPermitInfo.ts
+++ b/libs/permit-utils/src/lib/getTokenPermitInfo.ts
@@ -1,10 +1,17 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import type { JsonRpcProvider } from '@ethersproject/providers'
 
 import { DAI_LIKE_PERMIT_TYPEHASH, Eip2612PermitUtils } from '@1inch/permit-signed-approvals-utils'
 
 import { getPermitUtilsInstance } from './getPermitUtilsInstance'
 
-import { DEFAULT_MIN_GAS_LIMIT, DEFAULT_PERMIT_VALUE, PERMIT_SIGNER } from '../const'
+import {
+  DEFAULT_MIN_GAS_LIMIT,
+  DEFAULT_PERMIT_VALUE,
+  PERMIT_SIGNER,
+  PERMIT_TOKENS_BLACKLIST,
+  TOKEN_PERMIT_BLACKLISTED_ERROR,
+} from '../const'
 import { GetTokenPermitInfoParams, GetTokenPermitIntoResult, PermitInfo, PermitType } from '../types'
 import { buildDaiLikePermitCallData, buildEip2162PermitCallData } from '../utils/buildPermitCallData'
 import { Eip712Domain, getEip712Domain } from '../utils/getEip712Domain'
@@ -48,6 +55,10 @@ export async function getTokenPermitInfo(params: GetTokenPermitInfoParams): Prom
 
 async function actuallyCheckTokenIsPermittable(params: GetTokenPermitInfoParams): Promise<GetTokenPermitIntoResult> {
   const { spender, tokenAddress, chainId, provider, minGasLimit } = params
+
+  const isBlackListed = PERMIT_TOKENS_BLACKLIST[chainId as SupportedChainId]?.includes(tokenAddress.toLowerCase())
+
+  if (isBlackListed) return { error: TOKEN_PERMIT_BLACKLISTED_ERROR }
 
   const eip2612PermitUtils = getPermitUtilsInstance(chainId, provider)
 


### PR DESCRIPTION
# Summary

USDT in Arbitrum has a weird implementation of Permit and it doesn't work correctly.
To fix that, I added a blacklist.
I also bumped versions of localStorage caches in order to invalidate previous cached permits of this token.

![image](https://github.com/user-attachments/assets/2d308997-cef8-406f-9d37-b99c6aae3345)


# To Test

1. Reset allowance for USDT in Arb
2. Try to sell it
- [ ] CoW Swap should ask you to make a normal approval (transaction)
