### PR TITLE
feat(bridge): add bridging analytics

### DIFF
--- a/apps/cowswap-frontend/src/common/analytics/types.ts
+++ b/apps/cowswap-frontend/src/common/analytics/types.ts
@@ -7,6 +7,7 @@ import { AnalyticsCategory, GtmEvent, toGtmEvent } from '@cowprotocol/analytics'
 export enum CowSwapAnalyticsCategory {
   // Trade Categories
   TRADE = 'Trade',
+  Bridge = 'Bridge',
   LIST = 'Lists',
   HOOKS = 'Hooks',
   RECIPIENT_ADDRESS = 'Recipient address',

--- a/apps/cowswap-frontend/src/common/analytics/types.ts
+++ b/apps/cowswap-frontend/src/common/analytics/types.ts
@@ -1,23 +1,15 @@
-import { AnalyticsCategory, Category, GtmEvent, toGtmEvent } from '@cowprotocol/analytics'
+import { AnalyticsCategory, GtmEvent, toGtmEvent } from '@cowprotocol/analytics'
 
 /**
  * CowSwap-specific analytics categories
  * Extends the base Category enum with CowSwap-specific values
  */
 export enum CowSwapAnalyticsCategory {
-  // Base Category values (must match exactly)
-  SERVICE_WORKER = Category.SERVICE_WORKER,
-  FOOTER = Category.FOOTER,
-  EXTERNAL_LINK = Category.EXTERNAL_LINK,
-
   // Trade Categories
   TRADE = 'Trade',
   LIST = 'Lists',
   HOOKS = 'Hooks',
-  CURRENCY_SELECT = 'Currency Select',
   RECIPIENT_ADDRESS = 'Recipient address',
-  ORDER_SLIPPAGE_TOLERANCE = 'Order Slippage Tolerance',
-  ORDER_EXPIRATION_TIME = 'Order Expiration Time',
   WRAP_NATIVE_TOKEN = 'Wrapped Native Token',
   CLAIM_COW_FOR_LOCKED_GNO = 'Claim COW for Locked GNO',
   TWAP = 'TWAP',
@@ -26,12 +18,10 @@ export enum CowSwapAnalyticsCategory {
   LIMIT_ORDER_SETTINGS = 'Limit Order Settings',
 
   // UI Categories
-  THEME = 'Theme',
   WALLET = 'Wallet',
   NOTIFICATIONS = 'Notifications',
   PROGRESS_BAR = 'Progress Bar',
   GAMES = 'Games',
-  INIT = 'Init',
   COW_FORTUNE = 'CoWFortune',
 }
 

--- a/apps/cowswap-frontend/src/modules/bridge/updaters/PendingBridgeOrdersUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/updaters/PendingBridgeOrdersUpdater.tsx
@@ -55,10 +55,12 @@ function PendingOrderUpdater({ chainId, orderUid }: PendingOrderUpdaterProps): R
     const isOrderExecuted = orderStatus === BridgeStatus.EXECUTED
     const isOrderFailed = orderStatus === BridgeStatus.REFUND || orderStatus === BridgeStatus.EXPIRED
 
+    const { sourceChainId, destinationChainId } = crossChainOrder.bridgingParams
+
     // Update bridge order status for ALL status changes, not just EXECUTED
     updateBridgeOrderQuote(orderUid, crossChainOrder.statusResult)
 
-    const analyticsSummary = `From: ${crossChainOrder.bridgingParams.sourceChainId}, to: ${crossChainOrder.bridgingParams.destinationChainId}`
+    const analyticsSummary = `From: ${sourceChainId}, to: ${destinationChainId}`
 
     if (isOrderExecuted) {
       // Display surplus modal
@@ -71,7 +73,7 @@ function PendingOrderUpdater({ chainId, orderUid }: PendingOrderUpdaterProps): R
         action: 'Bridging succeeded',
         label: analyticsSummary,
         orderId: orderUid,
-        chainId: crossChainOrder.bridgingParams.sourceChainId,
+        chainId: sourceChainId,
       } as GtmEvent<CowSwapAnalyticsCategory.Bridge>)
     } else if (isOrderFailed) {
       getCowSoundError().play()
@@ -81,7 +83,7 @@ function PendingOrderUpdater({ chainId, orderUid }: PendingOrderUpdaterProps): R
         action: 'Bridging failed',
         label: analyticsSummary,
         orderId: orderUid,
-        chainId: crossChainOrder.bridgingParams.sourceChainId,
+        chainId: sourceChainId,
       } as GtmEvent<CowSwapAnalyticsCategory.Bridge>)
     }
   }, [crossChainOrder, updateBridgeOrderQuote, addOrderToSurplusQueue, analytics])

