### PR TITLE
fix(twap): reduce part size for l2s from 5 to 1 usd

### DIFF
--- a/apps/cowswap-frontend/src/modules/twap/const.ts
+++ b/apps/cowswap-frontend/src/modules/twap/const.ts
@@ -39,12 +39,12 @@ export const TWAP_FINAL_STATUSES = [TwapOrderStatus.Fulfilled, TwapOrderStatus.E
 
 export const MINIMUM_PART_SELL_AMOUNT_FIAT: Record<SupportedChainId, CurrencyAmount<Currency>> = {
   [SupportedChainId.MAINNET]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.MAINNET], 1_000e6), // 1k
-  [SupportedChainId.GNOSIS_CHAIN]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.GNOSIS_CHAIN], 5e6), // 5
-  [SupportedChainId.ARBITRUM_ONE]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.ARBITRUM_ONE], 5e6), // 5
-  [SupportedChainId.BASE]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.BASE], 5e6), // 5
+  [SupportedChainId.GNOSIS_CHAIN]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.GNOSIS_CHAIN], 1e6), // 1
+  [SupportedChainId.ARBITRUM_ONE]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.ARBITRUM_ONE], 1e6), // 1
+  [SupportedChainId.BASE]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.BASE], 1e6), // 1
   [SupportedChainId.SEPOLIA]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.SEPOLIA], 100e18), // 100
-  [SupportedChainId.POLYGON]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.POLYGON], 5e6), // 5
-  [SupportedChainId.AVALANCHE]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.AVALANCHE], 5e6), // 5
+  [SupportedChainId.POLYGON]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.POLYGON], 1e6), // 1
+  [SupportedChainId.AVALANCHE]: CurrencyAmount.fromRawAmount(USDC[SupportedChainId.AVALANCHE], 1e6), // 1
 }
 
 export const MINIMUM_PART_TIME = ms`5min` / 1000 // in seconds
@@ -58,6 +58,5 @@ export const DEFAULT_TWAP_EXECUTION_INFO: TwapOrderExecutionInfo = {
 
 export const UNSUPPORTED_SAFE_LINK =
   'https://cow.fi/learn/all-you-need-to-know-about-cow-swap-new-safe-fallback-handler'
-export const UNSUPPORTED_WALLET_LINK =
-  'https://cow.fi/learn/how-to-use-cow-swap-twap-orders-via-safe-wallet'
+export const UNSUPPORTED_WALLET_LINK = 'https://cow.fi/learn/how-to-use-cow-swap-twap-orders-via-safe-wallet'
 export const TWAP_LEARN_MORE_LINK = 'https://cow.fi/learn/cow-swap-launches-twap-orders'


### PR DESCRIPTION
# Summary

Reduce TWAP part size on L2s from $5 to $1 

# To Test

1. Open the app on Safe in one of: Gnosis, Arb1, Base, Polygon, Avalanche
2. Go to TWAP
3. Pick a sell amount < $5 >= 1$
* It should be possible to place the order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Lowered the minimum part sell amount in fiat currency from 5 USDC to 1 USDC for several supported networks, allowing smaller transactions.

- **Style**
  - Reformatted the display of an unsupported wallet message without changing its content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->