### PR TITLE
fix(bridge): swap protocol icon colors for better contrast

### DIFF
--- a/apps/cowswap-frontend/src/modules/bridge/pure/ProtocolIcons/StackedProtocolIcons.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/ProtocolIcons/StackedProtocolIcons.tsx
@@ -117,7 +117,7 @@ export function StackedProtocolIcons({
     hoveredIcon,
   )
 
-  const cowProtocolBgColor = UI.COLOR_PURPLE_200_PRIMARY
+  const cowProtocolBgColor = UI.COLOR_PURPLE_800_PRIMARY
   const firstIconZIndex = isFirstOnTop ? 3 : 1
   const secondIconZIndex = isSecondOnTop ? 3 : isFirstOnTop ? 1 : 2
 
@@ -126,7 +126,7 @@ export function StackedProtocolIcons({
       variant={ProductVariant.CowProtocol} 
       height={currentLogoHeight} 
       logoIconOnly 
-      overrideColor={`var(${UI.COLOR_PURPLE_800_PRIMARY})`}
+      overrideColor={`var(${UI.COLOR_PURPLE_200_PRIMARY})`}
     />
   )
   const secondIconChildContent = (

--- a/apps/cowswap-frontend/src/modules/bridge/pure/ProtocolIcons/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/ProtocolIcons/index.tsx
@@ -34,13 +34,13 @@ function SingleProtocolIcon({
   currentLogoHeight,
 }: SingleProtocolIconProps): ReactNode {
   const protocolName = showOnlyFirst ? COW_PROTOCOL_NAME : secondProtocol?.name
-  const protocolBgColor = showOnlyFirst ? UI.COLOR_PURPLE_200_PRIMARY : undefined
+  const protocolBgColor = showOnlyFirst ? UI.COLOR_PURPLE_800_PRIMARY : undefined
   const iconChild = showOnlyFirst ? (
     <ProductLogo
       variant={ProductVariant.CowProtocol}
       height={currentLogoHeight}
       logoIconOnly
-      overrideColor={`var(${UI.COLOR_PURPLE_800_PRIMARY})`}
+      overrideColor={`var(${UI.COLOR_PURPLE_200_PRIMARY})`}
     />
   ) : (
     <img
@@ -57,7 +57,7 @@ function SingleProtocolIcon({
       size={currentDisplaySize}
       isStacked={false}
       bgColor={protocolBgColor}
-      color={showOnlyFirst ? `var(${UI.COLOR_PURPLE_800_PRIMARY})` : undefined}
+      color={showOnlyFirst ? `var(${UI.COLOR_PURPLE_200_PRIMARY})` : undefined}
     >
       {iconChild}
     </ProtocolIcon>


### PR DESCRIPTION
## Summary

Quick fix to swap the protocol icon colors that were missing from PR #6056

- Background: `UI.COLOR_PURPLE_800_PRIMARY` (dark purple)
- Icon: `UI.COLOR_PURPLE_200_PRIMARY` (light purple)

This provides better contrast and uses consistent theme-aware UI enums.

## Test plan

Visual check that CoW Protocol icons now show dark purple background with light purple icon.