### PR TITLE
fix: update curve link

### DIFF
--- a/apps/cow-fi/data/cow-protocol/const.tsx
+++ b/apps/cow-fi/data/cow-protocol/const.tsx
@@ -475,7 +475,7 @@ export const UNIQUE_TRADING_LOGIC = [
 
 export const TOP_LOGOS = [
   { src: IMG_LOGO_LIDO, alt: 'Lido', url: 'https://lido.fi/' },
-  { src: IMG_LOGO_CURVE_TEXT, alt: 'Curve', url: 'https://curve.fi/' },
+  { src: IMG_LOGO_CURVE_TEXT, alt: 'Curve', url: 'https://curve.finance/' },
   { src: IMG_LOGO_SAFE, alt: 'Safe', url: 'https://safe.global/' },
 ]
 

--- a/apps/cowswap-frontend/src/modules/yield/lpPageLinks.ts
+++ b/apps/cowswap-frontend/src/modules/yield/lpPageLinks.ts
@@ -38,7 +38,7 @@ export const LP_PAGE_LINKS: Record<LpTokenProvider, (chainId: SupportedChainId, 
     `https://balancer.fi/pools/${COW_AMM_CHAINS[chainId]}/cow/${address}`,
   [LpTokenProvider.UNIV2]: (chainId, address) =>
     `https://app.uniswap.org/explore/pools/${UNI_CHAINS[chainId]}/${address}`,
-  [LpTokenProvider.CURVE]: () => `https://classic.curve.fi/pools`,
+  [LpTokenProvider.CURVE]: () => `https://classic.curve.finance/pools`,
   [LpTokenProvider.BALANCERV2]: () => `https://balancer.fi/pools`,
   [LpTokenProvider.SUSHI]: (chainId, address) => `https://www.sushi.com/${SUSHI_CHAINS[chainId]}/pool/v2/${address}`,
   [LpTokenProvider.PANCAKE]: (chainId, address) =>


### PR DESCRIPTION
Fixes https://cowservices.slack.com/archives/C036G0J90BU/p1747213978959299

1. Open [CoW Protocol page](https://cowfi-git-update-curve-link-cowswap.vercel.app/cow-protocol)
2. Scroll down to 'Trusted by the best' section
3. Check the Curve link
![image](https://github.com/user-attachments/assets/286c7947-8710-48a4-b8fa-f48eb035ec50)


**AR**: it should be https://www.curve.finance/

---
The PR also update the link that exists on the code, but is not used on the UI. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Curve-related URLs to use the correct domain for improved accuracy and reliability of external links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->