### PR TITLE
fix: fix 'partially filled' status color

### DIFF
--- a/apps/explorer/src/components/orders/StatusLabel/index.tsx
+++ b/apps/explorer/src/components/orders/StatusLabel/index.tsx
@@ -87,8 +87,7 @@ const PartiallyTagLabel = css<PartiallyTagProps>`
               border-left-width: 0;
               border-radius: 0 0.4rem 0.4rem 0;
               padding: 0 0.6rem;
-              font-size: 0.84em;
-              color: ${Color.explorer_textSecondary};
+              font-size: 0.84em;              
             `}
           `
         : null}


### PR DESCRIPTION
# Summary

Fixes #5502 

**To reproduce:** 
1. Open https://explorer-dev-git-fix-partially-filled-status-color-cowswap-dev.vercel.app//arb1/orders/0x7df30bd0dbb241e531d1b9fe459bd78d98f109cf280ec45cc2afc5c51063c5439fa3c00a92ec5f96b1ad2527ab41b3932efeda586819f377
2. Check 'PARTIALLY FILLED' text's color

**AR**: it should be visible
![image](https://github.com/user-attachments/assets/11777cdf-e103-4ca9-92e3-af7ebb7fa0d0)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the appearance of the status label by removing a specific text color from certain tag positions for a cleaner look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->