### PR TITLE
fix(wallets): show MM warning only to affected/unknown versions

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/MetamaskTransactionWarning/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/MetamaskTransactionWarning/index.tsx
@@ -114,7 +114,7 @@ function isMetamaskSemverSmallerThanTarget(version: string, target: string): boo
  * Returns true if the wallet is affected, false if it is not
  */
 function useShouldDisplayMetamaskWarning(): boolean {
-  const [isAffected, setIsAffected] = useState<boolean | undefined>(undefined)
+  const [isAffected, setIsAffected] = useState<boolean | undefined>(false)
 
   const isMetamaskBrowserExtension = useIsMetamaskBrowserExtensionWallet()
 

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/MetamaskTransactionWarning/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/MetamaskTransactionWarning/index.tsx
@@ -7,6 +7,7 @@ import { ProviderMetaInfoPayload, WidgetEthereumProvider } from '@cowprotocol/if
 import { InlineBanner } from '@cowprotocol/ui'
 import { METAMASK_RDNS, useIsMetamaskBrowserExtensionWallet } from '@cowprotocol/wallet'
 import { useWalletProvider } from '@cowprotocol/wallet-provider'
+import { ExternalProvider } from '@ethersproject/providers'
 import { Currency } from '@uniswap/sdk-core'
 
 import SVG from 'react-inlinesvg'
@@ -72,7 +73,9 @@ function useWidgetProviderMetaInfo() {
  * Fetch the Metamask version using the method defined in https://docs.metamask.io/wallet/reference/json-rpc-methods/web3_clientversion
  * Returns null if the version could not be fetched
  */
-async function getMetamaskVersion(provider: any): Promise<string | null> {
+async function getMetamaskVersion(provider: ExternalProvider): Promise<string | null> {
+  if (!provider.request) return null
+
   try {
     return await provider.request({
       method: 'web3_clientVersion',

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/MetamaskTransactionWarning/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/MetamaskTransactionWarning/index.tsx
@@ -18,6 +18,10 @@ const Banner = styled(InlineBanner)`
   font-size: 14px;
   text-align: center;
   width: 100%;
+
+  b {
+    display:contents;
+  }
 `
 
 const NetworkInfo = styled.div`
@@ -39,7 +43,7 @@ export function MetamaskTransactionWarning({ sellToken }: { sellToken: Currency 
 
   return (
     <Banner bannerType="danger" iconSize={32}>
-      Issues have been reported with Metamask sending transactions to the wrong chain. Before you sign, please check in
+      Issues have been reported with Metamask sending transactions to the wrong chain on versions prior to <b>v{VERSION_WHERE_BUG_WAS_FIXED}</b>. Before you sign, please check in
       your wallet that the transaction is being sent to the network:{' '}
       <NetworkInfo>
         <SVG src={chainInfo.logo.light} height={24} width={24} /> <span>{chainInfo.label}</span>

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/MetamaskTransactionWarning/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/MetamaskTransactionWarning/index.tsx
@@ -5,7 +5,7 @@ import { getIsNativeToken } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { ProviderMetaInfoPayload, WidgetEthereumProvider } from '@cowprotocol/iframe-transport'
 import { InlineBanner } from '@cowprotocol/ui'
-import { METAMASK_RDNS, useIsMetamaskBrowserExtensionWallet, useWalletDetails } from '@cowprotocol/wallet'
+import { METAMASK_RDNS, useIsMetamaskBrowserExtensionWallet } from '@cowprotocol/wallet'
 import { useWalletProvider } from '@cowprotocol/wallet-provider'
 import { Currency } from '@uniswap/sdk-core'
 
@@ -98,7 +98,7 @@ async function getMetamaskVersion(provider: any): Promise<string | null> {
 }
 
 const SEMVER_REGEX = /\d+\.\d+\.\d+/
-const EXTRACT_SEMVER_REGEX = new RegExp(`/v?(${SEMVER_REGEX.source})`)
+const EXTRACT_SEMVER_REGEX = new RegExp(`/v(${SEMVER_REGEX.source})`)
 
 function extractMetamaskSemver(version: string): string | null {
   const match = version.match(EXTRACT_SEMVER_REGEX)
@@ -132,25 +132,15 @@ function isMetamaskSemverSmallerThanTarget(version: string, target: string): boo
 function useShouldDisplayMetamaskWarning(): boolean {
   const [isAffected, setIsAffected] = useState<boolean | undefined>(undefined)
 
-  const walletDetails = useWalletDetails()
   const isMetamaskBrowserExtension = useIsMetamaskBrowserExtensionWallet()
 
   const widgetProviderMetaInfo = useWidgetProviderMetaInfo()
-  const isMetamaskMobileInjectedBrowser = useIsMetamaskMobileInjectedWallet()
-
-  const isMetamaskViaWalletConnect = METAMASK_WALLET_NAME_REGEX.test(walletDetails.walletName || '')
 
   const isWidgetMetamaskBrowserExtension = widgetProviderMetaInfo?.providerEip6963Info?.rdns === METAMASK_RDNS
-  const isWidgetMetamaskViaWalletConnect = METAMASK_WALLET_NAME_REGEX.test(
-    widgetProviderMetaInfo?.providerWcMetadata?.name || '',
-  )
 
   const isMetamask =
     isMetamaskBrowserExtension ||
-    isMetamaskViaWalletConnect ||
-    isMetamaskMobileInjectedBrowser ||
-    isWidgetMetamaskBrowserExtension ||
-    isWidgetMetamaskViaWalletConnect
+    isWidgetMetamaskBrowserExtension
 
   const provider = useWalletProvider()
 

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/MetamaskTransactionWarning/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/MetamaskTransactionWarning/index.tsx
@@ -94,7 +94,8 @@ async function getMetamaskVersion(provider: ExternalProvider): Promise<string | 
 }
 
 const SEMVER_REGEX = /\d+\.\d+\.\d+/
-const EXTRACT_SEMVER_REGEX = new RegExp(`/v(${SEMVER_REGEX.source})`)
+const EXTRACT_SEMVER_REGEX = new RegExp(`metamask/v(${SEMVER_REGEX.source})`, 'i')
+const METAMASK_EXTENSION_REGEX = /metamask/i
 
 function extractMetamaskSemver(version: string): string | null {
   const match = version.match(EXTRACT_SEMVER_REGEX)
@@ -151,8 +152,16 @@ function useShouldDisplayMetamaskWarning(): { shouldDisplayMetamaskWarning: bool
         setCurrentVersion('')
         return
       }
+      if (!METAMASK_EXTENSION_REGEX.test(version)) {
+        // Not the browser extension, assume the wallet is not affected
+        // MM via SDK on mobile returns this for example: "Geth/v1.14.13-stable-eb00f169/linux-arm64/go1.23.5"
+        setIsAffected(false)
+        setCurrentVersion('')
+        return
+      }
 
       const semver = extractMetamaskSemver(version)
+
       if (!semver) {
         // Invalid version, assume the wallet is affected
         setIsAffected(undefined)

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/MetamaskTransactionWarning/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/MetamaskTransactionWarning/index.tsx
@@ -69,17 +69,6 @@ function useWidgetProviderMetaInfo() {
 }
 
 /**
- * This is hacky way to detect if the wallet is metamask mobile injected wallet
- * Many injected wallet browsers emulate isMetaMask, but only metamask mobile has _metamask
- */
-function useIsMetamaskMobileInjectedWallet(): boolean {
-  const walletProvider = useWalletProvider()
-  const rawProvider = walletProvider?.provider as any
-
-  return Boolean(rawProvider?.isMetaMask && rawProvider._metamask && !rawProvider.isRabby)
-}
-
-/**
  * Fetch the Metamask version using the method defined in https://docs.metamask.io/wallet/reference/json-rpc-methods/web3_clientversion
  * Returns null if the version could not be fetched
  */
@@ -117,9 +106,7 @@ function isMetamaskSemverSmallerThanTarget(version: string, target: string): boo
 
   if (major < targetMajor) return true
   if (major === targetMajor && minor < targetMinor) return true
-  if (major === targetMajor && minor === targetMinor && patch < targetPatch) return true
-
-  return false
+  return major === targetMajor && minor === targetMinor && patch < targetPatch
 }
 
 /**

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/MetamaskTransactionWarning/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/MetamaskTransactionWarning/index.tsx
@@ -12,15 +12,13 @@ import { Currency } from '@uniswap/sdk-core'
 import SVG from 'react-inlinesvg'
 import styled from 'styled-components/macro'
 
-const METAMASK_WALLET_NAME_REGEX = /metamask/i
-
 const Banner = styled(InlineBanner)`
   font-size: 14px;
   text-align: center;
   width: 100%;
 
   b {
-    display:contents;
+    display: contents;
   }
 `
 
@@ -43,8 +41,9 @@ export function MetamaskTransactionWarning({ sellToken }: { sellToken: Currency 
 
   return (
     <Banner bannerType="danger" iconSize={32}>
-      Issues have been reported with Metamask sending transactions to the wrong chain on versions prior to <b>v{VERSION_WHERE_BUG_WAS_FIXED}</b>. Before you sign, please check in
-      your wallet that the transaction is being sent to the network:{' '}
+      Issues have been reported with Metamask sending transactions to the wrong chain on versions prior to{' '}
+      <b>v{VERSION_WHERE_BUG_WAS_FIXED}</b>. Before you sign, please check in your wallet that the transaction is being
+      sent to the network:{' '}
       <NetworkInfo>
         <SVG src={chainInfo.logo.light} height={24} width={24} /> <span>{chainInfo.label}</span>
       </NetworkInfo>
@@ -85,11 +84,10 @@ function useIsMetamaskMobileInjectedWallet(): boolean {
  * Returns null if the version could not be fetched
  */
 async function getMetamaskVersion(provider: any): Promise<string | null> {
-
   try {
     return await provider.request({
-      "method": "web3_clientVersion",
-      "params": [],
+      method: 'web3_clientVersion',
+      params: [],
     })
   } catch (error) {
     console.error('Failed to get Metamask version:', error)
@@ -104,7 +102,6 @@ function extractMetamaskSemver(version: string): string | null {
   const match = version.match(EXTRACT_SEMVER_REGEX)
   return match ? match[1] : null
 }
-
 
 /**
  * Check whether the Metamask version is smaller than the target version
@@ -138,9 +135,7 @@ function useShouldDisplayMetamaskWarning(): boolean {
 
   const isWidgetMetamaskBrowserExtension = widgetProviderMetaInfo?.providerEip6963Info?.rdns === METAMASK_RDNS
 
-  const isMetamask =
-    isMetamaskBrowserExtension ||
-    isWidgetMetamaskBrowserExtension
+  const isMetamask = isMetamaskBrowserExtension || isWidgetMetamaskBrowserExtension
 
   const provider = useWalletProvider()
 


### PR DESCRIPTION
# Summary

Show Metamask ETH warning only for MM version prior to `12.10.4`

According to MM, about 30% of wallets still are in a potentially affected version.
Of those, under 10% are active wallets.

This change checks the MM version and displays the warning now only for the wallets potentially affected.

Also, warning msg was updated to include the fix version.
![image](https://github.com/user-attachments/assets/07c706b3-5123-483b-bb6d-923ac3f05328)

# To Test

1. Pick ETH as sell or make a Wrapping selection
2. Connect with MM in a version 12.10.4 or later
* Should not see wallet warning
3. Connect with MM in a version prior to 12.10.4
* Should see the warning above
4. Connect with a non-metamask wallet
* Should not see wallet warning
5. Connect using MM mobile (inner browser of via WC)
* Should not see wallet warning

*Note*: ~I did not try with mobile. Also, I need to confirm with MM whether they follow the same versioning as the extension.~
_Edit 1_: MM confirmed the versioning is different and mobile wasn't affected. ~Will need to filter out mobile.~ Mobile MM is excluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated transaction warnings now display wallet version details, giving users clearer guidance when their Metamask wallet might be affected by known issues.

- **Refactor**
  - Enhanced the underlying logic for detecting wallet compatibility, resulting in more accurate and maintainable checks for potential transaction problems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->