### PR TITLE
fix(explorer): handle limit price is infinite

### DIFF
--- a/apps/explorer/src/components/orders/OrderPriceDisplay/index.tsx
+++ b/apps/explorer/src/components/orders/OrderPriceDisplay/index.tsx
@@ -44,7 +44,9 @@ export function OrderPriceDisplay(props: Readonly<OrderPriceDisplayProps>): Reac
     denominator: { amount: buyAmount, decimals: buyToken.decimals },
     numerator: { amount: sellAmount, decimals: sellToken.decimals },
   })
-  const displayPrice = (isPriceInverted ? invertPrice(calculatedPrice) : calculatedPrice).toString(10)
+  const displayPrice = calculatedPrice.isFinite()
+    ? (isPriceInverted ? invertPrice(calculatedPrice) : calculatedPrice).toString(10)
+    : '0'
   const formattedPrice = formatSmart({
     amount: displayPrice,
     precision: NO_ADJUSTMENT_NEEDED_PRECISION,

--- a/apps/explorer/src/components/orders/OrderPriceDisplay/index.tsx
+++ b/apps/explorer/src/components/orders/OrderPriceDisplay/index.tsx
@@ -3,20 +3,16 @@ import { useState } from 'react'
 import { Command } from '@cowprotocol/types'
 
 import { faExchangeAlt } from '@fortawesome/free-solid-svg-icons'
-import { calculatePrice, formatSmart, invertPrice, safeTokenName, TokenErc20 } from '@gnosis.pm/dex-js'
+import { safeTokenName, TokenErc20 } from '@gnosis.pm/dex-js'
 import BigNumber from 'bignumber.js'
 import Icon from 'components/Icon'
 
-import {
-  HIGH_PRECISION_DECIMALS,
-  HIGH_PRECISION_SMALL_LIMIT,
-  NO_ADJUSTMENT_NEEDED_PRECISION,
-} from '../../../explorer/const'
+import { getLimitPrice } from 'utils/getLimitPrice'
 
 export type OrderPriceDisplayProps = {
-  buyAmount: string | BigNumber
+  buyAmount: BigNumber
   buyToken: TokenErc20
-  sellAmount: string | BigNumber
+  sellAmount: BigNumber
   sellToken: TokenErc20
   isPriceInverted?: boolean
   invertPrice?: Command
@@ -40,28 +36,23 @@ export function OrderPriceDisplay(props: Readonly<OrderPriceDisplayProps>): Reac
   const isPriceInverted = parentIsInvertedPrice ?? innerIsPriceInverted
   const invert = parentInvertPrice ?? ((): void => setInnerIsPriceInverted((curr) => !curr))
 
-  const calculatedPrice = calculatePrice({
-    denominator: { amount: buyAmount, decimals: buyToken.decimals },
-    numerator: { amount: sellAmount, decimals: sellToken.decimals },
-  })
-  const displayPrice = calculatedPrice.isFinite()
-    ? (isPriceInverted ? invertPrice(calculatedPrice) : calculatedPrice).toString(10)
-    : '0'
-  const formattedPrice = formatSmart({
-    amount: displayPrice,
-    precision: NO_ADJUSTMENT_NEEDED_PRECISION,
-    smallLimit: HIGH_PRECISION_SMALL_LIMIT,
-    decimals: HIGH_PRECISION_DECIMALS,
-  })
+  const limitPrice = getLimitPrice({
+    buyAmount,
+    buyToken,
+    sellAmount,
+    sellToken,
+  },
+    isPriceInverted || false,
+  )
 
   const buySymbol = safeTokenName(buyToken)
   const sellSymbol = safeTokenName(sellToken)
 
-  const [baseSymbol, quoteSymbol] = isPriceInverted ? [sellSymbol, buySymbol] : [buySymbol, sellSymbol]
+  const baseSymbol = isPriceInverted ? sellSymbol : buySymbol
 
   return (
     <>
-      {formattedPrice} {quoteSymbol} for {baseSymbol}{' '}
+      {limitPrice} for {baseSymbol}{' '}
       {showInvertButton && <Icon icon={faExchangeAlt} onClick={invert} />}
     </>
   )

--- a/apps/explorer/src/utils/format.ts
+++ b/apps/explorer/src/utils/format.ts
@@ -14,14 +14,14 @@ import {
 } from '../explorer/const'
 
 export {
-  formatSmart,
-  formatAmountFull,
-  adjustPrecision,
-  parseAmount,
   abbreviateString,
-  safeTokenName,
-  safeFilledToken,
+  adjustPrecision,
+  formatAmountFull,
   formatPrice,
+  formatSmart,
+  parseAmount,
+  safeFilledToken,
+  safeTokenName,
 } from '@gnosis.pm/dex-js'
 
 // TODO: Move utils to dex-utils
@@ -88,13 +88,13 @@ export function formatPartialNumber(value: string): string {
 export const formatTimeInHours = (
   validTime: string | number,
   matchedConstraintText: string,
-  errorText = 'Invalid time - time cannot be negative'
+  errorText = 'Invalid time - time cannot be negative',
 ): string =>
   +validTime === 0
     ? matchedConstraintText
     : +validTime < 0
-    ? errorText
-    : `in ~
+      ? errorText
+      : `in ~
 ${(+validTime / 60).toFixed(2).replace(leadingAndTrailingZeros, '').replace(trailingZerosAfterDot, '$1')}
 hours`
 
@@ -233,9 +233,9 @@ export function formatCalculatedPriceToDisplay(
   calculatedPrice: BigNumber,
   buyToken: TokenErc20,
   sellToken: TokenErc20,
-  isPriceInverted?: boolean
+  isPriceInverted?: boolean,
 ): string {
-  const displayPrice = calculatedPrice.toString(10)
+  const displayPrice = calculatedPrice.isFinite() ? calculatedPrice.toString(10) : '0'
   const formattedPrice = formatSmart({
     amount: displayPrice,
     precision: NO_ADJUSTMENT_NEEDED_PRECISION,
@@ -254,9 +254,9 @@ export function formatExecutedPriceToDisplay(
   calculatedPrice: BigNumber,
   buyToken: TokenErc20,
   sellToken: TokenErc20,
-  isPriceInverted?: boolean
+  isPriceInverted?: boolean,
 ): string {
-  const displayPrice = calculatedPrice.toString(10)
+  const displayPrice = calculatedPrice.isFinite() ? calculatedPrice.toString(10) : '0'
   const formattedPrice = formatSmart({
     amount: displayPrice,
     precision: NO_ADJUSTMENT_NEEDED_PRECISION,
@@ -277,7 +277,7 @@ export function formatExecutedPriceToDisplay(
 export function formattingAmountPrecision(
   amount: BigNumber,
   token: TokenErc20 | null,
-  typePrecision: FormatAmountPrecision
+  typePrecision: FormatAmountPrecision,
 ): string {
   const typeFormatPrecision = {
     [FormatAmountPrecision.highPrecision]: HIGH_PRECISION_DECIMALS,
@@ -298,6 +298,6 @@ export function parseStringOrBytes32(value: string | undefined, defaultValue: st
   return value && BYTES32_REGEX.test(value) && arrayify(value)[31] === 0
     ? parseBytes32String(value)
     : value && value.length > 0
-    ? value
-    : defaultValue
+      ? value
+      : defaultValue
 }

--- a/apps/explorer/src/utils/getLimitPrice.ts
+++ b/apps/explorer/src/utils/getLimitPrice.ts
@@ -3,7 +3,10 @@ import { getOrderLimitPrice } from './operator'
 
 import { Order } from '../api/operator'
 
-export function getLimitPrice(order: Order, isPriceInverted: boolean): string {
+export function getLimitPrice(
+  order: Pick<Order, 'buyToken' | 'sellToken' | 'buyAmount' | 'sellAmount'>,
+  isPriceInverted: boolean,
+): string {
   if (!order.buyToken || !order.sellToken) return '-'
 
   const calculatedPrice = getOrderLimitPrice({


### PR DESCRIPTION
# Summary

Fixes a divide by zero crash caused by the buy amount being zero, causing a infinite limit price

# To Test

1. Open the order `0xfcbd64398f0a03405b4c37f356a36bc0acc538fa144f67a9471bafd905712d62ba3cb449bd2b4adddbc894d8697f5170800eadecffffffff`
* It should not crash
* The price should be `0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved price display reliability by ensuring only valid numeric values are shown. Non-finite prices now default to '0' to prevent display issues.
- **New Features**
  - Simplified order price display with clearer formatting showing limit price followed by the base symbol.
- **Chores**
  - Updated utility functions for better input handling and export organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->