### PR TITLE
fix(bridge): fix progress bar background

### DIFF
--- a/apps/cowswap-frontend/src/cosmos.decorator.tsx
+++ b/apps/cowswap-frontend/src/cosmos.decorator.tsx
@@ -21,6 +21,7 @@ import { cowSwapStore } from 'legacy/state'
 import { useDarkModeManager } from 'legacy/state/user/hooks'
 
 import { BlockNumberProvider } from './common/hooks/useBlockNumber'
+import { ThemeConfigUpdater } from './theme/ThemeConfigUpdater'
 
 const DarkModeToggleButton = styled.button`
   display: flex;
@@ -107,6 +108,7 @@ const Fixture = ({ children }: { children: ReactNode }) => {
               <Web3ReactProvider connectors={[[connector, hooks]]} network={chainId}>
                 <BlockNumberProvider>
                   <WalletUpdater />
+                  <ThemeConfigUpdater />
                   <Wrapper>
                     <CowAnalyticsProvider cowAnalytics={cowAnalytics}>
                       <DarkModeToggle>

--- a/apps/cowswap-frontend/src/modules/bridge/pure/CollapsibleBridgeRoute/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/CollapsibleBridgeRoute/index.tsx
@@ -30,16 +30,13 @@ interface CollapsibleBridgeRouteProps {
   className?: string
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function CollapsibleBridgeRoute(props: CollapsibleBridgeRouteProps) {
+export function CollapsibleBridgeRoute(props: CollapsibleBridgeRouteProps): ReactNode {
   const { isCollapsible = false, children, providerInfo, collapsedDefault, className } = props
 
   const [isExpanded, setIsExpanded] = useState(props.isExpanded || false)
 
   // TODO: Add proper return type annotation
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  const toggleExpanded = () => setIsExpanded((state) => !state)
+  const toggleExpanded = (): void => setIsExpanded((state) => !state)
 
   return (
     <Wrapper className={className}>

--- a/apps/cowswap-frontend/src/modules/bridge/pure/ProgressDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/ProgressDetails/index.tsx
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react'
+
 import { DividerHorizontal } from '../../styles'
 import { SwapAndBridgeStatus, SwapAndBridgeContext } from '../../types'
 import { BridgeDetailsContainer } from '../BridgeDetailsContainer'
@@ -13,9 +15,6 @@ interface QuoteDetailsProps {
   context: SwapAndBridgeContext
 }
 
-// TODO: Break down this large function into smaller functions
-// TODO: Add proper return type annotation
-// eslint-disable-next-line max-lines-per-function, @typescript-eslint/explicit-function-return-type
 export function ProgressDetails({
   className,
   context: {
@@ -27,7 +26,7 @@ export function ProgressDetails({
     bridgingStatus,
     statusResult,
   },
-}: QuoteDetailsProps) {
+}: QuoteDetailsProps): ReactNode {
   const { sourceAmounts, targetAmounts, sourceChainName, targetChainName } = overview
   const swapStatus = SwapAndBridgeStatus.DONE
   const bridgeStatus = bridgingStatus === SwapAndBridgeStatus.DEFAULT ? SwapAndBridgeStatus.PENDING : bridgingStatus

--- a/apps/cowswap-frontend/src/modules/orderProgressBar/pure/steps/BridgingStep.tsx
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/pure/steps/BridgingStep.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-import { Confetti } from '@cowprotocol/ui'
+import { Confetti, UI } from '@cowprotocol/ui'
 
 import styled from 'styled-components/macro'
 
@@ -32,7 +32,7 @@ const Wrapper = styled.div`
 
 const ProgressDetailsStyled = styled(ProgressDetails)`
   border-radius: 16px;
-  background: #f2f2f2;
+  background: var(${UI.COLOR_PAPER_DARKER});
   padding: 16px;
 `
 


### PR DESCRIPTION
# Summary

Before: 
![telegram-cloud-photo-size-5-6260377316454680345-y](https://github.com/user-attachments/assets/5a7106c4-4cb5-4afb-a5f7-031600fc963c)

After: 
<img width="604" alt="image" src="https://github.com/user-attachments/assets/d9c1f57d-ef69-42c6-9926-682ea501dab9" />

# To Test

The progress bar (bridge steps) background should look good both for light and dark themes
