### PR TITLE
fix(bridge): use custom receiver

### DIFF
--- a/libs/common-const/src/common.ts
+++ b/libs/common-const/src/common.ts
@@ -64,6 +64,8 @@ export const V_COW_CONTRACT_ADDRESS: Record<SupportedChainId, string | null> = {
   [SupportedChainId.ARBITRUM_ONE]: null, // doesn't exist!
   [SupportedChainId.BASE]: null, // doesn't exist!
   [SupportedChainId.SEPOLIA]: '0x21d06a222bbb94ec1406a0a8ba86b4d761bc9864',
+  [SupportedChainId.AVALANCHE]: 'TODONETOWRK',
+  [SupportedChainId.POLYGON]: 'TODONETOWRK',
 }
 
 export const COW_CONTRACT_ADDRESS: Record<SupportedChainId, string> = {
@@ -72,6 +74,8 @@ export const COW_CONTRACT_ADDRESS: Record<SupportedChainId, string> = {
   [SupportedChainId.ARBITRUM_ONE]: '0xcb8b5cd20bdcaea9a010ac1f8d835824f5c87a04',
   [SupportedChainId.BASE]: '0xc694a91e6b071bF030A18BD3053A7fE09B6DaE69',
   [SupportedChainId.SEPOLIA]: '0x0625aFB445C3B6B7B929342a04A22599fd5dBB59',
+  [SupportedChainId.AVALANCHE]: 'TODONETOWRK',
+  [SupportedChainId.POLYGON]: 'TODONETOWRK',
 }
 
 export const INPUT_OUTPUT_EXPLANATION = 'Only executed swaps incur fees.'
@@ -89,6 +93,8 @@ export const MINIMUM_ETH_FLOW_SLIPPAGE_BPS: Record<SupportedChainId, number> = {
   [SupportedChainId.ARBITRUM_ONE]: DEFAULT_SLIPPAGE_BPS,
   [SupportedChainId.BASE]: DEFAULT_SLIPPAGE_BPS,
   [SupportedChainId.SEPOLIA]: DEFAULT_SLIPPAGE_BPS,
+  [SupportedChainId.AVALANCHE]: DEFAULT_SLIPPAGE_BPS,
+  [SupportedChainId.POLYGON]: DEFAULT_SLIPPAGE_BPS,
 }
 
 export const MINIMUM_ETH_FLOW_SLIPPAGE: Record<SupportedChainId, Percent> = mapSupportedNetworks(
@@ -127,6 +133,8 @@ export const GAS_FEE_ENDPOINTS: Record<SupportedChainId, string> = {
   [SupportedChainId.ARBITRUM_ONE]: 'https://arbitrum.blockscout.com/api/v1/gas-price-oracle',
   [SupportedChainId.BASE]: 'https://base.blockscout.com/api/v1/gas-price-oracle',
   [SupportedChainId.SEPOLIA]: '',
+  [SupportedChainId.AVALANCHE]: 'TODONETOWRK',
+  [SupportedChainId.POLYGON]: 'TODONETOWRK',
 }
 export const GAS_API_KEYS: Record<SupportedChainId, string | null> = {
   [SupportedChainId.MAINNET]: process.env.REACT_APP_BLOCKNATIVE_API_KEY || null,
@@ -134,6 +142,8 @@ export const GAS_API_KEYS: Record<SupportedChainId, string | null> = {
   [SupportedChainId.ARBITRUM_ONE]: null,
   [SupportedChainId.BASE]: null,
   [SupportedChainId.SEPOLIA]: null,
+  [SupportedChainId.AVALANCHE]: 'TODONETOWRK',
+  [SupportedChainId.POLYGON]: 'TODONETOWRK',
 }
 
 export const UNSUPPORTED_TOKENS_FAQ_URL = 'https://docs.cow.fi/cow-protocol/reference/core/tokens'

--- a/libs/common-const/src/networks.ts
+++ b/libs/common-const/src/networks.ts
@@ -9,6 +9,8 @@ const RPC_URL_ENVS: Record<SupportedChainId, string | undefined> = {
   [SupportedChainId.ARBITRUM_ONE]: process.env.REACT_APP_NETWORK_URL_42161 || undefined,
   [SupportedChainId.BASE]: process.env.REACT_APP_NETWORK_URL_8453 || undefined,
   [SupportedChainId.SEPOLIA]: process.env.REACT_APP_NETWORK_URL_11155111 || undefined,
+  [SupportedChainId.AVALANCHE]: 'TODONETOWRK',
+  [SupportedChainId.POLYGON]: 'TODONETOWRK',
 }
 
 const DEFAULT_RPC_URL: Record<SupportedChainId, { url: string; usesInfura: boolean }> = {
@@ -17,6 +19,8 @@ const DEFAULT_RPC_URL: Record<SupportedChainId, { url: string; usesInfura: boole
   [SupportedChainId.ARBITRUM_ONE]: { url: `https://arbitrum-mainnet.infura.io/v3/${INFURA_KEY}`, usesInfura: true },
   [SupportedChainId.BASE]: { url: `https://base-mainnet.infura.io/v3/${INFURA_KEY}`, usesInfura: true },
   [SupportedChainId.SEPOLIA]: { url: `https://sepolia.infura.io/v3/${INFURA_KEY}`, usesInfura: true },
+  [SupportedChainId.AVALANCHE]: { url: `TODONETOWRK`, usesInfura: true },
+  [SupportedChainId.POLYGON]: { url: `TODONETOWRK`, usesInfura: true },
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@cowprotocol/cms": "^0.11.0",
     "@cowprotocol/contracts": "^1.7.0",
     "@cowprotocol/cow-runner-game": "^0.2.9",
-    "@cowprotocol/cow-sdk": "^6.0.0-RC.36",
+    "@cowprotocol/cow-sdk": "^6.0.0-RC.40",
     "@cowprotocol/ethflowcontract": "cowprotocol/ethflowcontract.git#main-artifacts",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1831,23 +1831,29 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.7.0.tgz#a3b93bebfe768b4911de54841b9d7b39b8bd0b99"
   integrity sha512-tog/0igLaWZv6kK30+aFJ267+yNyMINx6qDHaJQFKZs051XUXnzNFlZgCEfICwDz/821XYjZxOnNbe449tgD5w==
 
+"@cowprotocol/contracts@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.8.0.tgz#daffbd9846231c11a74b15a186bb754627e420b0"
+  integrity sha512-rMEHo1UBB6k4kRoWejHZNGggg6IBVt7vAd8x0FhEvjxhbq3zlAex61f9HpAcDExJNuvfwwDjsOc/7UGztCzhSw==
+
 "@cowprotocol/cow-runner-game@^0.2.9":
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/@cowprotocol/cow-runner-game/-/cow-runner-game-0.2.9.tgz#3f94b3f370bd114f77db8b1d238cba3ef4e9d644"
   integrity sha512-rX7HnoV+HYEEkBaqVUsAkGGo0oBrExi+d6Io+8nQZYwZk+IYLmS9jdcIObsLviM2h4YX8+iin6NuKl35AaiHmg==
 
-"@cowprotocol/cow-sdk@^6.0.0-RC.36":
-  version "6.0.0-RC.36"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.36.tgz#be454c14a8980bf72db978240ec4368dc772d1e3"
-  integrity sha512-ckgY0kHQFQLaFgv7ArW/34rVAQ5DJDZDJ6iny8wmlj1exo5DoOGfTMwO7bFzYAi6CB4NN3B8lVuG6f3v1/nbRg==
+"@cowprotocol/cow-sdk@^6.0.0-RC.40":
+  version "6.0.0-RC.40"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.40.tgz#42f271f38181d2e076f868a4dc6cd8c8f2d914b1"
+  integrity sha512-VAYFABLmMYFmnIyqztEakqmbzPkl/c+R7oeTVcnGIA+MlPgmZ3yWisVqrzNjSGo2+cA8l4mBvrd5F6201Cn7OQ==
   dependencies:
     "@cowprotocol/app-data" "^3.0.0"
-    "@cowprotocol/contracts" "^1.7.0"
+    "@cowprotocol/contracts" "^1.8.0"
     "@ethersproject/abstract-signer" "^5.8.0"
     "@openzeppelin/merkle-tree" "^1.0.8"
     "@weiroll/weiroll.js" "^0.3.0"
     cross-fetch "^3.2.0"
     deepmerge "^4.3.1"
+    ethers "^5.8.0"
     exponential-backoff "^3.1.2"
     graphql "^16.11.0"
     graphql-request "^4.3.0"


### PR DESCRIPTION
# Summary

Fixed two issues:
1. Eth-flow orders with bridging. It doesn't completely work! There is still a bug on backend side which doen't execute post-hooks. The only thing I fixed is now CoW Swap creates an order with ETH instead of WETH.
2. Custom receiver. Now you can specify a custom receiver and you should receive funds on that account at target chain.

# To Test

See above
