### PR TITLE
fix(notifications): do not automatically subscribe account

### DIFF
--- a/apps/cowswap-frontend/src/modules/notifications/containers/ConnectTelegram.tsx
+++ b/apps/cowswap-frontend/src/modules/notifications/containers/ConnectTelegram.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { getCmsClient } from '@cowprotocol/core'
 import { useWalletInfo } from '@cowprotocol/wallet'
@@ -80,20 +80,23 @@ export function ConnectTelegram() {
     })
   }
 
-  const checkOrAddTgSubscription = (method: string) => {
-    if (!tgData || !account) return
+  const checkOrAddTgSubscription = useCallback(
+    (method: string) => {
+      if (!tgData || !account) return
 
-    setIsCmsCallInProgress(true)
+      setIsCmsCallInProgress(true)
 
-    getCmsClient()
-      .POST(method, { body: { account, data: tgData } })
-      .then(({ data: result }: { data: boolean }) => {
-        setTgSubscribed(result)
-      })
-      .finally(() => {
-        setIsCmsCallInProgress(false)
-      })
-  }
+      getCmsClient()
+        .POST(method, { body: { account, data: tgData } })
+        .then(({ data: result }: { data: boolean }) => {
+          setTgSubscribed(result)
+        })
+        .finally(() => {
+          setIsCmsCallInProgress(false)
+        })
+    },
+    [tgData, account],
+  )
 
   const subscribeAccount = () => {
     const addSubscription = () => {
@@ -124,7 +127,7 @@ export function ConnectTelegram() {
     setTgSubscribed(false)
 
     checkOrAddTgSubscription('/check-tg-subscription')
-  }, [account, tgData])
+  }, [account, tgData, checkOrAddTgSubscription])
 
   useEffect(() => {
     if (!telegramWrapperRef.current) return

--- a/apps/cowswap-frontend/src/modules/notifications/containers/ConnectTelegram.tsx
+++ b/apps/cowswap-frontend/src/modules/notifications/containers/ConnectTelegram.tsx
@@ -97,7 +97,7 @@ export function ConnectTelegram() {
 
   const subscribeAccount = () => {
     const addSubscription = () => {
-      checkOrAddTgSubscription('add-tg-subscription')
+      checkOrAddTgSubscription('/add-tg-subscription')
     }
 
     if (!isTgSubscribed) {

--- a/apps/cowswap-frontend/src/modules/notifications/pure/TelegramConnectionStatus/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/modules/notifications/pure/TelegramConnectionStatus/index.cosmos.tsx
@@ -1,11 +1,11 @@
 import { TelegramConnectionStatus } from './index'
 
-const authenticate = () => {}
+const subscribeAccount = () => {}
 
 const Fixtures = {
-  loading: <TelegramConnectionStatus isLoading={true} isSubscribed={false} authenticate={authenticate} />,
-  subscribed: <TelegramConnectionStatus isLoading={false} isSubscribed={true} authenticate={authenticate} />,
-  needLogin: <TelegramConnectionStatus isLoading={false} isSubscribed={false} authenticate={authenticate} />,
+  loading: <TelegramConnectionStatus isLoading={true} isSubscribed={false} subscribeAccount={subscribeAccount} />,
+  subscribed: <TelegramConnectionStatus isLoading={false} isSubscribed={true} subscribeAccount={subscribeAccount} />,
+  needLogin: <TelegramConnectionStatus isLoading={false} isSubscribed={false} subscribeAccount={subscribeAccount} />,
 }
 
 export default Fixtures

--- a/apps/cowswap-frontend/src/modules/notifications/pure/TelegramConnectionStatus/index.tsx
+++ b/apps/cowswap-frontend/src/modules/notifications/pure/TelegramConnectionStatus/index.tsx
@@ -19,16 +19,16 @@ const Connected = styled.div`
 interface TelegramConnectionStatusProps {
   isLoading: boolean
   isSubscribed: boolean
-  authenticate(): void
+  subscribeAccount(): void
 }
 
-export function TelegramConnectionStatus({ isLoading, isSubscribed, authenticate }: TelegramConnectionStatusProps) {
+export function TelegramConnectionStatus({ isLoading, isSubscribed, subscribeAccount }: TelegramConnectionStatusProps) {
   if (isLoading) {
     return <Loader />
   }
 
   if (!isLoading && !isSubscribed) {
-    return <Toggle id="toggle-telegram-notifications" isActive={false} toggle={authenticate} />
+    return <Toggle id="toggle-telegram-notifications" isActive={false} toggle={subscribeAccount} />
   }
 
   return (


### PR DESCRIPTION
# Summary

Needs https://github.com/cowprotocol/cms/pull/60 to be merged first, before testing.
The bug was in the fact that we called `POST /add-tg-subscription` just if we have a Telegram auth session, which is not right.
Now we do:
1. Check Telegram authentication
2. If not authenticated, then display a toggle
3. If authenticated, check the Telegram subscription for given account
4. If the account is subscribed, then display "Connected", otherwise display a toggle

When we click on the toggle, we do:
1. If Telegram is authenticated, just add a subscription to CMS
2. Otherwise, authorize in telegram first and only then add a subscription to CMS 

# To Test

1. Terminate all sessions in telegram and disconnect all accounts. Also will be great to remove all subscriptions in CMS (elegram subscription) of your account
2. Open CoW Swap, open notifications settings
- [ ] a toggle should be displayed
3. Click on the toggle
- [ ] it should initiate Telegram authorization, after successful authorization should subscribe your account
- [ ] "connected" label should be displayed instead of the toggle
4. Reload the page
- [ ] "connected" label should be displayed
5. Change an account in your wallet
- [ ] a toggle should be displayed
6. Click on the toggle
- [ ] should not initiate a Telegram authorization
- [ ] should subscribe your account
- [ ] "connected" label should be displayed instead of the toggle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined and reorganized the Telegram authentication and subscription process for notifications.
  - Unified subscription checks and actions into a single flow for improved reliability.
  - Updated terminology and button actions for a clearer user experience when connecting Telegram.

- **Bug Fixes**
  - Improved handling of subscription status to prevent repeated or unnecessary subscription attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->