### PR TITLE
feat(appzi): disable appzi for Coinbase Wallet

### DIFF
--- a/apps/cowswap-frontend/src/appzi.ts
+++ b/apps/cowswap-frontend/src/appzi.ts
@@ -4,6 +4,7 @@ import {
   isProdLike,
   majorBrowserVersion,
   userAgent,
+  isCoinbaseWalletBrowser,
 } from '@cowprotocol/common-utils'
 import { UiOrderType } from '@cowprotocol/types'
 
@@ -17,7 +18,9 @@ const isOldChrome =
 
 const isFeedbackEnabled = process.env.REACT_APP_FEEDBACK_ENABLED_DEV === 'true' || process.env.NODE_ENV === 'production'
 const isImTokenIosBrowser = isImTokenBrowser && userAgent.os.name === 'iOS'
-export const isAppziEnabled = !isOldChrome && !isImTokenIosBrowser && isFeedbackEnabled && !isInjectedWidget()
+const isCoinbaseWalletIos = isCoinbaseWalletBrowser && userAgent.os.name === 'iOS'
+export const isAppziEnabled =
+  !isOldChrome && !isImTokenIosBrowser && !isCoinbaseWalletIos && isFeedbackEnabled && !isInjectedWidget()
 
 const PROD_FEEDBACK_KEY = 'f7591eca-72f7-4888-b15f-e7ff5fcd60cd'
 const TEST_FEEDBACK_KEY = '6da8bf10-4904-4952-9a34-12db70e9194e'

--- a/libs/common-utils/src/userAgent.ts
+++ b/libs/common-utils/src/userAgent.ts
@@ -1,11 +1,22 @@
 import { UAParser } from 'ua-parser-js'
 
+// Augment the Window interface to include the ethereum property
+declare global {
+  interface Window {
+    ethereum?: {
+      isCoinbaseWallet?: boolean
+      // Add other ethereum provider properties if needed by common-utils
+    }
+  }
+}
+
 let userAgentRaw: string = ''
 let parser: UAParser = new UAParser()
 let type: string = ''
 let userAgent: any = {}
 let isMobile: boolean = false
 let isImTokenBrowser: boolean = false
+let isCoinbaseWalletBrowser: boolean = false
 let majorBrowserVersion: number | undefined
 let isChrome: boolean = false
 
@@ -17,6 +28,7 @@ if (typeof window !== 'undefined') {
   userAgent = parser.getResult()
   isMobile = type === 'mobile' || type === 'tablet'
   isImTokenBrowser = /imToken/.test(userAgentRaw)
+  isCoinbaseWalletBrowser = window.ethereum?.isCoinbaseWallet === true
 
   function getBrowserMajorVersion() {
     const major = userAgent.browser.version?.split('.')[0]
@@ -29,4 +41,4 @@ if (typeof window !== 'undefined') {
   isChrome = name?.toLowerCase().startsWith('chrome') || false
 }
 
-export { userAgent, isMobile, isImTokenBrowser, majorBrowserVersion, isChrome }
+export { userAgent, isMobile, isImTokenBrowser, isCoinbaseWalletBrowser, majorBrowserVersion, isChrome }


### PR DESCRIPTION
# Summary

Fixes https://github.com/cowprotocol/cowswap/issues/5594

Disable Appzi feedback/surveys for Coinbase Wallet on iOS to prevent UI freezes.

Added a new utility function `isCoinbaseWalletBrowser` to detect Coinbase Wallet browser environments, then used it to disable Appzi for iOS specifically, following the same pattern used for imToken wallet.

# To Test

1. Open CoW Swap in Coinbase Wallet iOS app
   - [ ] UI should remain responsive throughout use
   - [ ] No Appzi feedback modals should appear

2. Place or have an open limit order 
   - [ ] When accessing the limit orders page, UI should not freeze
   - [ ] Trading functionality should work without interruption

3. Verify other wallets still show Appzi properly
   - [ ] Other supported wallets (except imToken) should still see Appzi surveys

# Background

Coinbase Wallet iOS app's browser environment was causing UI freezes when Appzi attempted to display surveys/feedback modals. This implementation follows the existing pattern used for disabling Appzi in imToken browser on iOS.

The fix uses `window.ethereum.isCoinbaseWallet` property checking rather than UA string parsing for more reliable detection.