### PR TITLE
fix: add period to Fills at tooltip

### DIFF
--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrderFillsAt/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrderFillsAt/index.tsx
@@ -159,7 +159,7 @@ export function OrderFillsAt({
                   <TokenAmount amount={executionPriceInverted} tokenSymbol={executionPriceInverted?.quoteCurrency} />
                 </b>
                 , {priceDiffs.percentage.toFixed(2)}% from market) and is expected to{' '}
-                {!percentIsAlmostHundred(filledPercentDisplay) ? 'partially' : ''} fill soon
+                {!percentIsAlmostHundred(filledPercentDisplay) ? 'partially' : ''} fill soon.
                 <styledEl.ExecuteInformationTooltipWarning>
                   This price is taken from external sources and may not accurately reflect the current on-chain price.
                 </styledEl.ExecuteInformationTooltipWarning>


### PR DESCRIPTION
# Summary

Adds  a missing period into the 'Fills at' tooltip when a price is close to the market one. 

**Steps**: 
1. Place a limit order at a market price (or 1% below it)
2. While the order i in the Open state, hover a mouse on the 'Pending execution' test 'Fills at' column

**AR**: there should be a period in the end of the 1st sentence. 
![period](https://github.com/user-attachments/assets/8632baa4-d2aa-4371-adbe-1837ccbafd58)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Refined tooltip messaging by adding a period to enhance readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->