### PR TITLE
fix: fix order presign flow

### DIFF
--- a/apps/cowswap-frontend/src/legacy/utils/trade.ts
+++ b/apps/cowswap-frontend/src/legacy/utils/trade.ts
@@ -15,7 +15,8 @@ import {
   SupportedChainId as ChainId,
   UnsignedOrder,
 } from '@cowprotocol/cow-sdk'
-import { Signer } from '@ethersproject/abstract-signer'
+import type { Signer } from '@ethersproject/abstract-signer'
+import type { JsonRpcSigner } from '@ethersproject/providers'
 import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
 
 import { orderBookApi } from 'cowSdk'
@@ -30,7 +31,7 @@ import OperatorError, { ApiErrorObject } from 'api/cowProtocol/errors/OperatorEr
 export type PostOrderParams = {
   account: string
   chainId: ChainId
-  signer: Signer
+  signer: JsonRpcSigner
   kind: OrderKind
   inputAmount: CurrencyAmount<Currency>
   outputAmount: CurrencyAmount<Currency>

--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useTradeFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useTradeFlowContext.ts
@@ -78,7 +78,7 @@ export function useTradeFlowContext(): TradeFlowContext | null {
       settlementContract,
       allowsOffchainSigning,
       dispatch,
-      signer: provider.getSigner(),
+      signer: provider.getUncheckedSigner(),
       rateImpact,
       permitInfo: !enoughAllowance ? permitInfo : undefined,
       generatePermitHook,

--- a/apps/cowswap-frontend/src/modules/limitOrders/services/types.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/services/types.ts
@@ -1,7 +1,7 @@
 import { Erc20, GPv2Settlement } from '@cowprotocol/abis'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import type { SendBatchTxCallback } from '@cowprotocol/wallet'
-import type { Signer } from '@ethersproject/abstract-signer'
+import type { JsonRpcSigner } from '@ethersproject/providers'
 
 import { AppDispatch } from 'legacy/state'
 import { PostOrderParams } from 'legacy/utils/trade'
@@ -19,7 +19,7 @@ export interface TradeFlowContext {
   chainId: SupportedChainId
   dispatch: AppDispatch
   rateImpact: number
-  signer: Signer
+  signer: JsonRpcSigner
   allowsOffchainSigning: boolean
   permitInfo: IsTokenPermittableResult
   generatePermitHook: GeneratePermitHook

--- a/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowContext.ts
@@ -181,7 +181,7 @@ export function useTradeFlowContext({ deadline }: TradeFlowParams): TradeFlowCon
           orderParams: {
             account,
             chainId,
-            signer: provider.getSigner(),
+            signer: provider.getUncheckedSigner(),
             kind: orderKind,
             inputAmount,
             outputAmount,


### PR DESCRIPTION
# Summary

Fixes https://cowservices.slack.com/archives/C0361CDG8GP/p1747392016614809
This bug came with TradingSDK integration. Before we've been doing this:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/cbd006e2-6893-46d6-978b-b13dacfee6d8" />

And now:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/d69c74e3-9487-49e7-8a4a-ac3b7ccf7828" />


Which looks similar, but under the hood `settlementContract.setPreSignature` uses `UncheckedSigner` instead of just `Signer`.

![image](https://github.com/user-attachments/assets/c03f78f2-9ddf-42e7-b8ea-6904a45bd9f4)

# To Test

1. Safe+WC
2. Run any TX
3. Then place an order (as a 2nd TX), and sign the TX
4. The UI hangs in the 'Confirm TX' state --> no order submitted modal

https://github.com/cowprotocol/cowswap/pull/5711 please recheck this case as well.