### PR TITLE
fix: add link to CoW Swap to Explorer menu

### DIFF
--- a/apps/explorer/src/components/common/MenuDropdown/MainMenuTree.stories.tsx
+++ b/apps/explorer/src/components/common/MenuDropdown/MainMenuTree.stories.tsx
@@ -14,7 +14,7 @@ import { GlobalStyles, ThemeToggler, Router } from 'storybook/decorators'
 
 import { MenuItemKind, MenuTreeItem } from './types'
 
-import { DOCS_LINK, DISCORD_LINK, PROTOCOL_LINK, DUNE_DASHBOARD_LINK, Routes } from '../../../explorer/const'
+import { DOCS_LINK, DISCORD_LINK, PROTOCOL_LINK, COWSWAP_LINK, DUNE_DASHBOARD_LINK, Routes } from '../../../explorer/const'
 
 export default {
   title: 'Common/Menu',
@@ -34,6 +34,12 @@ const DropdownMenu: MenuTreeItem[] = [
       {
         sectionTitle: 'OVERVIEW',
         links: [
+          {
+            title: 'CoW Swap',
+            url: COWSWAP_LINK,
+            kind: MenuItemKind.EXTERNAL_LINK,
+            iconSVG: IMAGE_COW,
+          },
           {
             title: 'CoW Protocol',
             url: PROTOCOL_LINK,

--- a/apps/explorer/src/components/common/MenuDropdown/MenuDropdownItem.stories.tsx
+++ b/apps/explorer/src/components/common/MenuDropdown/MenuDropdownItem.stories.tsx
@@ -9,7 +9,7 @@ import { GlobalStyles, ThemeToggler, Router } from 'storybook/decorators'
 
 import { DropDownItem, MenuItemKind } from './types'
 
-import { DOCS_LINK, DISCORD_LINK, PROTOCOL_LINK, Routes } from '../../../explorer/const'
+import { DOCS_LINK, DISCORD_LINK, PROTOCOL_LINK, COWSWAP_LINK, Routes } from '../../../explorer/const'
 
 import MenuDropdown, { DropdownProps } from '.'
 
@@ -30,12 +30,18 @@ const DropdownMenu: DropDownItem = {
       links: [
         {
           title: 'Option 1',
-          url: PROTOCOL_LINK,
+          url: COWSWAP_LINK,
           kind: MenuItemKind.EXTERNAL_LINK,
           iconSVG: IMAGE_COW,
         },
         {
           title: 'Option 2',
+          url: PROTOCOL_LINK,
+          kind: MenuItemKind.EXTERNAL_LINK,
+          iconSVG: IMAGE_COW,
+        },
+        {
+          title: 'Option 3',
           url: DOCS_LINK,
           kind: MenuItemKind.EXTERNAL_LINK,
           iconSVG: IMAGE_DOC,

--- a/apps/explorer/src/components/common/MenuDropdown/mainMenu.ts
+++ b/apps/explorer/src/components/common/MenuDropdown/mainMenu.ts
@@ -6,7 +6,7 @@ import IMAGE_ANALYTICS from 'assets/img/pie.svg'
 
 import { MenuItemKind, MenuTreeItem } from './types'
 
-import { DOCS_LINK, DISCORD_LINK, PROTOCOL_LINK, DUNE_DASHBOARD_LINK, Routes } from '../../../explorer/const'
+import { DOCS_LINK, DISCORD_LINK, PROTOCOL_LINK, COWSWAP_LINK, DUNE_DASHBOARD_LINK, Routes } from '../../../explorer/const'
 
 export const MAIN_MENU: MenuTreeItem[] = [
   {
@@ -20,6 +20,12 @@ export const MAIN_MENU: MenuTreeItem[] = [
       {
         sectionTitle: 'OVERVIEW',
         links: [
+          {
+            title: 'CoW Swap',
+            url: COWSWAP_LINK,
+            kind: MenuItemKind.EXTERNAL_LINK,
+            iconSVG: IMAGE_COW,
+          },
           {
             title: 'CoW Protocol',
             url: PROTOCOL_LINK,

--- a/apps/explorer/src/components/common/MenuDropdown/mainMenu.ts
+++ b/apps/explorer/src/components/common/MenuDropdown/mainMenu.ts
@@ -20,7 +20,7 @@ export const MAIN_MENU: MenuTreeItem[] = [
       {
         sectionTitle: 'OVERVIEW',
         links: [
-                    {
+          {
             title: 'CoW Protocol',
             url: PROTOCOL_LINK,
             kind: MenuItemKind.EXTERNAL_LINK,

--- a/apps/explorer/src/components/common/MenuDropdown/mainMenu.ts
+++ b/apps/explorer/src/components/common/MenuDropdown/mainMenu.ts
@@ -21,6 +21,12 @@ export const MAIN_MENU: MenuTreeItem[] = [
         sectionTitle: 'OVERVIEW',
         links: [
           {
+            title: 'CoW Swap',
+            url: COWSWAP_LINK,
+            kind: MenuItemKind.EXTERNAL_LINK,
+            iconSVG: IMAGE_COW,
+          },
+          {
             title: 'CoW Protocol',
             url: PROTOCOL_LINK,
             kind: MenuItemKind.EXTERNAL_LINK,

--- a/apps/explorer/src/components/common/MenuDropdown/mainMenu.ts
+++ b/apps/explorer/src/components/common/MenuDropdown/mainMenu.ts
@@ -20,13 +20,7 @@ export const MAIN_MENU: MenuTreeItem[] = [
       {
         sectionTitle: 'OVERVIEW',
         links: [
-          {
-            title: 'CoW Swap',
-            url: COWSWAP_LINK,
-            kind: MenuItemKind.EXTERNAL_LINK,
-            iconSVG: IMAGE_COW,
-          },
-          {
+                    {
             title: 'CoW Protocol',
             url: PROTOCOL_LINK,
             kind: MenuItemKind.EXTERNAL_LINK,

--- a/apps/explorer/src/explorer/const.ts
+++ b/apps/explorer/src/explorer/const.ts
@@ -30,6 +30,7 @@ export const CODE_LINK = 'https://github.com/' + GITHUB_REPOSITORY
 export const RAW_CODE_LINK = 'https://raw.githubusercontent.com/' + GITHUB_REPOSITORY
 export const DOCS_LINK = 'https://docs.cow.fi'
 export const PROTOCOL_LINK = 'https://cow.fi/cow-protocol'
+export const COWSWAP_LINK = 'https://swap.cow.fi'
 export const CONTRACTS_CODE_LINK = 'https://github.com/cowprotocol/contracts'
 export const DISCORD_LINK = 'https://discord.gg/cowprotocol'
 export const DUNE_DASHBOARD_LINK = 'https://dune.com/cowprotocol/cowswap'


### PR DESCRIPTION
# Summary

Fixes #3701

Adds link to CoW Swap app into the Explorer main menu. 

**Steps**: 
1. Open https://explorer-dev-git-link-to-cow-swap-cowswap-dev.vercel.app/
2. Press on the More button in the header

**AR**: the link to CoW Swap app is added to the menu, navigates to the https://swap.cow.fi/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new "CoW Swap" external link to the main menu and dropdown menus, allowing quick access to the CoW Swap platform.
  - Introduced additional external link options in dropdown menus for improved navigation.
- **Chores**
  - Updated menu items to include new links and icons for enhanced user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->