### PR TITLE
feat: use account proxy label for consistent naming

### DIFF
--- a/apps/cowswap-frontend/src/modules/account/containers/CowShedInfo/index.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/CowShedInfo/index.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react'
 
+import { ACCOUNT_PROXY_LABEL } from '@cowprotocol/common-const'
 import { Command } from '@cowprotocol/types'
 import { useWalletInfo } from '@cowprotocol/wallet'
 import { useWalletProvider } from '@cowprotocol/wallet-provider'
@@ -38,7 +39,7 @@ export function CowShedInfo({ className, onClick }: CowShedInfoProps): ReactNode
   return (
     <ProxyPageLink to={cowShedLink} className={className} onClick={onClick}>
       <Pocket size={14} />
-      <span>Account proxy</span>
+      <span>{ACCOUNT_PROXY_LABEL}</span>
     </ProxyPageLink>
   )
 }

--- a/apps/cowswap-frontend/src/modules/application/containers/App/menuConsts.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/App/menuConsts.tsx
@@ -1,3 +1,4 @@
+import { ACCOUNT_PROXY_LABEL } from '@cowprotocol/common-const'
 import { MenuItem, ProductVariant } from '@cowprotocol/ui'
 
 import AppziButton from 'legacy/components/AppziButton'
@@ -19,7 +20,7 @@ export const NAV_ITEMS: MenuItem[] = [
       },
       {
         href: '/account-proxy',
-        label: 'Account Proxy',
+        label: ACCOUNT_PROXY_LABEL,
       },
     ],
   },

--- a/apps/cowswap-frontend/src/modules/bridge/pure/ProxyAccountBanner/index.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/pure/ProxyAccountBanner/index.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react'
 
+import { ACCOUNT_PROXY_LABEL } from '@cowprotocol/common-const'
 import { BannerOrientation, CollapsibleInlineBanner, StatusColorVariant } from '@cowprotocol/ui'
 
 import { useSetShedModal } from 'entities/cowShed/useCowShedModal'
@@ -27,17 +28,17 @@ export function ProxyAccountBanner({ recipient, chainId }: ProxyAccountBannerPro
       fontSize={13}
       collapsedContent={
         <div>
-          Swap bridged via your proxy account: <AddressLink address={recipient} chainId={chainId} />
+          Swap bridged via your {ACCOUNT_PROXY_LABEL}: <AddressLink address={recipient} chainId={chainId} />
         </div>
       }
       expandedContent={
         <div>
-          CoW Swap uses a dedicated proxy account, controlled only by you, to ensure smooooth bridging. Confirm the
+          CoW Swap uses a dedicated {ACCOUNT_PROXY_LABEL}, controlled only by you, to ensure smooooth bridging. Confirm the
           recipient address above is <AddressLink address={recipient} chainId={chainId} />
           <br />
           <br />
           <b onClick={handleReadMore} style={{ cursor: 'pointer', textDecoration: 'underline' }}>
-            View your private proxy account +{' '}
+            View your private {ACCOUNT_PROXY_LABEL} +{' '}
           </b>
         </div>
       }

--- a/apps/cowswap-frontend/src/modules/cowShed/containers/CoWShedWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/cowShed/containers/CoWShedWidget/index.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useCallback, useEffect, useRef } from 'react'
 
+import { ACCOUNT_PROXY_LABEL } from '@cowprotocol/common-const'
 import { useOnClickOutside } from '@cowprotocol/common-hooks'
 import { useWalletInfo } from '@cowprotocol/wallet'
 
@@ -61,7 +62,7 @@ export function CoWShedWidget({ onDismiss, modalMode }: CoWShedWidgetProps): Rea
     <>
       <Content>
         <Title>
-          <Pocket size={20} /> Account Proxy
+          <Pocket size={20} /> {ACCOUNT_PROXY_LABEL}
         </Title>
 
         {proxyAddress && <AddressLinkStyled address={proxyAddress} chainId={chainId} noShorten />}
@@ -81,7 +82,7 @@ export function CoWShedWidget({ onDismiss, modalMode }: CoWShedWidgetProps): Rea
       <WidgetWrapper ref={widgetRef}>
         <NewModal
           modalMode={modalMode}
-          title="Account Proxy"
+          title={ACCOUNT_PROXY_LABEL}
           onDismiss={onDismissCallback}
           contentPadding="10px"
           justifyContent="flex-start"

--- a/apps/cowswap-frontend/src/modules/cowShed/containers/ProxyRecipient/index.tsx
+++ b/apps/cowswap-frontend/src/modules/cowShed/containers/ProxyRecipient/index.tsx
@@ -1,5 +1,7 @@
 import { ReactNode } from 'react'
 
+import { ACCOUNT_PROXY_LABEL } from '@cowprotocol/common-const'
+
 import { Pocket } from 'react-feather'
 import styled from 'styled-components/macro'
 
