### PR TITLE
fix: progress bar image alignment during `executing` step

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/OrderProgressBar/container/ProgressImageWrapper.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderProgressBar/container/ProgressImageWrapper.tsx
@@ -51,12 +51,12 @@ const PROCESS_IMAGE_WRAPPER_HEIGHT: HeightMap = {
   solved: '229px',
   finished: '229px',
   initial: undefined,
-  solving: undefined,
-  executing: undefined,
+  solving: 'auto',
+  executing: 'auto',
   cancelling: undefined,
   cancelled: undefined,
   expired: undefined,
-  unfillable: undefined,
+  unfillable: 'auto',
   cancellationFailed: undefined,
 }
 


### PR DESCRIPTION
# Summary

Fix incorrect progress bar image alignment during the `executing` step

# To Test

1. Execute a trade as usual

- [ ] during the 3rd step `executing`, the progress bar image should have no margins or paddings
