### PR TITLE
fix(trade): enhance TWAP navigation and state management

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
@@ -72,20 +72,7 @@ export function useSetupTradeState(): void {
 
   const debouncedSwitchNetworkInWallet = useCallback(debounce(switchNetworkInWallet, 200), [switchNetworkInWallet])
 
-  /**
-   * On chainId in provider changes
-   *
-   * 1. Do nothing, when provider's chainId matches to the chainId from URL, or it's not supported
-   * 2. If the URL state was remembered, then put it into URL
-   * 3. If it's the first load and wallet is connected, then switch network in the wallet to the chainId from URL
-   * 4. Otherwise, navigate to the new chainId with default tokens
-   */
-  useEffect(() => {
-    // When wallet provider is not loaded yet, or chainId has not changed
-    const shouldSkip = !providerChainId || providerChainId === urlChainId || providerChainId === prevProviderChainId
-
-    if (shouldSkip) return
-
+  const onProviderNetworkChanges = useCallback(() => {
     const rememberedUrlState = rememberedUrlStateRef.current
 
     if (rememberedUrlState) {
@@ -111,13 +98,71 @@ export function useSetupTradeState(): void {
         updateState(defaultState)
       }
     }
+  }, [
+    isFirstLoad,
+    isWalletConnected,
+    urlChainId,
+    providerChainId,
+    tradeNavigate,
+    switchNetworkInWallet,
+    isTwapMode,
+    updateState,
+  ])
+
+  /**
+   * On:
+   *  - chainId in URL changes
+   *  - provider changes
+   *
+   * Note: useEagerlyConnect() changes connectors several times at the beginning
+   *
+   * 1. When chainId in URL is changed, then set it to the provider
+   * 2. If provider's chainId is the same with chainId in URL, then do nothing
+   * 3. When the URL state is remembered, then set it's chainId to the provider
+   */
+  useEffect(() => {
+    // When wallet provider is loaded and chainId matches to the URL chainId
+    const isProviderChainIdMatchesUrl = providerChainId === urlChainId
+
+    if (isProviderChainIdMatchesUrl) {
+      setIsFirstLoad(false)
+    }
+
+    if (!providerChainId || providerChainId === currentChainId) return
+
+    const targetChainId = rememberedUrlStateRef.current?.chainId || currentChainId
+
+    // Debouncing switching multiple time in a quick span of time to avoid running into infinity loop of updating provider and url state.
+    // issue GH : https://github.com/cowprotocol/cowswap/issues/4734
+    debouncedSwitchNetworkInWallet(targetChainId)
+
+    console.debug('[TRADE STATE]', 'Set chainId to provider', { provider, urlChainId })
+    // Triggering only when chainId in URL is changes, provider is changed or rememberedUrlState is changed
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [provider, urlChainId])
+
+  /**
+   * On chainId in provider changes
+   *
+   * 1. Do nothing, when provider's chainId matches to the chainId from URL, or it's not supported
+   * 2. If the URL state was remembered, then put it into URL
+   * 3. If it's the first load and wallet is connected, then switch network in the wallet to the chainId from URL
+   * 4. Otherwise, navigate to the new chainId with default tokens
+   */
+  useEffect(() => {
+    // When wallet provider is not loaded yet, or chainId has not changed
+    const shouldSkip = !providerChainId || providerChainId === urlChainId || providerChainId === prevProviderChainId
+
+    if (shouldSkip) return
+
+    onProviderNetworkChanges()
 
     console.debug('[TRADE STATE]', 'Provider changed chainId', {
       providerChainId,
       urlChanges: rememberedUrlStateRef.current,
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [providerChainId, urlChainId, prevProviderChainId])
+  }, [onProviderNetworkChanges])
 
   /**
    * On URL parameter changes
@@ -216,38 +261,6 @@ export function useSetupTradeState(): void {
     // Triggering only on changes from URL
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tradeStateFromUrl, pendingNetworkChange, providerChainId, isTwapMode])
-
-  /**
-   * On:
-   *  - chainId in URL changes
-   *  - provider changes
-   *
-   * Note: useEagerlyConnect() changes connectors several times at the beginning
-   *
-   * 1. When chainId in URL is changed, then set it to the provider
-   * 2. If provider's chainId is the same with chainId in URL, then do nothing
-   * 3. When the URL state is remembered, then set it's chainId to the provider
-   */
-  useEffect(() => {
-    // When wallet provider is loaded and chainId matches to the URL chainId
-    const isProviderChainIdMatchesUrl = providerChainId === urlChainId
-
-    if (isProviderChainIdMatchesUrl) {
-      setIsFirstLoad(false)
-    }
-
-    if (!providerChainId || providerChainId === currentChainId) return
-
-    const targetChainId = rememberedUrlStateRef.current?.chainId || currentChainId
-
-    // Debouncing switching multiple time in a quick span of time to avoid running into infinity loop of updating provider and url state.
-    // issue GH : https://github.com/cowprotocol/cowswap/issues/4734
-    debouncedSwitchNetworkInWallet(targetChainId)
-
-    console.debug('[TRADE STATE]', 'Set chainId to provider', { provider, urlChainId })
-    // Triggering only when chainId in URL is changes, provider is changed or rememberedUrlState is changed
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [provider, urlChainId])
 
   /**
    * If user opened a link with some token symbol, and we have more than one token with the same symbol in the listing

--- a/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
@@ -46,7 +46,7 @@ export function useSetupTradeState(): void {
   // Track network changes in progress with target chainId
   const [pendingNetworkChange, setPendingNetworkChange] = useState<SupportedChainId | null>(null)
   // Use a ref to track if a forced URL update is in progress
-  const forceUrlUpdateTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const forceUrlUpdateTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   // Track retry attempts for URL updates
   const urlUpdateRetryCount = useRef<number>(0)
   // Track if current mode is TWAP (Advanced Orders)

--- a/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
@@ -96,7 +96,8 @@ export function useSetupTradeState(): void {
       const defaultState = getDefaultTradeRawState(providerChainId)
       tradeNavigate(providerChainId, defaultState)
 
-      // For TWAP mode, immediately update the state as well to ensure consistency
+      // Ensures TWAP internal state reflects the default state immediately after provider network change,
+      // preventing potential use of stale state before the URL-driven update cycle completes (unlike Swap/Limit modes).
       if (isTwapMode && updateState) {
         updateState(defaultState)
       }

--- a/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
@@ -6,11 +6,12 @@ import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { useSwitchNetwork, useWalletInfo } from '@cowprotocol/wallet'
 import { useWalletProvider } from '@cowprotocol/wallet-provider'
 
-import { Routes } from 'common/constants/routes'
 
 import { useTradeNavigate } from 'modules/trade/hooks/useTradeNavigate'
 import { useIsAlternativeOrderModalVisible } from 'modules/trade/state/alternativeOrder'
 import { getDefaultTradeRawState, TradeRawState } from 'modules/trade/types/TradeRawState'
+
+import { Routes } from 'common/constants/routes'
 
 import { useResetStateWithSymbolDuplication } from './useResetStateWithSymbolDuplication'
 import { useSetupTradeStateFromUrl } from './useSetupTradeStateFromUrl'

--- a/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
@@ -64,19 +64,22 @@ export function useSetupTradeState(): void {
         // Because it's a normal situation when we are not in Gnosis safe App
         if (error.name === 'NoSafeContext') return
 
-        console.error('[TRADE STATE]', 'Failed to switch network in wallet', error)
+        console.error('Network switching error: ', error)
       })
     },
     [switchNetwork],
   )
 
-  const debouncedSwitchNetworkInWallet = useCallback(debounce(switchNetworkInWallet, 200), [switchNetworkInWallet])
+  const debouncedSwitchNetworkInWallet = debounce(([targetChainId]: [SupportedChainId]) => {
+    switchNetworkInWallet(targetChainId)
+  }, 800)
 
   const onProviderNetworkChanges = useCallback(() => {
     const rememberedUrlState = rememberedUrlStateRef.current
 
     if (rememberedUrlState) {
       rememberedUrlStateRef.current = null
+
       tradeNavigate(rememberedUrlState.chainId, rememberedUrlState)
     } else {
       // When app loaded with connected wallet
@@ -98,71 +101,9 @@ export function useSetupTradeState(): void {
         updateState(defaultState)
       }
     }
-  }, [
-    isFirstLoad,
-    isWalletConnected,
-    urlChainId,
-    providerChainId,
-    tradeNavigate,
-    switchNetworkInWallet,
-    isTwapMode,
-    updateState,
-  ])
-
-  /**
-   * On:
-   *  - chainId in URL changes
-   *  - provider changes
-   *
-   * Note: useEagerlyConnect() changes connectors several times at the beginning
-   *
-   * 1. When chainId in URL is changed, then set it to the provider
-   * 2. If provider's chainId is the same with chainId in URL, then do nothing
-   * 3. When the URL state is remembered, then set it's chainId to the provider
-   */
-  useEffect(() => {
-    // When wallet provider is loaded and chainId matches to the URL chainId
-    const isProviderChainIdMatchesUrl = providerChainId === urlChainId
-
-    if (isProviderChainIdMatchesUrl) {
-      setIsFirstLoad(false)
-    }
-
-    if (!providerChainId || providerChainId === currentChainId) return
-
-    const targetChainId = rememberedUrlStateRef.current?.chainId || currentChainId
-
-    // Debouncing switching multiple time in a quick span of time to avoid running into infinity loop of updating provider and url state.
-    // issue GH : https://github.com/cowprotocol/cowswap/issues/4734
-    debouncedSwitchNetworkInWallet(targetChainId)
-
-    console.debug('[TRADE STATE]', 'Set chainId to provider', { provider, urlChainId })
-    // Triggering only when chainId in URL is changes, provider is changed or rememberedUrlState is changed
+    // Triggering only when chainId was changed in the provider
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [provider, urlChainId])
-
-  /**
-   * On chainId in provider changes
-   *
-   * 1. Do nothing, when provider's chainId matches to the chainId from URL, or it's not supported
-   * 2. If the URL state was remembered, then put it into URL
-   * 3. If it's the first load and wallet is connected, then switch network in the wallet to the chainId from URL
-   * 4. Otherwise, navigate to the new chainId with default tokens
-   */
-  useEffect(() => {
-    // When wallet provider is not loaded yet, or chainId has not changed
-    const shouldSkip = !providerChainId || providerChainId === urlChainId || providerChainId === prevProviderChainId
-
-    if (shouldSkip) return
-
-    onProviderNetworkChanges()
-
-    console.debug('[TRADE STATE]', 'Provider changed chainId', {
-      providerChainId,
-      urlChanges: rememberedUrlStateRef.current,
-    })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onProviderNetworkChanges])
+  }, [providerChainId, prevProviderChainId, isTwapMode, updateState])
 
   /**
    * On URL parameter changes
@@ -260,7 +201,62 @@ export function useSetupTradeState(): void {
 
     // Triggering only on changes from URL
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tradeStateFromUrl, pendingNetworkChange, providerChainId, isTwapMode])
+  }, [tradeStateFromUrl, pendingNetworkChange])
+
+  /**
+   * On:
+   *  - chainId in URL changes
+   *  - provider changes
+   *
+   * Note: useEagerlyConnect() changes connectors several times at the beginning
+   *
+   * 1. When chainId in URL is changed, then set it to the provider
+   * 2. If provider's chainId is the same with chainId in URL, then do nothing
+   * 3. When the URL state is remembered, then set it's chainId to the provider
+   */
+  useEffect(() => {
+    // When wallet provider is loaded and chainId matches to the URL chainId
+    const isProviderChainIdMatchesUrl = providerChainId === urlChainId
+
+    if (isProviderChainIdMatchesUrl) {
+      setIsFirstLoad(false)
+    }
+
+    if (!providerChainId || providerChainId === currentChainId) return
+
+    const targetChainId = rememberedUrlStateRef.current?.chainId || currentChainId
+
+    // Debouncing switching multiple time in a quick span of time to avoid running into infinity loop of updating provider and url state.
+    // issue GH : https://github.com/cowprotocol/cowswap/issues/4734
+    debouncedSwitchNetworkInWallet(targetChainId)
+
+    console.debug('[TRADE STATE]', 'Set chainId to provider', { provider, urlChainId })
+    // Triggering only when chainId in URL is changes, provider is changed or rememberedUrlState is changed
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [provider, urlChainId])
+
+  /**
+   * On chainId in provider changes
+   *
+   * 1. Do nothing, when provider's chainId matches to the chainId from URL, or it's not supported
+   * 2. If the URL state was remembered, then put it into URL
+   * 3. If it's the first load and wallet is connected, then switch network in the wallet to the chainId from URL
+   * 4. Otherwise, navigate to the new chainId with default tokens
+   */
+  useEffect(() => {
+    // When wallet provider is not loaded yet, or chainId has not changed
+    const shouldSkip = !providerChainId || providerChainId === urlChainId || providerChainId === prevProviderChainId
+
+    if (shouldSkip) return
+
+    onProviderNetworkChanges()
+
+    console.debug('[TRADE STATE]', 'Provider changed chainId', {
+      providerChainId,
+      urlChanges: rememberedUrlStateRef.current,
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onProviderNetworkChanges])
 
   /**
    * If user opened a link with some token symbol, and we have more than one token with the same symbol in the listing

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useTradeNavigate.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useTradeNavigate.ts
@@ -1,10 +1,11 @@
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { useWalletInfo } from '@cowprotocol/wallet'
 
 import { useLocation } from 'react-router'
 
-import { RoutesValues } from 'common/constants/routes'
+import { Routes, RoutesValues } from 'common/constants/routes'
 import { useNavigate } from 'common/hooks/useNavigate'
 
 import { useTradeTypeInfo } from './useTradeTypeInfo'
@@ -12,6 +13,9 @@ import { useTradeTypeInfo } from './useTradeTypeInfo'
 import { TradeCurrenciesIds } from '../types/TradeRawState'
 import { parameterizeTradeRoute } from '../utils/parameterizeTradeRoute'
 import { parameterizeTradeSearch, TradeSearchParams } from '../utils/parameterizeTradeSearch'
+
+// Debounce time for TWAP navigation to prevent rapid chainId flipping in URL
+const TWAP_NAVIGATION_DEBOUNCE_MS = 200
 
 interface UseTradeNavigateCallback {
   (
@@ -26,7 +30,11 @@ export function useTradeNavigate(): UseTradeNavigateCallback {
   const navigate = useNavigate()
   const location = useLocation()
   const tradeTypeInfo = useTradeTypeInfo()
+  const { chainId: providerChainId } = useWalletInfo()
   const tradeRoute = tradeTypeInfo?.route
+
+  // For TWAP mode: use a ref to track navigation debouncing
+  const navigationTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
   return useCallback(
     (
@@ -38,9 +46,14 @@ export function useTradeNavigate(): UseTradeNavigateCallback {
       const targetRoute = customRoute || tradeRoute
       if (!targetRoute) return
 
+      // For TWAP (Advanced Orders) mode, always use provider's chainId if available
+      // This ensures the chainId in URL always matches the network the wallet is connected to
+      const isTwapMode = targetRoute === Routes.ADVANCED_ORDERS
+      const effectiveChainId = isTwapMode && providerChainId ? providerChainId : chainId
+
       const route = parameterizeTradeRoute(
         {
-          chainId: chainId ? chainId.toString() : undefined,
+          chainId: effectiveChainId ? effectiveChainId.toString() : undefined,
           inputCurrencyId: inputCurrencyId || undefined,
           outputCurrencyId: outputCurrencyId || undefined,
           inputCurrencyAmount: undefined,
@@ -54,8 +67,22 @@ export function useTradeNavigate(): UseTradeNavigateCallback {
 
       const search = parameterizeTradeSearch(location.search, searchParams)
 
-      navigate({ pathname: route, search })
+      // For TWAP mode, use debouncing to prevent chain ID flipping
+      if (isTwapMode) {
+        // Clear any pending navigation
+        if (navigationTimeoutRef.current) {
+          clearTimeout(navigationTimeoutRef.current)
+        }
+
+        // Schedule the navigation with a delay
+        navigationTimeoutRef.current = setTimeout(() => {
+          navigate({ pathname: route, search })
+        }, TWAP_NAVIGATION_DEBOUNCE_MS)
+      } else {
+        // For non-TWAP modes, navigate immediately
+        navigate({ pathname: route, search })
+      }
     },
-    [tradeRoute, navigate, location.pathname, location.search],
+    [tradeRoute, navigate, location.pathname, location.search, providerChainId],
   )
 }

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useTradeNavigate.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useTradeNavigate.ts
@@ -34,7 +34,7 @@ export function useTradeNavigate(): UseTradeNavigateCallback {
   const tradeRoute = tradeTypeInfo?.route
 
   // For TWAP mode: use a ref to track navigation debouncing
-  const navigationTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const navigationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   return useCallback(
     (


### PR DESCRIPTION
# Summary

Fixes chain ID flickering in the URL when switching networks, specifically observed in TWAP (Advanced Orders) mode on Staging (`v1.106.0`). This issue was not present in Production (`v1.105.3`).

Detailed investigation confirmed that the core network switching hooks (`useTradeNavigate`, `useSetupTradeState`) remained unchanged between these versions. The regression is highly correlated with the upgrade of `react-router-dom` from v6 to v7 (introduced via commit `2470bfaf7` in the `v1.106.0` release branch).

The primary suspected cause is the shift in `react-router-dom` v7's default data fetching strategy to "Single Fetch". This change fundamentally alters the timing of navigation lifecycle events and state updates, likely creating a race condition with our application's existing logic for handling wallet network changes and updating the URL accordingly. While the underlying router change affects all modes, the timing sensitivity appears most pronounced in the TWAP flow.

This PR implements targeted mitigations *specifically for TWAP mode* to address the symptoms of this race condition. It introduces debouncing for TWAP URL updates, prioritizes the provider's chain ID during transitions, and adds explicit state tracking (`pendingNetworkChange`) to prevent conflicting updates during network switches. These changes restore stable URL behavior for TWAP by synchronizing state more effectively despite the altered router timing. A more generalized fix across all modes was deemed significantly more complex, potentially requiring a custom `dataStrategy` implementation.

# To Test

1.  Connect wallet and navigate to Advanced Orders mode
    *   [ ] Verify the URL shows the correct chain ID matching your wallet's connected network
2.  Switch to a different network in your wallet (e.g., from Mainnet to Gnosis Chain)
    *   [ ] Verify the URL updates to reflect the new chain ID
    *   [ ] Verify the URL stays stable with the new chain ID (no flipping back to the previous value)
    *   [ ] Verify token selections reset to defaults for the new chain (matching production behavior)
3.  Rapidly switch between multiple networks
    *   [ ] Verify the URL properly settles on the final network selected
    *   [ ] Verify no chain ID flickering occurs in the URL
    *   [ ] Verify tokens reset to defaults for the selected network
4.  Run the same tests for the other trading modes (Swap, Limit) to ensure behavior remains consistent and correct.