### PR TITLE
fix: consistent naming for Order history button and page

### DIFF
--- a/apps/explorer/src/components/orders/DetailsTable/index.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/index.tsx
@@ -237,7 +237,7 @@ export function DetailsTable(props: Props): React.ReactNode | null {
                 />
                 <LinkButton to={`/address/${owner}`}>
                   <FontAwesomeIcon icon={faHistory} />
-                  Order History
+                  Order history
                 </LinkButton>
               </Wrapper>
             </td>
@@ -261,7 +261,7 @@ export function DetailsTable(props: Props): React.ReactNode | null {
                 />
                 <LinkButton to={`/address/${receiver}`}>
                   <FontAwesomeIcon icon={faHistory} />
-                  Order History
+                  Order history
                 </LinkButton>
               </Wrapper>
             </td>

--- a/apps/explorer/src/explorer/pages/UserDetails.tsx
+++ b/apps/explorer/src/explorer/pages/UserDetails.tsx
@@ -28,13 +28,13 @@ const UserDetails: React.FC = () => {
   return (
     <Wrapper>
       <Helmet>
-        <title>User Details - {APP_TITLE}</title>
+        <title>Order History - {APP_TITLE}</title>
       </Helmet>
       <StyledSearch />
       {addressAccount ? (
         <>
           <FlexContainerVar>
-            <h1>User details</h1>
+            <h1>Order history</h1>
             <TitleAddress
               textToCopy={addressAccount.address}
               contentsToDisplay={


### PR DESCRIPTION
Attempts to fix #4638 
 In this PR I'm proposing to rename 'User details' page to 'Order history' to have consistent naming with the button inside an order

**To reproduce:** 
1. Open https://explorer-dev-git-consistent-naming-cowswap-dev.vercel.app/address/0x9fa3c00a92ec5f96b1ad2527ab41b3932efeda58
2. Check the page name: it should be 'Order history'
![image](https://github.com/user-attachments/assets/d8f775ba-1780-4784-8d2b-0cf8b1061d26)
---

Additionally, changed case on the 'history' word on the 'Order History' button
![image](https://github.com/user-attachments/assets/50c08e05-928a-4ebc-837e-2d1d7d510bc0)

---
**Note**: 
Letters' case corresponds to the pattern we have on other Explorer pages: 
![image](https://github.com/user-attachments/assets/cf46813a-c460-44a7-a271-88e2584b9059)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated label text from "Order History" to "Order history" for consistency.
  - Changed page title and main heading from "User Details" to "Order history".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->