### PR TITLE
fix: add '.e' to USDC.e on Arb1

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/types/TradeRawState.ts
+++ b/apps/cowswap-frontend/src/modules/trade/types/TradeRawState.ts
@@ -42,8 +42,8 @@ export function getDefaultTradeRawState(chainId: SupportedChainId | null): Trade
 
   return {
     chainId,
-    inputCurrencyId: inputCurrency?.symbol || null,
-    outputCurrencyId: outputCurrency?.symbol || null,
+    inputCurrencyId: inputCurrency?.address || null,
+    outputCurrencyId: outputCurrency?.address || null,
     recipient: null,
     recipientAddress: null,
   }

--- a/apps/cowswap-frontend/src/modules/trade/types/TradeRawState.ts
+++ b/apps/cowswap-frontend/src/modules/trade/types/TradeRawState.ts
@@ -42,8 +42,8 @@ export function getDefaultTradeRawState(chainId: SupportedChainId | null): Trade
 
   return {
     chainId,
-    inputCurrencyId: inputCurrency?.address || null,
-    outputCurrencyId: outputCurrency?.address || null,
+    inputCurrencyId: inputCurrency?.symbol || null, // Currently WETH/wxDAI, less likely to be duplicated, symbol is fine
+    outputCurrencyId: outputCurrency?.address || null, // Currently USDC, more likely to be duplicated, better to use address
     recipient: null,
     recipientAddress: null,
   }

--- a/libs/common-const/src/tokens.ts
+++ b/libs/common-const/src/tokens.ts
@@ -225,7 +225,7 @@ const USDCE_ARBITRUM_ONE = new TokenWithLogo(
   SupportedChainId.ARBITRUM_ONE,
   '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8',
   6,
-  'USDC',
+  'USDC.e',
   'USD Coin (Arb1)',
 )
 


### PR DESCRIPTION
# Summary

Attempt to fix bug reported by Chim9 on Discord.

Changes the local token name from USDC to USDC.e

# To Test

1. On arb1, load `0xff970a61a04b1ca14834a43f5de4533ebddb5cc8` and `0xaf88d065e77c8cC2239327C5EDb3A432268e5831` tokens
* Both should load
![image](https://github.com/user-attachments/assets/a2251168-7b1e-4057-b8fe-0f155ec6aa76)
