### PR TITLE
fix: disable Swap in insufficient balance - updated logic

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/index.tsx
@@ -28,9 +28,6 @@ import { useLabelsAndTooltips } from './useLabelsAndTooltips'
 import { useSwapDerivedState } from '../../hooks/useSwapDerivedState'
 import { useSwapDeadlineState } from '../../hooks/useSwapSettings'
 
-
-
-
 const CONFIRM_TITLE = 'Swap'
 const PRICE_UPDATE_INTERVAL = ms`30s`
 
@@ -44,8 +41,7 @@ export interface SwapConfirmModalProps {
 }
 
 export function SwapConfirmModal(props: SwapConfirmModalProps) {
-  const { inputCurrencyInfo, outputCurrencyInfo, priceImpact, recipient, doTrade } =
-    props
+  const { inputCurrencyInfo, outputCurrencyInfo, priceImpact, recipient, doTrade } = props
 
   const { account, chainId } = useWalletInfo()
   const { ensName } = useWalletDetails()
@@ -68,9 +64,9 @@ export function SwapConfirmModal(props: SwapConfirmModalProps) {
       let normalisedAddress
 
       if (getIsNativeToken(current)) {
-        normalisedAddress = NATIVE_CURRENCY_ADDRESS[current.chainId]
+        normalisedAddress = NATIVE_CURRENCY_ADDRESS[current.chainId].toLowerCase()
       } else {
-        normalisedAddress = current.address
+        normalisedAddress = current.address.toLowerCase()
       }
 
       const balance = balances[normalisedAddress]

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/index.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react'
 
-import { getIsNativeToken } from '@cowprotocol/common-utils'
-import { NATIVE_CURRENCY_ADDRESS } from '@cowprotocol/cow-sdk'
+import { getCurrencyAddress } from '@cowprotocol/common-utils'
 import { useWalletDetails, useWalletInfo } from '@cowprotocol/wallet'
+import { CurrencyAmount } from '@uniswap/sdk-core'
 
 import ms from 'ms.macro'
 
@@ -61,18 +61,16 @@ export function SwapConfirmModal(props: SwapConfirmModalProps) {
     const current = inputCurrencyInfo?.amount?.currency
 
     if (current) {
-      let normalisedAddress
-
-      if (getIsNativeToken(current)) {
-        normalisedAddress = NATIVE_CURRENCY_ADDRESS[current.chainId].toLowerCase()
-      } else {
-        normalisedAddress = current.address.toLowerCase()
-      }
-
+      const normalisedAddress = getCurrencyAddress(current).toLowerCase()
       const balance = balances[normalisedAddress]
-      const isBalanceEnough = balance ? inputCurrencyInfo?.amount?.lessThan(balance.toString()) : true
+      const balanceAsCurrencyAmount = CurrencyAmount.fromRawAmount(current, balance?.toString() ?? '0')
 
-      return Boolean(isBalanceEnough)
+      const isBalanceEnough = balanceAsCurrencyAmount
+        ? inputCurrencyInfo?.amount?.equalTo(balanceAsCurrencyAmount) ||
+          inputCurrencyInfo?.amount?.lessThan(balanceAsCurrencyAmount)
+        : false
+
+      return !isBalanceEnough
     }
 
     return true

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
@@ -186,7 +186,6 @@ export function SwapWidget({ topContent, bottomContent }: SwapWidgetProps) {
             priceImpact={priceImpact}
             inputCurrencyInfo={inputCurrencyPreviewInfo}
             outputCurrencyInfo={outputCurrencyPreviewInfo}
-            hasEnoughWrappedBalanceForSwap={hasEnoughWrappedBalanceForSwap}
           />
         }
         genericModal={showNativeWrapModal && <EthFlowModal {...ethFlowProps} />}


### PR DESCRIPTION
# Summary

Fix issue on disabling Swap confirmation modal 

When selling a native token, the wrapped token balance was considered to calculate if the balance was enough.

# To Test

1. Initiate a Swap, where the wrapped native token balance is lower than the native token balance.

- The Swap confirm modal should work as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation for confirming swaps, ensuring the confirm button is only enabled when all primary trade form requirements are met.
	- The button now displays a clearer message when the balance is insufficient.

- **Refactor**
	- Streamlined swap confirmation logic for better reliability and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->