### PR TITLE
chore(ci): harden

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,29 +23,22 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: yarn
-
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v3
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules1-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules1-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
       - name: Cache generated files
         id: cache-generated-files
-        uses: actions/cache@v3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             src/state/data
@@ -59,26 +52,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: yarn
 
-      - name: Load dependencies
-        id: cache-node-modules
-        uses: actions/cache@v3
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules1-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules1-
-
       - name: Load generated files
         id: cache-generated-files
-        uses: actions/cache@v3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             src/state/data
@@ -100,26 +86,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: yarn
 
-      - name: Load dependencies
-        id: cache-node-modules
-        uses: actions/cache@v3
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules1-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules1-
-
       - name: Load generated files
         id: cache-generated-files
-        uses: actions/cache@v3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             src/state/data
@@ -134,13 +113,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Increase watchers
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
       - name: Set up node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: yarn
@@ -148,7 +129,7 @@ jobs:
       # Install deps only
       - name: Cypress install dependencies
         id: cypress-deps
-        uses: cypress-io/github-action@v5.0.5
+        uses: cypress-io/github-action@b8ba51a856ba5f4c15cf39007636d4ab04f23e3c # v6.10.2
         # Do not consider failure a failure. Well, sort of.
         # See https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#steps-context
         continue-on-error: true
@@ -167,7 +148,7 @@ jobs:
       # Actually run tests, building repo
       - name: Cypress run
         id: cypress-run
-        uses: cypress-io/github-action@v5.8.3
+        uses: cypress-io/github-action@b8ba51a856ba5f4c15cf39007636d4ab04f23e3c # v6.10.2
         with:
           wait-on: http://[::1]:3000
           wait-on-timeout: 600

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: 'Get Team Members'
         id: team
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           result-encoding: string
           script: |
@@ -24,7 +24,7 @@ jobs:
 
       - name: 'CLA Assistant'
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/cow-files.yml
+++ b/.github/workflows/cow-files.yml
@@ -22,10 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
           role-to-assume: arn:aws:iam::693696263829:role/cow-files-github-action-role
           role-session-name: githubactionsession
@@ -42,5 +44,7 @@ jobs:
       - name: Invalidate CloudFront cache
         run: |
           aws cloudfront create-invalidation \
-            --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} \
+            --distribution-id $DIST_ID \
             --paths "/cow-files/*"
+        env:
+          DIST_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}

--- a/.github/workflows/epics.yml
+++ b/.github/workflows/epics.yml
@@ -8,7 +8,7 @@ jobs:
     name: Update epic issues
     steps:
       - name: Run epics action
-        uses: cloudaper/epics-action@v1
+        uses: cloudaper/epics-action@4dea9b8b2ccd4778a7c2426d8fd0bed9c9f665e6 # v1.1.7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           epic-label-name: feature

--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -25,34 +25,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-
-      - name: Set output of cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache yarn cache
-        uses: actions/cache@v4
-        id: cache-yarn-cache
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+          cache: yarn
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -27,6 +27,7 @@ on:
 
 env:
   NODE_VERSION: lts/jod
+  LIB: ${{ inputs.lib }}
   DESTINATION_PATH: dist/libs/${{ inputs.lib }}
 
 jobs:
@@ -36,38 +37,32 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
           cache: yarn
 
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v3
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules1-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}-nodemodules1-
-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
       - name: Build
-        run: npx nx build ${{ inputs.lib }}
+        run: npx nx build $LIB
 
       - name: Copy .npmrc to destination
-        run: cp ${{ env.NPM_CONFIG_USERCONFIG }} ${{ env.DESTINATION_PATH }}/
+        run: cp $NPM_CONFIG_USERCONFIG $DESTINATION_PATH
 
       - name: Copy README
-        run: cp libs/${{ inputs.lib }}/README.md ${{ env.DESTINATION_PATH }}/
+        run: cp libs/$LIB/README.md $DESTINATION_PATH
 
       - name: Publish
         working-directory: ${{ env.DESTINATION_PATH }}
