### PR TITLE
fix(trade): compare only selected metadata fields

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeQuote/utils/quoteUsingSameParameters.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/utils/quoteUsingSameParameters.ts
@@ -83,9 +83,17 @@ function compareAppDataWithoutQuoteData(a: AppDataInfo['doc'] | undefined, b: Ap
  */
 function removeQuoteMetadata(appData: AppDataInfo['doc']): string {
   const { metadata: fullMetadata, ...rest } = appData
-  const { quote: _, utm: __, bridging: ___, ...metadata } = fullMetadata
+  const { partnerFee, hooks, referrer, replacedOrder } = fullMetadata
 
-  const obj = { ...rest, metadata }
+  const obj = {
+    ...rest,
+    metadata: {
+      partnerFee: partnerFee ?? undefined,
+      hooks: hooks ?? undefined,
+      referrer: referrer ?? undefined,
+      replacedOrder: replacedOrder ?? undefined,
+    },
+  }
   return jsonStringify(obj)
 }
 


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/S-B-quote-cannot-be-loaded-in-the-widget-configurator-2348da5f04ca8075969bc1efde6aab7e?v=1c38da5f04ca812b9489000c81197879

It's again `compareAppDataWithoutQuoteData` 🤦 

To stop it breaking, I inverted `removeQuoteMetadata` logic.
Before this fix it was expluding some fields.
Now it only takes necessary fields and set `undefined` as default.

I inverted logic, because we add new fields to `metadata`, but we don't controll all the fields in the mentioned function. Now we only care about specific fields.
It's important to set `undefined` by default, because `JSON.stringify({ partnerFee: undefined })` !== JSON.stringify({ partnerFee: null }).

Full list of the fields:

```
 - signer
 - referrer
 - utm
 - quote
 - orderClass
 - hooks
 - widget
 - partnerFee
 - replacedOrder
 - bridging
```

For quote request we only track:
```
 - referrer
 - hooks
 - partnerFee
 - replacedOrder
```

Others don't actually affect quote.

# To Test

See https://www.notion.so/cownation/S-B-quote-cannot-be-loaded-in-the-widget-configurator-2348da5f04ca8075969bc1efde6aab7e?v=1c38da5f04ca812b9489000c81197879

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of quote metadata for more precise processing. No changes to visible features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->