### PR TITLE
fix: update email contact from people@cow.fi to jobs@cow.fi

### DIFF
--- a/apps/cow-fi/app/(main)/careers/refer-to-earn/page.tsx
+++ b/apps/cow-fi/app/(main)/careers/refer-to-earn/page.tsx
@@ -54,8 +54,8 @@ export default function Page() {
               <br />
               <b>
                 Have Questions? Ask us at{' '}
-                <a href="mailto:people@cow.fi" target="_blank" rel="noreferrer">
-                  people@cow.fi
+                <a href="mailto:jobs@cow.fi" target="_blank" rel="noreferrer">
+                  jobs@cow.fi
                 </a>
               </b>
             </p>
@@ -95,7 +95,7 @@ export default function Page() {
             <ul>
               <li>
                 The referrer should reach out to a CoW core team member or directly contact the People department via
-                email at <a href="mailto:people@cow.fi">people@cow.fi</a>, LinkedIn, or Telegram. When reaching out, the
+                email at <a href="mailto:jobs@cow.fi">jobs@cow.fi</a>, LinkedIn, or Telegram. When reaching out, the
                 Referrer must include the candidate's name, surname, and email or LinkedIn profile. The Referrer is
                 responsible for ensuring that the Candidate has given consent to share this information.
               </li>


### PR DESCRIPTION

# Overview
This PR updates the contact email address on the Refer-to-Earn careers page from `people@cow.fi` to `jobs@cow.fi`.

## Changes
- Updated email contact information in the "Have Questions?" section
- Updated email reference in the referral process instructions
- All instances of `people@cow.fi` have been replaced with `jobs@cow.fi`

## Files Changed
- `apps/cow-fi/app/(main)/careers/refer-to-earn/page.tsx`

## Type of Change
- [x] Bug fix (non-breaking change that corrects contact information)

## Testing
- Verify all email links on the Refer-to-Earn page point to `jobs@cow.fi`
- Confirm email links are properly formatted with `mailto:` prefix
- Ensure all HTML formatting and styling remains intact


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the inquiry email address on the referral program page to ensure users receive accurate contact information. All email link functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->