### PR TITLE
refactor: adjust border-radius for modal in small view

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/NewModal/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/NewModal/index.tsx
@@ -36,6 +36,7 @@ const Wrapper = styled.div<{
   ${Media.upToSmall()} {
     margin: 0;
     box-shadow: none;
+    ${({ modalMode }) => modalMode && 'border-radius: 0;'}
   }
 
   ${ModalInner} {

--- a/apps/cowswap-frontend/src/modules/cowShed/containers/CoWShedWidget/styled.tsx
+++ b/apps/cowswap-frontend/src/modules/cowShed/containers/CoWShedWidget/styled.tsx
@@ -1,4 +1,4 @@
-import { UI } from '@cowprotocol/ui'
+import { Media, UI } from '@cowprotocol/ui'
 
 import { transparentize } from 'color2k'
 import styled from 'styled-components/macro'
@@ -19,8 +19,12 @@ export const ModalWrapper = styled.div<{ $modalMode: boolean }>`
   top: 0;
   overflow-y: scroll;
   padding: 50px 0;
-  background: ${({ theme }) => (theme.isInjectedWidgetMode ? 'transparent' : transparentize(theme.black, 0.1))};
+  background: ${({ theme }) => (theme.isWidget ? 'transparent' : transparentize(theme.black, 0.5))};
   backdrop-filter: blur(3px);
+
+  ${Media.upToSmall()} {
+    padding: 0;
+  }
 `
 
 export const WidgetWrapper = styled.div`


### PR DESCRIPTION
# Summary

Fix Account Proxy modal padding and border-radius on mobile devices

<img width="738" height="904" alt="Screenshot 2025-07-11 at 17 07 43" src="https://github.com/user-attachments/assets/58f6b029-a682-4579-be6a-7d9a18b566cb" />
<img width="320" height="569" alt="Screenshot 2025-07-11 at 17 07 36" src="https://github.com/user-attachments/assets/f9b28877-545f-414b-9a4d-9c9a89e78393" />


  - Remove 50px vertical padding on mobile for better space utilization
  - Remove border-radius on mobile when modal is rendered via portal

  # To Test

  1. Open Account Proxy modal on mobile device (< 768px width)

  - [ ] Verify modal has no vertical padding (previously had 50px top/bottom)
  - [ ] Verify modal has no border-radius when opened as overlay
  - [ ] Modal should fill the entire viewport on mobile

  2. Open Account Proxy on desktop

  - [ ] Verify modal maintains 50px vertical padding
  - [ ] Verify modal maintains normal border-radius

  # Background

  The Account Proxy modal had excessive padding on mobile devices which reduced usable space. Additionally, the border-radius on mobile created visual inconsistency when the modal was rendered as a full-screen overlay via React portal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved modal appearance on small screens by removing rounded corners when in modal mode.
  * Enhanced modal background overlay for widgets and increased overlay opacity for better visibility.
  * Adjusted modal padding for better responsiveness on smaller devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->