### PR TITLE
fix: high fee warning banner style and logic

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/HighFeeWarning/HighFeeWarningTooltipContent.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/HighFeeWarning/HighFeeWarningTooltipContent.tsx
@@ -61,8 +61,8 @@ export function HighFeeWarningTooltipContent({
   bridgeFeePercentage,
 }: HighFeeWarningTooltipContentProps): ReactNode {
   const shouldShowSwapAndBridgeFee = isHighFee && isHighBridgeFee && feePercentage && bridgeFeePercentage
-  const shouldShowSwapFee = isHighFee && !isHighBridgeFee && feePercentage
-  const shouldShowBridgeFee = !isHighFee && isHighBridgeFee && bridgeFeePercentage
+  const shouldShowSwapFee = isHighFee && feePercentage
+  const shouldShowBridgeFee = isHighBridgeFee && bridgeFeePercentage
 
   return (
     <Wrapper>

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/HighFeeWarning/styled.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/HighFeeWarning/styled.tsx
@@ -78,6 +78,7 @@ export const InlineWarningCheckboxContainer = styled(WarningCheckboxContainer)`
 export const InlineWarningTextContainer = styled.span`
   padding-left: 8px;
   padding-right: 8px;
+  text-align: center;
 `
 
 export const WarningContainer = styled(AuxInformationContainer).attrs((props) => ({


### PR DESCRIPTION
# Summary

Fix High Fees warning banner style and content.

# To Test

1. Prepare a trade. For example, 0.5 DAI/Base => USDC/OP
2. Above the main action button, a warning banner should show up.
3. The text is centred on any screen size.
4. The banner tooltip is visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified the display logic for swap and bridge fee warnings, ensuring each warning appears whenever its respective fee is high.
  * Centered the text alignment in the fee warning tooltip for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->