### PR TITLE
fix(bridge): do not mix balances from different chains

### DIFF
--- a/apps/cowswap-frontend/src/modules/combinedBalances/hooks/useCurrencyAmountBalanceCombined.ts
+++ b/apps/cowswap-frontend/src/modules/combinedBalances/hooks/useCurrencyAmountBalanceCombined.ts
@@ -8,15 +8,17 @@ import { useTokensBalancesCombined } from './useTokensBalancesCombined'
 export function useCurrencyAmountBalanceCombined(
   token: TokenWithLogo | undefined | null,
 ): CurrencyAmount<TokenWithLogo> | undefined {
-  const { values: balances } = useTokensBalancesCombined()
+  const { values: balances, chainId } = useTokensBalancesCombined()
 
   return useMemo(() => {
     if (!token) return undefined
+
+    if (token.chainId !== chainId) return undefined
 
     const balance = balances[token.address.toLowerCase()]
 
     if (!balance) return undefined
 
     return CurrencyAmount.fromRawAmount(token, balance.toHexString())
-  }, [token, balances])
+  }, [token, balances, chainId])
 }


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Native-token-balance-in-Optimism-shows-a-wrong-value-21f8da5f04ca80e78124ce3f62211750?source=copy_link

<img width="547" alt="image" src="https://github.com/user-attachments/assets/2b5910ab-02ad-45e5-a7c0-06dcbc0b7021" />

# To Test

See https://www.notion.so/cownation/Native-token-balance-in-Optimism-shows-a-wrong-value-21f8da5f04ca80e78124ce3f62211750?source=copy_link


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of displayed currency balances by ensuring balances are only shown when the token's chain ID matches the active chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->