### PR TITLE
feat(learn): enhance search and article fetching functionality

### DIFF
--- a/apps/cow-fi/app/(learn)/learn/[article]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/[article]/page.tsx
@@ -62,7 +62,8 @@ export default async function ArticlePage({ params }: Props) {
     return notFound()
   }
 
-  const articlesResponse = await getArticles()
+  // Fetch all articles for search functionality
+  const articlesResponse = await getArticles({ fetchAll: true })
   const articles = articlesResponse.data
 
   // Fetch featured articles

--- a/apps/cow-fi/app/(learn)/learn/articles/[[...pageIndex]]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/articles/[[...pageIndex]]/page.tsx
@@ -4,7 +4,7 @@ import { Article, getArticles, getCategories } from '../../../../../services/cms
 import { ArticlesPageComponents } from '@/components/ArticlesPageComponents'
 import { redirect } from 'next/navigation'
 
-const ITEMS_PER_PAGE = 24
+const ITEMS_PER_PAGE = 48
 
 type Props = {
   params: Promise<{ pageIndex?: string }>
@@ -38,7 +38,12 @@ export default async function Page({ params }: Props) {
 
   const page = pageParam && pageIndexIsValid ? parseInt(pageParam, 10) : 1
 
+  // Fetch paginated articles for display
   const articlesResponse = (await getArticles({ page, pageSize: ITEMS_PER_PAGE })) as ArticlesResponse
+
+  // Fetch all articles for search functionality
+  const allArticlesResponse = await getArticles({ fetchAll: true })
+  const allArticles = allArticlesResponse.data
 
   const totalArticles = articlesResponse.meta?.pagination?.total || 0
   const articles =
@@ -67,6 +72,7 @@ export default async function Page({ params }: Props) {
   return (
     <ArticlesPageComponents
       articles={articles}
+      allArticles={allArticles}
       totalArticles={totalArticles}
       currentPage={page}
       allCategories={allCategories}

--- a/apps/cow-fi/app/(learn)/learn/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/page.tsx
@@ -4,15 +4,34 @@ import { getArticles, getCategories } from '../../../services/cms'
 
 import { LearnPageComponent } from '@/components/LearnPageComponent'
 
-export default async function Page() {
-  const categoriesResponse = await getCategories()
-  const articlesResponse = await getArticles()
+export default async function LearnPage() {
+  // Fetch all articles with the fetchAll parameter to ensure we get everything
+  const articlesResponse = await getArticles({ pageSize: 200, fetchAll: true })
+  const articles = articlesResponse.data
 
+  // Fetch featured articles
   const featuredArticlesResponse = await getArticles({
-    filters: { featured: { $eq: true } },
-    pageSize: 6,
+    filters: {
+      featured: {
+        $eq: true,
+      },
+    },
+    pageSize: 7, // Limit to 7 articles
   })
 
+  // Format featured articles for the component
+  const featuredArticles = featuredArticlesResponse.data.map((article) => {
+    const attributes = article.attributes
+    return {
+      title: attributes?.title || 'No title',
+      description: attributes?.description || 'No description',
+      link: `/learn/${attributes?.slug || 'no-slug'}`,
+      cover: attributes?.cover?.data?.attributes?.url || '',
+    }
+  })
+
+  const categoriesResponse = await getCategories()
+  // Format categories for the component
   const categories =
     categoriesResponse?.map((category: any) => {
       const imageUrl = category?.attributes?.image?.data?.attributes?.url || ''
@@ -29,17 +48,5 @@ export default async function Page() {
       }
     }) || []
 
-  const featuredArticles = featuredArticlesResponse.data.map((article) => {
-    const attributes = article.attributes
-    return {
-      title: attributes?.title || 'No title',
-      description: attributes?.description || 'No description',
-      link: `/learn/${attributes?.slug || 'no-slug'}`,
-      cover: attributes?.cover?.data?.attributes?.url || '',
-    }
-  })
-
-  return (
-    <LearnPageComponent categories={categories} articles={articlesResponse.data} featuredArticles={featuredArticles} />
-  )
+  return <LearnPageComponent articles={articles} featuredArticles={featuredArticles} categories={categories} />
 }

--- a/apps/cow-fi/app/(learn)/learn/topic/[topicSlug]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/topic/[topicSlug]/page.tsx
@@ -40,7 +40,8 @@ export default async function TopicPage({ params }: Props) {
     return notFound()
   }
 
-  const articlesResponse = await getArticles({
+  // Fetch articles for this specific topic
+  const topicArticlesResponse = await getArticles({
     page: 0,
     pageSize: 50,
     filters: {
@@ -52,7 +53,13 @@ export default async function TopicPage({ params }: Props) {
     },
   })
 
-  const articles = articlesResponse.data
+  // Fetch all articles for search functionality
+  const allArticlesResponse = await getArticles({
+    fetchAll: true,
+  })
+
+  const topicArticles = topicArticlesResponse.data
+  const allArticles = allArticlesResponse.data
 
   const categoriesResponse = await getCategories()
   const allCategories =
@@ -61,5 +68,12 @@ export default async function TopicPage({ params }: Props) {
       slug: category?.attributes?.slug || '',
     })) || []
 
-  return <TopicPageComponent category={category} allCategories={allCategories} articles={articles} />
+  return (
+    <TopicPageComponent
+      category={category}
+      allCategories={allCategories}
+      articles={topicArticles}
+      allArticles={allArticles}
+    />
+  )
 }

--- a/apps/cow-fi/app/(learn)/learn/topics/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/topics/page.tsx
@@ -6,7 +6,7 @@ import { TopicsPageComponent } from '@/components/TopicsPageComponent'
 
 export default async function Page() {
   const categoriesResponse = await getCategories()
-  const articlesResponse = await getArticles()
+  const articlesResponse = await getArticles({ pageSize: 200 })
 
   const categories =
     categoriesResponse?.map((category: any) => {

--- a/apps/cow-fi/components/ArticlesPageComponents.tsx
+++ b/apps/cow-fi/components/ArticlesPageComponents.tsx
@@ -61,16 +61,23 @@ interface ArticlesPageProps {
   totalArticles: number
   currentPage: number
   allCategories: { name: string; slug: string }[]
+  allArticles?: Article[]
 }
 
-export function ArticlesPageComponents({ articles, totalArticles, currentPage, allCategories }: ArticlesPageProps) {
+export function ArticlesPageComponents({
+  articles,
+  totalArticles,
+  currentPage,
+  allCategories,
+  allArticles,
+}: ArticlesPageProps) {
   const analytics = useCowAnalytics()
   const totalPages = Math.ceil(totalArticles / ITEMS_PER_PAGE)
 
   return (
     <Wrapper>
       <CategoryLinks allCategories={allCategories} />
-      <SearchBar articles={articles} />
+      <SearchBar articles={allArticles || articles} />
       <ContainerCard gap={42} gapMobile={24} touchFooter>
         <ContainerCardInner maxWidth={970} gap={24} gapMobile={24}>
           <ContainerCardSectionTop>

--- a/apps/cow-fi/components/SearchBar.tsx
+++ b/apps/cow-fi/components/SearchBar.tsx
@@ -231,7 +231,6 @@ export const SearchBar: React.FC<SearchBarProps> = ({ articles }) => {
     if (query.trim()) {
       const searchTerm = query.toLowerCase()
 
-      // Simplified and more robust search algorithm
       const filtered = (articles || []).filter((article) => {
         const title = article.attributes?.title?.toLowerCase() || ''
         const description = article.attributes?.description?.toLowerCase() || ''

--- a/apps/cow-fi/components/SearchBar.tsx
+++ b/apps/cow-fi/components/SearchBar.tsx
@@ -126,10 +126,11 @@ const ResultDescription = styled.div`
   font-size: 12px;
   color: ${Color.neutral40};
   white-space: pre-wrap;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
   overflow: hidden;
+  line-height: 1.5;
+  display: -webkit-box;
+  line-clamp: 2;
+  box-orient: vertical;
 `
 
 const HighlightedText = styled.span`

--- a/apps/cow-fi/components/TopicPageComponent.tsx
+++ b/apps/cow-fi/components/TopicPageComponent.tsx
@@ -94,9 +94,10 @@ interface TopicPageProps {
   category: any
   articles: any[]
   allCategories: { name: string; slug: string }[]
+  allArticles?: any[]
 }
 
-export function TopicPageComponent({ category, allCategories, articles }: TopicPageProps) {
+export function TopicPageComponent({ category, allCategories, articles, allArticles }: TopicPageProps) {
   const { name, description, image } = category.attributes || {}
   const imageUrl = image?.data?.attributes?.url
   const analytics = useCowAnalytics()
@@ -105,7 +106,7 @@ export function TopicPageComponent({ category, allCategories, articles }: TopicP
     <Wrapper>
       <CategoryLinks allCategories={allCategories} />
 
-      <SearchBar articles={articles} />
+      <SearchBar articles={allArticles || articles} />
 
       <ContainerCard gap={42} gapMobile={24} minHeight="100vh" alignContent="flex-start" touchFooter>
         <ContainerCardInner maxWidth={970} gap={24} gapMobile={24}>


### PR DESCRIPTION
# Summary

This PR enhances the search functionality in the cow-fi app by implementing a recursive pagination solution that ensures all articles from the CMS are available for search, regardless of the total number of articles.

Previously, the app was only fetching a limited number of articles (200 at most) from the CMS, which meant that as content grows beyond this limit, some articles wouldn't be included in search results. The screenshot shows we currently have 89 articles across 4 pages, but this solution future-proofs our search as content grows to 500+ articles.

<img width="1019" alt="Screenshot 2025-02-27 at 11 43 26" src="https://github.com/user-attachments/assets/5d16421a-e5e6-46e2-811e-709378d0ff2a" />
<img width="1027" alt="Screenshot 2025-02-27 at 11 43 16" src="https://github.com/user-attachments/assets/b5bd0392-91b4-4a55-9069-8d821a2910c5" />



# To Test

1. Open the learn page (`/learn`)
   - [ ] Verify the search bar is working
   - [ ] Type "what is b" in the search bar
   - [ ] Verify that the article "What is backrunning: MEV attacks explained" appears in the search results

2. Test search on other pages
   - [ ] Navigate to a topic page (e.g., `/learn/topic/defi`)
   - [ ] Type "what is b" in the search bar
   - [ ] Verify that the article "What is backrunning: MEV attacks explained" appears in the search results
   - [ ] Repeat the test on an article page and the articles listing page

3. Test with partial words
   - [ ] Try searching with other partial terms (e.g., "mev at")
   - [ ] Verify that relevant articles appear in the search results

# Background

The CMS API uses pagination to limit the number of articles returned in a single request. The default page size is 25 articles, and we currently have 89 articles total (4 pages).

This solution adds a new `fetchAll` parameter to the `getArticles` function that recursively fetches all pages of articles until it has the complete set. This ensures that the search functionality always has access to all articles, making it future-proof as content grows.

I've updated all relevant pages (`/learn`, `/learn/articles`, `/learn/[article]`, and `/learn/topic/[topicSlug]`) to use this new parameter, ensuring consistent search functionality throughout the app.