### PR TITLE
fix: use quote currency on fills at tooltip

### DIFF
--- a/apps/cowswap-frontend/src/modules/ordersTable/containers/OrderRow/EstimatedExecutionPrice.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/containers/OrderRow/EstimatedExecutionPrice.tsx
@@ -233,7 +233,12 @@ export function EstimatedExecutionPrice(props: EstimatedExecutionPriceProps) {
                 <>
                   Current market price is&nbsp;
                   <b>
-                    <TokenAmount amount={marketPrice} {...rest} round={false} tokenSymbol={marketPrice?.baseCurrency} />
+                    <TokenAmount
+                      amount={marketPrice}
+                      {...rest}
+                      round={false}
+                      tokenSymbol={marketPrice?.quoteCurrency}
+                    />
                   </b>
                   and needs to go {marketPriceNeedsToGoDown ? 'down 📉' : 'up 📈'} by&nbsp;
                   <b>
@@ -249,7 +254,7 @@ export function EstimatedExecutionPrice(props: EstimatedExecutionPriceProps) {
                       amount={executesAtPrice}
                       {...rest}
                       round={false}
-                      tokenSymbol={executesAtPrice?.baseCurrency}
+                      tokenSymbol={executesAtPrice?.quoteCurrency}
                     />
                   </b>
                   .


### PR DESCRIPTION
# Summary

Fixes https://github.com/cowprotocol/cowswap/issues/5415

Use quote currency on fills at tooltip

# To Test

1. On limit orders table, place an order that's not executed immediately
2. Check the fills at tooltip
* Currency displayed should use the quote currency