### PR TITLE
fix(permit): dai permit issues

### DIFF
--- a/apps/cowswap-frontend/src/modules/permit/hooks/usePermitInfo.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/usePermitInfo.ts
@@ -36,7 +36,7 @@ export const PERMIT_GAS_LIMIT_MIN: Record<SupportedChainId, number> = mapSupport
  * If not found, tries to load the info from chain
  * The result will be cached on localStorage if a final conclusion is found
  *
- * When it is, returned type is `{type: 'dai'|'permit', gasLimit: number}
+ * When it is, returned type is `{type: 'dai-like' | 'eip-2612', gasLimit: number}
  * When it is not, returned type is `{type: 'unsupported'}`
  * When it is unknown, returned type is `undefined`
  */

--- a/libs/permit-utils/src/const.ts
+++ b/libs/permit-utils/src/const.ts
@@ -5,7 +5,7 @@ import ms from 'ms.macro'
 
 // PK used only for signing permit requests for quoting and identifying token 'permittability'
 // Do not use or try to send funds to it. Or do. It'll be your funds 🤷
-const PERMIT_PK = '0x68012a4467ce455b6b278b1a6815db9b7224deaa6bced68c3848ec21e6380f8a' // address: 0xD711bD26Bf5B153001a7C0ACcb289782b6f775e9
+const PERMIT_PK = '0xa50dc0f7fc051309434deb3b1c71e927dbb711759231d8ecbf630c85d94a42fe' // address: 0xDa5F16F4ab0410096a4403e7223988649fac38cF
 
 export const PERMIT_SIGNER = new Wallet(PERMIT_PK)
 


### PR DESCRIPTION
# Summary

Rotate the permit signer PK as the previous one was approved ~300 days ago https://etherscan.io/tx/0x121b2bb18fe3439cd0d6f0387b0424e3272ef8e65dee0efd27060d4de9c68b85

# To Test

1. Block the network calls in the console to `https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/PermitInfo`*
2. Make sure the local storage keys `staticPermitCache:`, `userPermitCache:` and `permittableTokens:` are  removed
3. Pick DAI as sell token on mainnet
* Should be considered permittable
4. Make sure you don't have DAI approved
4. Place a sell order of DAI
* Should prompt for permit signature
* Should trade and approve DAI