### PR TITLE
feat: use received label constant for consistency in bridging content

### DIFF
--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/FailedBridgingContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/FailedBridgingContent/index.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react'
 
 import RefundIcon from '@cowprotocol/assets/cow-swap/icon-refund.svg'
+import { RECEIVED_LABEL } from '@cowprotocol/common-const'
 
 import { ConfirmDetailsItem, ReceiveAmountTitle } from 'modules/trade'
 
@@ -10,7 +11,7 @@ import { StyledAnimatedTimelineRefundIcon } from '../../styled'
 export function FailedBridgingContent(): ReactNode {
   return (
     <>
-      <ConfirmDetailsItem label="You received" withTimelineDot>
+      <ConfirmDetailsItem label={RECEIVED_LABEL} withTimelineDot>
         <DangerText>Bridging failed</DangerText>
       </ConfirmDetailsItem>
       <ConfirmDetailsItem

--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/PendingBridgingContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/PendingBridgingContent/index.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react'
 
+import { RECEIVED_LABEL } from '@cowprotocol/common-const'
 import { BridgeStatusResult, SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import { ConfirmDetailsItem, ReceiveAmountTitle } from 'modules/trade'
@@ -27,7 +28,7 @@ export function PendingBridgingContent({
       <ConfirmDetailsItem
         label={
           <ReceiveAmountTitle>
-            <b>You received</b>
+            <b>{RECEIVED_LABEL}</b>
           </ReceiveAmountTitle>
         }
       >

--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/ReceivedBridgingContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/ReceivedBridgingContent/index.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-import { getChainInfo } from '@cowprotocol/common-const'
+import { getChainInfo, RECEIVED_LABEL } from '@cowprotocol/common-const'
 import { ExplorerDataType, getExplorerLink } from '@cowprotocol/common-utils'
 import { BridgeStatusResult, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
@@ -47,7 +47,7 @@ export function ReceivedBridgingContent({
       <ConfirmDetailsItem
         label={
           <ReceiveAmountTitle variant="success">
-            <SuccessTextBold>You received</SuccessTextBold>
+            <SuccessTextBold>{RECEIVED_LABEL}</SuccessTextBold>
           </ReceiveAmountTitle>
         }
       >

--- a/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/RefundedBridgingContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/RefundedBridgingContent/index.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react'
 
 import CheckmarkIcon from '@cowprotocol/assets/cow-swap/checkmark.svg'
+import { RECEIVED_LABEL } from '@cowprotocol/common-const'
 import { ExplorerDataType, getExplorerLink, shortenAddress } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { NetworkLogo } from '@cowprotocol/ui'
@@ -22,7 +23,7 @@ export function RefundedBridgingContent({ account, bridgeSendCurrencyAmount }: R
 
   return (
     <>
-      <ConfirmDetailsItem label="You received" withTimelineDot>
+      <ConfirmDetailsItem label={RECEIVED_LABEL} withTimelineDot>
         <DangerText>Bridging failed</DangerText>
       </ConfirmDetailsItem>
       <ConfirmDetailsItem

--- a/apps/cowswap-frontend/src/modules/orderProgressBar/pure/steps/FinishedStep.tsx
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/pure/steps/FinishedStep.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useMemo, useState } from 'react'
 import ICON_SOCIAL_X from '@cowprotocol/assets/images/icon-social-x.svg'
 import LOTTIE_GREEN_CHECKMARK_DARK from '@cowprotocol/assets/lottie/green-checkmark-dark.json'
 import LOTTIE_GREEN_CHECKMARK from '@cowprotocol/assets/lottie/green-checkmark.json'
+import { RECEIVED_LABEL } from '@cowprotocol/common-const'
 import { ExplorerDataType, getExplorerLink, getRandomInt, isSellOrder, shortenAddress } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { TokenLogo } from '@cowprotocol/tokens'
@@ -72,7 +73,7 @@ function getReceivedAmount(
 ) {
   return (
     <styledEl.ReceivedAmount>
-      {!isCustomRecipient && 'You received '}
+      {!isCustomRecipient && `${RECEIVED_LABEL} `}
       <TokenLogo token={order.outputToken} size={20} />
       <b>
         <TokenAmount

--- a/apps/explorer/src/components/orders/BridgeDetailsTable/BridgeDetailsContent/index.tsx
+++ b/apps/explorer/src/components/orders/BridgeDetailsTable/BridgeDetailsContent/index.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react'
 
+import { RECEIVED_LABEL } from '@cowprotocol/common-const'
 import { BridgeStatus, CrossChainOrder } from '@cowprotocol/cow-sdk'
 
 import { AddressLink } from 'components/common/AddressLink'
@@ -74,7 +75,7 @@ export function BridgeDetailsContent({ crossChainOrder }: BridgeDetailsContentPr
         </AmountSectionWrapper>
       </DetailRow>
 
-      <DetailRow label="You received" tooltipText={BridgeDetailsTooltips.youReceived}>
+      <DetailRow label={RECEIVED_LABEL} tooltipText={BridgeDetailsTooltips.youReceived}>
         {outputAmount && destinationToken && bridgeStatus === BridgeStatus.EXECUTED && (
           <BridgeReceiveAmount
             amount={outputAmount}

--- a/libs/common-const/src/common.ts
+++ b/libs/common-const/src/common.ts
@@ -79,6 +79,7 @@ export const COW_CONTRACT_ADDRESS: Record<SupportedChainId, string | null> = {
   [SupportedChainId.AVALANCHE]: null,
 }
 
+export const RECEIVED_LABEL = 'Received'
 export const INPUT_OUTPUT_EXPLANATION = 'Only executed swaps incur fees.'
 export const PENDING_ORDERS_BUFFER = ms`60s` // 60s
 export const CANCELLED_ORDERS_PENDING_TIME = ms`5min` // 5min


### PR DESCRIPTION
# Summary

  Centralize "You received" text to "Received" across bridge contexts

  - Created `RECEIVED_LABEL = 'Received'` constant in `@cowprotocol/common-const`
  - Replaced all 6 instances of "You received" with centralized constant
  - Affects bridge progress components and order progress bar
  
  
<img width="493" height="186" alt="Screenshot 2025-07-31 at 18 24 32" src="https://github.com/user-attachments/assets/40a0c7b7-0a2d-4e90-9d70-aa39b2924fc2" />


  # To Test

  1. Navigate to any bridge transaction flow

  - [ ] Verify bridge progress states show "Received" instead of "You received"
  - [ ] Check failed bridging content uses "Received" label
  - [ ] Check refunded bridging content uses "Received" label
  - [ ] Check received bridging content uses "Received" label
  - [ ] Check pending bridging content uses "Received" label

  2. Complete a swap order

  - [ ] Verify order progress bar shows "Received" in finished step

  3. Check Explorer bridge details

  - [ ] Verify bridge details table shows "Received" label

  # Background

  Consolidates UI text for better consistency and maintainability. Single constant allows easy future changes across all
  bridge-related contexts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a centralized label for received amounts, ensuring consistency across the app.

* **Refactor**
  * Replaced hardcoded "You received" text with a shared constant throughout various components for improved maintainability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->