### PR TITLE
fix: do not clear url search when it's already clean

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/setupTradeState/useSetupTradeState.ts
@@ -79,27 +79,11 @@ export function useSetupTradeState(): void {
         }
       }
 
-      // For any chain change, use default tokens
-      const defaultState = getDefaultTradeRawState(providerChainId)
-
-      // Ensures internal state reflects the default state immediately after provider network change,
-      // preventing potential use of stale state before the URL-driven update cycle completes.
-      // Applied universally for robustness.
-      if (updateState) {
-        updateState(defaultState)
-      }
-
-      // Always navigate with the provider's chain ID as source of truth
-      tradeNavigate(providerChainId, defaultState)
+      tradeNavigate(providerChainId, getDefaultTradeRawState(providerChainId))
     }
-
-    console.debug('[TRADE STATE]', 'Provider changed chainId', {
-      providerChainId,
-      urlChanges: rememberedUrlStateRef.current,
-    })
     // Triggering only when chainId was changed in the provider
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [providerChainId, prevProviderChainId, updateState])
+  }, [providerChainId, prevProviderChainId])
 
   /**
    * On URL parameter changes

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useSetupTradeAmountsFromUrl.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useSetupTradeAmountsFromUrl.ts
@@ -48,6 +48,15 @@ export function useSetupTradeAmountsFromUrl({ onAmountsUpdate, onlySell }: Setup
 
     const queryParams = new URLSearchParams(search)
 
+    // Do nothing if queryParams are already clear
+    if (
+      !queryParams.has(TRADE_URL_BUY_AMOUNT_KEY) &&
+      !queryParams.has(TRADE_URL_SELL_AMOUNT_KEY) &&
+      !queryParams.has(TRADE_URL_ORDER_KIND_KEY)
+    ) {
+      return
+    }
+
     queryParams.delete(TRADE_URL_BUY_AMOUNT_KEY)
     queryParams.delete(TRADE_URL_SELL_AMOUNT_KEY)
     queryParams.delete(TRADE_URL_ORDER_KIND_KEY)
@@ -111,5 +120,5 @@ export function useSetupTradeAmountsFromUrl({ onAmountsUpdate, onlySell }: Setup
       }
     }
     // Trigger only when URL or assets are changed
-  }, [params, inputCurrency, outputCurrency, onlySell])
+  }, [params, inputCurrency, outputCurrency, cleanParams, onlySell])
 }

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useTradeNavigate.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useTradeNavigate.ts
@@ -1,7 +1,6 @@
-import { useCallback, useRef } from 'react'
+import { useCallback } from 'react'
 
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { useWalletInfo } from '@cowprotocol/wallet'
 
 import { useLocation } from 'react-router'
 
@@ -13,9 +12,6 @@ import { useTradeTypeInfo } from './useTradeTypeInfo'
 import { TradeCurrenciesIds } from '../types/TradeRawState'
 import { parameterizeTradeRoute } from '../utils/parameterizeTradeRoute'
 import { parameterizeTradeSearch, TradeSearchParams } from '../utils/parameterizeTradeSearch'
-
-// Debounce time to prevent rapid chainId flipping in URL
-const NAVIGATION_DEBOUNCE_MS = 300
 
 interface UseTradeNavigateCallback {
   (
@@ -30,11 +26,7 @@ export function useTradeNavigate(): UseTradeNavigateCallback {
   const navigate = useNavigate()
   const location = useLocation()
   const tradeTypeInfo = useTradeTypeInfo()
-  const { chainId: providerChainId } = useWalletInfo()
   const tradeRoute = tradeTypeInfo?.route
-
-  // Use a ref to keep track of the latest navigation timer
-  const navigationTimerRef = useRef<number | null>(null)
 
   return useCallback(
     (
@@ -46,13 +38,9 @@ export function useTradeNavigate(): UseTradeNavigateCallback {
       const targetRoute = customRoute || tradeRoute
       if (!targetRoute) return
 
-      // ALWAYS prioritize provider's chainId when available
-      // This ensures the chainId in URL always matches the network the wallet is connected to
-      const effectiveChainId = providerChainId || chainId
-
       const route = parameterizeTradeRoute(
         {
-          chainId: effectiveChainId ? effectiveChainId.toString() : undefined,
+          chainId: chainId ? chainId.toString() : undefined,
           inputCurrencyId: inputCurrencyId || undefined,
           outputCurrencyId: outputCurrencyId || undefined,
           inputCurrencyAmount: undefined,
@@ -67,19 +55,8 @@ export function useTradeNavigate(): UseTradeNavigateCallback {
       // Don't navigate if we're already on this route
       if (location.pathname === route && location.search.slice(1) === search) return
 
-      // Clear any existing navigation timer
-      if (navigationTimerRef.current) {
-        clearTimeout(navigationTimerRef.current)
-      }
-
-      // Create a new debounced navigation to prevent URL flipping
-      // This ensures we only navigate after things have settled, making URL updates more stable
-      navigationTimerRef.current = window.setTimeout(() => {
-        navigate({ pathname: route, search })
-        console.debug('[TRADE NAVIGATE] Navigating to:', route)
-        navigationTimerRef.current = null
-      }, NAVIGATION_DEBOUNCE_MS)
+      navigate({ pathname: route, search })
     },
-    [tradeRoute, navigate, location.pathname, location.search, providerChainId],
+    [tradeRoute, navigate, location.pathname, location.search],
   )
 }


### PR DESCRIPTION
# Summary

The fix https://github.com/cowprotocol/cowswap/pull/5657 has one problem, it breaks token selecting from different chain (bridging).

1. The initial bug with chainId changes in URL was replaced. I reverted previous fix and added a new one. The cause was in `useSetupTradeAmountsFromUrl`. That hook takes amounts from URL and set into state. It also removes `?sellAmount=4&buyAmount=360000` from URL after. There was a race condition, when URL is not updated yet and we do URL cleaning from unwanted query parameters, but with an old path. To avoid that, I added a check before clearing the URL. Now, when the url query is already clean, we do nothing.
2. Fixed problem with token selection from different chain.

# To Test

ChainId in URL case:
1. See https://github.com/cowprotocol/cowswap/pull/5657

Token selection from different chain:
1. Select Mainnet as a current network
2. Open sell token selector modal
3. Select any token from Base, for example USDC
- [ ] AR: USDC from Base is NOT selected as sell token
- [ ] ER: USDC from Base is selected as sell token


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of trade state updates when switching networks to prevent potential stale state issues.
  - Optimized URL parameter cleaning to avoid unnecessary updates when trade-related parameters are already absent.

- **Refactor**
  - Streamlined navigation logic for immediate updates without delay, removing debouncing and wallet chain prioritization for a more responsive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->