### PR TITLE
fix(bridge): use explorer link from provider networks

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/ClickableAddress/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ClickableAddress/index.tsx
@@ -1,9 +1,10 @@
-import { MouseEvent, useCallback, useRef, useState } from 'react'
+import { MouseEvent, ReactNode, useCallback, useRef, useState } from 'react'
 
 import { useMediaQuery } from '@cowprotocol/common-hooks'
 import { ExplorerDataType, getExplorerLink, shortenAddress, getIsNativeToken } from '@cowprotocol/common-utils'
 import { Media, Tooltip } from '@cowprotocol/ui'
 
+import { useBridgeSupportedNetworks } from 'entities/bridgeProvider'
 import { Info } from 'react-feather'
 
 import { Content } from './Content'
@@ -14,20 +15,20 @@ export type ClickableAddressProps = {
   chainId: number
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function ClickableAddress(props: ClickableAddressProps) {
+export function ClickableAddress(props: ClickableAddressProps): ReactNode {
   const { address, chainId } = props
 
   const wrapperRef = useRef<HTMLDivElement>(null)
 
   const isMobile = useMediaQuery(Media.upToMedium(false))
+  const { data: bridgeSupportedNetworks } = useBridgeSupportedNetworks()
+  const bridgeNetwork = bridgeSupportedNetworks?.find((network) => network.id === chainId)
 
   const [openTooltip, setOpenTooltip] = useState(false)
 
   const shortAddress = shortenAddress(address)
 
-  const target = getExplorerLink(chainId, address, ExplorerDataType.TOKEN)
+  const target = getExplorerLink(chainId, address, ExplorerDataType.TOKEN, bridgeNetwork?.blockExplorer.url)
 
   const shouldShowAddress = target && !getIsNativeToken(chainId, address)
 

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokenInfo/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokenInfo/index.tsx
@@ -14,9 +14,7 @@ export interface TokenInfoProps {
   tags?: ReactNode
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function TokenInfo(props: TokenInfoProps) {
+export function TokenInfo(props: TokenInfoProps): ReactNode {
   const { token, className, tags } = props
 
   return (

--- a/libs/common-utils/src/getExplorerLink.ts
+++ b/libs/common-utils/src/getExplorerLink.ts
@@ -13,9 +13,15 @@ export enum ExplorerDataType {
  * @param chainId the ID of the chain for which to return the data
  * @param data the data to return a link for
  * @param type the type of the data
+ * @param defaultPrefix
  */
-export function getExplorerLink(chainId: number, data: string, type: ExplorerDataType): string {
-  const prefix = CHAIN_INFO[chainId as SupportedChainId]?.explorer ?? 'https://etherscan.io'
+export function getExplorerLink(
+  chainId: number,
+  data: string,
+  type: ExplorerDataType,
+  defaultPrefix = 'https://etherscan.io',
+): string {
+  const prefix = CHAIN_INFO[chainId as SupportedChainId]?.explorer ?? defaultPrefix
 
   switch (type) {
     case ExplorerDataType.TRANSACTION:


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Token-link-navigates-to-ethereum-1c38da5f04ca802abf21f75838a663cd?source=copy_link

<img width="440" alt="image" src="https://github.com/user-attachments/assets/1842a81f-9962-4b6c-afce-445b441496c6" />


# To Test

1. Open buy token selector
2. Select Optimism network
3. Open some token info tooltip
4. Cick to "View details"
- [ ] AR: leads to Etherscan
- [ ] ER: leads to https://optimistic.etherscan.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Explorer links can now be customized based on bridge network data, potentially improving accuracy and user experience when viewing addresses on block explorers.

- **Refactor**
  - Improved type safety and clarity by explicitly specifying return types for key components.
  - Explorer link generation is now more flexible, allowing for configurable default URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->