### PR TITLE
feat(explorer): sort fills tab by execution date, descending

### DIFF
--- a/apps/explorer/src/hooks/useOperatorTrades.ts
+++ b/apps/explorer/src/hooks/useOperatorTrades.ts
@@ -46,7 +46,7 @@ async function fetchTradesTimestamps(rawTrades: RawTrade[]): Promise<TradesTimes
  * Fetches trades for given order
  */
 // TODO: Break down this large function into smaller functions
-// eslint-disable-next-line max-lines-per-function
+
 export function useOrderTrades(order: Order | null): Result {
   const [error, setError] = useState<UiError>()
   const [trades, setTrades] = useState<Trade[]>([])
@@ -78,7 +78,7 @@ export function useOrderTrades(order: Order | null): Result {
         setError({ message: msg, type: 'error' })
       }
     },
-    [order]
+    [order],
   )
 
   // Fetch blocks timestamps for trades
@@ -106,8 +106,14 @@ export function useOrderTrades(order: Order | null): Result {
       return { ...transformTrade(trade, order, timestamp), buyToken, sellToken }
     })
 
-    // Reverse trades, to show the newest on top
-    setTrades(trades.reverse())
+    // sort trades by execution time, newest first
+    trades.sort((a, b) => {
+      if (a.executionTime && b.executionTime) {
+        return b.executionTime > a.executionTime ? 1 : -1
+      }
+      return 0
+    })
+    setTrades(trades)
   }, [order, rawTrades, tradesTimestamps])
 
   const executedSellAmount = order?.executedSellAmount.toString()


### PR DESCRIPTION
# Summary

Sort order fills tab by execution date, descending

# To Test

1. Open an order with multiple fills, such as `0x08b03471f9c93215764b2160d7697487f8ba15916b7d5d0912d75c5c314a2db86067e32439c70f9549ccb31fa858598b54c48899689377b6`
2. Open the fills tab
* Fills should be sorted by execution date, descending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display order of trades to consistently show the newest trades first based on execution time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->