-        run: npm publish --tag ${{ inputs.tag }} --access public
+        run: npm publish --tag $TAG --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          TAG: ${{ inputs.tag }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4.0.2
+      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4.1.1
         name: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_AUTH }}

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -14,6 +14,8 @@ on:
 
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets[format('VERCEL_PROJECT_ID_{0}', inputs.app)] }}
+  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
 jobs:
   build_and_deploy:
@@ -23,54 +25,48 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Set VERCEL_PROJECT_ID env var
-        # It's set in each env's config on https://github.com/cowprotocol/cowswap/settings/environments
-        run: echo "VERCEL_PROJECT_ID=${{ secrets[format('VERCEL_PROJECT_ID_{0}', inputs.app)] }}" >> $GITHUB_ENV
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
 
       - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=production --token=$VERCEL_TOKEN
 
       - name: Build Project Artifacts
-        run: >
-          NX_CONFIGURATION=${{ inputs.env_name == 'prod' && 'production' || inputs.env_name }}
-          REACT_APP_SENTRY_DSN=${{ secrets.SENTRY_DSN }}
-          REACT_APP_PINATA_API_KEY=${{ secrets.REACT_APP_PINATA_API_KEY }}
-          REACT_APP_PINATA_SECRET_API_KEY=${{ secrets.REACT_APP_PINATA_SECRET_API_KEY }}
-          REACT_APP_BLOCKNATIVE_API_KEY=${{ secrets.REACT_APP_BLOCKNATIVE_API_KEY }}
-          REACT_APP_GOOGLE_ANALYTICS_ID=${{ secrets.REACT_APP_GOOGLE_ANALYTICS_ID }}
-          REACT_APP_LAUNCH_DARKLY_KEY=${{ secrets.REACT_APP_LAUNCH_DARKLY_KEY }}
-          REACT_APP_INFURA_KEY=${{ secrets.REACT_APP_INFURA_KEY }}
-          REACT_APP_NETWORK_URL_1=${{ secrets.REACT_APP_NETWORK_URL_1 }}
-          REACT_APP_NETWORK_URL_100=${{ secrets.REACT_APP_NETWORK_URL_100 }}
-          REACT_APP_NETWORK_URL_137=${{ secrets.REACT_APP_NETWORK_URL_137 }}
-          REACT_APP_NETWORK_URL_8453=${{ secrets.REACT_APP_NETWORK_URL_8453 }}
-          REACT_APP_NETWORK_URL_42161=${{ secrets.REACT_APP_NETWORK_URL_42161 }}
-          REACT_APP_NETWORK_URL_43114=${{ secrets.REACT_APP_NETWORK_URL_43114 }}
-          REACT_APP_NETWORK_URL_11155111=${{ secrets.REACT_APP_NETWORK_URL_11155111 }}
-          REACT_APP_WC_PROJECT_ID=${{ secrets.REACT_APP_WC_PROJECT_ID }}
-          REACT_APP_IPFS_READ_URI=${{ secrets.REACT_APP_IPFS_READ_URI }}
-          REACT_APP_EXPLORER_SENTRY_DSN=${{ secrets.EXPLORER_SENTRY_DSN }}
-          REACT_APP_SUBGRAPH_URL_MAINNET=${{ secrets.REACT_APP_SUBGRAPH_URL_MAINNET }}
-          REACT_APP_SUBGRAPH_URL_ARBITRUM_ONE=${{ secrets.REACT_APP_SUBGRAPH_URL_ARBITRUM_ONE }}
-          REACT_APP_SUBGRAPH_URL_BASE=${{ secrets.REACT_APP_SUBGRAPH_URL_BASE }}
-          REACT_APP_SUBGRAPH_URL_GNOSIS_CHAIN=${{ secrets.REACT_APP_SUBGRAPH_URL_GNOSIS_CHAIN }}
-          REACT_APP_BFF_BASE_URL=${{ secrets.BFF_BASE_URL }}
-          REACT_APP_CMS_BASE_URL=${{ secrets.CMS_BASE_URL }}
-          NEXT_PUBLIC_CMS_BASE_URL=${{ secrets.CMS_BASE_URL }}
-          vercel build -t ${{ secrets.VERCEL_TOKEN }} --prod
-
-      - name: Get the version
-        id: get_version
-        run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
+        run: vercel build -t $VERCEL_TOKEN --prod
+        env:
+          NX_CONFIGURATION: ${{ inputs.env_name == 'prod' && 'production' || inputs.env_name }}
+          REACT_APP_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          REACT_APP_PINATA_API_KEY: ${{ secrets.REACT_APP_PINATA_API_KEY }}
+          REACT_APP_PINATA_SECRET_API_KEY: ${{ secrets.REACT_APP_PINATA_SECRET_API_KEY }}
+          REACT_APP_BLOCKNATIVE_API_KEY: ${{ secrets.REACT_APP_BLOCKNATIVE_API_KEY }}
+          REACT_APP_GOOGLE_ANALYTICS_ID: ${{ secrets.REACT_APP_GOOGLE_ANALYTICS_ID }}
+          REACT_APP_LAUNCH_DARKLY_KEY: ${{ secrets.REACT_APP_LAUNCH_DARKLY_KEY }}
+          REACT_APP_INFURA_KEY: ${{ secrets.REACT_APP_INFURA_KEY }}
+          REACT_APP_NETWORK_URL_1: ${{ secrets.REACT_APP_NETWORK_URL_1 }}
+          REACT_APP_NETWORK_URL_100: ${{ secrets.REACT_APP_NETWORK_URL_100 }}
+          REACT_APP_NETWORK_URL_137: ${{ secrets.REACT_APP_NETWORK_URL_137 }}
+          REACT_APP_NETWORK_URL_8453: ${{ secrets.REACT_APP_NETWORK_URL_8453 }}
+          REACT_APP_NETWORK_URL_42161: ${{ secrets.REACT_APP_NETWORK_URL_42161 }}
+          REACT_APP_NETWORK_URL_43114: ${{ secrets.REACT_APP_NETWORK_URL_43114 }}
+          REACT_APP_NETWORK_URL_11155111: ${{ secrets.REACT_APP_NETWORK_URL_11155111 }}
+          REACT_APP_WC_PROJECT_ID: ${{ secrets.REACT_APP_WC_PROJECT_ID }}
+          REACT_APP_IPFS_READ_URI: ${{ secrets.REACT_APP_IPFS_READ_URI }}
+          REACT_APP_EXPLORER_SENTRY_DSN: ${{ secrets.EXPLORER_SENTRY_DSN }}
+          REACT_APP_SUBGRAPH_URL_MAINNET: ${{ secrets.REACT_APP_SUBGRAPH_URL_MAINNET }}
+          REACT_APP_SUBGRAPH_URL_ARBITRUM_ONE: ${{ secrets.REACT_APP_SUBGRAPH_URL_ARBITRUM_ONE }}
+          REACT_APP_SUBGRAPH_URL_BASE: ${{ secrets.REACT_APP_SUBGRAPH_URL_BASE }}
+          REACT_APP_SUBGRAPH_URL_GNOSIS_CHAIN: ${{ secrets.REACT_APP_SUBGRAPH_URL_GNOSIS_CHAIN }}
+          REACT_APP_BFF_BASE_URL: ${{ secrets.BFF_BASE_URL }}
+          REACT_APP_CMS_BASE_URL: ${{ secrets.CMS_BASE_URL }}
+          NEXT_PUBLIC_CMS_BASE_URL: ${{ secrets.CMS_BASE_URL }}
 
       - name: Deploy Project Artifacts to Vercel
         run: >
           vercel deploy --prebuilt --prod
-          -t ${{ secrets.VERCEL_TOKEN }}
-          -m VERSION=${{ steps.get_version.outputs.VERSION }}
-          -m COMMIT=${{ github.sha }}
+          -t $VERCEL_TOKEN
+          -m VERSION=$(echo $GITHUB_REF | cut -d / -f 3)
+          -m COMMIT=$GITHUB_SHA


### PR DESCRIPTION
This PR hardens the CI by explicitly pinning all GitHub actions to their exact commit SHAs. Additionally, it enables Dependabot (on Github Workflows, it was already enabled for npm) for future upgrades + security alerts.
