### PR TITLE
fix(order-progress): do not collapse image wrapper while loading

### DIFF
--- a/apps/cowswap-frontend/src/modules/orderProgressBar/sharedStyled.ts
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/sharedStyled.ts
@@ -33,7 +33,6 @@ export const ProgressImageWrapper = styled.div<{ bgColor?: string; padding?: str
   overflow: hidden;
 
   ${Media.upToSmall()} {
-    min-height: auto;
     height: auto;
   }
 


### PR DESCRIPTION
# Summary

Fixes [#issueNumber](https://www.notion.so/cownation/Progress-bar-animation-between-the-1st-and-the-2nd-step-blinks-20d8da5f04ca801d99ddd886b9ec9567?source=copy_link)

<img width="660" alt="image" src="https://github.com/user-attachments/assets/f6a1b1c0-cdbe-44f1-9743-12ac7d7c2bf2" />

# To Test

1. Post an order in mobile browser
2. Wait till the countdown is displayed in progress modal
- [ ] AR: while the banner background image is loading, the banner is collapsed
- [ ] ER: while the banner background image is loading, the banner height is at least 200px

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the styling for the progress image on small screens to improve visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->