### PR TITLE
fix: do not use RPC node when wallet is connected

### DIFF
--- a/libs/balances-and-allowances/src/hooks/useNativeTokenBalance.ts
+++ b/libs/balances-and-allowances/src/hooks/useNativeTokenBalance.ts
@@ -1,5 +1,4 @@
-import { getRpcProvider } from '@cowprotocol/common-const'
-import { getMulticallContract } from '@cowprotocol/multicall'
+import { getMulticallContract, useMultiCallRpcProvider } from '@cowprotocol/multicall'
 import { BigNumber } from '@ethersproject/bignumber'
 
 import ms from 'ms.macro'
@@ -17,7 +16,7 @@ export function useNativeTokenBalance(
   chainId: number,
   swrConfig: SWRConfiguration = SWR_CONFIG,
 ): SWRResponse<BigNumber> {
-  const provider = getRpcProvider(chainId)
+  const provider = useMultiCallRpcProvider()
 
   return useSWR(
     account && provider ? ['useNativeTokenBalance', account, provider, chainId] : null,

--- a/libs/multicall/src/hooks/useMultiCallRpcProvider.ts
+++ b/libs/multicall/src/hooks/useMultiCallRpcProvider.ts
@@ -12,10 +12,12 @@ export function useMultiCallRpcProvider(): JsonRpcProvider | null {
   const context = useAtomValue(multiCallContextAtom)
 
   return useMemo(() => {
-    if (!context) return null
+    const providerChainId = provider?.network?.chainId
+
+    if (!context || !providerChainId) return null
 
     // Use wallet provider if current network matches the wallet network
-    if (provider?.network?.chainId === context.chainId) {
+    if (providerChainId === context.chainId) {
       return provider
     }
 

--- a/libs/multicall/src/hooks/useMultiCallRpcProvider.ts
+++ b/libs/multicall/src/hooks/useMultiCallRpcProvider.ts
@@ -2,26 +2,25 @@ import { useAtomValue } from 'jotai/index'
 import { useMemo } from 'react'
 
 import { getRpcProvider } from '@cowprotocol/common-const'
-import { useWalletProvider } from '@cowprotocol/wallet-provider'
+import { useWalletChainId, useWalletProvider } from '@cowprotocol/wallet-provider'
 import { JsonRpcProvider } from '@ethersproject/providers'
 
 import { multiCallContextAtom } from '../state/multiCallContextAtom'
 
 export function useMultiCallRpcProvider(): JsonRpcProvider | null {
+  const walletChainId = useWalletChainId()
   const provider = useWalletProvider()
   const context = useAtomValue(multiCallContextAtom)
 
   return useMemo(() => {
-    const providerChainId = provider?.network?.chainId
-
-    if (!context || !providerChainId) return null
+    if (!context || !provider || !walletChainId) return null
 
     // Use wallet provider if current network matches the wallet network
-    if (providerChainId === context.chainId) {
+    if (walletChainId === context.chainId) {
       return provider
     }
 
     // Otherwise use RPC node
     return getRpcProvider(context.chainId)
-  }, [context, provider])
+  }, [context, provider, walletChainId])
 }

--- a/libs/multicall/src/index.ts
+++ b/libs/multicall/src/index.ts
@@ -1,6 +1,7 @@
 export { useSingleContractMultipleData } from './hooks/useSingleContractMultipleData'
 export { useMultipleContractSingleData } from './hooks/useMultipleContractSingleData'
 export { getMulticallContract } from './utils/getMulticallContract'
+export { useMultiCallRpcProvider } from './hooks/useMultiCallRpcProvider'
 export { multiCall } from './multicall'
 export type { MultiCallOptions } from './multicall'
 


### PR DESCRIPTION
# Summary

We noticed an increase in our RPC node consumption.
The issue came recently along with Briding feature.

1. `useNativeTokenBalance()` was always using RPC node
2. `useMultiCallRpcProvider()` could switch to RPC provider when wallet connector is not ready yet (provider?.network?.chainId is undefined)

# To Test

1. Balances and allowance should be updated as before


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an improved provider mechanism accessible through the public API, offering streamlined network interactions for faster and more consistent token balance retrieval. These changes enhance integration and overall user experience.
  
- **Refactor**
  - Simplified the logic for token balance calculation by removing redundant parameters and strengthening network verification, leading to a more robust and reliable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->