### PR TITLE
fix: do not check capabilities in mobile wc

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useCancelOrder/useSendOnChainCancellation.test.tsx
+++ b/apps/cowswap-frontend/src/common/hooks/useCancelOrder/useSendOnChainCancellation.test.tsx
@@ -25,8 +25,10 @@ jest.mock('@cowprotocol/wallet', () => {
   return {
     ...jest.requireActual('@cowprotocol/wallet'),
     useWalletInfo: jest.fn().mockReturnValue({ chainId }),
+    useSendBatchTransactions: jest.fn().mockResolvedValue('0x01'),
   }
 })
+
 jest.mock('common/hooks/useContract', () => {
   return {
     ...jest.requireActual('common/hooks/useContract'),


### PR DESCRIPTION
# Summary

Reported by a user: https://cowservices.slack.com/archives/C03S445V822/p1739567372032899

When connected via WC in mobile browser, on each `wallet_getCapabilities` rpc request it moves you into your connected wallet :(

# To Test

1. Open browser in your mobile device
2. Connect a wallet via WalletConnect (I've tests with Metamask)
3. Change trading assets and amounts
- [ ] AR: it moves you in Metamask unexpectedly
- [ ] ER: ot doesn't move you in Metamask when it should not


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced wallet connection checks now conditionally trigger capability requests only when necessary, improving overall performance and reliability.
  
- **Tests**
  - Updated testing setups to better simulate batch transaction scenarios, ensuring robustness for future transaction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->