### PR TITLE
refactor(ui): improve GlobalWarning component styling and responsiveness

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/GlobalWarning/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/GlobalWarning/index.tsx
@@ -1,18 +1,32 @@
 import { ReactNode } from 'react'
 
-import { UI } from '@cowprotocol/ui'
+import { Media, UI } from '@cowprotocol/ui'
 
 import { AlertTriangle, X } from 'react-feather'
 import styled from 'styled-components/macro'
 
 const StyledClose = styled(X as any)`
-  :hover {
+  flex-shrink: 0;
+  opacity: 0.5;
+  transition: opacity 0.2s ease-in-out;
+
+  &:hover {
     cursor: pointer;
+    opacity: 1;
   }
+
+  ${Media.upToSmall()} {
+    margin: 0 0 auto;
+  }
+`
+
+const StyledAlertTriangle = styled(AlertTriangle as any)`
+  flex-shrink: 0;
 `
 
 const Container = styled.div`
   display: flex;
+  gap: 10px;
   width: 100%;
   align-items: center;
   justify-content: space-between;
@@ -22,6 +36,10 @@ const Container = styled.div`
   background-color: var(${UI.COLOR_PRIMARY});
   border-radius: ${({ theme }) => (theme.isInjectedWidgetMode ? '8px' : '')};
   margin-bottom: ${({ theme }) => (theme.isInjectedWidgetMode ? '10px' : '')};
+
+  ${Media.upToSmall()} {
+    padding: 12px 8px;
+  }
 `
 
 const Wrapper = styled.div`
@@ -31,6 +49,11 @@ const Wrapper = styled.div`
 
   p {
     margin: 0;
+    line-height: 1.2;
+
+    ${Media.upToSmall()} {
+      line-height: 1.4;
+    }
   }
 `
 
@@ -38,7 +61,7 @@ export function GlobalWarning({ children, onClose }: { children: ReactNode; onCl
   return (
     <Container>
       <Wrapper>
-        <AlertTriangle />
+        <StyledAlertTriangle />
         {children}
       </Wrapper>
       {onClose && <StyledClose onClick={onClose} />}


### PR DESCRIPTION
# Summary

This PR improves the styling and responsiveness of the GlobalWarning component, enhancing its appearance and usability across different screen sizes.

<img width="317" alt="Screenshot 2025-02-26 at 16 24 55" src="https://github.com/user-attachments/assets/13fc215d-ccaf-434a-a9f0-8191bacc4d23" />
<img width="1293" alt="Screenshot 2025-02-26 at 16 24 42" src="https://github.com/user-attachments/assets/19f051df-3ab3-4541-9fd9-53426a5807cb" />


Key improvements:
- Improved hover effects on the close button with opacity transition
- Fixed potential layout issues by preventing icon shrinking
- Improved text readability with appropriate line-height values

# To Test

1. View the GlobalWarning component in desktop view

- [ ] Confirm the close button has a smooth opacity transition on hover
- [ ] Check that the text is properly aligned with appropriate line height

2. Test the component in mobile view  

- [ ] Verify the component adjusts properly to smaller screen sizes
- [ ] Check that the line height increases for better readability on small screens
- [ ] Ensure the close button positions correctly at the top right

 