### PR TITLE
fix(safe-wc): pass chainId to wallet_sendCalls in the body of the request

### DIFF
--- a/libs/wallet/src/api/hooks/useSendBatchTransactions.ts
+++ b/libs/wallet/src/api/hooks/useSendBatchTransactions.ts
@@ -23,7 +23,7 @@ export function useSendBatchTransactions(): SendBatchTxCallback {
         const chainIdHex = '0x' + (+chainId).toString(16)
         const calls = txs.map((tx) => ({ ...tx, chainId: chainIdHex }))
 
-        return provider.send('wallet_sendCalls', [{ version: '1.0', from: account, calls }])
+        return provider.send('wallet_sendCalls', [{ version: '1.0', from: account, calls, chainId: chainIdHex }])
       }
 
       if (safeAppsSdk) {


### PR DESCRIPTION
# Summary

Currently, Safe via WC on prod is broken.
Upon inspection, it fails at https://github.com/safe-global/safe-wallet-monorepo/blob/dev/apps/web/src/services/safe-wallet-provider/index.ts#L367

It expects the `chainId` to be at the root level.
However, we were passing only within the call.

This change adds it to the body:
![Screenshot 2025-06-06 at 18 50 59](https://github.com/user-attachments/assets/d61f0496-66cc-449c-b994-3357ec99a532)


# To Test

1. Open as CoW Swap and connect to Safe via WC
2. Place a TWAP order
* Should work
3. Cancel a TWAP
* Should work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved batch transaction sending by explicitly including the chain ID in requests, ensuring better compatibility and reliability when submitting transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->