### PR TITLE
fix(limit-orders): fix orders table filter

### DIFF
--- a/apps/cowswap-frontend/src/modules/ordersTable/hooks/useFilteredOrders.ts
+++ b/apps/cowswap-frontend/src/modules/ordersTable/hooks/useFilteredOrders.ts
@@ -41,18 +41,17 @@ export function useFilteredOrders(orders: OrderTableItem[], searchTerm: string):
       // If not a symbol match, check for address matches
       // Clean up the search term but preserve '0x' prefix if present
       const hasPrefix = searchTermLower.startsWith('0x')
-      const cleanedSearch = searchTermLower.replace(/[^0-9a-fx]/g, '')
 
       // For exact address matches (40 or 42 chars), do strict comparison
-      if (cleanedSearch.length === 40 || cleanedSearch.length === 42) {
-        const searchTermNormalized = hasPrefix ? cleanedSearch : `0x${cleanedSearch}`
+      if (searchTermLower.length === 40 || searchTermLower.length === 42) {
+        const searchTermNormalized = hasPrefix ? searchTermLower : `0x${searchTermLower}`
         return [inputToken.address, outputToken.address].some(
           (address) => address.toLowerCase() === searchTermNormalized.toLowerCase(),
         )
       }
 
       // For partial address matches
-      const searchWithoutPrefix = hasPrefix ? cleanedSearch.slice(2) : cleanedSearch
+      const searchWithoutPrefix = hasPrefix ? searchTermLower.slice(2) : searchTermLower
       if (searchWithoutPrefix.length >= 2) {
         // Only search if we have at least 2 characters
         return [inputToken.address, outputToken.address].some((address) => {


### PR DESCRIPTION
# Summary

Fix limit orders table filter

# To Test

1. Connect wallet with limit orders
2. Search on the table for `bla`
* There should be no results, unless you traded a token that contains `bla` in the symbol
3. Search for a symbol for which you have orders, like `weth`
* There should be orders that have `WETH`
4. Add a space before/after `weth`
* There should be orders that have `WETH`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search functionality in the orders table by updating how search terms are processed for address matching. Search terms now retain all characters except leading and trailing whitespace, enhancing flexibility in search queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->