### PR TITLE
fix(trade): add amountsToSign to validation context and update valida…

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormValidationContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormValidationContext.ts
@@ -23,7 +23,8 @@ export function useTradeFormValidationContext(): TradeFormValidationCommonContex
   const isOnline = useIsOnline()
 
   const { inputCurrency, outputCurrency, recipient, tradeType } = derivedTradeState || {}
-  const { maximumSendSellAmount } = useAmountsToSign() || {}
+  const amountsToSign = useAmountsToSign()
+  const { maximumSendSellAmount } = amountsToSign || {}
   const { state: approvalState } = useApproveState(maximumSendSellAmount)
   const { address: recipientEnsAddress } = useENSAddress(recipient)
   const isSwapUnsupported =
@@ -55,6 +56,7 @@ export function useTradeFormValidationContext(): TradeFormValidationCommonContex
     isProviderNetworkUnsupported,
     isOnline,
     derivedTradeState,
+    amountsToSign,
   }
 
   return useMemo(() => {

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/types.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/types.ts
@@ -58,6 +58,7 @@ export interface TradeFormValidationCommonContext {
   isInsufficientBalanceOrderAllowed: boolean
   isProviderNetworkUnsupported: boolean
   isOnline: boolean
+  amountsToSign: AmountsToSign | null
 }
 
 export interface TradeFormValidationContext extends TradeFormValidationCommonContext {}


### PR DESCRIPTION
 # Summary

  Fixes #5726

  Fixed insufficient balance validation for buy orders where the validation was only checking
   against the input amount without including network costs and slippage. This allowed users
  to create orders that would fail execution due to insufficient balance when fees and
  slippage were factored in.

  # To Test

  1. **Buy order with sufficient balance (should work)**
     - [ ] Connect wallet with ~52 GHO balance on Arbitrum
     - [ ] Navigate to Swap page: GHO → USDC
     - [ ] Set buy amount to 51.3 USDC (this should show "From (incl. costs)" ~51.39 GHO)
     - [ ] Verify "Swap" button is enabled and order can be placed
     - [ ] Verify order executes successfully

  2. **Buy order with insufficient balance including slippage (should be blocked)**
     - [ ] With same ~52 GHO balance
     - [ ] Set buy amount to 51.5 USDC (this should show "From (incl. costs)" ~51.59 GHO)
     - [ ] Verify "Insufficient GHO balance" message appears
     - [ ] Verify button is disabled preventing order creation

  3. **Edge case: Balance exactly at slippage threshold**
     - [ ] Test amounts where balance is between "From (incl. costs)" and maximum slippage
  amount
     - [ ] Verify validation correctly blocks orders that would exceed balance with slippage

  4. **Sell orders and limit orders still work**
     - [ ] Verify sell orders (regular and limit) are unaffected by changes
     - [ ] Verify limit orders can still be placed with insufficient balance (existing
  behavior)

  # Background

  The issue was in the balance validation logic in `validateTradeForm.ts`. For buy orders,
  the system was only validating against `inputCurrencyAmount` (the base sell amount) rather
  than `maximumSendSellAmount` (which includes network fees and slippage protection).

  ## Example Scenarios

  **Before fix:**
  - User balance: 51.7444 GHO
  - Buy 51.5 USDC → shows "From (incl. costs): 51.59 GHO"
  - Validation only checked: 51.7444 > 51.585 ✅ (allowed)
  - Actual maximum spend with slippage: 51.85 GHO
  - Result: Order placed but fails execution (51.7444 < 51.85)

  **After fix:**
  - User balance: 51.7444 GHO
  - Buy 51.5 USDC → shows "From (incl. costs): 51.59 GHO"
  - Validation now checks: 51.7444 > 51.85 ❌ (blocked)
  - Result: "Insufficient GHO balance" - prevents failed orders

  The fix ensures users can only create orders they can actually execute, improving UX by
  preventing failed transactions while maintaining the existing behavior for limit orders
  that are designed to be placed with insufficient balance for future execution.