### PR TITLE
fix(eth-flow): fix refund tx detection

### DIFF
--- a/apps/cowswap-frontend/src/common/updaters/orders/ExpiredOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/ExpiredOrdersUpdater.ts
@@ -67,7 +67,7 @@ export function ExpiredOrdersUpdater(): null {
         isUpdating.current = false
       }
     },
-    [setIsOrderRefundedBatch]
+    [setIsOrderRefundedBatch],
   )
 
   useEffect(() => {

--- a/apps/cowswap-frontend/src/modules/ethFlow/pure/EthFlowStepper/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ethFlow/pure/EthFlowStepper/index.tsx
@@ -16,7 +16,7 @@ export enum SmartOrderStatus {
   FILLED = 'FILLED',
 }
 
-type TxState = {
+export type TxState = {
   /**
    * undefined: there's no tx to track
    * string: tx was created and can be tracked

--- a/apps/cowswap-frontend/src/modules/ethFlow/pure/EthFlowStepper/steps/Step2.tsx
+++ b/apps/cowswap-frontend/src/modules/ethFlow/pure/EthFlowStepper/steps/Step2.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { ReactNode, useMemo } from 'react'
 
 import Checkmark from '@cowprotocol/assets/cow-swap/checkmark.svg'
 import Exclamation from '@cowprotocol/assets/cow-swap/exclamation.svg'
@@ -10,10 +10,7 @@ import { ExplorerLinkStyled, Step, StepProps } from '../Step'
 
 type Step2Config = StepProps & { error?: string }
 
-// TODO: Break down this large function into smaller functions
-// TODO: Add proper return type annotation
-// eslint-disable-next-line max-lines-per-function, @typescript-eslint/explicit-function-return-type
-export function Step2({ order, cancellation, creation }: EthFlowStepperProps) {
+export function Step2({ order, cancellation, creation }: EthFlowStepperProps): ReactNode {
   const { state, isExpired, orderId, rejectedReason } = order
   const isCreating = state === SmartOrderStatus.CREATING
   const isIndexing = state === SmartOrderStatus.CREATION_MINED
@@ -30,8 +27,7 @@ export function Step2({ order, cancellation, creation }: EthFlowStepperProps) {
     state: stepState,
     icon,
     error,
-  // TODO: Reduce function complexity by extracting logic
-  // eslint-disable-next-line complexity
+    // TODO: Reduce function complexity by extracting logic
   } = useMemo<Step2Config>(() => {
     if ((rejectedReason || creationCancelled || (creationReplaced && isCreating)) && !isFilled) {
       return {
@@ -41,7 +37,7 @@ export function Step2({ order, cancellation, creation }: EthFlowStepperProps) {
         icon: X,
       }
     }
-    if (expiredBeforeCreate) {
+    if (expiredBeforeCreate && !isFilled) {
       return {
         label: 'Order Creation Failed',
         error: 'Expired before creation',

--- a/apps/cowswap-frontend/src/modules/ethFlow/pure/EthFlowStepper/steps/Step3.tsx
+++ b/apps/cowswap-frontend/src/modules/ethFlow/pure/EthFlowStepper/steps/Step3.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useMemo } from 'react'
+import { ReactElement, ReactNode, useMemo } from 'react'
 
 import Checkmark from '@cowprotocol/assets/cow-swap/checkmark.svg'
 import Exclamation from '@cowprotocol/assets/cow-swap/exclamation.svg'
@@ -20,11 +20,15 @@ const ExpiredMessage = styled.span`
   color: var(${UI.COLOR_WARNING});
 `
 
-// TODO: Break down this large function into smaller functions
-// TODO: Add proper return type annotation
-// TODO: Reduce function complexity by extracting logic
-// eslint-disable-next-line max-lines-per-function, @typescript-eslint/explicit-function-return-type, complexity
-export function Step3({ nativeTokenSymbol, tokenLabel, order, creation, refund, cancellation }: EthFlowStepperProps) {
+// eslint-disable-next-line complexity,max-lines-per-function
+export function Step3({
+  nativeTokenSymbol,
+  tokenLabel,
+  order,
+  creation,
+  refund,
+  cancellation,
+}: EthFlowStepperProps): ReactNode {
   const { state, isExpired, rejectedReason } = order
   const { failed: creationFailed, cancelled: creationCancelled, replaced: creationReplaced } = creation
   const { hash: refundHash, failed: refundFailed } = refund
@@ -34,7 +38,7 @@ export function Step3({ nativeTokenSymbol, tokenLabel, order, creation, refund, 
   const isIndexed = state === SmartOrderStatus.INDEXED
   const isCreating = state === SmartOrderStatus.CREATING
   const isFilled = state === SmartOrderStatus.FILLED
-  const expiredBeforeCreate = isExpired && (isCreating || isIndexing)
+  const expiredBeforeCreate = isExpired && (isCreating || isIndexing) && !isFilled
   const isRefunded = refundFailed === false || cancellationFailed === false
 
   const orderIsNotCreated = !!(creationFailed || creationCancelled || creationReplaced) && !isFilled


### PR DESCRIPTION
# Summary

Fixes #5883

![image](https://github.com/user-attachments/assets/a39ef42c-375f-48bd-8343-fdb10f260938)

# To Test

1. Create ETH-flow order with extremely low sell amount, set deadline to 10 minutes and minimum slippage
2. Wait till the order gets expired
- [ ] AR: displays "Replaced" state
- [ ] ER: displays "ETH refunded" state with a link to transaction

See Fixes #5883
