### PR TITLE
fix(explorer): resolve native tokens from hardcode

### DIFF
--- a/apps/explorer/src/components/orders/BridgeDetailsTable/BridgeDetailsContent/index.tsx
+++ b/apps/explorer/src/components/orders/BridgeDetailsTable/BridgeDetailsContent/index.tsx
@@ -67,7 +67,7 @@ export function BridgeDetailsContent({ crossChainOrder }: BridgeDetailsContentPr
         <AmountSectionWrapper>
           <BridgeAmountDisplay labelPrefix="From:" bridgeToken={sourceToken} amount={inputAmount.toString()} />
           <BridgeAmountDisplay
-            labelPrefix="To at least:"
+            labelPrefix="To:"
             bridgeToken={destinationToken}
             amount={outputAmount?.toString() || '0'}
             bridgeProvider={bridgeProvider}

--- a/apps/explorer/src/hooks/useTokenList.ts
+++ b/apps/explorer/src/hooks/useTokenList.ts
@@ -4,7 +4,9 @@ import { SWR_NO_REFRESH_OPTIONS } from '@cowprotocol/common-const'
 import { ALL_SUPPORTED_CHAIN_IDS, mapSupportedNetworks, SupportedChainId } from '@cowprotocol/cow-sdk'
 import type { TokenInfo, TokenList } from '@uniswap/token-lists'
 
-import useSWR from 'swr'
+import useSWR, { SWRResponse } from 'swr'
+
+import { NATIVE_TOKEN_ADDRESS, NATIVE_TOKEN_PER_NETWORK } from '../const'
 
 type TokenListByAddress = Record<string, TokenInfo>
 type TokenListPerNetwork = Record<SupportedChainId, TokenListByAddress>
@@ -21,8 +23,8 @@ const COINGECKO_CHAINS: Record<SupportedChainId, string | null> = {
   [SupportedChainId.AVALANCHE]: 'avalanche',
 }
 
-// TODO: Reduce function complexity by extracting logic
-// eslint-disable-next-line complexity
+const EMPTY_TOKENS: TokenListByAddress = {}
+
 export function useTokenList(chainId: SupportedChainId | undefined): { data: TokenListByAddress; isLoading: boolean } {
   const { data: cowSwapList, isLoading: isCowListLoading } = useTokenListByUrl(
     chainId !== SupportedChainId.SEPOLIA
@@ -39,26 +41,31 @@ export function useTokenList(chainId: SupportedChainId | undefined): { data: Tok
   const { data: coingeckoList, isLoading: isCoingeckoLoading } = useTokenListByUrl(
     coingeckoUrlKey ? `https://tokens.coingecko.com/${coingeckoUrlKey}/all.json` : '',
   )
-  const { data: baseList, isLoading: isBaseListLoading } = useTokenListByUrl(
-    chainId === SupportedChainId.BASE ? 'https://tokens.coingecko.com/base/all.json' : '',
-  )
 
   const isLoading = chainId
-    ? isCowListLoading || isHoneyswapListLoading || isCoingeckoUniswapLoading || isCoingeckoLoading || isBaseListLoading
+    ? isCowListLoading || isHoneyswapListLoading || isCoingeckoUniswapLoading || isCoingeckoLoading
     : false
 
   return useMemo(() => {
-    const data = chainId
-      ? { ...coingeckoUniswapList, ...honeyswapList, ...cowSwapList, ...coingeckoList, ...baseList }[chainId]
-      : {}
+    if (!chainId) return { data: EMPTY_TOKENS, isLoading: false }
+
+    const data =
+      { ...coingeckoUniswapList, ...honeyswapList, ...cowSwapList, ...coingeckoList }[chainId] || EMPTY_TOKENS
+
+    const nativeToken = NATIVE_TOKEN_PER_NETWORK[chainId]
+
+    data[NATIVE_TOKEN_ADDRESS.toLowerCase()] = {
+      ...nativeToken,
+      name: nativeToken.name || '',
+      symbol: nativeToken.symbol || '',
+      chainId,
+    }
 
     return { data, isLoading }
-  }, [chainId, coingeckoUniswapList, honeyswapList, cowSwapList, coingeckoList, isLoading, baseList])
+  }, [chainId, coingeckoUniswapList, honeyswapList, cowSwapList, coingeckoList, isLoading])
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function useTokenListByUrl(tokenListUrl: string) {
+function useTokenListByUrl(tokenListUrl: string): SWRResponse<TokenListPerNetwork> {
   return useSWR(tokenListUrl, fetcher, {
     fallbackData: INITIAL_TOKEN_LIST_PER_NETWORK,
     ...SWR_NO_REFRESH_OPTIONS,


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Explorer-from-amount-is-not-displayed-when-buy-ETH-2428da5f04ca80c8bc43e3d54a2050d8?source=copy_link

1. Changed `To at least` to `To` in amounts (Bridge tab)
2. Removed an excessive request of tokens for Base network. There is a generic request to Coingeck which already covers that
3. Added native token to the result of `useTokenList()`. Coingecko list for Arbitrum doesn't include native token, but we have a hardcoded map of native tokens (per chain). So, we can add the hardcoded native token to the hook results. 

<img width="943" height="439" alt="image" src="https://github.com/user-attachments/assets/0bef643a-2dc5-445e-99c0-58294f465924" />


# To Test

See https://www.notion.so/cownation/Explorer-from-amount-is-not-displayed-when-buy-ETH-2428da5f04ca80c8bc43e3d54a2050d8
