### PR TITLE
fix(cow-fi): enhance caching strategy and middleware for /learn route…

### DIFF
--- a/apps/cow-fi/app/(learn)/learn/[article]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/[article]/page.tsx
@@ -22,8 +22,8 @@ import { stripHtmlTags } from '@/util/stripHTMLTags'
 
 
 // Next.js requires revalidate to be a literal number for static analysis
-// This value (3600 seconds = 1 hour) should match CMS_CACHE_TIME in services/cms/index.ts
-export const revalidate = 3600
+// 12 hours (43200 seconds) - balanced between freshness and cache efficiency
+export const revalidate = 43200
 
 // Maximum length for metadata descriptions. When content exceeds MAX_LENGTH,
 // we truncate to TRUNCATE_LENGTH (MAX_LENGTH - 3) to make room for "..." ellipsis
@@ -95,6 +95,7 @@ export async function generateStaticParams(): Promise<{ article: string }[]> {
 
 export default async function ArticlePage({ params }: Props): Promise<ReactNode> {
   const articleSlug = (await params).article
+
 
   try {
     const article = await fetchArticleWithRetry(articleSlug)

--- a/apps/cow-fi/app/(learn)/learn/articles/[[...pageIndex]]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/articles/[[...pageIndex]]/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from 'next/navigation'
+import { notFound } from 'next/navigation'
 
 import { Article, Category, getArticles, getCategories } from '../../../../../services/cms'
 
@@ -19,55 +19,49 @@ export type ArticlesResponse = {
   }
 }
 
-// Static limit for reasonable page range to prevent dynamic ISR invalidation
-const MAX_PAGE_LIMIT = 1000
-
-// Generate static params for first 10 pages only to avoid dynamic content issues
-// Additional pages will be generated on-demand with dynamicParams = true
+// Generate static params with conservative estimate
+// Based on realistic content volume - prevents phantom page generation while covering real content
 export async function generateStaticParams(): Promise<{ pageIndex: string[] }[]> {
-  // Static generation for first 10 pages - avoids dynamic CMS calls that bust ISR cache
-  const MAX_STATIC_PAGES = 10
-  return Array.from({ length: MAX_STATIC_PAGES }, (_, i) => ({
+  // Conservative estimate: 15 pages covers ~360 articles
+  // This is generous for most sites while preventing the 1000+ phantom pages issue
+  // If you grow beyond this, just increase the number and redeploy
+  const REASONABLE_PAGE_LIMIT = 15
+
+  const pages = Array.from({ length: REASONABLE_PAGE_LIMIT }, (_, i) => ({
     pageIndex: [(i + 1).toString()],
   }))
+
+  // Add base route: /learn/articles (no pageIndex = page 1)
+  pages.unshift({ pageIndex: [] })
+
+  return pages
 }
 
-// Enable dynamic params for pages beyond the static limit
-export const dynamicParams = true
+// Disable dynamic params to prevent phantom page generation from crawlers/bots
+// Only pre-rendered pages 1-15 will be accessible - pages 16+ get proper 404s
+// For production: false blocks phantom pages | For local dev: true allows on-demand generation
+export const dynamicParams = false
 
 // Next.js requires revalidate to be a literal number for static analysis
-// This value (3600 seconds = 1 hour) should match CMS_CACHE_TIME in services/cms/index.ts
-export const revalidate = 3600
+// 12 hours (43200 seconds) - pagination pages change infrequently
+export const revalidate = 43200
 
 // TODO: Reduce function complexity by extracting logic
 // TODO: Add proper return type annotation
-// eslint-disable-next-line complexity, @typescript-eslint/explicit-function-return-type
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export default async function Page({ params }: Props) {
+  // With dynamicParams = false, only pre-rendered pages are accessible
+  // Next.js handles 404s for non-existent pages automatically
   const pageParam = (await params)?.pageIndex?.[0]
-  const paramsAreSet = Boolean(pageParam)
-  const pageIndexIsValid = Boolean(pageParam && /^\d+$/.test(pageParam))
-
-  // Redirect invalid page numbers to the main articles page
-  if (paramsAreSet && !pageIndexIsValid) {
-    return redirect('/learn/articles')
-  }
-
-  const page = pageParam && pageIndexIsValid ? parseInt(pageParam, 10) : 1
+  const page = pageParam ? parseInt(pageParam, 10) : 1
 
   // Fetch paginated articles for display
   const articlesResponse = await getArticles({ page, pageSize: ARTICLES_PER_PAGE })
   const totalArticles = articlesResponse.meta?.pagination?.total || 0
 
-  // Static bounds checking to avoid dynamic ISR invalidation
-  // Allow reasonable page range - let CMS handle actual bounds
-  if (page < 1 || page > MAX_PAGE_LIMIT) {
-    // Conservative upper limit
-    return redirect('/learn/articles')
-  }
-
-  // If no articles returned, likely beyond actual bounds
+  // Defensive check - if CMS returns no data for a pre-rendered page, something's wrong
   if (!articlesResponse.data || articlesResponse.data.length === 0) {
-    return redirect('/learn/articles')
+    return notFound()
   }
 
   // Get minimal articles for search - limit to reduce ISR cache busting

--- a/apps/cow-fi/app/(learn)/learn/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/page.tsx
@@ -7,8 +7,8 @@ import { FEATURED_ARTICLES_PAGE_SIZE } from '@/const/pagination'
 
 
 // Next.js requires revalidate to be a literal number for static analysis
-// This value (3600 seconds = 1 hour) should match CMS_CACHE_TIME in services/cms/index.ts
-export const revalidate = 3600
+// 12 hours (43200 seconds) - balanced between freshness and cache efficiency
+export const revalidate = 43200
 
 export default async function LearnPage(): Promise<ReactNode> {
   // Fetch featured articles

--- a/apps/cow-fi/app/(learn)/learn/topic/[topicSlug]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/topic/[topicSlug]/page.tsx
@@ -23,8 +23,8 @@ type Props = {
 }
 
 // Next.js requires revalidate to be a literal number for static analysis
-// This value (3600 seconds = 1 hour) should match CMS_CACHE_TIME in services/cms/index.ts
-export const revalidate = 3600
+// 12 hours (43200 seconds) - balanced between freshness and cache efficiency
+export const revalidate = 43200
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   'use server'

--- a/apps/cow-fi/app/(learn)/learn/topics/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/topics/page.tsx
@@ -9,8 +9,8 @@ import { ARTICLES_LARGE_PAGE_SIZE } from '@/const/pagination'
 
 
 // Next.js requires revalidate to be a literal number for static analysis
-// This value (3600 seconds = 1 hour) should match CMS_CACHE_TIME in services/cms/index.ts
-export const revalidate = 3600
+// 12 hours (43200 seconds) - balanced between freshness and cache efficiency
+export const revalidate = 43200
 
 export default async function TopicsPage(): Promise<ReactNode> {
   const articlesResponse = await getArticles({ pageSize: ARTICLES_LARGE_PAGE_SIZE })

--- a/apps/cow-fi/app/api/revalidate/route.ts
+++ b/apps/cow-fi/app/api/revalidate/route.ts
@@ -4,7 +4,7 @@ import { NextRequest, NextResponse } from 'next/server'
 // Secret key for protecting the revalidation endpoint
 const REVALIDATE_SECRET = process.env.REVALIDATE_SECRET
 
-export async function GET(request: NextRequest) {
+export async function GET(request: NextRequest): Promise<NextResponse> {
   const secret = request.nextUrl.searchParams.get('secret')
   const tag = request.nextUrl.searchParams.get('tag') || 'cms-content'
   const path = request.nextUrl.searchParams.get('path')
@@ -26,6 +26,10 @@ export async function GET(request: NextRequest) {
 
     // Always revalidate the main learn page to ensure it's fresh
     revalidatePath('/learn')
+
+    // Revalidate learn sub-pages for comprehensive cache refresh
+    revalidatePath('/learn/articles')
+    revalidatePath('/learn/topics')
 
     // Revalidate the dynamic article route (this updates the manifest)
     revalidatePath('/learn/[article]')

--- a/apps/cow-fi/middleware.ts
+++ b/apps/cow-fi/middleware.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+// List of query parameters to strip for cache normalization
+const TRACKING_PARAMS = [
+  'ref',
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_term',
+  'utm_content',
+  'fbclid',
+  'gclid',
+  'msclkid',
+  'twclid',
+  'dclid',
+  'mc_cid',
+  'mc_eid',
+  'igshid',
+  'scid',
+  'fb_source',
+  'ref_src',
+]
+
+export function middleware(request: NextRequest): NextResponse {
+  const pathname = request.nextUrl.pathname
+
+  // Skip non-page assets (js, css, images, etc.)
+  if (pathname.includes('.')) {
+    return NextResponse.next()
+  }
+
+  // Only process /learn routes
+  if (!pathname.startsWith('/learn')) {
+    return NextResponse.next()
+  }
+
+  const url = request.nextUrl.clone()
+  const searchParams = url.searchParams
+  let hasTracking = false
+
+  // Check if any tracking parameters exist (case-insensitive)
+  TRACKING_PARAMS.forEach((param) => {
+    // Check both lowercase and as-is
+    if (searchParams.has(param) || searchParams.has(param.toLowerCase())) {
+      hasTracking = true
+      searchParams.delete(param)
+      searchParams.delete(param.toLowerCase())
+    }
+    // Also check for camelCase variants (e.g., utmSource)
+    const camelCase = param.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase())
+    if (searchParams.has(camelCase)) {
+      hasTracking = true
+      searchParams.delete(camelCase)
+    }
+  })
+
+  // If we removed any params, redirect to clean URL with 308 (permanent)
+  if (hasTracking) {
+    return NextResponse.redirect(url, 308)
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: '/learn/:path*',
+}


### PR DESCRIPTION
# Summary

Continues from our last changes in https://github.com/cowprotocol/cowswap/pull/6079

Optimize ISR caching strategy to reduce Vercel ISR writes.

  - Block phantom page generation with `dynamicParams = false`
  - Extend revalidation cycles from 1 hour to 12 hours
  - Strip tracking parameters via middleware to prevent cache pollution
  - Eliminate non-deterministic content causing cache misses

  # To Test

  1. **Navigate to learn pages**
     - [ ] `/learn` renders correctly
     - [ ] `/learn/articles` shows article list (page 1)
     - [ ] `/learn/articles/2` shows page 2 pagination
     - [ ] `/learn/topics` displays topic categories

  2. **Test middleware query normalization**
     - [ ] Visit `/learn/articles?utm_source=twitter&ref=social`
     - [ ] Should redirect (308) to clean `/learn/articles` URL
     - [ ] Marketing campaign URLs get normalized

  3. **Verify phantom page blocking (production only)**
     - [ ] `/learn/articles/999` should 404 in production
     - [ ] Only pages 1-15 accessible beyond static generation

  # Background

  Learn pages are burning through Vercel ISR quota with 755K writes vs 8.3K reads (91x ratio). Probable root cause: pagination route accepting unlimited page numbers allowed crawlers to generate phantom pages (16-1000). Solution blocks dynamic generation while covering real content needs (15 pages = ~360 articles).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic removal of common tracking parameters from URLs under the Learn section, ensuring cleaner and more privacy-friendly links.
* **Improvements**
  * Increased cache refresh intervals for Learn pages from 1 hour to 12 hours, improving performance and reducing unnecessary data fetching.
  * Expanded cache revalidation to cover more Learn sub-pages.
  * Improved handling of Learn article pagination—pages beyond 15 now correctly return a 404 error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->