### PR TITLE
fix(bridge): adjust displayed amounts

### DIFF
--- a/apps/cowswap-frontend/src/common/utils/calculateTargetAmountsBeforeBridging.ts
+++ b/apps/cowswap-frontend/src/common/utils/calculateTargetAmountsBeforeBridging.ts
@@ -29,5 +29,5 @@ function estimateWalletMinReceived(
     receivedAmount.quotient,
     bridgeMinReceiveAmount.quotient,
   )
-  return bridgeMinReceiveAmount.multiply(koeff)
+  return receivedAmount.multiply(koeff)
 }

--- a/apps/cowswap-frontend/src/modules/bridge/pure/BridgeActivitySummary/BridgeSummaryHeader.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/BridgeActivitySummary/BridgeSummaryHeader.tsx
@@ -14,7 +14,7 @@ import type { Order } from 'legacy/state/orders/actions'
 
 import { ShimmerWrapper, SummaryRow } from 'common/pure/OrderSummaryRow'
 
-import { SwapAndBridgeContext, SwapAndBridgeOverview } from '../../types'
+import { SwapAndBridgeContext, SwapAndBridgeOverview, SwapAndBridgeStatus } from '../../types'
 
 interface BridgeSummaryHeaderProps {
   order: Order
@@ -32,9 +32,10 @@ export function BridgeSummaryHeader({
   const { sourceAmounts, targetAmounts, sourceChainName, targetChainName, targetRecipient } = swapAndBridgeOverview
   const isCustomRecipient = !!targetRecipient && !areAddressesEqual(order.owner, targetRecipient)
   const targetAmount = targetAmounts?.buyAmount
-  
+
   // Only show destination chain when we have confirmed bridge data (crossChainOrder loaded)
   const showDestinationChain = !!swapAndBridgeContext?.statusResult
+  const isFinished = swapAndBridgeContext?.bridgingStatus === SwapAndBridgeStatus.DONE
 
   return (
     <>
@@ -48,7 +49,7 @@ export function BridgeSummaryHeader({
       </SummaryRow>
 
       <SummaryRow>
-        <b>To at least</b>
+        <b>{isFinished ? 'To' : 'To at least'}</b>
 
         <i>
           {targetAmount && showDestinationChain ? (

--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/index.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react'
 
+import { isFractionFalsy } from '@cowprotocol/common-utils'
 import { BridgeStatusResult } from '@cowprotocol/cow-sdk'
 
 import { FailedBridgingContent } from './FailedBridgingContent'
@@ -32,9 +33,8 @@ export function BridgingProgressContent(props: BridgingContentProps): ReactNode 
     explorerUrl,
   } = props
 
-
   return (
-    <QuoteBridgeContent {...props}>
+    <QuoteBridgeContent {...props} isFinished={!isFractionFalsy(receivedAmount)}>
       {receivedAmount ? (
         <ReceivedBridgingContent
           statusResult={statusResult}

--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/QuoteBridgeContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/QuoteBridgeContent/index.tsx
@@ -21,12 +21,14 @@ const estBridgeTimeTooltip = (
 
 export interface QuoteBridgeContentProps {
   isQuoteDisplay?: boolean
+  isFinished?: boolean
   quoteContext: QuoteBridgeContext
   children?: ReactNode
 }
 
 export function QuoteBridgeContent({
   isQuoteDisplay = false,
+  isFinished = false,
   quoteContext: {
     recipient,
     bridgeFee,
@@ -89,20 +91,22 @@ export function QuoteBridgeContent({
 
       <RecipientDetailsItem recipient={recipient} chainId={buyAmount.currency.chainId} />
 
-      <ConfirmDetailsItem
-        withTimelineDot
-        label={
-          !isQuoteDisplay ? (
-            MIN_RECEIVE_TITLE
-          ) : (
-            <ReceiveAmountTitle>
-              <b>{MIN_RECEIVE_TITLE}</b>
-            </ReceiveAmountTitle>
-          )
-        }
-      >
-        {!isQuoteDisplay ? minReceiveAmountEl : <b>{minReceiveAmountEl}</b>}
-      </ConfirmDetailsItem>
+      {!isFinished && (
+        <ConfirmDetailsItem
+          withTimelineDot
+          label={
+            !isQuoteDisplay ? (
+              MIN_RECEIVE_TITLE
+            ) : (
+              <ReceiveAmountTitle>
+                <b>{MIN_RECEIVE_TITLE}</b>
+              </ReceiveAmountTitle>
+            )
+          }
+        >
+          {!isQuoteDisplay ? minReceiveAmountEl : <b>{minReceiveAmountEl}</b>}
+        </ConfirmDetailsItem>
+      )}
 
       {children}
     </>


### PR DESCRIPTION
# Summary

Fixes:
 - https://www.notion.so/cownation/Account-modal-Bridge-at-least-shows-a-final-outcome-2318da5f04ca808da4f2c9e58a804359?v=1c38da5f04ca812b9489000c81197879&source=copy_link
 - https://www.notion.so/cownation/Bridging-at-least-amount-is-changing-2388da5f04ca8071a069e7ebee458a9f?source=copy_link

1. Hide "Min to receive" in activities list (bridging data) when bridging is finished

<img width="593" height="177" alt="image" src="https://github.com/user-attachments/assets/e43473c1-c2da-4357-8c6d-ff6c5939d1c3" />


2. Display "To" instead of "To at least" in activities list when bridging is finished
 
<img width="343" height="98" alt="image" src="https://github.com/user-attachments/assets/9282f381-a0b1-4259-bfa1-1ea41314cec5" />

3. Fix expected output amount when bridging is in progress. Expected but amount ("0.969022") should be the same in two cases: 1) Loading bridge data... 2) You received: In progress...
Before the fix it was displaying wrong value in the first case.

<img width="454" height="310" alt="image" src="https://github.com/user-attachments/assets/6c8dd6cd-a29d-4f42-aa41-76eb0051ec30" />

<img width="454" height="210" alt="image" src="https://github.com/user-attachments/assets/8af5e495-3456-4852-847e-821620254694" />


# To Test

See above
