### PR TITLE
fix(bridge): display only supported favorite tokens

### DIFF
--- a/apps/cowswap-frontend/src/modules/tokensList/containers/SelectTokenWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/containers/SelectTokenWidget/index.tsx
@@ -9,7 +9,6 @@ import {
   useAddList,
   useAddUserToken,
   useAllListsList,
-  useFavoriteTokens,
   useTokenListsTags,
   useUnsupportedTokens,
   useUserAddedTokens,
@@ -93,8 +92,7 @@ export function SelectTokenWidget({ displayLpTokenLists }: SelectTokenWidgetProp
   })
   const importTokenCallback = useAddUserToken()
 
-  const { tokens: allTokens, isLoading: areTokensLoading } = useTokensToSelect()
-  const favoriteTokens = useFavoriteTokens()
+  const { tokens: allTokens, isLoading: areTokensLoading, favoriteTokens } = useTokensToSelect()
   const userAddedTokens = useUserAddedTokens()
   const allTokenLists = useAllListsList()
   const balancesState = useTokensBalancesCombined()

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/FavoriteTokensList/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/FavoriteTokensList/index.tsx
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react'
+
 import { TokenWithLogo } from '@cowprotocol/common-const'
 import { TokenLogo } from '@cowprotocol/tokens'
 import { HelpTooltip, TokenSymbol } from '@cowprotocol/ui'
