### PR TITLE
fix(bridge): load networks info in all trade widgets

### DIFF
--- a/apps/cowswap-frontend/src/entities/bridgeProvider/useBridgeSupportedNetworks.ts
+++ b/apps/cowswap-frontend/src/entities/bridgeProvider/useBridgeSupportedNetworks.ts
@@ -1,4 +1,3 @@
-import { useIsBridgingEnabled } from '@cowprotocol/common-hooks'
 import type { ChainInfo } from '@cowprotocol/cow-sdk'
 
 import useSWR, { SWRResponse } from 'swr'
@@ -6,13 +5,9 @@ import useSWR, { SWRResponse } from 'swr'
 import { useBridgeProvider } from './useBridgeProvider'
 
 export function useBridgeSupportedNetworks(): SWRResponse<ChainInfo[]> {
-  const isBridgingEnabled = useIsBridgingEnabled()
   const bridgeProvider = useBridgeProvider()
 
-  return useSWR(
-    isBridgingEnabled ? [bridgeProvider, bridgeProvider.info.dappId, 'useBridgeSupportedNetworks'] : null,
-    ([bridgeProvider]) => {
-      return bridgeProvider.getNetworks()
-    },
-  )
+  return useSWR([bridgeProvider, bridgeProvider.info.dappId, 'useBridgeSupportedNetworks'], ([bridgeProvider]) => {
+    return bridgeProvider.getNetworks()
+  })
 }


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Swap-details-are-not-loaded-when-open-Account-modal-from-limit-twap-hooks-tab-2248da5f04ca8052bfd2ef86df3d17eb?source=copy_link

`useIsBridgingEnabled()` returns true only in Swap widget, but account modal can be opened in any page.
To fix that I removed `isBridgingEnabled` condition from `useBridgeSupportedNetworks`.

# To Test

See https://www.notion.so/cownation/Swap-details-are-not-loaded-when-open-Account-modal-from-limit-twap-hooks-tab-2248da5f04ca8052bfd2ef86df3d17eb?source=copy_link