### PR TITLE
Fix Orders Table Status Box Layout

### DIFF
--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrderStatusBox/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrderStatusBox/index.tsx
@@ -87,6 +87,7 @@ const StatusContent = styled.div`
   gap: 4px;
   position: relative;
   z-index: 2;
+  white-space: nowrap;
 
   svg {
     width: 14px;

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/styled.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/styled.tsx
@@ -24,25 +24,25 @@ export const TableHeader = styled.div<{ isHistoryTab: boolean; isRowSelectable: 
       if (isHistoryTab) {
         return `minmax(200px, 2.5fr)
                 repeat(4, minmax(110px, 1fr))
-                minmax(80px, 0.8fr)
+                minmax(106px,112px)
                 minmax(120px, 1fr)
-                minmax(100px, 0.8fr)
+                minmax(106px, 0.8fr)
                 24px`
       }
-      return `${checkboxColumn} minmax(160px,2fr) minmax(120px,1fr) minmax(140px,1fr) minmax(120px,1fr) minmax(120px,1fr) minmax(100px,110px) minmax(120px,1fr) minmax(100px,0.8fr) 24px`
+      return `${checkboxColumn} minmax(160px,2fr) minmax(120px,1fr) minmax(140px,1fr) minmax(120px,1fr) minmax(120px,1fr) minmax(106px,112px) minmax(120px,1fr) minmax(106px, 0.8fr) 24px`
     }
 
     // Default layout for history tab
     if (isHistoryTab) {
       return `minmax(200px, 2.5fr)
               repeat(4, minmax(110px, 1fr))
-              minmax(80px, 0.8fr)
-              minmax(100px, 1fr)
+              minmax(106px,112px)
+              minmax(106px, 0.8fr)
               24px`
     }
 
     // Default/Limit orders layout
-    return `${checkboxColumn} minmax(160px,2fr) minmax(120px,1fr) minmax(140px,1fr) minmax(120px,1fr) minmax(120px,1fr) minmax(100px,110px) minmax(106px,0.8fr) 24px`
+    return `${checkboxColumn} minmax(160px,2fr) minmax(120px,1fr) minmax(140px,1fr) minmax(120px,1fr) minmax(120px,1fr) minmax(106px,112px) minmax(106px, 0.8fr) 24px`
   }};
   grid-template-rows: minmax(var(--header-height), 1fr);
   align-items: center;


### PR DESCRIPTION
# Fix Orders Table Status Box Layout

Addresses https://github.com/cowprotocol/cowswap/issues/5403

## Description
This PR addresses layout issues in the orders table, specifically focusing on the status box component and overall column widths. The changes ensure better visual consistency and prevent text wrapping issues in the status indicators.

### Changes
1. **Status Box Improvements**
   - Added `white-space: nowrap` to prevent status text from breaking into multiple lines
   - This ensures status indicators remain on a single line for better readability. Specifically for the 'partially filled' status.

2. **Table Column Width Adjustments**
   - Fine-tuned column widths in both history tab and default layouts
   - Standardized status column width to `minmax(106px,112px)` (previously `minmax(80px, 0.8fr)`)
   - Adjusted adjacent columns for better overall table balance

### Files Changed
- `apps/cowswap-frontend/src/modules/ordersTable/pure/OrderStatusBox/index.tsx`
- `apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/styled.tsx`

### Type of Change
- [x] Bug fix (non-breaking change fixing layout issues)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)

### Testing Steps
1. Open the orders table
2. Verify status indicators don't wrap to multiple lines
3. Check both history tab and default layouts
4. Ensure column widths are consistent and properly aligned

### Screenshots
<img width="808" alt="Screenshot 2025-02-06 at 11 31 32" src="https://github.com/user-attachments/assets/083ed0e5-b4b8-4a0e-b854-591c0cbfc0c2" />
<img width="974" alt="Screenshot 2025-02-06 at 11 31 22" src="https://github.com/user-attachments/assets/312b2c17-3662-4e0a-9213-c3644431453d" />
<img width="1331" alt="Screenshot 2025-02-06 at 11 31 11" src="https://github.com/user-attachments/assets/7ec40f3e-c071-459b-b1d2-c60ffc2e3646" />
<img width="1356" alt="Screenshot 2025-02-06 at 11 31 02" src="https://github.com/user-attachments/assets/c0814d2f-4c92-4ce0-8a0a-df3c96db851d" />
<img width="807" alt="Screenshot 2025-02-06 at 11 30 55" src="https://github.com/user-attachments/assets/6d29bd0e-b292-416d-acce-867cc8e361fe" />
