### PR TITLE
refactor(bridge): enhance progress bar logic for bridge orders

### DIFF
--- a/apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
@@ -205,7 +205,18 @@ export function ActivityDetails(props: {
 
   const { disableProgressBar } = useInjectedWidgetParams()
 
-  const showProgressBar = activityState === 'open' && isSwap && order && !disableProgressBar
+  const skipBridgingDisplay = isExpired || isCancelled || isFailed || isCancelling
+  const isBridgeOrder = getIsBridgeOrder(order) && !skipBridgingDisplay
+
+  // Enhanced activity derived state that incorporates bridge status for bridge orders
+  const enhancedActivityDerivedState = useEnhancedActivityDerivedState(
+    activityDerivedState,
+    chainId,
+  )
+
+  // Use enhanced state to determine when to show progress bar for bridge orders
+  const enhancedActivityState = getActivityState(enhancedActivityDerivedState)
+  const showProgressBar = (enhancedActivityState === 'open' || enhancedActivityState === 'loading') && (isSwap || isBridgeOrder) && order && !disableProgressBar
   const showCancellationModal = order ? getShowCancellationModal(order) : null
 
   const { surplusFiatValue, showFiatValue, surplusToken, surplusAmount } = useGetSurplusData(order)
@@ -216,20 +227,12 @@ export function ActivityDetails(props: {
   const setShowProgressBar = useAddOrderToSurplusQueue() // TODO: not exactly the proper tool, rethink this
   const toggleAccountModal = useToggleAccountModal()
 
-  const skipBridgingDisplay = isExpired || isCancelled || isFailed || isCancelling
   const fullAppData = order?.apiAdditionalInfo?.fullAppData || order?.fullAppData
-  const isBridgeOrder = getIsBridgeOrder(order) && !skipBridgingDisplay
 
   const { swapAndBridgeContext, swapResultContext, swapAndBridgeOverview } = useSwapAndBridgeContext(
     chainId,
     isBridgeOrder ? order : undefined,
     undefined,
-  )
-
-  // Enhanced activity derived state that incorporates bridge status for bridge orders
-  const enhancedActivityDerivedState = useEnhancedActivityDerivedState(
-    activityDerivedState,
-    chainId,
   )
 
   const bridgeOrderData = useBridgeOrderData(order?.id)


### PR DESCRIPTION
# Summary

  Enables "Show progress" link for bridge orders when bridging is still pending


https://github.com/user-attachments/assets/e033c729-14e3-4479-b46e-2e5a219789dd



  Currently, the "Show progress" link only appears for regular swap orders in 'open' state. For bridge orders, even when the swap is complete but bridging is still in progress, the link doesn't appear. This change uses the enhanced activity state to show progress for bridge orders in both 'open' and 'loading' states.

  # To Test

  1. **Create a bridge order** (swap + bridge transaction)
     - [ ] Complete the swap portion but leave bridge pending
     - [ ] Verify "Show progress" link appears in activity modal
     - [ ] Click link opens progress modal with bridge status

  2. **Verify existing functionality**
     - [ ] Regular swap orders still show "Show progress" when open
     - [ ] Bridge orders in final states (completed/failed) don't show progress link
     - [ ] Progress modal displays correct bridge status information

  # Background

  This builds on PR #5986 which implemented `useEnhancedActivityDerivedState` to properly handle combined swap/bridge status. The fix leverages this enhanced state to determine when bridge orders should show progress tracking, particularly in the gap between swap completion and bridge completion.