### PR TITLE
fix(bridge): display deposit tx link in pending state

### DIFF
--- a/apps/cowswap-frontend/src/modules/bridge/pure/DepositTxLink/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/DepositTxLink/index.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react'
+
+import { ExplorerDataType, getExplorerLink } from '@cowprotocol/common-utils'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import { TransactionLinkItem } from '../TransactionLink'
+
+interface DepositTxLinkProps {
+  sourceChainId: SupportedChainId
+  depositTxHash: string | undefined
+}
+
+export function DepositTxLink({ depositTxHash, sourceChainId }: DepositTxLinkProps): ReactNode {
+  const depositLink = depositTxHash && getExplorerLink(sourceChainId, depositTxHash, ExplorerDataType.TRANSACTION)
+
+  if (!depositLink) return null
+
+  return <TransactionLinkItem link={depositLink} label="Source transaction" chainId={sourceChainId} />
+}

--- a/apps/cowswap-frontend/src/modules/bridge/pure/TransactionLink/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/TransactionLink/index.tsx
@@ -1,0 +1,41 @@
+import { ReactNode } from 'react'
+
+import ReceiptIcon from '@cowprotocol/assets/cow-swap/icon-receipt.svg'
+import { getChainInfo } from '@cowprotocol/common-const'
+import { useMediaQuery } from '@cowprotocol/common-hooks'
+import { ExternalLink, Media } from '@cowprotocol/ui'
+
+import { useBridgeSupportedNetworks } from 'entities/bridgeProvider'
+
+import { ConfirmDetailsItem } from 'modules/trade'
+
+import { StyledTimelineReceiptIcon, TimelineIconCircleWrapper } from '../../styles'
+
+interface TransactionLinkItemProps {
+  link: string
+  label: string
+  chainId: number
+}
+
+export function TransactionLinkItem({ link, label, chainId }: TransactionLinkItemProps): ReactNode {
+  const { data: bridgeSupportedNetworks } = useBridgeSupportedNetworks()
+  const bridgeNetwork = bridgeSupportedNetworks?.find((network) => network.id === chainId)
+  const isMobile = useMediaQuery(Media.upToSmall(false))
+
+  const explorerTitle = bridgeNetwork?.blockExplorer.name || getChainInfo(chainId)?.explorerTitle || 'Explorer'
+
+  return (
+    <ConfirmDetailsItem
+      label={
+        <>
+          <TimelineIconCircleWrapper padding="0" bgColor={'transparent'}>
+            <StyledTimelineReceiptIcon src={ReceiptIcon} />
+          </TimelineIconCircleWrapper>{' '}
+          {label}
+        </>
+      }
+    >
+      <ExternalLink href={link}>{isMobile ? `${explorerTitle} ↗` : `View on ${explorerTitle} ↗`}</ExternalLink>
+    </ConfirmDetailsItem>
+  )
+}

--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/PendingBridgingContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/PendingBridgingContent/index.tsx
@@ -1,25 +1,39 @@
 import { ReactNode } from 'react'
 
+import { BridgeStatusResult, SupportedChainId } from '@cowprotocol/cow-sdk'
+
 import { ConfirmDetailsItem, ReceiveAmountTitle } from 'modules/trade'
 
 import { AnimatedEllipsis, StatusAwareText } from '../../../../styles'
 import { SwapAndBridgeStatus } from '../../../../types'
+import { DepositTxLink } from '../../../DepositTxLink'
 
