### PR TITLE
fix(bridge): show solver name and logo for swap and bridge

### DIFF
--- a/apps/cowswap-frontend/src/modules/orderProgressBar/hooks/useOrderProgressBarProps.ts
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/hooks/useOrderProgressBarProps.ts
@@ -158,7 +158,7 @@ function useOrderBaseProgressBarProps(params: UseOrderProgressBarPropsParams): U
 
   const doNotQuery = getDoNotQueryStatusEndpoint(order, apiSolverCompetition, !!disableProgressBar)
 
-  const winnerSolver = apiSolverCompetition?.[0]
+  const winnerSolver = apiSolverCompetition?.[0] ? mergeSolverData(apiSolverCompetition[0], solversInfo) : undefined
   const swapAndBridgeContext = useSwapAndBridgeContext(
     chainId,
     isBridgingTrade ? order : undefined,


### PR DESCRIPTION
# Summary

  Fix winning solver display showing raw API names instead of human-friendly labels for
  swap+bridge orders.
<img width="541" height="644" alt="Screenshot 2025-07-15 at 11 31 14" src="https://github.com/user-attachments/assets/75280aab-2311-4ed4-bac8-d5a23d3a5cb8" />
<img width="511" height="749" alt="Screenshot 2025-07-15 at 11 30 17" src="https://github.com/user-attachments/assets/e4a14cee-a4b7-4106-bf8b-d8e30836a48b" />

  Before: Shows "zeroex-solve"
  After: Shows "0x" with proper logo

  # To Test

  1. Create a swap+bridge order and let it execute

  - [ ] Verify winning solver shows display name (e.g., "0x" not "zeroex-solve")
  - [ ] Verify solver logo displays correctly
  - [ ] Verify behavior matches regular swap orders

  # Background

  Bridge orders weren't applying the same `mergeSolverData` transformation that regular
  swap orders use to convert raw API solver IDs to CMS display names and logos.