### PR TITLE
fix(swap): reset recipient when turn off settings

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/hooks/useSwapSettings.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useSwapSettings.ts
@@ -4,6 +4,8 @@ import { useMemo } from 'react'
 
 import { StatefulValue } from '@cowprotocol/types'
 
+import { useUpdateSwapRawState } from './useUpdateSwapRawState'
+
 import { updateSwapSettingsAtom, swapSettingsAtom } from '../state/swapSettingsAtom'
 
 export function useSwapSettings() {
@@ -23,9 +25,18 @@ export function useSwapDeadlineState(): StatefulValue<number> {
 export function useSwapRecipientToggleState(): StatefulValue<boolean> {
   const updateState = useSetAtom(updateSwapSettingsAtom)
   const settings = useSwapSettings()
+  const updateSwapRawState = useUpdateSwapRawState()
 
   return useMemo(
-    () => [settings.showRecipient, (showRecipient: boolean) => updateState({ showRecipient })],
-    [settings.showRecipient, updateState],
+    () => [
+      settings.showRecipient,
+      (showRecipient: boolean) => {
+        updateState({ showRecipient })
+        if (!showRecipient) {
+          updateSwapRawState({ recipient: undefined, recipientAddress: undefined })
+        }
+      },
+    ],
+    [settings.showRecipient, updateState, updateSwapRawState],
   )
 }


### PR DESCRIPTION
# Summary

Fixes #5537

We didn't reset recipient address after turning off the option in settings!

# To Test

1. Set a custom recipient in Swap
2. Try to swap
- [ ] you should see the specified recipient in order while signing
3. Cancel order signing and go back to Swap
4. Keep the entered recipient in the input
5. Disable custom recipient option in settings
6. Try to swap again
- [ ] order should not contain a custom recipient while signing