### PR TITLE
fix(time-offset): detect time in the past

### DIFF
--- a/apps/cowswap-frontend/src/common/containers/InvalidLocalTimeWarning/index.tsx
+++ b/apps/cowswap-frontend/src/common/containers/InvalidLocalTimeWarning/index.tsx
@@ -12,7 +12,7 @@ const TIME_OFFSET_THRESHOLD = 60 // 60 seconds
 export function InvalidLocalTimeWarning() {
   const localTimeOffset = useLocalTimeOffset()
 
-  if (!localTimeOffset || localTimeOffset < TIME_OFFSET_THRESHOLD) return null
+  if (!localTimeOffset || Math.abs(localTimeOffset) < TIME_OFFSET_THRESHOLD) return null
 
   console.debug('Local time offset:', localTimeOffset)
 

--- a/apps/cowswap-frontend/src/common/containers/InvalidLocalTimeWarning/index.tsx
+++ b/apps/cowswap-frontend/src/common/containers/InvalidLocalTimeWarning/index.tsx
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react'
+
 import { useLocalTimeOffset } from './localTimeOffsetState'
 
 import { GlobalWarning } from '../../pure/GlobalWarning'
@@ -7,9 +9,7 @@ const TIME_OFFSET_THRESHOLD = 60 // 60 seconds
 /**
  * When the local device time is not valid ()
  */
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function InvalidLocalTimeWarning() {
+export function InvalidLocalTimeWarning(): ReactNode | null {
   const localTimeOffset = useLocalTimeOffset()
 
   if (!localTimeOffset || Math.abs(localTimeOffset) < TIME_OFFSET_THRESHOLD) return null


### PR DESCRIPTION
# Summary

Fix for detection of local time mismatch

# To Test

1. Set your local clock to the past > 1min
* Should show the warning
<img width="698" height="107" alt="image" src="https://github.com/user-attachments/assets/8e85e408-8858-4ce8-9af2-9264d64fa54e" />

2. Set your local clock to the future > 1min
* Same as above
3. Set it to regular time
* Warning should not be displayed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy of the invalid local device time warning, ensuring it only appears when the device time offset exceeds the threshold in either direction. Small deviations in time will no longer trigger unnecessary warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->