### PR TITLE
fix(service-worker): disable verbose workbox logging in production

### DIFF
--- a/apps/cowswap-frontend/src/serviceWorker/index.ts
+++ b/apps/cowswap-frontend/src/serviceWorker/index.ts
@@ -1,3 +1,7 @@
+// Disable workbox verbose logging
+declare const self: ServiceWorkerGlobalScope & { __WB_DISABLE_DEV_LOGS?: boolean }
+self.__WB_DISABLE_DEV_LOGS = true
+
 import 'workbox-precaching' // defines __WB_MANIFEST
 
 import { clientsClaim, setCacheNameDetails } from 'workbox-core'
@@ -14,8 +18,6 @@ import { toURL } from './utils'
 import pkg from '../../package.json'
 
 const WEB_VERSION = pkg.version
-
-declare const self: ServiceWorkerGlobalScope
 
 // Set Cache name
 //  See https://dev.to/atonchev/flawless-and-silent-upgrade-of-the-service-worker-2o95


### PR DESCRIPTION
# Summary

  Fixes verbose workbox logging appearing in browser console on production/preview environments.

  After upgrading `vite-plugin-pwa` from v0.19.8 to v1.0.0 (PR #5663), Workbox was upgraded from v6 to v7,
  which enabled verbose logging by default. This caused numerous "No cached response found" and precaching
  messages to appear in the browser console on dev.swap.cow.fi and other production/preview environments.

 

  # To Test

  1. **Before this fix** - Visit https://dev.swap.cow.fi and open browser console

  - [ ] Should see numerous workbox logging messages like "No cached response found in
  'CowSwap-precache-v2-1.108.2'"
  - [ ] Should see "Precaching X files" messages
  - [ ] Should see "Updating cache with new Response" messages

  2. **After this fix** - Deploy and visit the same URL

  - [ ] Console should be clean of workbox verbose logging
  - [ ] Service worker should still function normally (offline caching works)
  - [ ] PWA features should remain intact

  3. **Localhost behavior** - Test `yarn start` locally

  - [ ] Should continue to work as before (no verbose logging on localhost was already the case)
  - [ ] Service worker registration should work normally

  # Background

  The issue was introduced when `vite-plugin-pwa` was upgraded from v0.19.8 to v1.0.0 in PR #5663 (May 13,
  2025). This upgrade brought Workbox from v6.x to v7.x, and Workbox 7 has verbose logging enabled by
  default in non-production environments.

  The verbose logging only appeared on deployed environments (Vercel preview/production) because:
  - Localhost uses `checkValidServiceWorker()` which validates the SW before registering
  - Production environments directly register the service worker without validation
  - The logging messages are informational (not errors) showing normal cache population behavior

  The fix uses Workbox's built-in `__WB_DISABLE_DEV_LOGS` flag to suppress verbose logging while preserving
   all service worker functionality.