### PR TITLE
fix: mix UI fixes

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
@@ -40,14 +40,15 @@ export function ApproveButton(props: ApproveButtonProps) {
       return (
         <>
           {/* we need to shorten this string on mobile */}
-          <span>
+          <span
             style={{
               paddingLeft: '3px',
               paddingRight: '3px',            
              }}
-            <Trans>
-              Allow CoW Swap to use your <TokenSymbol token={currency} />
-            </Trans>             
+            >
+              <Trans>
+                Allow CoW Swap to use your <TokenSymbol token={currency} />
+              </Trans>             
           </span>
           <HoverTooltip
             wrapInContainer

--- a/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
@@ -42,7 +42,7 @@ export function ApproveButton(props: ApproveButtonProps) {
           {/* we need to shorten this string on mobile */}
           <span>
             <Trans>
-              {' '}Allow CoW Swap to use your <TokenSymbol token={currency}{' '}/>
+              {' '}Allow CoW Swap to use your <TokenSymbol token={currency}/>{' '}
             </Trans>
           </span>
           <HoverTooltip

--- a/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
@@ -25,6 +25,9 @@ export function ApproveButton(props: ApproveButtonProps) {
   const isPending = state === ApprovalState.PENDING
   const isConfirmed = state === ApprovalState.APPROVED
   const disabled = isDisabled || state !== ApprovalState.NOT_APPROVED
+  const Wrapper = styled.span`
+   padding: 0 3px;  
+`
 
   const content = useMemo(() => {
     if (isConfirmed) {
@@ -40,16 +43,11 @@ export function ApproveButton(props: ApproveButtonProps) {
       return (
         <>
           {/* we need to shorten this string on mobile */}
-          <span
-            style={{
-              paddingLeft: '3px',
-              paddingRight: '3px',            
-             }}
-            >
+          <Wrapper>
               <Trans>
                 Allow CoW Swap to use your <TokenSymbol token={currency} />
               </Trans>             
-          </span>
+          </Wrapper>
           <HoverTooltip
             wrapInContainer
             content={

--- a/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
@@ -44,6 +44,10 @@ export function ApproveButton(props: ApproveButtonProps) {
             <Trans>
               Allow CoW Swap to use your <TokenSymbol token={currency} />
             </Trans>
+            style={{
+            paddingLeft: '3px',
+            paddingRight: '3px',            
+          }}
           </span>
           <HoverTooltip
             wrapInContainer

--- a/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
@@ -41,13 +41,13 @@ export function ApproveButton(props: ApproveButtonProps) {
         <>
           {/* we need to shorten this string on mobile */}
           <span>
+            style={{
+              paddingLeft: '3px',
+              paddingRight: '3px',            
+             }}
             <Trans>
               Allow CoW Swap to use your <TokenSymbol token={currency} />
-            </Trans>
-            style={{
-            paddingLeft: '3px',
-            paddingRight: '3px',            
-          }}
+            </Trans>             
           </span>
           <HoverTooltip
             wrapInContainer

--- a/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
@@ -42,7 +42,7 @@ export function ApproveButton(props: ApproveButtonProps) {
           {/* we need to shorten this string on mobile */}
           <span>
             <Trans>
-              Allow CoW Swap to use your <TokenSymbol token={currency} />
+              {' '}Allow CoW Swap to use your <TokenSymbol token={currency}{' '}/>
             </Trans>
           </span>
           <HoverTooltip

--- a/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
@@ -11,6 +11,18 @@ import styled, { ThemeContext } from 'styled-components/macro'
 
 import { ApprovalState } from '../../hooks/useApproveState'
 
+const ApproveButtonContentWrapper = styled.span`
+  padding: 0 3px;
+`
+
+const TokenLogoContainer = styled.span`
+  display: flex;
+  align-items: center;
+  justify-content: space-evenly;
+  width: 100%;
+  font-size: 14px;
+`
+
 export interface ApproveButtonProps {
   currency: Currency | undefined | null
   state: ApprovalState
@@ -25,17 +37,14 @@ export function ApproveButton(props: ApproveButtonProps) {
   const isPending = state === ApprovalState.PENDING
   const isConfirmed = state === ApprovalState.APPROVED
   const disabled = isDisabled || state !== ApprovalState.NOT_APPROVED
-  const Wrapper = styled.span`
-   padding: 0 3px;  
-`
 
   const content = useMemo(() => {
     if (isConfirmed) {
       return (
         <>
-         <Trans>
-           You can now trade <TokenSymbol token={currency} />
-         </Trans>
+          <Trans>
+            You can now trade <TokenSymbol token={currency} />
+          </Trans>
           <CheckCircle size="24" />
         </>
       )
@@ -43,11 +52,11 @@ export function ApproveButton(props: ApproveButtonProps) {
       return (
         <>
           {/* we need to shorten this string on mobile */}
-          <Wrapper>
-              <Trans>
-                Allow CoW Swap to use your <TokenSymbol token={currency} />
-              </Trans>             
-          </Wrapper>
+          <ApproveButtonContentWrapper>
+            <Trans>
+              Allow CoW Swap to use your <TokenSymbol token={currency} />
+            </Trans>
+          </ApproveButtonContentWrapper>
           <HoverTooltip
             wrapInContainer
             content={
@@ -75,19 +84,10 @@ export function ApproveButton(props: ApproveButtonProps) {
       confirmed={isConfirmed}
     >
       <AutoRow justify="space-between" style={{ flexWrap: 'nowrap' }}>
-        <span
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-evenly',
-            width: '100%',
-            fontSize: '14px',
-          }}
-        >
+        <TokenLogoContainer>
           <TokenLogo token={currency} size={24} />
-
           {content}
-        </span>
+        </TokenLogoContainer>
       </AutoRow>
     </ButtonConfirmed>
   )

--- a/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
@@ -33,9 +33,9 @@ export function ApproveButton(props: ApproveButtonProps) {
     if (isConfirmed) {
       return (
         <>
-          <Trans>
-            You can now trade <TokenSymbol token={currency} />
-          </Trans>
+         <Trans>
+           You can now trade <TokenSymbol token={currency} />
+         </Trans>
           <CheckCircle size="24" />
         </>
       )

--- a/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
@@ -42,7 +42,7 @@ export function ApproveButton(props: ApproveButtonProps) {
           {/* we need to shorten this string on mobile */}
           <span>
             <Trans>
-              {' '}Allow CoW Swap to use your <TokenSymbol token={currency}/>{' '}
+              Allow CoW Swap to use your <TokenSymbol token={currency}/>
             </Trans>
           </span>
           <HoverTooltip

--- a/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
@@ -7,7 +7,7 @@ import { Currency } from '@uniswap/sdk-core'
 
 import { Trans } from '@lingui/macro'
 import { CheckCircle, HelpCircle } from 'react-feather'
-import { ThemeContext } from 'styled-components/macro'
+import styled, { ThemeContext } from 'styled-components/macro'
 
 import { ApprovalState } from '../../hooks/useApproveState'
 

--- a/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ApproveButton/index.tsx
@@ -42,7 +42,7 @@ export function ApproveButton(props: ApproveButtonProps) {
           {/* we need to shorten this string on mobile */}
           <span>
             <Trans>
-              Allow CoW Swap to use your <TokenSymbol token={currency}/>
+              Allow CoW Swap to use your <TokenSymbol token={currency} />
             </Trans>
           </span>
           <HoverTooltip

--- a/apps/cowswap-frontend/src/modules/fortune/containers/FortuneWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/fortune/containers/FortuneWidget/index.tsx
@@ -198,7 +198,7 @@ const FortuneText = styled.h3`
 
   &:before,
   &:after {
-    color: inherit;
+    color: var(${UI.COLOR_TEXT_PAPER});
     font-size: 100px;
     position: absolute;
     z-index: 1;


### PR DESCRIPTION
# Summary

Fixes:

- [ ] https://www.notion.so/cownation/Rebrand-tests-CoW-Swap-deb5ca44d8bd4ce8bed18c674f5a8135?pvs=4#4e356f9233ec4e1c8211664a9294adcc

**To reproduce:**
1. Open CoW Fortune cookie in the dark (and in the light) mode
2. Check that the quotes sign is visible
![image](https://github.com/user-attachments/assets/9c55d787-aafc-4e55-a9fc-9f8c60b35516)



- [ ] https://www.notion.so/cownation/Rebrand-tests-CoW-Swap-deb5ca44d8bd4ce8bed18c674f5a8135?pvs=4#78963eb1d6ce471cabf8b18ef4b694ee

**To reproduce:**
1. Connect to a wallet
2. Pick a not permittable token that is not yet approved into the Sell field
3. Pick a Buy token
4. Check the 'Allow CoW Swap...' button in a mobile view

**AR**: the text on the button should not be glued to a token's icon and to the tooltip.
![image](https://github.com/user-attachments/assets/8c048185-c382-4314-bd8d-f68b92fefea6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Refined styling of the approval button for consistent spacing and alignment.
  - Updated quotation mark colors in the fortune widget to align with the theme for improved visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->