@@ -12,9 +14,7 @@ export interface FavoriteTokensListProps {
   onSelectToken(token: TokenWithLogo): void
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function FavoriteTokensList(props: FavoriteTokensListProps) {
+export function FavoriteTokensList(props: FavoriteTokensListProps): ReactNode {
   const { tokens, hideTooltip, selectedToken, onSelectToken } = props
 
   return (

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/SelectTokenModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/SelectTokenModal/index.tsx
@@ -1,14 +1,13 @@
-import React, { useState } from 'react'
+import React, { ReactNode, useState } from 'react'
 
 import { BalancesState } from '@cowprotocol/balances-and-allowances'
 import { TokenWithLogo } from '@cowprotocol/common-const'
-import { getCurrencyAddress } from '@cowprotocol/common-utils'
 import { ChainInfo } from '@cowprotocol/cow-sdk'
 import { TokenListCategory, TokenListTags, UnsupportedTokensState } from '@cowprotocol/tokens'
-import { Loader, SearchInput } from '@cowprotocol/ui'
+import { SearchInput } from '@cowprotocol/ui'
 import { Currency } from '@uniswap/sdk-core'
 
-import { Edit, X } from 'react-feather'
+import { X } from 'react-feather'
 import { Nullish } from 'types'
 
 import { PermitCompatibleTokens } from 'modules/permit'
@@ -16,12 +15,10 @@ import { PermitCompatibleTokens } from 'modules/permit'
 import * as styledEl from './styled'
 
 import { LpTokenListsWidget } from '../../containers/LpTokenListsWidget'
-import { TokenSearchResults } from '../../containers/TokenSearchResults'
 import { ChainsToSelectState, SelectTokenContext } from '../../types'
 import { ChainsSelector } from '../ChainsSelector'
 import { IconButton } from '../commonElements'
-import { FavoriteTokensList } from '../FavoriteTokensList'
-import { TokensVirtualList } from '../TokensVirtualList'
+import { TokensContent } from '../TokensContent'
 
 export interface SelectTokenModalProps<T = TokenListCategory[] | null> {
   allTokens: TokenWithLogo[]
@@ -41,34 +38,22 @@ export interface SelectTokenModalProps<T = TokenListCategory[] | null> {
   tokenListTags: TokenListTags
 
   onSelectToken(token: TokenWithLogo): void
-
   openPoolPage(poolAddress: string): void
-
   onInputPressEnter?(): void
-
   onOpenManageWidget(): void
-
   onDismiss(): void
-
   onSelectChain(chain: ChainInfo): void
 }
 
-// TODO: Break down this large function into smaller functions
-// TODO: Add proper return type annotation
-// eslint-disable-next-line max-lines-per-function, @typescript-eslint/explicit-function-return-type
-export function SelectTokenModal(props: SelectTokenModalProps) {
+export function SelectTokenModal(props: SelectTokenModalProps): ReactNode {
   const {
     defaultInputValue = '',
-    favoriteTokens,
-    allTokens,
     selectedToken,
     balancesState,
     unsupportedTokens,
     permitCompatibleTokens,
-    hideFavoriteTokensTooltip,
     onSelectToken,
     onDismiss,
-    onOpenManageWidget,
     onInputPressEnter,
     account,
     displayLpTokenLists,
@@ -77,10 +62,8 @@ export function SelectTokenModal(props: SelectTokenModalProps) {
     disableErc20,
     chainsToSelect,
     onSelectChain,
-    areTokensLoading,
     tokenListTags,
   } = props
-
   const [inputValue, setInputValue] = useState<string>(defaultInputValue)
 
   const selectTokenContext: SelectTokenContext = {
@@ -95,41 +78,7 @@ export function SelectTokenModal(props: SelectTokenModalProps) {
   const trimmedInputValue = inputValue.trim()
 
   const allListsContent = (
-    <>
-      <styledEl.Row>
-        <FavoriteTokensList
-          onSelectToken={onSelectToken}
-          selectedToken={(selectedToken && getCurrencyAddress(selectedToken)) || undefined}
-          tokens={favoriteTokens}
-          hideTooltip={hideFavoriteTokensTooltip}
-        />
-      </styledEl.Row>
-      <styledEl.Separator />
-      {areTokensLoading ? (
-        <styledEl.TokensLoader>
-          <Loader />
-        </styledEl.TokensLoader>
-      ) : (
-        <>
-          {trimmedInputValue ? (
-            <TokenSearchResults searchInput={trimmedInputValue} {...selectTokenContext} />
-          ) : (
-            <TokensVirtualList
-              allTokens={allTokens}
-              {...selectTokenContext}
-              account={account}
-              displayLpTokenLists={displayLpTokenLists}
-            />
-          )}
-        </>
-      )}
-      <styledEl.Separator />
-      <div>
-        <styledEl.ActionButton id="list-token-manage-button" onClick={onOpenManageWidget}>
-          <Edit /> <span>Manage Token Lists</span>
-        </styledEl.ActionButton>
-      </div>
-    </>
+    <TokensContent {...props} selectTokenContext={selectTokenContext} searchInput={trimmedInputValue} />
   )
 
   return (

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokensContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokensContent/index.tsx
@@ -44,14 +44,16 @@ export function TokensContent({
 }: TokensContentProps): ReactNode {
   return (
     <>
-      <styledEl.Row>
-        <FavoriteTokensList
-          onSelectToken={onSelectToken}
-          selectedToken={(selectedToken && getCurrencyAddress(selectedToken)) || undefined}
-          tokens={favoriteTokens}
-          hideTooltip={hideFavoriteTokensTooltip}
-        />
-      </styledEl.Row>
+      {!areTokensLoading && (
+        <styledEl.Row>
+          <FavoriteTokensList
+            onSelectToken={onSelectToken}
+            selectedToken={(selectedToken && getCurrencyAddress(selectedToken)) || undefined}
+            tokens={favoriteTokens}
+            hideTooltip={hideFavoriteTokensTooltip}
+          />
+        </styledEl.Row>
+      )}
       <styledEl.Separator />
       {areTokensLoading ? (
         <styledEl.TokensLoader>

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokensContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokensContent/index.tsx
@@ -44,7 +44,7 @@ export function TokensContent({
 }: TokensContentProps): ReactNode {
   return (
     <>
-      {!areTokensLoading && favoriteTokens.length && (
+      {!areTokensLoading && !!favoriteTokens.length && (
         <>
           <styledEl.Row>
             <FavoriteTokensList

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokensContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokensContent/index.tsx
@@ -1,0 +1,82 @@
+import React, { ReactNode } from 'react'
+
+import { TokenWithLogo } from '@cowprotocol/common-const'
+import { getCurrencyAddress } from '@cowprotocol/common-utils'
+import { Nullish } from '@cowprotocol/types'
+import { Loader } from '@cowprotocol/ui'
+import { Currency } from '@uniswap/sdk-core'
+
+import { Edit } from 'react-feather'
+
+import { TokenSearchResults } from '../../containers/TokenSearchResults'
+import { SelectTokenContext } from '../../types'
+import { FavoriteTokensList } from '../FavoriteTokensList'
+import * as styledEl from '../SelectTokenModal/styled'
+import { TokensVirtualList } from '../TokensVirtualList'
+
+export interface TokensContentProps {
+  displayLpTokenLists?: boolean
+  selectTokenContext: SelectTokenContext
+  favoriteTokens: TokenWithLogo[]
+  selectedToken?: Nullish<Currency>
+  hideFavoriteTokensTooltip?: boolean
+  areTokensLoading: boolean
+  allTokens: TokenWithLogo[]
+  account: string | undefined
+  searchInput: string
+
+  onSelectToken(token: TokenWithLogo): void
+  onOpenManageWidget(): void
+}
+
+export function TokensContent({
+  selectTokenContext,
+  onSelectToken,
+  onOpenManageWidget,
+  selectedToken,
+  favoriteTokens,
+  hideFavoriteTokensTooltip,
+  areTokensLoading,
+  allTokens,
+  account,
+  displayLpTokenLists,
+  searchInput,
+}: TokensContentProps): ReactNode {
+  return (
+    <>
+      <styledEl.Row>
+        <FavoriteTokensList
+          onSelectToken={onSelectToken}
+          selectedToken={(selectedToken && getCurrencyAddress(selectedToken)) || undefined}
+          tokens={favoriteTokens}
+          hideTooltip={hideFavoriteTokensTooltip}
+        />
+      </styledEl.Row>
+      <styledEl.Separator />
+      {areTokensLoading ? (
+        <styledEl.TokensLoader>
+          <Loader />
+        </styledEl.TokensLoader>
+      ) : (
+        <>
+          {searchInput ? (
+            <TokenSearchResults searchInput={searchInput} {...selectTokenContext} />
+          ) : (
+            <TokensVirtualList
+              allTokens={allTokens}
+              {...selectTokenContext}
+              account={account}
+              displayLpTokenLists={displayLpTokenLists}
+            />
+          )}
+        </>
+      )}
+      <styledEl.Separator />
+      <div>
+        <styledEl.ActionButton id="list-token-manage-button" onClick={onOpenManageWidget}>
+          <Edit /> <span>Manage Token Lists</span>
+        </styledEl.ActionButton>
+      </div>
+    </>
+  )
+}

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokensContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokensContent/index.tsx
@@ -44,17 +44,19 @@ export function TokensContent({
 }: TokensContentProps): ReactNode {
   return (
     <>
-      {!areTokensLoading && (
-        <styledEl.Row>
-          <FavoriteTokensList
-            onSelectToken={onSelectToken}
-            selectedToken={(selectedToken && getCurrencyAddress(selectedToken)) || undefined}
-            tokens={favoriteTokens}
-            hideTooltip={hideFavoriteTokensTooltip}
-          />
-        </styledEl.Row>
+      {!areTokensLoading && favoriteTokens.length && (
+        <>
+          <styledEl.Row>
+            <FavoriteTokensList
+              onSelectToken={onSelectToken}
+              selectedToken={(selectedToken && getCurrencyAddress(selectedToken)) || undefined}
+              tokens={favoriteTokens}
+              hideTooltip={hideFavoriteTokensTooltip}
+            />
+          </styledEl.Row>
+          <styledEl.Separator />
+        </>
       )}
-      <styledEl.Separator />
       {areTokensLoading ? (
         <styledEl.TokensLoader>
           <Loader />

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@cowprotocol/cms": "^0.11.0",
     "@cowprotocol/contracts": "^1.7.0",
     "@cowprotocol/cow-runner-game": "^0.2.9",
-    "@cowprotocol/cow-sdk": "6.0.0-RC.63",
+    "@cowprotocol/cow-sdk": "6.0.0-RC.64",
     "@cowprotocol/ethflowcontract": "cowprotocol/ethflowcontract.git#main-artifacts",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1841,10 +1841,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/cow-runner-game/-/cow-runner-game-0.2.9.tgz#3f94b3f370bd114f77db8b1d238cba3ef4e9d644"
   integrity sha512-rX7HnoV+HYEEkBaqVUsAkGGo0oBrExi+d6Io+8nQZYwZk+IYLmS9jdcIObsLviM2h4YX8+iin6NuKl35AaiHmg==
 
-"@cowprotocol/cow-sdk@6.0.0-RC.63":
-  version "6.0.0-RC.63"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.63.tgz#b031051d6d85f35446bea094c7df7870eb7729b9"
-  integrity sha512-3oKP2fvW08eoVT3SIp2ghESLitPpmJP5xdoMRhIsO98Z54vjJ/WidGQN3YRQZuPRXF61LwJ+gFKZPtOBtF7I1g==
+"@cowprotocol/cow-sdk@6.0.0-RC.64":
+  version "6.0.0-RC.64"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.64.tgz#a25126047f4aa9a9fa65ce620150b5127233e777"
+  integrity sha512-6hDvlOD+bObZhkk160F8XAXAj3IwssKt0pEQcW4nfyDK3CnhF+7ge6UfNbFgZcIzRdFDkuPTYDKA0wRa5GKYmg==
   dependencies:
     "@cowprotocol/app-data" "^3.1.0"
     "@cowprotocol/contracts" "^1.8.0"


### PR DESCRIPTION
# Summary

Related to https://github.com/cowprotocol/cow-sdk/pull/352

Fixes: 
 - https://www.notion.so/cownation/Improve-favorite-tokens-logic-for-destination-chain-1c48da5f04ca80d49af7ff5bce4acf07?source=copy_link
 - https://www.notion.so/cownation/Wrong-native-token-name-on-destination-chain-2158da5f04ca8003b83aeb953e45660f?source=copy_link

Favorite tokens selector currently displays hardcoded set of tokens.
Since not all of the tokens are supported by bridge provider, we must filter them and display only supported.

<img width="685" alt="image" src="https://github.com/user-attachments/assets/fb9ee3e8-0e94-4a7e-8fe2-fe4ff0afecdf" />

# To Test

1. Set USDC (Base) as a sell token
2. Open buy token selector
- [ ] AR: WETH is displayed in favorite tokens
- [ ] ER: WETH is NOT displayed in favorite tokens


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a unified token selection interface that displays favorite tokens, search results, and a virtualized token list within a streamlined modal.
- **Refactor**
  - Simplified the token selection modal by consolidating multiple components into a single, cohesive view for easier navigation and improved user experience.
  - Enhanced token selection logic to include favorite tokens filtered by bridge support within a single hook.
- **Style**
  - Updated UI layout and styling for the token selection and management interface.
- **Chores**
  - Upgraded the "@cowprotocol/cow-sdk" dependency to a newer version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->