### PR TITLE
fix: change links on suplus card and twap form

### DIFF
--- a/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/SurplusCard.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/SurplusCard.tsx
@@ -188,7 +188,7 @@ export function SurplusCard() {
           <small>{surplusUsdAmount && <FiatAmount amount={surplusUsdAmount} accurate={false} />}</small>
         </div>
         <div>
-          <ExternalLink href={'https://blog.cow.fi/announcing-cow-swap-surplus-notifications-f679c77702ea'}>
+          <ExternalLink href={'https://cow.fi/learn/announcing-cow-swap-surplus-notifications'}>
             Learn about surplus on CoW Swap ↗
           </ExternalLink>
         </div>

--- a/apps/cowswap-frontend/src/modules/twap/const.ts
+++ b/apps/cowswap-frontend/src/modules/twap/const.ts
@@ -55,7 +55,7 @@ export const DEFAULT_TWAP_EXECUTION_INFO: TwapOrderExecutionInfo = {
 }
 
 export const UNSUPPORTED_SAFE_LINK =
-  'https://blog.cow.fi/all-you-need-to-know-about-cow-swaps-new-safe-fallback-handler-8ef0439925d1'
+  'https://cow.fi/learn/all-you-need-to-know-about-cow-swap-new-safe-fallback-handler'
 export const UNSUPPORTED_WALLET_LINK =
-  'https://blog.cow.fi/how-to-use-cow-swaps-twap-orders-via-safe-wallet-1a0854484dfb'
-export const TWAP_LEARN_MORE_LINK = 'https://blog.cow.fi/cow-swap-launches-twap-orders-d5583135b472'
+  'https://cow.fi/learn/how-to-use-cow-swap-twap-orders-via-safe-wallet'
+export const TWAP_LEARN_MORE_LINK = 'https://cow.fi/learn/cow-swap-launches-twap-orders'


### PR DESCRIPTION
Currently, there are links that navigate to articles on an external resource. 
This PR changes the navigation links to eponymous articles on cow.fi

**1. Surplus card**
- Connect to a wallet
- Open Account modal
-  Check the link on the Surplus card
![image](https://github.com/user-attachments/assets/a9ed86bc-a8cc-4dda-ae73-a30a1be897ca)
**AR**: should navigate to https://cow.fi/learn/announcing-cow-swap-surplus-notifications

**2. TWAP: unsupported wallet**
 - Open TWAP page
 - connect to any EOA wallet
 - Check 'click here' link
 ![image](https://github.com/user-attachments/assets/be3387fd-7b29-4851-9e9b-6f2cdfdbd90e)

**AR**: should navigate to https://cow.fi/learn/how-to-use-cow-swap-twap-orders-via-safe-wallet

**3. TWAP: Fallback handler is not installed**
 - Create a new Safe, fund it
 - Open TWAP page
 - specify a TWAP order
 - Check 'Learn more' link on the warning 
![image](https://github.com/user-attachments/assets/51112bb0-333e-4fa7-9677-5c24dd9a3254)

**AR**: should navigate to https://cow.fi/learn/all-you-need-to-know-about-cow-swap-new-safe-fallback-handler

**4. TWAP: unlock screen**
 - open the app in incognito mode
 - navigate to TWAP form
 - check the link on the Unlock screen
![image](https://github.com/user-attachments/assets/5e1a7f6c-fea6-4000-96df-2a1b625bd4c4)

**AR**: should navigate to https://cow.fi/learn/cow-swap-launches-twap-orders