### PR TITLE
fix(bridge): adjust AnimatedEllipsis width

### DIFF
--- a/apps/cowswap-frontend/src/modules/bridge/styles.ts
+++ b/apps/cowswap-frontend/src/modules/bridge/styles.ts
@@ -337,9 +337,10 @@ export const StatusAwareText = styled.span<{ status?: SwapAndBridgeStatus }>`
  */
 export const AnimatedEllipsis = styled.span<{ isVisible?: boolean }>`
   display: inline-block;
-  width: 0.8em;
+  min-width: 1em;
   text-align: left;
   vertical-align: bottom;
+  white-space: nowrap;
 
   &::after {
     content: '.';
@@ -350,6 +351,7 @@ export const AnimatedEllipsis = styled.span<{ isVisible?: boolean }>`
           `
         : 'none'};
     display: inline-block;
+    width: 1em;
   }
 `
 


### PR DESCRIPTION
# Summary

  Fixed animated ellipsis line break issue in bridge progress indicators


https://github.com/user-attachments/assets/377a4964-cd4b-4cb7-9789-64deb7af073a



  # To Test

  1. Go to swap & bridge flow and observe the bridge step

  - [ ] "in progress..." text should not break to new line when third dot appears
  - [ ] Ellipsis animation should display smoothly without layout shifts
  - [ ] Text should scale properly with different font sizes

  # Background

  The `AnimatedEllipsis` component had a fixed width of `0.8em` which was too narrow for 3 dots, causing line breaks. Changed to `1em` with
  `white-space: nowrap` to prevent wrapping while maintaining responsive sizing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the layout and spacing of the animated ellipsis for a more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->