### PR TITLE
fix(twap): use indexedDB to persist state

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useCancelOrder/useSendOnChainCancellation.test.tsx
+++ b/apps/cowswap-frontend/src/common/hooks/useCancelOrder/useSendOnChainCancellation.test.tsx
@@ -36,6 +36,18 @@ jest.mock('common/hooks/useContract', () => {
     useGP2SettlementContract: jest.fn(),
   }
 })
+jest.mock('modules/twap/hooks/useSetPartOrderCancelling', () => {
+  return {
+    ...jest.requireActual('modules/twap/hooks/useSetPartOrderCancelling'),
+    useSetPartOrderCancelling: jest.fn().mockReturnValue(jest.fn()),
+  }
+})
+jest.mock('modules/twap/hooks/useCancelTwapOrder', () => {
+  return {
+    ...jest.requireActual('modules/twap/hooks/useCancelTwapOrder'),
+    useCancelTwapOrder: jest.fn(),
+  }
+})
 jest.mock('legacy/state/enhancedTransactions/hooks')
 
 const orderMock = {
@@ -117,7 +129,12 @@ describe('useSendOnChainCancellation() + useGetOnChainCancellation()', () => {
   })
 
   it('When is ETH-flow order, then should call eth-flow contract', async () => {
-    const { result } = renderHook(() => useSendOnChainCancellation(), { wrapper: WithProviders })
+    const { result } = renderHook(
+      () => {
+        return useSendOnChainCancellation()
+      },
+      { wrapper: WithProviders },
+    )
 
     await result.current({ ...orderMock, inputToken: NATIVE_CURRENCIES[chainId] })
 

--- a/apps/cowswap-frontend/src/common/hooks/useUpdateTradeApproveState.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useUpdateTradeApproveState.ts
@@ -1,4 +1,4 @@
-import { useSetAtom } from 'jotai/index'
+import { useSetAtom } from 'jotai'
 
 import { updateTradeApproveStateAtom } from '../containers/TradeApprove/tradeApproveStateAtom'
 

--- a/apps/cowswap-frontend/src/common/updaters/GasUpdater.tsx
+++ b/apps/cowswap-frontend/src/common/updaters/GasUpdater.tsx
@@ -1,4 +1,4 @@
-import { useSetAtom } from 'jotai/index'
+import { useSetAtom } from 'jotai'
 import { useCallback, useEffect } from 'react'
 
 import { GAS_PRICE_UPDATE_THRESHOLD } from '@cowprotocol/common-const'
@@ -28,7 +28,7 @@ function useUpdateGasPrices() {
       dispatch(updateGasPrices(gasParams))
       setGasPrice(gasParams)
     },
-    [dispatch, setGasPrice]
+    [dispatch, setGasPrice],
   )
 }
 

--- a/apps/cowswap-frontend/src/modules/ethFlow/updaters/InFlightOrderFinalizeUpdater.ts
+++ b/apps/cowswap-frontend/src/modules/ethFlow/updaters/InFlightOrderFinalizeUpdater.ts
@@ -1,4 +1,4 @@
-import { useSetAtom } from 'jotai/index'
+import { useSetAtom } from 'jotai'
 import { useEffect } from 'react'
 
 import ms from 'ms.macro'

--- a/apps/cowswap-frontend/src/modules/hooksStore/hooks/useCustomHookDapps.ts
+++ b/apps/cowswap-frontend/src/modules/hooksStore/hooks/useCustomHookDapps.ts
@@ -1,4 +1,4 @@
-import { useAtomValue } from 'jotai/index'
+import { useAtomValue } from 'jotai'
 
 import { customPostHookDappsAtom, customPreHookDappsAtom } from '../state/customHookDappsAtom'
 

--- a/apps/cowswap-frontend/src/modules/hooksStore/hooks/useOrderParams.ts
+++ b/apps/cowswap-frontend/src/modules/hooksStore/hooks/useOrderParams.ts
@@ -1,4 +1,4 @@
-import { useAtomValue } from 'jotai/index'
+import { useAtomValue } from 'jotai'
 
 import { orderParamsStateAtom } from '../state/orderParamsStateAtom'
 

--- a/apps/cowswap-frontend/src/modules/hooksStore/hooks/useReorderHooks.ts
+++ b/apps/cowswap-frontend/src/modules/hooksStore/hooks/useReorderHooks.ts
@@ -1,4 +1,4 @@
-import { useSetAtom } from 'jotai/index'
+import { useSetAtom } from 'jotai'
 import { useCallback } from 'react'
 
 import { useHooks } from './useHooks'

--- a/apps/cowswap-frontend/src/modules/hooksStore/updaters/iframeDappsManifestUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/hooksStore/updaters/iframeDappsManifestUpdater.tsx
@@ -1,5 +1,5 @@
 import { useSetAtom } from 'jotai'
-import { useAtomValue } from 'jotai/index'
+import { useAtomValue } from 'jotai'
 import { useCallback, useEffect, useMemo } from 'react'
 
 import { HookDappBase, HookDappType } from '@cowprotocol/hook-dapp-lib'

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/RateInput/hooks/useExecutionPriceUsdValue.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/RateInput/hooks/useExecutionPriceUsdValue.ts
@@ -1,4 +1,4 @@
-import { useAtomValue } from 'jotai/index'
+import { useAtomValue } from 'jotai'
 
 import { tryParseCurrencyAmount } from '@cowprotocol/common-utils'
 import { Currency, Price } from '@uniswap/sdk-core'

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/RateInput/hooks/useRateDisplayedValue.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/RateInput/hooks/useRateDisplayedValue.ts
@@ -1,4 +1,4 @@
-import { useAtomValue } from 'jotai/index'
+import { useAtomValue } from 'jotai'
 import { useMemo } from 'react'
 
 import { formatInputAmount, tryParseCurrencyAmount } from '@cowprotocol/common-utils'

--- a/apps/cowswap-frontend/src/modules/limitOrders/updaters/SetupLimitOrderAmountsFromUrlUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/updaters/SetupLimitOrderAmountsFromUrlUpdater.tsx
@@ -1,4 +1,4 @@
-import { useSetAtom } from 'jotai/index'
+import { useSetAtom } from 'jotai'
 import { useEffect, useMemo } from 'react'
 
 import { usePrevious } from '@cowprotocol/common-hooks'

--- a/apps/cowswap-frontend/src/modules/notifications/containers/NotificationsList/index.tsx
+++ b/apps/cowswap-frontend/src/modules/notifications/containers/NotificationsList/index.tsx
@@ -1,4 +1,4 @@
-import { useSetAtom } from 'jotai/index'
+import { useSetAtom } from 'jotai'
 import React, { ReactNode, useEffect, useMemo } from 'react'
 
 import { CowSwapAnalyticsCategory, toCowSwapGtmEvent } from 'common/analytics/types'

--- a/apps/cowswap-frontend/src/modules/notifications/hooks/useUnreadNotifications.ts
+++ b/apps/cowswap-frontend/src/modules/notifications/hooks/useUnreadNotifications.ts
@@ -1,4 +1,4 @@
-import { useAtomValue } from 'jotai/index'
+import { useAtomValue } from 'jotai'
 
 import { useWalletInfo } from '@cowprotocol/wallet'
 
@@ -30,7 +30,7 @@ export function useUnreadNotifications(): UnreadNotifications {
 
           return acc
         }, {})
