### PR TITLE
fix(trade): fix quote refetching triggers

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useTradeQuotePolling.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useTradeQuotePolling.ts
@@ -37,6 +37,8 @@ export function useTradeQuotePolling(isConfirmOpen = false): null {
   isOnlineRef.current = isOnline
 
   const pollQuote = usePollQuoteCallback(isConfirmOpen, quoteParamsState)
+  const pollQuoteRef = useRef(pollQuote)
+  pollQuoteRef.current = pollQuote
 
   /**
    * Reset quote when window is not visible or sell amount has been cleared
@@ -56,10 +58,16 @@ export function useTradeQuotePolling(isConfirmOpen = false): null {
    * Fetch the quote instantly once the quote params are changed
    */
   useLayoutEffect(() => {
-    if (pollQuote(true)) {
+    /**
+     * Quote params are not supposed to be changed once confirm screen is open
+     * So, we should not refetch quote
+     */
+    if (isConfirmOpen) return
+
+    if (pollQuoteRef.current(true)) {
       resetQuoteCounter()
     }
-  }, [pollQuote, quoteParams, resetQuoteCounter])
+  }, [isConfirmOpen, quoteParams, resetQuoteCounter])
 
   /**
    * Update quote once a QUOTE_POLLING_INTERVAL
@@ -67,8 +75,8 @@ export function useTradeQuotePolling(isConfirmOpen = false): null {
   useLayoutEffect(() => {
     if (tradeQuotePolling !== 0) return
 
-    pollQuote(false, true)
-  }, [pollQuote, tradeQuotePolling])
+    pollQuoteRef.current(false, true)
+  }, [tradeQuotePolling])
 
   /**
    * Reset counter and update quote each time when confirmation modal is closed


### PR DESCRIPTION
# Summary

There is an issue when quote refetching is triggered when it's not expected.
There are two causes:
1. Since the recent refactoring (#5859), I added a hook `usePollQuoteCallback` which triggers quote fetching when some of its deps are changed. It should not happen, so the callback was moved to a ref
2. Quote was refetching when appData changes in confirm modal. It should not happen as well, so I added `if (isConfirmOpen) return`

# To Test

1. Quote refreshing (when sell amount changes, receiver changes, manual slippages changes)
2. Permit flow
