### PR TITLE
fix(bridge): display custom recipient in activity header

### DIFF
--- a/apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
@@ -390,6 +390,8 @@ export function ActivityDetails(props: {
               {order && isBridgeOrder ? (
                 swapAndBridgeOverview ? (
                   <BridgeActivitySummary
+                    isCustomRecipientWarning={!!isCustomRecipientWarningBannerVisible}
+                    order={order}
                     swapAndBridgeContext={swapAndBridgeContext}
                     swapResultContext={swapResultContext}
                     swapAndBridgeOverview={swapAndBridgeOverview}

--- a/apps/cowswap-frontend/src/modules/bridge/pure/BridgeActivitySummary/BridgeSummaryHeader.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/BridgeActivitySummary/BridgeSummaryHeader.tsx
@@ -1,19 +1,35 @@
 import { ReactNode } from 'react'
 
-import { capitalizeFirstLetter } from '@cowprotocol/common-utils'
+import {
+  areAddressesEqual,
+  capitalizeFirstLetter,
+  ExplorerDataType,
+  getExplorerLink,
+  shortenAddress,
+} from '@cowprotocol/common-utils'
 import { TokenLogo } from '@cowprotocol/tokens'
-import { TokenAmount } from '@cowprotocol/ui'
+import { ExternalLink, Icon, IconType, TokenAmount, UI } from '@cowprotocol/ui'
+
+import type { Order } from 'legacy/state/orders/actions'
 
 import { ShimmerWrapper, SummaryRow } from 'common/pure/OrderSummaryRow'
 
 import { SwapAndBridgeOverview } from '../../types'
 
 interface BridgeSummaryHeaderProps {
+  order: Order
   swapAndBridgeOverview: SwapAndBridgeOverview
+  isCustomRecipientWarning: boolean
 }
 
-export function BridgeSummaryHeader({ swapAndBridgeOverview }: BridgeSummaryHeaderProps): ReactNode {
-  const { sourceAmounts, targetAmounts, sourceChainName, targetChainName } = swapAndBridgeOverview
+export function BridgeSummaryHeader({
+  order,
+  swapAndBridgeOverview,
+  isCustomRecipientWarning,
+}: BridgeSummaryHeaderProps): ReactNode {
+  const { sourceAmounts, targetAmounts, sourceChainName, targetChainName, targetRecipient } = swapAndBridgeOverview
+  const isCustomRecipient = !!targetRecipient && !areAddressesEqual(order.owner, targetRecipient)
+  const targetAmount = targetAmounts?.buyAmount
 
   return (
     <>
@@ -30,10 +46,10 @@ export function BridgeSummaryHeader({ swapAndBridgeOverview }: BridgeSummaryHead
         <b>To at least</b>
 
         <i>
-          {targetAmounts ? (
+          {targetAmount ? (
             <>
-              <TokenLogo token={targetAmounts.buyAmount.currency} size={20} />
-              <TokenAmount amount={targetAmounts.buyAmount} tokenSymbol={targetAmounts.buyAmount.currency} />
+              <TokenLogo token={targetAmount.currency} size={20} />
+              <TokenAmount amount={targetAmount} tokenSymbol={targetAmount.currency} />
             </>
           ) : (
             <ShimmerWrapper />
@@ -41,6 +57,22 @@ export function BridgeSummaryHeader({ swapAndBridgeOverview }: BridgeSummaryHead
           {` on ${capitalizeFirstLetter(targetChainName)}`}
         </i>
       </SummaryRow>
+
+      {isCustomRecipient && targetRecipient && targetAmount && (
+        <SummaryRow>
+          <b>Recipient:</b>
+          <i>
+            {isCustomRecipientWarning && (
+              <Icon image={IconType.ALERT} color={UI.COLOR_ALERT} description="Alert" size={18} />
+            )}
+            <ExternalLink
+              href={getExplorerLink(targetAmount.currency.chainId, targetRecipient, ExplorerDataType.ADDRESS)}
+            >
+              {shortenAddress(targetRecipient)} ↗
+            </ExternalLink>
+          </i>
+        </SummaryRow>
+      )}
     </>
   )
 }

--- a/apps/cowswap-frontend/src/modules/bridge/pure/BridgeActivitySummary/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/BridgeActivitySummary/index.tsx
@@ -1,5 +1,7 @@
 import { ReactNode } from 'react'
 
+import type { Order } from 'legacy/state/orders/actions'
+
 import { ShimmerWrapper, SummaryRow } from 'common/pure/OrderSummaryRow'
 
 import { BridgeStepRow } from './BridgeStepRow'
@@ -9,6 +11,8 @@ import { SwapStepRow } from './SwapStepRow'
 import { SwapAndBridgeContext, SwapAndBridgeOverview, SwapResultContext } from '../../types'
 
 interface BridgeActivitySummaryProps {
+  order: Order
+  isCustomRecipientWarning: boolean
   swapAndBridgeContext: SwapAndBridgeContext | undefined
   swapResultContext: SwapResultContext | undefined
   swapAndBridgeOverview: SwapAndBridgeOverview
@@ -17,11 +21,23 @@ interface BridgeActivitySummaryProps {
 }
 
 export function BridgeActivitySummary(props: BridgeActivitySummaryProps): ReactNode {
-  const { swapAndBridgeContext, swapResultContext, swapAndBridgeOverview, orderBasicDetails, children } = props
+  const {
+    order,
+    swapAndBridgeContext,
+    swapResultContext,
+    swapAndBridgeOverview,
+    orderBasicDetails,
+    children,
+    isCustomRecipientWarning,
+  } = props
 
   return (
     <>
-      <BridgeSummaryHeader swapAndBridgeOverview={swapAndBridgeOverview} />
+      <BridgeSummaryHeader
+        order={order}
+        isCustomRecipientWarning={isCustomRecipientWarning}
+        swapAndBridgeOverview={swapAndBridgeOverview}
+      />
 
       <SwapStepRow
         swapResultContext={swapResultContext}


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Custom-recipient-is-not-displayed-on-the-Open-order-when-swap-in-progress-21e8da5f04ca80d881cfcf59dd8da1ae?v=1c38da5f04ca812b9489000c81197879

1. The recipient should be displayed in the header only when it differs from the order owner
2. There should be (!) exclamation icon before recipient when "Caution: ..." banner is displayed

<img width="829" height="504" alt="image" src="https://github.com/user-attachments/assets/e158bd70-88c2-4c8d-8d6a-abe9884e757e" />

# To Test

See https://www.notion.so/cownation/Custom-recipient-is-not-displayed-on-the-Open-order-when-swap-in-progress-21e8da5f04ca80d881cfcf59dd8da1ae?v=1c38da5f04ca812b9489000c81197879


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible warning banner when a custom recipient address is used in bridge transactions.
  * Displayed the custom recipient address as a shortened external link, including an alert icon when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->