### PR TITLE
fix(bridge): distinguish native tokens in diff networks

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/state/isWrapOrUnwrapAtom.ts
+++ b/apps/cowswap-frontend/src/modules/trade/state/isWrapOrUnwrapAtom.ts
@@ -9,8 +9,12 @@ export const isWrapOrUnwrapAtom = atom((get) => {
   const { chainId } = get(walletInfoAtom)
   const { inputCurrency, outputCurrency } = get(derivedTradeStateAtom) || {}
 
-  const onputCurrencyId = inputCurrency ? getCurrencyAddress(inputCurrency) : null
-  const outputCurrencyId = outputCurrency ? getCurrencyAddress(outputCurrency) : null
+  if (!inputCurrency || !outputCurrency) return false
+
+  if (inputCurrency.chainId !== outputCurrency.chainId) return false
+
+  const onputCurrencyId = getCurrencyAddress(inputCurrency)
+  const outputCurrencyId = getCurrencyAddress(outputCurrency)
 
   return getIsWrapOrUnwrap(chainId, onputCurrencyId, outputCurrencyId)
 })

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
@@ -117,6 +117,7 @@ export const tradeButtonsMap: Record<TradeFormValidation, ButtonErrorConfig | Bu
             <Trans>Bridge quote error</Trans>
             {'  '}
             <InfoTooltip>
+              <p>{quote.error.message}</p>
               <JsonDisplay>{JSON.stringify(quote.error.context, null, 2)}</JsonDisplay>
             </InfoTooltip>
           </>


### PR DESCRIPTION
# Summary

Fixes: https://www.notion.so/cownation/1c38da5f04ca80b1acc2d6348c943827?v=1c38da5f04ca812b9489000c81197879&p=2148da5f04ca8040bbacf1f667ccafa9&pm=s

`isWrapOrUnwrapAtom` didn't consider a case when tokens are from different networks.

# To Test

See [the case](https://www.notion.so/cownation/1c38da5f04ca80b1acc2d6348c943827?v=1c38da5f04ca812b9489000c81197879&p=2148da5f04ca8040bbacf1f667ccafa9&pm=s).

@elena-zh I wasn't able to find a route for such a trade anyway.
But the trade is not considered as wrap/unwrap anymore.