### PR TITLE
fix(bridge): trigger appzi only when bridging is finished

### DIFF
--- a/apps/cowswap-frontend/src/appzi.ts
+++ b/apps/cowswap-frontend/src/appzi.ts
@@ -55,6 +55,7 @@ type AppziCustomSettings = {
   waitedTooLong?: true
   expired?: true
   traded?: true
+  bridged?: true
   created?: true
   cancelled?: true
   openedLimitPage?: true

--- a/apps/cowswap-frontend/src/common/updaters/orders/PendingOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/PendingOrdersUpdater.ts
@@ -349,9 +349,7 @@ function getReplacedOrCancelledEthFlowOrders(
 
 // Check if there is any order pending for a long time
 // If so, trigger appzi
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function _triggerNps(pending: Order[], chainId: ChainId, account: string) {
+function _triggerNps(pending: Order[], chainId: ChainId, account: string): void {
   for (const order of pending) {
     const { openSince, id: orderId } = order
     const orderType = getUiOrderType(order)


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Appzi-modal-appears-after-swap-part-22c8da5f04ca8020bf4fdddf3c40104e?v=1c38da5f04ca812b9489000c81197879&source=copy_link

# To Test

Appzi survey should open only when bridging is finished, not after swap is finished.
