### PR TITLE
fix(bridge): show at least when swap hasn't being completed yet

### DIFF
--- a/apps/cowswap-frontend/src/modules/bridge/pure/BridgeActivitySummary/BridgeSummaryHeader.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/BridgeActivitySummary/BridgeSummaryHeader.tsx
@@ -33,8 +33,6 @@ export function BridgeSummaryHeader({
   const isCustomRecipient = !!targetRecipient && !areAddressesEqual(order.owner, targetRecipient)
   const targetAmount = targetAmounts?.buyAmount
 
-  // Only show destination chain when we have confirmed bridge data (crossChainOrder loaded)
-  const showDestinationChain = !!swapAndBridgeContext?.statusResult
   const isFinished = swapAndBridgeContext?.bridgingStatus === SwapAndBridgeStatus.DONE
 
   return (
@@ -52,7 +50,7 @@ export function BridgeSummaryHeader({
         <b>{isFinished ? 'To' : 'To at least'}</b>
 
         <i>
-          {targetAmount && showDestinationChain ? (
+          {targetAmount ? (
             <>
               <TokenLogo token={targetAmount.currency} size={20} />
               <TokenAmount amount={targetAmount} tokenSymbol={targetAmount.currency} />


### PR DESCRIPTION
# Summary

Fixes [issue](https://www.notion.so/cownation/At-least-amount-is-not-displayed-when-swap-in-progress-br-data-is-loading-23f8da5f04ca8053b23ffbcee538564c)

We show 'at least amount' in an activity only when tokens were transfered on bridge account. After the fix 'at least amount' should be visible from sending an order to Backend.

<img width="931" height="852" alt="image" src="https://github.com/user-attachments/assets/a9d955d4-3675-4e51-9237-5ab30942bf22" />


# To Test

1. Open swap and bridge form
2. set order and sign it
3. open the activities list and check 'At least amount' value

- [ ] 'At least amount' value should be visible since an order was sending to BE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the display logic in the bridge activity summary to always show the target amount and destination chain when a target amount is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->