### PR TITLE
fix(bridge): display quote errors

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
@@ -1,8 +1,8 @@
 import { ReactElement } from 'react'
 
 import { getIsNativeToken, getWrappedToken } from '@cowprotocol/common-utils'
-import { BridgeProviderQuoteError } from '@cowprotocol/cow-sdk'
-import { HelpTooltip, InfoTooltip, TokenSymbol } from '@cowprotocol/ui'
+import { BridgeProviderQuoteError, BridgeQuoteErrors } from '@cowprotocol/cow-sdk'
+import { HelpTooltip, TokenSymbol } from '@cowprotocol/ui'
 
 import { Trans } from '@lingui/macro'
 import styled from 'styled-components/macro'
@@ -29,14 +29,10 @@ const CompatibilityIssuesWarningWrapper = styled.div`
   margin-top: -10px;
 `
 
-const JsonDisplay = styled.pre`
-  word-break: break-word;
-  white-space: pre-wrap;
-  width: 100%;
-`
+const DEFAULT_QUOTE_ERROR = 'Error loading price. Try again later.'
 
 const quoteErrorTexts: Record<QuoteApiErrorCodes, string> = {
-  [QuoteApiErrorCodes.UNHANDLED_ERROR]: 'Error loading price. Try again later.',
+  [QuoteApiErrorCodes.UNHANDLED_ERROR]: DEFAULT_QUOTE_ERROR,
   [QuoteApiErrorCodes.TransferEthToContract]:
     'Buying native currency with smart contract wallets is not currently supported',
   [QuoteApiErrorCodes.UnsupportedToken]: 'Unsupported token',
@@ -44,6 +40,17 @@ const quoteErrorTexts: Record<QuoteApiErrorCodes, string> = {
   [QuoteApiErrorCodes.FeeExceedsFrom]: 'Sell amount is too small',
   [QuoteApiErrorCodes.ZeroPrice]: 'Invalid price. Try increasing input/output amount.',
   [QuoteApiErrorCodes.SameBuyAndSellToken]: 'Tokens must be different',
+}
+
+const bridgeQuoteErrorTexts: Record<BridgeQuoteErrors, string> = {
+  [BridgeQuoteErrors.API_ERROR]: DEFAULT_QUOTE_ERROR,
+  [BridgeQuoteErrors.INVALID_BRIDGE]: DEFAULT_QUOTE_ERROR,
+  [BridgeQuoteErrors.TX_BUILD_ERROR]: DEFAULT_QUOTE_ERROR,
+  [BridgeQuoteErrors.QUOTE_ERROR]: DEFAULT_QUOTE_ERROR,
+  [BridgeQuoteErrors.INVALID_API_JSON_RESPONSE]: DEFAULT_QUOTE_ERROR,
+  [BridgeQuoteErrors.NO_INTERMEDIATE_TOKENS]: 'No routes found',
+  [BridgeQuoteErrors.NO_ROUTES]: 'No routes found',
+  [BridgeQuoteErrors.ONLY_SELL_ORDER_SUPPORTED]: 'Only "sell" orders are supported',
 }
 
 // TODO: Add proper return type annotation
@@ -96,30 +103,29 @@ export const tradeButtonsMap: Record<TradeFormValidation, ButtonErrorConfig | Bu
   },
   [TradeFormValidation.QuoteErrors]: (context) => {
     const { quote } = context
-    const defaultError = quoteErrorTexts[QuoteApiErrorCodes.UNHANDLED_ERROR]
 
     if (quote.error instanceof QuoteApiError) {
       if (quote.error.type === QuoteApiErrorCodes.UnsupportedToken) {
         return unsupportedTokenButton(context)
       }
 
+      const errorText = quoteErrorTexts[quote.error.type] || DEFAULT_QUOTE_ERROR
+
       return (
         <TradeFormBlankButton disabled={true}>
-          <Trans>{quoteErrorTexts[quote.error.type] || defaultError}</Trans>
+          <Trans>{errorText}</Trans>
         </TradeFormBlankButton>
       )
     }
 
     if (quote.error instanceof BridgeProviderQuoteError) {
+      const errorMessage = quote.error.message as BridgeQuoteErrors
+      const errorText = bridgeQuoteErrorTexts[errorMessage] || DEFAULT_QUOTE_ERROR
+
       return (
         <TradeFormBlankButton disabled={true}>
           <>
-            <Trans>Bridge quote error</Trans>
-            {'  '}
-            <InfoTooltip>
-              <p>{quote.error.message}</p>
-              <JsonDisplay>{JSON.stringify(quote.error.context, null, 2)}</JsonDisplay>
-            </InfoTooltip>
+            <Trans>{errorText}</Trans>
           </>
         </TradeFormBlankButton>
       )

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@cowprotocol/cms": "^0.11.0",
     "@cowprotocol/contracts": "^1.7.0",
     "@cowprotocol/cow-runner-game": "^0.2.9",
-    "@cowprotocol/cow-sdk": "6.0.0-RC.64",
+    "@cowprotocol/cow-sdk": "6.0.0-RC.66",
     "@cowprotocol/ethflowcontract": "cowprotocol/ethflowcontract.git#main-artifacts",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1841,10 +1841,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/cow-runner-game/-/cow-runner-game-0.2.9.tgz#3f94b3f370bd114f77db8b1d238cba3ef4e9d644"
   integrity sha512-rX7HnoV+HYEEkBaqVUsAkGGo0oBrExi+d6Io+8nQZYwZk+IYLmS9jdcIObsLviM2h4YX8+iin6NuKl35AaiHmg==
 
-"@cowprotocol/cow-sdk@6.0.0-RC.64":
-  version "6.0.0-RC.64"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.64.tgz#a25126047f4aa9a9fa65ce620150b5127233e777"
-  integrity sha512-6hDvlOD+bObZhkk160F8XAXAj3IwssKt0pEQcW4nfyDK3CnhF+7ge6UfNbFgZcIzRdFDkuPTYDKA0wRa5GKYmg==
+"@cowprotocol/cow-sdk@6.0.0-RC.66":
+  version "6.0.0-RC.66"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.66.tgz#39efcf1766669433bd027d3ca97dc5d1caee84ce"
+  integrity sha512-kaCsPFgriPoS2KOPbBVfQU8oD6DvrGZXt5HvfkDjIWojs48iGKmMZJRaunYbH+faNLDMASpcZgmCBKZgCG3OLw==
   dependencies:
     "@cowprotocol/app-data" "^3.1.0"
     "@cowprotocol/contracts" "^1.8.0"


### PR DESCRIPTION
# Summary

Using: https://github.com/cowprotocol/cow-sdk/pull/361

Fixes: https://www.notion.so/cownation/edge-no-routes-display-nicer-2108da5f04ca80a99d4dfa96b67eafcb?source=copy_link

<img width="525" alt="image" src="https://github.com/user-attachments/assets/f342a1bc-7c0f-456f-86aa-46601b80124b" />


# To Test

There is a set of possible errors fro bridge quote:

```
export enum BridgeQuoteErrors {
  NO_INTERMEDIATE_TOKENS = 'NO_INTERMEDIATE_TOKENS',
  API_ERROR = 'API_ERROR',
  INVALID_API_JSON_RESPONSE = 'INVALID_API_JSON_RESPONSE',
  ONLY_SELL_ORDER_SUPPORTED = 'ONLY_SELL_ORDER_SUPPORTED',
  TX_BUILD_ERROR = 'TX_BUILD_ERROR',
  QUOTE_ERROR = 'QUOTE_ERROR',
  NO_ROUTES = 'NO_ROUTES',
  INVALID_BRIDGE = 'INVALID_BRIDGE',
}
```

The errors should be mapped as:

```
const DEFAULT_QUOTE_ERROR = 'Error loading price. Try again later.'

const bridgeQuoteErrorTexts: Record<BridgeQuoteErrors, string> = {
  [BridgeQuoteErrors.API_ERROR]: DEFAULT_QUOTE_ERROR,
  [BridgeQuoteErrors.INVALID_BRIDGE]: DEFAULT_QUOTE_ERROR,
  [BridgeQuoteErrors.TX_BUILD_ERROR]: DEFAULT_QUOTE_ERROR,
  [BridgeQuoteErrors.QUOTE_ERROR]: DEFAULT_QUOTE_ERROR,
  [BridgeQuoteErrors.INVALID_API_JSON_RESPONSE]: DEFAULT_QUOTE_ERROR,
  [BridgeQuoteErrors.NO_INTERMEDIATE_TOKENS]: 'No routes found',
  [BridgeQuoteErrors.NO_ROUTES]: 'No routes found',
  [BridgeQuoteErrors.ONLY_SELL_ORDER_SUPPORTED]: 'Only "sell" orders are supported',
}
```