### PR TITLE
fix: fix quote updating when window visibility changes

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useTradeQuotePolling.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useTradeQuotePolling.ts
@@ -55,8 +55,9 @@ export function useTradeQuotePolling(isConfirmOpen = false, isQuoteUpdatePossibl
 
     if (!isWindowVisible || !amountStr) {
       tradeQuoteManager.reset()
+      setTradeQuotePolling(0)
     }
-  }, [isWindowVisible, tradeQuoteManager, isConfirmOpen, amountStr])
+  }, [isWindowVisible, tradeQuoteManager, isConfirmOpen, amountStr, setTradeQuotePolling])
 
   /**
    * Fetch the quote instantly once the quote params are changed


### PR DESCRIPTION
# Summary

Very nasty bag when switches from current tab and go back.
See the test descriotion.

# To Test

1. Connect a wallet and specify some trade
2. Wait till a quote is loaded
3. Switch to another browser tab
4. Go back to cowswap tab
- [ ] AR: the form goes to "Hang in there..." state and can hang in this state for awhile
- [ ] ER: the form goes to loading state and updates quote in a few seconds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trade quote polling behavior to ensure the polling counter resets correctly when the window is not visible or the amount field is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->