### PR TITLE
fix(bridge): update display logic for min to receive

### DIFF
--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/QuoteBridgeContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/QuoteBridgeContent/index.tsx
@@ -91,19 +91,20 @@ export function QuoteBridgeContent({
 
       <RecipientDetailsItem recipient={recipient} chainId={buyAmount.currency.chainId} />
 
-      {!isFinished && (
+      {(!isFinished || !isQuoteDisplay) && (
         <ConfirmDetailsItem
+          withTimelineDot={!isQuoteDisplay}
           label={
-            !isQuoteDisplay ? (
-              MIN_RECEIVE_TITLE
-            ) : (
+            isQuoteDisplay ? (
               <ReceiveAmountTitle>
                 <b>{MIN_RECEIVE_TITLE}</b>
               </ReceiveAmountTitle>
+            ) : (
+              MIN_RECEIVE_TITLE
             )
           }
         >
-          {!isQuoteDisplay ? minReceiveAmountEl : <b>{minReceiveAmountEl}</b>}
+          {isQuoteDisplay ? <b>{minReceiveAmountEl}</b> : minReceiveAmountEl}
         </ConfirmDetailsItem>
       )}
 


### PR DESCRIPTION
 # Summary

  Add timeline dot to bridge "Min. to receive" in progress mode

  Updates the bridge "Min. to receive" row to show a timeline dot in progress mode (matching other progress items) while keeping the equal sign icon in quote/confirm modals.

  # To Test
<img width="513" height="732" alt="Screenshot 2025-07-31 at 14 53 07" src="https://github.com/user-attachments/assets/81bb7f2f-ddb3-468f-a114-803605f78415" />

<img width="521" height="917" alt="Screenshot 2025-07-31 at 14 44 41" src="https://github.com/user-attachments/assets/1152a9c6-5d3c-481e-9afa-ea4b9f62fd2b" />
<img width="516" height="847" alt="Screenshot 2025-07-31 at 14 44 28" src="https://github.com/user-attachments/assets/e2d3e87f-d12f-43a5-b9a4-d577b0ddfc43" />


  1. Create a swap + bridge order (e.g., DAI on Arbitrum → USDC on Base)

  - [ ] In swap form/confirm modal: "Min. to receive" shows with equal sign icon
  - [ ] During bridge progress: "Min. to receive" shows with timeline dot
  - [ ] "Min. to receive" remains visible throughout bridge progress (including after completion)

  # Background

  The `QuoteBridgeContent` component now conditionally applies `withTimelineDot={!isQuoteDisplay}` to maintain visual consistency. Progress mode uses timeline dots while quote/confirm modes use the equal sign icon.
