### PR TITLE
fix: hooks expected order balances diff

### DIFF
--- a/apps/cowswap-frontend/src/modules/hooksStore/hooks/useBalancesDiff.ts
+++ b/apps/cowswap-frontend/src/modules/hooksStore/hooks/useBalancesDiff.ts
@@ -45,7 +45,7 @@ export function useHookBalancesDiff(isPreHook: boolean, hookToEditUid?: string):
     if (orderParams?.sellAmount && orderParams.sellTokenAddress && account)
       balanceDiff[orderParams.sellTokenAddress.toLowerCase()] = `-${orderParams.sellAmount}`
 
-    return { account: balanceDiff }
+    return { [account.toLowerCase()]: balanceDiff }
   }, [orderParams, account])
 
   const firstPostHookBalanceDiff = useMemo(() => {


### PR DESCRIPTION
# Summary

Balances diff on first post hook are being exposed differently of the proposed format (shown [here](https://github.com/cowprotocol/bff/blob/main/libs/repositories/src/repos/SimulationRepository/SimulationRepositoryTenderly.ts#L201)).

Current:

```
balancesDiff = {
  "account": {
    "0xabc...":"10000"
  },
  ...
}
```

After this PR:

```
balancesDiff = {
  "0x123...": {
    "0xabc...":"10000"
  },
  ...
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated balance difference display to use the actual wallet account address for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->