### PR TITLE
fix(trade): remove link from trade mode dropdown button

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidgetLinks/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidgetLinks/index.tsx
@@ -119,10 +119,10 @@ export function TradeWidgetLinks({ isDropdown = false }: TradeWidgetLinksProps) 
         onClick={() => !singleMenuItem && setDropdownVisible(!isDropdownVisible)}
         isDropdownVisible={isDropdownVisible}
       >
-        <styledEl.Link to={selectedMenuItem.props.routePath || '#'}>
+        <styledEl.DropdownButton>
           {selectedMenuItem.props.item.label}
           {!singleMenuItem ? <SVG src={IMAGE_CARET} title="select" /> : null}
-        </styledEl.Link>
+        </styledEl.DropdownButton>
       </styledEl.MenuItem>
 
       {isDropdownVisible && (

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidgetLinks/styled.ts
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidgetLinks/styled.ts
@@ -3,19 +3,7 @@ import { Badge, UI } from '@cowprotocol/ui'
 import { NavLink } from 'react-router-dom'
 import styled, { css } from 'styled-components/macro'
 
-export const Link = styled(NavLink)`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-decoration: none;
-  color: inherit;
-  gap: 4px;
-  font-weight: inherit;
-  line-height: 1;
-  transition:
-    color var(${UI.ANIMATION_DURATION}) ease-in-out,
-    fill var(${UI.ANIMATION_DURATION}) ease-in-out;
-
+const ItemWithIcon = css`
   svg {
     width: 10px;
     height: 10px;
@@ -40,6 +28,36 @@ export const Link = styled(NavLink)`
   svg > path {
     fill: currentColor;
   }
+`
+
+export const Link = styled(NavLink)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  color: inherit;
+  gap: 4px;
+  font-weight: inherit;
+  line-height: 1;
+  transition:
+    color var(${UI.ANIMATION_DURATION}) ease-in-out,
+    fill var(${UI.ANIMATION_DURATION}) ease-in-out;
+
+  ${ItemWithIcon};
+`
+
+export const DropdownButton = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  color: inherit;
+  gap: 4px;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 5px 10px;
+
+  ${ItemWithIcon};
 `
 
 export const Wrapper = styled.div`


### PR DESCRIPTION
# Summary

Fixes #5567

The dropdown button is a router link and for some reason in Coinbase dapp browser it causes navigation.
To fix that I just made it div instead of a.

<img width="1207" alt="image" src="https://github.com/user-attachments/assets/a7ee147d-a809-4105-ae2a-5868fcab4c22" />

# To Test

See #5567


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The trade widget now displays a dropdown button instead of a navigational link when the menu is active, offering a more interactive element.
  
- **Style**
	- Updated component styling with a reusable icon mixin for consistent SVG presentation and smoother transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->