### PR TITLE
Add token address display and copy functionality

### DIFF
--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokenInfo/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokenInfo/index.tsx
@@ -1,6 +1,11 @@
 import { TokenWithLogo } from '@cowprotocol/common-const'
+import { useCopyClipboard } from '@cowprotocol/common-hooks'
 import { TokenLogo } from '@cowprotocol/tokens'
 import { TokenName, TokenSymbol } from '@cowprotocol/ui'
+
+import { getEtherscanLink, shortenAddress } from 'libs/common-utils/src/legacyAddressUtils'
+import { getExplorerAddressLink } from 'libs/common-utils/src/explorer'
+import CopyHelper from 'legacy/components/Copy/CopyMod'
 
 import * as styledEl from './styled'
 
@@ -11,6 +16,12 @@ export interface TokenInfoProps {
 
 export function TokenInfo(props: TokenInfoProps) {
   const { token, className } = props
+  const [isCopied, setCopied] = useCopyClipboard()
+  
+  const handleAddressClick = (event: React.MouseEvent) => {
+    // Prevent the event from propagating to avoid triggering token selection
+    event.stopPropagation()
+  }
 
   return (
     <styledEl.Wrapper className={className}>
@@ -20,6 +31,21 @@ export function TokenInfo(props: TokenInfoProps) {
         <styledEl.TokenName>
           <TokenName token={token} />
         </styledEl.TokenName>
+        {token.address && (
+          <styledEl.AddressContainer>
+            <styledEl.Address 
+              href={getExplorerAddressLink(token.chainId, token.address)} 
+              target="_blank" 
+              rel="noopener noreferrer"
+              onClick={handleAddressClick}
+            >
+              {shortenAddress(token.address)}
+            </styledEl.Address>
+            <styledEl.CopyIconWrapper onClick={handleAddressClick}>
+              <CopyHelper toCopy={token.address} />
+            </styledEl.CopyIconWrapper>
+          </styledEl.AddressContainer>
+        )}
       </styledEl.TokenDetails>
     </styledEl.Wrapper>
   )

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokenInfo/styled.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokenInfo/styled.ts
@@ -1,6 +1,7 @@
 import { Media } from '@cowprotocol/ui'
 
 import styled from 'styled-components/macro'
+import { LinkStyledButton } from 'theme'
 
 export const Wrapper = styled.div`
   display: flex;
@@ -25,4 +26,33 @@ export const TokenDetails = styled.div`
   flex-flow: column wrap;
   flex: 1 1 100%;
   gap: 4px;
+`
+
+export const AddressContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  font-weight: 400;
+  opacity: 0.6;
+  margin-top: 2px;
+`
+
+export const Address = styled.a`
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  
+  &:hover {
+    text-decoration: underline;
+  }
+`
+
+export const CopyIconWrapper = styled.div`
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+  
+  ${AddressContainer}:hover & {
+    opacity: 1;
+  }
 `


### PR DESCRIPTION
# Summary

<<if there's an issue>>Fixes #issueNumber

High-level description of what your changes are accomplishing

Add screenshots if applicable. Images are nice :)

# To Test

1. <<Step one>> Open the page `about`

- [x] <<What to expect?>> Verify it contains about information...
- [x] Checkbox Style list of things a QA person could verify, i.e.
- [x] Should display Text Input our storybook
- [x] Input should not accept Numbers

2. <<Step two>> ...

# Background

Optional: Give background information for changes you've made, that might be difficult to explain via comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced token information displays by adding a dedicated section for token addresses that links to an external explorer.
  - Introduced a clipboard copy feature, enabling users to easily copy token addresses without unintended interactions.

- **Style**
  - Refined the visual presentation with responsive hover effects and improved layout styling for a clearer, more interactive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->