### PR TITLE
fix(progress-bar): keep querying order status for 3s

### DIFF
--- a/apps/cowswap-frontend/src/modules/orderProgressBar/hooks/useOrderProgressBarProps.ts
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/hooks/useOrderProgressBarProps.ts
@@ -489,12 +489,12 @@ function useBackendApiStatusUpdater(chainId: SupportedChainId, orderId: string, 
   const [stopQuerying, setStopQuerying] = useState(false)
   const { type: backendApiStatus, value } = usePendingOrderStatus(chainId, orderId, stopQuerying) || {}
 
-  // Once doNotQuery is set to true, keep querying for another 5 seconds to ensure we get the final status and then stop
+  // Once doNotQuery is set to true, keep querying for another 3 seconds to ensure we get the final status and then stop
   useEffect(() => {
     let timer: NodeJS.Timeout | undefined
 
     if (doNotQuery) {
-      timer = setTimeout(() => setStopQuerying(true), ms`5s`)
+      timer = setTimeout(() => setStopQuerying(true), ms`3s`)
     } else {
       setStopQuerying(false) // Reset the stop querying state when doNotQuery is false
     }

--- a/apps/cowswap-frontend/src/modules/orderProgressBar/hooks/useOrderProgressBarProps.ts
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/hooks/useOrderProgressBarProps.ts
@@ -1,5 +1,5 @@
 import { useAtomValue, useSetAtom } from 'jotai'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { SWR_NO_REFRESH_OPTIONS } from '@cowprotocol/common-const'
 import { SolverInfo } from '@cowprotocol/core'
@@ -486,7 +486,23 @@ const BACKEND_TYPE_TO_PROGRESS_BAR_STEP_NAME: Record<CompetitionOrderStatus.type
 
 function useBackendApiStatusUpdater(chainId: SupportedChainId, orderId: string, doNotQuery: boolean): void {
   const setAtom = useSetAtom(updateOrderProgressBarBackendInfo)
-  const { type: backendApiStatus, value } = usePendingOrderStatus(chainId, orderId, doNotQuery) || {}
+  const [stopQuerying, setStopQuerying] = useState(false)
+  const { type: backendApiStatus, value } = usePendingOrderStatus(chainId, orderId, stopQuerying) || {}
+
+  // Once doNotQuery is set to true, keep querying for another 5 seconds to ensure we get the final status and then stop
+  useEffect(() => {
+    let timer: NodeJS.Timeout | undefined
+
+    if (doNotQuery) {
+      timer = setTimeout(() => setStopQuerying(true), ms`5s`)
+    } else {
+      setStopQuerying(false) // Reset the stop querying state when doNotQuery is false
+    }
+
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [doNotQuery, orderId])
 
   useEffect(() => {
     if (orderId && (backendApiStatus || value)) {

--- a/apps/cowswap-frontend/src/modules/orderProgressBar/hooks/useOrderProgressBarProps.ts
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/hooks/useOrderProgressBarProps.ts
@@ -491,16 +491,16 @@ function useBackendApiStatusUpdater(chainId: SupportedChainId, orderId: string, 
 
   // Once doNotQuery is set to true, keep querying for another 3 seconds to ensure we get the final status and then stop
   useEffect(() => {
-    let timer: NodeJS.Timeout | undefined
-
     if (doNotQuery) {
-      timer = setTimeout(() => setStopQuerying(true), ms`3s`)
+      const timer = setTimeout(() => setStopQuerying(true), ms`3s`)
+
+      return () => {
+        clearTimeout(timer)
+      }
     } else {
       setStopQuerying(false) // Reset the stop querying state when doNotQuery is false
-    }
 
-    return () => {
-      clearTimeout(timer)
+      return
     }
   }, [doNotQuery, orderId])
 


### PR DESCRIPTION
# Summary

Keep querying order status for additional ~5s~ 3s after order is finished to be sure the status is the latest

# To Test

1. Open dev console, filter network tab for `status`
2. Place SWAP, wait for it to trade
3. Observe the console
* After the order is traded, it should keep pooling for additional 3 seconds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved order status updates by adding a short delay before stopping backend polling, resulting in more accurate and timely status displays for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->