### PR TITLE
chore: fix COW_SHED_FACTORY usage

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useContract.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useContract.ts
@@ -22,7 +22,7 @@ import { isEns, isProd, isStaging } from '@cowprotocol/common-utils'
 import { COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { useWalletInfo } from '@cowprotocol/wallet'
 import { useWalletProvider } from '@cowprotocol/wallet-provider'
-import { Contract } from '@ethersproject/contracts'
+import { Contract, ContractInterface } from '@ethersproject/contracts'
 import { Web3Provider } from '@ethersproject/providers'
 
 const WETH_CONTRACT_ADDRESS_MAP = Object.fromEntries(
@@ -41,9 +41,7 @@ export type UseContractResult<T extends Contract = Contract> = {
 // returns null on errors
 export function useContract<T extends Contract = Contract>(
   addressOrAddressMap: string | { [chainId: number]: string | undefined | null } | undefined,
-  // TODO: Replace any with proper type definitions
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ABI: any,
+  ABI: ContractInterface,
   withSignerIfPossible = true,
   customProvider?: Web3Provider,
 ): UseContractResult<T> {
@@ -77,17 +75,17 @@ export function useContract<T extends Contract = Contract>(
     try {
       // Load and return the contract
       const contract = getContract(address, ABI, provider, withSignerIfPossible && account ? account : undefined)
+
       return {
         contract,
         error: null,
         chainId,
         loading: false,
       }
-    // TODO: Replace any with proper type definitions
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
+    } catch (error) {
       // Error getting the contract instance
       console.error('Failed to get contract', error)
+
       return {
         contract: null,
         error: error,
@@ -98,15 +96,11 @@ export function useContract<T extends Contract = Contract>(
   }, [addressOrAddressMap, ABI, provider, chainId, withSignerIfPossible, account]) as UseContractResult<T>
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function useTokenContract(tokenAddress?: string, withSignerIfPossible?: boolean) {
+export function useTokenContract(tokenAddress?: string, withSignerIfPossible?: boolean): UseContractResult<Erc20> {
   return useContract<Erc20>(tokenAddress, Erc20Abi, withSignerIfPossible)
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function useWethContract(withSignerIfPossible?: boolean) {
+export function useWethContract(withSignerIfPossible?: boolean): UseContractResult<Weth> {
   return useContract<Weth>(WETH_CONTRACT_ADDRESS_MAP, WethAbi, withSignerIfPossible)
 }
 

--- a/apps/cowswap-frontend/src/modules/cowShed/hooks/useRecoverFundsFromProxy.ts
+++ b/apps/cowswap-frontend/src/modules/cowShed/hooks/useRecoverFundsFromProxy.ts
@@ -2,7 +2,6 @@ import { useCallback, useState } from 'react'
 
 import { CowShedContract, CowShedContractAbi } from '@cowprotocol/abis'
 import { SigningScheme } from '@cowprotocol/contracts'
-import { COW_SHED_FACTORY } from '@cowprotocol/cow-sdk'
 import { useWalletInfo } from '@cowprotocol/wallet'
 import { useWalletProvider } from '@cowprotocol/wallet-provider'
 import { formatBytes32String } from '@ethersproject/strings'
@@ -39,7 +38,10 @@ export function useRecoverFundsFromProxy(
   const provider = useWalletProvider()
   const { account } = useWalletInfo()
   const cowShedHooks = useCowShedHooks()
-  const { contract: cowShedContract } = useContract<CowShedContract>(COW_SHED_FACTORY, CowShedContractAbi)
+
+  const factoryAddress = cowShedHooks?.getFactoryAddress()
+
+  const { contract: cowShedContract } = useContract<CowShedContract>(factoryAddress, CowShedContractAbi)
 
   const proxyAddress = useCurrentAccountProxyAddress()
 
@@ -52,8 +54,10 @@ export function useRecoverFundsFromProxy(
       !selectedTokenAddress ||
       !account ||
       !tokenBalance
-    )
+    ) {
+      console.error('Context is not ready for proxy funds recovering!')
       return
+    }
 
     setTxSigningStep(RecoverSigningStep.SIGN_RECOVER_FUNDS)
 


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Recover-funds-button-is-not-clickable-23f8da5f04ca80e28353d0c327ad38df

`COW_SHED_FACTORY` is a key-value now, that fact has broken `useRecoverFundsFromProxy`.
To avioid that problem, I repalced the const usage with `const factoryAddress = cowShedHooks?.getFactoryAddress()`.

# To Test

See https://www.notion.so/cownation/Recover-funds-button-is-not-clickable-23f8da5f04ca80e28353d0c327ad38df
