### PR TITLE
fix(bridge): ignore buy token selection when bridging is not enabled

### DIFF
--- a/apps/cowswap-frontend/src/modules/tokensList/hooks/useOpenTokenSelectWidget.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/hooks/useOpenTokenSelectWidget.ts
@@ -1,6 +1,8 @@
 import { useCallback } from 'react'
 
 import { LpToken, TokenWithLogo } from '@cowprotocol/common-const'
+import { useIsBridgingEnabled } from '@cowprotocol/common-hooks'
+import { useIsSmartContractWallet } from '@cowprotocol/wallet'
 import { Currency } from '@uniswap/sdk-core'
 
 import { Nullish } from 'types'
@@ -18,10 +20,13 @@ export function useOpenTokenSelectWidget(): (
 ) => void {
   const updateSelectTokenWidget = useUpdateSelectTokenWidgetState()
   const closeTokenSelectWidget = useCloseTokenSelectWidget()
+  const isSmartContractWallet = useIsSmartContractWallet()
+  const isBridgingEnabled = useIsBridgingEnabled(isSmartContractWallet)
 
   return useCallback(
     (selectedToken, field, oppositeToken, onSelectToken) => {
-      const selectedTargetChainId = field === Field.OUTPUT && selectedToken ? selectedToken.chainId : undefined
+      const selectedTargetChainId =
+        field === Field.OUTPUT && selectedToken && isBridgingEnabled ? selectedToken.chainId : undefined
 
       updateSelectTokenWidget({
         selectedToken,
@@ -35,6 +40,6 @@ export function useOpenTokenSelectWidget(): (
         },
       })
     },
-    [closeTokenSelectWidget, updateSelectTokenWidget],
+    [closeTokenSelectWidget, updateSelectTokenWidget, isBridgingEnabled],
   )
 }


### PR DESCRIPTION
# Summary

Fixes https://github.com/cowprotocol/cowswap/issues/5559

# To Test

1. Open buy token selector
2. Change network
* Token list should be displayed

Bridging feature flag must be OFF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced token selection behavior: The token interface now conditionally displays target chain options based on live bridging support, improving the experience for users operating with smart contract wallets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->