### PR TITLE
fix(bridge): display unsupported network details in Explorer

### DIFF
--- a/apps/explorer/src/components/common/BlockExplorerLink/BlockExplorerLink.tsx
+++ b/apps/explorer/src/components/common/BlockExplorerLink/BlockExplorerLink.tsx
@@ -38,6 +38,9 @@ export interface Props {
    * to show explorer logo
    */
   showLogo?: boolean
+
+  explorerUrl?: string
+  explorerTitle?: string
 }
 
 /**
@@ -53,13 +56,16 @@ export const BlockExplorerLink: React.FC<Props> = (props: Props) => {
     return null
   }
 
-  const url = getBlockExplorerUrl(networkId, type, identifier)
+  const url = getBlockExplorerUrl(networkId, type, identifier, props.explorerUrl)
   const label = labelProp || (useUrlAsLabel && url) || abbreviateString(identifier, 6, 4)
+  const explorerTitle = props.explorerTitle || CHAIN_INFO[networkId]?.explorerTitle
+
+  if (!url) return null
 
   return (
     <ExternalLink href={url} target="_blank" rel="noopener noreferrer" className={className}>
       <span>{label}</span>
-      {showLogo && <LogoWrapper title={`Open it on ${CHAIN_INFO[networkId].explorerTitle}`} src={LOGO_MAP.etherscan} />}
+      {showLogo && <LogoWrapper title={`Open it on ${explorerTitle}`} src={LOGO_MAP.etherscan} />}
     </ExternalLink>
   )
 }

--- a/apps/explorer/src/components/common/TokenDisplay/styled.ts
+++ b/apps/explorer/src/components/common/TokenDisplay/styled.ts
@@ -1,6 +1,6 @@
 import { Color } from '@cowprotocol/ui'
 
-import TokenImg from 'components/common/TokenImg'
+import { TokenImg } from 'components/common/TokenImg'
 import styled from 'styled-components/macro'
 
 export const Wrapper = styled.div`

--- a/apps/explorer/src/components/common/TokenImg/index.tsx
+++ b/apps/explorer/src/components/common/TokenImg/index.tsx
@@ -21,6 +21,7 @@ export interface Props {
   address: string
   addressMainnet?: string
   faded?: boolean
+  tokenLogo?: string
 }
 
 const tokensIconsRequire =
@@ -43,7 +44,7 @@ const tokensIconsFilesByAddress: Record<string, string> = Object.keys(tokensIcon
 }, {})
 
 export const TokenImg: React.FC<Props> = (props) => {
-  const { address, addressMainnet, symbol, name, network } = props
+  const { address, addressMainnet, symbol, name, network, tokenLogo } = props
   const { data: tokenListTokens } = useTokenList(network)
 
   let iconFile = tokensIconsFilesByAddress[address.toLowerCase()]
@@ -51,9 +52,11 @@ export const TokenImg: React.FC<Props> = (props) => {
     iconFile = tokensIconsFilesByAddress[addressMainnet.toLowerCase()]
   }
 
-  const iconFileUrl: string | undefined = iconFile
-    ? tokensIconsRequire[iconFile].default
-    : tokenListTokens[address.toLowerCase()]?.logoURI || getImageUrl(addressMainnet || address)
+  const iconFileUrl: string | undefined =
+    tokenLogo ||
+    (iconFile
+      ? tokensIconsRequire[iconFile].default
+      : tokenListTokens?.[address.toLowerCase()]?.logoURI || getImageUrl(addressMainnet || address))
 
   // TODO: Simplify safeTokenName signature, it doesn't need the addressMainnet or id!
   // https://github.com/gnosis/gp-v1-ui/issues/1442
@@ -61,5 +64,3 @@ export const TokenImg: React.FC<Props> = (props) => {
 
   return <Wrapper alt={safeName} src={iconFileUrl} onError={_loadFallbackTokenImage} {...props} />
 }
-
-export default TokenImg

--- a/apps/explorer/src/components/orders/BridgeDetailsTable/BridgeAmountDisplay.tsx
+++ b/apps/explorer/src/components/orders/BridgeDetailsTable/BridgeAmountDisplay.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react'
 
+import type { CrossChainOrder } from '@cowprotocol/cow-sdk'
 import type { TokenInfo } from '@uniswap/token-lists'
 
 import BigNumber from 'bignumber.js'
@@ -17,6 +18,7 @@ interface BridgeAmountDisplayProps {
   bridgeToken?: TokenInfo
   amount?: string | null
   isLoading?: boolean
+  bridgeProvider?: CrossChainOrder['provider']
 }
 
 export function BridgeAmountDisplay({
@@ -24,14 +26,22 @@ export function BridgeAmountDisplay({
   bridgeToken,
   amount,
   isLoading,
+  bridgeProvider,
 }: BridgeAmountDisplayProps): React.ReactNode {
   const isNative = !!bridgeToken && isNativeToken(bridgeToken.address)
 
   const tokenDisplayElement = useMemo(() => {
     if (!bridgeToken?.chainId) return null
 
-    return <CommonTokenDisplay erc20={bridgeToken} network={bridgeToken.chainId} showNetworkName />
-  }, [bridgeToken])
+    return (
+      <CommonTokenDisplay
+        erc20={bridgeToken}
+        network={bridgeToken.chainId}
+        bridgeProvider={bridgeProvider}
+        showNetworkName
+      />
+    )
+  }, [bridgeToken, bridgeProvider])
 
   if (isLoading) {
     return (

--- a/apps/explorer/src/components/orders/BridgeDetailsTable/BridgeDetailsContent/index.tsx
+++ b/apps/explorer/src/components/orders/BridgeDetailsTable/BridgeDetailsContent/index.tsx
@@ -66,13 +66,18 @@ export function BridgeDetailsContent({ crossChainOrder }: BridgeDetailsContentPr
             labelPrefix="To at least:"
             bridgeToken={destinationToken}
             amount={outputAmount?.toString() || '0'}
+            bridgeProvider={crossChainOrder.provider}
           />
         </AmountSectionWrapper>
       </DetailRow>
 
       <DetailRow label="You received" tooltipText={BridgeDetailsTooltips.youReceived}>
         {outputAmount && destinationToken && bridgeStatus === BridgeStatus.EXECUTED && (
-          <BridgeReceiveAmount amount={outputAmount} destinationToken={destinationToken} />
+          <BridgeReceiveAmount
+            amount={outputAmount}
+            destinationToken={destinationToken}
+            bridgeProvider={crossChainOrder.provider}
+          />
         )}
       </DetailRow>
 

--- a/apps/explorer/src/components/orders/BridgeDetailsTable/BridgeReceiveAmount.tsx
+++ b/apps/explorer/src/components/orders/BridgeDetailsTable/BridgeReceiveAmount.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react'
 
+import type { CrossChainOrder } from '@cowprotocol/cow-sdk'
 import type { TokenInfo } from '@uniswap/token-lists'
 
 import BigNumber from 'bignumber.js'
@@ -12,13 +13,19 @@ import { TokenAmount } from '../../token/TokenAmount'
 interface BridgeReceiveAmountProps {
   destinationToken: TokenInfo
   amount: bigint
+  bridgeProvider: CrossChainOrder['provider']
 }
 
-export function BridgeReceiveAmount({ destinationToken, amount }: BridgeReceiveAmountProps): ReactNode {
+export function BridgeReceiveAmount({ destinationToken, amount, bridgeProvider }: BridgeReceiveAmountProps): ReactNode {
   const isNative = isNativeToken(destinationToken.address)
 
   const tokenDisplayElement = (
-    <CommonTokenDisplay erc20={destinationToken} network={destinationToken.chainId} showNetworkName={true} />
+    <CommonTokenDisplay
+      erc20={destinationToken}
+      network={destinationToken.chainId}
+      bridgeProvider={bridgeProvider}
+      showNetworkName
+    />
   )
 
   return (

--- a/apps/explorer/src/modules/bridge/hooks/useBridgeProviderBuyTokens.ts
+++ b/apps/explorer/src/modules/bridge/hooks/useBridgeProviderBuyTokens.ts
@@ -1,0 +1,29 @@
+import { SWR_NO_REFRESH_OPTIONS } from '@cowprotocol/common-const'
+import type { CrossChainOrder } from '@cowprotocol/cow-sdk'
+import type { TokenInfo } from '@uniswap/token-lists'
+
+import useSWR, { SWRResponse } from 'swr'
+
+export function useBridgeProviderBuyTokens(
+  provider: CrossChainOrder['provider'] | undefined,
+  chainId: number,
+): SWRResponse<Record<string, TokenInfo> | undefined> {
+  return useSWR(
+    [provider, chainId, provider?.info.dappId],
+    async ([provider, chainId]) => {
+      if (!provider) return undefined
+
+      const tokens = await provider.getBuyTokens(chainId)
+
+      return tokens.reduce<Record<string, TokenInfo>>((acc, val) => {
+        acc[val.address.toLowerCase()] = {
+          ...val,
+          name: val.name || '',
+          symbol: val.symbol || '',
+        } as TokenInfo
+        return acc
+      }, {})
+    },
+    SWR_NO_REFRESH_OPTIONS,
+  )
+}

--- a/apps/explorer/src/modules/bridge/hooks/useBridgeProviderNetworks.ts
+++ b/apps/explorer/src/modules/bridge/hooks/useBridgeProviderNetworks.ts
@@ -1,0 +1,24 @@
+import { SWR_NO_REFRESH_OPTIONS } from '@cowprotocol/common-const'
+import type { CrossChainOrder } from '@cowprotocol/cow-sdk'
+import { ChainInfo } from '@cowprotocol/cow-sdk'
+
+import useSWR, { SWRResponse } from 'swr'
+
+export function useBridgeProviderNetworks(
+  provider: CrossChainOrder['provider'] | undefined,
+): SWRResponse<Record<number, ChainInfo> | undefined> {
+  return useSWR(
+    [provider, provider?.info.dappId],
+    async ([provider]) => {
+      if (!provider) return undefined
+
+      return provider.getNetworks().then((chains) => {
+        return chains.reduce<Record<number, ChainInfo>>((acc, val) => {
+          acc[val.id] = val
+          return acc
+        }, {})
+      })
+    },
+    SWR_NO_REFRESH_OPTIONS,
+  )
+}

--- a/apps/explorer/src/modules/bridge/hooks/useCrossChainOrder.ts
+++ b/apps/explorer/src/modules/bridge/hooks/useCrossChainOrder.ts
@@ -1,3 +1,4 @@
+import { SWR_NO_REFRESH_OPTIONS } from '@cowprotocol/common-const'
 import { CrossChainOrder, getCrossChainOrder, CowEnv } from '@cowprotocol/cow-sdk'
 
 import { orderBookApi, knownBridgeProviders } from 'sdk/cowSdk'
@@ -8,19 +9,23 @@ import { useNetworkId } from '../../../state/network'
 export function useCrossChainOrder(orderId: string | undefined): SWRResponse<CrossChainOrder | null | undefined> {
   const chainId = useNetworkId()
 
-  return useSWR(['useCrossChainOrder', orderId, chainId], async ([_, orderId, chainId]) => {
-    if (!orderId || !chainId) return
+  return useSWR(
+    ['useCrossChainOrder', orderId, chainId],
+    async ([_, orderId, chainId]) => {
+      if (!orderId || !chainId) return
 
-    const getOrder = (env: CowEnv): ReturnType<typeof getCrossChainOrder> => {
-      return getCrossChainOrder({
-        chainId,
-        orderId,
-        env,
-        providers: knownBridgeProviders,
-        orderBookApi,
-      })
-    }
+      const getOrder = (env: CowEnv): ReturnType<typeof getCrossChainOrder> => {
+        return getCrossChainOrder({
+          chainId,
+          orderId,
+          env,
+          providers: knownBridgeProviders,
+          orderBookApi,
+        })
+      }
 
-    return getOrder('prod').catch(() => getOrder('staging'))
-  })
+      return getOrder('prod').catch(() => getOrder('staging'))
+    },
+    SWR_NO_REFRESH_OPTIONS,
+  )
 }

--- a/apps/explorer/src/modules/bridge/hooks/useCrossChainTokens.ts
+++ b/apps/explorer/src/modules/bridge/hooks/useCrossChainTokens.ts
@@ -1,6 +1,8 @@
 import { CrossChainOrder } from '@cowprotocol/cow-sdk'
 import type { TokenInfo } from '@uniswap/token-lists'
 
+import { useBridgeProviderBuyTokens } from './useBridgeProviderBuyTokens'
+
 import { useTokenList } from '../../../hooks/useTokenList'
 
 export interface CrossChainTokens<T = TokenInfo | undefined> {
@@ -13,15 +15,16 @@ export function useCrossChainTokens(crossChainOrder: CrossChainOrder): CrossChai
   const {
     bridgingParams: { sourceChainId, destinationChainId, inputTokenAddress, outputTokenAddress },
     order,
+    provider,
   } = crossChainOrder
   const { data: sourceTokens } = useTokenList(sourceChainId)
-  const { data: destinationTokens } = useTokenList(destinationChainId)
+
+  const { data: destinationChainTokens } = useBridgeProviderBuyTokens(provider, destinationChainId)
 
   const sourceToken = sourceTokens && sourceTokens[inputTokenAddress.toLowerCase()]
-  const intermediateToken = destinationTokens && destinationTokens[order.buyToken.toLowerCase()]
-  const destinationToken = Boolean(destinationTokens && outputTokenAddress)
-    ? destinationTokens[outputTokenAddress.toLowerCase()]
-    : undefined
+  const intermediateToken = sourceTokens && sourceTokens[order.buyToken.toLowerCase()]
+  const destinationToken =
+    destinationChainTokens && outputTokenAddress ? destinationChainTokens[outputTokenAddress.toLowerCase()] : undefined
 
   return { sourceToken, intermediateToken, destinationToken }
 }

--- a/apps/explorer/src/modules/bridge/index.ts
+++ b/apps/explorer/src/modules/bridge/index.ts
@@ -1,2 +1,4 @@
 export { useCrossChainOrder } from './hooks/useCrossChainOrder'
 export { useCrossChainTokens } from './hooks/useCrossChainTokens'
+export { useBridgeProviderBuyTokens } from './hooks/useBridgeProviderBuyTokens'
+export { useBridgeProviderNetworks } from './hooks/useBridgeProviderNetworks'

--- a/libs/common-utils/src/legacyAddressUtils.ts
+++ b/libs/common-utils/src/legacyAddressUtils.ts
@@ -40,7 +40,7 @@ export function getContract(
   address: string,
   ABI: ContractInterface,
   provider: JsonRpcProvider,
-  account?: string
+  account?: string,
 ): Contract {
   if (!isAddress(address) || address === AddressZero) {
     throw Error(`Invalid 'address' parameter '${address}'.`)
@@ -65,8 +65,11 @@ export type BlockExplorerLinkType =
   | 'event'
   | 'contract'
 
-function getEtherscanUrl(chainId: SupportedChainId, data: string, type: BlockExplorerLinkType): string {
-  const basePath = CHAIN_INFO[chainId].explorer
+// eslint-disable-next-line complexity
+function getEtherscanUrl(chainId: SupportedChainId, data: string, type: BlockExplorerLinkType, base?: string): string {
+  const basePath = base || CHAIN_INFO[chainId]?.explorer
+
+  if (!basePath) return ''
 
   switch (type) {
     case 'transaction':
@@ -88,8 +91,13 @@ function getEtherscanUrl(chainId: SupportedChainId, data: string, type: BlockExp
 }
 
 // Get the right block explorer URL by chainId
-export function getBlockExplorerUrl(chainId: SupportedChainId, type: BlockExplorerLinkType, data: string): string {
-  return getEtherscanUrl(chainId, data, type)
+export function getBlockExplorerUrl(
+  chainId: SupportedChainId,
+  type: BlockExplorerLinkType,
+  data: string,
+  base?: string,
+): string {
+  return getEtherscanUrl(chainId, data, type, base)
 }
 
 // TODO: Add proper return type annotation


### PR DESCRIPTION
# Summary

Fixes [#issueNumber](https://www.notion.so/cownation/Explorer-bridge-data-to-Optimism-cannot-be-fetched-2228da5f04ca80d2b95bc8351aca4a20?source=copy_link)

Added network and tokens data fetching from bridge provider when network is not supported.

<img width="942" alt="image" src="https://github.com/user-attachments/assets/6a25dc95-20cd-4b7a-8f89-37ce7966f918" />


# To Test

See https://www.notion.so/cownation/Explorer-bridge-data-to-Optimism-cannot-be-fetched-2228da5f04ca80d2b95bc8351aca4a20?source=copy_link
