### PR TITLE
Fix: `Arbitrum` logo theme independent when used together token image

### DIFF
--- a/apps/cowswap-frontend/src/modules/tokensList/hooks/useChainsToSelect.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/hooks/useChainsToSelect.ts
@@ -27,7 +27,7 @@ function mapChainInfo(chainId: number, info: BaseChainInfo): ChainInfo {
     blockExplorer: info.explorer,
     logoUrl: {
       light: info.logo.light,
-      dark: info.logo.light,
+      dark: info.logo.dark,
     },
     mainColor: info.color,
   }

--- a/libs/common-const/src/chainInfo.ts
+++ b/libs/common-const/src/chainInfo.ts
@@ -1,4 +1,5 @@
 import ArbitrumOneLogoLight from '@cowprotocol/assets/cow-swap/network-arbitrum-one-logo-blue.svg'
+import ArbitrumOneLogoDark from '@cowprotocol/assets/cow-swap/network-arbitrum-one-logo-white.svg'
 import BaseLogo from '@cowprotocol/assets/cow-swap/network-base-logo.svg'
 import GnosisChainLogo from '@cowprotocol/assets/cow-swap/network-gnosis-chain-logo.svg'
 import EthereumLogo from '@cowprotocol/assets/cow-swap/network-mainnet-logo.svg'
@@ -51,7 +52,7 @@ export const CHAIN_INFO: ChainInfoMap = {
     name: 'arbitrum_one',
     explorerTitle: 'Arbiscan',
     urlAlias: 'arb1',
-    logo: { light: ArbitrumOneLogoLight, dark: ArbitrumOneLogoLight },
+    logo: { light: ArbitrumOneLogoLight, dark: ArbitrumOneLogoDark },
     color: '#1B4ADD',
     nativeCurrency: NATIVE_CURRENCIES[SupportedChainId.ARBITRUM_ONE],
   },

--- a/libs/common-const/src/chainInfo.ts
+++ b/libs/common-const/src/chainInfo.ts
@@ -1,5 +1,4 @@
 import ArbitrumOneLogoLight from '@cowprotocol/assets/cow-swap/network-arbitrum-one-logo-blue.svg'
-import ArbitrumOneLogoDark from '@cowprotocol/assets/cow-swap/network-arbitrum-one-logo-white.svg'
 import BaseLogo from '@cowprotocol/assets/cow-swap/network-base-logo.svg'
 import GnosisChainLogo from '@cowprotocol/assets/cow-swap/network-gnosis-chain-logo.svg'
 import EthereumLogo from '@cowprotocol/assets/cow-swap/network-mainnet-logo.svg'
@@ -52,7 +51,7 @@ export const CHAIN_INFO: ChainInfoMap = {
     name: 'arbitrum_one',
     explorerTitle: 'Arbiscan',
     urlAlias: 'arb1',
-    logo: { light: ArbitrumOneLogoLight, dark: ArbitrumOneLogoDark },
+    logo: { light: ArbitrumOneLogoLight, dark: ArbitrumOneLogoLight },
     color: '#1B4ADD',
     nativeCurrency: NATIVE_CURRENCIES[SupportedChainId.ARBITRUM_ONE],
   },

--- a/libs/tokens/src/hooks/tokens/useNetworkLogo.ts
+++ b/libs/tokens/src/hooks/tokens/useNetworkLogo.ts
@@ -3,9 +3,9 @@ import { useMemo } from 'react'
 
 import { getChainInfo } from '@cowprotocol/common-const'
 import { useFeatureFlags, useTheme } from '@cowprotocol/common-hooks'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import { environmentAtom } from '../../state/environmentAtom'
-
 export function useNetworkLogo(chainId?: number) {
   const { bridgeNetworkInfo } = useAtomValue(environmentAtom)
   const theme = useTheme()
@@ -18,7 +18,8 @@ export function useNetworkLogo(chainId?: number) {
 
     const chainInfo = getChainInfo(chainId)
 
-    if (chainInfo?.name === 'arbitrum_one') {
+    // Always use light (blue) logo for Arbitrum to ensure visibility against white backgrounds
+    if (chainId === SupportedChainId.ARBITRUM_ONE) {
       return chainInfo.logo.light
     }
 

--- a/libs/tokens/src/hooks/tokens/useNetworkLogo.ts
+++ b/libs/tokens/src/hooks/tokens/useNetworkLogo.ts
@@ -16,7 +16,13 @@ export function useNetworkLogo(chainId?: number) {
       return undefined
     }
 
-    return theme.darkMode ? getChainInfo(chainId)?.logo?.dark : getChainInfo(chainId)?.logo?.light
+    const chainInfo = getChainInfo(chainId)
+
+    if (chainInfo?.name === 'arbitrum_one') {
+      return chainInfo.logo.light
+    }
+
+    return theme.darkMode ? chainInfo?.logo?.dark : chainInfo?.logo?.light
   }, [chainId, theme.darkMode])
 
   if (!chainId || !isBridgingEnabled) return undefined


### PR DESCRIPTION
# Summary

We are using 2 versions of Arbitrum logo, one in blue and the other in white. The white one is not visible when applied on a white background, hence we're going to use only the blue one when displayed with a token image.

<img width="486" alt="Screenshot 2025-03-19 at 16 48 23" src="https://github.com/user-attachments/assets/ba3d1459-be8e-45ba-8b6a-e08c65b3187c" />

<img width="482" alt="Screenshot 2025-03-19 at 16 48 31" src="https://github.com/user-attachments/assets/25ce0326-167b-473e-99df-11c6eda31b81" />


# To Test

1. Open the token list selector

- [ ] Select `Arbitrum` chain, light theme
- [ ] Verify the chain logo is visible (should be in blue, both chain selector and token chain image)
- [ ] Select dark theme
- [ ] Verify the chain logo is visible (should be in white in chain selector and blue in token chain image)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected logo display in dark mode to ensure the appropriate dark-themed asset appears.
  - Enhanced network logo logic to conditionally display the light version for the ARBITRUM_ONE chain, improving visibility against white backgrounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->