### PR TITLE
feat(bridge): add moo sound for success/failure orders

### DIFF
--- a/apps/cowswap-frontend/src/modules/bridge/updaters/PendingBridgeOrdersUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/updaters/PendingBridgeOrdersUpdater.tsx
@@ -7,7 +7,6 @@ import { useCrossChainOrder, usePendingBridgeOrders, useUpdateBridgeOrderQuote }
 import { useAddOrderToSurplusQueue } from 'entities/surplusModal'
 
 import { emitBridgingSuccessEvent } from 'modules/orders'
-
 import { getCowSoundError, getCowSoundSuccess } from 'modules/sounds'
 
 interface PendingOrderUpdaterProps {


### PR DESCRIPTION
No moo sound for failed/completed bridge TX/no pop-up

Fixes [issue](https://www.notion.so/cownation/No-moo-sound-for-failed-completed-bridge-TX-no-pop-up-2148da5f04ca809293d0f4c05a878e5d)

# To Test

1. Open swap and sign bridge order, wait until order execution

- [ ] Moo sound should be played also when tokens were transfered from bridge to user wallet 
- [ ] If swap was failed - sound also should be played


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sound effects for pending orders based on status: a success sound plays when an order is executed, and an error sound plays when an order fails (refunded or expired).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->