### PR TITLE
fix: update wrong chain prefix warning's text

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/ChainPrefixWarning/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ChainPrefixWarning/index.tsx
@@ -46,11 +46,11 @@ export default function ChainPrefixWarning({ chainPrefixWarning, chainInfo, isDa
   return (
     <Wrapper>
       <p>
-        The recipient address you inputted had the chain prefix <strong>{chainPrefixWarning}</strong>, which is not the
-        expected for the network you are in.
+        The recipient address you inputted had the chain prefix <strong>{chainPrefixWarning}</strong>, which 
+        does not match the network in the Buy field.
       </p>
       <p>
-        You are connected to
+        The network in the Buy field is
         <Label color={color}>
           <NetworkImg src={logoUrl} /> {label}
         </Label>

--- a/apps/cowswap-frontend/src/common/pure/ChainPrefixWarning/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ChainPrefixWarning/index.tsx
@@ -47,10 +47,10 @@ export default function ChainPrefixWarning({ chainPrefixWarning, chainInfo, isDa
     <Wrapper>
       <p>
         The recipient address you inputted had the chain prefix <strong>{chainPrefixWarning}</strong>, which 
-        does not match the network in the Buy field.
+        does not match the network of the token to buy.
       </p>
       <p>
-        The network in the Buy field is
+        The network of the token to buy is
         <Label color={color}>
           <NetworkImg src={logoUrl} /> {label}
         </Label>


### PR DESCRIPTION
1. Switch ON the custom recipient option in the settings
2. Specify a swap/cross-chain swap
3. Set a custom recipient in the format: eth:0xEE7983B9449c74CC1EFf5793dcc336275015Fba0
4. Do the same test on Limit orders
5. Do the same test on Twap orders page

**ER**: 
- if a destination token is on Ethereum --> no additional warning should appear
- if a destination token is on another chain --> the warning should appear
- The warning text is: 
<img width="462" height="227" alt="image" src="https://github.com/user-attachments/assets/20721dae-786b-4a1f-9507-1e04e492ba3e" />
