### PR TITLE
fix: TX amount change on MEV blocker page

### DIFF
--- a/apps/cow-fi/app/(mev-blocker)/mev-blocker/page.tsx
+++ b/apps/cow-fi/app/(mev-blocker)/mev-blocker/page.tsx
@@ -129,7 +129,7 @@ export default function Page() {
           <MetricsCard bgColor={Color.cowfi_orange_bright} color={Color.cowfi_orange_pale} columns={3} touchFooter>
             <MetricsItem dividerColor={Color.cowfi_orange_light}>
               <h2>$208B+</h2>
-              <p>volume protected from MEV, across 20M+ transactions</p>
+              <p>volume protected from MEV, across 46M+ transactions</p>
             </MetricsItem>
             <MetricsItem dividerColor={Color.cowfi_orange_light}>
               <h2>4.6K+</h2>


### PR DESCRIPTION
1. Open [MEV blocker page](https://cowfi-git-fix-amount-on-mev-blocker-page-cowswap.vercel.app/mev-blocker)
2. Check volume protected from MEV metric

**Expected**: it should contain 46M+ transactions (instead of 20+)
![image](https://github.com/user-attachments/assets/b6596667-46df-47e1-a5a7-99a1e4fd7380)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

In this update, we’ve refined the transaction metric on our MEV protection display to provide a clearer view of activity levels.

- **New Features**
  - The displayed MEV protection metric now shows 46M+ transactions, offering users improved and more accurate performance insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->