### PR TITLE
fix(slippage): cap auto-slippage with 50%

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useTradeQuoteManager.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useTradeQuoteManager.ts
@@ -26,8 +26,6 @@ export interface TradeQuoteManager {
   onResponse(data: QuoteAndPost, bridgeQuote: BridgeQuoteResults | null, fetchParams: TradeQuoteFetchParams): void
 }
 
-// TODO: Break down this large function into smaller functions
-// eslint-disable-next-line max-lines-per-function
 export function useTradeQuoteManager(
   sellTokenAddress: SellTokenAddress | undefined,
   enableSmartSlippage: boolean,

--- a/apps/cowswap-frontend/src/modules/tradeSlippage/hooks/useSetSmartSlippage.ts
+++ b/apps/cowswap-frontend/src/modules/tradeSlippage/hooks/useSetSmartSlippage.ts
@@ -1,9 +1,7 @@
 import { useSetAtom } from 'jotai'
 
-import { smartTradeSlippageAtom } from '../state/slippageValueAndTypeAtom'
+import { setSmartTradeSlippageAtom } from '../state/slippageValueAndTypeAtom'
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function useSetSmartSlippage() {
-  return useSetAtom(smartTradeSlippageAtom)
+export function useSetSmartSlippage(): (slippage: number) => void {
+  return useSetAtom(setSmartTradeSlippageAtom)
 }

--- a/apps/cowswap-frontend/src/modules/tradeSlippage/hooks/useTradeSlippage.ts
+++ b/apps/cowswap-frontend/src/modules/tradeSlippage/hooks/useTradeSlippage.ts
@@ -6,13 +6,12 @@ import { Percent } from '@uniswap/sdk-core'
 
 import {
   defaultSlippageAtom,
+  SlippageType,
   slippageValueAndTypeAtom,
   smartTradeSlippageAtom,
 } from '../state/slippageValueAndTypeAtom'
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function useTradeSlippageValueAndType() {
+export function useTradeSlippageValueAndType(): { type: SlippageType; value: number } {
   return useAtomValue(slippageValueAndTypeAtom)
 }
 export function useTradeSlippage(): Percent {
@@ -21,14 +20,10 @@ export function useTradeSlippage(): Percent {
   return useMemo(() => bpsToPercent(value), [value])
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function useDefaultTradeSlippage() {
+export function useDefaultTradeSlippage(): Percent {
   return bpsToPercent(useAtomValue(defaultSlippageAtom))
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function useSmartTradeSlippage() {
+export function useSmartTradeSlippage(): number | null {
   return useAtomValue(smartTradeSlippageAtom)
 }


### PR DESCRIPTION
# Summary

Since we cap manual slippage (in settings) with 50% it will make sense to have a consistent logic with auto slippage.

<img width="510" alt="image" src="https://github.com/user-attachments/assets/852288c6-1daf-4b7e-bfb2-7e2b4658e965" />

# To Test

1. Setup WBTC -> 0.000001 USDC (buy order)
- [ ] AR: slippage is 100%
- [ ] ER: slippage is 50%
