### PR TITLE
feat: add overrideHoverColor for StackedProtocolIcons and SingleProto…

### DIFF
--- a/apps/cowswap-frontend/src/modules/bridge/pure/ProtocolIcons/StackedProtocolIcons.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/ProtocolIcons/StackedProtocolIcons.tsx
@@ -127,6 +127,7 @@ export function StackedProtocolIcons({
       height={currentLogoHeight} 
       logoIconOnly 
       overrideColor={`var(${UI.COLOR_PURPLE_200_PRIMARY})`}
+      overrideHoverColor={`var(${UI.COLOR_PURPLE_200_PRIMARY})`}
     />
   )
   const secondIconChildContent = (

--- a/apps/cowswap-frontend/src/modules/bridge/pure/ProtocolIcons/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/ProtocolIcons/index.tsx
@@ -41,6 +41,7 @@ function SingleProtocolIcon({
       height={currentLogoHeight}
       logoIconOnly
       overrideColor={`var(${UI.COLOR_PURPLE_200_PRIMARY})`}
+      overrideHoverColor={`var(${UI.COLOR_PURPLE_200_PRIMARY})`}
     />
   ) : (
     <img


### PR DESCRIPTION
# Summary

  Fixes protocol icon hover color turning black

  Adds `overrideHoverColor` prop to maintain consistent purple color (`UI.COLOR_PURPLE_200_PRIMARY`) on hover for CoW Protocol icons, preventing them from turning black.

## Before
https://github.com/user-attachments/assets/ba1360b0-a9c9-4025-bb30-d3520a762833

## After 

https://github.com/user-attachments/assets/91128c94-a0b2-4234-9867-82539b003a3b





  # To Test

  1. Navigate to any page with bridge protocol icons (e.g., bridge order details)

  - [ ] Hover over the CoW Protocol icon
  - [ ] Verify icon stays purple instead of turning black
  - [ ] Check both stacked icons and single icon displays

  # Background

  Follow-up to PRs #6059 and #6056 which fixed the icon colors but missed the hover state.