### PR TITLE
fix: improve bridge details on cow explorer

### DIFF
--- a/apps/explorer/src/components/orders/BridgeDetailsTable/BridgeDetailsContent/index.tsx
+++ b/apps/explorer/src/components/orders/BridgeDetailsTable/BridgeDetailsContent/index.tsx
@@ -20,11 +20,14 @@ interface BridgeDetailsContentProps {
   crossChainOrder: CrossChainOrder
 }
 
+// TODO: Break down this large function into smaller functions
+//eslint-disable-next-line max-lines-per-function
 export function BridgeDetailsContent({ crossChainOrder }: BridgeDetailsContentProps): ReactNode {
   const {
     statusResult: { status: bridgeStatus, fillTxHash, depositTxHash, fillTimeInSeconds },
     bridgingParams: { inputAmount, outputAmount, owner, sourceChainId, destinationChainId, recipient },
     provider: { info: providerInfo },
+    order: { receiver },
   } = crossChainOrder
   const bridgeProvider = crossChainOrder.provider
   const { sourceToken, destinationToken } = useCrossChainTokens(crossChainOrder)
@@ -41,7 +44,16 @@ export function BridgeDetailsContent({ crossChainOrder }: BridgeDetailsContentPr
         </ProviderDisplayWrapper>
       </DetailRow>
 
-      <DetailRow label="From" tooltipText={BridgeDetailsTooltips.ownerAddress}>
+      {receiver && (
+        <DetailRow label="From" tooltipText={BridgeDetailsTooltips.accountProxy}>
+          <RowWithCopyButton
+            textToCopy={receiver}
+            contentsToDisplay={<AddressLink address={receiver} chainId={sourceChainId} showNetworkName />}
+          />
+        </DetailRow>
+      )}
+
+      <DetailRow label="Sender" tooltipText={BridgeDetailsTooltips.senderAddress}>
         <RowWithCopyButton
           textToCopy={owner}
           contentsToDisplay={<AddressLink address={owner} chainId={sourceChainId} showNetworkName />}

--- a/apps/explorer/src/components/orders/BridgeDetailsTable/bridgeDetailsTooltips.tsx
+++ b/apps/explorer/src/components/orders/BridgeDetailsTable/bridgeDetailsTooltips.tsx
@@ -1,3 +1,5 @@
+import { ExternalLink } from '@cowprotocol/ui'
+
 export const BridgeDetailsTooltips = {
   transactionHash: 'The transaction hash or provider-specific explorer link for the bridge operation.',
   status: 'The current status of the bridge operation.',
@@ -7,6 +9,15 @@ export const BridgeDetailsTooltips = {
   bridgingTime: 'Expected time for the bridge operation to complete.',
   maxSlippage: 'The maximum allowed slippage for the bridge in percentage.',
   provider: 'The bridging solution provider.',
-  ownerAddress: 'The account address from which the tokens are bridged.',
+  senderAddress: 'The account address from which the tokens are bridged.',
+  accountProxy: (
+    <span>
+      The{' '}
+      <ExternalLink href="https://swap.cow.fi/#/account-proxy" target="_blank" rel="noopener noreferrer">
+        Account Proxy
+      </ExternalLink>{' '}
+      address which will/did receive bought amount of the Swap before the bridge is initiated.
+    </span>
+  ),
   receiverAddress: 'The account address to which the tokens are bridged on the destination chain.',
 }

--- a/apps/explorer/src/components/orders/DetailsTable/BaseDetailsTable.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/BaseDetailsTable.tsx
@@ -77,6 +77,7 @@ export function BaseDetailsTable({
     })
   }
   const isSigning = status === 'signing'
+  const isBridging = !!order?.bridgeProviderId
 
   return (
     <SimpleTable
@@ -133,7 +134,11 @@ export function BaseDetailsTable({
           <tr>
             <td>
               <span>
-                <HelpTooltip tooltip={DetailsTableTooltips.to} /> To
+                <HelpTooltip
+                  placement="bottom"
+                  tooltip={isBridging ? DetailsTableTooltips.toBridge : DetailsTableTooltips.to}
+                />{' '}
+                To
               </span>
             </td>
             <td>

--- a/apps/explorer/src/components/orders/DetailsTable/detailsTableTooltips.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/detailsTableTooltips.tsx
@@ -1,7 +1,18 @@
+import { ExternalLink } from '@cowprotocol/ui'
+
 export const DetailsTableTooltips = {
   orderID: 'A unique identifier ID for this order.',
   from: 'The account address which signed the order.',
   to: 'The account address which will/did receive the bought amount.',
+  toBridge: (
+    <span>
+      The{' '}
+      <ExternalLink href="https://swap.cow.fi/#/account-proxy" target="_blank" rel="noopener noreferrer">
+        Account Proxy
+      </ExternalLink>{' '}
+      address which will/did receive bought amount of the Swap before the bridge is initiated.
+    </span>
+  ),
   hash: 'The onchain settlement transaction for this order. Can be viewed on Etherscan.',
   appData:
     'The AppData hash for this order. It can denote encoded metadata with info on the app, environment and more, although not all interfaces follow the same pattern. Show more will try to decode that information.',


### PR DESCRIPTION
# Summary

Cow Explorer shows ambiguous Swap and Bridge order details:

- on the Swap tab, the `From` row should specify it's the Account Proxy account  
- on the Bridge tab
  - the `From` row should specify it's the Account Proxy account  
  - the `Sender` row should display the `sender` account of the bridge

<img width="1149" height="294" alt="Screenshot 2025-07-29 at 16 06 12" src="https://github.com/user-attachments/assets/3d18f0ec-28e9-45bc-a332-99e4175b0172" />

<img width="1011" height="453" alt="Screenshot 2025-07-29 at 16 06 03" src="https://github.com/user-attachments/assets/7a6cbde7-0d98-4e1b-adaf-5b6c68b31af1" />

## Test

An example order is [here](https://explorer-dev-git-fix-explorer-discrepancy-pr-60a703-cowswap-dev.vercel.app/orders/0x36c4ff3aacb2ce2faedffeccb82b05e213ae1e28f2db60d108eba022b15207109fa3c00a92ec5f96b1ad2527ab41b3932efeda586880d514?tab=overview)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "From" detail row to display the receiver address with a tooltip and copy functionality when available.
  * Introduced a "Sender" detail row to explicitly show the sender address with an updated tooltip.
  * Enhanced tooltips with additional explanations and external links for account proxy and bridging details.
  * The "To" field tooltip now adapts based on whether bridging is involved, providing more relevant information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->