### PR TITLE
feat(bridge): add explorer URL to swap and bridge context

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useSwapAndBridgeContext.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useSwapAndBridgeContext.ts
@@ -140,6 +140,7 @@ export function useSwapAndBridgeContext(
         overview: swapAndBridgeOverview,
         bridgeProvider,
         swapResultContext,
+        explorerUrl: crossChainOrder?.explorerUrl,
       }
     }
 
@@ -175,6 +176,7 @@ export function useSwapAndBridgeContext(
       bridgingProgressContext,
       swapResultContext,
       statusResult: crossChainOrder.statusResult,
+      explorerUrl: crossChainOrder.explorerUrl,
     }
   }, [
     order,

--- a/apps/cowswap-frontend/src/modules/bridge/pure/BridgeActivitySummary/BridgeStepRow.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/BridgeActivitySummary/BridgeStepRow.tsx
@@ -51,7 +51,6 @@ export function BridgeStepRow({ context }: BridgeStepRowProps): ReactNode {
               progressContext={bridgingProgressContext}
               quoteContext={quoteBridgeContext}
               explorerUrl={explorerUrl}
-              bridgeProvider={bridgeProvider}
             />
           ) : (
             <PreparingBridgingContent overview={context.overview} />

--- a/apps/cowswap-frontend/src/modules/bridge/pure/BridgeActivitySummary/BridgeStepRow.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/BridgeActivitySummary/BridgeStepRow.tsx
@@ -20,6 +20,7 @@ export function BridgeStepRow({ context }: BridgeStepRowProps): ReactNode {
     bridgingProgressContext,
     quoteBridgeContext,
     statusResult,
+    explorerUrl,
   } = context
 
   const bridgeStatus = bridgingStatus === SwapAndBridgeStatus.DEFAULT ? SwapAndBridgeStatus.PENDING : bridgingStatus
@@ -42,12 +43,15 @@ export function BridgeStepRow({ context }: BridgeStepRowProps): ReactNode {
           chainName={targetChainName}
           sellAmount={targetAmounts?.sellAmount}
           buyAmount={targetAmounts?.buyAmount}
+          explorerUrl={explorerUrl}
         >
           {bridgingProgressContext && quoteBridgeContext ? (
             <BridgingProgressContent
               statusResult={statusResult}
               progressContext={bridgingProgressContext}
               quoteContext={quoteBridgeContext}
+              explorerUrl={explorerUrl}
+              bridgeProvider={bridgeProvider}
             />
           ) : (
             <PreparingBridgingContent overview={context.overview} />

--- a/apps/cowswap-frontend/src/modules/bridge/pure/BridgeDetailsContainer/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/BridgeDetailsContainer/index.tsx
@@ -5,13 +5,7 @@ import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
 
 import { ToggleArrow } from 'common/pure/ToggleArrow'
 
-import {
-  ClickableStopTitle,
-  SectionContent,
-  StopTitle as BaseStopTitle,
-  ExplorerLink,
-  ToggleIconContainer,
-} from '../../styles'
+import { ClickableStopTitle, SectionContent, StopTitle as BaseStopTitle, ToggleIconContainer } from '../../styles'
 import { SwapAndBridgeStatus } from '../../types'
 import { BridgeRouteTitle } from '../BridgeRouteTitle'
 import { RouteTitle } from '../RouteTitle'
@@ -96,23 +90,9 @@ interface TitleActionsComponentProps {
   isExpanded?: boolean
 }
 
-function TitleActionsComponent({
-  explorerUrl,
-  isCollapsible = false,
-  isExpanded = false,
-}: TitleActionsComponentProps): ReactNode {
+function TitleActionsComponent({ isCollapsible = false, isExpanded = false }: TitleActionsComponentProps): ReactNode {
   return (
     <>
-      {explorerUrl && (
-        <ExplorerLink
-          href={explorerUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="View transaction details on explorer (opens in new tab)"
-        >
-          View details <span aria-hidden="true">↗</span>
-        </ExplorerLink>
-      )}
       {isCollapsible && (
         <ToggleIconContainer>
           <ToggleArrow isOpen={isExpanded} />

--- a/apps/cowswap-frontend/src/modules/bridge/pure/BridgeTransactionLink/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/BridgeTransactionLink/index.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from 'react'
+
+import { useMediaQuery } from '@cowprotocol/common-hooks'
+import { Media } from '@cowprotocol/ui'
+
+import { TransactionLinkDisplay } from '../TransactionLink/TransactionLinkDisplay'
+
+function getBridgeTransactionLinkText(isMobile: boolean): string {
+  return isMobile ? 'Bridge explorer ↗' : 'View on bridge explorer ↗'
+}
+
+interface BridgeTransactionLinkProps {
+  link: string
+  label: string
+}
+
+export function BridgeTransactionLink({ link, label }: BridgeTransactionLinkProps): ReactNode {
+  const isMobile = useMediaQuery(Media.upToSmall(false))
+  const linkText = getBridgeTransactionLinkText(isMobile)
+
+  return <TransactionLinkDisplay link={link} label={label} linkText={linkText} />
+}

--- a/apps/cowswap-frontend/src/modules/bridge/pure/ProgressDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/ProgressDetails/index.tsx
@@ -74,7 +74,6 @@ function BridgeStep({ context, bridgeStatus }: BridgeStepProps): ReactNode {
           progressContext={bridgingProgressContext}
           quoteContext={quoteBridgeContext}
           explorerUrl={explorerUrl}
-          bridgeProvider={bridgeProvider}
         />
       ) : (
         <PreparingBridgingContent overview={overview} />

--- a/apps/cowswap-frontend/src/modules/bridge/pure/ProgressDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/ProgressDetails/index.tsx
@@ -50,7 +50,7 @@ function SwapStep({ context }: SwapStepProps): ReactNode {
 }
 
 function BridgeStep({ context, bridgeStatus }: BridgeStepProps): ReactNode {
-  const { bridgeProvider, overview, quoteBridgeContext, bridgingProgressContext, statusResult } = context
+  const { bridgeProvider, overview, quoteBridgeContext, bridgingProgressContext, statusResult, explorerUrl } = context
   const { targetAmounts, targetChainName } = overview
 
   return (
@@ -66,12 +66,15 @@ function BridgeStep({ context, bridgeStatus }: BridgeStepProps): ReactNode {
       chainName={targetChainName}
       sellAmount={targetAmounts?.sellAmount}
       buyAmount={targetAmounts?.buyAmount}
+      explorerUrl={explorerUrl}
     >
       {bridgingProgressContext && quoteBridgeContext ? (
         <BridgingProgressContent
           statusResult={statusResult}
           progressContext={bridgingProgressContext}
           quoteContext={quoteBridgeContext}
+          explorerUrl={explorerUrl}
+          bridgeProvider={bridgeProvider}
         />
       ) : (
         <PreparingBridgingContent overview={overview} />

--- a/apps/cowswap-frontend/src/modules/bridge/pure/TransactionLink/TransactionLinkDisplay.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/TransactionLink/TransactionLinkDisplay.tsx
@@ -1,0 +1,31 @@
+import { ReactNode } from 'react'
+
+import ReceiptIcon from '@cowprotocol/assets/cow-swap/icon-receipt.svg'
+import { ExternalLink } from '@cowprotocol/ui'
+
+import { ConfirmDetailsItem } from 'modules/trade'
+
+import { StyledTimelineReceiptIcon, TimelineIconCircleWrapper } from '../../styles'
+
+interface TransactionLinkDisplayProps {
+  link: string
+  label: string
+  linkText: string
+}
+
+export function TransactionLinkDisplay({ link, label, linkText }: TransactionLinkDisplayProps): ReactNode {
+  return (
+    <ConfirmDetailsItem
+      label={
+        <>
+          <TimelineIconCircleWrapper padding="0" bgColor={'transparent'}>
+            <StyledTimelineReceiptIcon src={ReceiptIcon} />
+          </TimelineIconCircleWrapper>{' '}
+          {label}
+        </>
+      }
+    >
+      <ExternalLink href={link}>{linkText}</ExternalLink>
+    </ConfirmDetailsItem>
+  )
+}

--- a/apps/cowswap-frontend/src/modules/bridge/pure/TransactionLink/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/TransactionLink/index.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from 'react'
 import ReceiptIcon from '@cowprotocol/assets/cow-swap/icon-receipt.svg'
 import { getChainInfo } from '@cowprotocol/common-const'
 import { useMediaQuery } from '@cowprotocol/common-hooks'
+import { BridgeProviderInfo } from '@cowprotocol/cow-sdk'
 import { ExternalLink, Media } from '@cowprotocol/ui'
 
 import { useBridgeSupportedNetworks } from 'entities/bridgeProvider'
@@ -11,18 +12,37 @@ import { ConfirmDetailsItem } from 'modules/trade'
 
 import { StyledTimelineReceiptIcon, TimelineIconCircleWrapper } from '../../styles'
 
+function getTransactionLinkText(
+  bridgeProvider: BridgeProviderInfo | undefined,
+  label: string,
+  explorerTitle: string,
+  isMobile: boolean,
+): string {
+  const isBridgeTransaction = label === 'Bridge transaction'
+
+  return bridgeProvider || isBridgeTransaction
+    ? isMobile
+      ? 'Bridge explorer ↗'
+      : 'View on bridge explorer ↗'
+    : isMobile
+      ? `${explorerTitle} ↗`
+      : `View on ${explorerTitle} ↗`
+}
+
 interface TransactionLinkItemProps {
   link: string
   label: string
   chainId: number
+  bridgeProvider?: BridgeProviderInfo
 }
 
-export function TransactionLinkItem({ link, label, chainId }: TransactionLinkItemProps): ReactNode {
+export function TransactionLinkItem({ link, label, chainId, bridgeProvider }: TransactionLinkItemProps): ReactNode {
   const { data: bridgeSupportedNetworks } = useBridgeSupportedNetworks()
   const bridgeNetwork = bridgeSupportedNetworks?.find((network) => network.id === chainId)
   const isMobile = useMediaQuery(Media.upToSmall(false))
 
   const explorerTitle = bridgeNetwork?.blockExplorer.name || getChainInfo(chainId)?.explorerTitle || 'Explorer'
+  const linkText = getTransactionLinkText(bridgeProvider, label, explorerTitle, isMobile)
 
   return (
     <ConfirmDetailsItem
@@ -35,7 +55,7 @@ export function TransactionLinkItem({ link, label, chainId }: TransactionLinkIte
         </>
       }
     >
-      <ExternalLink href={link}>{isMobile ? `${explorerTitle} ↗` : `View on ${explorerTitle} ↗`}</ExternalLink>
+      <ExternalLink href={link}>{linkText}</ExternalLink>
     </ConfirmDetailsItem>
   )
 }

--- a/apps/cowswap-frontend/src/modules/bridge/pure/TransactionLink/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/TransactionLink/index.tsx
@@ -14,12 +14,10 @@ import { StyledTimelineReceiptIcon, TimelineIconCircleWrapper } from '../../styl
 
 function getTransactionLinkText(
   bridgeProvider: BridgeProviderInfo | undefined,
-  label: string,
+  isBridgeTransaction: boolean,
   explorerTitle: string,
   isMobile: boolean,
 ): string {
-  const isBridgeTransaction = label === 'Bridge transaction'
-
   return bridgeProvider || isBridgeTransaction
     ? isMobile
       ? 'Bridge explorer ↗'
@@ -34,15 +32,16 @@ interface TransactionLinkItemProps {
   label: string
   chainId: number
   bridgeProvider?: BridgeProviderInfo
+  isBridgeTransaction?: boolean
 }
 
-export function TransactionLinkItem({ link, label, chainId, bridgeProvider }: TransactionLinkItemProps): ReactNode {
+export function TransactionLinkItem({ link, label, chainId, bridgeProvider, isBridgeTransaction = false }: TransactionLinkItemProps): ReactNode {
   const { data: bridgeSupportedNetworks } = useBridgeSupportedNetworks()
   const bridgeNetwork = bridgeSupportedNetworks?.find((network) => network.id === chainId)
   const isMobile = useMediaQuery(Media.upToSmall(false))
 
   const explorerTitle = bridgeNetwork?.blockExplorer.name || getChainInfo(chainId)?.explorerTitle || 'Explorer'
-  const linkText = getTransactionLinkText(bridgeProvider, label, explorerTitle, isMobile)
+  const linkText = getTransactionLinkText(bridgeProvider, isBridgeTransaction, explorerTitle, isMobile)
 
   return (
     <ConfirmDetailsItem

--- a/apps/cowswap-frontend/src/modules/bridge/pure/TransactionLink/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/TransactionLink/index.tsx
@@ -1,60 +1,30 @@
 import { ReactNode } from 'react'
 
-import ReceiptIcon from '@cowprotocol/assets/cow-swap/icon-receipt.svg'
 import { getChainInfo } from '@cowprotocol/common-const'
 import { useMediaQuery } from '@cowprotocol/common-hooks'
-import { BridgeProviderInfo } from '@cowprotocol/cow-sdk'
-import { ExternalLink, Media } from '@cowprotocol/ui'
+import { Media } from '@cowprotocol/ui'
 
 import { useBridgeSupportedNetworks } from 'entities/bridgeProvider'
 
-import { ConfirmDetailsItem } from 'modules/trade'
+import { TransactionLinkDisplay } from './TransactionLinkDisplay'
 
-import { StyledTimelineReceiptIcon, TimelineIconCircleWrapper } from '../../styles'
-
-function getTransactionLinkText(
-  bridgeProvider: BridgeProviderInfo | undefined,
-  isBridgeTransaction: boolean,
-  explorerTitle: string,
-  isMobile: boolean,
-): string {
-  return bridgeProvider || isBridgeTransaction
-    ? isMobile
-      ? 'Bridge explorer ↗'
-      : 'View on bridge explorer ↗'
-    : isMobile
-      ? `${explorerTitle} ↗`
-      : `View on ${explorerTitle} ↗`
+function getChainTransactionLinkText(explorerTitle: string, isMobile: boolean): string {
+  return isMobile ? `${explorerTitle} ↗` : `View on ${explorerTitle} ↗`
 }
 
 interface TransactionLinkItemProps {
   link: string
   label: string
   chainId: number
-  bridgeProvider?: BridgeProviderInfo
-  isBridgeTransaction?: boolean
 }
 
-export function TransactionLinkItem({ link, label, chainId, bridgeProvider, isBridgeTransaction = false }: TransactionLinkItemProps): ReactNode {
+export function TransactionLinkItem({ link, label, chainId }: TransactionLinkItemProps): ReactNode {
   const { data: bridgeSupportedNetworks } = useBridgeSupportedNetworks()
   const bridgeNetwork = bridgeSupportedNetworks?.find((network) => network.id === chainId)
   const isMobile = useMediaQuery(Media.upToSmall(false))
 
   const explorerTitle = bridgeNetwork?.blockExplorer.name || getChainInfo(chainId)?.explorerTitle || 'Explorer'
-  const linkText = getTransactionLinkText(bridgeProvider, isBridgeTransaction, explorerTitle, isMobile)
+  const linkText = getChainTransactionLinkText(explorerTitle, isMobile)
 
-  return (
-    <ConfirmDetailsItem
-      label={
-        <>
-          <TimelineIconCircleWrapper padding="0" bgColor={'transparent'}>
-            <StyledTimelineReceiptIcon src={ReceiptIcon} />
-          </TimelineIconCircleWrapper>{' '}
-          {label}
-        </>
-      }
-    >
-      <ExternalLink href={link}>{linkText}</ExternalLink>
-    </ConfirmDetailsItem>
-  )
+  return <TransactionLinkDisplay link={link} label={label} linkText={linkText} />
 }

--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/PendingBridgingContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/PendingBridgingContent/index.tsx
@@ -1,26 +1,24 @@
 import { ReactNode } from 'react'
 
-import { BridgeStatusResult, SupportedChainId, BridgeProviderInfo } from '@cowprotocol/cow-sdk'
+import { BridgeStatusResult, SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import { ConfirmDetailsItem, ReceiveAmountTitle } from 'modules/trade'
 
 import { AnimatedEllipsis, StatusAwareText } from '../../../../styles'
 import { SwapAndBridgeStatus } from '../../../../types'
+import { BridgeTransactionLink } from '../../../BridgeTransactionLink'
 import { DepositTxLink } from '../../../DepositTxLink'
-import { TransactionLinkItem } from '../../../TransactionLink'
 
 interface PendingBridgingContentProps {
   sourceChainId: SupportedChainId
   statusResult?: BridgeStatusResult
   explorerUrl?: string
-  bridgeProvider?: BridgeProviderInfo
 }
 
 export function PendingBridgingContent({
   sourceChainId,
   statusResult,
   explorerUrl,
-  bridgeProvider,
 }: PendingBridgingContentProps): ReactNode {
   const { depositTxHash } = statusResult || {}
 
@@ -42,7 +40,7 @@ export function PendingBridgingContent({
       </ConfirmDetailsItem>
       
       {explorerUrl ? (
-        <TransactionLinkItem link={explorerUrl} label="Bridge transaction" chainId={0} bridgeProvider={bridgeProvider} isBridgeTransaction />
+        <BridgeTransactionLink link={explorerUrl} label="Bridge transaction" />
       ) : (
         <DepositTxLink depositTxHash={depositTxHash} sourceChainId={sourceChainId} />
       )}

--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/PendingBridgingContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/PendingBridgingContent/index.tsx
@@ -42,7 +42,7 @@ export function PendingBridgingContent({
       </ConfirmDetailsItem>
       
       {explorerUrl ? (
-        <TransactionLinkItem link={explorerUrl} label="Bridge transaction" chainId={0} bridgeProvider={bridgeProvider} />
+        <TransactionLinkItem link={explorerUrl} label="Bridge transaction" chainId={0} bridgeProvider={bridgeProvider} isBridgeTransaction />
       ) : (
         <DepositTxLink depositTxHash={depositTxHash} sourceChainId={sourceChainId} />
       )}

--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/PendingBridgingContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/PendingBridgingContent/index.tsx
@@ -1,19 +1,27 @@
 import { ReactNode } from 'react'
 
-import { BridgeStatusResult, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { BridgeStatusResult, SupportedChainId, BridgeProviderInfo } from '@cowprotocol/cow-sdk'
 
 import { ConfirmDetailsItem, ReceiveAmountTitle } from 'modules/trade'
 
 import { AnimatedEllipsis, StatusAwareText } from '../../../../styles'
 import { SwapAndBridgeStatus } from '../../../../types'
 import { DepositTxLink } from '../../../DepositTxLink'
+import { TransactionLinkItem } from '../../../TransactionLink'
 
 interface PendingBridgingContentProps {
   sourceChainId: SupportedChainId
   statusResult?: BridgeStatusResult
+  explorerUrl?: string
+  bridgeProvider?: BridgeProviderInfo
 }
 
-export function PendingBridgingContent({ sourceChainId, statusResult }: PendingBridgingContentProps): ReactNode {
+export function PendingBridgingContent({
+  sourceChainId,
+  statusResult,
+  explorerUrl,
+  bridgeProvider,
+}: PendingBridgingContentProps): ReactNode {
   const { depositTxHash } = statusResult || {}
 
   return (
@@ -32,8 +40,12 @@ export function PendingBridgingContent({ sourceChainId, statusResult }: PendingB
           </StatusAwareText>
         </b>
       </ConfirmDetailsItem>
-
-      <DepositTxLink depositTxHash={depositTxHash} sourceChainId={sourceChainId} />
+      
+      {explorerUrl ? (
+        <TransactionLinkItem link={explorerUrl} label="Bridge transaction" chainId={0} bridgeProvider={bridgeProvider} />
+      ) : (
+        <DepositTxLink depositTxHash={depositTxHash} sourceChainId={sourceChainId} />
+      )}
     </>
   )
 }

--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/ReceivedBridgingContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/ReceivedBridgingContent/index.tsx
@@ -64,6 +64,7 @@ export function ReceivedBridgingContent({
           label="Bridge transaction"
           chainId={0}
           bridgeProvider={bridgeProvider}
+          isBridgeTransaction
         />
       ) : (
         <>

--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/ReceivedBridgingContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/ReceivedBridgingContent/index.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react'
 
 import { getChainInfo } from '@cowprotocol/common-const'
 import { ExplorerDataType, getExplorerLink } from '@cowprotocol/common-utils'
-import { BridgeStatusResult, SupportedChainId, BridgeProviderInfo } from '@cowprotocol/cow-sdk'
+import { BridgeStatusResult, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
 
 import { useBridgeSupportedNetworks } from 'entities/bridgeProvider'
@@ -10,6 +10,7 @@ import { useBridgeSupportedNetworks } from 'entities/bridgeProvider'
 import { ConfirmDetailsItem, ReceiveAmountTitle } from 'modules/trade'
 
 import { SuccessTextBold } from '../../../../styles'
+import { BridgeTransactionLink } from '../../../BridgeTransactionLink'
 import { DepositTxLink } from '../../../DepositTxLink'
 import { TokenAmountDisplay } from '../../../TokenAmountDisplay'
 import { TransactionLinkItem } from '../../../TransactionLink'
@@ -21,7 +22,6 @@ interface ReceivedBridgingContentProps {
   receivedAmount: CurrencyAmount<Currency>
   receivedAmountUsd: CurrencyAmount<Token> | null | undefined
   explorerUrl?: string
-  bridgeProvider?: BridgeProviderInfo
 }
 
 export function ReceivedBridgingContent({
@@ -31,7 +31,6 @@ export function ReceivedBridgingContent({
   sourceChainId,
   destinationChainId,
   explorerUrl,
-  bridgeProvider,
 }: ReceivedBridgingContentProps): ReactNode {
   const { depositTxHash, fillTxHash } = statusResult || {}
   const { data: bridgeSupportedNetworks } = useBridgeSupportedNetworks()
@@ -59,12 +58,9 @@ export function ReceivedBridgingContent({
       </ConfirmDetailsItem>
 
       {explorerUrl ? (
-        <TransactionLinkItem
+        <BridgeTransactionLink
           link={explorerUrl}
           label="Bridge transaction"
-          chainId={0}
-          bridgeProvider={bridgeProvider}
-          isBridgeTransaction
         />
       ) : (
         <>

--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/ReceivedBridgingContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/ReceivedBridgingContent/index.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react'
 
 import { getChainInfo } from '@cowprotocol/common-const'
 import { ExplorerDataType, getExplorerLink } from '@cowprotocol/common-utils'
-import { BridgeStatusResult, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { BridgeStatusResult, SupportedChainId, BridgeProviderInfo } from '@cowprotocol/cow-sdk'
 import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
 
 import { useBridgeSupportedNetworks } from 'entities/bridgeProvider'
@@ -20,6 +20,8 @@ interface ReceivedBridgingContentProps {
   destinationChainId: number
   receivedAmount: CurrencyAmount<Currency>
   receivedAmountUsd: CurrencyAmount<Token> | null | undefined
+  explorerUrl?: string
+  bridgeProvider?: BridgeProviderInfo
 }
 
 export function ReceivedBridgingContent({
@@ -28,6 +30,8 @@ export function ReceivedBridgingContent({
   receivedAmount,
   sourceChainId,
   destinationChainId,
+  explorerUrl,
+  bridgeProvider,
 }: ReceivedBridgingContentProps): ReactNode {
   const { depositTxHash, fillTxHash } = statusResult || {}
   const { data: bridgeSupportedNetworks } = useBridgeSupportedNetworks()
@@ -54,9 +58,20 @@ export function ReceivedBridgingContent({
         </b>
       </ConfirmDetailsItem>
 
-      <DepositTxLink depositTxHash={depositTxHash} sourceChainId={sourceChainId} />
-      {fillTxLink && (
-        <TransactionLinkItem link={fillTxLink} label="Destination transaction" chainId={destinationChainId} />
+      {explorerUrl ? (
+        <TransactionLinkItem
+          link={explorerUrl}
+          label="Bridge transaction"
+          chainId={0}
+          bridgeProvider={bridgeProvider}
+        />
+      ) : (
+        <>
+          <DepositTxLink depositTxHash={depositTxHash} sourceChainId={sourceChainId} />
+          {fillTxLink && (
+            <TransactionLinkItem link={fillTxLink} label="Destination transaction" chainId={destinationChainId} />
+          )}
+        </>
       )}
     </>
   )

--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/index.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-import { BridgeStatusResult, BridgeProviderInfo } from '@cowprotocol/cow-sdk'
+import { BridgeStatusResult } from '@cowprotocol/cow-sdk'
 
 import { FailedBridgingContent } from './FailedBridgingContent'
 import { PendingBridgingContent } from './PendingBridgingContent'
@@ -14,7 +14,6 @@ interface BridgingContentProps extends QuoteBridgeContentProps {
   progressContext: BridgingProgressContext
   statusResult?: BridgeStatusResult
   explorerUrl?: string
-  bridgeProvider?: BridgeProviderInfo
 }
 
 export function BridgingProgressContent(props: BridgingContentProps): ReactNode {
@@ -31,7 +30,6 @@ export function BridgingProgressContent(props: BridgingContentProps): ReactNode 
     quoteContext,
     statusResult,
     explorerUrl,
-    bridgeProvider,
   } = props
 
 
@@ -45,14 +43,13 @@ export function BridgingProgressContent(props: BridgingContentProps): ReactNode 
           receivedAmount={receivedAmount}
           receivedAmountUsd={receivedAmountUsd}
           explorerUrl={explorerUrl}
-          bridgeProvider={bridgeProvider}
         />
       ) : isRefunded ? (
         <RefundedBridgingContent account={account} bridgeSendCurrencyAmount={quoteContext.sellAmount} />
       ) : isFailed ? (
         <FailedBridgingContent />
       ) : (
-        <PendingBridgingContent sourceChainId={sourceChainId} statusResult={statusResult} explorerUrl={explorerUrl} bridgeProvider={bridgeProvider} />
+        <PendingBridgingContent sourceChainId={sourceChainId} statusResult={statusResult} explorerUrl={explorerUrl} />
       )}
     </QuoteBridgeContent>
   )

--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/index.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-import { BridgeStatusResult } from '@cowprotocol/cow-sdk'
+import { BridgeStatusResult, BridgeProviderInfo } from '@cowprotocol/cow-sdk'
 
 import { FailedBridgingContent } from './FailedBridgingContent'
 import { PendingBridgingContent } from './PendingBridgingContent'
@@ -13,6 +13,8 @@ import { QuoteBridgeContent, QuoteBridgeContentProps } from '../QuoteBridgeConte
 interface BridgingContentProps extends QuoteBridgeContentProps {
   progressContext: BridgingProgressContext
   statusResult?: BridgeStatusResult
+  explorerUrl?: string
+  bridgeProvider?: BridgeProviderInfo
 }
 
 export function BridgingProgressContent(props: BridgingContentProps): ReactNode {
@@ -28,7 +30,10 @@ export function BridgingProgressContent(props: BridgingContentProps): ReactNode 
     },
     quoteContext,
     statusResult,
+    explorerUrl,
+    bridgeProvider,
   } = props
+
 
   return (
     <QuoteBridgeContent {...props}>
@@ -39,13 +44,15 @@ export function BridgingProgressContent(props: BridgingContentProps): ReactNode 
           destinationChainId={destinationChainId}
           receivedAmount={receivedAmount}
           receivedAmountUsd={receivedAmountUsd}
+          explorerUrl={explorerUrl}
+          bridgeProvider={bridgeProvider}
         />
       ) : isRefunded ? (
         <RefundedBridgingContent account={account} bridgeSendCurrencyAmount={quoteContext.sellAmount} />
       ) : isFailed ? (
         <FailedBridgingContent />
       ) : (
-        <PendingBridgingContent sourceChainId={sourceChainId} statusResult={statusResult} />
+        <PendingBridgingContent sourceChainId={sourceChainId} statusResult={statusResult} explorerUrl={explorerUrl} bridgeProvider={bridgeProvider} />
       )}
     </QuoteBridgeContent>
   )

--- a/apps/cowswap-frontend/src/modules/bridge/types.ts
+++ b/apps/cowswap-frontend/src/modules/bridge/types.ts
@@ -91,4 +91,5 @@ export interface SwapAndBridgeContext {
   quoteBridgeContext?: QuoteBridgeContext
   bridgingProgressContext?: BridgingProgressContext
   statusResult?: BridgeStatusResult
+  explorerUrl?: string
 }


### PR DESCRIPTION
# Summary

  Added bridge provider transaction link to bridge order activity details with the
  bridge explorer URL (e.g., socketscan.io).
 
<img width="498" height="212" alt="Screenshot 2025-07-15 at 18 24 07" src="https://github.com/user-attachments/assets/870d1da1-b283-41a1-a690-4642c4e4d3a1" />


  # To Test

  1. **View completed bridge orders** in Account → Activity

  - [ ] Bridge orders show "Bridge transaction" link as first line item
  - [ ] Link text shows "View on bridge explorer ↗"
  - [ ] Clicking opens bridge explorer (socketscan.io) in new tab
  - [ ] Uses receipt icon (consistent with other transaction links)

  2. **Verify conditional logic** for different bridge states

  - [ ] When bridge explorer URL exists: only shows "Bridge transaction" link
  - [ ] When bridge explorer URL missing: shows "Source transaction" + "Destination
  transaction" links
  - [ ] Non-bridge orders: no bridge transaction links shown

  # Background

  Bridge orders previously only showed individual source/destination transaction
  links. Users needed a unified view of the entire bridge transaction via the bridge
   provider's explorer. Added bridge transaction URLs with
  proper fallback to individual transaction links when bridge explorer unavailable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying external explorer links related to cross-chain orders in bridge activity and progress views.
  * Introduced a new bridge transaction link component with responsive labeling for better user clarity.

* **Improvements**
  * Enhanced transaction link presentation in bridging status, providing conditional rendering of explorer links for improved navigation experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->