### PR TITLE
fix: order status view under limit orders

### DIFF
--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrderStatusBox/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrderStatusBox/index.tsx
@@ -38,7 +38,6 @@ const Wrapper = styled.div<{
   align-items: center;
   justify-content: center;
   color: var(--statusColor);
-  padding: 0 10px;
   position: relative;
   z-index: 2;
   font-size: 12px;


### PR DESCRIPTION
Fixes https://github.com/cowprotocol/cowswap/issues/5403

This pull request fixes the tooltip display issue in the Limit Orders section.

@elena-zh  Could you please verify?