### PR TITLE
fix(bridge): update bridge fee display to use green styling for "FREE"

### DIFF
--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/QuoteBridgeContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/QuoteBridgeContent/index.tsx
@@ -6,6 +6,7 @@ import { InfoTooltip } from '@cowprotocol/ui'
 import { ConfirmDetailsItem, ReceiveAmountTitle } from 'modules/trade'
 import { useUsdAmount } from 'modules/usdAmount'
 
+import { SuccessTextBold } from '../../../styles'
 import { QuoteBridgeContext } from '../../../types'
 import { RecipientDetailsItem } from '../../RecipientDetailsItem'
 import { TokenAmountDisplay } from '../../TokenAmountDisplay'
@@ -42,7 +43,11 @@ export function QuoteBridgeContent({
             </>
           }
         >
-          {bridgeFee.equalTo(0) ? 'FREE' : <TokenAmountDisplay currencyAmount={bridgeFee} usdValue={bridgeFeeUsd} />}
+          {bridgeFee.equalTo(0) ? (
+            <SuccessTextBold>FREE</SuccessTextBold>
+          ) : (
+            <TokenAmountDisplay currencyAmount={bridgeFee} usdValue={bridgeFeeUsd} />
+          )}
         </ConfirmDetailsItem>
       )}
 


### PR DESCRIPTION
# Summary

  Apply success color to "FREE" bridge fee text for better visual hierarchy

<img width="507" height="220" alt="Screenshot 2025-07-16 at 15 45 30" src="https://github.com/user-attachments/assets/6bbfd17b-6857-48cf-b469-df65a9522342" />


  When bridge fee is free, the text now displays in success green color instead of default text color, providing consistent visual feedback with
  other positive states in the bridge UI.

  # To Test

  1. **Navigate to bridge flow** - Go to swap page and select bridge option

  - [ ] Verify bridge fee shows as "FREE" in success green color when no fee applies
  - [ ] Verify bridge fee shows normal TokenAmountDisplay when fee exists
  - [ ] Verify success color matches other positive states in bridge UI

  # Background

  Uses existing `SuccessTextBold` component to maintain consistency with other bridge success states like "You received" and "Refunded to"
  messages.