### PR TITLE
feat: add wallet and account to appZi feedback for debugging

### DIFF
--- a/apps/cowswap-frontend/src/appzi.ts
+++ b/apps/cowswap-frontend/src/appzi.ts
@@ -62,6 +62,7 @@ type AppziCustomSettings = {
   orderType?: string
   account?: string
   pendingOrderIds?: string
+  walletName?: string
 }
 
 type AppziSettings = {
@@ -85,8 +86,11 @@ function updateAppziSettings({ data = {}, userId = '' }: AppziSettings) {
   }
 }
 
-export function openFeedbackAppzi() {
+export function openFeedbackAppzi(params: { account?: string; walletName?: string; chainId: number }) {
+  const { account, chainId, walletName } = params
+
   if (typeof window !== 'undefined') {
+    updateAppziSettings({ data: { account, chainId, walletName } })
     window.appzi?.openWidget(FEEDBACK_KEY)
   }
 }
@@ -125,7 +129,7 @@ type SurveyType = 'nps' | 'limit'
  */
 export function triggerAppziSurvey(
   data?: Omit<AppziCustomSettings, 'userTradedOrWaitedForLong' | 'isTestNps'>,
-  surveyType: SurveyType = 'nps'
+  surveyType: SurveyType = 'nps',
 ) {
   if (isInjectedWidget()) return
 

--- a/apps/cowswap-frontend/src/common/updaters/orders/PendingOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/PendingOrdersUpdater.ts
@@ -200,7 +200,7 @@ async function _updateOrders({
   if (!pending.length) {
     return
   } else {
-    _triggerNps(pending, chainId)
+    _triggerNps(pending, chainId, account)
   }
 
   // Iterate over pending orders fetching API data
@@ -340,7 +340,7 @@ function getReplacedOrCancelledEthFlowOrders(
 
 // Check if there is any order pending for a long time
 // If so, trigger appzi
-function _triggerNps(pending: Order[], chainId: ChainId) {
+function _triggerNps(pending: Order[], chainId: ChainId, account: string) {
   for (const order of pending) {
     const { openSince, id: orderId } = order
     const orderType = getUiOrderType(order)
@@ -354,6 +354,7 @@ function _triggerNps(pending: Order[], chainId: ChainId) {
         explorerUrl,
         chainId,
         orderType,
+        account,
       })
       // Break the loop, don't need to show more than once
       break

--- a/apps/cowswap-frontend/src/legacy/components/AppziButton/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/AppziButton/index.tsx
@@ -1,10 +1,11 @@
+import { useCallback } from 'react'
+
 import FeedbackIcon from '@cowprotocol/assets/cow-swap/feedback.svg'
 import { Media } from '@cowprotocol/ui'
 import { useWalletDetails, useWalletInfo } from '@cowprotocol/wallet'
 
 import { isAppziEnabled, openFeedbackAppzi } from 'appzi'
 import { transparentize } from 'color2k'
-import { useCallback } from 'react'
 import SVG from 'react-inlinesvg'
 import styled from 'styled-components/macro'
 
@@ -62,15 +63,16 @@ interface AppziButtonProps {
 }
 
 export default function Appzi({ menuTitle }: AppziButtonProps) {
-  if (!isAppziEnabled) {
-    return null
-  }
   const { account, chainId } = useWalletInfo()
   const { walletName } = useWalletDetails()
 
   const showFeedbackModal = useCallback(() => {
     openFeedbackAppzi({ account, chainId, walletName })
   }, [account, chainId, walletName])
+
+  if (!isAppziEnabled) {
+    return null
+  }
 
   return (
     <Wrapper onClick={showFeedbackModal}>

--- a/apps/cowswap-frontend/src/legacy/components/AppziButton/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/AppziButton/index.tsx
@@ -1,8 +1,10 @@
 import FeedbackIcon from '@cowprotocol/assets/cow-swap/feedback.svg'
 import { Media } from '@cowprotocol/ui'
+import { useWalletDetails, useWalletInfo } from '@cowprotocol/wallet'
 
 import { isAppziEnabled, openFeedbackAppzi } from 'appzi'
 import { transparentize } from 'color2k'
+import { useCallback } from 'react'
 import SVG from 'react-inlinesvg'
 import styled from 'styled-components/macro'
 
@@ -19,7 +21,9 @@ const Wrapper = styled.div`
   z-index: 10;
   cursor: pointer;
   transform: translateY(0);
-  transition: background 0.5s ease-in-out, transform 0.5s ease-in-out;
+  transition:
+    background 0.5s ease-in-out,
+    transform 0.5s ease-in-out;
 
   > svg {
     width: 100%;
@@ -28,7 +32,9 @@ const Wrapper = styled.div`
     color: inherit;
     fill: currentColor;
     transform: rotate(0);
-    transition: fill 0.5s ease-in-out, transform 0.5s ease-in-out;
+    transition:
+      fill 0.5s ease-in-out,
+      transform 0.5s ease-in-out;
   }
 
   &:hover {
@@ -59,9 +65,15 @@ export default function Appzi({ menuTitle }: AppziButtonProps) {
   if (!isAppziEnabled) {
     return null
   }
+  const { account, chainId } = useWalletInfo()
+  const { walletName } = useWalletDetails()
+
+  const showFeedbackModal = useCallback(() => {
+    openFeedbackAppzi({ account, chainId, walletName })
+  }, [account, chainId, walletName])
 
   return (
-    <Wrapper onClick={openFeedbackAppzi}>
+    <Wrapper onClick={showFeedbackModal}>
       {menuTitle && <span>{menuTitle}</span>}
       <SVG src={FeedbackIcon} description="Provide Feedback" />
     </Wrapper>


### PR DESCRIPTION
# Summary

This PR adds the wallet address and the wallet name to appZi button. 

Users ask for help on various issues, this additional context gives support important information to help the user.

<img width="1225" alt="image" src="https://github.com/user-attachments/assets/85e50fee-e2aa-480e-b8d0-02e5a2f4d168" />


# To Test

- Conect your wallet
- Send feedback using the feedback button
- Check your feedback in appzi. Make sure it has your account

Additional tests
- Verify it still works if you are not connected
- Use different wallets to see if the wallet name is recognise 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced feedback and survey interactions by incorporating wallet identification for a more personalized experience.
- **Refactor**
	- Updated survey triggers now utilize account information during order processing for improved contextual engagement.
- **Style**
	- Refined visual transitions in the feedback interface for smoother and more consistent interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->