### PR TITLE
refactor(bridge): enhance transaction link display with dynamic explo…

### DIFF
--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/ReceivedBridgingContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/ReceivedBridgingContent/index.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react'
 
 import ReceiptIcon from '@cowprotocol/assets/cow-swap/icon-receipt.svg'
+import { getChainInfo } from '@cowprotocol/common-const'
 import { ExplorerDataType, getExplorerLink } from '@cowprotocol/common-utils'
 import { BridgeStatusResult, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { ExternalLink } from '@cowprotocol/ui'
@@ -22,9 +23,12 @@ interface ReceivedBridgingContentProps {
 interface TransactionLinkProps {
   link: string
   label: string
+  chainId: SupportedChainId
 }
 
-function TransactionLink({ link, label }: TransactionLinkProps): ReactNode {
+function TransactionLink({ link, label, chainId }: TransactionLinkProps): ReactNode {
+  const explorerTitle = getChainInfo(chainId).explorerTitle
+
   return (
     <ConfirmDetailsItem
       label={
@@ -36,7 +40,7 @@ function TransactionLink({ link, label }: TransactionLinkProps): ReactNode {
         </>
       }
     >
-      <ExternalLink href={link}>View on bridge explorer ↗</ExternalLink>
+      <ExternalLink href={link}>View on {explorerTitle} ↗</ExternalLink>
     </ConfirmDetailsItem>
   )
 }
@@ -70,8 +74,8 @@ export function ReceivedBridgingContent({
         </b>
       </ConfirmDetailsItem>
 
-      {depositLink && <TransactionLink link={depositLink} label="Source transaction" />}
-      {fillTxLink && <TransactionLink link={fillTxLink} label="Destination transaction" />}
+      {depositLink && <TransactionLink link={depositLink} label="Source transaction" chainId={sourceChainId} />}
+      {fillTxLink && <TransactionLink link={fillTxLink} label="Destination transaction" chainId={destinationChainId as SupportedChainId} />}
     </>
   )
 }


### PR DESCRIPTION
# Summary

  Makes explorer link labels dynamic based on actual blockchain explorer

  Previously, all explorer links showed generic "View on bridge explorer ↗" text. Now displays the specific explorer name (e.g., "View on Basescan ↗", "View on Arbiscan ↗") based on the chain being used.

 

 ## Before
<img width="506" alt="Screenshot 2025-06-26 at 10 26 39" src="https://github.com/user-attachments/assets/158b4de7-1e8b-400f-90be-88c732822e50" />
 
## After
<img width="511" alt="Screenshot 2025-06-26 at 10 40 29" src="https://github.com/user-attachments/assets/c06044cd-9b55-425b-b50e-0e58bbea9a66" />


  # To Test

  1. Complete a bridge transaction to any supported chain
     - [ ] Verify the explorer link shows the correct explorer name for the destination chain
     - [ ] Test with Base - should show "View on Basescan ↗"
     - [ ] Test with Arbitrum - should show "View on Arbiscan ↗"
     - [ ] Test with Mainnet - should show "View on Etherscan ↗"

  2. Check both source and destination transaction links
     - [ ] Source transaction link shows correct explorer for source chain
     - [ ] Destination transaction link shows correct explorer for destination chain

  # Background

  The app already had chain-specific explorer titles in `CHAIN_INFO`, just needed to use them in the bridge progress UI.