### PR TITLE
fix(url-trade-amounts): don't store url state when amount is 0

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/hooks/useSetupTradeAmountsFromUrl.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useSetupTradeAmountsFromUrl.ts
@@ -19,12 +19,13 @@ import { TradeAmounts } from 'common/types'
 import { useDerivedTradeState } from './useDerivedTradeState'
 import { useTradeState } from './useTradeState'
 
-import { ExtendedTradeRawState } from '../types/TradeRawState'
+import { ExtendedTradeRawState } from '../types'
 
 interface SetupTradeAmountsParams {
   onlySell?: boolean
   onAmountsUpdate?: (amounts: TradeAmounts) => void
 }
+
 /**
  * Parse sell/buy amount from URL and apply to Limit orders widget
  * Example:
@@ -33,9 +34,7 @@ interface SetupTradeAmountsParams {
  * In case when both sellAmount and buyAmount specified, the price will be automatically calculated
  */
 // TODO: Break down this large function into smaller functions
-// TODO: Add proper return type annotation
-// eslint-disable-next-line max-lines-per-function, @typescript-eslint/explicit-function-return-type
-export function useSetupTradeAmountsFromUrl({ onAmountsUpdate, onlySell }: SetupTradeAmountsParams) {
+export function useSetupTradeAmountsFromUrl({ onAmountsUpdate, onlySell }: SetupTradeAmountsParams): void {
   const navigate = useNavigate()
   const { search, pathname } = useLocation()
   const params = useMemo(() => new URLSearchParams(search), [search])
@@ -75,8 +74,8 @@ export function useSetupTradeAmountsFromUrl({ onAmountsUpdate, onlySell }: Setup
     const buyAmount = getIntOrFloat(params.get(TRADE_URL_BUY_AMOUNT_KEY))
     const update: Partial<Writeable<ExtendedTradeRawState>> = {}
 
-    const isSellAmountValid = inputCurrency && sellAmount && +sellAmount >= 0
-    const isBuyAmountValid = outputCurrency && buyAmount && +buyAmount >= 0
+    const isSellAmountValid = inputCurrency && sellAmount && +sellAmount > 0
+    const isBuyAmountValid = outputCurrency && buyAmount && +buyAmount > 0
 
     const sellCurrencyAmount = isSellAmountValid ? tryParseCurrencyAmount(sellAmount, inputCurrency) : null
     const buyCurrencyAmount = isBuyAmountValid ? tryParseCurrencyAmount(buyAmount, outputCurrency) : null


### PR DESCRIPTION
# Summary

Fix https://github.com/cowprotocol/cowswap/issues/6023

Prevent crash when 0 is inserted as input amount

# To Test

1. Open Swap page
2. Connect to a wallet
3. Set 0 amounts in the swap form
4. Navigate to the limit orders page
* Page should not crash
* Input value should be set to previous value (not 0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for trade amounts to ensure only values strictly greater than zero are accepted when parsing from the URL. This prevents invalid or zero amounts from being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->