### PR TITLE
fix:  Orders table: 'Learn more' link update

### DIFF
--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/index.tsx
@@ -143,7 +143,7 @@ export function OrdersTableContainer({
                     <br />
                     <Trans>Time to create a new one!</Trans>{' '}
                     {orderType === TabOrderTypes.LIMIT ? (
-                      <styledEl.ExternalLinkStyled href="https://cow-protocol.medium.com/how-to-user-cow-swaps-surplus-capturing-limit-orders-24324326dc9e">
+                      <styledEl.ExternalLinkStyled href="https://cow.fi/learn/limit-orders-explained">
                         <Trans>Learn more</Trans>
                         <styledEl.ExternalArrow />
                       </styledEl.ExternalLinkStyled>


### PR DESCRIPTION
Update a link in the Your orders table to https://cow.fi/learn/limit-orders-explained
![image](https://github.com/user-attachments/assets/74881b8c-630b-4a00-a1cc-c3002ee07742)

To test: 
1. Open Limit orders page 
2. Connect to a wallet with no limit orders placed before
3. Check the 'Learn more' link on the 'All orders' and 'Open' tabs.