### PR TITLE
fix: fix explorer deep links

### DIFF
--- a/apps/explorer/src/components/NetworkSelector/index.tsx
+++ b/apps/explorer/src/components/NetworkSelector/index.tsx
@@ -63,7 +63,7 @@ export const NetworkSelector: React.FC<networkSelectorProps> = ({ networkId }) =
             const url = shouldPreservePath ? `${network.urlAlias}/${pathSuffix || ''}` : network.urlAlias
 
             return (
-              <Option to={url} color={network.color} key={itemNetworkId}>
+              <Option to={'../' + url} color={network.color} key={itemNetworkId}>
                 <div className="dot" />
                 <div className={`name ${itemNetworkId === networkId && 'selected'}`}>{network.label}</div>
                 {itemNetworkId === networkId && <StyledFAIcon icon={faCheck} />}

--- a/apps/explorer/vercel.json
+++ b/apps/explorer/vercel.json
@@ -1,0 +1,11 @@
+{
+  "redirects": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ],
+  "buildCommand": "cd ../../ && yarn build:explorer",
+  "outputDirectory": "../../build/explorer",
+  "installCommand": "cd ../../ && yarn"
+}

--- a/apps/explorer/vercel.json
+++ b/apps/explorer/vercel.json
@@ -2,7 +2,7 @@
   "redirects": [
     {
       "source": "/(.*)",
-      "destination": "/index.html"
+      "destination": "/"
     }
   ],
   "buildCommand": "cd ../../ && yarn build:explorer",

--- a/apps/explorer/vercel.json
+++ b/apps/explorer/vercel.json
@@ -1,8 +1,8 @@
 {
-  "redirects": [
+  "rewrites": [
     {
       "source": "/(.*)",
-      "destination": "/"
+      "destination": "/index.html"
     }
   ],
   "buildCommand": "cd ../../ && yarn build:explorer",


### PR DESCRIPTION
# Summary

After migrating to react-router v7 (https://github.com/cowprotocol/cowswap/pull/5618), deeplinks stopped working.
I still didn't see anything relevant that could have caused it, but anyway. Adding a vercel.json config file seems to have fixed it.

# To Test

1. Open a deep link to an explorer page, like https://explorer-dev-git-fix-explorer-deep-links-cowswap-dev.vercel.app/sepolia/address/0x7b22232698Aeb07dB39278982E68263Ac4655Dd9
* Should load
* Link navigation in general should work as well

Other apps are unnaffected by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added deployment configuration to improve routing and build process for the Explorer app.
- **Bug Fixes**
  - Updated network navigation links to correct their relative paths for improved routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->