### PR TITLE
fix(bridge): correctly render rate line item

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/index.tsx
@@ -23,12 +23,12 @@ import {
   useReceiveAmountInfo,
   useTradeConfirmActions,
 } from 'modules/trade'
+import { StyledRateInfo } from 'modules/trade/containers/TradeTotalCostsDetails/styled'
 import { useTradeQuote } from 'modules/tradeQuote'
 import { HighFeeWarning, RowDeadline } from 'modules/tradeWidgetAddons'
 
 import { useRateInfoParams } from 'common/hooks/useRateInfoParams'
 import { CurrencyPreviewInfo } from 'common/pure/CurrencyAmountPreview'
-import { RateInfo } from 'common/pure/RateInfo'
 
 import { useLabelsAndTooltips } from './useLabelsAndTooltips'
 
@@ -131,7 +131,7 @@ export function SwapConfirmModal(props: SwapConfirmModalProps): ReactNode {
         {shouldDisplayBridgeDetails && bridgeProvider && swapContext && bridgeContext
           ? (restContent) => (
               <>
-                <RateInfo label="Price" rateInfoParams={rateInfoParams} />
+                <StyledRateInfo label="Price" rateInfoParams={rateInfoParams} />
                 <QuoteDetails
                   isCollapsible
                   bridgeProvider={bridgeProvider}


### PR DESCRIPTION
 # Summary

  Fix font size inconsistency in swap + bridge confirmation dialog
<img width="533" height="442" alt="Screenshot 2025-07-15 at 11 15 42" src="https://github.com/user-attachments/assets/5674122d-1d0c-467b-8b16-33016e889779" />

  # To Test

  1. Open swap + bridge flow

  - [ ] Verify "Price" text in confirmation dialog matches regular swap font size (13px)
  - [ ] Confirm consistent styling between swap and swap + bridge dialogs

  # Background

  Swap + bridge used unstyled `RateInfo` while regular swap used `StyledRateInfo` with 13px font