### PR TITLE
feat(bridge): display combined fee in collapsed accordion

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/TradeDetailsAccordion/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/TradeDetailsAccordion/index.tsx
@@ -31,21 +31,11 @@ export const TradeDetailsAccordion = ({
   open,
   onToggle,
   feeWrapper,
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-}: TradeDetailsAccordionProps) => {
-  // TODO: Add proper return type annotation
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  const handleToggle = () => {
-    onToggle?.()
-  }
-
-  // TODO: Add proper return type annotation
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  const handleKeyDown = (e: { key: string; preventDefault: () => void }) => {
+}: TradeDetailsAccordionProps): ReactNode => {
+  const handleKeyDown = (e: { key: string; preventDefault: () => void }): void => {
     if (['Enter', ' ', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
       e.preventDefault()
-      handleToggle()
+      onToggle?.()
     }
   }
 
@@ -67,13 +57,7 @@ export const TradeDetailsAccordion = ({
     <Wrapper isOpen={open}>
       <Summary>
         {rateInfo}
-        <SummaryClickable
-          onClick={handleToggle}
-          onKeyDown={handleKeyDown}
-          aria-expanded={open}
-          tabIndex={0}
-          isOpen={open}
-        >
+        <SummaryClickable onClick={onToggle} onKeyDown={handleKeyDown} aria-expanded={open} tabIndex={0} isOpen={open}>
           {feeWrapper ? feeWrapper(defaultFeeContent) : defaultFeeContent}
 
           <ToggleArrow isOpen={open} />

--- a/apps/cowswap-frontend/src/modules/bridge/pure/BridgeAccordionSummary.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/BridgeAccordionSummary.tsx
@@ -22,9 +22,11 @@ interface BridgeAccordionSummaryProps {
  * Component to display bridge-related information in the collapsed state of an accordion
  * Shows the bridge time estimation and protocol icons next to the fee amount
  */
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function BridgeAccordionSummary({ bridgeEstimatedTime, bridgeProtocol, children }: BridgeAccordionSummaryProps) {
+export function BridgeAccordionSummary({
+  bridgeEstimatedTime,
+  bridgeProtocol,
+  children,
+}: BridgeAccordionSummaryProps): ReactNode {
   return (
     <>
       <span>

--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/QuoteBridgeContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/QuoteBridgeContent/index.tsx
@@ -4,6 +4,7 @@ import { displayTime, isTruthy } from '@cowprotocol/common-utils'
 import { InfoTooltip } from '@cowprotocol/ui'
 
 import { ConfirmDetailsItem, ReceiveAmountTitle } from 'modules/trade'
+import { useUsdAmount } from 'modules/usdAmount'
 
 import { QuoteBridgeContext } from '../../../types'
 import { RecipientDisplay } from '../../RecipientDisplay'
@@ -18,6 +19,8 @@ export function QuoteBridgeContent({
   quoteContext: { recipient, bridgeFee, estimatedTime, buyAmount, buyAmountUsd },
   children,
 }: QuoteBridgeContentProps): ReactNode {
+  const bridgeFeeUsd = useUsdAmount(bridgeFee).value
+
   const buyAmountEl = <TokenAmountDisplay displaySymbol usdValue={buyAmountUsd} currencyAmount={buyAmount} />
 
   const contents = [
@@ -29,7 +32,11 @@ export function QuoteBridgeContent({
               Bridge fee <InfoTooltip content="The fee for the bridge transaction." size={14} />
             </>
           ),
-          content: bridgeFee.equalTo(0) ? 'FREE' : <TokenAmountDisplay currencyAmount={bridgeFee} />,
+          content: bridgeFee.equalTo(0) ? (
+            'FREE'
+          ) : (
+            <TokenAmountDisplay currencyAmount={bridgeFee} usdValue={bridgeFeeUsd} />
+          ),
         }
       : null,
     estimatedTime

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapRateDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapRateDetails/index.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react'
+import { ReactNode, useCallback } from 'react'
 
 import {
   BridgeAccordionSummary,
@@ -17,9 +17,7 @@ export interface SwapRateDetailsProps {
   deadline: number
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function SwapRateDetails({ rateInfoParams, deadline }: SwapRateDetailsProps) {
+export function SwapRateDetails({ rateInfoParams, deadline }: SwapRateDetailsProps): ReactNode {
   const { isLoading: isRateLoading, bridgeQuote } = useTradeQuote()
 
   const shouldDisplayBridgeDetails = useShouldDisplayBridgeDetails()
@@ -29,6 +27,19 @@ export function SwapRateDetails({ rateInfoParams, deadline }: SwapRateDetailsPro
 
   const swapContext = useQuoteSwapContext()
   const bridgeContext = useQuoteBridgeContext()
+
+  const feeWrapper = useCallback(
+    (feeElement: ReactNode) => {
+      if (!providerDetails) return null
+
+      return (
+        <BridgeAccordionSummary bridgeEstimatedTime={bridgeEstimatedTime} bridgeProtocol={providerDetails}>
+          {feeElement}
+        </BridgeAccordionSummary>
+      )
+    },
+    [providerDetails, bridgeEstimatedTime],
+  )
 
   return (
     <TradeRateDetails
@@ -45,17 +56,7 @@ export function SwapRateDetails({ rateInfoParams, deadline }: SwapRateDetailsPro
           </>
         )
       }
-      feeWrapper={
-        shouldDisplayBridgeDetails && providerDetails
-          // TODO: Extract nested component outside render function
-          // eslint-disable-next-line react/no-unstable-nested-components
-          ? (feeElement: ReactNode) => (
-              <BridgeAccordionSummary bridgeEstimatedTime={bridgeEstimatedTime} bridgeProtocol={providerDetails}>
-                {feeElement}
-              </BridgeAccordionSummary>
-            )
-          : undefined
-      }
+      feeWrapper={shouldDisplayBridgeDetails && providerDetails ? feeWrapper : undefined}
     />
   )
 }

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeTotalCostsDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeTotalCostsDetails/index.tsx
@@ -18,9 +18,7 @@ export interface TradeRatesProps {
   feeWrapper?: (defaultFeeContent: React.ReactNode) => React.ReactNode
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function TradeTotalCostsDetails(props: TradeRatesProps) {
+export function TradeTotalCostsDetails(props: TradeRatesProps): ReactNode {
   const { rateInfoParams, totalCosts, isFeeDetailsOpen, toggleAccordion, children, feeWrapper } = props
   const totalCostsUsd = useUsdAmount(totalCosts).value
 

--- a/apps/cowswap-frontend/src/modules/trade/utils/getReceiveAmountInfo.ts
+++ b/apps/cowswap-frontend/src/modules/trade/utils/getReceiveAmountInfo.ts
@@ -21,10 +21,15 @@ export function getOrderTypeReceiveAmounts(info: ReceiveAmountInfo): OrderTypeRe
   }
 }
 
-export function getTotalCosts(info: ReceiveAmountInfo): CurrencyAmount<Currency> {
+export function getTotalCosts(
+  info: ReceiveAmountInfo,
+  additionalCosts?: CurrencyAmount<Currency>,
+): CurrencyAmount<Currency> {
   const { networkFeeAmount } = getOrderTypeReceiveAmounts(info)
 
-  return networkFeeAmount.add(info.costs.partnerFee.amount)
+  const fee = networkFeeAmount.add(info.costs.partnerFee.amount)
+
+  return additionalCosts ? fee.add(additionalCosts) : fee
 }
 
 type AmountsAndCosts = Omit<QuoteAmountsAndCosts<CurrencyAmount<Currency>>, 'quotePrice'>

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/TradeRateDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/TradeRateDetails/index.tsx
@@ -28,20 +28,16 @@ interface TradeRateDetailsProps {
   rateInfoParams: RateInfoParams
   isTradePriceUpdating: boolean
   accordionContent?: ReactNode
-  feeWrapper?: (feeElement: ReactNode) => React.ReactNode
+  feeWrapper?: (feeElement: ReactNode) => ReactNode
 }
 
-// TODO: Break down this large function into smaller functions
-// TODO: Add proper return type annotation
-// TODO: Reduce function complexity by extracting logic
-// eslint-disable-next-line max-lines-per-function, @typescript-eslint/explicit-function-return-type, complexity
 export function TradeRateDetails({
   rateInfoParams,
   deadline,
   isTradePriceUpdating,
   accordionContent,
   feeWrapper,
-}: TradeRateDetailsProps) {
+}: TradeRateDetailsProps): ReactNode {
   const [isFeeDetailsOpen, setFeeDetailsOpen] = useState(false)
 
   const slippage = useTradeSlippage()

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/TradeRateDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/TradeRateDetails/index.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, useCallback, ReactNode } from 'react'
 
 import { CurrencyAmount } from '@uniswap/sdk-core'
 
+import { useBridgeQuoteAmounts } from 'modules/bridge'
 import {
   getTotalCosts,
   TradeFeesAndCosts,
@@ -46,6 +47,7 @@ export function TradeRateDetails({
   const derivedTradeState = useDerivedTradeState()
   const tradeQuote = useTradeQuote()
   const shouldPayGas = useShouldPayGas()
+  const bridgeQuoteAmounts = useBridgeQuoteAmounts(receiveAmountInfo, tradeQuote.bridgeQuote)
 
   const inputCurrency = derivedTradeState?.inputCurrency
 
@@ -78,7 +80,7 @@ export function TradeRateDetails({
     )
   }
 
-  const totalCosts = getTotalCosts(receiveAmountInfo)
+  const totalCosts = getTotalCosts(receiveAmountInfo, bridgeQuoteAmounts?.bridgeFee)
 
   // Default expanded content if accordionContent prop is not supplied
   const defaultExpandedContent = (


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Fee-amount-is-wrong-on-the-collapsed-view-2238da5f04ca80ad941aec82a2b7c3ec?source=copy_link

1. Added combined (swap network costs + bridging fee) fee displaying in collapsed accordion
2. Added USD value dispaying for bridging fee

<img width="501" alt="image" src="https://github.com/user-attachments/assets/90ee9108-be0d-405b-b78b-19588abd482c" />

<img width="517" alt="image" src="https://github.com/user-attachments/assets/fbba9875-5d58-40f4-a712-e506a4824392" />

# To Test

See https://www.notion.so/cownation/Fee-amount-is-wrong-on-the-collapsed-view-2238da5f04ca80ad941aec82a2b7c3ec?source=copy_link

