### PR TITLE
fix: handle presign tx signature for Safe via Rabby

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeFlow/services/swapFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/services/swapFlow/index.ts
@@ -103,7 +103,19 @@ export async function swapFlow(
       logTradeFlow('SWAP FLOW', 'STEP 5: presign order (optional)')
       const presignTx = await tradingSdk.getPreSignTransaction({ orderId, account })
 
-      presignTxHash = (await orderParams.signer.sendTransaction(presignTx)).hash
+      presignTxHash = (
+        await orderParams.signer.sendTransaction(presignTx).catch((error) => {
+          /**
+           * When using Rabby and Safe, the presign transaction is not a real transaction
+           * It's a safe signature
+           */
+          if (error.transactionHash) {
+            return { hash: error.transactionHash }
+          } else {
+            throw error
+          }
+        })
+      ).hash
     }
 
     const order = mapUnsignedOrderToOrder({


### PR DESCRIPTION
# Summary

Fixes #5710

When we try to send a transaction of order presign, Safe doesn't really send a transaction, it only sign it.
In that case, `signer.sendTransaction()` throws an error with `error.transactionHash` which is a signature hash.

# To Test

See  #5710