### PR TITLE
feat(protocol-fees): turn on protocol fees on Base

### DIFF
--- a/apps/cowswap-frontend/src/modules/volumeFee/state/cowswapFeeAtom.ts
+++ b/apps/cowswap-frontend/src/modules/volumeFee/state/cowswapFeeAtom.ts
@@ -16,7 +16,10 @@ const COWSWAP_VOLUME_FEES: Record<SupportedChainId, VolumeFee | null> = {
     bps: 10, // 0.1%
     recipient: '0x451100Ffc88884bde4ce87adC8bB6c7Df7fACccd', // Arb1 Protocol fee safe
   },
-  [SupportedChainId.BASE]: null,
+  [SupportedChainId.BASE]: {
+    bps: 10, // 0.1%
+    recipient: '0x3c4DBcCf8d80D3d92B0d82197aebf52574ED1F3B', // Base Protocol fee safe
+  },
   [SupportedChainId.GNOSIS_CHAIN]: {
     bps: 10, // 0.1%
     recipient: '0x6b3214fD11dc91De14718DeE98Ef59bCbFcfB432', // Gnosis Chain Protocol fee safe

--- a/libs/common-const/src/tokens.ts
+++ b/libs/common-const/src/tokens.ts
@@ -511,8 +511,6 @@ const MAINNET_STABLECOINS = [
   sUSD_MAINNET.address,
 ].map((t) => t.toLowerCase())
 
-// NOTE: whenever this list is updated, make sure to update the docs section regarding the volume fees
-// https://github.com/cowprotocol/docs/blob/main/docs/governance/fees/fees.md?plain=1#L40
 const GNOSIS_CHAIN_STABLECOINS = [
   SDAI_GNOSIS_CHAIN_ADDRESS,
   NATIVE_CURRENCIES[SupportedChainId.GNOSIS_CHAIN].address, //xDAI
@@ -535,7 +533,6 @@ const ARBITRUM_ONE_STABLECOINS = [
   MIM_ARBITRUM_ONE.address,
 ].map((t) => t.toLowerCase())
 
-// Not used for fees
 const BASE_STABLECOINS = [
   USDC_BASE.address,
   DAI_BASE.address,


### PR DESCRIPTION
# Summary

Turn on protocol volume fee on Base.

# To Test

1. Connect to Base
2. Pick a pair that's not both stables
* Fee (0.1%) should be displayed for all accounts
3. Pick a stable pair
* Fee should not be displayed
4. Check other chains
* No changes to any other chain

## Note

Stablecoins are defined in https://github.com/cowprotocol/cowswap/blob/feat/base-volume-fee/libs/common-const/src/tokens.ts/#L536-L546
~The CMS values are not used for the volume fee AFAICT~
Edit: the CMS values are ALSO used, in combination with the hardcoded stable coins defined above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a fee configuration for Base network transactions with a 0.1% fee and a designated fee recipient.

- **Chores**
  - Cleaned up internal comments related to stablecoin fee documentation for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->