### PR TITLE
feat: change Avalanche explorer from Snowtrace to Snowscan

### DIFF
--- a/libs/common-const/src/tokens.ts
+++ b/libs/common-const/src/tokens.ts
@@ -406,7 +406,7 @@ export const DAI_POLYGON = new TokenWithLogo(
 export const USDC_AVALANCHE = new TokenWithLogo(
   USDC_MAINNET.logoURI,
   SupportedChainId.AVALANCHE,
-  // https://snowtrace.io/token/0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e
+  // https://snowscan.xyz/token/0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e
   '0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e',
   6,
   'USDC',
@@ -416,7 +416,7 @@ export const USDC_AVALANCHE = new TokenWithLogo(
 export const USDT_AVALANCHE = new TokenWithLogo(
   USDT.logoURI,
   SupportedChainId.AVALANCHE,
-  // https://snowtrace.io/token/0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7
+  // https://snowscan.xyz/token/0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7
   '0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7',
   6,
   'USDT',

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@cowprotocol/cms": "^0.11.0",
     "@cowprotocol/contracts": "^1.7.0",
     "@cowprotocol/cow-runner-game": "^0.2.9",
-    "@cowprotocol/cow-sdk": "6.0.0-RC.62",
+    "@cowprotocol/cow-sdk": "6.0.0-RC.63",
     "@cowprotocol/ethflowcontract": "cowprotocol/ethflowcontract.git#main-artifacts",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1841,10 +1841,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/cow-runner-game/-/cow-runner-game-0.2.9.tgz#3f94b3f370bd114f77db8b1d238cba3ef4e9d644"
   integrity sha512-rX7HnoV+HYEEkBaqVUsAkGGo0oBrExi+d6Io+8nQZYwZk+IYLmS9jdcIObsLviM2h4YX8+iin6NuKl35AaiHmg==
 
-"@cowprotocol/cow-sdk@6.0.0-RC.62":
-  version "6.0.0-RC.62"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.62.tgz#826554e6d1a827a3db38f1efd89db3a4d1f40475"
-  integrity sha512-awbLFxhRB5+dkfSLYFDL+N9qhD+mdU2WstaPFhwRQizCbH0HR2w1BLYy+slblp0cn9zeR9MnBGDbH/akQB5IiQ==
+"@cowprotocol/cow-sdk@6.0.0-RC.63":
+  version "6.0.0-RC.63"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.63.tgz#b031051d6d85f35446bea094c7df7870eb7729b9"
+  integrity sha512-3oKP2fvW08eoVT3SIp2ghESLitPpmJP5xdoMRhIsO98Z54vjJ/WidGQN3YRQZuPRXF61LwJ+gFKZPtOBtF7I1g==
   dependencies:
     "@cowprotocol/app-data" "^3.1.0"
     "@cowprotocol/contracts" "^1.8.0"


### PR DESCRIPTION
# Summary

- Change Avalanche explorer from SnowTrace to [SnowScan](https://snowscan.xyz)
- update `cow-sdk`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated block explorer URLs in token comments to use "https://snowscan.xyz" for Avalanche USDC and USDT.

- **Chores**
  - Upgraded the "@cowprotocol/cow-sdk" dependency to version 6.0.0-RC.63.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->