--- a/apps/cowswap-frontend/src/modules/trade/utils/tradeFlowAnalytics.ts
+++ b/apps/cowswap-frontend/src/modules/trade/utils/tradeFlowAnalytics.ts
@@ -1,9 +1,10 @@
+import { useMemo } from 'react'
+
 import { useCowAnalytics } from '@cowprotocol/analytics'
 import { UiOrderType } from '@cowprotocol/types'
 
 import { CowSwapAnalyticsCategory } from 'common/analytics/types'
-
-import { USER_SWAP_REJECTED_ERROR } from '../../../common/utils/getSwapErrorMessage'
+import { USER_SWAP_REJECTED_ERROR } from 'common/utils/getSwapErrorMessage'
 
 export interface TradeFlowAnalyticsContext {
   account: string | null
@@ -25,45 +26,45 @@ export interface TradeFlowAnalytics {
 export function useTradeFlowAnalytics(): TradeFlowAnalytics {
   const analytics = useCowAnalytics()
 
-  // TODO: Add proper return type annotation
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  const sendTradeAnalytics = (action: string, orderType: UiOrderType, marketLabel?: string, value?: number) => {
-    analytics.sendEvent({
-      category: CowSwapAnalyticsCategory.TRADE,
-      action,
-      label: `${orderType}|${marketLabel}`,
-      ...(value !== undefined && { value }),
-    })
-  }
+  return useMemo(() => {
+    const sendTradeAnalytics = (action: string, orderType: UiOrderType, marketLabel?: string, value?: number): void => {
+      analytics.sendEvent({
+        category: CowSwapAnalyticsCategory.TRADE,
+        action,
+        label: `${orderType}|${marketLabel}`,
+        ...(value !== undefined && { value }),
+      })
+    }
 
-  return {
-    trade(context: TradeFlowAnalyticsContext) {
-      sendTradeAnalytics('Send', context.orderType, context.marketLabel)
-    },
-    sign(context: TradeFlowAnalyticsContext) {
-      const { marketLabel, orderType } = context
-      sendTradeAnalytics('Sign', orderType, marketLabel)
-    },
-    approveAndPresign(context: TradeFlowAnalyticsContext) {
-      const { marketLabel, orderType } = context
-      sendTradeAnalytics('Bundle Approve and Swap', orderType, marketLabel)
-    },
-    placeAdvancedOrder(context: TradeFlowAnalyticsContext) {
-      const { marketLabel, orderType } = context
-      sendTradeAnalytics('Place Advanced Order', orderType, marketLabel)
-    },
-    wrapApproveAndPresign(context: TradeFlowAnalyticsContext) {
-      const { marketLabel, orderType } = context
-      sendTradeAnalytics('Bundled Eth Flow', orderType, marketLabel)
-    },
-    error(error: Error & { code?: number }, errorMessage: string, context: TradeFlowAnalyticsContext) {
-      const { marketLabel, orderType } = context
+    return {
+      trade(context: TradeFlowAnalyticsContext) {
+        sendTradeAnalytics('Send', context.orderType, context.marketLabel)
+      },
+      sign(context: TradeFlowAnalyticsContext) {
+        const { marketLabel, orderType } = context
+        sendTradeAnalytics('Sign', orderType, marketLabel)
+      },
+      approveAndPresign(context: TradeFlowAnalyticsContext) {
+        const { marketLabel, orderType } = context
+        sendTradeAnalytics('Bundle Approve and Swap', orderType, marketLabel)
+      },
+      placeAdvancedOrder(context: TradeFlowAnalyticsContext) {
+        const { marketLabel, orderType } = context
+        sendTradeAnalytics('Place Advanced Order', orderType, marketLabel)
+      },
+      wrapApproveAndPresign(context: TradeFlowAnalyticsContext) {
+        const { marketLabel, orderType } = context
+        sendTradeAnalytics('Bundled Eth Flow', orderType, marketLabel)
+      },
+      error(error: Error & { code?: number }, errorMessage: string, context: TradeFlowAnalyticsContext) {
+        const { marketLabel, orderType } = context
 
-      if (errorMessage === USER_SWAP_REJECTED_ERROR) {
-        sendTradeAnalytics('Reject', orderType, marketLabel)
-      } else {
-        sendTradeAnalytics('Error', orderType, marketLabel, error.code)
-      }
-    },
-  }
+        if (errorMessage === USER_SWAP_REJECTED_ERROR) {
+          sendTradeAnalytics('Reject', orderType, marketLabel)
+        } else {
+          sendTradeAnalytics('Error', orderType, marketLabel, error.code)
+        }
+      },
+    }
+  }, [analytics])
 }

--- a/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowContext.ts
@@ -19,7 +19,7 @@ import {
   useIsHooksTradeType,
   useTradeConfirmActions,
   useTradeTypeInfo,
-  TradeTypeToUiOrderType
+  TradeTypeToUiOrderType,
 } from 'modules/trade'
 import { getOrderValidTo, useTradeQuote } from 'modules/tradeQuote'
 
@@ -193,6 +193,7 @@ export function useTradeFlowContext({ deadline }: TradeFlowParams): TradeFlowCon
             recipientAddress,
             marketLabel: [inputAmount?.currency.symbol, outputAmount?.currency.symbol].join(','),
             orderType: uiOrderType,
+            isBridgeOrder: inputAmount.currency.chainId !== outputAmount.currency.chainId,
           },
           contract: settlementContract,
           permitInfo: !enoughAllowance ? permitInfo : undefined,

--- a/libs/analytics/src/context/CowAnalyticsContext.tsx
+++ b/libs/analytics/src/context/CowAnalyticsContext.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, useContext, PropsWithChildren } from 'react'
+import { createContext, useContext, PropsWithChildren, ReactNode } from 'react'
 
 import { CowAnalytics } from '../CowAnalytics'
 
