### PR TITLE
feat(bridge): add disclaimer about third-party bridging features

### DIFF
--- a/apps/cowswap-frontend/src/modules/bridge/constants.ts
+++ b/apps/cowswap-frontend/src/modules/bridge/constants.ts
@@ -1,3 +1,4 @@
 export const COW_PROTOCOL_NAME = 'CoW Protocol'
 
-export const BRIDGE_DISCLAIMER_TOOLTIP_CONTENT = 'Bridging features are exclusively operated by third parties. Please review their terms.'
+export const BRIDGE_DISCLAIMER_TOOLTIP_CONTENT =
+  'Bridging feature is exclusively operated by the indicated third party. Please review their terms.'

--- a/apps/cowswap-frontend/src/modules/bridge/constants.ts
+++ b/apps/cowswap-frontend/src/modules/bridge/constants.ts
@@ -1,0 +1,1 @@
+export const BRIDGE_DISCLAIMER_TOOLTIP_CONTENT = 'Bridging features are exclusively operated by third parties. Please review their terms.'

--- a/apps/cowswap-frontend/src/modules/bridge/constants.ts
+++ b/apps/cowswap-frontend/src/modules/bridge/constants.ts
@@ -1,1 +1,3 @@
+export const COW_PROTOCOL_NAME = 'CoW Protocol'
+
 export const BRIDGE_DISCLAIMER_TOOLTIP_CONTENT = 'Bridging features are exclusively operated by third parties. Please review their terms.'

--- a/apps/cowswap-frontend/src/modules/bridge/pure/BridgeActivitySummary/SwapStepRow.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/BridgeActivitySummary/SwapStepRow.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react'
 
 import { StepContent, SwapSummaryRow } from './styled'
 
+import { COW_PROTOCOL_NAME } from '../../constants'
 import { SwapAndBridgeContext, SwapAndBridgeStatus } from '../../types'
 import { BridgeDetailsContainer } from '../BridgeDetailsContainer'
 import { SwapResultContent } from '../contents/SwapResultContent'
