### PR TITLE
chore: replace eip2162 with eip2612

### DIFF
--- a/apps/cowswap-frontend/src/modules/permit/hooks/useGeneratePermitHook.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/useGeneratePermitHook.ts
@@ -42,12 +42,12 @@ export function useGeneratePermitHook(): GeneratePermitHook {
         return
       }
 
-      const eip2162Utils = getPermitUtilsInstance(chainId, provider, account)
+      const eip2612Utils = getPermitUtilsInstance(chainId, provider, account)
       const spender = customSpender || COW_PROTOCOL_VAULT_RELAYER_ADDRESS[chainId]
 
       // Always get the nonce for the real account, to know whether the cache should be invalidated
       // Static account should never need to pre-check the nonce as it'll never change once cached
-      const nonce = account ? await eip2162Utils.getTokenNonce(inputToken.address, account) : undefined
+      const nonce = account ? await eip2612Utils.getTokenNonce(inputToken.address, account) : undefined
 
       const permitParams = { chainId, tokenAddress: inputToken.address, account, nonce }
 
@@ -63,7 +63,7 @@ export function useGeneratePermitHook(): GeneratePermitHook {
         spender,
         provider,
         permitInfo,
-        eip2162Utils,
+        eip2612Utils,
         account,
         nonce,
       })

