### PR TITLE
fix(appzi): remove open state styles

### DIFF
--- a/apps/cowswap-frontend/src/theme/ThemedGlobalStyle.tsx
+++ b/apps/cowswap-frontend/src/theme/ThemedGlobalStyle.tsx
@@ -19,7 +19,7 @@ export const ThemedGlobalStyle = createGlobalStyle`
       font-family: 'Inter var', sans-serif;
     }
   }
- 
+
   html,
   body {
     margin: 0;
@@ -78,16 +78,6 @@ export const ThemedGlobalStyle = createGlobalStyle`
       top: 0 !important;
       bottom: 0 !important;
     }
-  }
-
-  // Appzi Container override
-  div[id*='appzi-wfo-'] {
-    display: none !important; // Force hiding Appzi container when not opened
-  }
-
-  body[class*='appzi-f-w-open-'] div[id^='appzi-wfo-'] {
-    z-index: 2147483004 !important;
-    display: block !important;
   }
 
   // Walletconnect V2 mobile override


### PR DESCRIPTION
# Summary

Appzi stopped working today.
It seems like they changed css selectors and those changes are not compatible with out styles.
More specificaly, before they were adding 'appzi-f-w-open-' class but now they don't.

# To Test

1. Appzi feedback widget should open when needed
2. Appzi NPS should open when needed
