### PR TITLE
fix(trade): hide auto-slippage warning when amounts are not set

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeSlippage/containers/HighSuggestedSlippageWarning/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeSlippage/containers/HighSuggestedSlippageWarning/index.tsx
@@ -1,9 +1,12 @@
-import { percentToBps } from '@cowprotocol/common-utils'
+import { ReactNode } from 'react'
+
+import { isFractionFalsy, percentToBps } from '@cowprotocol/common-utils'
 import { BannerOrientation, InfoTooltip, InlineBanner, StatusColorVariant } from '@cowprotocol/ui'
 import { useWalletInfo } from '@cowprotocol/wallet'
 
 import styled from 'styled-components/macro'
 
+import { useDerivedTradeState } from 'modules/trade'
 import { useIsSmartSlippageApplied, useTradeSlippage } from 'modules/tradeSlippage'
 
 const StyledInlineBanner = styled(InlineBanner)`
@@ -14,18 +17,18 @@ export type HighSuggestedSlippageWarningProps = {
   isTradePriceUpdating: boolean
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function HighSuggestedSlippageWarning(props: HighSuggestedSlippageWarningProps) {
+export function HighSuggestedSlippageWarning(props: HighSuggestedSlippageWarningProps): ReactNode {
   const { isTradePriceUpdating } = props
   const { account } = useWalletInfo()
   const slippage = useTradeSlippage()
+  const state = useDerivedTradeState()
 
   const isSmartSlippageApplied = useIsSmartSlippageApplied()
   const isSuggestedSlippage = isSmartSlippageApplied && !isTradePriceUpdating && !!account
   const slippageBps = percentToBps(slippage)
+  const amountsAreSet = !isFractionFalsy(state?.inputCurrencyAmount) && !isFractionFalsy(state?.outputCurrencyAmount)
 
-  if (!isSuggestedSlippage || !slippageBps || slippageBps <= 200) {
+  if (!isSuggestedSlippage || !slippageBps || slippageBps <= 200 || !amountsAreSet) {
     return null
   }
 


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Slippage-banner-is-not-removed-from-the-form-20d8da5f04ca80c88fced30c5ccd51ad?source=copy_link

<img width="652" alt="image" src="https://github.com/user-attachments/assets/1f69af19-c5f8-4332-87f3-35a4c50fbcb0" />

# To Test

1. Specify a tiny trade to get a dynamic slippage > 2%
2. Remove a sell amount from the form
- [ ] AR: slippage banner is remains to be displayed
- [ ] ER: slippage banner is not displayed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the display logic for the high slippage warning banner to ensure it only appears when both input and output amounts are set, reducing unnecessary warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->