### PR TITLE
[DRAFT] add forceExpandOnWarnings components

### DIFF
--- a/apps/cowswap-frontend/src/modules/bridge/pure/CollapsibleBridgeRoute/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/CollapsibleBridgeRoute/index.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from 'react'
+import { ReactNode, useState, useEffect } from 'react'
 
 import { BridgeProviderInfo } from '@cowprotocol/cow-sdk'
 import { Media } from '@cowprotocol/ui'
@@ -24,6 +24,7 @@ const Wrapper = styled.div`
 interface CollapsibleBridgeRouteProps {
   isCollapsible?: boolean
   isExpanded?: boolean
+  forceExpandOnWarnings?: { showRecipientWarning: boolean; showPriceUpdated: boolean }
   children: ReactNode
   providerInfo: BridgeProviderInfo
   collapsedDefault?: ReactNode
@@ -31,9 +32,31 @@ interface CollapsibleBridgeRouteProps {
 }
 
 export function CollapsibleBridgeRoute(props: CollapsibleBridgeRouteProps): ReactNode {
-  const { isCollapsible = false, children, providerInfo, collapsedDefault, className } = props
+  const {
+    isCollapsible = false,
+    children,
+    providerInfo,
+    collapsedDefault,
+    className,
+    isExpanded: propIsExpanded,
+    forceExpandOnWarnings,
+  } = props
 
-  const [isExpanded, setIsExpanded] = useState(props.isExpanded || false)
+  const [isExpanded, setIsExpanded] = useState(propIsExpanded ?? false)
+
+  // Force expansion when individual warnings appear
+  useEffect(() => {
+    if (forceExpandOnWarnings?.showPriceUpdated || forceExpandOnWarnings?.showRecipientWarning) {
+      setIsExpanded(true)
+    }
+  }, [forceExpandOnWarnings?.showPriceUpdated, forceExpandOnWarnings?.showRecipientWarning])
+
+  // Regular support for direct isExpanded prop
+  useEffect(() => {
+    if (propIsExpanded === true) {
+      setIsExpanded(true)
+    }
+  }, [propIsExpanded])
 
   // TODO: Add proper return type annotation
   const toggleExpanded = (): void => setIsExpanded((state) => !state)

--- a/apps/cowswap-frontend/src/modules/bridge/pure/CollapsibleBridgeRoute/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/CollapsibleBridgeRoute/index.tsx
@@ -42,7 +42,9 @@ export function CollapsibleBridgeRoute(props: CollapsibleBridgeRouteProps): Reac
     forceExpandOnWarnings,
   } = props
 
-  const [isExpanded, setIsExpanded] = useState(propIsExpanded ?? false)
+  const [isExpanded, setIsExpanded] = useState(
+    propIsExpanded ?? (forceExpandOnWarnings?.showPriceUpdated || forceExpandOnWarnings?.showRecipientWarning) ?? false
+  )
 
   // Force expansion when individual warnings appear
   useEffect(() => {

--- a/apps/cowswap-frontend/src/modules/bridge/pure/QuoteDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/QuoteDetails/index.tsx
@@ -13,6 +13,7 @@ import { BridgeStatusTitlePrefixes, SwapStatusTitlePrefixes } from '../StopStatu
 
 interface QuoteDetailsProps {
   isCollapsible?: boolean
+  forceExpandOnWarnings?: { showRecipientWarning: boolean; showPriceUpdated: boolean }
   stepsCollapsible?: boolean
   hideRecommendedSlippage?: boolean
 
@@ -87,6 +88,7 @@ function BridgeStep({ stepsCollapsible, bridgeProvider, bridgeContext }: BridgeS
 
 export function QuoteDetails({
   isCollapsible,
+  forceExpandOnWarnings,
   stepsCollapsible = false,
   bridgeProvider,
   swapContext,
@@ -97,7 +99,7 @@ export function QuoteDetails({
   return (
     <CollapsibleBridgeRoute
       isCollapsible={isCollapsible}
-      isExpanded
+      forceExpandOnWarnings={forceExpandOnWarnings}
       providerInfo={bridgeProvider}
       collapsedDefault={collapsedDefault}
     >

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/index.tsx
@@ -124,11 +124,12 @@ export function SwapConfirmModal(props: SwapConfirmModalProps): ReactNode {
         appData={appData || undefined}
       >
         {shouldDisplayBridgeDetails && bridgeProvider && swapContext && bridgeContext
-          ? (restContent) => (
+          ? (restContent, warningStates) => (
               <>
                 <RateInfo label="Price" rateInfoParams={rateInfoParams} fontSize={13} fontBold labelBold />
                 <QuoteDetails
                   isCollapsible
+                  forceExpandOnWarnings={warningStates}
                   bridgeProvider={bridgeProvider}
                   swapContext={swapContext}
                   bridgeContext={bridgeContext}

--- a/apps/cowswap-frontend/src/modules/trade/pure/TradeConfirmation/hooks/useWarningStates.ts
+++ b/apps/cowswap-frontend/src/modules/trade/pure/TradeConfirmation/hooks/useWarningStates.ts
@@ -1,0 +1,16 @@
+export function useWarningStates(
+  recipient: string | null | undefined,
+  account: string | undefined,
+  ensName: string | undefined,
+  isPriceChanged: boolean,
+  isPriceStatic: boolean | undefined
+): { showRecipientWarning: boolean; showPriceUpdated: boolean } {
+  const showRecipientWarning =
+    recipient &&
+    (account || ensName) &&
+    ![account?.toLowerCase(), ensName?.toLowerCase()].includes(recipient.toLowerCase())
+
+  const showPriceUpdated = isPriceChanged && !isPriceStatic
+
+  return { showRecipientWarning: !!showRecipientWarning, showPriceUpdated: !!showPriceUpdated }
+}

--- a/apps/cowswap-frontend/src/modules/trade/pure/TradeConfirmation/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/TradeConfirmation/index.tsx
@@ -22,15 +22,13 @@ import * as styledEl from './styled'
 import { NoImpactWarning } from '../../containers/NoImpactWarning'
 import { useTradeConfirmState } from '../../hooks/useTradeConfirmState'
 
-function createHookDetailsElement(appData: string | AppDataInfo | undefined): ReactNode {
+function HookDetailsElement({ appData }: { appData: string | AppDataInfo | undefined }): ReactNode {
+  if (!appData) return null
+
   return (
-    <>
-      {appData && (
-        <OrderHooksDetails appData={appData} isTradeConfirmation>
-          {(hookChildren) => hookChildren}
-        </OrderHooksDetails>
-      )}
-    </>
+    <OrderHooksDetails appData={appData} isTradeConfirmation>
+      {(hookChildren) => hookChildren}
+    </OrderHooksDetails>
   )
 }
 
@@ -102,7 +100,6 @@ export function TradeConfirmation(_props: TradeConfirmationProps): ReactNode {
     window.scrollTo(0, 0)
   }, [])
 
-  const hookDetailsElement = createHookDetailsElement(appData)
 
   return (
     <styledEl.WidgetWrapper onKeyDown={(e) => e.key === 'Escape' && onDismiss()}>
@@ -122,7 +119,7 @@ export function TradeConfirmation(_props: TradeConfirmationProps): ReactNode {
         />
         {children?.(
           <>
-            {hookDetailsElement}
+            <HookDetailsElement appData={appData} />
             <NoImpactWarning withoutAccepting />
           </>,
           warningStates,


### PR DESCRIPTION
# Summary

  Auto-expand CollapsibleBridgeRoute when custom recipient or price update banners appear in swap + bridge confirmation modal.
  
## NO custom recipient -> collapsed

https://github.com/user-attachments/assets/d9463f44-3d22-4d9a-a027-2dabc2bb354e

## NO custom recipient -> price gets updated -> trigger expandsion

https://github.com/user-attachments/assets/70ff9a07-3907-4875-abcd-c957f4376f11


  
## Custom recipient -> expand by default

https://github.com/user-attachments/assets/e2586794-63c9-40c2-b81b-2ff586a98e5d

## Custom recipient + price gets updated in Review modal -> trigger expansion

https://github.com/user-attachments/assets/e017bd40-a48a-4786-a6c4-cdc795df5778



  # To Test

  1. **Custom Recipient Warning Test**
     - [ ] Set custom recipient in swap + bridge transaction
     - [ ] Verify CollapsibleBridgeRoute expands automatically when modal opens
     - [ ] User can still manually collapse/expand the section

  2. **Price Update Banner Test**
     - [ ] Start swap + bridge transaction (no custom recipient)
     - [ ] Wait for quote refresh to trigger "Price Updated" banner
     - [ ] Verify CollapsibleBridgeRoute expands automatically when banner appears
     - [ ] User can still manually collapse/expand the section

  3. **Combined Warnings Test**
     - [ ] Set custom recipient AND wait for price update
     - [ ] Collapse the section manually
     - [ ] Wait for another price update
     - [ ] Verify section expands automatically on price update even with existing custom recipient warning

  # Background

  When users see important warnings (custom recipient or price updates) in the swap + bridge confirmation modal, they need immediate visibility into the transaction details to make informed decisions. 
  
  This feature automatically expands the CollapsibleBridgeRoute section
   when these critical banners appear, ensuring users can easily review swap and bridge details without manual interaction while preserving their ability to collapse the section if desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic expansion of bridge route details when recipient or price warnings are present during swaps and trades.
  * Warning states are now calculated and passed through to relevant components, improving visibility for recipient and price updates.

* **Refactor**
  * Enhanced component interfaces to support new warning-driven expansion behavior.
  * Improved internal structure for rendering order hook details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->