### PR TITLE
fix(cow-fi): ISR optimization to prevent cache-busting in learn pages

### DIFF
--- a/apps/cow-fi/app/(learn)/learn/[article]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/[article]/page.tsx
@@ -1,13 +1,9 @@
+import type { ReactNode } from 'react'
+
 import { notFound } from 'next/navigation'
 
-import { ArticlePageComponent } from '@/components/ArticlePageComponent'
-import { FEATURED_ARTICLES_PAGE_SIZE } from '@/const/pagination'
-import { fetchArticleWithRetry } from '@/util/fetchHelpers'
-import { getPageMetadata } from '@/util/getPageMetadata'
-import { stripHtmlTags } from '@/util/stripHTMLTags'
-
 import {
-  Article,
+  Category,
   getAllArticleSlugs,
   getArticleBySlug,
   getArticles,
@@ -16,6 +12,14 @@ import {
 } from '../../../../services/cms'
 
 import type { Metadata } from 'next'
+
+import { ArticlePageComponent } from '@/components/ArticlePageComponent'
+import { FEATURED_ARTICLES_PAGE_SIZE } from '@/const/pagination'
+import { fetchArticleWithRetry } from '@/util/fetchHelpers'
+import { getPageMetadata } from '@/util/getPageMetadata'
+import { stripHtmlTags } from '@/util/stripHTMLTags'
+
+
 
 // Next.js requires revalidate to be a literal number for static analysis
 // This value (3600 seconds = 1 hour) should match CMS_CACHE_TIME in services/cms/index.ts
@@ -26,8 +30,8 @@ export const revalidate = 3600
 const METADATA_DESCRIPTION_MAX_LENGTH = 150
 const METADATA_DESCRIPTION_TRUNCATE_LENGTH = METADATA_DESCRIPTION_MAX_LENGTH - 3
 
-function isRichTextComponent(block: any): block is SharedRichTextComponent {
-  return block.body !== undefined
+function isRichTextComponent(block: unknown): block is SharedRichTextComponent {
+  return typeof block === 'object' && block !== null && 'body' in block
 }
 
 type Props = {
@@ -74,7 +78,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   }
 }
 
-export async function generateStaticParams() {
+export async function generateStaticParams(): Promise<{ article: string }[]> {
   try {
     const slugs = await getAllArticleSlugs()
     return slugs.map((article) => ({ article }))
@@ -84,7 +88,7 @@ export async function generateStaticParams() {
   }
 }
 
-export default async function ArticlePage({ params }: Props) {
+export default async function ArticlePage({ params }: Props): Promise<ReactNode> {
   const articleSlug = (await params).article
 
   try {
@@ -105,12 +109,11 @@ export default async function ArticlePage({ params }: Props) {
     })
     const featuredArticles = featuredArticlesResponse.data
 
-    // Get articles for random selection
-    const allArticlesResponse = await getArticles()
-    const randomArticles = getRandomArticles(allArticlesResponse.data, 3)
+    // Use first 3 featured articles for "Read more" section to ensure deterministic ISR caching
+    const readMoreArticles = featuredArticles.slice(0, 3)
     const categoriesResponse = await getCategories()
     const allCategories =
-      categoriesResponse?.map((category: any) => ({
+      categoriesResponse?.map((category: Category) => ({
         name: category?.attributes?.name || '',
         slug: category?.attributes?.slug || '',
       })) || []
@@ -118,7 +121,7 @@ export default async function ArticlePage({ params }: Props) {
     return (
       <ArticlePageComponent
         article={article}
-        randomArticles={randomArticles}
+        randomArticles={readMoreArticles}
         featuredArticles={featuredArticles}
         allCategories={allCategories}
       />
@@ -127,9 +130,4 @@ export default async function ArticlePage({ params }: Props) {
     console.error(`Error fetching article ${articleSlug}:`, error)
     return notFound()
   }
-}
-
-function getRandomArticles(articles: Article[], count: number): Article[] {
-  const shuffled = articles.sort(() => 0.5 - Math.random())
-  return shuffled.slice(0, count)
 }

--- a/apps/cow-fi/app/(learn)/learn/[article]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/[article]/page.tsx
@@ -31,7 +31,12 @@ const METADATA_DESCRIPTION_MAX_LENGTH = 150
 const METADATA_DESCRIPTION_TRUNCATE_LENGTH = METADATA_DESCRIPTION_MAX_LENGTH - 3
 
 function isRichTextComponent(block: unknown): block is SharedRichTextComponent {
-  return typeof block === 'object' && block !== null && 'body' in block
+  return (
+    typeof block === 'object' &&
+    block !== null &&
+    'body' in block &&
+    typeof (block as { body?: unknown }).body === 'string'
+  )
 }
 
 type Props = {

--- a/apps/cow-fi/app/(learn)/learn/articles/[[...pageIndex]]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/articles/[[...pageIndex]]/page.tsx
@@ -19,6 +19,9 @@ export type ArticlesResponse = {
   }
 }
 
+// Static limit for reasonable page range to prevent dynamic ISR invalidation
+const MAX_PAGE_LIMIT = 1000
+
 // Generate static params for first 10 pages only to avoid dynamic content issues
 // Additional pages will be generated on-demand with dynamicParams = true
 export async function generateStaticParams(): Promise<{ pageIndex: string[] }[]> {
@@ -57,7 +60,7 @@ export default async function Page({ params }: Props) {
 
   // Static bounds checking to avoid dynamic ISR invalidation
   // Allow reasonable page range - let CMS handle actual bounds
-  if (page < 1 || page > 1000) {
+  if (page < 1 || page > MAX_PAGE_LIMIT) {
     // Conservative upper limit
     return redirect('/learn/articles')
   }

--- a/apps/cow-fi/app/(learn)/learn/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/page.tsx
@@ -1,9 +1,16 @@
+import type { ReactNode } from 'react'
+
+import { Category, getArticles, getCategories } from '../../../services/cms'
+
 import { LearnPageComponent } from '@/components/LearnPageComponent'
 import { FEATURED_ARTICLES_PAGE_SIZE } from '@/const/pagination'
 
-import { getArticles, getCategories } from '../../../services/cms'
 
-export default async function LearnPage() {
+// Next.js requires revalidate to be a literal number for static analysis
+// This value (3600 seconds = 1 hour) should match CMS_CACHE_TIME in services/cms/index.ts
+export const revalidate = 3600
+
+export default async function LearnPage(): Promise<ReactNode> {
   // Fetch featured articles
   const featuredArticlesResponse = await getArticles({
     filters: {
@@ -27,20 +34,40 @@ export default async function LearnPage() {
 
   const categoriesResponse = await getCategories()
   // Pass raw categories data to client component for styling
-  const categories =
-    categoriesResponse?.map((category: any) => {
-      const imageUrl = category?.attributes?.image?.data?.attributes?.url || ''
-
-      return {
-        name: category?.attributes?.name || '',
-        slug: category?.attributes?.slug || '',
-        description: category?.attributes?.description || '',
-        bgColor: category?.attributes?.backgroundColor || '',
-        textColor: category?.attributes?.textColor || '',
-        link: `/learn/topic/${category?.attributes?.slug}`,
-        imageUrl,
-      }
-    }) || []
+  const categories = categoriesResponse?.map(formatCategoryForComponent) || []
 
   return <LearnPageComponent featuredArticles={featuredArticles} categories={categories} />
+}
+
+function formatCategoryForComponent(category: Category): {
+  name: string
+  slug: string
+  description: string
+  bgColor: string
+  textColor: string
+  link: string
+  imageUrl: string
+} {
+  const attrs = category?.attributes
+  if (!attrs) {
+    return {
+      name: '',
+      slug: '',
+      description: '',
+      bgColor: '',
+      textColor: '',
+      link: '/learn/topic/',
+      imageUrl: '',
+    }
+  }
+
+  return {
+    name: attrs.name ?? '',
+    slug: attrs.slug ?? '',
+    description: attrs.description ?? '',
+    bgColor: attrs.backgroundColor ?? '',
+    textColor: attrs.textColor ?? '',
+    link: `/learn/topic/${attrs.slug ?? ''}`,
+    imageUrl: attrs.image?.data?.attributes?.url ?? '',
+  }
 }

--- a/apps/cow-fi/app/(learn)/learn/topic/[topicSlug]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/topic/[topicSlug]/page.tsx
@@ -2,7 +2,13 @@ import type { ReactNode } from 'react'
 
 import { notFound } from 'next/navigation'
 
-import { Category, getAllCategorySlugs, getArticles, getCategories, getCategoryBySlug } from '../../../../../services/cms'
+import {
+  Category,
+  getAllCategorySlugs,
+  getArticles,
+  getCategories,
+  getCategoryBySlug,
+} from '../../../../../services/cms'
 
 import type { Metadata } from 'next'
 
@@ -14,23 +20,6 @@ import { getPageMetadata } from '@/util/getPageMetadata'
 type Props = {
   params: Promise<{ topicSlug: string }>
   searchParams?: Promise<{ [key: string]: string | string[] | undefined }>
-}
-
-interface CategoryWithAttributes {
-  attributes?: {
-    name?: string
-    slug?: string
-    description?: string
-    backgroundColor?: string
-    textColor?: string
-    image?: {
-      data?: {
-        attributes?: {
-          url?: string
-        }
-      }
-    }
-  }
 }
 
 // Next.js requires revalidate to be a literal number for static analysis
@@ -98,7 +87,7 @@ export default async function TopicPage({ params }: { params: Promise<{ topicSlu
   )
 }
 
-function formatCategoryForTopicPage(category: CategoryWithAttributes): {
+function formatCategoryForTopicPage(category: Category): {
   name: string
   slug: string
   description: string

--- a/apps/cow-fi/app/(learn)/learn/topic/[topicSlug]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/topic/[topicSlug]/page.tsx
@@ -1,13 +1,41 @@
+import type { ReactNode } from 'react'
+
+import { notFound } from 'next/navigation'
+
+import { Category, getAllCategorySlugs, getArticles, getCategories, getCategoryBySlug } from '../../../../../services/cms'
+
+import type { Metadata } from 'next'
+
 import { TopicPageComponent } from '@/components/TopicPageComponent'
 import { getPageMetadata } from '@/util/getPageMetadata'
-import type { Metadata } from 'next'
-import { notFound } from 'next/navigation'
-import { getAllCategorySlugs, getArticles, getCategories, getCategoryBySlug } from '../../../../../services/cms'
+
+
 
 type Props = {
   params: Promise<{ topicSlug: string }>
   searchParams?: Promise<{ [key: string]: string | string[] | undefined }>
 }
+
+interface CategoryWithAttributes {
+  attributes?: {
+    name?: string
+    slug?: string
+    description?: string
+    backgroundColor?: string
+    textColor?: string
+    image?: {
+      data?: {
+        attributes?: {
+          url?: string
+        }
+      }
+    }
+  }
+}
+
+// Next.js requires revalidate to be a literal number for static analysis
+// This value (3600 seconds = 1 hour) should match CMS_CACHE_TIME in services/cms/index.ts
+export const revalidate = 3600
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   'use server'
@@ -25,7 +53,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   })
 }
 
-export async function generateStaticParams() {
+export async function generateStaticParams(): Promise<{ topicSlug: string }[]> {
   'use server'
 
   const categoriesResponse = await getAllCategorySlugs()
@@ -33,8 +61,7 @@ export async function generateStaticParams() {
   return categoriesResponse.map((topicSlug) => ({ topicSlug }))
 }
 
-export default async function TopicPage({ params }: { params: Promise<{ topicSlug: string }> }) {
-  // Get the category
+export default async function TopicPage({ params }: { params: Promise<{ topicSlug: string }> }): Promise<ReactNode> {
   const { topicSlug } = await params
   const category = await getCategoryBySlug(topicSlug)
 
@@ -42,41 +69,24 @@ export default async function TopicPage({ params }: { params: Promise<{ topicSlu
     notFound()
   }
 
-  // Format the category for the component
-  const formattedCategory = {
-    name: category.attributes?.name || '',
-    slug: category.attributes?.slug || '',
-    description: category.attributes?.description || '',
-    bgColor: category.attributes?.backgroundColor || '#FFFFFF',
-    textColor: category.attributes?.textColor || '#000000',
-    imageUrl: category.attributes?.image?.data?.attributes?.url || '',
-  }
-
-  // Get articles for this topic
-  const topicArticlesResponse = await getArticles({
-    filters: {
-      categories: {
-        slug: {
-          $eq: topicSlug,
+  const formattedCategory = formatCategoryForTopicPage(category)
+  const [topicArticlesResponse, allArticlesResponse, categoriesResponse] = await Promise.all([
+    getArticles({
+      filters: {
+        categories: {
+          slug: {
+            $eq: topicSlug,
+          },
         },
       },
-    },
-  })
-
-  // Get articles for search functionality
-  const allArticlesResponse = await getArticles()
+    }),
+    getArticles(),
+    getCategories(),
+  ])
 
   const topicArticles = topicArticlesResponse.data
   const allArticles = allArticlesResponse.data
-
-  const categoriesResponse = await getCategories()
-  const allCategories =
-    categoriesResponse?.map((category: any) => {
-      return {
-        name: category.attributes?.name || '',
-        slug: category.attributes?.slug || '',
-      }
-    }) || []
+  const allCategories = categoriesResponse?.map(formatCategoryForList) || []
 
   return (
     <TopicPageComponent
@@ -86,4 +96,44 @@ export default async function TopicPage({ params }: { params: Promise<{ topicSlu
       allArticles={allArticles}
     />
   )
+}
+
+function formatCategoryForTopicPage(category: CategoryWithAttributes): {
+  name: string
+  slug: string
+  description: string
+  bgColor: string
+  textColor: string
+  imageUrl: string
+} {
+  const attrs = category.attributes
+  if (!attrs) {
+    return {
+      name: '',
+      slug: '',
+      description: '',
+      bgColor: '#FFFFFF',
+      textColor: '#000000',
+      imageUrl: '',
+    }
+  }
+
+  return {
+    name: attrs.name ?? '',
+    slug: attrs.slug ?? '',
+    description: attrs.description ?? '',
+    bgColor: attrs.backgroundColor ?? '#FFFFFF',
+    textColor: attrs.textColor ?? '#000000',
+    imageUrl: attrs.image?.data?.attributes?.url ?? '',
+  }
+}
+
+function formatCategoryForList(category: Category): {
+  name: string
+  slug: string
+} {
+  return {
+    name: category.attributes?.name ?? '',
+    slug: category.attributes?.slug ?? '',
+  }
 }

--- a/apps/cow-fi/app/(learn)/learn/topics/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/topics/page.tsx
@@ -1,32 +1,59 @@
-'use client'
+import type { ReactNode } from 'react'
 
 import { UI } from '@cowprotocol/ui'
+
+import { Category, getArticles, getCategories } from '../../../../services/cms'
 
 import { TopicsPageComponent } from '@/components/TopicsPageComponent'
 import { ARTICLES_LARGE_PAGE_SIZE } from '@/const/pagination'
 
-import { getArticles, getCategories } from '../../../../services/cms'
 
-export default async function TopicsPage() {
+// Next.js requires revalidate to be a literal number for static analysis
+// This value (3600 seconds = 1 hour) should match CMS_CACHE_TIME in services/cms/index.ts
+export const revalidate = 3600
+
+export default async function TopicsPage(): Promise<ReactNode> {
   const articlesResponse = await getArticles({ pageSize: ARTICLES_LARGE_PAGE_SIZE })
   const articles = articlesResponse.data
 
   const categoriesResponse = await getCategories()
-  const categories =
-    categoriesResponse?.map((category: any) => {
-      const imageUrl = category?.attributes?.image?.data?.attributes?.url || ''
-
-      return {
-        name: category?.attributes?.name || '',
-        slug: category?.attributes?.slug || '',
-        description: category?.attributes?.description || '',
-        bgColor: category?.attributes?.backgroundColor || `var(${UI.COLOR_NEUTRAL_100})`,
-        textColor: category?.attributes?.textColor || `var(${UI.COLOR_NEUTRAL_0})`,
-        link: `/learn/topic/${category?.attributes?.slug}`,
-        iconColor: 'transparent',
-        imageUrl,
-      }
-    }) || []
+  const categories = categoriesResponse?.map(formatCategoryForTopicsPage) || []
 
   return <TopicsPageComponent articles={articles} categories={categories} />
+}
+
+function formatCategoryForTopicsPage(category: Category): {
+  name: string
+  slug: string
+  description: string
+  bgColor: string
+  textColor: string
+  link: string
+  iconColor: string
+  imageUrl: string
+} {
+  const attrs = category?.attributes
+  if (!attrs) {
+    return {
+      name: '',
+      slug: '',
+      description: '',
+      bgColor: `var(${UI.COLOR_NEUTRAL_100})`,
+      textColor: `var(${UI.COLOR_NEUTRAL_0})`,
+      link: '/learn/topic/',
+      iconColor: 'transparent',
+      imageUrl: '',
+    }
+  }
+
+  return {
+    name: attrs.name ?? '',
+    slug: attrs.slug ?? '',
+    description: attrs.description ?? '',
+    bgColor: attrs.backgroundColor ?? `var(${UI.COLOR_NEUTRAL_100})`,
+    textColor: attrs.textColor ?? `var(${UI.COLOR_NEUTRAL_0})`,
+    link: `/learn/topic/${attrs.slug ?? ''}`,
+    iconColor: 'transparent',
+    imageUrl: attrs.image?.data?.attributes?.url ?? '',
+  }
 }


### PR DESCRIPTION
## Summary

Fixes ISR cache-busting issues in learn pages by eliminating non-deterministic patterns and adding proper revalidation.

## Changes

- Replace random article selection with deterministic approach
- Add revalidate exports to all learn routes
- Limit static generation to first 10 pages with dynamic fallback
- Improve type safety and code organization

## To Test

1. Navigate all learn pages - `/learn`, `/learn/articles`, `/learn/[article]`, `/learn/topics`
2. Verify consistent "Read more" articles (not random)
3. Check pagination works correctly
4. Confirm fast page loads from cache