### PR TITLE
Update cla.yml

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -10,27 +10,13 @@ jobs:
   cla:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Get Team Members'
-        id: team
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.ORG_TOKEN }}
-          result-encoding: string
-          script: |
-            const members = await github.paginate(
-              github.rest.orgs.listMembers,
-              { org: "cowprotocol" },
-            );
-            return members.map(m => m.login).join(",");
-
       - name: 'CLA Assistant'
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.1.3-beta
+        uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.ORG_TOKEN }}
         with:
           branch: 'cla-signatures'
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/cowprotocol/cla/blob/main/Cow%20Services%20CLA.md'
-          allowlist: '${{ steps.team.outputs.result }},*[bot],lint-action,dependabot,mergify'
+          allowlist: '*[bot],lint-action,dependabot,mergify'


### PR DESCRIPTION
Remove ORG_TOKEN as it's no longer required in the new version. Team members may have to sign the CLA now (which probably is a good idea anyways)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CLA Assistant GitHub Action to a newer version.
  - Simplified the allowlist to include only specific bot and automation accounts.
  - Removed use of organization team member fetching and related environment variables from workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->