### PR TITLE
fix: fix input amount validation for buy order

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
@@ -1,4 +1,4 @@
-import { getIsNativeToken, isAddress, isFractionFalsy } from '@cowprotocol/common-utils'
+import { getIsNativeToken, isAddress, isFractionFalsy, isSellOrder } from '@cowprotocol/common-utils'
 import { PriceQuality } from '@cowprotocol/cow-sdk'
 
 import { TradeType } from 'modules/trade'
@@ -27,7 +27,15 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
     isOnline,
   } = context
 
-  const { inputCurrency, outputCurrency, inputCurrencyAmount, inputCurrencyBalance, recipient } = derivedTradeState
+  const {
+    inputCurrency,
+    outputCurrency,
+    inputCurrencyAmount,
+    outputCurrencyAmount,
+    inputCurrencyBalance,
+    recipient,
+    orderKind,
+  } = derivedTradeState
   const isBalanceGreaterThan1Atom = inputCurrencyBalance
     ? BigInt(inputCurrencyBalance.quotient.toString()) > BigInt(0)
     : false
@@ -37,7 +45,10 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
   const approvalRequired =
     !isPermitSupported && (approvalState === ApprovalState.NOT_APPROVED || approvalState === ApprovalState.PENDING)
 
-  const inputAmountIsNotSet = !inputCurrencyAmount || isFractionFalsy(inputCurrencyAmount)
+  const inputAmountIsNotSet = isSellOrder(orderKind)
+    ? !inputCurrencyAmount || isFractionFalsy(inputCurrencyAmount)
+    : !outputCurrencyAmount || isFractionFalsy(outputCurrencyAmount)
+
   const isFastQuote = tradeQuote.fetchParams?.priceQuality === PriceQuality.FAST
 
   const validations: TradeFormValidation[] = []


### PR DESCRIPTION
# Summary

Due to recent changes (#5914) we don't poll quotes when there is a trade form validation error.
`inputAmountIsNotSet` wasn't considering buy orders and with recent changes it led to the problem.

# To Test

1. Remove all amounts from Swap form
- [ ] "Enter an amount" validation should be displayed
2. Enter some amount in output token (buy order)
- [ ] AR: "Enter an amount" is still displayed, no quote request
- [ ] ER: It loads a quote and displays input amount