--- a/apps/cowswap-frontend/src/modules/permit/hooks/useGetCachedPermit.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/useGetCachedPermit.ts
@@ -26,11 +26,11 @@ export function useGetCachedPermit(): (
       const spender = customSpender || COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS[chainId]
 
       try {
-        const eip2162Utils = getPermitUtilsInstance(chainId, provider, account)
+        const eip2612Utils = getPermitUtilsInstance(chainId, provider, account)
 
         // Always get the nonce for the real account, to know whether the cache should be invalidated
         // Static account should never need to pre-check the nonce as it'll never change once cached
-        const nonce = account ? await eip2162Utils.getTokenNonce(tokenAddress, account) : undefined
+        const nonce = account ? await eip2612Utils.getTokenNonce(tokenAddress, account) : undefined
 
         const permitParams = { chainId, tokenAddress, account, nonce, spender }
 

--- a/libs/permit-utils/README.md
+++ b/libs/permit-utils/README.md
@@ -43,7 +43,7 @@ const hookData = await generatePermitHook({
   spender,
   provider,
   permitInfo,
-  eip2162Utils,
+  eip2612Utils,
   account,
   nonce
 })
@@ -57,7 +57,7 @@ import { checkIsCallDataAValidPermit } from "@cowprotocol/permit-utils"
 const isCallDataAValidPermit = await checkIsCallDataAValidPermit(
   account,
   chainId,
-  eip2612Utils, 
+  eip2612Utils,
   tokenAddress,
   tokenName,
   callData,
@@ -97,7 +97,7 @@ if (!permitInfo) {
 const eip2612Utils = getPermitUtilsInstance(chainId, provider, account)
 
 // Need to know what the current permit nonce is
-const nonce = await eip2162Utils.getTokenNonce(inputToken.address, account)
+const nonce = await eip2612Utils.getTokenNonce(inputToken.address, account)
 
 // Calling this fn should trigger the signature in the user's wallet
 const hookData = await generatePermitHook({

--- a/libs/permit-utils/src/lib/checkIsCallDataAValidPermit.ts
+++ b/libs/permit-utils/src/lib/checkIsCallDataAValidPermit.ts
@@ -5,7 +5,7 @@ import { PermitInfo } from '../types'
 export async function checkIsCallDataAValidPermit(
   owner: string,
   chainId: number,
-  eip2162Utils: Eip2612PermitUtils,
+  eip2612Utils: Eip2612PermitUtils,
   tokenAddress: string,
   _tokenName: string | undefined,
   callData: string,
@@ -28,7 +28,7 @@ export async function checkIsCallDataAValidPermit(
 
   // If pre-hook doesn't start with either selector, it's not a permit
   if (callData.startsWith(EIP_2612_PERMIT_SELECTOR)) {
-    recoverPermitOwnerPromise = eip2162Utils.recoverPermitOwnerFromCallData({
+    recoverPermitOwnerPromise = eip2612Utils.recoverPermitOwnerFromCallData({
       ...params,
       // I don't know why this was removed, ok?
       // We added it back on buildPermitCallData.ts
@@ -37,7 +37,7 @@ export async function checkIsCallDataAValidPermit(
       callData: callData.replace(EIP_2612_PERMIT_SELECTOR, '0x'),
     })
   } else if (callData.startsWith(DAI_PERMIT_SELECTOR)) {
-    recoverPermitOwnerPromise = eip2162Utils.recoverDaiLikePermitOwnerFromCallData({
+    recoverPermitOwnerPromise = eip2612Utils.recoverDaiLikePermitOwnerFromCallData({
       ...params,
       callData: callData.replace(DAI_PERMIT_SELECTOR, '0x'),
     })

--- a/libs/permit-utils/src/lib/generatePermitHook.ts
+++ b/libs/permit-utils/src/lib/generatePermitHook.ts
@@ -2,7 +2,7 @@ import { JsonRpcProvider } from '@ethersproject/providers'
 
 import { DEFAULT_PERMIT_GAS_LIMIT, DEFAULT_PERMIT_VALUE, PERMIT_SIGNER } from '../const'
 import { PermitHookData, PermitHookParams } from '../types'
-import { buildDaiLikePermitCallData, buildEip2162PermitCallData } from '../utils/buildPermitCallData'
+import { buildDaiLikePermitCallData, buildEip2612PermitCallData } from '../utils/buildPermitCallData'
 import { getPermitDeadline } from '../utils/getPermitDeadline'
 import { isSupportedPermitInfo } from '../utils/isSupportedPermitInfo'
 
@@ -37,7 +37,7 @@ export async function generatePermitHook(params: PermitHookParams): Promise<Perm
 }
 
 async function generatePermitHookRaw(params: PermitHookParams): Promise<PermitHookData> {
-  const { inputToken, spender, chainId, permitInfo, provider, account, eip2162Utils, nonce: preFetchedNonce } = params
+  const { inputToken, spender, chainId, permitInfo, provider, account, eip2612Utils, nonce: preFetchedNonce } = params
 
   const tokenAddress = inputToken.address
   // TODO: remove the need for `name` from input token. Should come from permitInfo instead
@@ -55,15 +55,15 @@ async function generatePermitHookRaw(params: PermitHookParams): Promise<PermitHo
 
   // Only fetch the nonce in case it wasn't pre-fetched before
   // That's the case for static account
-  const nonce = preFetchedNonce === undefined ? await eip2162Utils.getTokenNonce(tokenAddress, owner) : preFetchedNonce
+  const nonce = preFetchedNonce === undefined ? await eip2612Utils.getTokenNonce(tokenAddress, owner) : preFetchedNonce
 
   const deadline = getPermitDeadline()
   const value = DEFAULT_PERMIT_VALUE
 
   const callData =
     permitInfo.type === 'eip-2612'
-      ? await buildEip2162PermitCallData({
-          eip2162Utils,
+      ? await buildEip2612PermitCallData({
+          eip2612Utils,
           callDataParams: [
             {
               owner,
@@ -79,7 +79,7 @@ async function generatePermitHookRaw(params: PermitHookParams): Promise<PermitHo
           ],
         })
       : await buildDaiLikePermitCallData({
-          eip2162Utils,
+          eip2612Utils,
           callDataParams: [
             {
               holder: owner,

--- a/libs/permit-utils/src/lib/getTokenPermitInfo.ts
+++ b/libs/permit-utils/src/lib/getTokenPermitInfo.ts
@@ -6,13 +6,13 @@ import { getPermitUtilsInstance } from './getPermitUtilsInstance'
 
 import { DEFAULT_MIN_GAS_LIMIT, DEFAULT_PERMIT_VALUE, PERMIT_SIGNER } from '../const'
 import { GetTokenPermitInfoParams, GetTokenPermitIntoResult, PermitInfo, PermitType } from '../types'
-import { buildDaiLikePermitCallData, buildEip2162PermitCallData } from '../utils/buildPermitCallData'
+import { buildDaiLikePermitCallData, buildEip2612PermitCallData } from '../utils/buildPermitCallData'
 import { Eip712Domain, getEip712Domain } from '../utils/getEip712Domain'
 import { getPermitDeadline } from '../utils/getPermitDeadline'
 import { getTokenName } from '../utils/getTokenName'
 import { getTokenPermitVersion } from '../utils/getTokenPermitVersion'
 
-const EIP_2162_PERMIT_PARAMS = {
+const EIP_2612_PERMIT_PARAMS = {
   value: DEFAULT_PERMIT_VALUE,
   nonce: 0,
   deadline: getPermitDeadline(),
@@ -215,20 +215,20 @@ async function estimateTokenPermit(params: EstimateParams): Promise<GetTokenPerm
 
   return gasLimit > minGasLimit
     ? {
-        type,
-        version,
-        name: tokenName,
-      }
+      type,
+      version,
+      name: tokenName,
+    }
     : { ...UNSUPPORTED, name: tokenName }
 }
 
 async function getEip2612CallData(params: BaseParams): Promise<string> {
   const { eip2612PermitUtils, walletAddress, spender, nonce, chainId, tokenName, tokenAddress, version } = params
-  return buildEip2162PermitCallData({
-    eip2162Utils: eip2612PermitUtils,
+  return buildEip2612PermitCallData({
+    eip2612Utils: eip2612PermitUtils,
     callDataParams: [
       {
-        ...EIP_2162_PERMIT_PARAMS,
+        ...EIP_2612_PERMIT_PARAMS,
         owner: walletAddress,
         spender,
         nonce,
@@ -254,7 +254,7 @@ async function getDaiLikeCallData(params: BaseParams): Promise<string | false> {
 
   if (permitTypeHash === DAI_LIKE_PERMIT_TYPEHASH) {
     return buildDaiLikePermitCallData({
-      eip2162Utils: eip2612PermitUtils,
+      eip2612Utils: eip2612PermitUtils,
       callDataParams: [
         {
           ...DAI_LIKE_PERMIT_PARAMS,

--- a/libs/permit-utils/src/types.ts
+++ b/libs/permit-utils/src/types.ts
@@ -25,7 +25,7 @@ export type PermitHookParams = {
   chainId: number
   permitInfo: PermitInfo
   provider: JsonRpcProvider
-  eip2162Utils: Eip2612PermitUtils
+  eip2612Utils: Eip2612PermitUtils
   account?: string | undefined
   nonce?: number | undefined
 }
@@ -41,9 +41,9 @@ export type GetTokenPermitIntoResult =
   | FailedToIdentify
 
 type BasePermitCallDataParams = {
-  eip2162Utils: Eip2612PermitUtils
+  eip2612Utils: Eip2612PermitUtils
 }
-export type BuildEip2162PermitCallDataParams = BasePermitCallDataParams & {
+export type BuildEip2612PermitCallDataParams = BasePermitCallDataParams & {
   callDataParams: Parameters<Eip2612PermitUtils['buildPermitCallData']>
 }
 export type BuildDaiLikePermitCallDataParams = BasePermitCallDataParams & {

--- a/libs/permit-utils/src/utils/buildPermitCallData.ts
+++ b/libs/permit-utils/src/utils/buildPermitCallData.ts
@@ -1,14 +1,14 @@
 import { DAI_PERMIT_SELECTOR, EIP_2612_PERMIT_SELECTOR } from '@1inch/permit-signed-approvals-utils'
 
-import { BuildDaiLikePermitCallDataParams, BuildEip2162PermitCallDataParams } from '../types'
+import { BuildDaiLikePermitCallDataParams, BuildEip2612PermitCallDataParams } from '../types'
 
-export async function buildEip2162PermitCallData({
-  eip2162Utils,
+export async function buildEip2612PermitCallData({
+  eip2612Utils,
   callDataParams,
-}: BuildEip2162PermitCallDataParams): Promise<string> {
+}: BuildEip2612PermitCallDataParams): Promise<string> {
   const [permitParams, chainId, tokenName, ...rest] = callDataParams
 
-  const callData = await eip2162Utils.buildPermitCallData(permitParams, chainId, tokenName, ...rest)
+  const callData = await eip2612Utils.buildPermitCallData(permitParams, chainId, tokenName, ...rest)
   // For some reason, the method above removes the permit selector prefix
   // https://github.com/1inch/permit-signed-approvals-utils/blob/master/src/eip-2612-permit.utils.ts#L92
   // Adding it back
@@ -16,10 +16,10 @@ export async function buildEip2162PermitCallData({
 }
 
 export async function buildDaiLikePermitCallData({
-  eip2162Utils,
+  eip2612Utils,
   callDataParams,
 }: BuildDaiLikePermitCallDataParams): Promise<string> {
-  const callData = await eip2162Utils.buildDaiLikePermitCallData(...callDataParams)
+  const callData = await eip2612Utils.buildDaiLikePermitCallData(...callDataParams)
 
   // Same as above, but for dai like
   // https://github.com/1inch/permit-signed-approvals-utils/blob/master/src/eip-2612-permit.utils.ts#L140


### PR DESCRIPTION
# Summary

This PR corrects variables that are using the incorrect EIP reference by replacing all instances of `eip2162` with `eip2612` across the codebase. 

# To Test

Any CI regression tests would be helpful.

# Background

Ref: [EIP-2612](https://eips.ethereum.org/EIPS/eip-2612)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal permit processing by aligning with updated standards to enhance clarity and consistency, while ensuring the end-user experience remains unchanged.
  
- **Documentation**
  - Updated permit-related documentation to reflect these internal improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->