### PR TITLE
fix(swap): disable button when costs warning is not accepted

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/containers/TradeButtons/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/TradeButtons/index.tsx
@@ -65,7 +65,7 @@ export function TradeButtons({
   if (!tradeFormButtonContext) return null
 
   if (localFormValidation && isPrimaryValidationPassed) {
-    return swapTradeButtonsMap[localFormValidation](context)
+    return swapTradeButtonsMap[localFormValidation](context, isDisabled)
   }
 
   return (

--- a/apps/cowswap-frontend/src/modules/swap/containers/TradeButtons/swapTradeButtonsMap.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/TradeButtons/swapTradeButtonsMap.tsx
@@ -27,26 +27,26 @@ interface SwapTradeButtonsContext {
   onCurrencySelection: (field: Field, currency: Currency) => void
 }
 
-type SwapTradeButton = (props: SwapTradeButtonsContext) => ReactNode | string
+type SwapTradeButton = (props: SwapTradeButtonsContext, isDisabled: boolean) => ReactNode | string
 
 export const swapTradeButtonsMap: Record<SwapFormState, SwapTradeButton> = {
-  [SwapFormState.SwapWithWrappedToken]: (props: SwapTradeButtonsContext) => (
-    <ButtonError buttonSize={ButtonSize.BIG} onClick={props.onEthFlow}>
+  [SwapFormState.SwapWithWrappedToken]: (props: SwapTradeButtonsContext, isDisabled: boolean) => (
+    <ButtonError buttonSize={ButtonSize.BIG} onClick={props.onEthFlow} disabled={isDisabled}>
       <div>
         <Trans>Swap with {props.wrappedToken.symbol}</Trans>
       </div>
     </ButtonError>
   ),
-  [SwapFormState.WrapAndSwap]: (props: SwapTradeButtonsContext) => (
-    <ButtonError buttonSize={ButtonSize.BIG} onClick={props.openSwapConfirm}>
+  [SwapFormState.WrapAndSwap]: (props: SwapTradeButtonsContext, isDisabled: boolean) => (
+    <ButtonError buttonSize={ButtonSize.BIG} onClick={props.openSwapConfirm} disabled={isDisabled}>
       <div>
         <Trans>Wrap&nbsp;{<TokenSymbol token={props.inputCurrency} length={6} />}&nbsp;and Swap</Trans>
       </div>
     </ButtonError>
   ),
-  [SwapFormState.RegularEthFlowSwap]: (props: SwapTradeButtonsContext) => (
+  [SwapFormState.RegularEthFlowSwap]: (props: SwapTradeButtonsContext, isDisabled: boolean) => (
     <Wrapper>
-      <ButtonError buttonSize={ButtonSize.BIG} onClick={props.openSwapConfirm}>
+      <ButtonError buttonSize={ButtonSize.BIG} onClick={props.openSwapConfirm} disabled={isDisabled}>
         <div>
           <Trans>Swap</Trans>
         </div>

--- a/apps/cowswap-frontend/src/modules/swap/containers/Warnings/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/Warnings/index.tsx
@@ -6,7 +6,7 @@ import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
 import { useInjectedWidgetParams } from 'modules/injectedWidget'
 import { useTradePriceImpact, useTradeRouteContext } from 'modules/trade'
-import { HighFeeWarning, MetamaskTransactionWarning } from 'modules/tradeWidgetAddons'
+import { BundleTxWrapBanner, HighFeeWarning, MetamaskTransactionWarning } from 'modules/tradeWidgetAddons'
 import { SellNativeWarningBanner } from 'modules/tradeWidgetAddons'
 
 import { useSwapDerivedState } from '../../hooks/useSwapDerivedState'
@@ -34,6 +34,7 @@ export function Warnings({ buyingFiatAmount }: WarningsProps) {
       {inputCurrency && !isNativeSellInHooksStore && <MetamaskTransactionWarning sellToken={inputCurrency} />}
       {isNativeSellInHooksStore && <SellNativeWarningBanner />}
       <HighFeeWarning />
+      <BundleTxWrapBanner />
       {showTwapSuggestionBanner && (
         <TwapSuggestionBanner
           chainId={chainId}


### PR DESCRIPTION
# Summary

Swap button should be disabled when "Costs exceed..." warning checkbox is not checked.

![image](https://github.com/user-attachments/assets/a1926611-a2f6-4c4d-b117-623673671da1)

# To Test

1. Open Cow Swap in Safe
2. Setup a trade selling ETH and input small enough value (0.2$ in Sepolia)
- [ ] AR: "Costs exceed..." warning checkbox is not checked and "Wrap ETH and Swap" button is enabled
- [ ] ER: "Costs exceed..." warning checkbox is not checked and "Wrap ETH and Swap" button is DISABLED
