### PR TITLE
fix(bridge): display swap and bride confirm text

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/index.tsx
@@ -47,7 +47,6 @@ export interface SwapConfirmModalProps {
 }
 
 // TODO: Break down this large function into smaller functions
-// TODO: Add proper return type annotation
 // eslint-disable-next-line max-lines-per-function
 export function SwapConfirmModal(props: SwapConfirmModalProps): ReactNode {
   const { inputCurrencyInfo, outputCurrencyInfo, priceImpact, recipient, doTrade } = props
@@ -103,13 +102,15 @@ export function SwapConfirmModal(props: SwapConfirmModalProps): ReactNode {
     return true
   }, [balances, inputCurrencyInfo, shouldDisplayBridgeDetails, bridgeQuoteAmounts])
 
+  const confirmText = shouldDisplayBridgeDetails ? 'Confirm Swap and Bridge' : 'Confirm Swap'
+
   const buttonText = useMemo(() => {
     if (disableConfirm) {
       const { amount } = inputCurrencyInfo
       return `Insufficient ${amount?.currency?.symbol || 'token'} balance`
     }
-    return 'Confirm Swap'
-  }, [disableConfirm, inputCurrencyInfo])
+    return confirmText
+  }, [confirmText, disableConfirm, inputCurrencyInfo])
 
   return (
     <TradeConfirmModal title={CONFIRM_TITLE} submittedContent={submittedContent}>

--- a/apps/cowswap-frontend/src/modules/swap/containers/TradeButtons/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/TradeButtons/index.tsx
@@ -1,6 +1,11 @@
-import React from 'react'
+import React, { ReactNode } from 'react'
 
-import { useIsNoImpactWarningAccepted, useTradeConfirmActions, useWrappedToken } from 'modules/trade'
+import {
+  useIsCurrentTradeBridging,
+  useIsNoImpactWarningAccepted,
+  useTradeConfirmActions,
+  useWrappedToken,
+} from 'modules/trade'
 import {
   TradeFormButtons,
   TradeFormValidation,
@@ -17,21 +22,17 @@ import { useOnCurrencySelection } from '../../hooks/useOnCurrencySelection'
 import { useSwapDerivedState } from '../../hooks/useSwapDerivedState'
 import { useSwapFormState } from '../../hooks/useSwapFormState'
 
-const confirmText = 'Swap'
-
 interface TradeButtonsProps {
   isTradeContextReady: boolean
   openNativeWrapModal(): void
   hasEnoughWrappedBalanceForSwap: boolean
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function TradeButtons({
   isTradeContextReady,
   openNativeWrapModal,
   hasEnoughWrappedBalanceForSwap,
-}: TradeButtonsProps) {
+}: TradeButtonsProps): ReactNode {
   const { inputCurrency } = useSwapDerivedState()
 
   const primaryFormValidation = useGetTradeFormValidation()
@@ -41,8 +42,11 @@ export function TradeButtons({
   const localFormValidation = useSwapFormState()
   const wrappedToken = useWrappedToken()
   const onCurrencySelection = useOnCurrencySelection()
+  const isCurrentTradeBridging = useIsCurrentTradeBridging()
 
   const confirmTrade = tradeConfirmActions.onOpen
+
+  const confirmText = isCurrentTradeBridging ? 'Swap and Bridge' : 'Swap'
 
   const tradeFormButtonContext = useTradeFormButtonContext(confirmText, confirmTrade)
 

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ReactNode } from 'react'
 
 import { Trans } from '@lingui/macro'
 
@@ -15,9 +15,7 @@ export interface TradeFormButtonsProps {
   isDisabled?: boolean
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function TradeFormButtons(props: TradeFormButtonsProps) {
+export function TradeFormButtons(props: TradeFormButtonsProps): ReactNode {
   const { validation, context, isDisabled, confirmText, className } = props
 
   // When there are no validation errors


### PR DESCRIPTION
# Summary

1. Swap form

<img width="1014" height="964" alt="image" src="https://github.com/user-attachments/assets/dab82be2-9b27-4ec3-809b-186355bbe783" />

2. Swap confirm screen

<img width="1114" height="576" alt="image" src="https://github.com/user-attachments/assets/3a5a1151-2cac-44cc-90e4-a6cb747ccd4f" />


# To Test

1. Text should be "Swap and Bridge" for bridging orders
2. For regular orders should be just "Swap"
