### PR TITLE
feat(bridge): replace address links with AddressLink component for ow…

### DIFF
--- a/apps/explorer/src/components/orders/DetailsTable/BaseDetailsTable.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/BaseDetailsTable.tsx
@@ -8,6 +8,7 @@ import { TruncatedText } from '@cowprotocol/ui/pure/TruncatedText'
 
 import { faGroupArrowsRotate, faHistory, faProjectDiagram } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { AddressLink } from 'components/common/AddressLink'
 import { DateDisplay } from 'components/common/DateDisplay'
 import { RowWithCopyButton } from 'components/common/RowWithCopyButton'
 import { SimpleTable } from 'components/common/SimpleTable'
@@ -120,11 +121,7 @@ export function BaseDetailsTable({
                 <RowWithCopyButton
                   textToCopy={owner}
                   onCopy={(): void => onCopy('ownerAddress')}
-                  contentsToDisplay={
-                    <Link to={getExplorerLink(chainId, owner, ExplorerDataType.ADDRESS)} target="_blank">
-                      {owner}↗
-                    </Link>
-                  }
+                  contentsToDisplay={<AddressLink address={owner} chainId={chainId} showNetworkName />}
                 />
                 <LinkButton to={`/address/${owner}`}>
                   <FontAwesomeIcon icon={faHistory} />
@@ -144,11 +141,7 @@ export function BaseDetailsTable({
                 <RowWithCopyButton
                   textToCopy={receiver}
                   onCopy={(): void => onCopy('receiverAddress')}
-                  contentsToDisplay={
-                    <Link to={getExplorerLink(chainId, receiver, ExplorerDataType.ADDRESS)} target="_blank">
-                      {receiver}↗
-                    </Link>
-                  }
+                  contentsToDisplay={<AddressLink address={receiver} chainId={chainId} showNetworkName />}
                 />
                 <LinkButton to={`/address/${receiver}`}>
                   <FontAwesomeIcon icon={faHistory} />


### PR DESCRIPTION
# Summary

  Adds chain icons and "on <NetworkName>" text to the From/To address fields in the Swap tab to match the formatting used in the Bridge Details table.
  
<img width="1401" height="456" alt="Screenshot 2025-07-25 at 13 16 09" src="https://github.com/user-attachments/assets/ad4ed3cf-3505-4ff4-8d19-995a4d252aa5" />

  # To Test

  1. Open an order detail page in the explorer (e.g., `/orders/0x...`)

  - [ ] Verify the "From" address shows the chain icon and "on <NetworkName>" text
  - [ ] Verify the "To" address shows the chain icon and "on <NetworkName>" text
  - [ ] Verify the addresses still link to the correct block explorer
  - [ ] Verify the copy functionality still works for both addresses

  2. Compare with Bridge Details tab

  - [ ] Open an order with bridging (swap + bridge order)
  - [ ] Switch between "1. Swap" and "2. Bridge" tabs
  - [ ] Verify the address formatting is consistent between tabs

  # Background

  Previously, only the Bridge Details table showed chain icons and network names next to addresses. This change brings visual consistency by using the same `AddressLink` component in the Swap tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the display of "owner" and "receiver" addresses to use a consistent, reusable address link component with network name shown. This streamlines address presentation and improves maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->