### PR TITLE
chore: add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviwers:
+      - "cowprotocol/frontend"
+    commit-message:
+      prefix: "fix(deps-update): "
+      prefix-development: "chore(dev-deps-update): "
+    groups:
+      dev-deps:
+        dependency-type: "development"
+      # uncomment if we decide that production updates can be grouped
+      #prod-deps:
+      #  dependency-type: "production"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviwers:
+    reviewers:
       - "cowprotocol/frontend"
     commit-message:
       prefix: "fix(deps-update): "


### PR DESCRIPTION
# Summary

Add dependabot file for controlling auto-update management

Reference: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#about-the-dependabotyml-file

Notes:
- Starting with a `daily` update cycle is recommended. Once we get our outdated packages under control, move to weekly.
- Grouping dev dependency updates into a single PR. We care less about these kind of updates, and it has a smaller impact
- Grouping for prod dependency updates is commented out. Not sure we want to enable it even though it's more convenient.

# To Test

Only after deployed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Introduced automated dependency update management for npm packages. Daily checks ensure that dependencies remain current, with improved grouping for development packages and designated reviews to streamline maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->