### PR TITLE
feat(bridge): display funds recovering stepper

### DIFF
--- a/apps/cowswap-frontend/src/modules/cowShed/containers/RecoverFundsWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/cowShed/containers/RecoverFundsWidget/index.tsx
@@ -93,7 +93,7 @@ export function RecoverFundsWidget({ defaultToken: defaultTokenToRefund }: Recov
                   {txSigningStep && (
                     <>
                       {txSigningStep === RecoverSigningStep.SIGN_RECOVER_FUNDS && '1/2 Confirm funds recovering'}
-                      {txSigningStep === RecoverSigningStep.SING_TRANSACTION && '2/2 Sign transaction'}
+                      {txSigningStep === RecoverSigningStep.SIGN_TRANSACTION && '2/2 Sign transaction'}
                       <CenteredDots smaller />
                     </>
                   )}

--- a/apps/cowswap-frontend/src/modules/cowShed/hooks/useRecoverFundsFromProxy.ts
+++ b/apps/cowswap-frontend/src/modules/cowShed/hooks/useRecoverFundsFromProxy.ts
@@ -20,7 +20,7 @@ const DEFAULT_GAS_LIMIT = 600_000
 
 export enum RecoverSigningStep {
   SIGN_RECOVER_FUNDS = 'SIGN_RECOVER_FUNDS',
-  SING_TRANSACTION = 'SING_TRANSACTION',
+  SIGN_TRANSACTION = 'SIGN_TRANSACTION',
 }
 
 export interface RecoverFundsContext {
@@ -78,7 +78,7 @@ export function useRecoverFundsFromProxy(
         SigningScheme.EIP712, // TODO: support other signing types
       )
 
-      setTxSigningStep(RecoverSigningStep.SING_TRANSACTION)
+      setTxSigningStep(RecoverSigningStep.SIGN_TRANSACTION)
 
       const transaction = await cowShedContract.executeHooks(calls, nonce, BigInt(validTo), account, encodedSignature, {
         gasLimit: DEFAULT_GAS_LIMIT,


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Add-2-steps-singing-process-to-the-Recover-funds-screen-2298da5f04ca8025a8c9c487924c2cb7?v=1c38da5f04ca812b9489000c81197879&source=copy_link

<img width="506" height="365" alt="image" src="https://github.com/user-attachments/assets/02b70b1c-6a30-4a3a-8b89-0ebfa3b39e90" />

<img width="505" height="358" alt="image" src="https://github.com/user-attachments/assets/fa008c03-ee1e-4ab8-acbb-8d7899ce3f97" />


# To Test

Should correspond to attached screenshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The "Recover funds" button now provides step-by-step feedback during the signing process, displaying specific labels and an animated indicator for each signing stage.
  * Button appearance is improved, including a styled variant and smaller font when disabled.

* **Bug Fixes**
  * The button is now correctly disabled during any signing step or when no balance is available, preventing unintended actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->