@@ -34,7 +35,7 @@ export function SwapStepRow({ context }: SwapStepRowProps): ReactNode {
           protocolIconSize={21}
           circleSize={21}
           titlePrefix=""
-          protocolName="Swapped on CoW Protocol"
+          protocolName={`Swapped on ${COW_PROTOCOL_NAME}`}
           bridgeProvider={bridgeProvider}
           chainName={sourceChainName}
           sellAmount={sourceAmounts.sellAmount}

--- a/apps/cowswap-frontend/src/modules/bridge/pure/BridgeRouteTitle/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/BridgeRouteTitle/index.tsx
@@ -1,7 +1,9 @@
 import { ReactNode } from 'react'
 
 import { BridgeProviderInfo } from '@cowprotocol/cow-sdk'
+import { InfoTooltip } from '@cowprotocol/ui'
 
+import { BRIDGE_DISCLAIMER_TOOLTIP_CONTENT } from '../../constants'
 import { StopNumberCircle } from '../../styles'
 import { SwapAndBridgeStatus } from '../../types'
 import { ProtocolIcons } from '../ProtocolIcons'
@@ -43,6 +45,7 @@ export function BridgeRouteTitle({
           secondProtocol={bridgeProvider}
         />
         <span> {protocolName}</span>
+        {protocolName !== 'CoW Protocol' && <InfoTooltip content={BRIDGE_DISCLAIMER_TOOLTIP_CONTENT} size={14} />}
       </b>
     </>
   )

--- a/apps/cowswap-frontend/src/modules/bridge/pure/BridgeRouteTitle/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/BridgeRouteTitle/index.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react'
 import { BridgeProviderInfo } from '@cowprotocol/cow-sdk'
 import { InfoTooltip } from '@cowprotocol/ui'
 
-import { BRIDGE_DISCLAIMER_TOOLTIP_CONTENT } from '../../constants'
+import { BRIDGE_DISCLAIMER_TOOLTIP_CONTENT, COW_PROTOCOL_NAME } from '../../constants'
 import { StopNumberCircle } from '../../styles'
 import { SwapAndBridgeStatus } from '../../types'
 import { ProtocolIcons } from '../ProtocolIcons'
@@ -45,7 +45,7 @@ export function BridgeRouteTitle({
           secondProtocol={bridgeProvider}
         />
         <span> {protocolName}</span>
-        {protocolName !== 'CoW Protocol' && <InfoTooltip content={BRIDGE_DISCLAIMER_TOOLTIP_CONTENT} size={14} />}
+        {protocolName !== COW_PROTOCOL_NAME && <InfoTooltip content={BRIDGE_DISCLAIMER_TOOLTIP_CONTENT} size={14} />}
       </b>
     </>
   )

--- a/apps/cowswap-frontend/src/modules/bridge/pure/ProgressDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/ProgressDetails/index.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react'
 
+import { COW_PROTOCOL_NAME } from '../../constants'
 import { DividerHorizontal } from '../../styles'
 import { SwapAndBridgeStatus, SwapAndBridgeContext } from '../../types'
 import { BridgeDetailsContainer } from '../BridgeDetailsContainer'
@@ -37,7 +38,7 @@ function SwapStep({ context }: SwapStepProps): ReactNode {
       protocolIconShowOnly="first"
       protocolIconSize={21}
       titlePrefix={SwapStatusTitlePrefixes[swapStatus]}
-      protocolName="CoW Protocol"
+      protocolName={COW_PROTOCOL_NAME}
       bridgeProvider={bridgeProvider}
       chainName={sourceChainName}
       sellAmount={sourceAmounts.sellAmount}

--- a/apps/cowswap-frontend/src/modules/bridge/pure/QuoteDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/QuoteDetails/index.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react'
 
 import { BridgeProviderInfo } from '@cowprotocol/cow-sdk'
 
+import { COW_PROTOCOL_NAME } from '../../constants'
 import { DividerHorizontal } from '../../styles'
 import { QuoteBridgeContext, QuoteSwapContext, SwapAndBridgeStatus } from '../../types'
 import { BridgeDetailsContainer } from '../BridgeDetailsContainer'
@@ -46,7 +47,7 @@ function SwapStep({ stepsCollapsible, bridgeProvider, swapContext }: SwapStepPro
       protocolIconShowOnly="first"
       protocolIconSize={21}
       titlePrefix={SwapStatusTitlePrefixes[status]}
-      protocolName="CoW Protocol"
+      protocolName={COW_PROTOCOL_NAME}
       bridgeProvider={bridgeProvider}
       chainName={swapContext.chainName}
       sellAmount={swapContext.sellAmount}

--- a/apps/cowswap-frontend/src/modules/bridge/pure/RouteOverviewTitle/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/RouteOverviewTitle/index.tsx
@@ -7,6 +7,7 @@ import { ToggleArrow } from 'common/pure/ToggleArrow'
 
 import { ClickableRouteHeader, CollapsibleStopsInfo, RouteHeader, RouteTitle, StopsInfo } from './styled'
 
+import { BRIDGE_DISCLAIMER_TOOLTIP_CONTENT } from '../../constants'
 import { ProtocolIcons } from '../ProtocolIcons'
 
 interface RouteOverviewTitleProps {
@@ -35,7 +36,7 @@ export function RouteOverviewTitle({
               via <b>{providerInfo.name} (Stop 2)</b>.
               <br />
               <br />
-              Bridging features are exclusively operated by third parties. Please review their terms.
+              {BRIDGE_DISCLAIMER_TOOLTIP_CONTENT}
             </>
           }
           size={14}

--- a/apps/cowswap-frontend/src/modules/bridge/pure/RouteOverviewTitle/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/RouteOverviewTitle/index.tsx
@@ -7,7 +7,7 @@ import { ToggleArrow } from 'common/pure/ToggleArrow'
 
 import { ClickableRouteHeader, CollapsibleStopsInfo, RouteHeader, RouteTitle, StopsInfo } from './styled'
 
-import { BRIDGE_DISCLAIMER_TOOLTIP_CONTENT } from '../../constants'
+import { BRIDGE_DISCLAIMER_TOOLTIP_CONTENT, COW_PROTOCOL_NAME } from '../../constants'
 import { ProtocolIcons } from '../ProtocolIcons'
 
 interface RouteOverviewTitleProps {
@@ -32,7 +32,7 @@ export function RouteOverviewTitle({
         <InfoTooltip
           content={
             <>
-              Your trade will be executed in 2 stops. First, you swap on <b>CoW Protocol (Stop 1)</b>, then you bridge
+              Your trade will be executed in 2 stops. First, you swap on <b>{COW_PROTOCOL_NAME} (Stop 1)</b>, then you bridge
               via <b>{providerInfo.name} (Stop 2)</b>.
               <br />
               <br />

--- a/apps/cowswap-frontend/src/modules/bridge/pure/RouteOverviewTitle/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/RouteOverviewTitle/index.tsx
@@ -33,6 +33,9 @@ export function RouteOverviewTitle({
             <>
               Your trade will be executed in 2 stops. First, you swap on <b>CoW Protocol (Stop 1)</b>, then you bridge
               via <b>{providerInfo.name} (Stop 2)</b>.
+              <br />
+              <br />
+              Bridging features are exclusively operated by third parties. Please review their terms.
             </>
           }
           size={14}


### PR DESCRIPTION
# Summary

  Adds disclaimer tooltips to bridge provider names in Stop 2 titles, informing users that bridging features are operated by third parties.

<img width="605" height="847" alt="Screenshot 2025-07-14 at 18 03 39" src="https://github.com/user-attachments/assets/a9f194cd-3182-45ec-8320-98deeeefec7d" />

 
<img width="583" height="444" alt="Screenshot 2025-07-14 at 17 43 41" src="https://github.com/user-attachments/assets/f98baad0-6718-4f9a-887e-f00f3941d7cf" />


  # To Test

  1. Navigate to the swap interface and select tokens from different networks to trigger bridging

  - [ ] Hover over the route info icon in the trade details
  - [ ] Verify the tooltip displays the disclaimer: "Bridging features are exclusively operated by third parties. Please review their terms."
  - [ ] Confirm the disclaimer appears after the existing route explanation text with proper spacing

  2. Open the bridge activity modal or progress details to see Step 2 (Bridge) section

  - [ ] Locate the bridge provider name (e.g., "Across", "Bungee") in the Stop 2 title
  - [ ] Hover over the info icon next to the bridge provider name
  - [ ] Verify the tooltip displays: "Bridging feature is exclusively operated by the indicated third party. Please review their terms."
  - [ ] Confirm the tooltip does NOT appear next to "CoW Protocol" in Step 1 (Swap)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added informational tooltips with a disclaimer message next to protocol names in bridge-related components, enhancing user awareness about third-party operations.

* **Refactor**
  * Replaced hardcoded protocol names with a centralized constant across multiple bridge components for consistency.
  * Updated tooltip content to include a standardized disclaimer and dynamic protocol name display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->