### PR TITLE
fix(bridge): display full list of networks

### DIFF
--- a/apps/cowswap-frontend/src/modules/tokensList/pure/ChainsSelector/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/ChainsSelector/index.tsx
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react'
+
 import { useTheme } from '@cowprotocol/common-hooks'
 import { useMediaQuery } from '@cowprotocol/common-hooks'
 import { ChainInfo } from '@cowprotocol/cow-sdk'
@@ -10,7 +12,7 @@ import { Check, ChevronDown, ChevronUp } from 'react-feather'
 import * as styledEl from './styled'
 
 // Number of skeleton shimmers to show during loading state
-const LOADING_ITEMS_COUNT = 5
+const LOADING_ITEMS_COUNT = 7
 
 const LoadingShimmerElements = (
   <styledEl.Wrapper>
@@ -28,17 +30,13 @@ export interface ChainsSelectorProps {
   isLoading: boolean
 }
 
-// TODO: Break down this large function into smaller functions
-// TODO: Add proper return type annotation
-// eslint-disable-next-line max-lines-per-function, @typescript-eslint/explicit-function-return-type
 export function ChainsSelector({
   chains,
   onSelectChain,
   defaultChainId,
   isLoading,
-  // TODO: change the value to 7 after tests
-  visibleNetworkIcons = 3,
-}: ChainsSelectorProps) {
+  visibleNetworkIcons = LOADING_ITEMS_COUNT,
+}: ChainsSelectorProps): ReactNode {
   const isMobile = useMediaQuery(Media.upToSmall(false))
 
   const theme = useTheme()


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Expand-a-list-of-chains-on-desktop-view-2118da5f04ca808fa100fe9c737561f4?source=copy_link

<img width="670" alt="image" src="https://github.com/user-attachments/assets/06c33a40-2303-4c0e-a1f9-90d9ecddfc74" />


# To Test

1. At least 7 networks should be displayed in the selector without


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the default number of visible network icons in the ChainsSelector component from 3 to 7.
  - Improved code clarity by adding explicit type annotations and cleaning up comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->