### PR TITLE
fix(new-networks): add coingecko and uniswap tokens lists to pol and avax

### DIFF
--- a/libs/tokens/src/const/tokensList.json
+++ b/libs/tokens/src/const/tokensList.json
@@ -103,6 +103,16 @@
       "priority": 1,
       "enabledByDefault": true,
       "source": "https://files.cow.fi/tokens/CowSwap.json"
+    },
+    {
+      "priority": 2,
+      "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/CoinGecko.137.json",
+      "enabledByDefault": true
+    },
+    {
+      "priority": 3,
+      "enabledByDefault": true,
+      "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/Uniswap.137.json"
     }
   ],
   "43114": [
@@ -110,6 +120,17 @@
       "priority": 1,
       "enabledByDefault": true,
       "source": "https://files.cow.fi/tokens/CowSwap.json"
+    },
+    {
+      "priority": 2,
+      "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/CoinGecko.43114.json",
+      "enabledByDefault": true
+    },
+    {
+      "priority": 3,
+      "enabledByDefault": true,
+      "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/Uniswap.43114.json"
     }
   ]
 }
+


### PR DESCRIPTION
# Summary

We have new token lists for the new networks, but they were not added to CoW Swap yet.
This change adds both Uni and Coingecko token lists to Polygon and Avalanche.

![image](https://github.com/user-attachments/assets/6e304b2c-008e-48d2-9f34-fab76eb27339)

# To Test

1. Try Polygon then Avalanche
2. Connect to the chosen network
3. Open the token selector
* It should contain 3 token lists: cowswap, coingecko and uniswap
4. Repeat 2-3 with the other network

# Notes

Polygon is weird, and their native token also has an address.
Some of the new token lists has it inside. To be addressed later.
![image](https://github.com/user-attachments/assets/0fbe70f4-e0fb-40ab-a947-2071029c034e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added additional token list sources for Polygon and Avalanche networks, expanding available tokens from new sources by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->