### PR TITLE
fix(limit-orders): udpate quote when back from confirm

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetUpdaters.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetUpdaters.tsx
@@ -46,9 +46,10 @@ export function TradeWidgetUpdaters({
       <PriorityTokensUpdater account={account} chainId={chainId} tokenAddresses={priorityTokenAddressesAsArray} />
       <RecipientAddressUpdater />
 
-      {!disableQuotePolling && (
-        <TradeQuoteUpdater isConfirmOpen={isConfirmOpen} isQuoteUpdatePossible={isQuoteUpdatePossible} />
-      )}
+      <TradeQuoteUpdater
+        isConfirmOpen={isConfirmOpen}
+        isQuoteUpdatePossible={isQuoteUpdatePossible && !disableQuotePolling}
+      />
       <PriceImpactUpdater />
       <TradeFormValidationUpdater />
       <CommonTradeUpdater />


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Limit-orders-form-hangs-in-the-calculating-price-state-after-order-placement-2248da5f04ca808fb7cee1f32f0ee2d3

Logic of quote refreshing when you came back from confirm screen was changed (useTradeQuotePolling):

<img width="729" alt="image" src="https://github.com/user-attachments/assets/662c3728-925a-4452-be63-f95a0226bbc2" />

But it was'nt consider limit orders widget correctly. In limit orders `TradeQuoteUpdater` was conditionally displaying, so `prevIsConfirmOpen` wasn't defined properly.

# To Test

See https://www.notion.so/cownation/Limit-orders-form-hangs-in-the-calculating-price-state-after-order-placement-2248da5f04ca808fb7cee1f32f0ee2d3