### PR TITLE
fix(twap): do not reset output amount

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/hooks/useSetupTradeAmountsFromUrl.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useSetupTradeAmountsFromUrl.ts
@@ -88,7 +88,7 @@ export function useSetupTradeAmountsFromUrl({ onAmountsUpdate, onlySell }: Setup
     }
 
     if (onlySell) {
-      update.outputCurrencyAmount = null
+      delete update.outputCurrencyAmount
 
       update.orderKind = OrderKind.SELL
     } else {


### PR DESCRIPTION
# Summary

Fixes https://cowservices.slack.com/archives/C0361CDG8GP/p1747215937525659

`useSetupTradeAmountsFromUrl()` was resetting output amount instead of skipping it to be updated from URL for widgets that don't support buy orders.

# To Test

Sorry, the only way to test with Safe is run it locally. I've tested that:

https://github.com/user-attachments/assets/9f0afbf4-32dc-4da9-b1bd-9ed5bab0beaf

Anway, can you please test CoW Swap:
1. Navigation between widgets
2. Setting amounts from URL
