### PR TITLE
Fix: remove 'new' from cow amm

### DIFF
--- a/apps/cowswap-frontend/src/modules/application/containers/App/menuConsts.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/App/menuConsts.tsx
@@ -41,8 +41,7 @@ export const NAV_ITEMS: MenuItem[] = [
   },
   {
     label: 'More',
-    badgeType: BadgeTypes.ALERT,
-    children: [
+   children: [
       {
         href: 'https://cow.fi/cow-protocol',
         label: 'CoW Protocol',
@@ -51,7 +50,6 @@ export const NAV_ITEMS: MenuItem[] = [
       {
         href: 'https://cow.fi/cow-amm',
         label: 'CoW AMM',
-        badgeType: BadgeTypes.ALERT,
         external: true,
       },
       {

--- a/apps/cowswap-frontend/src/modules/application/containers/App/menuConsts.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/App/menuConsts.tsx
@@ -1,4 +1,4 @@
-import { BadgeTypes, MenuItem, ProductVariant } from '@cowprotocol/ui'
+import { MenuItem, ProductVariant } from '@cowprotocol/ui'
 
 import AppziButton from 'legacy/components/AppziButton'
 import { Version } from 'legacy/components/Version'

--- a/apps/cowswap-frontend/src/modules/application/containers/App/menuConsts.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/App/menuConsts.tsx
@@ -41,7 +41,6 @@ export const NAV_ITEMS: MenuItem[] = [
   },
   {
     label: 'More',
-    badge: 'New',
     badgeType: BadgeTypes.ALERT,
     children: [
       {
@@ -52,7 +51,6 @@ export const NAV_ITEMS: MenuItem[] = [
       {
         href: 'https://cow.fi/cow-amm',
         label: 'CoW AMM',
-        badge: 'New',
         badgeType: BadgeTypes.ALERT,
         external: true,
       },

--- a/apps/cowswap-frontend/src/modules/application/containers/App/menuConsts.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/App/menuConsts.tsx
@@ -41,7 +41,7 @@ export const NAV_ITEMS: MenuItem[] = [
   },
   {
     label: 'More',
-   children: [
+    children: [
       {
         href: 'https://cow.fi/cow-protocol',
         label: 'CoW Protocol',


### PR DESCRIPTION
Fixes https://cowservices.slack.com/archives/C0361CDG8GP/p1750425431668179

1. Open the [app](https://swap-dev-git-remove-new-label-cowswap-dev.vercel.app/)
2. Check the menu - 'More' option --> there should not be 'New' label
3. Expand the menu option --> there should not be 'new' label close to CoW AMM
![image](https://github.com/user-attachments/assets/c526e73b-4d9d-4a33-a490-971111937d09)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Removed the "New" badge and alert styling from the "More" and "CoW AMM" menu items in the navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->