### PR TITLE
fix(trade): do not display quote error when loading

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
@@ -63,7 +63,9 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
       validations.push(TradeFormValidation.InputAmountNotSet)
     }
 
-    validations.push(TradeFormValidation.QuoteErrors)
+    if (!tradeQuote.isLoading) {
+      validations.push(TradeFormValidation.QuoteErrors)
+    }
   }
 
   if (!isSwapUnsupported && !account) {


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Hide-previous-error-when-bridge-quote-is-loading-2178da5f04ca804e908bf184c4f7e956?source=copy_link

When quote is loading, we should not display quote error in the form. Loading state should be displayed instead.

# To Test

See https://www.notion.so/cownation/Hide-previous-error-when-bridge-quote-is-loading-2178da5f04ca804e908bf184c4f7e956?source=copy_link
