### PR TITLE
Fix/5379 page name not updating

### DIFF
--- a/apps/cowswap-frontend/src/modules/application/containers/PageTitle/index.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/PageTitle/index.tsx
@@ -8,7 +8,8 @@ type PageTitleProps = {
 
 export function PageTitle({ title }: PageTitleProps) {
   return (
-    <Helmet>
+    <Helmet defer={false}>
+      <meta charSet="utf-8" />
       <title>
         {title ? `${title} - ` : ''}
         {APP_TITLE}

--- a/apps/cowswap-frontend/src/pages/Account/Tokens/TokensOverview.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/Tokens/TokensOverview.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState, useCallback, useRef, ChangeEventHandler } from 'react'
 
 import { useTokensBalances } from '@cowprotocol/balances-and-allowances'
-import { TokenWithLogo } from '@cowprotocol/common-const'
+import { PAGE_TITLES, TokenWithLogo } from '@cowprotocol/common-const'
 import { useTheme, useDebounce, useOnClickOutside, usePrevious } from '@cowprotocol/common-hooks'
 import { isAddress, isTruthy } from '@cowprotocol/common-utils'
 import { useTokensByAddressMap, useFavoriteTokens, useResetFavoriteTokens } from '@cowprotocol/tokens'
@@ -205,7 +205,7 @@ export default function TokensOverview() {
         </AccountHeading>
       )}
       <Overview>
-        <PageTitle title="Tokens Overview" />
+        <PageTitle title={PAGE_TITLES.TOKENS_OVERVIEW} />
 
         {isProviderNetworkUnsupported ? 'Unsupported network' : renderTableContent()}
       </Overview>

--- a/apps/cowswap-frontend/src/pages/Account/index.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/index.tsx
@@ -1,5 +1,7 @@
 import { lazy, Suspense } from 'react'
 
+import { PAGE_TITLES } from '@cowprotocol/common-const'
+
 import { useLocation, Outlet } from 'react-router-dom'
 
 import { Loading } from 'legacy/components/FlashingLoading'
@@ -36,7 +38,7 @@ export const AccountOverview = () => {
   return (
     <>
       <Container>
-        <PageTitle title="Account Overview" />
+        <PageTitle title={PAGE_TITLES.ACCOUNT_OVERVIEW} />
         <CardsWrapper>
           <Balances />
           <Governance />

--- a/apps/cowswap-frontend/src/pages/AdvancedOrders/index.tsx
+++ b/apps/cowswap-frontend/src/pages/AdvancedOrders/index.tsx
@@ -1,5 +1,7 @@
 import { useAtomValue } from 'jotai'
 
+import { PAGE_TITLES } from '@cowprotocol/common-const'
+
 import { OrderStatus } from 'legacy/state/orders/actions'
 
 import {
@@ -46,7 +48,7 @@ export default function AdvancedOrdersPage() {
 
   return (
     <>
-      <PageTitle title="TWAP" />
+      <PageTitle title={PAGE_TITLES.ADVANCED} />
       <FillAdvancedOrdersDerivedStateUpdater slippage={twapSlippage} />
       <SetupAdvancedOrderAmountsFromUrlUpdater />
       <styledEl.PageWrapper

--- a/apps/cowswap-frontend/src/pages/AdvancedOrders/index.tsx
+++ b/apps/cowswap-frontend/src/pages/AdvancedOrders/index.tsx
@@ -8,6 +8,7 @@ import {
   FillAdvancedOrdersDerivedStateUpdater,
   SetupAdvancedOrderAmountsFromUrlUpdater,
 } from 'modules/advancedOrders'
+import { PageTitle } from 'modules/application/containers/PageTitle'
 import { useInjectedWidgetParams } from 'modules/injectedWidget'
 import { limitOrdersSettingsAtom } from 'modules/limitOrders/state/limitOrdersSettingsAtom'
 import { OrdersTableWidget, TabOrderTypes } from 'modules/ordersTable'
@@ -45,6 +46,7 @@ export default function AdvancedOrdersPage() {
 
   return (
     <>
+      <PageTitle title="TWAP" />
       <FillAdvancedOrdersDerivedStateUpdater slippage={twapSlippage} />
       <SetupAdvancedOrderAmountsFromUrlUpdater />
       <styledEl.PageWrapper

--- a/apps/cowswap-frontend/src/pages/Hooks/index.tsx
+++ b/apps/cowswap-frontend/src/pages/Hooks/index.tsx
@@ -1,9 +1,13 @@
+import { PAGE_TITLES } from '@cowprotocol/common-const'
+
+import { PageTitle } from 'modules/application/containers/PageTitle'
 import { HooksStoreWidget } from 'modules/hooksStore'
 import { SwapUpdaters } from 'modules/swap'
 
 export function HooksPage() {
   return (
     <>
+      <PageTitle title={PAGE_TITLES.HOOKS} />
       <SwapUpdaters />
       <HooksStoreWidget />
     </>

--- a/apps/cowswap-frontend/src/pages/LimitOrders/index.tsx
+++ b/apps/cowswap-frontend/src/pages/LimitOrders/index.tsx
@@ -1,6 +1,7 @@
 import { percentToBps } from '@cowprotocol/common-utils'
 
 import { AppDataUpdater } from 'modules/appData'
+import { PageTitle } from 'modules/application/containers/PageTitle'
 import {
   AlternativeLimitOrderUpdater,
   ExecutionPriceUpdater,
@@ -39,6 +40,7 @@ export default function LimitOrderPage() {
           <RegularLimitOrders />
         </>
       )}
+      <PageTitle title={'Limit Order'} />
     </>
   )
 }

--- a/apps/cowswap-frontend/src/pages/LimitOrders/index.tsx
+++ b/apps/cowswap-frontend/src/pages/LimitOrders/index.tsx
@@ -1,3 +1,4 @@
+import { PAGE_TITLES } from '@cowprotocol/common-const'
 import { percentToBps } from '@cowprotocol/common-utils'
 
 import { AppDataUpdater } from 'modules/appData'
@@ -40,7 +41,7 @@ export default function LimitOrderPage() {
           <RegularLimitOrders />
         </>
       )}
-      <PageTitle title={'Limit Order'} />
+      <PageTitle title={PAGE_TITLES.LIMIT_ORDERS} />
     </>
   )
 }

--- a/apps/cowswap-frontend/src/pages/Swap/index.tsx
+++ b/apps/cowswap-frontend/src/pages/Swap/index.tsx
@@ -3,6 +3,7 @@ import { useWalletInfo } from '@cowprotocol/wallet'
 
 import { Navigate, useLocation, useParams } from 'react-router-dom'
 
+import { PageTitle } from 'modules/application/containers/PageTitle'
 import { SwapUpdaters, SwapWidget } from 'modules/swap'
 import { getDefaultTradeRawState } from 'modules/trade/types/TradeRawState'
 import { parameterizeTradeRoute } from 'modules/trade/utils/parameterizeTradeRoute'
@@ -18,6 +19,7 @@ export function SwapPage() {
 
   return (
     <>
+      <PageTitle title={'Swap'} />
       <SwapUpdaters />
       <SwapWidget />
     </>

--- a/apps/cowswap-frontend/src/pages/Swap/index.tsx
+++ b/apps/cowswap-frontend/src/pages/Swap/index.tsx
@@ -1,4 +1,4 @@
-import { WRAPPED_NATIVE_CURRENCIES as WETH } from '@cowprotocol/common-const'
+import { PAGE_TITLES, WRAPPED_NATIVE_CURRENCIES as WETH } from '@cowprotocol/common-const'
 import { useWalletInfo } from '@cowprotocol/wallet'
 
 import { Navigate, useLocation, useParams } from 'react-router-dom'
@@ -19,7 +19,7 @@ export function SwapPage() {
 
   return (
     <>
-      <PageTitle title={'Swap'} />
+      <PageTitle title={PAGE_TITLES.SWAP} />
       <SwapUpdaters />
       <SwapWidget />
     </>

--- a/apps/cowswap-frontend/src/pages/Yield/index.tsx
+++ b/apps/cowswap-frontend/src/pages/Yield/index.tsx
@@ -1,10 +1,12 @@
+import { PAGE_TITLES } from '@cowprotocol/common-const'
+
 import { PageTitle } from 'modules/application/containers/PageTitle'
 import { YieldWidget, YieldUpdaters } from 'modules/yield'
 
 export default function YieldPage() {
   return (
     <>
-      <PageTitle title={'Yield'} />
+      <PageTitle title={PAGE_TITLES.YIELD} />
       <YieldUpdaters />
       <YieldWidget />
     </>

--- a/apps/cowswap-frontend/src/pages/Yield/index.tsx
+++ b/apps/cowswap-frontend/src/pages/Yield/index.tsx
@@ -1,8 +1,10 @@
+import { PageTitle } from 'modules/application/containers/PageTitle'
 import { YieldWidget, YieldUpdaters } from 'modules/yield'
 
 export default function YieldPage() {
   return (
     <>
+      <PageTitle title={'Yield'} />
       <YieldUpdaters />
       <YieldWidget />
     </>

--- a/apps/cowswap-frontend/src/pages/games/CowRunner/index.tsx
+++ b/apps/cowswap-frontend/src/pages/games/CowRunner/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 
 import { useCowAnalytics } from '@cowprotocol/analytics'
+import { PAGE_TITLES } from '@cowprotocol/common-const'
 import { CowGame } from '@cowprotocol/cow-runner-game'
 
 import styled from 'styled-components/macro'
@@ -48,7 +49,7 @@ export default function CowRunnerPage() {
 
   return (
     <Wrapper>
-      <PageTitle title="CoW Runner" />
+      <PageTitle title={PAGE_TITLES.COW_RUNNER} />
       <p>
         Run! ...and try not getting sandwiched{' '}
         <span role="img" aria-label="sandwich-icon">

--- a/apps/cowswap-frontend/src/pages/games/MevSlicer/index.tsx
+++ b/apps/cowswap-frontend/src/pages/games/MevSlicer/index.tsx
@@ -1,4 +1,5 @@
 import ninjaCowImg from '@cowprotocol/assets/cow-swap/ninja-cow.png'
+import { PAGE_TITLES } from '@cowprotocol/common-const'
 import { ButtonPrimary } from '@cowprotocol/ui'
 
 import styled from 'styled-components/macro'
@@ -50,7 +51,7 @@ function openGame() {
 export default function MevSlicer() {
   return (
     <Wrapper>
-      <PageTitle title="Mev Slicer" />
+      <PageTitle title={PAGE_TITLES.MEV_SLICER} />
       <p>This CoW doesn&apos;t run away any more! Not from MEV!</p>
       <p>
         Now is the time to take some action! -{' '}

--- a/libs/common-const/src/common.ts
+++ b/libs/common-const/src/common.ts
@@ -35,6 +35,17 @@ export const SAFE_APP_CODE = `${DEFAULT_APP_CODE}-SafeApp`
 
 export const APP_TITLE = 'CoW Swap | The smartest way to trade cryptocurrencies'
 
+export const PAGE_TITLES = {
+  SWAP: 'Swap',
+  LIMIT_ORDERS: 'Limit Orders',
+  YIELD: 'Yield',
+  ADVANCED: 'TWAP',
+  ACCOUNT_OVERVIEW: 'Account Overview',
+  TOKENS_OVERVIEW: 'Tokens Overview',
+  COW_RUNNER: 'CoW Runner',
+  MEV_SLICER: 'Mev Slicer',
+}
+
 type Env = 'barn' | 'prod'
 
 const NEW_COWSWAP_ETHFLOW_CONTRACT_ADDRESS: Record<Env, string> = {

--- a/libs/common-const/src/common.ts
+++ b/libs/common-const/src/common.ts
@@ -44,6 +44,7 @@ export const PAGE_TITLES = {
   TOKENS_OVERVIEW: 'Tokens Overview',
   COW_RUNNER: 'CoW Runner',
   MEV_SLICER: 'Mev Slicer',
+  HOOKS: 'Hooks',
 }
 
 type Env = 'barn' | 'prod'


### PR DESCRIPTION
# Summary

Fixes #5379  

This PR fixes the issue where the page title was not updating correctly when navigating between pages. Previously, after navigating from the **Account** page to **Limit Orders**, the title remained as "Account" instead of updating to "Limit Orders".  

# To Test  

1. Open the **Swap** page.  
2. Go to the **Account** page.  
3. Using the app menu, navigate to the **Limit Orders** page.  
   - [ ] Verify that the page title updates correctly to "Limit Orders".  

# Background  

The issue occurred because the document title was not re-rendering on navigation changes. This fix ensures that the title dynamically updates based on the current page.  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced document header configuration with improved metadata for better browser compatibility.
  - Standardized page titles across various sections (Account, Tokens, Orders, Swap, Yield, and Games) by centralizing title management for a consistent and easily updatable user experience.
  - Added a new title for the Hooks page, improving the user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->