### PR TITLE
chore: ethflow contracts

### DIFF
--- a/libs/common-const/src/common.ts
+++ b/libs/common-const/src/common.ts
@@ -1,4 +1,5 @@
-import { SupportedChainId, mapSupportedNetworks } from '@cowprotocol/cow-sdk'
+import { ethFlowBarnJson, ethFlowProdJson } from '@cowprotocol/abis'
+import { mapSupportedNetworks, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { Fraction, Percent } from '@uniswap/sdk-core'
 
 import BigNumber from 'bignumber.js'
@@ -38,8 +39,8 @@ export const APP_TITLE = 'CoW Swap | The smartest way to trade cryptocurrencies'
 type Env = 'barn' | 'prod'
 
 const NEW_COWSWAP_ETHFLOW_CONTRACT_ADDRESS: Record<Env, string> = {
-  prod: '0xba3cb449bd2b4adddbc894d8697f5170800eadec',
-  barn: '0x04501b9b1d52e67f6862d157e00d13419d2d6e95',
+  prod: ethFlowProdJson['CoWSwapEthFlow']['1'].address, // Now all chains have the same address
+  barn: ethFlowBarnJson['CoWSwapEthFlow']['1'].address,
 }
 
 export function getEthFlowContractAddresses(env: Env): string {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@cowprotocol/contracts": "^1.3.1",
     "@cowprotocol/cow-runner-game": "^0.2.9",
     "@cowprotocol/cow-sdk": "^5.10.0-RC.0",
-    "@cowprotocol/ethflowcontract": "cowprotocol/ethflowcontract.git#main-artifacts",
+    "@cowprotocol/ethflowcontract": "cowprotocol/ethflowcontract.git#v1.3.0-artifacts",
     "@davatar/react": "1.8.1",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2439,9 +2439,9 @@
     graphql-request "^4.3.0"
     limiter "^2.1.0"
 
-"@cowprotocol/ethflowcontract@cowprotocol/ethflowcontract.git#main-artifacts":
+"@cowprotocol/ethflowcontract@cowprotocol/ethflowcontract.git#v1.3.0-artifacts":
   version "1.3.0"
-  resolved "https://codeload.github.com/cowprotocol/ethflowcontract/tar.gz/ed75d811aba0e18aa80e949cbc979d34ab7fd9ee"
+  resolved "https://codeload.github.com/cowprotocol/ethflowcontract/tar.gz/696a57d9a6e356b50caa74022fad8ecb1b10af06"
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"


### PR DESCRIPTION
# Summary

Use ethflow contracts from contracts repo instead of hardcoded.
No functional changes.

# To Test

1. Barn addresses should remain `0x04501b9b1d52e67f6862d157e00d13419d2d6e95` on all chains
2. Prod addresses should remain `0xba3cb449bd2b4adddbc894d8697f5170800eadec` on all chains

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced dynamic management of configuration values for environment settings.
  
- **Chores**
  - Upgraded a key dependency to a specific stable release, improving overall reliability and predictability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->