### PR TITLE
fix(explorer): remove flickering from app-data details

### DIFF
--- a/apps/explorer/src/components/AppData/AppDataContent.tsx
+++ b/apps/explorer/src/components/AppData/AppDataContent.tsx
@@ -1,0 +1,39 @@
+import { ReactNode } from 'react'
+
+import { useAppData } from '../../hooks/useAppData'
+import { RowWithCopyButton } from '../common/RowWithCopyButton'
+import Spinner from '../common/Spinner'
+import { Notification } from '../Notification'
+
+interface AppDataContentProps {
+  appData: string
+  fullAppData?: string
+  showDecodedAppData: boolean
+}
+
+export function AppDataContent({ appData, fullAppData, showDecodedAppData }: AppDataContentProps): ReactNode {
+  const {
+    isLoading: appDataLoading,
+    appDataDoc: decodedAppData,
+    hasError: appDataError,
+  } = useAppData(appData, fullAppData)
+
+  const appDataString = JSON.stringify(decodedAppData, null, 2)
+
+  if (appDataLoading) return <Spinner />
+
+  if (showDecodedAppData) {
+    if (appDataError)
+      return (
+        <Notification type="error" message="Error when getting metadata info." closable={false} appendMessage={false} />
+      )
+    return (
+      <RowWithCopyButton
+        textToCopy={appDataString}
+        contentsToDisplay={<pre className="json-formatter">{appDataString}</pre>}
+      />
+    )
+  }
+
+  return null
+}

--- a/apps/explorer/src/components/AppData/DecodeAppData.tsx
+++ b/apps/explorer/src/components/AppData/DecodeAppData.tsx
@@ -1,57 +1,41 @@
-import { useState } from 'react'
+import { ReactNode, useState } from 'react'
 
 import { Color } from '@cowprotocol/ui'
 
 import AppDataWrapper from 'components/common/AppDataWrapper'
 import { RowWithCopyButton } from 'components/common/RowWithCopyButton'
-import Spinner from 'components/common/Spinner'
-import { Notification } from 'components/Notification'
 import { useAppData } from 'hooks/useAppData'
 import styled from 'styled-components/macro'
 
