### PR TITLE
Fix: button's text color on Confirm price impact modal

### DIFF
--- a/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/SurplusCard.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/SurplusCard.tsx
@@ -170,7 +170,7 @@ export function SurplusCard() {
             <i>
               Your total surplus{' '}
               <HelpTooltip
-                text={`The total surplus CoW Swap has generated for you in ${nativeSymbol} across all your trades since ${startDate}`}
+                text={`The total surplus CoW Swap has generated for you in ${nativeSymbol} across all your trades since ${startDate}.`}
               />
             </i>
           </span>

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/SettingsTab/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/SettingsTab/index.tsx
@@ -108,7 +108,7 @@ export function SettingsTab({ className, recipientToggleState, hooksEnabledState
                           <b>
                             <SVG src={EXPERIMENT_ICON} width={12} height={12} /> Experimental:
                           </b>{' '}
-                          Add DeFI interactions before and after your trade
+                          Add DeFI interactions before and after your trade.
                         </Trans>
                       }
                     />

--- a/libs/ui/src/pure/Button/index.tsx
+++ b/libs/ui/src/pure/Button/index.tsx
@@ -170,14 +170,14 @@ export const ButtonConfirmedStyle = styled(ButtonConfirmedStyleMod)`
 export const ButtonErrorStyle = styled(ButtonPrimary)`
   // CSS overrides
   background: var(${UI.COLOR_DANGER});
-  color: var(${UI.COLOR_BUTTON_TEXT});
+  color: var(${UI.COLOR_PAPER});
   transition: background var(${UI.ANIMATION_DURATION}) ease-in-out;
 
   &:focus,
   &:hover,
   &:active {
     background: var(${UI.COLOR_DANGER});
-    color: var(${UI.COLOR_BUTTON_TEXT});
+    color: var(${UI.COLOR_PAPER});
   }
 `
 


### PR DESCRIPTION
# Summary

Fixes  #4723 

To reproduce: 
1. Open Swap page, switch to the light mode
2. Connect to sepolia
3. Pick UNI token as a buy token
4. Specify a trade --> most likely, you will get a price impact **>5%**
5. Confirm the trade on the Confirm modal
7. (if needed) type in 'Confirm' into the field
8. Check the button's text color in the light and dark modes

**AR**: it should not be a blue one in the light mode
![image](https://github.com/user-attachments/assets/3a6f86b2-fdbd-4625-89a9-b724c4ba1ff7)

And it should not be changed in the dark mode


-------

**Bonus**!
Some typos/missing periods on: 
1. Surplus tooltip
2. Hooks setting



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the error button color for improved visual consistency across different states (default, focus, hover, active).
  - Added punctuation to tooltip descriptions for clearer communication in the settings tab and account surplus card.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->