@@ -31,7 +33,7 @@ export function ProxyRecipient({ recipient, chainId, size = 14 }: ProxyRecipient
 
   if (recipient.toLowerCase() !== proxyAddress.toLowerCase()) {
     throw new Error(
-      `Provided proxy address does not match CoW Shed proxy address!, recipient=${recipient}, proxyAddress=${proxyAddress}`,
+      `Provided proxy address does not match ${ACCOUNT_PROXY_LABEL} address!, recipient=${recipient}, proxyAddress=${proxyAddress}`,
     )
   }
 

--- a/apps/cowswap-frontend/src/modules/cowShed/containers/RecoverFundsWidget/RecoverFundsButtons.tsx
+++ b/apps/cowswap-frontend/src/modules/cowShed/containers/RecoverFundsWidget/RecoverFundsButtons.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react'
 
+import { ACCOUNT_PROXY_LABEL } from '@cowprotocol/common-const'
 import { getCurrencyAddress, getIsNativeToken } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { ButtonPrimary, CenteredDots } from '@cowprotocol/ui'
@@ -43,13 +44,13 @@ export function RecoverFundsButtons({ selectedCurrency, sourceChainId }: Recover
   if (accountProxyLoading) {
     return (
       <ButtonPrimaryStyled disabled>
-        Loading account proxy <CenteredDots smaller />
+        Loading {ACCOUNT_PROXY_LABEL} <CenteredDots smaller />
       </ButtonPrimaryStyled>
     )
   }
 
   if (accountProxy?.isProxySetupValid === null) {
-    return <ButtonPrimaryStyled disabled>Couldn't verify account proxy, please try later</ButtonPrimaryStyled>
+    return <ButtonPrimaryStyled disabled>Couldn't verify {ACCOUNT_PROXY_LABEL}, please try later</ButtonPrimaryStyled>
   }
 
   if (selectedTokenAddress) {

--- a/apps/cowswap-frontend/src/modules/cowShed/hooks/useRecoverFundsCallback.ts
+++ b/apps/cowswap-frontend/src/modules/cowShed/hooks/useRecoverFundsCallback.ts
@@ -1,5 +1,7 @@
 import { useCallback } from 'react'
 
+import { ACCOUNT_PROXY_LABEL } from '@cowprotocol/common-const'
+
 import { useErrorModal } from 'legacy/hooks/useErrorMessageAndModal'
 import { useTransactionAdder } from 'legacy/state/enhancedTransactions/hooks'
 
@@ -16,7 +18,7 @@ export function useRecoverFundsCallback(recoverFundsContext: RecoverFundsContext
       const txHash = await recoverFundsCallback()
 
       if (txHash) {
-        addTransaction({ hash: txHash, summary: 'Recover funds from CoW Shed Proxy' })
+        addTransaction({ hash: txHash, summary: `Recover funds from ${ACCOUNT_PROXY_LABEL}` })
       }
 
       return txHash

--- a/apps/cowswap-frontend/src/modules/cowShed/pure/CoWShedFAQ.tsx
+++ b/apps/cowswap-frontend/src/modules/cowShed/pure/CoWShedFAQ.tsx
@@ -2,6 +2,7 @@ import { useState, ReactNode } from 'react'
 
 import IMG_ICON_MINUS from '@cowprotocol/assets/images/icon-minus.svg'
 import IMG_ICON_PLUS from '@cowprotocol/assets/images/icon-plus.svg'
+import { ACCOUNT_PROXY_LABEL } from '@cowprotocol/common-const'
 import { ExternalLink } from '@cowprotocol/ui'
 
 import SVG from 'react-inlinesvg'
@@ -11,11 +12,11 @@ import { FAQItem, FAQWrapper } from '../containers/CoWShedWidget/styled'
 
 const FAQ_DATA = [
   {
-    question: 'What is Account Proxy?',
+    question: `What is ${ACCOUNT_PROXY_LABEL}?`,
     answer: (
       <>
         <ExternalLink href="https://github.com/cowdao-grants/cow-shed">
-          Account Proxy (also known as CoW Shed)
+{ACCOUNT_PROXY_LABEL} (also known as CoW Shed)
         </ExternalLink>{' '}
         is a helper contract that improves the user experience within CoW Swap for features like{' '}
         <ExternalLink href="https://docs.cow.fi/cow-protocol/reference/core/intents/hooks">CoW Hooks</ExternalLink>

--- a/apps/cowswap-frontend/src/modules/cowShed/pure/TokensInProxyBanner/index.tsx
+++ b/apps/cowswap-frontend/src/modules/cowShed/pure/TokensInProxyBanner/index.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react'
 
+import { ACCOUNT_PROXY_LABEL } from '@cowprotocol/common-const'
 import { TokenLogo } from '@cowprotocol/tokens'
 import { BannerOrientation, InlineBanner, StatusColorVariant, TokenAmount } from '@cowprotocol/ui'
 import { CurrencyAmount } from '@uniswap/sdk-core'
@@ -36,7 +37,7 @@ export function TokensInProxyBanner({ tokensToRefund }: TokensInProxyBannerProps
   return (
     <InlineBanner bannerType={StatusColorVariant.Warning} orientation={BannerOrientation.Horizontal}>
       <div>
-        Your proxy account contains the following tokens:
+        Your {ACCOUNT_PROXY_LABEL} contains the following tokens:
         <TokensList>
           {tokensToRefund.map(({ token, balance }) => {
             const amount = CurrencyAmount.fromRawAmount(token, balance.toString())

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
@@ -1,5 +1,6 @@
 import { ReactElement, ReactNode } from 'react'
 
+import { ACCOUNT_PROXY_LABEL } from '@cowprotocol/common-const'
 import { getIsNativeToken, getWrappedToken } from '@cowprotocol/common-utils'
 import { BridgeProviderQuoteError, BridgeQuoteErrors } from '@cowprotocol/cow-sdk'
 import { CenteredDots, HelpTooltip, TokenSymbol } from '@cowprotocol/ui'
@@ -228,12 +229,12 @@ export const tradeButtonsMap: Record<TradeFormValidation, ButtonErrorConfig | Bu
   [TradeFormValidation.ProxyAccountLoading]: {
     text: (
       <>
-        <span>Loading account proxy</span>
+        <span>Loading {ACCOUNT_PROXY_LABEL}</span>
         <CenteredDots smaller />
       </>
     ),
   },
   [TradeFormValidation.ProxyAccountUnknown]: {
-    text: "Couldn't verify account proxy, please try later",
+    text: `Couldn't verify ${ACCOUNT_PROXY_LABEL}, please try later`,
   },
 }

--- a/apps/explorer/src/components/orders/BridgeDetailsTable/bridgeDetailsTooltips.tsx
+++ b/apps/explorer/src/components/orders/BridgeDetailsTable/bridgeDetailsTooltips.tsx
@@ -1,3 +1,4 @@
+import { ACCOUNT_PROXY_LABEL } from '@cowprotocol/common-const'
 import { ExternalLink } from '@cowprotocol/ui'
 
 export const BridgeDetailsTooltips = {
@@ -13,7 +14,7 @@ export const BridgeDetailsTooltips = {
     <span>
       The{' '}
       <ExternalLink href="https://swap.cow.fi/#/account-proxy" target="_blank" rel="noopener noreferrer">
-        Account Proxy
+{ACCOUNT_PROXY_LABEL}
       </ExternalLink>{' '}
       address which will/did receive bought amount of the Swap before the bridge is initiated.
     </span>

--- a/apps/explorer/src/components/orders/DetailsTable/detailsTableTooltips.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/detailsTableTooltips.tsx
@@ -1,3 +1,4 @@
+import { ACCOUNT_PROXY_LABEL } from '@cowprotocol/common-const'
 import { ExternalLink } from '@cowprotocol/ui'
 
 export const DetailsTableTooltips = {
@@ -8,7 +9,7 @@ export const DetailsTableTooltips = {
     <span>
       The{' '}
       <ExternalLink href="https://swap.cow.fi/#/account-proxy" target="_blank" rel="noopener noreferrer">
-        Account Proxy
+{ACCOUNT_PROXY_LABEL}
       </ExternalLink>{' '}
       address which will/did receive bought amount of the Swap before the bridge is initiated.
     </span>

--- a/libs/common-const/src/common.ts
+++ b/libs/common-const/src/common.ts
@@ -79,6 +79,7 @@ export const COW_CONTRACT_ADDRESS: Record<SupportedChainId, string | null> = {
   [SupportedChainId.AVALANCHE]: null,
 }
 
+export const ACCOUNT_PROXY_LABEL = 'Account Proxy'
 export const INPUT_OUTPUT_EXPLANATION = 'Only executed swaps incur fees.'
 export const PENDING_ORDERS_BUFFER = ms`60s` // 60s
 export const CANCELLED_ORDERS_PENDING_TIME = ms`5min` // 5min


### PR DESCRIPTION
# Summary

  Centralize all "Account Proxy" terminology across codebase

  - Created `ACCOUNT_PROXY_LABEL = 'Account Proxy'` constant in `@cowprotocol/common-const`
  - Replaced 15+ instances of "Account Proxy"/"account proxy" with centralized constant
  - Affects tooltips, navigation, error messages, transaction summaries, and UI text

  # To Test

  1. Navigate through Account Proxy functionality

  - [ ] Verify navigation menu shows "Account Proxy"
  - [ ] Check tooltips in explorer bridge details use consistent terminology
  - [ ] Verify error/loading states show "Account Proxy" text
  - [ ] Check FAQ section uses consistent terminology

  2. Test proxy interactions

  - [ ] Verify transaction summaries use "Account Proxy" terminology
  - [ ] Check error messages display consistent terminology
  - [ ] Confirm modal titles and headers are updated

  # Background

  Consolidates "Account Proxy" terminology for consistency and maintainability. Single constant allows easy future terminology changes across all user-facing text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated user-facing messages to use a consistent and centralized label for "Account Proxy" throughout the app, improving clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->