### PR TITLE
feat(bridge): do not search output tokens in selector

### DIFF
--- a/apps/cowswap-frontend/src/modules/tokensList/containers/SelectTokenWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/containers/SelectTokenWidget/index.tsx
@@ -95,7 +95,7 @@ export function SelectTokenWidget({ displayLpTokenLists, standalone }: SelectTok
   })
   const importTokenCallback = useAddUserToken()
 
-  const { tokens: allTokens, isLoading: areTokensLoading, favoriteTokens } = useTokensToSelect()
+  const { tokens: allTokens, isLoading: areTokensLoading, favoriteTokens, areTokensFromBridge } = useTokensToSelect()
   const userAddedTokens = useUserAddedTokens()
   const allTokenLists = useAllListsList()
   const balancesState = useTokensBalancesCombined()
@@ -130,17 +130,13 @@ export function SelectTokenWidget({ displayLpTokenLists, standalone }: SelectTok
     closeTokenSelectWidget()
   }, [closeTokenSelectWidget])
 
-  // TODO: Add proper return type annotation
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  const importTokenAndClose = (tokens: TokenWithLogo[]) => {
+  const importTokenAndClose = (tokens: TokenWithLogo[]): void => {
     importTokenCallback(tokens)
     onSelectToken?.(tokens[0])
     onDismiss()
   }
 
-  // TODO: Add proper return type annotation
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  const importListAndBack = (list: ListState) => {
+  const importListAndBack = (list: ListState): void => {
     try {
       addCustomTokenLists(list)
     } catch (error) {
@@ -222,6 +218,7 @@ export function SelectTokenWidget({ displayLpTokenLists, standalone }: SelectTok
             onSelectChain={onSelectChain}
             areTokensLoading={areTokensLoading}
             tokenListTags={tokenListTags}
+            areTokensFromBridge={areTokensFromBridge}
           />
         )
       })()}

--- a/apps/cowswap-frontend/src/modules/tokensList/containers/TokenSearchResults/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/containers/TokenSearchResults/index.tsx
@@ -1,7 +1,8 @@
 import { ReactNode, useCallback, useEffect, useMemo } from 'react'
 
+import { TokenWithLogo } from '@cowprotocol/common-const'
 import { doesTokenMatchSymbolOrAddress } from '@cowprotocol/common-utils'
-import { useSearchToken } from '@cowprotocol/tokens'
+import { getTokenSearchFilter, TokenSearchResponse, useSearchToken } from '@cowprotocol/tokens'
 import {
   BannerOrientation,
   ExternalLink,
@@ -20,12 +21,32 @@ export interface TokenSearchResultsProps {
   searchInput: string
   selectTokenContext: SelectTokenContext
   areTokensFromBridge: boolean
+  allTokens: TokenWithLogo[]
 }
 
-export function TokenSearchResults({ searchInput, selectTokenContext }: TokenSearchResultsProps): ReactNode {
+export function TokenSearchResults({
+  searchInput,
+  selectTokenContext,
+  areTokensFromBridge,
+  allTokens,
+}: TokenSearchResultsProps): ReactNode {
   const { onSelectToken } = selectTokenContext
 
-  const searchResults = useSearchToken(searchInput)
+  // Do not make search when tokens are from bridge
+  const defaultSearchResults = useSearchToken(areTokensFromBridge ? null : searchInput)
+
+  // For bridge output tokens just filter them instead of making search
+  const searchResults: TokenSearchResponse = useMemo(() => {
+    if (!areTokensFromBridge) return defaultSearchResults
+
+    const filter = getTokenSearchFilter(searchInput)
+    const filteredTokens = allTokens.filter(filter)
+
+    return {
+      ...defaultSearchResults,
+      activeListsResult: filteredTokens,
+    }
+  }, [searchInput, areTokensFromBridge, allTokens, defaultSearchResults])
 
   const { activeListsResult } = searchResults
 

--- a/apps/cowswap-frontend/src/modules/tokensList/containers/TokenSearchResults/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/containers/TokenSearchResults/index.tsx
@@ -1,91 +1,39 @@
-import { useCallback, useEffect, useMemo } from 'react'
+import { ReactNode, useCallback, useEffect, useMemo } from 'react'
 
-import { TokenWithLogo } from '@cowprotocol/common-const'
 import { doesTokenMatchSymbolOrAddress } from '@cowprotocol/common-utils'
-import { useSearchToken, useTokenListsTags } from '@cowprotocol/tokens'
+import { useSearchToken } from '@cowprotocol/tokens'
 import {
   BannerOrientation,
   ExternalLink,
   InlineBanner,
   LINK_GUIDE_ADD_CUSTOM_TOKEN,
-  Loader,
   StatusColorVariant,
 } from '@cowprotocol/ui'
-import { useWalletInfo } from '@cowprotocol/wallet'
-
-import { useNetworkName } from 'common/hooks/useNetworkName'
-
-import * as styledEl from './styled'
 
 import { useAddTokenImportCallback } from '../../hooks/useAddTokenImportCallback'
 import { useUpdateSelectTokenWidgetState } from '../../hooks/useUpdateSelectTokenWidgetState'
 import { CommonListContainer } from '../../pure/commonElements'
-import { ImportTokenItem } from '../../pure/ImportTokenItem'
-import { TokenListItem } from '../../pure/TokenListItem'
-import { TokenSourceTitle } from '../../pure/TokenSourceTitle'
+import { TokenSearchContent } from '../../pure/TokenSearchContent'
 import { SelectTokenContext } from '../../types'
 
-const SEARCH_RESULTS_LIMIT = 10
-
-export interface TokenSearchResultsProps extends SelectTokenContext {
+export interface TokenSearchResultsProps {
   searchInput: string
+  selectTokenContext: SelectTokenContext
 }
 
-// TODO: Break down this large function into smaller functions
-// TODO: Add proper return type annotation
-// eslint-disable-next-line max-lines-per-function, @typescript-eslint/explicit-function-return-type
-export function TokenSearchResults({
-  searchInput,
-  balancesState,
-  selectedToken,
-  onSelectToken,
-  unsupportedTokens,
-  permitCompatibleTokens,
-}: TokenSearchResultsProps) {
-  const { account } = useWalletInfo()
-  const isWalletConnected = !!account
+export function TokenSearchResults({ searchInput, selectTokenContext }: TokenSearchResultsProps): ReactNode {
+  const { onSelectToken } = selectTokenContext
 
   const searchResults = useSearchToken(searchInput)
-  const { values: balances } = balancesState
 
-  const { inactiveListsResult, blockchainResult, activeListsResult, externalApiResult, isLoading } = searchResults
+  const { activeListsResult } = searchResults
 
   const updateSelectTokenWidget = useUpdateSelectTokenWidgetState()
 
   const addTokenImportCallback = useAddTokenImportCallback()
 
-  const networkName = useNetworkName()
-
-  const tokenListTags = useTokenListsTags()
-
-  const searchCount = [
-    activeListsResult.length,
-    inactiveListsResult.length,
-    blockchainResult.length,
-    externalApiResult.length,
-  ].reduce<number>((acc, cur) => acc + (cur ?? 0), 0)
-
-  const isTokenNotFound = useMemo(() => {
-    if (isLoading) return false
-
-    return searchCount === 0
-  }, [isLoading, searchCount])
-
-  const [matchedTokens, activeList] = useMemo(() => {
-    const matched: TokenWithLogo[] = []
-    const remaining: TokenWithLogo[] = []
-
-    for (const t of activeListsResult) {
-      if (doesTokenMatchSymbolOrAddress(t, searchInput)) {
-        // There should ever be only 1 token with a given address
-        // There can be multiple with the same symbol
-        matched.push(t)
-      } else {
-        remaining.push(t)
-      }
-    }
-
-    return [matched, remaining]
+  const matchedTokens = useMemo(() => {
+    return activeListsResult.filter((t) => doesTokenMatchSymbolOrAddress(t, searchInput))
   }, [activeListsResult, searchInput])
 
   // On press Enter, select first token if only one token is found or it fully matches to the search input
@@ -117,90 +65,12 @@ export function TokenSearchResults({
         </p>
       </InlineBanner>
 
-      {(() => {
-        if (isLoading)
-          return (
-            <styledEl.LoaderWrapper>
-              <Loader />
-            </styledEl.LoaderWrapper>
-          )
-
-        if (isTokenNotFound) return <styledEl.TokenNotFound>No tokens found in {networkName}</styledEl.TokenNotFound>
-
-        return (
-          <>
-            {/*Matched tokens first, followed by tokens from active lists*/}
-            {matchedTokens.concat(activeList).map((token) => {
-              const addressLowerCase = token.address.toLowerCase()
-
-              return (
-                <TokenListItem
-                  key={token.address}
-                  isUnsupported={!!unsupportedTokens[addressLowerCase]}
-                  isPermitCompatible={permitCompatibleTokens[addressLowerCase]}
-                  selectedToken={selectedToken}
-                  token={token}
-                  balance={balances ? balances[token.address.toLowerCase()] : undefined}
-                  onSelectToken={onSelectToken}
-                  isWalletConnected={isWalletConnected}
-                  tokenListTags={tokenListTags}
-                />
-              )
-            })}
-
-            {/*Tokens from blockchain*/}
-            {blockchainResult?.length ? (
-              <styledEl.ImportTokenWrapper id="currency-import">
-                {blockchainResult.slice(0, SEARCH_RESULTS_LIMIT).map((token) => {
-                  return <ImportTokenItem key={token.address} token={token} importToken={addTokenImportCallback} />
-                })}
-              </styledEl.ImportTokenWrapper>
-            ) : null}
-
-            {/*Tokens from inactive lists*/}
-            {inactiveListsResult?.length ? (
-              <div>
-                <TokenSourceTitle tooltip="Tokens from inactive lists. Import specific tokens below or click Manage to activate more lists.">
-                  Expanded results from inactive Token Lists
-                </TokenSourceTitle>
-                <div>
-                  {inactiveListsResult.slice(0, SEARCH_RESULTS_LIMIT).map((token) => {
-                    return (
-                      <ImportTokenItem
-                        key={token.address}
-                        token={token}
-                        importToken={addTokenImportCallback}
-                        shadowed={true}
-                      />
-                    )
-                  })}
-                </div>
-              </div>
-            ) : null}
-
-            {/*Tokens from external sources*/}
-            {externalApiResult?.length ? (
-              <div>
-                <TokenSourceTitle tooltip="Tokens from external sources.">
-                  Additional Results from External Sources
-                </TokenSourceTitle>
-                <div>
-                  {externalApiResult.map((token) => {
-                    return (
-                      <ImportTokenItem
-                        key={token.address}
-                        token={token}
-                        importToken={addTokenImportCallback}
-                        shadowed={true}
-                      />
-                    )
-                  })}
-                </div>
-              </div>
-            ) : null}
-          </>
-        )
-      })()}
+      <TokenSearchContent
+        importToken={addTokenImportCallback}
+        searchInput={searchInput}
+        selectTokenContext={selectTokenContext}
+        searchResults={searchResults}
+      />
     </CommonListContainer>
   )
 }

--- a/apps/cowswap-frontend/src/modules/tokensList/containers/TokenSearchResults/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/containers/TokenSearchResults/index.tsx
@@ -19,6 +19,7 @@ import { SelectTokenContext } from '../../types'
 export interface TokenSearchResultsProps {
   searchInput: string
   selectTokenContext: SelectTokenContext
+  areTokensFromBridge: boolean
 }
 
 export function TokenSearchResults({ searchInput, selectTokenContext }: TokenSearchResultsProps): ReactNode {

--- a/apps/cowswap-frontend/src/modules/tokensList/hooks/useAddTokenImportCallback.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/hooks/useAddTokenImportCallback.ts
@@ -4,9 +4,7 @@ import { TokenWithLogo } from '@cowprotocol/common-const'
 
 import { useUpdateSelectTokenWidgetState } from './useUpdateSelectTokenWidgetState'
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function useAddTokenImportCallback() {
+export function useAddTokenImportCallback(): (tokenToImport: TokenWithLogo) => void {
   const updateSelectTokenWidget = useUpdateSelectTokenWidgetState()
 
   return useCallback(

--- a/apps/cowswap-frontend/src/modules/tokensList/hooks/useTokensToSelect.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/hooks/useTokensToSelect.ts
@@ -17,6 +17,7 @@ export interface TokensToSelectContext {
   isLoading: boolean
   tokens: TokenWithLogo[]
   favoriteTokens: TokenWithLogo[]
+  areTokensFromBridge: boolean
 }
 
 export function useTokensToSelect(): TokensToSelectContext {
@@ -51,6 +52,7 @@ export function useTokensToSelect(): TokensToSelectContext {
       isLoading: areTokensFromBridge ? isLoading : false,
       tokens: (areTokensFromBridge ? bridgeSupportedTokens : allTokens) || EMPTY_TOKENS,
       favoriteTokens: favoriteTokensToSelect,
+      areTokensFromBridge,
     }
   }, [allTokens, bridgeSupportedTokens, bridgeSupportedTokensMap, isLoading, areTokensFromBridge, favoriteTokens])
 }

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/SelectTokenModal/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/SelectTokenModal/index.cosmos.tsx
@@ -34,6 +34,7 @@ const defaultProps: SelectTokenModalProps = {
   allTokens: allTokensMock,
   favoriteTokens: favoriteTokensMock,
   areTokensLoading: false,
+  areTokensFromBridge: false,
   chainsToSelect: undefined,
   onSelectChain(chain: ChainInfo) {
     console.log('onSelectChain', chain)

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/SelectTokenModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/SelectTokenModal/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react'
+import React, { ReactNode, useMemo, useState } from 'react'
 
 import { BalancesState } from '@cowprotocol/balances-and-allowances'
 import { TokenWithLogo } from '@cowprotocol/common-const'
@@ -37,6 +37,7 @@ export interface SelectTokenModalProps<T = TokenListCategory[] | null> {
   areTokensLoading: boolean
   tokenListTags: TokenListTags
   standalone?: boolean
+  areTokensFromBridge: boolean
 
   onSelectToken(token: TokenWithLogo): void
   openPoolPage(poolAddress: string): void
@@ -46,13 +47,34 @@ export interface SelectTokenModalProps<T = TokenListCategory[] | null> {
   onSelectChain(chain: ChainInfo): void
 }
 
-export function SelectTokenModal(props: SelectTokenModalProps): ReactNode {
+function useSelectTokenContext(props: SelectTokenModalProps): SelectTokenContext {
   const {
-    defaultInputValue = '',
     selectedToken,
     balancesState,
     unsupportedTokens,
     permitCompatibleTokens,
+    onSelectToken,
+    account,
+    tokenListTags,
+  } = props
+
+  return useMemo(
+    () => ({
+      balancesState,
+      selectedToken,
+      onSelectToken,
+      unsupportedTokens,
+      permitCompatibleTokens,
+      tokenListTags,
+      isWalletConnected: !!account,
+    }),
+    [balancesState, selectedToken, onSelectToken, unsupportedTokens, permitCompatibleTokens, tokenListTags, account],
+  )
+}
+
+export function SelectTokenModal(props: SelectTokenModalProps): ReactNode {
+  const {
+    defaultInputValue = '',
     onSelectToken,
     onDismiss,
     onInputPressEnter,
@@ -63,24 +85,21 @@ export function SelectTokenModal(props: SelectTokenModalProps): ReactNode {
     disableErc20,
     chainsToSelect,
     onSelectChain,
-    tokenListTags,
+    areTokensFromBridge,
   } = props
   const [inputValue, setInputValue] = useState<string>(defaultInputValue)
 
-  const selectTokenContext: SelectTokenContext = {
-    balancesState,
-    selectedToken,
-    onSelectToken,
-    unsupportedTokens,
-    permitCompatibleTokens,
-    tokenListTags,
-    isWalletConnected: !!account,
-  }
+  const selectTokenContext = useSelectTokenContext(props)
 
   const trimmedInputValue = inputValue.trim()
 
   const allListsContent = (
-    <TokensContent {...props} selectTokenContext={selectTokenContext} searchInput={trimmedInputValue} />
+    <TokensContent
+      {...props}
+      selectTokenContext={selectTokenContext}
+      searchInput={trimmedInputValue}
+      areTokensFromBridge={areTokensFromBridge}
+    />
   )
 
   return (

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/SelectTokenModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/SelectTokenModal/index.tsx
@@ -74,6 +74,7 @@ export function SelectTokenModal(props: SelectTokenModalProps): ReactNode {
     unsupportedTokens,
     permitCompatibleTokens,
     tokenListTags,
+    isWalletConnected: !!account,
   }
 
   const trimmedInputValue = inputValue.trim()

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokenListItem/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokenListItem/index.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler } from 'react'
+import { MouseEventHandler, ReactNode } from 'react'
 
 import { TokenWithLogo } from '@cowprotocol/common-const'
 import { getCurrencyAddress } from '@cowprotocol/common-utils'
@@ -34,10 +34,7 @@ export interface TokenListItemProps {
   tokenListTags: TokenListTags
 }
 
-// TODO: Break down this large function into smaller functions
-// TODO: Add proper return type annotation
-// eslint-disable-next-line max-lines-per-function, @typescript-eslint/explicit-function-return-type
-export function TokenListItem(props: TokenListItemProps) {
+export function TokenListItem(props: TokenListItemProps): ReactNode {
   const {
     token,
     selectedToken,

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokenListItemContainer/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokenListItemContainer/index.tsx
@@ -1,0 +1,38 @@
+import { ReactNode } from 'react'
+
+import { TokenWithLogo } from '@cowprotocol/common-const'
+
+import { SelectTokenContext } from '../../types'
+import { TokenListItem } from '../TokenListItem'
+
+interface TokenListItemContainerProps {
+  token: TokenWithLogo
+  context: SelectTokenContext
+}
+
+export function TokenListItemContainer({ token, context }: TokenListItemContainerProps): ReactNode {
+  const {
+    unsupportedTokens,
+    onSelectToken,
+    selectedToken,
+    tokenListTags,
+    permitCompatibleTokens,
+    balancesState: { values: balances },
+    isWalletConnected,
+  } = context
+
+  const addressLowerCase = token.address.toLowerCase()
+
+  return (
+    <TokenListItem
+      isUnsupported={!!unsupportedTokens[addressLowerCase]}
+      isPermitCompatible={permitCompatibleTokens[addressLowerCase]}
+      selectedToken={selectedToken}
+      token={token}
+      balance={balances ? balances[token.address.toLowerCase()] : undefined}
+      onSelectToken={onSelectToken}
+      isWalletConnected={isWalletConnected}
+      tokenListTags={tokenListTags}
+    />
+  )
+}

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokenSearchContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokenSearchContent/index.tsx
@@ -35,11 +35,7 @@ export function TokenSearchContent({
     externalApiResult.length,
   ].reduce<number>((acc, cur) => acc + (cur ?? 0), 0)
 
-  const isTokenNotFound = useMemo(() => {
-    if (isLoading) return false
-
-    return searchCount === 0
-  }, [isLoading, searchCount])
+  const isTokenNotFound = isLoading ? false : searchCount === 0
 
   const [matchedTokens, activeList] = useMemo(() => {
     const matched: TokenWithLogo[] = []

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokensContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokensContent/index.tsx
@@ -24,6 +24,7 @@ export interface TokensContentProps {
   allTokens: TokenWithLogo[]
   searchInput: string
   standalone?: boolean
+  areTokensFromBridge: boolean
 
   onSelectToken(token: TokenWithLogo): void
   onOpenManageWidget(): void
@@ -41,6 +42,7 @@ export function TokensContent({
   displayLpTokenLists,
   searchInput,
   standalone,
+  areTokensFromBridge,
 }: TokensContentProps): ReactNode {
   return (
     <>
@@ -64,7 +66,11 @@ export function TokensContent({
       ) : (
         <>
           {searchInput ? (
-            <TokenSearchResults searchInput={searchInput} selectTokenContext={selectTokenContext} />
+            <TokenSearchResults
+              searchInput={searchInput}
+              selectTokenContext={selectTokenContext}
+              areTokensFromBridge={areTokensFromBridge}
+            />
           ) : (
             <TokensVirtualList
               selectTokenContext={selectTokenContext}

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokensContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokensContent/index.tsx
@@ -22,7 +22,6 @@ export interface TokensContentProps {
   hideFavoriteTokensTooltip?: boolean
   areTokensLoading: boolean
   allTokens: TokenWithLogo[]
-  account: string | undefined
   searchInput: string
   standalone?: boolean
 
@@ -39,7 +38,6 @@ export function TokensContent({
   hideFavoriteTokensTooltip,
   areTokensLoading,
   allTokens,
-  account,
   displayLpTokenLists,
   searchInput,
   standalone,
@@ -66,12 +64,11 @@ export function TokensContent({
       ) : (
         <>
           {searchInput ? (
-            <TokenSearchResults searchInput={searchInput} {...selectTokenContext} />
+            <TokenSearchResults searchInput={searchInput} selectTokenContext={selectTokenContext} />
           ) : (
             <TokensVirtualList
+              selectTokenContext={selectTokenContext}
               allTokens={allTokens}
-              {...selectTokenContext}
-              account={account}
               displayLpTokenLists={displayLpTokenLists}
             />
           )}

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokensContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokensContent/index.tsx
@@ -70,6 +70,7 @@ export function TokensContent({
               searchInput={searchInput}
               selectTokenContext={selectTokenContext}
               areTokensFromBridge={areTokensFromBridge}
+              allTokens={allTokens}
             />
           ) : (
             <TokensVirtualList

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokensVirtualList/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokensVirtualList/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { ReactNode, useCallback, useMemo } from 'react'
 
 import { TokenWithLogo } from '@cowprotocol/common-const'
 import { useFeatureFlags } from '@cowprotocol/common-hooks'
@@ -10,63 +10,32 @@ import { VirtualList } from 'common/pure/VirtualList'
 
 import { SelectTokenContext } from '../../types'
 import { tokensListSorter } from '../../utils/tokensListSorter'
-import { TokenListItem } from '../TokenListItem'
+import { TokenListItemContainer } from '../TokenListItemContainer'
 
-export interface TokensVirtualListProps extends SelectTokenContext {
+export interface TokensVirtualListProps {
   allTokens: TokenWithLogo[]
-  account: string | undefined
   displayLpTokenLists?: boolean
+  selectTokenContext: SelectTokenContext
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function TokensVirtualList(props: TokensVirtualListProps) {
-  const {
-    allTokens,
-    selectedToken,
-    balancesState,
-    onSelectToken,
-    unsupportedTokens,
-    permitCompatibleTokens,
-    tokenListTags,
-    account,
-    displayLpTokenLists,
-  } = props
-  const { values: balances } = balancesState
+export function TokensVirtualList(props: TokensVirtualListProps): ReactNode {
+  const { allTokens, selectTokenContext, displayLpTokenLists } = props
+  const { values: balances } = selectTokenContext.balancesState
 
-  const isWalletConnected = !!account
   const { isYieldEnabled } = useFeatureFlags()
 
-  const sortedTokens = useMemo(() => balances ? allTokens.sort(tokensListSorter(balances)) : allTokens, [allTokens, balances])
+  const sortedTokens = useMemo(
+    () => (balances ? allTokens.sort(tokensListSorter(balances)) : allTokens),
+    [allTokens, balances],
+  )
 
   const getItemView = useCallback(
     (sortedTokens: TokenWithLogo[], virtualRow: VirtualItem) => {
       const token = sortedTokens[virtualRow.index]
-      const addressLowerCase = token.address.toLowerCase()
-      const balance = balances ? balances[token.address.toLowerCase()] : undefined
 
-      return (
-        <TokenListItem
-          token={token}
-          isUnsupported={!!unsupportedTokens[addressLowerCase]}
-          isPermitCompatible={permitCompatibleTokens[addressLowerCase]}
-          selectedToken={selectedToken}
-          balance={balance}
-          onSelectToken={onSelectToken}
-          isWalletConnected={isWalletConnected}
-          tokenListTags={tokenListTags}
-        />
-      )
+      return <TokenListItemContainer key={token.address} token={token} context={selectTokenContext} />
     },
-    [
-      balances,
-      unsupportedTokens,
-      permitCompatibleTokens,
-      selectedToken,
-      onSelectToken,
-      isWalletConnected,
-      tokenListTags,
-    ],
+    [selectTokenContext],
   )
 
   return (

--- a/apps/cowswap-frontend/src/modules/tokensList/types.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/types.ts
@@ -17,6 +17,7 @@ export interface SelectTokenContext {
   unsupportedTokens: { [tokenAddress: string]: { dateAdded: number } }
   permitCompatibleTokens: PermitCompatibleTokens
   tokenListTags: TokenListTags
+  isWalletConnected: boolean
 }
 
 export interface ChainsToSelectState {

--- a/libs/tokens/src/hooks/tokens/useSearchToken.ts
+++ b/libs/tokens/src/hooks/tokens/useSearchToken.ts
@@ -7,7 +7,7 @@ import { isAddress } from '@cowprotocol/common-utils'
 import { useWalletProvider } from '@cowprotocol/wallet-provider'
 
 import ms from 'ms.macro'
-import useSWR from 'swr'
+import useSWR, { SWRResponse } from 'swr'
 
 import { searchTokensInApi } from '../../services/searchTokensInApi'
 import { environmentAtom } from '../../state/environmentAtom'
@@ -46,11 +46,10 @@ const emptyFromListsResult: FromListsResult = { tokensFromActiveLists: [], token
  * The hook is searching into 4 sources: active lists, inactive lists, external API, and blockchain
  * useSWR is widely used inside to cache the search results
  */
-// TODO: Break down this large function into smaller functions
-// eslint-disable-next-line max-lines-per-function
 export function useSearchToken(input: string | null): TokenSearchResponse {
   const inputLowerCase = input?.toLowerCase()
   const [isLoading, setIsLoading] = useState(false)
+
   const debouncedInputInList = useDebounce(inputLowerCase, IN_LISTS_DEBOUNCE_TIME)
   const debouncedInputInExternals = useDebounce(inputLowerCase, IN_EXTERNALS_DEBOUNCE_TIME)
 
@@ -153,9 +152,10 @@ function useSearchTokensInLists(input: string | undefined): FromListsResult {
   return inListsResult || emptyFromListsResult
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function useSearchTokensInApi(input: string | undefined, isTokenAlreadyFoundByAddress: boolean) {
+function useSearchTokensInApi(
+  input: string | undefined,
+  isTokenAlreadyFoundByAddress: boolean,
+): SWRResponse<TokenWithLogo[] | null> {
   const { chainId } = useAtomValue(environmentAtom)
 
   return useSWR<TokenWithLogo[] | null>(['searchTokensInApi', input], () => {
@@ -167,9 +167,10 @@ function useSearchTokensInApi(input: string | undefined, isTokenAlreadyFoundByAd
   })
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function useFetchTokenFromBlockchain(input: string | undefined, isTokenAlreadyFoundByAddress: boolean) {
+function useFetchTokenFromBlockchain(
+  input: string | undefined,
+  isTokenAlreadyFoundByAddress: boolean,
+): SWRResponse<TokenWithLogo | null> {
   const { chainId } = useAtomValue(environmentAtom)
   const provider = useWalletProvider()
 


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Swap-weth-in-mainnet-for-Cow-in-base-2398da5f04ca80f691a1ed471c40be8e?v=1c38da5f04ca812b9489000c81197879&source=copy_link

and https://www.notion.so/cownation/Search-for-dst-token-not-found-message-mentions-source-chain-2328da5f04ca803cb6f6f405a93841fb

We should not search tokens in token lists, API, etc when bridge output tokens selector is open. We should only filter list of bridge supported tokens.

Please review this PR commit by commit, because I did some refactoring without functional changes, the actual fix is [in the last commit](https://github.com/cowprotocol/cowswap/commit/63b6be9021a70b3a7c81525e16d012c6703453ed).

<img width="763" height="459" alt="image" src="https://github.com/user-attachments/assets/ea00c550-4448-48b6-ae5a-10c1a550e6e0" />

# To Test

See https://www.notion.so/cownation/Swap-weth-in-mainnet-for-Cow-in-base-2398da5f04ca80f691a1ed471c40be8e?v=1c38da5f04ca812b9489000c81197879&source=copy_link

I changed "No tokens found in Ethereum" to "No tokens found" to make it simplier.