### PR TITLE
fix(tokens): fix token import logic for user-added tokens

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/hooks/useAutoImportTokensState.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useAutoImportTokensState.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 
 import { LpToken, TokenWithLogo } from '@cowprotocol/common-const'
 import { isTruthy } from '@cowprotocol/common-utils'
-import { useSearchNonExistentToken } from '@cowprotocol/tokens'
+import { useSearchNonExistentToken, useUserAddedTokens } from '@cowprotocol/tokens'
 import { useWalletInfo } from '@cowprotocol/wallet'
 
 import { Nullish } from 'types'
@@ -21,6 +21,7 @@ export function useAutoImportTokensState(
 ): AutoImportTokensState {
   const { inputCurrency, outputCurrency } = useDerivedTradeState() || {}
   const { chainId } = useWalletInfo()
+  const userAddedTokens = useUserAddedTokens()
 
   /**
    * If sell or buy token is already derived, and it doesn't match current network
@@ -37,10 +38,26 @@ export function useAutoImportTokensState(
   const foundOutputToken = useSearchNonExistentToken(currencyNetworkMismatch ? null : outputToken || null)
 
   const tokensToImport = useMemo(() => {
-    return [foundInputToken, foundOutputToken].filter(isTruthy).filter((token) => {
+    // First filter just the valid tokens
+    const validTokens = [foundInputToken, foundOutputToken].filter(isTruthy).filter((token) => {
       return token.chainId === chainId && !(token instanceof LpToken)
     })
-  }, [foundInputToken, foundOutputToken, chainId])
+
+    // Then filter out any tokens that are already in the user's custom token list
+    return validTokens.filter((token) => {
+      // Check if this token is already in user's custom tokens
+      const isAlreadyInUserTokens = userAddedTokens.some(
+        (userToken) => userToken.address.toLowerCase() === token.address.toLowerCase(),
+      )
+
+      console.log(
+        `[useAutoImportTokensState] Token ${token.symbol} (${token.address}) already in custom list: ${isAlreadyInUserTokens}`,
+      )
+
+      // Only return tokens that aren't already in the user's list
+      return !isAlreadyInUserTokens
+    })
+  }, [foundInputToken, foundOutputToken, chainId, userAddedTokens])
 
   const tokensToImportCount = tokensToImport.length
 

--- a/libs/tokens/src/hooks/tokens/useTokenBySymbolOrAddress.ts
+++ b/libs/tokens/src/hooks/tokens/useTokenBySymbolOrAddress.ts
@@ -38,7 +38,7 @@ export function useTokenBySymbolOrAddress(symbolOrAddress?: string | null): Toke
       // Ignore if not a valid address (e.g., it's a symbol)
     }
 
-    // NEW: Check all user-added tokens to see if any match the symbol
+    // Check all user-added tokens to see if any match the symbol
     if (userAddedTokensForChain && Object.keys(userAddedTokensForChain).length > 0) {
       // Find the first token with a matching symbol
       const userTokenWithMatchingSymbol = Object.values(userAddedTokensForChain).find(

--- a/libs/tokens/src/hooks/tokens/useTokenBySymbolOrAddress.ts
+++ b/libs/tokens/src/hooks/tokens/useTokenBySymbolOrAddress.ts
@@ -2,30 +2,61 @@ import { useAtomValue } from 'jotai'
 import { useMemo } from 'react'
 
 import { TokenWithLogo } from '@cowprotocol/common-const'
+import { getAddress } from '@ethersproject/address'
 
 import { useTokensByAddressMap } from './useTokensByAddressMap'
 
+import { environmentAtom } from '../../state/environmentAtom'
 import { tokensBySymbolAtom } from '../../state/tokens/allTokensAtom'
+import { userAddedTokensAtom } from '../../state/tokens/userAddedTokensAtom'
 
 export function useTokenBySymbolOrAddress(symbolOrAddress?: string | null): TokenWithLogo | null {
   const tokensByAddress = useTokensByAddressMap()
   const tokensBySymbol = useAtomValue(tokensBySymbolAtom).tokens
+  // Get user added tokens state
+  const userAddedTokens = useAtomValue(userAddedTokensAtom)
+  const { chainId } = useAtomValue(environmentAtom)
 
   return useMemo(() => {
-    if (!symbolOrAddress) {
+    if (!symbolOrAddress || !chainId) {
       return null
     }
 
     const symbolOrAddressLowerCase = symbolOrAddress.toLowerCase()
+    const userAddedTokensForChain = userAddedTokens[chainId] || {}
 
+    // Check if it's an address in the userAddedTokens map first
+    try {
+      const checksummedAddress = getAddress(symbolOrAddress)
+      const tokenInfo = userAddedTokensForChain[checksummedAddress.toLowerCase()]
+
+      if (tokenInfo) {
+        // Need to reconstruct TokenWithLogo as userAddedTokensAtom stores TokenInfo
+        return TokenWithLogo.fromToken(tokenInfo, tokenInfo.logoURI)
+      }
+    } catch {
+      // Ignore if not a valid address (e.g., it's a symbol)
+    }
+
+    // NEW: Check all user-added tokens to see if any match the symbol
+    if (userAddedTokensForChain && Object.keys(userAddedTokensForChain).length > 0) {
+      // Find the first token with a matching symbol
+      const userTokenWithMatchingSymbol = Object.values(userAddedTokensForChain).find(
+        (tokenInfo) => tokenInfo.symbol?.toLowerCase() === symbolOrAddressLowerCase,
+      )
+
+      if (userTokenWithMatchingSymbol) {
+        return TokenWithLogo.fromToken(userTokenWithMatchingSymbol, userTokenWithMatchingSymbol.logoURI)
+      }
+    }
+
+    // Check the derived active tokens maps if not found in userAddedTokens
     const foundByAddress = tokensByAddress[symbolOrAddressLowerCase]
-
     if (foundByAddress) return foundByAddress
 
     const foundBySymbol = tokensBySymbol[symbolOrAddressLowerCase]
-
-    if (foundBySymbol) return foundBySymbol[0]
+    if (foundBySymbol?.length) return foundBySymbol[0] // Return the first match by symbol
 
     return null
-  }, [symbolOrAddress, tokensByAddress, tokensBySymbol])
+  }, [symbolOrAddress, tokensByAddress, tokensBySymbol, userAddedTokens, chainId])
 }

--- a/libs/tokens/src/state/tokenLists/tokenListsStateAtom.ts
+++ b/libs/tokens/src/state/tokenLists/tokenListsStateAtom.ts
@@ -95,15 +95,17 @@ export const listsStatesMapAtom = atom((get) => {
   }, {})
 
   const listsSources = Object.keys(currentNetworkLists).filter((source) => {
+    // This filter is key: in curated mode, only user-added and LP lists pass.
     return useCuratedListOnly ? userAddedListSources[source] || lpTokenListSources[source] : true
   })
 
   const lists = useCuratedListOnly ? [get(curatedListSourceAtom).source, ...listsSources] : listsSources
 
+  // Build the map based on the filtered and ordered list sources
   return lists.reduce<{ [source: string]: ListState }>((acc, source) => {
     const list = currentNetworkLists[source]
 
-    if (!list) return acc
+    if (!list) return acc // If list data isn't present for the source, skip it.
 
     const isDefaultList = !list.widgetAppCode
     const sourceLowerCased = source.toLowerCase()
@@ -146,8 +148,8 @@ export const listsEnabledStateAtom = atom((get) => {
   const virtualListsState = get(virtualListsStateAtom)
 
   const state = allTokensLists.reduce<{ [source: string]: boolean }>((acc, tokenList) => {
-    const state = listStates[tokenList.source]
-    const isActive = state?.isEnabled
+    const listState = listStates[tokenList.source] // Use listState (lowercase l)
+    const isActive = listState?.isEnabled
 
     acc[tokenList.source] = typeof isActive === 'boolean' ? isActive : !!tokenList.enabledByDefault
 

--- a/libs/tokens/src/state/tokens/allTokensAtom.ts
+++ b/libs/tokens/src/state/tokens/allTokensAtom.ts
@@ -42,7 +42,9 @@ const tokensStateAtom = atom<TokensState>((get) => {
         const tokenInfo = parseTokenInfo(chainId, token)
         const tokenAddressKey = tokenInfo?.address.toLowerCase()
 
-        if (!tokenInfo || !tokenAddressKey) return
+        if (!tokenInfo || !tokenAddressKey || tokenInfo.chainId !== chainId) {
+          return
+        }
 
         if (lpTokenProvider) {
           tokenInfo.lpTokenProvider = lpTokenProvider

--- a/libs/tokens/src/updaters/TokensListsUpdater/index.ts
+++ b/libs/tokens/src/updaters/TokensListsUpdater/index.ts
@@ -53,7 +53,7 @@ const GEOBLOCK_ERRORS_TO_IGNORE = /(failed to fetch)|(load failed)/i
 
 export function TokensListsUpdater({
   chainId: currentChainId,
-  isGeoBlockEnabled = true,
+  isGeoBlockEnabled,
   enableLpTokensByDefault,
   isYieldEnabled,
   bridgeNetworkInfo,

--- a/libs/tokens/src/updaters/TokensListsUpdater/index.ts
+++ b/libs/tokens/src/updaters/TokensListsUpdater/index.ts
@@ -53,7 +53,7 @@ const GEOBLOCK_ERRORS_TO_IGNORE = /(failed to fetch)|(load failed)/i
 
 export function TokensListsUpdater({
   chainId: currentChainId,
-  isGeoBlockEnabled,
+  isGeoBlockEnabled = true,
   enableLpTokensByDefault,
   isYieldEnabled,
   bridgeNetworkInfo,
@@ -108,6 +108,7 @@ export function TokensListsUpdater({
         const isUsUser = country === 'US'
 
         if (isUsUser) {
+          // set curated first, then update time
           setEnvironment({ useCuratedListOnly: true })
           updateLastUpdateTime({ [chainId]: 0 })
         }

--- a/libs/tokens/src/utils/mergeTokenMaps.ts
+++ b/libs/tokens/src/utils/mergeTokenMaps.ts
@@ -1,12 +1,12 @@
 import { TokensMap } from '../types'
 
 /**
- * Merges multiple token maps into a single map, combining token properties and tags
- * Earlier® maps in the list take precedence for basic properties, but tags are concatenated
+ * Merges multiple token maps into a single map, combining token properties and tags.
+ * Later maps in the list take precedence for basic properties (overwriting earlier ones),
+ * but tags are concatenated (preserving original list order).
  */
 export function mergeTokenMaps(...tokenMaps: (TokensMap | null | undefined)[]): TokensMap {
-  // Note: Earlier maps in the original list (processed later here)
-  // have their properties OVERRIDDEN by later maps in the original list (processed earlier here).
+  // Maps processed later in the array override properties of earlier maps when addresses match
   return tokenMaps.reduce<TokensMap>((acc, currentMap) => {
     if (!currentMap) return acc
 
@@ -14,10 +14,9 @@ export function mergeTokenMaps(...tokenMaps: (TokensMap | null | undefined)[]): 
       const lowerAddress = address.toLowerCase()
       if (acc[lowerAddress]) {
         acc[lowerAddress] = {
-          ...token, // Properties from the current map (earlier in original list)
-          ...acc[lowerAddress], // Properties from the accumulator (later in original list - these override)
-          // Tags are concatenated, preserving original list order (acc first, then token)
-          tags: [...(acc[lowerAddress].tags || []), ...(token.tags || [])],
+          ...token, // Properties from the current token (processed earlier)
+          ...acc[lowerAddress], // Properties from accumulated tokens override (processed later)
+          tags: [...(acc[lowerAddress].tags || []), ...(token.tags || [])], // Tags are concatenated
         }
       } else {
         acc[lowerAddress] = token

--- a/libs/tokens/src/utils/mergeTokenMaps.ts
+++ b/libs/tokens/src/utils/mergeTokenMaps.ts
@@ -5,7 +5,7 @@ import { TokensMap } from '../types'
  * Earlier® maps in the list take precedence for basic properties, but tags are concatenated
  */
 export function mergeTokenMaps(...tokenMaps: (TokensMap | null | undefined)[]): TokensMap {
-  // Note: Develop version logic. Earlier maps in the original list (processed later here)
+  // Note: Earlier maps in the original list (processed later here)
   // have their properties OVERRIDDEN by later maps in the original list (processed earlier here).
   return tokenMaps.reduce<TokensMap>((acc, currentMap) => {
     if (!currentMap) return acc

--- a/libs/tokens/src/utils/mergeTokenMaps.ts
+++ b/libs/tokens/src/utils/mergeTokenMaps.ts
@@ -5,6 +5,8 @@ import { TokensMap } from '../types'
  * Earlier® maps in the list take precedence for basic properties, but tags are concatenated
  */
 export function mergeTokenMaps(...tokenMaps: (TokensMap | null | undefined)[]): TokensMap {
+  // Note: Develop version logic. Earlier maps in the original list (processed later here)
+  // have their properties OVERRIDDEN by later maps in the original list (processed earlier here).
   return tokenMaps.reduce<TokensMap>((acc, currentMap) => {
     if (!currentMap) return acc
 
@@ -12,8 +14,9 @@ export function mergeTokenMaps(...tokenMaps: (TokensMap | null | undefined)[]): 
       const lowerAddress = address.toLowerCase()
       if (acc[lowerAddress]) {
         acc[lowerAddress] = {
-          ...token,
-          ...acc[lowerAddress],
+          ...token, // Properties from the current map (earlier in original list)
+          ...acc[lowerAddress], // Properties from the accumulator (later in original list - these override)
+          // Tags are concatenated, preserving original list order (acc first, then token)
           tags: [...(acc[lowerAddress].tags || []), ...(token.tags || [])],
         }
       } else {


### PR DESCRIPTION
# Summary

Fixes two related token handling issues for users, particularly those with US IP addresses operating in "curated list only" mode:

1.  **Imported Token Not Selectable & Modal Reappearing:** Previously, when a US-geoblocked user imported a token (e.g., by pasting an address like CRV's), the token would appear to add successfully but wouldn't be selected in the swap input. The import confirmation modal would then incorrectly reappear. This was due to the token lookup logic (especially by URL symbol) not properly recognizing newly added custom tokens against the restricted active token set in curated mode.
2.  **Uniswap List Tokens Not Available:** For US-geoblocked users, tokens from the default Uniswap list (which should be their primary active list) were not appearing as available for selection and were instead prompting for import. This was caused by an issue where token definitions from other chains within the Uniswap list (sharing the same address as an Ethereum token) would overwrite the correct Ethereum version during processing, effectively removing the Ethereum token from the active set for the current chain (Ethereum/chainId 1).

The primary fixes are:
*   Modified `useTokenBySymbolOrAddress` to prioritize checking the user's added custom tokens by symbol *and* address before checking the main active token lists. This ensures that once a token is imported, it's found correctly, especially when referenced by its symbol in the URL.
*   In `allTokensAtom`, when processing tokens from any list, we now strictly ensure that only token definitions matching the application's current `chainId` are processed and added to the temporary map for that list. This prevents tokens intended for other chains (but present in a multi-chain list like Uniswap's) from overwriting the correct token for the current active chain.
*   Adjusted `useAutoImportTokensState` to prevent attempting to auto-import tokens that are already present in the user's custom added tokens list.

# To Test

**Scenario 1: US User - Curated Mode (CRV Import & Uniswap List Token - MANA)**

1.  Connect from a US IP address or enable the geo-blocking flag locally.
    *   **Verify Uniswap Token (MANA):**
        *   Search for "MANA" (or its Ethereum address `0x0F5D2fB29fb7d3CFeE444a200298f468908cC942`).
        *   [ ] Verify MANA appears as an active, selectable token (from the Uniswap Default list) and does *not* prompt for import.

**Scenario 2: Non-US User - Default Mode**

1.  Connect from a non-US IP address or ensure geo-blocking is disabled.
    *   [ ] Verify that default lists are active and their tokens are selectable without import.
    *   [ ] Test importing a new custom token not on any default list. Verify it imports correctly and is selectable.

# Background

The core of the problem was twofold:
1.  **Chain ID Mismatch in Token Processing:** When processing multi-chain token lists like Uniswap's, token definitions for a given symbol/address but intended for other chains (e.g., MANA on Arbitrum) were overwriting the token definition for the current active chain (e.g., MANA on Ethereum). The fix in `allTokensAtom.ts` ensures strict chain ID matching.
2.  **Token Lookup Order:** The `useTokenBySymbolOrAddress` hook did not adequately prioritize user-added custom tokens, especially when a symbol from a URL was used. This, combined with the restricted active set in curated mode, made imported tokens appear "lost." The fix reorders the lookup priorities.
3.  **Auto-Import Redundancy:** The `useAutoImportTokensState` hook would sometimes try to re-import tokens that the user had already manually added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved token import and lookup features to automatically filter out tokens already added by the user.
  - Enhanced token search to include user-added tokens and respect the current network selection.

- **Bug Fixes**
  - Ensured that tokens already in the user's custom list are not suggested for import or duplicated in search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->