### PR TITLE
fix: remove irrelevant link from cancellation modal

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/CancellationModal/RequestCancellationModal.tsx
+++ b/apps/cowswap-frontend/src/common/pure/CancellationModal/RequestCancellationModal.tsx
@@ -2,19 +2,17 @@ import React, { useCallback, useState } from 'react'
 
 import { TokenWithLogo } from '@cowprotocol/common-const'
 import { Command } from '@cowprotocol/types'
-import { TokenAmount, ButtonPrimary } from '@cowprotocol/ui'
-import { UI } from '@cowprotocol/ui'
+import { ButtonPrimary, TokenAmount, UI } from '@cowprotocol/ui'
 import type { BigNumber } from '@ethersproject/bignumber'
 import { CurrencyAmount } from '@uniswap/sdk-core'
 
-import { ArrowRight, ArrowLeft } from 'react-feather'
+import { ArrowLeft, ArrowRight } from 'react-feather'
 import styled from 'styled-components/macro'
 import { LinkStyledButton } from 'theme'
 
 import NotificationBanner from 'legacy/components/NotificationBanner'
 import { LegacyConfirmationModalContent } from 'legacy/components/TransactionConfirmationModal/LegacyConfirmationModalContent'
 
-import { Routes } from 'common/constants/routes'
 import { CancellationType } from 'common/hooks/useCancelOrder/state'
 
 export type RequestCancellationModalProps = {
@@ -139,7 +137,7 @@ export function RequestCancellationModal(props: RequestCancellationModalProps): 
               </p>
               <p>
                 Keep in mind a solver might already have included the order in a solution even if this cancellation is
-                successful. 
+                successful.
                 {isOnChainType && (
                   <StyledNotificationBanner isVisible={true} canClose={false} level="INFO">
                     <div>

--- a/apps/cowswap-frontend/src/common/pure/CancellationModal/RequestCancellationModal.tsx
+++ b/apps/cowswap-frontend/src/common/pure/CancellationModal/RequestCancellationModal.tsx
@@ -140,11 +140,7 @@ export function RequestCancellationModal(props: RequestCancellationModalProps): 
               </p>
               <p>
                 Keep in mind a solver might already have included the order in a solution even if this cancellation is
-                successful. Read more in the{' '}
-                <HashLink target="_blank" rel="noreferrer" to={`${Routes.FAQ_TRADING}#can-i-cancel-an-order`}>
-                  FAQ
-                </HashLink>
-                .
+                successful. 
                 {isOnChainType && (
                   <StyledNotificationBanner isVisible={true} canClose={false} level="INFO">
                     <div>

--- a/apps/cowswap-frontend/src/common/pure/CancellationModal/RequestCancellationModal.tsx
+++ b/apps/cowswap-frontend/src/common/pure/CancellationModal/RequestCancellationModal.tsx
@@ -8,7 +8,6 @@ import type { BigNumber } from '@ethersproject/bignumber'
 import { CurrencyAmount } from '@uniswap/sdk-core'
 
 import { ArrowRight, ArrowLeft } from 'react-feather'
-// import { HashLink } from 'react-router-hash-link'
 import styled from 'styled-components/macro'
 import { LinkStyledButton } from 'theme'
 
@@ -141,11 +140,6 @@ export function RequestCancellationModal(props: RequestCancellationModalProps): 
               <p>
                 Keep in mind a solver might already have included the order in a solution even if this cancellation is
                 successful. 
-                // Read more in the{' '}
-                // <HashLink target="_blank" rel="noreferrer" to={`${Routes.FAQ_TRADING}#can-i-cancel-an-order`}>
-                //  FAQ
-                // </HashLink>
-                // .
                 {isOnChainType && (
                   <StyledNotificationBanner isVisible={true} canClose={false} level="INFO">
                     <div>

--- a/apps/cowswap-frontend/src/common/pure/CancellationModal/RequestCancellationModal.tsx
+++ b/apps/cowswap-frontend/src/common/pure/CancellationModal/RequestCancellationModal.tsx
@@ -8,7 +8,7 @@ import type { BigNumber } from '@ethersproject/bignumber'
 import { CurrencyAmount } from '@uniswap/sdk-core'
 
 import { ArrowRight, ArrowLeft } from 'react-feather'
-import { HashLink } from 'react-router-hash-link'
+// import { HashLink } from 'react-router-hash-link'
 import styled from 'styled-components/macro'
 import { LinkStyledButton } from 'theme'
 
@@ -141,6 +141,11 @@ export function RequestCancellationModal(props: RequestCancellationModalProps): 
               <p>
                 Keep in mind a solver might already have included the order in a solution even if this cancellation is
                 successful. 
+                // Read more in the{' '}
+                // <HashLink target="_blank" rel="noreferrer" to={`${Routes.FAQ_TRADING}#can-i-cancel-an-order`}>
+                //  FAQ
+                // </HashLink>
+                // .
                 {isOnChainType && (
                   <StyledNotificationBanner isVisible={true} canClose={false} level="INFO">
                     <div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2413,7 +2413,7 @@
 
 "@cowprotocol/ethflowcontract@cowprotocol/ethflowcontract.git#main-artifacts":
   version "1.3.0"
-  resolved "https://codeload.github.com/cowprotocol/ethflowcontract/tar.gz/ed75d811aba0e18aa80e949cbc979d34ab7fd9ee"
+  resolved "https://codeload.github.com/cowprotocol/ethflowcontract/tar.gz/9797105dfa25330a2e88cc4180df0fc34cf8fbbd"
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"


### PR DESCRIPTION
# Summary

There is a link to read more in the FAQ on an order cancellation modal. 
However, the link is outdated, and we don't have a relevant article in the knowledge base. 
IMO, it would be nice to remove the link for now. 
[Discussion](https://cowservices.slack.com/archives/C0361CDG8GP/p1743428323525759)

**Steps**: 

1. Open the [app](https://swap-dev-git-remove-irrelevant-link-from-can-73ca83-cowswap-dev.vercel.app/)
2. Connect to a wallet
3. Place any order
4. While the order is Open, call the cancellation modal
5. Expand the modal's text 

![image](https://github.com/user-attachments/assets/ac347752-adc1-42e6-8164-c455cf63b062)

**AR**: there should not be 'read more' link
![image](https://github.com/user-attachments/assets/7fed016d-4059-45c8-ae3d-3fbf370494b7)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
	- Refined the cancellation confirmation message by removing extraneous warning details and associated links, resulting in a clearer, more concise notification for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->