### PR TITLE
fix: Buy COW link

### DIFF
--- a/apps/cowswap-frontend/src/pages/Account/Balances.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/Balances.tsx
@@ -5,6 +5,7 @@ import CowImage from '@cowprotocol/assets/cow-swap/cow_token.svg'
 import vCOWImage from '@cowprotocol/assets/images/vCOW.svg'
 import { useCurrencyAmountBalance } from '@cowprotocol/balances-and-allowances'
 import { COW_TOKEN_TO_CHAIN, COW_CONTRACT_ADDRESS, V_COW } from '@cowprotocol/common-const'
+import { WRAPPED_NATIVE_CURRENCIES as WETH } from '@cowprotocol/common-const'
 import { usePrevious } from '@cowprotocol/common-hooks'
 import { getBlockExplorerUrl, getProviderErrorMessage } from '@cowprotocol/common-utils'
 import { ButtonPrimary, HoverTooltip, TokenAmount } from '@cowprotocol/ui'
@@ -44,7 +45,7 @@ import {
 } from 'pages/Account/styled'
 
 import LockedGnoVesting from './LockedGnoVesting'
-import { WRAPPED_NATIVE_CURRENCIES as WETH } from '@cowprotocol/common-const'
+
 // Number of blocks to wait before we re-enable the swap COW -> vCOW button after confirmation
 const BLOCKS_TO_WAIT = 2
 

--- a/apps/cowswap-frontend/src/pages/Account/Balances.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/Balances.tsx
@@ -300,7 +300,7 @@ export default function Profile() {
                   }
                 />
 
-                <Link to={`/swap/${nativeWrappedToken.address}/${COW_CONTRACT_ADDRESS[chainId]}`}>Buy COW</Link>
+                <Link to={`/${chainId}/swap/${nativeWrappedToken.address}/${COW_CONTRACT_ADDRESS[chainId]}`}>Buy COW</Link>
               </CardActions>
             </Card>
           )}

--- a/apps/cowswap-frontend/src/pages/Account/Balances.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/Balances.tsx
@@ -44,7 +44,7 @@ import {
 } from 'pages/Account/styled'
 
 import LockedGnoVesting from './LockedGnoVesting'
-
+import { WRAPPED_NATIVE_CURRENCIES as WETH } from '@cowprotocol/common-const'
 // Number of blocks to wait before we re-enable the swap COW -> vCOW button after confirmation
 const BLOCKS_TO_WAIT = 2
 
@@ -58,7 +58,7 @@ export default function Profile() {
   const previousAccount = usePrevious(account)
 
   const cowContractAddress = COW_CONTRACT_ADDRESS[chainId]
-
+  const nativeWrappedToken = WETH[chainId]
   const isProviderNetworkUnsupported = useIsProviderNetworkUnsupported()
   const blockNumber = useBlockNumber()
   const [confirmationBlock, setConfirmationBlock] = useState<undefined | number>(undefined)
@@ -300,7 +300,7 @@ export default function Profile() {
                   }
                 />
 
-                <Link to={`/swap?outputCurrency=${COW_CONTRACT_ADDRESS[chainId]}`}>Buy COW</Link>
+                <Link to={`/swap/${nativeWrappedToken.address}/${cowToken?.address}`}>Buy COW</Link>
               </CardActions>
             </Card>
           )}

--- a/apps/cowswap-frontend/src/pages/Account/Balances.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/Balances.tsx
@@ -300,7 +300,7 @@ export default function Profile() {
                   }
                 />
 
-                <Link to={`/swap/${nativeWrappedToken.address}/${cowToken?.address}`}>Buy COW</Link>
+                <Link to={`/swap/${nativeWrappedToken.address}/${COW_CONTRACT_ADDRESS[chainId]}`}>Buy COW</Link>
               </CardActions>
             </Card>
           )}


### PR DESCRIPTION
# Summary
It appeared that the way how 'Buy COW' link is build is [deprecated](https://cowservices.slack.com/archives/C0361CDG8GP/p1751026168987709?thread_ts=1751023838.837159&cid=C0361CDG8GP)

In this PR I gave a try to fix it. 

**Steps**: 
1. Open https://swap-dev-git-fix-buy-cow-link-cowswap-dev.vercel.app/#/account
2. Press on the 'Buy COW link on the COW widget
![image](https://github.com/user-attachments/assets/efb94fc1-d9ef-4970-8b0d-5c85e2711d63)

**AR**: it should navigate to the Swap widget with [native token]/COW tokens in the fields. 
![image](https://github.com/user-attachments/assets/de8435b7-8dcb-4660-9876-92242c7b0b7e)


4. Check in all chains. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the "Buy COW" link to use a new URL format that includes the current network and token addresses for improved clarity and accuracy when navigating to the swap page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->