### PR TITLE
fix(bridge): better destination tokens filtering

### DIFF
--- a/apps/cowswap-frontend/src/entities/bridgeProvider/useBridgeSupportedTokens.ts
+++ b/apps/cowswap-frontend/src/entities/bridgeProvider/useBridgeSupportedTokens.ts
@@ -1,21 +1,32 @@
-import { TokenWithLogo } from '@cowprotocol/common-const'
+import { SWR_NO_REFRESH_OPTIONS, TokenWithLogo } from '@cowprotocol/common-const'
 import { useIsBridgingEnabled } from '@cowprotocol/common-hooks'
+import { BuyTokensParams } from '@cowprotocol/cow-sdk'
 
 import useSWR, { SWRResponse } from 'swr'
 
 import { useBridgeProvider } from './useBridgeProvider'
 
-export function useBridgeSupportedTokens(chainId: number | undefined): SWRResponse<TokenWithLogo[] | null> {
+export function useBridgeSupportedTokens(params: BuyTokensParams | undefined): SWRResponse<TokenWithLogo[] | null> {
   const isBridgingEnabled = useIsBridgingEnabled()
   const bridgeProvider = useBridgeProvider()
 
   return useSWR(
-    isBridgingEnabled ? [bridgeProvider, chainId, bridgeProvider.info.dappId, 'useBridgeSupportedTokens'] : null,
-    ([bridgeProvider, chainId]) => {
-      if (typeof chainId === 'undefined') return null
+    isBridgingEnabled
+      ? [
+          bridgeProvider,
+          params,
+          params?.sellChainId,
+          params?.buyChainId,
+          params?.sellTokenAddress,
+          bridgeProvider.info.dappId,
+          'useBridgeSupportedTokens',
+        ]
+      : null,
+    ([bridgeProvider, params]) => {
+      if (typeof params === 'undefined') return null
 
       return bridgeProvider
-        .getBuyTokens(chainId)
+        .getBuyTokens(params)
         .then((tokens) => {
           return (
             tokens &&
@@ -36,5 +47,6 @@ export function useBridgeSupportedTokens(chainId: number | undefined): SWRRespon
           return Promise.reject(error)
         })
     },
+    SWR_NO_REFRESH_OPTIONS,
   )
 }

--- a/apps/cowswap-frontend/src/modules/tokensList/hooks/useTokensToSelect.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/hooks/useTokensToSelect.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 
 import { TokenWithLogo } from '@cowprotocol/common-const'
+import { BuyTokensParams } from '@cowprotocol/cow-sdk'
 import { useAllActiveTokens, useFavoriteTokens } from '@cowprotocol/tokens'
 import { useWalletInfo } from '@cowprotocol/wallet'
 
@@ -26,9 +27,13 @@ export function useTokensToSelect(): TokensToSelectContext {
 
   const areTokensFromBridge = field === Field.OUTPUT && selectedTargetChainId !== chainId
 
-  const { data: bridgeSupportedTokens, isLoading } = useBridgeSupportedTokens(
-    areTokensFromBridge ? selectedTargetChainId : undefined,
-  )
+  const params: BuyTokensParams | undefined = useMemo(() => {
+    if (!areTokensFromBridge) return undefined
+
+    return { buyChainId: selectedTargetChainId, sellChainId: chainId }
+  }, [areTokensFromBridge, chainId, selectedTargetChainId])
+
+  const { data: bridgeSupportedTokens, isLoading } = useBridgeSupportedTokens(params)
 
   const bridgeSupportedTokensMap = useMemo(() => {
     return bridgeSupportedTokens?.reduce<Record<string, boolean>>((acc, val) => {

--- a/apps/explorer/src/modules/bridge/hooks/useBridgeProviderBuyTokens.ts
+++ b/apps/explorer/src/modules/bridge/hooks/useBridgeProviderBuyTokens.ts
@@ -6,14 +6,14 @@ import useSWR, { SWRResponse } from 'swr'
 
 export function useBridgeProviderBuyTokens(
   provider: CrossChainOrder['provider'] | undefined,
-  chainId: number,
+  buyChainId: number,
 ): SWRResponse<Record<string, TokenInfo> | undefined> {
   return useSWR(
-    [provider, chainId, provider?.info.dappId],
-    async ([provider, chainId]) => {
+    [provider, buyChainId, provider?.info.dappId],
+    async ([provider, buyChainId]) => {
       if (!provider) return undefined
 
-      const tokens = await provider.getBuyTokens(chainId)
+      const tokens = await provider.getBuyTokens({ buyChainId })
 
       return tokens.reduce<Record<string, TokenInfo>>((acc, val) => {
         acc[val.address.toLowerCase()] = {

--- a/apps/explorer/src/modules/bridge/hooks/useBridgeProviderBuyTokens.ts
+++ b/apps/explorer/src/modules/bridge/hooks/useBridgeProviderBuyTokens.ts
@@ -9,7 +9,7 @@ export function useBridgeProviderBuyTokens(
   buyChainId: number,
 ): SWRResponse<Record<string, TokenInfo> | undefined> {
   return useSWR(
-    [provider, buyChainId, provider?.info.dappId],
+    [provider, buyChainId, provider?.info.dappId, 'useBridgeProviderBuyTokens'],
     async ([provider, buyChainId]) => {
       if (!provider) return undefined
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@cowprotocol/cms": "^0.11.0",
     "@cowprotocol/contracts": "^1.7.0",
     "@cowprotocol/cow-runner-game": "^0.2.9",
-    "@cowprotocol/cow-sdk": "6.0.0-RC.71",
+    "@cowprotocol/cow-sdk": "6.0.0-RC.72",
     "@cowprotocol/ethflowcontract": "cowprotocol/ethflowcontract.git#main-artifacts",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1841,10 +1841,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/cow-runner-game/-/cow-runner-game-0.2.9.tgz#3f94b3f370bd114f77db8b1d238cba3ef4e9d644"
   integrity sha512-rX7HnoV+HYEEkBaqVUsAkGGo0oBrExi+d6Io+8nQZYwZk+IYLmS9jdcIObsLviM2h4YX8+iin6NuKl35AaiHmg==
 
-"@cowprotocol/cow-sdk@6.0.0-RC.71":
-  version "6.0.0-RC.71"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.71.tgz#7b23c2e1058fba0ebf4d63a8e755b9b552383370"
-  integrity sha512-4ydCp/PlbZibeXhp9ZLaqg3rzq3VZDM/z7nbncqWuXj7muJ6bkWv6j/C+QsX79l5FAFmoHECR0e2q4qeV+k1uQ==
+"@cowprotocol/cow-sdk@6.0.0-RC.72":
+  version "6.0.0-RC.72"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.72.tgz#76e360312992c33393cb8ec46d9ce12f6b7ffb37"
+  integrity sha512-e3CDF4o3ciEkEll4eHXwJbbuiW8bF4UB7+g90LHh0iRj7XaPq/v5n1g1cwiJDYCms8fmS17JgMIyRvmj6fmZYQ==
   dependencies:
     "@cowprotocol/app-data" "^3.1.0"
     "@cowprotocol/contracts" "^1.8.0"


### PR DESCRIPTION
# Summary

Related to https://github.com/cowprotocol/cow-sdk/pull/384

Buy tokens list was not well filtered, so we could face "Route not found" quite often.
After that fix the list should be better filtered. 

Before:

<img width="822" height="842" alt="image" src="https://github.com/user-attachments/assets/69632a34-7018-452a-ac06-4f897c8aad88" />

After:
<img width="816" height="828" alt="image" src="https://github.com/user-attachments/assets/a2c66003-8869-497d-9ac6-d344f5f7f660" />

# To Test

1. Specify sell USDC from Base
2. Open buy token selector
3. Select Arbitrum in the selector
- [ ] AR: ACX token is in the list
- [ ] ER: There is no ACX in the tokens list


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how token selection and bridging logic handle parameters, now supporting both buy and sell chain IDs for more accurate token fetching.
  * Updated parameter naming for clarity in bridge-related hooks.
* **Chores**
  * Upgraded the `@cowprotocol/cow-sdk` dependency to version 6.0.0-RC.72.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->