### PR TITLE
fix: bump InputAmountNotSet validation priority

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
@@ -48,6 +48,10 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
   }
 
   if (!isWrapUnwrap && tradeQuote.error) {
+    if (inputAmountIsNotSet) {
+      return TradeFormValidation.InputAmountNotSet
+    }
+
     return TradeFormValidation.QuoteErrors
   }
 


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Bridge-quote-error-when-no-amounts-2108da5f04ca80cab170d7801a29c694?source=copy_link

# To Test

See https://www.notion.so/cownation/Bridge-quote-error-when-no-amounts-2108da5f04ca80cab170d7801a29c694?source=copy_link


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved trade form validation to provide a more specific error message when the input amount is missing, ensuring clearer feedback for users during trade operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->