### PR TITLE
fix(balances): update balances after network switching

### DIFF
--- a/apps/cowswap-frontend/src/modules/application/containers/App/Updaters.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/App/Updaters.tsx
@@ -100,7 +100,7 @@ export function Updaters(): ReactNode {
       <WidgetTokensUpdater />
 
       <UnsupportedTokensUpdater />
-      <CommonPriorityBalancesAndAllowancesUpdater/>
+      <CommonPriorityBalancesAndAllowancesUpdater />
       <LpBalancesAndAllowancesUpdater chainId={sourceChainId} account={balancesAccount} enablePolling={isYieldWidget} />
       <PoolsInfoUpdater />
       <LpTokensWithBalancesUpdater />

--- a/apps/cowswap-frontend/src/modules/combinedBalances/state/balanceCombinedAtom.ts
+++ b/apps/cowswap-frontend/src/modules/combinedBalances/state/balanceCombinedAtom.ts
@@ -1,5 +1,5 @@
 import { atomWithReset } from 'jotai/utils'
 
-import { BalancesState } from '@cowprotocol/balances-and-allowances'
+import { BalancesState, DEFAULT_BALANCES_STATE } from '@cowprotocol/balances-and-allowances'
 
-export const balancesCombinedAtom = atomWithReset<BalancesState>({ isLoading: false, values: {}, chainId: null })
+export const balancesCombinedAtom = atomWithReset<BalancesState>(DEFAULT_BALANCES_STATE)

--- a/apps/cowswap-frontend/src/modules/combinedBalances/updater/BalancesCombinedUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/combinedBalances/updater/BalancesCombinedUpdater.tsx
@@ -60,5 +60,6 @@ function applyBalanceDiffs(
     isLoading: currentBalances.isLoading,
     values: normalizedValues,
     chainId,
+    fromCache: false,
   }
 }

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/SelectTokenModal/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/SelectTokenModal/index.cosmos.tsx
@@ -43,6 +43,7 @@ const defaultProps: SelectTokenModalProps = {
     values: balances,
     isLoading: false,
     chainId: SupportedChainId.SEPOLIA,
+    fromCache: false,
   },
   selectedToken,
   onSelectToken() {

--- a/libs/balances-and-allowances/src/hooks/usePersistBalancesAndAllowances.ts
+++ b/libs/balances-and-allowances/src/hooks/usePersistBalancesAndAllowances.ts
@@ -72,15 +72,15 @@ export function usePersistBalancesAndAllowances(params: PersistBalancesAndAllowa
   useEffect(() => {
     if (!setLoadingState) return
 
-    setBalances((state) => ({ ...state, isLoading: isBalancesLoading }))
-  }, [setBalances, isBalancesLoading, setLoadingState])
+    setBalances((state) => ({ ...state, isLoading: isBalancesLoading, chainId }))
+  }, [setBalances, isBalancesLoading, setLoadingState, chainId])
 
   // Set allowances loading state
   useEffect(() => {
     if (!setLoadingState) return
 
-    setAllowances((state) => ({ ...state, isLoading: isAllowancesLoading }))
-  }, [setAllowances, isAllowancesLoading, setLoadingState])
+    setAllowances((state) => ({ ...state, isLoading: isAllowancesLoading, chainId }))
+  }, [setAllowances, isAllowancesLoading, setLoadingState, chainId])
 
   // Set balances to the store
   useEffect(() => {

--- a/libs/balances-and-allowances/src/hooks/useSwrConfigWithPauseForNetwork.ts
+++ b/libs/balances-and-allowances/src/hooks/useSwrConfigWithPauseForNetwork.ts
@@ -27,7 +27,8 @@ export function useSwrConfigWithPauseForNetwork(
 
   const lastUpdateTimestampRef = useRef(lastUpdateTimestamp)
 
-  if (balancesChainId && balancesChainId !== chainId) {
+  // Update lastUpdateTimestampRef only when balances state chainId in sync with current chainId
+  if (!balancesChainId || balancesChainId === chainId) {
     lastUpdateTimestampRef.current = lastUpdateTimestamp
   }
 

--- a/libs/balances-and-allowances/src/hooks/useSwrConfigWithPauseForNetwork.ts
+++ b/libs/balances-and-allowances/src/hooks/useSwrConfigWithPauseForNetwork.ts
@@ -27,7 +27,7 @@ export function useSwrConfigWithPauseForNetwork(
 
   const lastUpdateTimestampRef = useRef(lastUpdateTimestamp)
 
-  if (!(balancesChainId && balancesChainId !== chainId)) {
+  if (balancesChainId && balancesChainId !== chainId) {
     lastUpdateTimestampRef.current = lastUpdateTimestamp
   }
 

--- a/libs/balances-and-allowances/src/index.ts
+++ b/libs/balances-and-allowances/src/index.ts
@@ -16,3 +16,6 @@ export { usePersistBalancesAndAllowances } from './hooks/usePersistBalancesAndAl
 // Types
 export type { BalancesState } from './state/balancesAtom'
 export type { AllowancesState } from './state/allowancesAtom'
+
+// Consts
+export { DEFAULT_BALANCES_STATE } from './state/balancesAtom'

--- a/libs/balances-and-allowances/src/state/balancesAtom.ts
+++ b/libs/balances-and-allowances/src/state/balancesAtom.ts
@@ -14,6 +14,14 @@ type BalancesCache = PersistentStateByChain<Record<Account, Record<TokenAddress,
 
 export interface BalancesState extends Erc20MulticallState {
   chainId: SupportedChainId | null
+  fromCache: boolean
+}
+
+export const DEFAULT_BALANCES_STATE: BalancesState = {
+  isLoading: false,
+  values: {},
+  chainId: null,
+  fromCache: false,
 }
 
 export const balancesCacheAtom = atomWithStorage<BalancesCache>(
@@ -22,11 +30,7 @@ export const balancesCacheAtom = atomWithStorage<BalancesCache>(
   getJotaiMergerStorage(),
 )
 
-export const balancesAtom = atomWithReset<BalancesState>({
-  isLoading: false,
-  values: {},
-  chainId: null,
-})
+export const balancesAtom = atomWithReset<BalancesState>(DEFAULT_BALANCES_STATE)
 
 export const balancesUpdateAtom = atom<PersistentStateByChain<Record<string, number | undefined>>>(
   mapSupportedNetworks({}),

--- a/libs/balances-and-allowances/src/updaters/BalancesCacheUpdater.tsx
+++ b/libs/balances-and-allowances/src/updaters/BalancesCacheUpdater.tsx
@@ -14,11 +14,7 @@ interface BalancesCacheUpdaterProps {
 export function BalancesCacheUpdater({ chainId, account }: BalancesCacheUpdaterProps): null {
   const [balances, setBalances] = useAtom(balancesAtom)
   const [balancesCache, setBalancesCache] = useAtom(balancesCacheAtom)
-  const areBalancesRestoredFromCacheRef = useRef(false)
-
-  useEffect(() => {
-    areBalancesRestoredFromCacheRef.current = false
-  }, [chainId])
+  const lastChainCacheUpdateRef = useRef<SupportedChainId | null>(null)
 
   // Persist into localStorage only non-zero balances
   useEffect(() => {
@@ -69,7 +65,7 @@ export function BalancesCacheUpdater({ chainId, account }: BalancesCacheUpdaterP
   // Restore balances from cache once
   useLayoutEffect(() => {
     if (!account) return
-    if (areBalancesRestoredFromCacheRef.current) return
+    if (lastChainCacheUpdateRef.current === chainId) return
 
     const cache = balancesCache[chainId]?.[account.toLowerCase()]
 
@@ -79,10 +75,11 @@ export function BalancesCacheUpdater({ chainId, account }: BalancesCacheUpdaterP
 
     if (cacheKeys.length === 0) return
 
-    areBalancesRestoredFromCacheRef.current = true
+    lastChainCacheUpdateRef.current = chainId
 
     setBalances((state) => {
       return {
+        fromCache: true,
         chainId,
         isLoading: state.isLoading,
         values: {

--- a/libs/balances-and-allowances/src/updaters/BalancesResetUpdater.ts
+++ b/libs/balances-and-allowances/src/updaters/BalancesResetUpdater.ts
@@ -1,0 +1,56 @@
+import { useSetAtom } from 'jotai'
+import { useResetAtom } from 'jotai/utils'
+import { useEffect } from 'react'
+
+import { usePrevious } from '@cowprotocol/common-hooks'
+import { mapSupportedNetworks } from '@cowprotocol/cow-sdk'
+
+import { allowancesFullState } from '../state/allowancesAtom'
+import { balancesAtom, balancesCacheAtom, DEFAULT_BALANCES_STATE } from '../state/balancesAtom'
+
+interface BalancesResetUpdaterProps {
+  account: string | undefined
+  chainId: number
+}
+
+export function BalancesResetUpdater({ account, chainId }: BalancesResetUpdaterProps): null {
+  const prevChainId = usePrevious(chainId)
+  const prevAccount = usePrevious(account)
+  const setBalancesCache = useSetAtom(balancesCacheAtom)
+
+  const setBalances = useSetAtom(balancesAtom)
+  const resetAllowances = useResetAtom(allowancesFullState)
+
+  // Reset states when wallet is not connected
+  useEffect(() => {
+    if (prevAccount && prevAccount !== account) {
+      setBalances(DEFAULT_BALANCES_STATE)
+      resetAllowances()
+      setBalancesCache(mapSupportedNetworks({}))
+    }
+  }, [chainId, account, prevAccount, resetAllowances, setBalances, setBalancesCache])
+
+  /**
+   * Reset balances and allowances when chainId is changed.
+   *
+   * If we don't reset the values, you might see balances from the previous network after switching,
+   * because it takes awhile to load balances for the new chain.
+   * p.s. there is BalancesCacheUpdater which fills cached values in.
+   */
+  useEffect(() => {
+    if (prevChainId && chainId === prevChainId) return
+
+    setBalances((state) => {
+      // Reset balances only when current state is not from cache
+      // Because cache set values only to the current network
+      if (!state.fromCache) {
+        return DEFAULT_BALANCES_STATE
+      }
+
+      return state
+    })
+    resetAllowances()
+  }, [chainId, prevChainId, setBalances, resetAllowances])
+
+  return null
+}


### PR DESCRIPTION
# Summary

Fixes #5939

There was a race condition between `BalancesResetUpdater` and `BalancesCacheUpdater`.
It was resetting balances just after restoring them from cache, which created a situation with "Couldn't load balances".
To fix that I added `fromCache` flag to balances state which prevents state resetting.

I extracted `BalancesResetUpdater` from `usePersistBalancesAndAllowances` because:
 - the hook is used in three different places, but the resetting logic should be applied once
 - to reduce the hook complexity

# To Test

See #5939
