### PR TITLE
fix(bridge): adjust success bridging message

### DIFF
--- a/apps/cowswap-frontend/src/modules/orders/containers/BridgingSuccessNotification/index.tsx
+++ b/apps/cowswap-frontend/src/modules/orders/containers/BridgingSuccessNotification/index.tsx
@@ -11,9 +11,27 @@ import { getUiOrderType } from 'utils/orderUtils/getUiOrderType'
 import { OrderNotification } from '../OrderNotification'
 import { mapBridgingResultToOrderInfo } from '../OrderNotification/utils'
 
+import type { OrderSummaryTemplateProps } from '../../pure/OrderSummary/summaryTemplates'
+
+function summaryTemplate({
+  inputAmount,
+  outputAmount,
+  srcChainData,
+  dstChainData,
+}: OrderSummaryTemplateProps): ReactNode {
+  return (
+    <>
+      Sell {inputAmount}
+      {srcChainData && ` (${srcChainData.label})`} for {outputAmount}
+      {dstChainData && ` (${dstChainData.label})`}
+    </>
+  )
+}
+
 interface BridgingSuccessNotificationProps {
   payload: OnBridgingSuccessPayload
 }
+
 export function BridgingSuccessNotification({ payload }: BridgingSuccessNotificationProps): ReactNode {
   const { chainId, order } = payload
   const bridgingOrder = useBridgeOrderData(order.uid)
@@ -29,6 +47,7 @@ export function BridgingSuccessNotification({ payload }: BridgingSuccessNotifica
       skipExplorerLink
       chainId={chainId}
       orderInfo={orderInfo}
+      customTemplate={summaryTemplate}
       orderType={getUiOrderType(order)}
       orderUid={order.uid}
       receiver={bridgingOrder.recipient}

--- a/apps/cowswap-frontend/src/modules/orders/containers/BridgingSuccessNotification/index.tsx
+++ b/apps/cowswap-frontend/src/modules/orders/containers/BridgingSuccessNotification/index.tsx
@@ -22,7 +22,7 @@ function summaryTemplate({
   return (
     <>
       Sell {inputAmount}
-      {srcChainData && ` (${srcChainData.label})`} for {outputAmount}
+      {srcChainData && ` (${srcChainData.label})`} for a total of {outputAmount}
       {dstChainData && ` (${dstChainData.label})`}
     </>
   )

--- a/apps/cowswap-frontend/src/modules/orders/containers/OrderNotification/index.tsx
+++ b/apps/cowswap-frontend/src/modules/orders/containers/OrderNotification/index.tsx
@@ -19,6 +19,7 @@ import {
 } from './utils'
 
 import { OrderSummary } from '../../pure/OrderSummary'
+import { SellForAtLeastTemplate } from '../../pure/OrderSummary/summaryTemplates'
 import { ReceiverInfo } from '../../pure/ReceiverInfo'
 import { TransactionContentWithLink } from '../TransactionContentWithLink'
 
@@ -37,6 +38,7 @@ export interface BaseOrderNotificationProps {
   bottomContent?: ReactNode
   receiver?: string
   hideReceiver?: boolean
+  customTemplate?: typeof SellForAtLeastTemplate
 }
 
 export function OrderNotification(props: BaseOrderNotificationProps): ReactNode {
@@ -107,6 +109,7 @@ export function OrderNotification(props: BaseOrderNotificationProps): ReactNode 
             buyAmount={order.outputAmount.toString()}
             srcChainData={srcChainData}
             dstChainData={dstChainData}
+            customTemplate={props.customTemplate}
           />
         ) : null)}
       {!hideReceiver && <ReceiverInfo receiver={order.receiver} owner={order.owner} />}


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Bridge-succesfull-notification-has-incorrect-data-on-the-tooltip-that-appears-2398da5f04ca801087c0ceb029ff5641?v=1c38da5f04ca812b9489000c81197879&source=copy_link

<img width="1152" height="524" alt="image" src="https://github.com/user-attachments/assets/b9e53b0b-eb38-412f-b6ca-7558d823c23a" />


# To Test

See https://www.notion.so/cownation/Bridge-succesfull-notification-has-incorrect-data-on-the-tooltip-that-appears-2398da5f04ca801087c0ceb029ff5641?v=1c38da5f04ca812b9489000c81197879&source=copy_link


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced order notifications to display a custom summary for bridging orders, showing input and output amounts with their respective source and destination chain labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->