### PR TITLE
fix(volume-fee): remove hardcoded stablecoins check for Safe fee

### DIFF
--- a/apps/cowswap-frontend/src/modules/volumeFee/state/safeAppFeeAtom.ts
+++ b/apps/cowswap-frontend/src/modules/volumeFee/state/safeAppFeeAtom.ts
@@ -66,5 +66,11 @@ export const safeAppFeeAtom = atom<VolumeFee | null>((get) => {
     return isStableCoinTrade ? FEE_PERCENTAGE_BPS.STABLE.TIER_3 : FEE_PERCENTAGE_BPS.REGULAR.TIER_3
   })()
 
+  console.debug('[Volume Fee] Calculated a fee for Safe App (not added yet)', {
+    bps,
+    fiatAmount,
+    isStableCoinTrade,
+  })
+
   return { bps, recipient: SAFE_FEE_RECIPIENT }
 })

--- a/apps/cowswap-frontend/src/modules/volumeFee/state/safeAppFeeAtom.ts
+++ b/apps/cowswap-frontend/src/modules/volumeFee/state/safeAppFeeAtom.ts
@@ -38,7 +38,7 @@ const FEE_PERCENTAGE_BPS = {
 export const safeAppFeeAtom = atom<VolumeFee | null>((get) => {
   const { chainId } = get(walletInfoAtom)
   const { isSafeApp } = get(walletDetailsAtom)
-  const { isSafeAppFeeEnabled, isSafeAppStableCoinsFeeEnabled } = get(featureFlagsAtom)
+  const { isSafeAppFeeEnabled } = get(featureFlagsAtom)
   const { inputCurrency, outputCurrency, inputCurrencyFiatAmount, outputCurrencyFiatAmount, orderKind } =
     get(derivedTradeStateAtom) || {}
 
@@ -53,8 +53,6 @@ export const safeAppFeeAtom = atom<VolumeFee | null>((get) => {
   const isInputStableCoin = !!inputCurrency && stablecoins.has(getCurrencyAddress(inputCurrency).toLowerCase())
   const isOutputStableCoin = !!outputCurrency && stablecoins.has(getCurrencyAddress(outputCurrency).toLowerCase())
   const isStableCoinTrade = isInputStableCoin && isOutputStableCoin
-
-  if (isStableCoinTrade && !isSafeAppStableCoinsFeeEnabled) return null
 
   const bps = (() => {
     if (fiatAmount < FEE_TIERS.TIER_1) {

--- a/apps/cowswap-frontend/src/modules/volumeFee/state/volumeFeeAtom.ts
+++ b/apps/cowswap-frontend/src/modules/volumeFee/state/volumeFeeAtom.ts
@@ -46,7 +46,7 @@ const shouldSkipFeeAtom = atom<boolean>((get) => {
   const inputCurrencyAddress = getCurrencyAddress(inputCurrency).toLowerCase()
   const outputCurrencyAddress = getCurrencyAddress(outputCurrency).toLowerCase()
 
-  return correlatedTokens.some((tokens) => {
+  const isCorrelated = correlatedTokens.some((tokens) => {
     // If there is only one asset in the list, it means that it is a global correlated token
     const addresses = Object.keys(tokens)
     if (addresses.length === 1) {
@@ -56,6 +56,16 @@ const shouldSkipFeeAtom = atom<boolean>((get) => {
       return tokens[inputCurrencyAddress] && tokens[outputCurrencyAddress]
     }
   })
+
+  if (isCorrelated) {
+    console.debug('[Volume Fee] Skipping fee for correlated tokens', {
+      inputCurrencyAddress,
+      outputCurrencyAddress,
+      correlatedTokens,
+    })
+  }
+
+  return isCorrelated
 })
 
 const widgetPartnerFeeAtom = atom<VolumeFee | undefined>((get) => {


### PR DESCRIPTION
# Summary

In #5187 we added `isSafeAppStableCoinsFeeEnabled` flag in order to not add fees to stablecoins in Safe.
But since we have #5427, we don't need this check because it's already covered by the data from CMS.

# To Test

1. Now only CMS decides if a token is a fee free
2. [Fee tier](https://help.safe.global/en/articles/178530-how-does-the-widget-fee-work-for-native-swaps) is still calculating based on hardcoded stablecoins list


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced fee calculation for safe app transactions: fees are now consistently applied and displayed for transfers involving stablecoins, ensuring more transparent fee details for users.
  - Improved clarity in fee skipping logic for correlated tokens, with additional logging for better context during transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->