### PR TITLE
fix(progress-bar): ignore active solvers flag from CMS

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useSolversInfo.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useSolversInfo.ts
@@ -2,7 +2,7 @@ import { useAtomValue } from 'jotai'
 import { useMemo } from 'react'
 
 import { isProdLike } from '@cowprotocol/common-utils'
-import { solversInfoAtom, SolverInfo } from '@cowprotocol/core'
+import { SolverInfo, solversInfoAtom } from '@cowprotocol/core'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 export function useSolversInfo(chainId: SupportedChainId): Record<string, SolverInfo> {
@@ -15,8 +15,7 @@ export function useSolversInfo(chainId: SupportedChainId): Record<string, Solver
     return allSolversInfo.reduce<Record<string, SolverInfo>>((acc, info) => {
       if (
         info.solverNetworks.some(
-          ({ env: solverEnv, chainId: solverChainId, active }) =>
-            solverEnv === envToFilter && solverChainId === chainId && active,
+          ({ env: solverEnv, chainId: solverChainId }) => solverEnv === envToFilter && solverChainId === chainId,
         )
       ) {
         acc[info.solverId] = info

--- a/apps/cowswap-frontend/src/common/hooks/useSolversInfo.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useSolversInfo.ts
@@ -1,7 +1,7 @@
 import { useAtomValue } from 'jotai'
 import { useMemo } from 'react'
 
-import { isProdLike } from '@cowprotocol/common-utils'
+import { isBarnBackendEnv } from '@cowprotocol/common-utils'
 import { SolverInfo, solversInfoAtom } from '@cowprotocol/core'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
@@ -10,7 +10,7 @@ export function useSolversInfo(chainId: SupportedChainId): Record<string, Solver
 
   return useMemo(() => {
     // Filters by 'staging' for non-prod (dev/local/"barn") environments because the `solversInfoAtom` data (via CMS mapping) uses 'staging' for these cases.
-    const envToFilter = isProdLike ? 'prod' : 'staging'
+    const envToFilter = isBarnBackendEnv ? 'staging' : 'prod'
 
     return allSolversInfo.reduce<Record<string, SolverInfo>>((acc, info) => {
       if (

--- a/apps/cowswap-frontend/src/modules/orderProgressBar/hooks/useOrderProgressBarProps.ts
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/hooks/useOrderProgressBarProps.ts
@@ -27,7 +27,7 @@ import { ActivityDerivedState } from 'common/types/activity'
 import { ApiSolverCompetition, SolverCompetition } from 'common/types/soverCompetition'
 import { getIsFinalizedOrder } from 'utils/orderUtils/getIsFinalizedOrder'
 
-import { OrderProgressBarStepName, DEFAULT_STEP_NAME } from '../constants'
+import { DEFAULT_STEP_NAME, OrderProgressBarStepName } from '../constants'
 import {
   ordersProgressBarStateAtom,
   setOrderProgressBarCancellationTriggered,
@@ -240,13 +240,11 @@ function useOrderBaseProgressBarProps(params: UseOrderProgressBarPropsParams): U
  * @param apiSolverCompetition
  * @param disableProgressBar
  */
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function getDoNotQueryStatusEndpoint(
   order: Order | undefined,
   apiSolverCompetition: CompetitionOrderStatus['value'] | undefined,
   disableProgressBar: boolean,
-) {
+): boolean {
   return (
     !!(
       (
@@ -268,17 +266,13 @@ function useGetExecutingOrderState(orderId: string): OrderProgressBarState {
   return useMemo(() => singleState || DEFAULT_STATE, [singleState])
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function useSetExecutingOrderCountdownCallback() {
+function useSetExecutingOrderCountdownCallback(): (orderId: string, value: number | null) => void {
   const setAtom = useSetAtom(updateOrderProgressBarCountdown)
 
   return useCallback((orderId: string, value: number | null) => setAtom({ orderId, value }), [setAtom])
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function useSetExecutingOrderProgressBarStepNameCallback() {
+function useSetExecutingOrderProgressBarStepNameCallback(): (orderId: string, value: OrderProgressBarStepName) => void {
   const setValue = useSetAtom(updateOrderProgressBarStepName)
 
   return useCallback(
@@ -291,13 +285,11 @@ function useSetExecutingOrderProgressBarStepNameCallback() {
 
 // local updaters
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function useCountdownStartUpdater(
   orderId: string,
   countdown: OrderProgressBarState['countdown'],
   backendApiStatus: OrderProgressBarState['backendApiStatus'],
-) {
+): void {
   const setCountdown = useSetExecutingOrderCountdownCallback()
 
   useEffect(() => {
@@ -312,9 +304,7 @@ function useCountdownStartUpdater(
   }, [backendApiStatus, setCountdown, countdown, orderId])
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function useCancellingOrderUpdater(orderId: string, isCancelling: boolean) {
+function useCancellingOrderUpdater(orderId: string, isCancelling: boolean): void {
   const setCancellationTriggered = useSetAtom(setOrderProgressBarCancellationTriggered)
 
   useEffect(() => {
@@ -323,8 +313,6 @@ function useCancellingOrderUpdater(orderId: string, isCancelling: boolean) {
 }
 
 // TODO: Break down this large function into smaller functions
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function useProgressBarStepNameUpdater(
   orderId: string,
   isUnfillable: boolean,
@@ -340,7 +328,7 @@ function useProgressBarStepNameUpdater(
   previousStepName: OrderProgressBarState['previousStepName'],
   bridgingStatus: SwapAndBridgeStatus | undefined,
   isBridgingTrade: boolean,
-) {
+): void {
   const setProgressBarStepName = useSetExecutingOrderProgressBarStepNameCallback()
 
   const stepName = getProgressBarStepName(
@@ -360,9 +348,7 @@ function useProgressBarStepNameUpdater(
 
   // Update state with new step name
   useEffect(() => {
-    // TODO: Add proper return type annotation
-    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-    function updateStepName(name: OrderProgressBarStepName) {
+    function updateStepName(name: OrderProgressBarStepName): void {
       setProgressBarStepName(orderId, name || DEFAULT_STEP_NAME)
     }
 
@@ -521,9 +507,11 @@ const POOLING_SWR_OPTIONS = {
   refreshInterval: ms`1s`,
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function usePendingOrderStatus(chainId: SupportedChainId, orderId: string, doNotQuery?: boolean) {
+function usePendingOrderStatus(
+  chainId: SupportedChainId,
+  orderId: string,
+  doNotQuery?: boolean,
+): CompetitionOrderStatus | undefined {
   return useSWR(
     chainId && orderId && !doNotQuery ? ['getOrderCompetitionStatus', chainId, orderId] : null,
     async ([, _chainId, _orderId]) => getOrderCompetitionStatus(_chainId, _orderId),

--- a/libs/core/src/cms/types.ts
+++ b/libs/core/src/cms/types.ts
@@ -16,7 +16,6 @@ export type SolverInfo = {
 export type SolverNetwork = {
   chainId: SupportedChainId
   env: CowEnv
-  active: boolean
 }
 
 export type CmsAnnouncements = components['schemas']['AnnouncementListResponseDataItem'][]

--- a/libs/core/src/cms/utils/mapCmsSolversInfoToSolversInfo.ts
+++ b/libs/core/src/cms/utils/mapCmsSolversInfoToSolversInfo.ts
@@ -9,18 +9,16 @@ export function mapCmsSolversInfoToSolversInfo(cmsSolversInfo: CmsSolversInfo): 
       // eslint-disable-next-line complexity
       const solverNetworks = solver_networks?.data?.reduce<SolverNetwork[]>((acc, entry) => {
         if (entry.attributes) {
-          const { active, network, environment } = entry.attributes
+          const { network, environment } = entry.attributes
           const chainId = network?.data?.attributes?.chainId
           const cmsEnv = environment?.data?.attributes?.name
 
-          // Ignore the ones that are not active
-          if (chainId && cmsEnv && active) {
+          if (chainId && cmsEnv) {
             // Map to CowEnv
             const env = cmsEnv === 'barn' ? 'staging' : 'prod'
             acc.push({
               chainId,
               env,
-              active,
             })
           }
         }


### PR DESCRIPTION
# Summary

No longer check for solver `active` flag from CMS.
In the UI, we don't really care whether the solver is active or not. After all, we'll match the info received from the backend.

Before this change, if for some reason we forget to mark the solver as enabled in the CMS, it won't show up nicely in the progress bar, even though it's returned by the backend and registered in the CMS.
Now we just need to make sure they are in the CMS, the flag doesn't matter.

# To Test

1. Check the CMS for barn. I have set all Sepolia solvers flag to `false.
![image](https://github.com/user-attachments/assets/91f72cbc-a33e-41e6-935c-350d9da30e37)

2. Place an order on Sepolia
* Solvers should have the nice image (when applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated environment filtering logic for solver information, simplifying how solvers are selected based on environment.
  * Removed usage and checks for the "active" property in solver networks.

* **Style**
  * Added explicit TypeScript return types to several functions for improved type safety and clarity.

* **Chores**
  * Cleaned up code comments and unnecessary ESLint disables related to return type annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->