### PR TITLE
refactor(explorer): update color system and styling for order components

### DIFF
--- a/apps/explorer/src/components/orders/DetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/index.tsx
@@ -89,8 +89,6 @@ const tooltip = {
 }
 
 export const Wrapper = styled.div`
-  --cow-color-alert: ${() => Color.explorer_red1};
-
   display: flex;
   flex-direction: row;
 
@@ -224,7 +222,7 @@ export function DetailsTable(props: Props): React.ReactNode | null {
               <Wrapper>
                 {isSigning && (
                   <>
-                    <Icon image="ALERT" color={UI.COLOR_ALERT} />
+                    <Icon image="ALERT" color={UI.COLOR_ALERT_TEXT} />
                     &nbsp;
                   </>
                 )}

--- a/apps/explorer/src/components/orders/UnsignedOrderWarning/index.tsx
+++ b/apps/explorer/src/components/orders/UnsignedOrderWarning/index.tsx
@@ -1,15 +1,9 @@
-import { BannerOrientation, Color, InlineBanner } from '@cowprotocol/ui'
-
-import styled from 'styled-components/macro'
-
-const StyledInlineBanner = styled(InlineBanner)`
-  --cow-color-danger-text: ${Color.explorer_textError};
-`
+import { BannerOrientation, InlineBanner } from '@cowprotocol/ui'
 
 export const UnsignedOrderWarning: React.FC = () => {
   return (
-    <StyledInlineBanner orientation={BannerOrientation.Horizontal} bannerType="danger" padding="0">
+    <InlineBanner orientation={BannerOrientation.Horizontal} bannerType="alert" padding="0">
       An unsigned order is not necessarily placed by the owner's account. Please be cautious.
-    </StyledInlineBanner>
+    </InlineBanner>
   )
 }

--- a/apps/explorer/src/explorer/styled.ts
+++ b/apps/explorer/src/explorer/styled.ts
@@ -1,4 +1,4 @@
-import { Media } from '@cowprotocol/ui'
+import { Color, Media } from '@cowprotocol/ui'
 
 import styled, { createGlobalStyle, css } from 'styled-components/macro'
 
@@ -36,6 +36,11 @@ export const GlobalStyle = createGlobalStyle`
     padding: 0;
     position: relative;
     ${ScrollBarStyle}
+  }
+
+  // TODO: remove this once we have a proper way to set global CSS variables for all apps
+  :root {
+    --cow-color-alert-text: ${Color.explorer_yellow4};
   }
 
   .hover {


### PR DESCRIPTION
# Summary
Fixes #5452 
Moves CSS variable for alert text color to global scope

This PR moves the `--cow-color-alert-text` CSS variable from the component level to the global application level, ensuring consistent styling across all components that use this variable. This change improves maintainability by centralizing the color definition.

# To Test

1. Navigate to any order details page with an unsigned order

   - [ ] Verify the warning banner about unsigned orders is displayed
   - [ ] Verify the warning text color is yellow (specifically `#f6c343`)
   - [ ] The text should say "An unsigned order is not necessarily placed by the owner's account. Please be cautious."
 
# Background

A TODO comment was also added to indicate that this approach is temporary until we have a proper way to set global CSS variables for all apps in the monorepo.