### PR TITLE
fix(cowfi): update article link generation to use slug variable

### DIFF
--- a/apps/cow-fi/app/(learn)/learn/[article]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/[article]/page.tsx
@@ -1,10 +1,11 @@
+import { notFound } from 'next/navigation'
+
 import { ArticlePageComponent } from '@/components/ArticlePageComponent'
 import { FEATURED_ARTICLES_PAGE_SIZE } from '@/const/pagination'
+import { fetchArticleWithRetry } from '@/util/fetchHelpers'
 import { getPageMetadata } from '@/util/getPageMetadata'
 import { stripHtmlTags } from '@/util/stripHTMLTags'
-import { fetchArticleWithRetry } from '@/util/fetchHelpers'
-import type { Metadata } from 'next'
-import { notFound } from 'next/navigation'
+
 import {
   Article,
   getAllArticleSlugs,
@@ -13,6 +14,10 @@ import {
   getCategories,
   SharedRichTextComponent,
 } from '../../../../services/cms'
+
+import type { Metadata } from 'next'
+
+export const revalidate = 3600 // Revalidate at most once per hour
 
 // Maximum length for metadata descriptions. When content exceeds MAX_LENGTH,
 // we truncate to TRUNCATE_LENGTH (MAX_LENGTH - 3) to make room for "..." ellipsis

--- a/apps/cow-fi/app/(learn)/learn/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/page.tsx
@@ -19,10 +19,14 @@ export default async function LearnPage() {
   // Format featured articles for the component
   const featuredArticles = featuredArticlesResponse.data.map((article) => {
     const attributes = article.attributes
+    const slug = attributes?.slug || 'no-slug'
     return {
       title: attributes?.title || 'No title',
       description: attributes?.description || 'No description',
-      link: `/learn/${attributes?.slug || 'no-slug'}`,
+      // IMPORTANT: Must use direct string interpolation for href in Next.js App Router
+      // Object format ({ pathname: '/learn/[article]', query: { article: slug } })
+      // is not supported and will cause "Dynamic href" errors
+      link: `/learn/${slug}`,
       cover: attributes?.cover?.data?.attributes?.url || '',
     }
   })

--- a/apps/cow-fi/app/(learn)/learn/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/page.tsx
@@ -19,14 +19,10 @@ export default async function LearnPage() {
   // Format featured articles for the component
   const featuredArticles = featuredArticlesResponse.data.map((article) => {
     const attributes = article.attributes
-    const slug = attributes?.slug || 'no-slug'
     return {
       title: attributes?.title || 'No title',
       description: attributes?.description || 'No description',
-      // IMPORTANT: Must use direct string interpolation for href in Next.js App Router
-      // Object format ({ pathname: '/learn/[article]', query: { article: slug } })
-      // is not supported and will cause "Dynamic href" errors
-      link: `/learn/${slug}`,
+      link: `/learn/${attributes?.slug || 'no-slug'}`,
       cover: attributes?.cover?.data?.attributes?.url || '',
     }
   })

--- a/apps/cow-fi/app/(learn)/learn/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/page.tsx
@@ -1,6 +1,9 @@
 import { LearnPageComponent } from '@/components/LearnPageComponent'
 import { ARTICLES_LARGE_PAGE_SIZE, FEATURED_ARTICLES_PAGE_SIZE } from '@/const/pagination'
+
 import { getArticles, getCategories } from '../../../services/cms'
+
+export const revalidate = 3600 // Revalidate at most once per hour
 
 export default async function LearnPage() {
   const articlesResponse = await getArticles({ pageSize: ARTICLES_LARGE_PAGE_SIZE })


### PR DESCRIPTION
# Summary

Fixed an issue where clicking on newly added featured articles on the `/learn` page would result in a 404 error until a page refresh or a new deployment. This was due to the client-side route manifest not being aware of articles added after the initial build.

This PR enhances the `/api/revalidate` endpoint to correctly use `revalidatePath` for specific article slugs when provided, ensuring the route manifest is updated. It also adds a 60-minute ISR (`revalidate = 3600`) to `/learn` and `/learn/[article]` pages as a fallback freshness mechanism.

# To Test

**Note: This can only be tested on production (cow.fi)**

1.  **Existing Featured Articles:**
    *   Go to `/learn` page.
    *   Click on any existing featured article.
    *   Verify the article loads correctly without a 404.

2.  **Newly Added Article (On-Demand Revalidation):**
    *   Add a new article in the CMS. Note its slug (e.g., `my-new-article`).
    *   Trigger revalidation for the specific article path: `/api/revalidate?secret=[YOUR_SECRET]&path=/learn/my-new-article`
    *   Go to the `/learn` page (it should now list the new article if `revalidatePath('/learn')` was also triggered or data revalidated correctly).
    *   Click on the new featured article.
    *   Verify it loads immediately without a 404.

3.  **Newly Added Article (CMS Tag Revalidation + ISR Fallback):**
    *   Add another new article in the CMS.
    *   Trigger revalidation using only the tag: `/api/revalidate?secret=[YOUR_SECRET]&tag=cms-content`
    *   Go to the `/learn` page. The new article should appear in the list.
    *   Click on this new featured article.
        *   **Expected:** It should load correctly because the revalidation endpoint now also calls `revalidatePath('/learn')` and `revalidatePath('/learn/[article]', 'layout')` implicitly when `tag=cms-content` (as per our latest `route.ts` changes). If not, the hourly ISR on `/[article]/page.tsx` will eventually make it navigable.
    *   Verify it loads without a 404.

4.  **ISR Functionality (Optional - harder to test precisely):**
    *   After an hour, revisit an existing article or the `/learn` page.
    *   If content for that page was updated in the CMS (and on-demand revalidation was *not* called for it), verify the page eventually shows the updated content after a refresh (due to ISR).

# Background

The root cause of the "404 on first click" for new articles was that Next.js's App Router generates a client-side route manifest at build time. Articles added to the CMS post-build were not in this manifest. While direct URL access or a page refresh would trigger server-side rendering (which could find the new article if `dynamicParams=true`), client-side navigation would fail.

The solution involves two main parts:
1.  **Enhanced On-Demand Revalidation:** The `/api/revalidate/route.ts` endpoint now correctly uses `revalidatePath` for specific article paths (when the `path` parameter is provided by the CMS webhook). It also revalidates `/learn` by default when `cms-content` is tagged.
2.  **Incremental Static Regeneration (ISR):** Added `export const revalidate = 3600;` to both `/learn/page.tsx` and `/learn/[article]/page.tsx`. This ensures pages are re-evaluated at most once per hour, providing a fallback mechanism for content freshness and allowing new dynamically rendered slugs to eventually be treated as static.

This combination ensures both immediate updates for new content (via a correctly configured CMS webhook calling the revalidation API with the specific path) and periodic freshness for all learn section content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pages in the Learn section now automatically refresh their content at least once per hour for up-to-date information.
  - The revalidation endpoint now supports more flexible and accurate refreshing of specific Learn pages, ensuring content stays current.

- **Bug Fixes**
  - Improved handling of path normalization when revalidating Learn pages via the API.

- **Chores**
  - Updated Curve-related URLs to use the current domain for improved link accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->