### PR TITLE
feat(bridge): display execution price in swap details

### DIFF
--- a/apps/cowswap-frontend/src/modules/bridge/pure/BridgeActivitySummary/SwapStepRow.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/BridgeActivitySummary/SwapStepRow.tsx
@@ -40,7 +40,7 @@ export function SwapStepRow({ context }: SwapStepRowProps): ReactNode {
           sellAmount={sourceAmounts.sellAmount}
           buyAmount={sourceAmounts.buyAmount}
         >
-          <SwapResultContent context={swapResultContext} />
+          <SwapResultContent context={swapResultContext} sellAmount={sourceAmounts.sellAmount} />
         </BridgeDetailsContainer>
       </StepContent>
     </SwapSummaryRow>

--- a/apps/cowswap-frontend/src/modules/bridge/pure/ProgressDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/ProgressDetails/index.tsx
@@ -49,7 +49,7 @@ export function ProgressDetails({
         sellAmount={sourceAmounts.sellAmount}
         buyAmount={sourceAmounts.buyAmount}
       >
-        <SwapResultContent context={swapResultContext} />
+        <SwapResultContent context={swapResultContext} sellAmount={sourceAmounts.sellAmount} />
       </BridgeDetailsContainer>
       <DividerHorizontal margin="8px 0 4px" />
       <BridgeDetailsContainer

--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/SwapResultContent/contents.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/SwapResultContent/contents.tsx
@@ -1,0 +1,114 @@
+import { ReactNode } from 'react'
+
+import PlusIcon from '@cowprotocol/assets/cow-swap/plus.svg'
+import { buildPriceFromCurrencyAmounts } from '@cowprotocol/common-utils'
+import { TokenAmount, TokenSymbol } from '@cowprotocol/ui'
+import type { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
+
+import styled from 'styled-components/macro'
+
+import { AMM_LOGOS } from 'legacy/components/AMMsLogo'
+
+import { ReceiveAmountTitle } from 'modules/trade'
+
+import type { SolverCompetition } from 'common/types/soverCompetition'
+
+import { StyledTimelinePlusIcon, SuccessTextBold, TimelineIconCircleWrapper } from '../../../styles'
+import { TokenAmountDisplay } from '../../TokenAmountDisplay'
+
+interface ContentConfig {
+  withTimelineDot?: boolean
+  label: ReactNode
+  content: ReactNode
+}
+
+const WinningSolverContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+`
+
+export function getReceivedContent(
+  receivedAmount: CurrencyAmount<Currency>,
+  receivedAmountUsd: CurrencyAmount<Token> | null,
+): ContentConfig {
+  return {
+    label: (
+      <ReceiveAmountTitle>
+        <b>Received</b>
+      </ReceiveAmountTitle>
+    ),
+    content: (
+      <b>
+        <TokenAmountDisplay currencyAmount={receivedAmount} displaySymbol usdValue={receivedAmountUsd} />
+      </b>
+    ),
+  }
+}
+
+export function getExecPriceContent(
+  sellAmount: CurrencyAmount<Currency>,
+  receivedAmount: CurrencyAmount<Currency>,
+): ContentConfig {
+  const price = buildPriceFromCurrencyAmounts(sellAmount, receivedAmount)
+
+  return {
+    withTimelineDot: true,
+    label: <span>Exec. price</span>,
+    content: (
+      <>
+        1 {<TokenSymbol token={sellAmount.currency} />} ={' '}
+        <TokenAmount amount={price} tokenSymbol={receivedAmount.currency} />
+      </>
+    ),
+  }
+}
+
+export function getSolverContent(winningSolver: SolverCompetition): ContentConfig {
+  return {
+    withTimelineDot: true,
+    label: 'Winning solver',
+    content: (
+      <WinningSolverContainer>
+        <b>{winningSolver.displayName || winningSolver.solver}</b>
+        <img
+          src={winningSolver.image || AMM_LOGOS[winningSolver.solver]?.src || AMM_LOGOS.default.src}
+          alt={`${winningSolver.solver} logo`}
+          width="16"
+          height="16"
+        />
+      </WinningSolverContainer>
+    ),
+  }
+}
+
+export function getSurplusConfig(
+  surplusAmount: CurrencyAmount<Currency>,
+  surplusAmountUsd: CurrencyAmount<Token> | null,
+): ContentConfig {
+  return {
+    label: (
+      <ReceiveAmountTitle
+        icon={
+          <TimelineIconCircleWrapper>
+            <StyledTimelinePlusIcon src={PlusIcon} />
+          </TimelineIconCircleWrapper>
+        }
+      >
+        <SuccessTextBold>Surplus received</SuccessTextBold>
+      </ReceiveAmountTitle>
+    ),
+    content: (
+      <SuccessTextBold>
+        <TokenAmountDisplay
+          currencyAmount={surplusAmount}
+          displaySymbol
+          usdValue={surplusAmountUsd}
+          hideTokenIcon={true}
+        >
+          +
+        </TokenAmountDisplay>
+      </SuccessTextBold>
+    ),
+  }
+}

--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/SwapResultContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/SwapResultContent/index.tsx
@@ -1,88 +1,28 @@
 import { ReactNode } from 'react'
 
-import PlusIcon from '@cowprotocol/assets/cow-swap/plus.svg'
 import { isTruthy } from '@cowprotocol/common-utils'
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
-import styled from 'styled-components/macro'
+import { ConfirmDetailsItem } from 'modules/trade'
 
-import { AMM_LOGOS } from 'legacy/components/AMMsLogo'
+import { getExecPriceContent, getReceivedContent, getSolverContent, getSurplusConfig } from './contents'
 
-import { ConfirmDetailsItem, ReceiveAmountTitle } from 'modules/trade'
-
-import { StyledTimelinePlusIcon, SuccessTextBold, TimelineIconCircleWrapper } from '../../../styles'
 import { SwapResultContext } from '../../../types'
-import { TokenAmountDisplay } from '../../TokenAmountDisplay'
-
-const WinningSolverContainer = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 4px;
-`
 
 interface SwapResultContentProps {
   context: SwapResultContext
+  sellAmount: CurrencyAmount<Currency>
 }
 
 export function SwapResultContent({
+  sellAmount,
   context: { winningSolver, receivedAmount, receivedAmountUsd, surplusAmount, surplusAmountUsd },
 }: SwapResultContentProps): ReactNode {
   const contents = [
-    winningSolver
-      ? {
-          withTimelineDot: true,
-          label: 'Winning solver',
-          content: (
-            <WinningSolverContainer>
-              <b>{winningSolver.displayName || winningSolver.solver}</b>
-              <img
-                src={winningSolver.image || AMM_LOGOS[winningSolver.solver]?.src || AMM_LOGOS.default.src}
-                alt={`${winningSolver.solver} logo`}
-                width="16"
-                height="16"
-              />
-            </WinningSolverContainer>
-          ),
-        }
-      : null,
-    {
-      label: (
-        <ReceiveAmountTitle>
-          <b>Received</b>
-        </ReceiveAmountTitle>
-      ),
-      content: (
-        <b>
-          <TokenAmountDisplay currencyAmount={receivedAmount} displaySymbol usdValue={receivedAmountUsd} />
-        </b>
-      ),
-    },
-    surplusAmount.greaterThan(0)
-      ? {
-          label: (
-            <ReceiveAmountTitle
-              icon={
-                <TimelineIconCircleWrapper>
-                  <StyledTimelinePlusIcon src={PlusIcon} />
-                </TimelineIconCircleWrapper>
-              }
-            >
-              <SuccessTextBold>Surplus received</SuccessTextBold>
-            </ReceiveAmountTitle>
-          ),
-          content: (
-            <SuccessTextBold>
-              <TokenAmountDisplay
-                currencyAmount={surplusAmount}
-                displaySymbol
-                usdValue={surplusAmountUsd}
-                hideTokenIcon={true}
-              >
-                +
-              </TokenAmountDisplay>
-            </SuccessTextBold>
-          ),
-        }
-      : null,
+    winningSolver ? getSolverContent(winningSolver) : null,
+    getReceivedContent(receivedAmount, receivedAmountUsd),
+    getExecPriceContent(sellAmount, receivedAmount),
+    surplusAmount.greaterThan(0) ? getSurplusConfig(surplusAmount, surplusAmountUsd) : null,
   ]
 
   return (


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Account-modal-No-Execution-price-on-the-Swap-order-details-21e8da5f04ca80c29405d10385e4fa1e?source=copy_link

<img width="808" alt="image" src="https://github.com/user-attachments/assets/900aff67-6890-4488-bf9f-0627b36cb35e" />

# To Test

1. Exec. price should be displayed in activities list for briding orders
2. Exec. price should be displayed in progress modal when swap is executed
