### PR TITLE
fix(trade): reset loading state when confirm wasn't happen

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeConfirmModal/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeConfirmModal/index.cosmos.tsx
@@ -32,7 +32,7 @@ const confirmationState: TradeConfirmationProps = {
   isConfirmDisabled: false,
   refreshInterval: 10_000,
   recipient: null,
-  onConfirm() {
+  async onConfirm() {
     console.log('onConfirm')
   },
   onDismiss() {

--- a/apps/cowswap-frontend/src/modules/trade/pure/TradeConfirmation/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/TradeConfirmation/index.cosmos.tsx
@@ -10,7 +10,7 @@ const Fixtures = {
       ensName={undefined}
       inputCurrencyInfo={inputCurrencyInfoMock}
       outputCurrencyInfo={outputCurrencyInfoMock}
-      onConfirm={() => void 0}
+      onConfirm={async () => void 0}
       onDismiss={() => void 0}
       isConfirmDisabled={false}
       priceImpact={priceImpactMock}

--- a/apps/cowswap-frontend/src/modules/trade/pure/TradeConfirmation/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/TradeConfirmation/index.tsx
@@ -22,7 +22,7 @@ import { useTradeConfirmState } from '../../hooks/useTradeConfirmState'
 import { PriceUpdatedBanner } from '../PriceUpdatedBanner'
 
 export interface TradeConfirmationProps {
-  onConfirm(): void
+  onConfirm(): Promise<void | false>
 
   onDismiss(): void
 
@@ -107,13 +107,17 @@ export function TradeConfirmation(props: TradeConfirmationProps) {
   // Combine local onClick logic with incoming onClick
   // TODO: Add proper return type annotation
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  const handleConfirmClick = () => {
+  const handleConfirmClick = async () => {
     if (isUpToMedium) {
       window.scrollTo({ top: 0, left: 0 })
     }
 
     setIsConfirmClicked(true)
-    onConfirm()
+    const isConfirmed = await onConfirm()
+
+    if (!isConfirmed) {
+      setIsConfirmClicked(false)
+    }
   }
 
   const hookDetailsElement = (


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Confirm-with-your-wallet-appears-when-swap-is-not-yet-sent-to-a-wallet-2118da5f04ca80df8348cccd43228e4a

# To Test

See https://www.notion.so/cownation/Confirm-with-your-wallet-appears-when-swap-is-not-yet-sent-to-a-wallet-2118da5f04ca80df8348cccd43228e4a