-type Props = {
+import { AppDataContent } from './AppDataContent'
+
+type DecodeAppDataProps = {
   appData: string
   fullAppData?: string
   showExpanded?: boolean
 }
 
-// TODO: Break down this large function into smaller functions
-// eslint-disable-next-line max-lines-per-function
-const DecodeAppData = (props: Props): React.ReactNode => {
+const ShowMoreButton = styled.button`
+  font-size: 1.4rem;
+  margin-top: 0.5rem;
+  border: none;
+  background: none;
+  color: ${Color.explorer_textActive};
+  align-self: flex-start;
+  padding: 0;
+
+  :hover {
+    text-decoration: underline;
+    cursor: pointer;
+  }
+`
+
+export const DecodeAppData = (props: DecodeAppDataProps): ReactNode => {
   const { appData, showExpanded = false, fullAppData } = props
-  const {
-    isLoading: appDataLoading,
-    appDataDoc: decodedAppData,
-    ipfsUri,
-    hasError: appDataError,
-  } = useAppData(appData, fullAppData)
+  const { ipfsUri, hasError: appDataError } = useAppData(appData, fullAppData)
 
   const isLegacyAppDataHex = fullAppData === undefined
   const [showDecodedAppData, setShowDecodedAppData] = useState<boolean>(showExpanded)
-
-  const renderAppData = (): React.ReactNode | null => {
-    const appDataString = JSON.stringify(decodedAppData, null, 2)
-
-    if (appDataLoading) return <Spinner />
-    if (showDecodedAppData) {
-      if (appDataError)
-        return (
-          <Notification
-            type="error"
-            message="Error when getting metadata info."
-            closable={false}
-            appendMessage={false}
-          />
-        )
-      return (
-        <RowWithCopyButton
-          textToCopy={appDataString}
-          contentsToDisplay={<pre className="json-formatter">{appDataString}</pre>}
-        />
-      )
-    }
-    return null
-  }
 
   return (
     <AppDataWrapper>
@@ -77,24 +61,9 @@ const DecodeAppData = (props: Props): React.ReactNode => {
           {showDecodedAppData ? '[-] Show less' : '[+] Show more'}
         </ShowMoreButton>
       </>
-      <div className={`hidden-content ${appDataError && 'error'}`}>{renderAppData()}</div>
+      <div className={`hidden-content ${appDataError && 'error'}`}>
+        <AppDataContent appData={appData} fullAppData={fullAppData} showDecodedAppData={showDecodedAppData} />
+      </div>
     </AppDataWrapper>
   )
 }
-
-const ShowMoreButton = styled.button`
-  font-size: 1.4rem;
-  margin-top: 0.5rem;
-  border: none;
-  background: none;
-  color: ${Color.explorer_textActive};
-  align-self: flex-start;
-  padding: 0;
-
-  :hover {
-    text-decoration: underline;
-    cursor: pointer;
-  }
-`
-
-export default DecodeAppData

--- a/apps/explorer/src/components/orders/DetailsTable/VerboseDetails.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/VerboseDetails.tsx
@@ -10,7 +10,7 @@ import { LinkButton, Wrapper } from './styled'
 
 import { Order } from '../../../api/operator'
 import { TAB_QUERY_PARAM_KEY } from '../../../explorer/const'
-import DecodeAppData from '../../AppData/DecodeAppData'
+import { DecodeAppData } from '../../AppData/DecodeAppData'
 import { DetailRow } from '../../common/DetailRow'
 import { FilledProgress } from '../FilledProgress'
 import { GasFeeDisplay } from '../GasFeeDisplay'

--- a/apps/explorer/src/explorer/pages/AppData/DecodePage.tsx
+++ b/apps/explorer/src/explorer/pages/AppData/DecodePage.tsx
@@ -4,7 +4,7 @@ import Form, { FormValidation } from '@rjsf/core'
 
 import { decodeAppDataSchema, FormProps, handleErrors, transformErrors } from './config'
 
-import DecodeAppData from '../../../components/AppData/DecodeAppData'
+import { DecodeAppData } from '../../../components/AppData/DecodeAppData'
 
 import { TabData } from './index'
 
@@ -13,15 +13,13 @@ type DecodeProps = {
   setTabData: React.Dispatch<React.SetStateAction<TabData>>
 }
 
-// TODO: Break down this large function into smaller functions
-// eslint-disable-next-line max-lines-per-function
 const DecodePage: React.FC<DecodeProps> = ({ tabData, setTabData }) => {
   const { decode } = tabData
   const [formData, setFormdata] = useState<FormProps>(decode.formData)
   const [isSubmitted, setIsSubmitted] = useState<boolean>(decode.options.isSubmitted ?? false)
   const [disabled, setDisabled] = useState<boolean>(decode.options.disabled ?? true)
   const [invalidFormDataAttempted, setInvalidFormDataAttempted] = useState<boolean>(
-    decode.options.invalidFormDataAttempted ?? false
+    decode.options.invalidFormDataAttempted ?? false,
   )
 
   useEffect(() => {

--- a/apps/explorer/src/hooks/useAppData.ts
+++ b/apps/explorer/src/hooks/useAppData.ts
@@ -1,10 +1,16 @@
 import { AnyAppDataDocVersion } from '@cowprotocol/app-data'
+import { SWR_NO_REFRESH_OPTIONS } from '@cowprotocol/common-const'
 
 import { DEFAULT_IPFS_READ_URI, IPFS_INVALID_APP_IDS } from 'const'
 import { metadataApiSDK, orderBookSDK } from 'cowSdk'
-import useSWR from 'swr'
+import useSWR, { SWRConfiguration } from 'swr'
 
 import { decodeFullAppData } from '../utils/decodeFullAppData'
+
+const SWR_OPTIONS: SWRConfiguration = {
+  ...SWR_NO_REFRESH_OPTIONS,
+  errorRetryCount: 0,
+}
 
 interface AppDataDecodingResult {
   isLoading: boolean
@@ -21,25 +27,33 @@ export const useAppData = (appData: string, fullAppData?: string): AppDataDecodi
     error: ipfsError,
     isLoading: isIpfsLoading,
     data: ipfsUri,
-  } = useSWR(['appDataHexToCid', appData, isLegacyAppDataHex], async ([_, appData, isLegacyAppDataHex]) => {
-    const cid = await appDataHexToCid(appData.toString(), isLegacyAppDataHex)
+  } = useSWR(
+    ['appDataHexToCid', appData, isLegacyAppDataHex],
+    async ([_, appData, isLegacyAppDataHex]) => {
+      const cid = await appDataHexToCid(appData.toString(), isLegacyAppDataHex)
 
-    return `${DEFAULT_IPFS_READ_URI}/${cid}`
-  })
+      return `${DEFAULT_IPFS_READ_URI}/${cid}`
+    },
+    SWR_OPTIONS,
+  )
 
   const {
     error: appDataError,
     isLoading: isAppDataLoading,
     data: appDataDocFromApi,
-  } = useSWR(['appDataFromApi', appData], async ([_, appDataHash]) => {
-    const response = await orderBookSDK.getAppData(appDataHash)
+  } = useSWR(
+    ['appDataFromApi', appData],
+    async ([_, appDataHash]) => {
+      const response = await orderBookSDK.getAppData(appDataHash)
 
-    const { error, decodedAppData } = await getDecodedAppData(appData, isLegacyAppDataHex, response.fullAppData)
+      const { error, decodedAppData } = await getDecodedAppData(appData, isLegacyAppDataHex, response.fullAppData)
 
-    if (error) throw error
+      if (error) throw error
 
-    return decodedAppData
-  })
+      return decodedAppData
+    },
+    SWR_OPTIONS,
+  )
 
   const {
     error,
@@ -54,6 +68,7 @@ export const useAppData = (appData: string, fullAppData?: string): AppDataDecodi
 
       return decodedAppData || undefined
     },
+    SWR_OPTIONS,
   )
 
   return {


### PR DESCRIPTION
# Summary

Fixes #5862

1. Main fix is `errorRetryCount: 0` in SWR options of `useAppData()`
2. Got rid of re-rendering issue by converting a rendering function into `AppDataContent` component

# To Test

See #5862

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a component for displaying decoded application data with loading indicators, error notifications, and copy-to-clipboard functionality.

* **Refactor**
  * Simplified the decoded app data display by delegating rendering and error/loading handling to a dedicated component.
  * Updated component exports and import statements to use named exports for improved clarity.
  * Applied consistent configuration for data fetching to improve reliability and maintainability.

* **Style**
  * Minor formatting improvements for code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->