### PR TITLE
feat(hooks): add polygon to morpho and update info

### DIFF
--- a/libs/hook-dapp-lib/src/hookDappsRegistry.json
+++ b/libs/hook-dapp-lib/src/hookDappsRegistry.json
@@ -139,17 +139,17 @@
     }
   },
   "MORPHO_LENDING": {
-    "name": "Morpho Lending",
+    "name": "Morpho Borrow",
     "type": "IFRAME",
-    "descriptionShort": "Supply, borrow, repay and withdraw on Morpho Protocol.",
-    "description": "Seamlessly add and remove liquidity on the Morpho Lending Protocol. Whether you're optimizing your yield or efficiently deploying assets, this hook streamlines the process, ensuring your liquidity transactions happen in a smooth, efficient flow.",
+    "descriptionShort": "Supply collateral, borrow, repay and withdraw collateral on Morpho Protocol.",
+    "description": "The Morpho Borrow hook enables users to seamlessly combine swaps with borrow-related actions. Users can enter new positions, leave existing ones, or move between different markets through a unified, streamlined process.",
     "version": "0.0.1",
     "website": "https://app.morpho.org/",
     "image": "https://cow-hooks-dapps-morpho-lending.vercel.app/icon.png",
     "url": "https://cow-hooks-dapps-morpho-lending.vercel.app/",
     "conditions": {
       "walletCompatibility": ["EOA"],
-      "supportedNetworks": [1, 8453],
+      "supportedNetworks": [1, 137, 8453],
       "smartContractWalletSupported": false
     }
   }

--- a/libs/hook-dapp-lib/src/hookDappsRegistry.json
+++ b/libs/hook-dapp-lib/src/hookDappsRegistry.json
@@ -138,7 +138,7 @@
       "supportedNetworks": [1, 42161, 11155111, 8453]
     }
   },
-  "MORPHO_LENDING": {
+  "MORPHO_BORROW": {
     "name": "Morpho Borrow",
     "type": "IFRAME",
     "descriptionShort": "Supply collateral, borrow, repay and withdraw collateral on Morpho Protocol.",


### PR DESCRIPTION
# Summary

- Rename hook 'Morpho Lending' to 'Morpho Borrow'
- Update descriptions to be more consistent with hook proposal
- Add Polygon to Morpho hook networks

# To Test

- Go to swap/hooks section
- Switch to Polygon
- click on Add Pre-Hook or Add Post-Hook -> Morpho Borrow should appear on the list
  - Morpho Borrow should work normally on Polygon
  - Morpho Borrow description should be updated

New short description: `Supply collateral, borrow, repay and withdraw collateral on Morpho Protocol.`

New long description: `The Morpho Borrow hook enables users to seamlessly combine swaps with borrow-related actions. Users can enter new positions, leave existing ones, or move between different markets through a unified, streamlined process.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded network support for Morpho Borrow to include an additional network.
* **Enhancements**
  * Updated the name and descriptions for Morpho Borrow to better reflect its borrowing and collateral management capabilities, as well as its integration with swap actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->