### PR TITLE
fix: update InlineBanner width for UnsignedOrderWarning component

### DIFF
--- a/apps/explorer/src/components/orders/UnsignedOrderWarning/index.tsx
+++ b/apps/explorer/src/components/orders/UnsignedOrderWarning/index.tsx
@@ -2,7 +2,13 @@ import { BannerOrientation, InlineBanner, StatusColorVariant } from '@cowprotoco
 
 export const UnsignedOrderWarning: React.FC = () => {
   return (
-    <InlineBanner orientation={BannerOrientation.Horizontal} bannerType={StatusColorVariant.Alert} width="fit-content">
+    <InlineBanner
+      orientation={BannerOrientation.Horizontal}
+      bannerType={StatusColorVariant.Alert}
+      noBackground
+      padding="0"
+      breakWord
+    >
       <p>An unsigned order is not necessarily placed by the owner's account. Please be cautious.</p>
     </InlineBanner>
   )

--- a/libs/ui/src/pure/InlineBanner/InlineBanner/index.tsx
+++ b/libs/ui/src/pure/InlineBanner/InlineBanner/index.tsx
@@ -23,6 +23,8 @@ export function InlineBanner({
   noWrapContent,
   backDropBlur,
   fontSize,
+  noBackground,
+  breakWord,
 }: InlineBannerProps): ReactNode {
   const colorEnums = getStatusColorEnums(bannerType)
 
@@ -38,6 +40,8 @@ export function InlineBanner({
       dismissable={!!onClose}
       backDropBlur={backDropBlur}
       fontSize={fontSize}
+      noBackground={noBackground}
+      breakWord={breakWord}
     >
       <span>
         <BannerIcon

--- a/libs/ui/src/pure/InlineBanner/InlineBanner/styled.ts
+++ b/libs/ui/src/pure/InlineBanner/InlineBanner/styled.ts
@@ -16,12 +16,14 @@ export const Wrapper = styled.span<{
   dismissable?: boolean
   backDropBlur?: boolean
   fontSize?: number
+  noBackground?: boolean
+  breakWord?: boolean
 }>`
   display: flex;
   align-items: center;
   justify-content: center;
   position: relative;
-  background: ${({ colorEnums }) => `var(${colorEnums.bg})`};
+  background: ${({ colorEnums, noBackground }) => noBackground ? 'transparent' : `var(${colorEnums.bg})`};
   color: ${({ colorEnums }) => `var(${colorEnums.text})`};
   gap: 24px 10px;
   border-radius: ${({ borderRadius = '16px' }) => borderRadius};
@@ -77,6 +79,7 @@ export const Wrapper = styled.span<{
       width: 100%;
       text-align: ${({ orientation = BannerOrientation.Vertical }) =>
         orientation === BannerOrientation.Horizontal ? 'left' : 'center'};
+      ${({ breakWord }) => breakWord ? 'word-break: break-word;' : ''}
     }
 
     > i {

--- a/libs/ui/src/pure/InlineBanner/shared/types.ts
+++ b/libs/ui/src/pure/InlineBanner/shared/types.ts
@@ -24,6 +24,8 @@ export interface InlineBannerProps {
   onClose?: () => void
   backDropBlur?: boolean
   fontSize?: number
+  noBackground?: boolean
+  breakWord?: boolean
 }
 
 export interface CollapsibleInlineBannerProps extends Omit<InlineBannerProps, 'children'> {


### PR DESCRIPTION
# Summary

Fixes a layout issue for the alert banner in the explorer

<img width="1424" alt="Screenshot 2025-07-09 at 12 43 29" src="https://github.com/user-attachments/assets/92af4d6d-9ef7-42cf-b823-3c91c0772d27" />
