### PR TITLE
fix: Update update link  on add custom token banner

### DIFF
--- a/libs/ui/src/consts.ts
+++ b/libs/ui/src/consts.ts
@@ -1,7 +1,7 @@
 'use client'
 
 export const SAFE_COW_APP_LINK = 'https://app.safe.global/share/safe-app?appUrl=https%3A%2F%2Fswap.cow.fi&chain=eth'
-export const LINK_GUIDE_ADD_CUSTOM_TOKEN = 'https://blog.cow.fi/how-to-add-custom-tokens-on-cow-swap-a72d677c78c0'
+export const LINK_GUIDE_ADD_CUSTOM_TOKEN = 'https://cow.fi/learn/how-to-add-custom-tokens-on-cow-swap'
 export const MY_ORDERS_ID = 'my-orders'
 
 export const MEDIA_WIDTHS = {


### PR DESCRIPTION
Currently, we are using a link to the https://blog.cow.fi/how-to-add-custom-tokens-on-cow-swap-a72d677c78c0
The current changes update the link to https://cow.fi/learn/how-to-add-custom-tokens-on-cow-swap


**Steps**:
1. Open the app https://swap-dev-git-update-add-custom-token-link-cowswap.vercel.app/
2. Open token list in the sell/buy field
3. search for any token
4. Check the link in the banner
![image](https://github.com/user-attachments/assets/6033078c-4b3f-4c84-ad56-012ba8f1254c)

**AR**: it should navigate to https://cow.fi/learn/how-to-add-custom-tokens-on-cow-swap



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
  - Updated the guidance link for adding custom tokens, directing users to a revised learning page.