-export function PendingBridgingContent(): ReactNode {
+interface PendingBridgingContentProps {
+  sourceChainId: SupportedChainId
+  statusResult?: BridgeStatusResult
+}
+
+export function PendingBridgingContent({ sourceChainId, statusResult }: PendingBridgingContentProps): ReactNode {
+  const { depositTxHash } = statusResult || {}
+
   return (
-    <ConfirmDetailsItem
-      label={
-        <ReceiveAmountTitle>
-          <b>You received</b>
-        </ReceiveAmountTitle>
-      }
-    >
-      <b>
-        <StatusAwareText status={SwapAndBridgeStatus.PENDING}>
-          in progress
-          <AnimatedEllipsis isVisible />
-        </StatusAwareText>
-      </b>
-    </ConfirmDetailsItem>
+    <>
+      <ConfirmDetailsItem
+        label={
+          <ReceiveAmountTitle>
+            <b>You received</b>
+          </ReceiveAmountTitle>
+        }
+      >
+        <b>
+          <StatusAwareText status={SwapAndBridgeStatus.PENDING}>
+            in progress
+            <AnimatedEllipsis isVisible />
+          </StatusAwareText>
+        </b>
+      </ConfirmDetailsItem>
+
+      <DepositTxLink depositTxHash={depositTxHash} sourceChainId={sourceChainId} />
+    </>
   )
 }

--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/ReceivedBridgingContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/ReceivedBridgingContent/index.tsx
@@ -1,19 +1,18 @@
 import { ReactNode } from 'react'
 
-import ReceiptIcon from '@cowprotocol/assets/cow-swap/icon-receipt.svg'
 import { getChainInfo } from '@cowprotocol/common-const'
-import { useMediaQuery } from '@cowprotocol/common-hooks'
 import { ExplorerDataType, getExplorerLink } from '@cowprotocol/common-utils'
 import { BridgeStatusResult, SupportedChainId } from '@cowprotocol/cow-sdk'
-import { ExternalLink, Media } from '@cowprotocol/ui'
 import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
 
 import { useBridgeSupportedNetworks } from 'entities/bridgeProvider'
 
 import { ConfirmDetailsItem, ReceiveAmountTitle } from 'modules/trade'
 
-import { StyledTimelineReceiptIcon, SuccessTextBold, TimelineIconCircleWrapper } from '../../../../styles'
+import { SuccessTextBold } from '../../../../styles'
+import { DepositTxLink } from '../../../DepositTxLink'
 import { TokenAmountDisplay } from '../../../TokenAmountDisplay'
+import { TransactionLinkItem } from '../../../TransactionLink'
 
 interface ReceivedBridgingContentProps {
   statusResult?: BridgeStatusResult
@@ -21,35 +20,6 @@ interface ReceivedBridgingContentProps {
   destinationChainId: number
   receivedAmount: CurrencyAmount<Currency>
   receivedAmountUsd: CurrencyAmount<Token> | null | undefined
-}
-
-interface TransactionLinkProps {
-  link: string
-  label: string
-  chainId: number
-}
-
-function TransactionLink({ link, label, chainId }: TransactionLinkProps): ReactNode {
-  const { data: bridgeSupportedNetworks } = useBridgeSupportedNetworks()
-  const bridgeNetwork = bridgeSupportedNetworks?.find((network) => network.id === chainId)
-  const isMobile = useMediaQuery(Media.upToSmall(false))
-
-  const explorerTitle = bridgeNetwork?.blockExplorer.name || getChainInfo(chainId)?.explorerTitle || 'Explorer'
-
-  return (
-    <ConfirmDetailsItem
-      label={
-        <>
-          <TimelineIconCircleWrapper padding="0" bgColor={'transparent'}>
-            <StyledTimelineReceiptIcon src={ReceiptIcon} />
-          </TimelineIconCircleWrapper>{' '}
-          {label}
-        </>
-      }
-    >
-      <ExternalLink href={link}>{isMobile ? `${explorerTitle} ↗` : `View on ${explorerTitle} ↗`}</ExternalLink>
-    </ConfirmDetailsItem>
-  )
 }
 
 export function ReceivedBridgingContent({
@@ -63,7 +33,6 @@ export function ReceivedBridgingContent({
   const { data: bridgeSupportedNetworks } = useBridgeSupportedNetworks()
   const destinationBridgeNetwork = bridgeSupportedNetworks?.find((network) => network.id === destinationChainId)
 
-  const depositLink = depositTxHash && getExplorerLink(sourceChainId, depositTxHash, ExplorerDataType.TRANSACTION)
   const blockExplorerUrl = destinationBridgeNetwork?.blockExplorer?.url || getChainInfo(destinationChainId)?.explorer
 
   const fillTxLink =
@@ -85,8 +54,10 @@ export function ReceivedBridgingContent({
         </b>
       </ConfirmDetailsItem>
 
-      {depositLink && <TransactionLink link={depositLink} label="Source transaction" chainId={sourceChainId} />}
-      {fillTxLink && <TransactionLink link={fillTxLink} label="Destination transaction" chainId={destinationChainId} />}
+      <DepositTxLink depositTxHash={depositTxHash} sourceChainId={sourceChainId} />
+      {fillTxLink && (
+        <TransactionLinkItem link={fillTxLink} label="Destination transaction" chainId={destinationChainId} />
+      )}
     </>
   )
 }

--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/index.tsx
@@ -45,7 +45,7 @@ export function BridgingProgressContent(props: BridgingContentProps): ReactNode 
       ) : isFailed ? (
         <FailedBridgingContent />
       ) : (
-        <PendingBridgingContent />
+        <PendingBridgingContent sourceChainId={sourceChainId} statusResult={statusResult} />
       )}
     </QuoteBridgeContent>
   )


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Show-TX-links-and-bridge-fee-on-Progress-state-2148da5f04ca8077b14cd845f5cd090e

Just added deposit tx displaying in pending state.

<img width="556" alt="image" src="https://github.com/user-attachments/assets/fd32b74f-9a29-4f8e-9ba9-edfded98c447" />

# To Test

See https://www.notion.so/cownation/Show-TX-links-and-bridge-fee-on-Progress-state-2148da5f04ca8077b14cd845f5cd090e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a deposit transaction link to the bridging progress and received bridging content, allowing users to view their deposit transaction on the appropriate blockchain explorer.
  * Transaction links now adapt their display for mobile and desktop screens for improved readability.

* **Refactor**
  * Simplified transaction link rendering by introducing reusable components and removing redundant internal logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->