### PR TITLE
chore: fix app crash in getIsNativeToken

### DIFF
--- a/libs/common-utils/src/getIsNativeToken.ts
+++ b/libs/common-utils/src/getIsNativeToken.ts
@@ -16,6 +16,8 @@ export function getIsNativeToken(chainIdOrTokenParams: SupportedChainId | Curren
   if (typeof chainIdOrTokenParams === 'number') {
     const nativeToken = NATIVE_CURRENCIES[chainIdOrTokenParams as SupportedChainId]
 
+    if (!nativeToken) return false
+
     return doesTokenMatchSymbolOrAddress(nativeToken, _tokenId)
   }
 


### PR DESCRIPTION
# Summary
Fixes the crash when pick a token from a different chain
1. isBridgingEnabled flag is ON
2. open the app
3. pick a token from a different chain in the Buy field
![image](https://github.com/user-attachments/assets/400b5d8a-49ae-46a8-a013-470ec5270fda)