-      }
+      },
     ).data || EMPTY
   )
 }

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTablePagination/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTablePagination/index.tsx
@@ -26,14 +26,13 @@ export function OrdersTablePagination({
   const pagesCount = Math.ceil(totalCount / pageSize)
 
   const pagesArray = useMemo(() => [...new Array(pagesCount)].map((item, i) => i), [pagesCount])
-
   const pageLimitMiddle = Math.ceil(PAGES_LIMIT / 2)
   const batchOffset = currentPage > pageLimitMiddle ? currentPage - pageLimitMiddle : 0
   const isListBig = pagesCount > PAGES_LIMIT
   const isFirstPagesBatch = currentPage <= pageLimitMiddle
   const isLastPagesBatch = currentPage > pagesCount - pageLimitMiddle
 
-  const batchStart = Math.min(batchOffset, pagesCount - PAGES_LIMIT)
+  const batchStart = Math.max(Math.min(batchOffset, pagesCount - PAGES_LIMIT), 0)
   const batchEnd = Math.min(PAGES_LIMIT + batchOffset, pagesCount)
 
   const goToPage = useCallback(
@@ -48,7 +47,7 @@ export function OrdersTablePagination({
         return
       }
     },
-    [onPageChange, getPageUrl]
+    [onPageChange, getPageUrl],
   )
 
   return (

--- a/apps/cowswap-frontend/src/modules/permit/hooks/useGetCachedPermit.ts
+++ b/apps/cowswap-frontend/src/modules/permit/hooks/useGetCachedPermit.ts
@@ -1,4 +1,4 @@
-import { useSetAtom } from 'jotai/index'
+import { useSetAtom } from 'jotai'
 import { useCallback } from 'react'
 
 import { COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS } from '@cowprotocol/cow-sdk'

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useSwapDerivedState.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useSwapDerivedState.ts
@@ -1,5 +1,5 @@
 import { useAtomValue } from 'jotai'
-import { useSetAtom } from 'jotai/index'
+import { useSetAtom } from 'jotai'
 import { useEffect } from 'react'
 
 import { DEFAULT_TRADE_DERIVED_STATE, TradeType, useBuildTradeDerivedState } from 'modules/trade'

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useSwapSettings.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useSwapSettings.ts
@@ -1,5 +1,5 @@
 import { useSetAtom } from 'jotai'
-import { useAtomValue } from 'jotai/index'
+import { useAtomValue } from 'jotai'
 import { useMemo } from 'react'
 
 import { StatefulValue } from '@cowprotocol/types'

--- a/apps/cowswap-frontend/src/modules/swap/state/swapRawStateAtom.ts
+++ b/apps/cowswap-frontend/src/modules/swap/state/swapRawStateAtom.ts
@@ -1,4 +1,4 @@
-import { atom } from 'jotai/index'
+import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 
 import { atomWithPartialUpdate } from '@cowprotocol/common-utils'

--- a/apps/cowswap-frontend/src/modules/tokensList/hooks/useSelectTokenWidgetState.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/hooks/useSelectTokenWidgetState.ts
@@ -1,4 +1,4 @@
-import { useAtomValue } from 'jotai/index'
+import { useAtomValue } from 'jotai'
 
 import { selectTokenWidgetAtom } from '../state/selectTokenWidgetAtom'
 

--- a/apps/cowswap-frontend/src/modules/tokensList/hooks/useUpdateSelectTokenWidgetState.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/hooks/useUpdateSelectTokenWidgetState.ts
@@ -1,4 +1,4 @@
-import { useSetAtom } from 'jotai/index'
+import { useSetAtom } from 'jotai'
 
 import { updateSelectTokenWidgetAtom } from '../state/selectTokenWidgetAtom'
 

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useIsEoaEthFlow.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useIsEoaEthFlow.ts
@@ -1,4 +1,4 @@
-import { useAtomValue } from 'jotai/index'
+import { useAtomValue } from 'jotai'
 
 import { isEoaEthFlowAtom } from '../state/isEoaEthFlowAtom'
 

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useIsWrapOrUnwrap.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useIsWrapOrUnwrap.ts
@@ -1,4 +1,4 @@
-import { useAtomValue } from 'jotai/index'
+import { useAtomValue } from 'jotai'
 
 import { isWrapOrUnwrapAtom } from '../state/isWrapOrUnwrapAtom'
 

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useTradeConfirmState.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useTradeConfirmState.ts
@@ -1,4 +1,4 @@
-import { useAtomValue } from 'jotai/index'
+import { useAtomValue } from 'jotai'
 
 import { tradeConfirmStateAtom } from '../state/tradeConfirmStateAtom'
 

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useWrapNativeScreenState.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useWrapNativeScreenState.ts
@@ -1,4 +1,4 @@
-import { useAtom } from 'jotai/index'
+import { useAtom } from 'jotai'
 
 import { wrapNativeStateAtom } from '../state/wrapNativeStateAtom'
 

--- a/apps/cowswap-frontend/src/modules/trade/state/isEoaEthFlowAtom.ts
+++ b/apps/cowswap-frontend/src/modules/trade/state/isEoaEthFlowAtom.ts
@@ -1,4 +1,4 @@
-import { atom } from 'jotai/index'
+import { atom } from 'jotai'
 
 import { getIsNativeToken } from '@cowprotocol/common-utils'
 import { walletDetailsAtom } from '@cowprotocol/wallet'

--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useTradeQuoteManager.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useTradeQuoteManager.ts
@@ -1,4 +1,4 @@
-import { useSetAtom } from 'jotai/index'
+import { useSetAtom } from 'jotai'
 import { useMemo } from 'react'
 
 import { BridgeQuoteResults, PriceQuality, QuoteBridgeRequest, SupportedChainId } from '@cowprotocol/cow-sdk'

--- a/apps/cowswap-frontend/src/modules/tradeSlippage/hooks/useIsSlippageModified.ts
+++ b/apps/cowswap-frontend/src/modules/tradeSlippage/hooks/useIsSlippageModified.ts
@@ -1,4 +1,4 @@
-import { useAtomValue } from 'jotai/index'
+import { useAtomValue } from 'jotai'
 
 import { slippageValueAndTypeAtom } from '../state/slippageValueAndTypeAtom'
 

--- a/apps/cowswap-frontend/src/modules/tradeSlippage/hooks/useIsSmartSlippageApplied.ts
+++ b/apps/cowswap-frontend/src/modules/tradeSlippage/hooks/useIsSmartSlippageApplied.ts
@@ -1,4 +1,4 @@
-import { useAtomValue } from 'jotai/index'
+import { useAtomValue } from 'jotai'
 
 import { slippageValueAndTypeAtom } from '../state/slippageValueAndTypeAtom'
 

--- a/apps/cowswap-frontend/src/modules/tradeSlippage/hooks/useTradeSlippage.ts
+++ b/apps/cowswap-frontend/src/modules/tradeSlippage/hooks/useTradeSlippage.ts
@@ -1,4 +1,4 @@
-import { useAtomValue } from 'jotai/index'
+import { useAtomValue } from 'jotai'
 import { useMemo } from 'react'
 
 import { bpsToPercent } from '@cowprotocol/common-utils'

--- a/apps/cowswap-frontend/src/modules/twap/containers/AmountParts/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/AmountParts/index.tsx
@@ -1,4 +1,4 @@
-import { useAtomValue } from 'jotai/index'
+import { useAtomValue } from 'jotai'
 import { ReactElement, ReactNode } from 'react'
 
 import { HelpTooltip, renderTooltip } from '@cowprotocol/ui'

--- a/apps/cowswap-frontend/src/modules/twap/containers/SetupFallbackHandlerWarning/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/SetupFallbackHandlerWarning/index.tsx
@@ -1,5 +1,5 @@
 import { atom, useAtom } from 'jotai'
-import { useSetAtom } from 'jotai/index'
+import { useSetAtom } from 'jotai'
 import { useCallback, useEffect, useState } from 'react'
 
 import { usePrevious } from '@cowprotocol/common-hooks'

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useEmulatedPartOrders.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useEmulatedPartOrders.ts
@@ -8,8 +8,10 @@ import ms from 'ms.macro'
 
 import { Order } from 'legacy/state/orders/actions'
 
+import { useTwapPartOrdersList } from './useTwapPartOrdersList'
+
 import { twapOrdersAtom, TwapOrdersList } from '../state/twapOrdersListAtom'
-import { TwapPartOrderItem, twapPartOrdersListAtom } from '../state/twapPartOrdersAtom'
+import { TwapPartOrderItem } from '../state/twapPartOrdersAtom'
 import { emulatePartAsOrder } from '../utils/emulatePartAsOrder'
 import { mapPartOrderToStoreOrder } from '../utils/mapPartOrderToStoreOrder'
 
@@ -17,7 +19,7 @@ const EMULATED_ORDERS_REFRESH_MS = ms`5s`
 
 export function useEmulatedPartOrders(tokensByAddress: TokensByAddress | undefined): Order[] {
   const twapOrders = useAtomValue(twapOrdersAtom)
-  const twapParticleOrders = useAtomValue(twapPartOrdersListAtom)
+  const twapParticleOrders = useTwapPartOrdersList()
   // Update emulated part orders every 5 seconds to recalculate expired state
   const refresher = useMachineTimeMs(EMULATED_ORDERS_REFRESH_MS)
 
@@ -33,7 +35,7 @@ export function useEmulatedPartOrders(tokensByAddress: TokensByAddress | undefin
 function emulatePartOrders(
   twapParticleOrders: TwapPartOrderItem[],
   twapOrders: TwapOrdersList,
-  tokensByAddress: TokensByAddress
+  tokensByAddress: TokensByAddress,
 ): Order[] {
   return twapParticleOrders.reduce<Order[]>((acc, item) => {
     if (item.isCreatedInOrderBook) return acc

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useEmulatedTwapOrders.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useEmulatedTwapOrders.ts
@@ -1,4 +1,4 @@
-import { useAtomValue } from 'jotai'
+import { useAtomValue } from 'jotai/index'
 import { useMemo } from 'react'
 
 import { useMachineTimeMs } from '@cowprotocol/common-hooks'

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useEmulatedTwapOrders.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useEmulatedTwapOrders.ts
@@ -1,4 +1,4 @@
-import { useAtomValue } from 'jotai/index'
+import { useAtomValue } from 'jotai'
 import { useMemo } from 'react'
 
 import { useMachineTimeMs } from '@cowprotocol/common-hooks'

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useFetchTwapOrdersFromSafe.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useFetchTwapOrdersFromSafe.ts
@@ -9,7 +9,7 @@ import { useSafeApiKit } from 'common/hooks/useSafeApiKit'
 import { fetchTwapOrdersFromSafe } from '../services/fetchTwapOrdersFromSafe'
 import { TwapOrdersSafeData } from '../types'
 
-const PENDING_TWAP_UPDATE_INTERVAL = ms`15s`
+const PENDING_TWAP_UPDATE_INTERVAL = ms`45s`
 
 export function useFetchTwapOrdersFromSafe({
   safeAddress,

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useTwapOrderByChildId.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useTwapOrderByChildId.ts
@@ -1,13 +1,12 @@
-import { useAtomValue } from 'jotai'
 import { useMemo } from 'react'
 
 import { useTwapOrderById } from './useTwapOrderById'
+import { useTwapPartOrdersList } from './useTwapPartOrdersList'
 
-import { twapPartOrdersListAtom } from '../state/twapPartOrdersAtom'
 import { TwapOrderItem } from '../types'
 
 export function useTwapOrderByChildId(orderId: string | undefined): TwapOrderItem | null {
-  const twapPartOrdersList = useAtomValue(twapPartOrdersListAtom)
+  const twapPartOrdersList = useTwapPartOrdersList()
 
   const parentId = useMemo(() => {
     return twapPartOrdersList.find(({ uid }) => uid === orderId)?.twapOrderId

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useTwapOrdersTokens.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useTwapOrdersTokens.ts
@@ -1,4 +1,4 @@
-import { useAtomValue } from 'jotai/index'
+import { useAtomValue } from 'jotai'
 import { useMemo } from 'react'
 
 import { TokensByAddress } from '@cowprotocol/tokens'
@@ -7,12 +7,13 @@ import { useAsyncMemo } from 'use-async-memo'
 
 import { useTokensForOrdersList, getTokensListFromOrders } from 'modules/orders'
 
+import { useTwapPartOrdersList } from './useTwapPartOrdersList'
+
 import { twapOrdersListAtom } from '../state/twapOrdersListAtom'
-import { twapPartOrdersListAtom } from '../state/twapPartOrdersAtom'
 
 export function useTwapOrdersTokens(): TokensByAddress | undefined {
   const allTwapOrders = useAtomValue(twapOrdersListAtom)
-  const twapPartOrders = useAtomValue(twapPartOrdersListAtom)
+  const twapPartOrders = useTwapPartOrdersList()
 
   const getTokensForOrdersList = useTokensForOrdersList()
 

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useTwapPartOrdersList.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useTwapPartOrdersList.ts
@@ -1,0 +1,33 @@
+import { useAtomValue } from 'jotai'
+
+import { useWalletInfo } from '@cowprotocol/wallet'
+
+import useSWR from 'swr'
+
+import { TwapPartOrderItem, twapPartOrdersAtom } from '../state/twapPartOrdersAtom'
+
+const EMPTY_PART_ITEMS: TwapPartOrderItem[] = []
+const swrConfig = {
+  fallbackData: EMPTY_PART_ITEMS,
+}
+
+export function useTwapPartOrdersList(): TwapPartOrderItem[] {
+  const { account, chainId } = useWalletInfo()
+  const twapPartOrders = useAtomValue(twapPartOrdersAtom)
+
+  const result = useSWR(
+    account ? [account, chainId, twapPartOrders, 'useTwapPartOrdersList'] : null,
+    async ([account, chainId, twapPartOrders]) => {
+      if (!account || !chainId) return EMPTY_PART_ITEMS
+
+      const accountLowerCase = account.toLowerCase()
+
+      const orders = Object.values(twapPartOrders)
+
+      return orders.flat().filter((order) => order.safeAddress === accountLowerCase && order.chainId === chainId)
+    },
+    swrConfig,
+  )
+
+  return result.data
+}

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useTwapSlippage.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useTwapSlippage.ts
@@ -1,4 +1,4 @@
-import { useAtomValue } from 'jotai/index'
+import { useAtomValue } from 'jotai'
 
 import { twapOrderSlippageAtom } from '../state/twapOrdersSettingsAtom'
 

--- a/apps/cowswap-frontend/src/modules/twap/services/fetchTwapOrdersFromSafe.ts
+++ b/apps/cowswap-frontend/src/modules/twap/services/fetchTwapOrdersFromSafe.ts
@@ -12,8 +12,8 @@ import { ConditionalOrderParams, TwapOrdersSafeData } from '../types'
 
 // ComposableCoW.createWithContext method
 const CREATE_COMPOSABLE_ORDER_SELECTOR = '0d0d9800'
-// Each page contains 20 transactions by default, so we need to fetch 10 pages to get 200 transactions
-const SAFE_TX_HISTORY_DEPTH = 10
+// Each page contains 20 transactions by default, so we need to fetch 200 pages to get 4000 transactions
+const SAFE_TX_HISTORY_DEPTH = 200
 // Just in case, make a short delay between requests
 const SAFE_TX_REQUEST_DELAY = ms`100ms`
 

--- a/apps/cowswap-frontend/src/modules/twap/updaters/CreatedInOrderBookOrdersUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/updaters/CreatedInOrderBookOrdersUpdater.tsx
@@ -12,8 +12,9 @@ import { useAddOrUpdateOrders } from 'legacy/state/orders/hooks'
 
 import { useTokensForOrdersList, getTokensListFromOrders, useSWRProdOrders } from 'modules/orders'
 
+import { useTwapPartOrdersList } from '../hooks/useTwapPartOrdersList'
 import { twapOrdersAtom } from '../state/twapOrdersListAtom'
-import { TwapPartOrderItem, twapPartOrdersListAtom, updatePartOrdersAtom } from '../state/twapPartOrdersAtom'
+import { TwapPartOrderItem, updatePartOrdersAtom } from '../state/twapPartOrdersAtom'
 import { TwapOrderItem } from '../types'
 import { mapPartOrderToStoreOrder } from '../utils/mapPartOrderToStoreOrder'
 
@@ -35,7 +36,7 @@ export function CreatedInOrderBookOrdersUpdater() {
   const isSafeWallet = useIsSafeWallet()
   const prodOrders = useSWRProdOrders()
   const getTokensForOrdersList = useTokensForOrdersList()
-  const twapPartOrdersList = useAtomValue(twapPartOrdersListAtom)
+  const twapPartOrdersList = useTwapPartOrdersList()
   const twapOrders = useAtomValue(twapOrdersAtom)
   const updatePartOrders = useSetAtom(updatePartOrdersAtom)
   const addOrUpdateOrders = useAddOrUpdateOrders()
@@ -74,7 +75,7 @@ export function CreatedInOrderBookOrdersUpdater() {
         .filter(isTruthy)
     },
     [prodOrders, twapPartOrdersMap, getTokensForOrdersList, twapOrders],
-    []
+    [],
   )
 
   useEffect(() => {

--- a/apps/cowswap-frontend/src/modules/twap/updaters/PartOrdersUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/updaters/PartOrdersUpdater.tsx
@@ -1,5 +1,4 @@
-import { useSetAtom } from 'jotai'
-import { useAtomValue } from 'jotai/index'
+import { useSetAtom, useAtomValue } from 'jotai'
 import { useEffect } from 'react'
 
 import { isTruthy } from '@cowprotocol/common-utils'

--- a/apps/cowswap-frontend/src/modules/twap/updaters/PartOrdersUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/updaters/PartOrdersUpdater.tsx
@@ -1,4 +1,5 @@
-import { useAtomValue, useSetAtom } from 'jotai'
+import { useSetAtom } from 'jotai'
+import { useAtomValue } from 'jotai/index'
 import { useEffect } from 'react'
 
 import { isTruthy } from '@cowprotocol/common-utils'
@@ -44,7 +45,7 @@ export function PartOrdersUpdater() {
 async function generateTwapOrderParts(
   twapOrder: TwapOrderItem,
   safeAddress: string,
-  chainId: SupportedChainId
+  chainId: SupportedChainId,
 ): Promise<{ [id: string]: TwapPartOrderItem[] }> {
   const twapOrderId = twapOrder.id
 

--- a/apps/cowswap-frontend/src/modules/yield/hooks/useYieldDerivedState.ts
+++ b/apps/cowswap-frontend/src/modules/yield/hooks/useYieldDerivedState.ts
@@ -1,5 +1,5 @@
 import { useAtomValue } from 'jotai'
-import { useSetAtom } from 'jotai/index'
+import { useSetAtom } from 'jotai'
 import { useEffect } from 'react'
 
 import { INITIAL_ALLOWED_SLIPPAGE_PERCENT } from '@cowprotocol/common-const'

--- a/apps/cowswap-frontend/src/modules/yield/hooks/useYieldSettings.ts
+++ b/apps/cowswap-frontend/src/modules/yield/hooks/useYieldSettings.ts
@@ -1,5 +1,5 @@
 import { useSetAtom } from 'jotai'
-import { useAtomValue } from 'jotai/index'
+import { useAtomValue } from 'jotai'
 import { useMemo } from 'react'
 
 import { StatefulValue } from '@cowprotocol/types'

--- a/apps/cowswap-frontend/src/modules/yield/state/yieldRawStateAtom.ts
+++ b/apps/cowswap-frontend/src/modules/yield/state/yieldRawStateAtom.ts
@@ -1,4 +1,4 @@
-import { atom } from 'jotai/index'
+import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 
 import { atomWithPartialUpdate } from '@cowprotocol/common-utils'

--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
     "launchdarkly-react-client-sdk": "^3.0.4",
     "lightweight-charts": "^3.3.0",
     "limiter": "^2.1.0",
+    "localforage": "^1.10.0",
     "lottie-react": "^2.4.0",
     "make-plural": "^7.0.0",
     "ms": "^2.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18958,6 +18958,11 @@ image-size@~0.5.0:
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
   integrity sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
+
 immer@^10.0.2:
   version "10.0.2"
   resolved "https://registry.yarnpkg.com/immer/-/immer-10.0.2.tgz#11636c5b77acf529e059582d76faf338beb56141"
@@ -21939,6 +21944,13 @@ license-webpack-plugin@^4.0.2:
   dependencies:
     webpack-sources "^3.0.0"
 
+lie@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
+  integrity sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==
+  dependencies:
+    immediate "~3.0.5"
+
 lightweight-charts@^3.3.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/lightweight-charts/-/lightweight-charts-3.8.0.tgz#8c41ad7c1c083f18621f11ece7fc1096e131a0d3"
@@ -22121,6 +22133,13 @@ local-pkg@^1.0.0:
     mlly "^1.7.4"
     pkg-types "^2.0.1"
     quansync "^0.2.8"
+
+localforage@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.10.0.tgz#5c465dc5f62b2807c3a84c0c6a1b1b3212781dd4"
+  integrity sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==
+  dependencies:
+    lie "3.1.1"
 
 locate-path@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
# Summary

1. Increased Safe transaction history fetching limit from 200 up to 4000 tx
2. Changed twap state persistance storage from localStorage to IndexedDB
3. Fixed twap order table pagination

<img width="1718" alt="image" src="https://github.com/user-attachments/assets/5fe0945e-be63-4f70-b091-5d6f6601fa2b" />

https://github.com/user-attachments/assets/a5e958e5-cfca-4f7f-8b09-a4db2e615d20

# To Test
1. Open a Safe with huge amount of TWAP orders
2. Go to TWAP

- [ ] there should not be `twap-part-orders-list:v1` keys in CoW Swap localStorage
- [ ] `twap-part-orders-list:v1` should be present in `cowswap_jotai.keyvaluepairs` IndexedDB storage
- [ ] Orders should be displayed in the table

> **Since it takes awhile to fetch Safe history, you might notice a significant delay before orders are appearing in the table.**