@@ -13,17 +13,13 @@ export const CowAnalyticsContext = createContext<AnalyticsContextType | undefine
 export const CowAnalyticsProvider = ({
   children,
   cowAnalytics: analyticsInstance,
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-}: PropsWithChildren<AnalyticsContextType>) => {
+}: PropsWithChildren<AnalyticsContextType>): ReactNode => {
   return (
     <CowAnalyticsContext.Provider value={{ cowAnalytics: analyticsInstance }}>{children}</CowAnalyticsContext.Provider>
   )
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const useCowAnalytics = () => {
+export const useCowAnalytics = (): CowAnalytics => {
   const context = useContext(CowAnalyticsContext)
   if (!context) {
     throw new Error('required CowAnalyticsProvider')

--- a/libs/analytics/src/gtm/CowAnalyticsGtm.ts
+++ b/libs/analytics/src/gtm/CowAnalyticsGtm.ts
@@ -200,6 +200,8 @@ export class CowAnalyticsGtm implements CowAnalytics {
   }
 
   sendEvent(event: string | EventOptions, params?: unknown): void {
+    const gtmEvent = event as GtmEvent<Category>
+
     const eventData: DataLayerEvent =
       typeof event === 'string'
         ? { event, ...(params as Record<string, unknown>) }
@@ -211,12 +213,13 @@ export class CowAnalyticsGtm implements CowAnalytics {
             value: event.value,
             non_interaction: event.nonInteraction,
             ...this.getDimensions(),
-            ...((event as GtmEvent<Category>).orderId && { order_id: (event as GtmEvent<Category>).orderId }),
-            ...((event as GtmEvent<Category>).orderType && { order_type: (event as GtmEvent<Category>).orderType }),
-            ...((event as GtmEvent<Category>).tokenSymbol && {
-              token_symbol: (event as GtmEvent<Category>).tokenSymbol,
+            ...(gtmEvent.isBridgeOrder && { isBridgeOrder: gtmEvent.isBridgeOrder }),
+            ...(gtmEvent.orderId && { order_id: gtmEvent.orderId }),
+            ...(gtmEvent.orderType && { order_type: gtmEvent.orderType }),
+            ...(gtmEvent.tokenSymbol && {
+              token_symbol: gtmEvent.tokenSymbol,
             }),
-            ...((event as GtmEvent<Category>).chainId && { chain_id: (event as GtmEvent<Category>).chainId }),
+            ...(gtmEvent.chainId && { chain_id: gtmEvent.chainId }),
           }
 
     this.pushToDataLayer(eventData)

--- a/libs/analytics/src/types.ts
+++ b/libs/analytics/src/types.ts
@@ -39,6 +39,7 @@ export interface BaseGtmEvent<T extends string = Category> {
   orderId?: string
   orderType?: string
   tokenSymbol?: string
+  isBridgeOrder?: boolean
   chainId?: number
   // TODO: Replace any with proper type definitions
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@cowprotocol/cms": "^0.11.0",
     "@cowprotocol/contracts": "^1.7.0",
     "@cowprotocol/cow-runner-game": "^0.2.9",
-    "@cowprotocol/cow-sdk": "6.0.0-RC.78",
+    "@cowprotocol/cow-sdk": "6.0.0-RC.79",
     "@cowprotocol/ethflowcontract": "cowprotocol/ethflowcontract.git#main-artifacts",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1841,10 +1841,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/cow-runner-game/-/cow-runner-game-0.2.9.tgz#3f94b3f370bd114f77db8b1d238cba3ef4e9d644"
   integrity sha512-rX7HnoV+HYEEkBaqVUsAkGGo0oBrExi+d6Io+8nQZYwZk+IYLmS9jdcIObsLviM2h4YX8+iin6NuKl35AaiHmg==
 
-"@cowprotocol/cow-sdk@6.0.0-RC.78":
-  version "6.0.0-RC.78"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.78.tgz#d82ca582ff350d74384b785623387d2e7b5613d6"
-  integrity sha512-QVc+It/QgJT38xsYA7XUiqgLKdb47K1++cWYRx9kQm0P/xQlb3BNpOccBQJuWckEE2+WcnQhAcjD/WUKnqWp9w==
+"@cowprotocol/cow-sdk@6.0.0-RC.79":
+  version "6.0.0-RC.79"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.79.tgz#4e77745d5a5a7cf9d3013bbac170bffa98a244e8"
+  integrity sha512-3Fblp9f++NMNaHTb+ouq51yekock3rtWW8cVPl3TOiCpV5+z+qYBzTDX20TggJp1K17FG8K41oQAPQdsqDynpw==
   dependencies:
     "@cowprotocol/app-data" "^3.2.0"
     "@cowprotocol/contracts" "^1.8.0"


### PR DESCRIPTION
# Summary

1. Added an event to Google Analytics to track when bridging is finised (see To Test)
2. Also added a similar event in case when Bridging is failed, but for now it's almost imposible to reproduce
3. I also updated cow-sdk, no functional changes, just version bump

# To Test

Once bridging is complete, you should see this in console ([with that extension installed](https://chromewebstore.google.com/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna)):
```
Processing data layer push: {event: "Bridging succeeded", category: "Bridge", action: "Bridging succeeded", label: "From: 8453, to: 42161", value: undefined, non_interaction: undefined, dimension_customBrowserType: "desktop", dimension_chainId: "8453", dimension_userAddress: "0xfb3c7eb936cAA12B5A884d612393969A557d4307", dimension_walletName: "Rabby Wallet", dimension_market: "USDC,DAI::SWAP", order_id: "0xfb71feddd9f8e168bcd820919a75d348997475654096814d7742a77bc1a7a03cfb3c7eb936caa12b5a884d612393969a557d430768879009", chain_id: 8453, gtm.uniqueEventId: 51}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added analytics event tracking for bridging order status changes, including success and failure events.
  * Introduced a flag to identify bridge orders in trade analytics.

* **Bug Fixes**
  * Improved type safety and clarity in analytics provider and hook.

* **Refactor**
  * Simplified and updated analytics categories, including removal of unused entries and addition of "Bridge".
  * Enhanced memoization of analytics functions to optimize performance.
  * Added bridge order detection in trade flow context.

* **Chores**
  * Updated "@cowprotocol/cow-sdk" dependency to version 6.0.0-RC.79.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->