### PR TITLE
fix/cowfi fix learn

### DIFF
--- a/apps/cow-fi/app/(learn)/learn/articles/[[...pageIndex]]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/articles/[[...pageIndex]]/page.tsx
@@ -37,7 +37,7 @@ export default async function Page({ params }: Props) {
   const page = pageParam && pageIndexIsValid ? parseInt(pageParam, 10) : 1
 
   // Fetch paginated articles for display
-  const articlesResponse = (await getArticles({ page, pageSize: ARTICLES_PER_PAGE })) as ArticlesResponse
+  const articlesResponse = await getArticles({ page, pageSize: ARTICLES_PER_PAGE })
   const totalArticles = articlesResponse.meta?.pagination?.total || 0
 
   // If page number is out of bounds, redirect to page 1

--- a/apps/cow-fi/app/(learn)/learn/articles/[[...pageIndex]]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/articles/[[...pageIndex]]/page.tsx
@@ -41,9 +41,9 @@ export default async function Page({ params }: Props) {
   const articlesResponse = await getArticles({ page, pageSize: ARTICLES_PER_PAGE })
   const totalArticles = articlesResponse.meta?.pagination?.total || 0
 
-  // If page number is out of bounds, redirect to page 1
+  // If page number is out of bounds (either less than 1 or greater than total pages), redirect to page 1
   const numberOfPages = calculateTotalPages(totalArticles)
-  if (page > numberOfPages) {
+  if (page < 1 || page > numberOfPages) {
     return redirect('/learn/articles')
   }
 

--- a/apps/cow-fi/app/(learn)/learn/articles/[[...pageIndex]]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/articles/[[...pageIndex]]/page.tsx
@@ -2,6 +2,7 @@ import { ArticlesPageComponents } from '@/components/ArticlesPageComponents'
 import { redirect } from 'next/navigation'
 import { Article, getArticles, getCategories } from '../../../../../services/cms'
 import { ARTICLES_PER_PAGE } from '@/const/pagination'
+import { calculateTotalPages } from '@/util/paginationUtils'
 
 type Props = {
   params: Promise<{ pageIndex?: string[] }>
@@ -19,7 +20,7 @@ export type ArticlesResponse = {
 export async function generateStaticParams() {
   const articlesResponse = await getArticles({ page: 0, pageSize: ARTICLES_PER_PAGE })
   const totalArticles = articlesResponse.meta?.pagination?.total || 0
-  const totalPages = Math.ceil(totalArticles / ARTICLES_PER_PAGE)
+  const totalPages = calculateTotalPages(totalArticles)
 
   return Array.from({ length: totalPages }, (_, i) => ({ pageIndex: [(i + 1).toString()] }))
 }
@@ -41,7 +42,7 @@ export default async function Page({ params }: Props) {
   const totalArticles = articlesResponse.meta?.pagination?.total || 0
 
   // If page number is out of bounds, redirect to page 1
-  const numberOfPages = Math.ceil(totalArticles / ARTICLES_PER_PAGE)
+  const numberOfPages = calculateTotalPages(totalArticles)
   if (page > numberOfPages) {
     return redirect('/learn/articles')
   }

--- a/apps/cow-fi/app/(learn)/learn/articles/[[...pageIndex]]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/articles/[[...pageIndex]]/page.tsx
@@ -41,7 +41,8 @@ export default async function Page({ params }: Props) {
   const totalArticles = articlesResponse.meta?.pagination?.total || 0
 
   // If page number is out of bounds, redirect to page 1
-  if (page > Math.ceil(totalArticles / ARTICLES_PER_PAGE)) {
+  const numberOfPages = Math.ceil(totalArticles / ARTICLES_PER_PAGE)
+  if (page > numberOfPages) {
     return redirect('/learn/articles')
   }
 

--- a/apps/cow-fi/components/ArticlesPageComponents.tsx
+++ b/apps/cow-fi/components/ArticlesPageComponents.tsx
@@ -19,7 +19,7 @@ import styled from 'styled-components/macro'
 import { Color, Font, Media } from '@cowprotocol/ui'
 import Link from 'next/link'
 import { useCowAnalytics } from '@cowprotocol/analytics'
-import { ARTICLES_PER_PAGE } from '@/const/pagination'
+import { calculateTotalPages, calculatePageRange, createPaginationArray } from '@/util/paginationUtils'
 
 const LEARN_PATH = '/learn'
 const ARTICLES_PATH = `${LEARN_PATH}/articles`
@@ -71,7 +71,8 @@ export function ArticlesPageComponents({
   allArticles,
 }: ArticlesPageProps) {
   const analytics = useCowAnalytics()
-  const totalPages = Math.ceil(totalArticles / ARTICLES_PER_PAGE)
+  const totalPages = calculateTotalPages(totalArticles)
+  const { start, end } = calculatePageRange(currentPage, totalArticles)
 
   return (
     <Wrapper>
@@ -96,8 +97,7 @@ export function ArticlesPageComponents({
               <h1>All articles</h1>
             </Breadcrumbs>
             <ArticleCount>
-              Showing {ARTICLES_PER_PAGE * (currentPage - 1) + 1}-
-              {Math.min(ARTICLES_PER_PAGE * currentPage, totalArticles)} of {totalArticles} articles
+              Showing {start}-{end} of {totalArticles} articles
             </ArticleCount>
           </ContainerCardSectionTop>
           <ContainerCardSection>
@@ -106,20 +106,20 @@ export function ArticlesPageComponents({
             </LinkSection>
           </ContainerCardSection>
           <Pagination>
-            {Array.from({ length: totalPages }, (_, i) => (
+            {createPaginationArray(totalPages).map((pageNum) => (
               <Link
-                key={i}
-                href={i === 0 ? ARTICLES_PATH : `${ARTICLES_PATH}/${i + 1}`}
-                className={i + 1 === currentPage ? 'active' : ''}
+                key={pageNum - 1}
+                href={pageNum === 1 ? ARTICLES_PATH : `${ARTICLES_PATH}/${pageNum}`}
+                className={pageNum === currentPage ? 'active' : ''}
                 onClick={() =>
                   analytics.sendEvent({
                     category: CowFiCategory.KNOWLEDGEBASE,
                     action: 'Click pagination',
-                    label: `page-${i + 1}`,
+                    label: `page-${pageNum}`,
                   })
                 }
               >
-                {i + 1}
+                {pageNum}
               </Link>
             ))}
           </Pagination>

--- a/apps/cow-fi/util/paginationUtils.ts
+++ b/apps/cow-fi/util/paginationUtils.ts
@@ -1,0 +1,29 @@
+import { ARTICLES_PER_PAGE } from '@/const/pagination'
+
+/**
+ * Calculates the total number of pages based on total items and items per page
+ */
+export function calculateTotalPages(totalItems: number, itemsPerPage: number = ARTICLES_PER_PAGE): number {
+  return Math.ceil(totalItems / itemsPerPage)
+}
+
+/**
+ * Calculates the range of items being displayed on the current page
+ * Returns an object with start and end indices
+ */
+export function calculatePageRange(
+  currentPage: number,
+  totalItems: number,
+  itemsPerPage: number = ARTICLES_PER_PAGE,
+): { start: number; end: number } {
+  const start = itemsPerPage * (currentPage - 1) + 1
+  const end = Math.min(itemsPerPage * currentPage, totalItems)
+  return { start, end }
+}
+
+/**
+ * Creates an array of page numbers for pagination
+ */
+export function createPaginationArray(totalPages: number): number[] {
+  return Array.from({ length: totalPages }, (_, i) => i + 1)
+}

--- a/apps/cow-fi/util/paginationUtils.ts
+++ b/apps/cow-fi/util/paginationUtils.ts
@@ -16,8 +16,11 @@ export function calculatePageRange(
   totalItems: number,
   itemsPerPage: number = ARTICLES_PER_PAGE,
 ): { start: number; end: number } {
-  const start = itemsPerPage * (currentPage - 1) + 1
-  const end = Math.min(itemsPerPage * currentPage, totalItems)
+  // Ensure currentPage is valid (minimum 1)
+  const validCurrentPage = Math.max(1, currentPage)
+
+  const start = itemsPerPage * (validCurrentPage - 1) + 1
+  const end = Math.min(itemsPerPage * validCurrentPage, totalItems)
   return { start, end }
 }
 


### PR DESCRIPTION
# Summary

Refactored pagination logic into reusable utility functions

This PR extracts pagination math that was duplicated across components into a dedicated utility file, making the code more maintainable and consistent. Key improvements:

1. Created a new `paginationUtils.ts` with reusable pagination functions
2. Extracted complex calculations into named functions with descriptive signatures
3. Improved readability by replacing inline math with named function calls
4. Named the total pages calculation (previously an inline expression) as `numberOfPages`
5. Fixed edge cases to ensure valid pagination in all scenarios

# To Test

1. Navigate to the articles page (`/learn/articles`)

- [ ] Verify pagination works correctly at the bottom of the page
- [ ] Navigate through multiple pages to ensure correct article ranges are displayed
- [ ] Verify "Showing X-Y of Z articles" text displays correct numbers
- [ ] Check that when visiting a page number higher than total pages, it redirects to the first page

2. Navigate to an out-of-bounds page

- [ ] Verify `/learn/articles/999` correctly redirects to the main articles page
- [ ] Verify `/learn/articles/0` correctly redirects to the main articles page

# Background

This refactor addresses a code review comment that suggested extracting pagination math into utilities and giving the calculation `Math.ceil(totalArticles / ARTICLES_PER_PAGE)` a proper name (`numberOfPages`).

Regarding the concern "Can it be negative?": `numberOfPages` cannot be negative because:
- `totalArticles` is either a positive number or defaults to 0
- `ARTICLES_PER_PAGE` is a positive constant (24)
- `Math.ceil()` of a non-negative division will always return a non-negative number

Added validation to handle the edge case of invalid page numbers (like 0) which would produce negative numbers in the range calculation.