### PR TITLE
fix: proper styling of cancel status label

### DIFF
--- a/apps/cowswap-frontend/src/modules/account/containers/Transaction/StatusDetails.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/Transaction/StatusDetails.tsx
@@ -9,7 +9,7 @@ import { ExplorerDataType, getExplorerLink } from '@cowprotocol/common-utils'
 import { getSafeWebUrl } from '@cowprotocol/core'
 import { Command } from '@cowprotocol/types'
 
-import { Info, ExternalLink as LinkIconFeather } from 'react-feather'
+import { Info } from 'react-feather'
 import SVG from 'react-inlinesvg'
 
 import { getActivityState, ActivityState } from 'legacy/hooks/useActivityDerivedState'
@@ -159,16 +159,7 @@ export type StatusDetailsProps = {
 export function StatusDetails(props: StatusDetailsProps): ReactNode | null {
   const { chainId, activityDerivedState, showCancellationModal, showProgressBar } = props
 
-  const {
-    status,
-    type,
-    isCancelling,
-    isConfirmed,
-    isCancelled,
-    isReplaced,
-    isLoading,
-    order,
-  } = activityDerivedState
+  const { status, type, isCancelling, isConfirmed, isCancelled, isReplaced, isLoading, order } = activityDerivedState
 
   const cancellationHash = activityDerivedState.order?.cancellationHash
   const isCancellable = order ? isOrderCancellable(order) : true
@@ -194,7 +185,7 @@ export function StatusDetails(props: StatusDetailsProps): ReactNode | null {
   }
 
   return (
-    <StatusLabelWrapper withCancellationHash$={!!cancellationHash}>
+    <StatusLabelWrapper>
       <StatusLabel color={determinePillColour(status, type)} {..._getStatusLabelProps(activityDerivedState)}>
         {_getStatusIcon(activityDerivedState)}
         {isReplaced ? 'Replaced' : _getStateLabel(activityDerivedState)}
@@ -204,16 +195,13 @@ export function StatusDetails(props: StatusDetailsProps): ReactNode | null {
         <StatusLabelBelow>
           {showCancelButton && <CancelButton onClick={showCancellationModal} />}
           {showProgressBar && !isLoading && (
-            <ProgressLink
-              role="button"
-              onClick={handleProgressClick}
-            >
+            <ProgressLink role="button" onClick={handleProgressClick}>
               Show progress
             </ProgressLink>
           )}
           {showCancelTxLink && (
             <CancelTxLink href={cancellationTxLink} target="_blank" title="Cancellation transaction">
-              <LinkIconFeather size={16} />
+              View cancellation ↗
             </CancelTxLink>
           )}
         </StatusLabelBelow>

--- a/apps/cowswap-frontend/src/modules/account/containers/Transaction/styled.ts
+++ b/apps/cowswap-frontend/src/modules/account/containers/Transaction/styled.ts
@@ -196,18 +196,21 @@ export const StatusLabelWrapper = styled.div<{ withCancellationHash$: boolean }>
   gap: 4px;
   font-size: 13px;
   font-weight: 500;
+
   > span,
   > button {
     cursor: pointer;
     font-size: inherit;
     padding: 0;
   }
+
   > span {
     color: inherit;
     &:hover {
       text-decoration: underline;
     }
   }
+
   > button {
     appearance: none;
     border: none;
@@ -391,7 +394,7 @@ export const ActivityVisual = styled.div`
 `
 
 export const CancelTxLink = styled(ExternalLink)`
-  margin-left: 10px;
+  margin: 0 auto;
 `
 
 export const ProgressLink = styled.span`

--- a/apps/cowswap-frontend/src/modules/account/containers/Transaction/styled.ts
+++ b/apps/cowswap-frontend/src/modules/account/containers/Transaction/styled.ts
@@ -186,9 +186,9 @@ export const TransactionStatusText = styled.div`
   }
 `
 
-export const StatusLabelWrapper = styled.div<{ withCancellationHash$: boolean }>`
+export const StatusLabelWrapper = styled.div`
   display: flex;
-  flex-flow: ${({ withCancellationHash$ }) => (withCancellationHash$ ? 'row' : 'column wrap')};
+  flex-flow: column wrap;
   flex: 0 1 auto;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
 # Summary

Addresses https://github.com/cowprotocol/cowswap/issues/6065

  Replace cancellation link icon with text label "View cancellation ↗" and remove flex layout exception

https://github.com/user-attachments/assets/39cf3b2f-e9e0-4e1a-bd0d-fc1087979563




  # To Test

  1. Open account activity with cancelled orders

  - [ ] Verify cancelled orders show "View cancellation" text link instead of icon
  - [ ] Click link opens cancellation transaction in explorer/Safe
  - [ ] Status labels maintain vertical layout for all transaction types

  # Background

  Changed icon-only link to text for better UX. Removed `withCancellationHash$` prop that was creating a special row layout for cancelled orders - now all statuses use consistent column layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the cancellation link to display as centered plain text without an external link icon.
  * Simplified layout styling for status labels to use consistent column flow.
  * Improved code formatting and JSX structure for clarity without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->