### PR TITLE
fix(explorer): load coingecko tokens for all chains

### DIFF
--- a/apps/explorer/src/hooks/useTokenList.ts
+++ b/apps/explorer/src/hooks/useTokenList.ts
@@ -11,6 +11,16 @@ type TokenListPerNetwork = Record<SupportedChainId, TokenListByAddress>
 
 const INITIAL_TOKEN_LIST_PER_NETWORK: TokenListPerNetwork = mapSupportedNetworks({})
 
+const COINGECKO_CHAINS: Record<SupportedChainId, string | null> = {
+  [SupportedChainId.MAINNET]: 'ethereum',
+  [SupportedChainId.GNOSIS_CHAIN]: 'xdai',
+  [SupportedChainId.BASE]: 'base',
+  [SupportedChainId.ARBITRUM_ONE]: 'arbitrum-one',
+  [SupportedChainId.SEPOLIA]: null,
+  [SupportedChainId.POLYGON]: 'polygon-pos',
+  [SupportedChainId.AVALANCHE]: 'avalanche',
+}
+
 // TODO: Reduce function complexity by extracting logic
 // eslint-disable-next-line complexity
 export function useTokenList(chainId: SupportedChainId | undefined): { data: TokenListByAddress; isLoading: boolean } {
@@ -19,34 +29,31 @@ export function useTokenList(chainId: SupportedChainId | undefined): { data: Tok
       ? 'https://files.cow.fi/tokens/CowSwap.json'
       : 'https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/CowSwapSepolia.json',
   )
-  const { data: coingeckoList, isLoading: isCoingeckoListLoading } = useTokenListByUrl(
+  const { data: coingeckoUniswapList, isLoading: isCoingeckoUniswapLoading } = useTokenListByUrl(
     chainId === SupportedChainId.MAINNET ? 'https://tokens.coingecko.com/uniswap/all.json' : '',
   )
   const { data: honeyswapList, isLoading: isHoneyswapListLoading } = useTokenListByUrl(
     chainId === SupportedChainId.GNOSIS_CHAIN ? 'https://tokens.honeyswap.org' : '',
   )
-  const { data: arbitrumOneList, isLoading: isArbitrumOneListLoading } = useTokenListByUrl(
-    chainId === SupportedChainId.ARBITRUM_ONE ? 'https://tokens.coingecko.com/arbitrum-one/all.json' : '',
+  const coingeckoUrlKey = chainId && COINGECKO_CHAINS[chainId]
+  const { data: coingeckoList, isLoading: isCoingeckoLoading } = useTokenListByUrl(
+    coingeckoUrlKey ? `https://tokens.coingecko.com/${coingeckoUrlKey}/all.json` : '',
   )
   const { data: baseList, isLoading: isBaseListLoading } = useTokenListByUrl(
     chainId === SupportedChainId.BASE ? 'https://tokens.coingecko.com/base/all.json' : '',
   )
 
   const isLoading = chainId
-    ? isCowListLoading ||
-      isHoneyswapListLoading ||
-      isCoingeckoListLoading ||
-      isArbitrumOneListLoading ||
-      isBaseListLoading
+    ? isCowListLoading || isHoneyswapListLoading || isCoingeckoUniswapLoading || isCoingeckoLoading || isBaseListLoading
     : false
 
   return useMemo(() => {
     const data = chainId
-      ? { ...coingeckoList, ...honeyswapList, ...cowSwapList, ...arbitrumOneList, ...baseList }[chainId]
+      ? { ...coingeckoUniswapList, ...honeyswapList, ...cowSwapList, ...coingeckoList, ...baseList }[chainId]
       : {}
 
     return { data, isLoading }
-  }, [chainId, coingeckoList, honeyswapList, cowSwapList, arbitrumOneList, isLoading, baseList])
+  }, [chainId, coingeckoUniswapList, honeyswapList, cowSwapList, coingeckoList, isLoading, baseList])
 }
 
 // TODO: Add proper return type annotation


### PR DESCRIPTION
# Summary

For some reason we've been loading tokens from coingecko exclusively for Arbitrum.

<img width="1008" height="431" alt="image" src="https://github.com/user-attachments/assets/cb899577-5b45-4e3c-bf18-7a5d45015a4c" />


# To Test

1. Open /pol/orders/0x108467520bafc95f4c1188e1fee05299784a36281c16ef5af4473770731c89979fa3c00a92ec5f96b1ad2527ab41b3932efeda586880d1da?tab=bridge

- [ ] AR: "From" amount is not displayed
- [ ] ER: "From" amount is displayed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved token list fetching by dynamically constructing Coingecko URLs based on supported chains, streamlining the retrieval process.
  * Unified the fetch logic for different chains, reducing redundancy and improving maintainability.
  * Enhanced loading state handling to better reflect the status of all token lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->