### PR TITLE
fix(widget): do not request wallet capabilities for wallet-connect

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/MetamaskTransactionWarning/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/MetamaskTransactionWarning/index.tsx
@@ -3,9 +3,8 @@ import { useEffect, useState } from 'react'
 import { CHAIN_INFO } from '@cowprotocol/common-const'
 import { getIsNativeToken } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { ProviderMetaInfoPayload, WidgetEthereumProvider } from '@cowprotocol/iframe-transport'
 import { InlineBanner, StatusColorVariant } from '@cowprotocol/ui'
-import { METAMASK_RDNS, useIsMetamaskBrowserExtensionWallet } from '@cowprotocol/wallet'
+import { METAMASK_RDNS, useIsMetamaskBrowserExtensionWallet, useWidgetProviderMetaInfo } from '@cowprotocol/wallet'
 import { useWalletProvider } from '@cowprotocol/wallet-provider'
 import { ExternalProvider } from '@ethersproject/providers'
 import { Currency } from '@uniswap/sdk-core'
@@ -58,25 +57,6 @@ export function MetamaskTransactionWarning({ sellToken }: { sellToken: Currency 
       </NetworkInfo>
     </Banner>
   )
-}
-
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function useWidgetProviderMetaInfo() {
-  const provider = useWalletProvider()
-  const [widgetProviderMetaInfo, setWidgetProviderMetaInfo] = useState<ProviderMetaInfoPayload | null>(null)
-
-  const rawProvider = provider?.provider as unknown
-
-  useEffect(() => {
-    const isWidgetEthereumProvider = rawProvider instanceof WidgetEthereumProvider
-
-    if (!isWidgetEthereumProvider) return
-
-    rawProvider.onProviderMetaInfo(setWidgetProviderMetaInfo)
-  }, [rawProvider])
-
-  return widgetProviderMetaInfo
 }
 
 /**

--- a/libs/wallet/src/api/hooks/useWalletCapabilities.ts
+++ b/libs/wallet/src/api/hooks/useWalletCapabilities.ts
@@ -5,6 +5,8 @@ import { useWalletProvider } from '@cowprotocol/wallet-provider'
 import ms from 'ms.macro'
 import useSWR, { SWRResponse } from 'swr'
 
+import { useWidgetProviderMetaInfo } from './useWidgetProviderMetaInfo'
+
 import { useIsWalletConnect } from '../../web3-react/hooks/useIsWalletConnect'
 import { useWalletInfo } from '../hooks'
 
@@ -17,12 +19,15 @@ const requestTimeout = ms`10s`
 export function useWalletCapabilities(): SWRResponse<WalletCapabilities | undefined> {
   const provider = useWalletProvider()
   const isWalletConnect = useIsWalletConnect()
+  const widgetProviderMetaInfo = useWidgetProviderMetaInfo()
   const { chainId, account } = useWalletInfo()
+
+  const isWalletConnectViaWidget = Boolean(widgetProviderMetaInfo?.providerWcMetadata)
   /**
    * Walletconnect in mobile browsers initiates a request with confirmation to the wallet
    * to get the capabilities. It breaks the flow with perpetual reuqests.
    */
-  const shouldCheckCapabilities = !(isWalletConnect && isMobile)
+  const shouldCheckCapabilities = !((isWalletConnect || isWalletConnectViaWidget) && isMobile)
 
   return useSWR(
     shouldCheckCapabilities && provider && account && chainId ? [provider, account, chainId] : null,

--- a/libs/wallet/src/api/hooks/useWidgetProviderMetaInfo.ts
+++ b/libs/wallet/src/api/hooks/useWidgetProviderMetaInfo.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react'
+
+import { ProviderMetaInfoPayload, WidgetEthereumProvider } from '@cowprotocol/iframe-transport'
+import { useWalletProvider } from '@cowprotocol/wallet-provider'
+
+export function useWidgetProviderMetaInfo(): ProviderMetaInfoPayload | null {
+  const provider = useWalletProvider()
+  const [widgetProviderMetaInfo, setWidgetProviderMetaInfo] = useState<ProviderMetaInfoPayload | null>(null)
+
+  const rawProvider = provider?.provider as unknown
+
+  useEffect(() => {
+    const isWidgetEthereumProvider = rawProvider instanceof WidgetEthereumProvider
+
+    if (!isWidgetEthereumProvider) return
+
+    rawProvider.onProviderMetaInfo(setWidgetProviderMetaInfo)
+  }, [rawProvider])
+
+  return widgetProviderMetaInfo
+}

--- a/libs/wallet/src/index.ts
+++ b/libs/wallet/src/index.ts
@@ -8,6 +8,7 @@ export * from './constants'
 // Hooks
 export * from './api/hooks'
 export { useWalletCapabilities } from './api/hooks/useWalletCapabilities'
+export { useWidgetProviderMetaInfo } from './api/hooks/useWidgetProviderMetaInfo'
 export { useSendBatchTransactions } from './api/hooks/useSendBatchTransactions'
 export type { SendBatchTxCallback } from './api/hooks/useSendBatchTransactions'
 export * from './web3-react/hooks/useWalletMetadata'


### PR DESCRIPTION
# Summary

As you might remember, we did #5429 fix because `wallet_getCapabilities` request gives unwanted effect in mobile wallets connected through wallet-connect.
This case is a bit more advanced, here it's reproducible when you connect a mobile wallet via WalletConnect in the widget!


https://github.com/user-attachments/assets/de3e86c3-a0fd-445a-8681-c7b9b49128ef


# To Test

1. Open widget-configurator in mobile in Dapp mode
2. Connect a wallet via WalletConnect
3. Change sell token in the widget
- [ ] AR: you have been switched to the connected wallet app
- [ ] ER: nothing happens