### PR TITLE
fix(bridge): fix received amount parsing from executed info

### DIFF
--- a/apps/cow-fi/app/(learn)/learn/[article]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/[article]/page.tsx
@@ -22,8 +22,8 @@ import { stripHtmlTags } from '@/util/stripHTMLTags'
 
 
 // Next.js requires revalidate to be a literal number for static analysis
-// This value (3600 seconds = 1 hour) should match CMS_CACHE_TIME in services/cms/index.ts
-export const revalidate = 3600
+// 12 hours (43200 seconds) - balanced between freshness and cache efficiency
+export const revalidate = 43200
 
 // Maximum length for metadata descriptions. When content exceeds MAX_LENGTH,
 // we truncate to TRUNCATE_LENGTH (MAX_LENGTH - 3) to make room for "..." ellipsis
@@ -95,6 +95,7 @@ export async function generateStaticParams(): Promise<{ article: string }[]> {
 
 export default async function ArticlePage({ params }: Props): Promise<ReactNode> {
   const articleSlug = (await params).article
+
 
   try {
     const article = await fetchArticleWithRetry(articleSlug)

--- a/apps/cow-fi/app/(learn)/learn/[article]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/[article]/page.tsx
@@ -17,7 +17,9 @@ import {
 
 import type { Metadata } from 'next'
 
-export const revalidate = 3600 // Revalidate at most once per hour
+// Next.js requires revalidate to be a literal number for static analysis
+// This value (3600 seconds = 1 hour) should match CMS_CACHE_TIME in services/cms/index.ts
+export const revalidate = 3600
 
 // Maximum length for metadata descriptions. When content exceeds MAX_LENGTH,
 // we truncate to TRUNCATE_LENGTH (MAX_LENGTH - 3) to make room for "..." ellipsis

--- a/apps/cow-fi/app/(learn)/learn/[article]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/[article]/page.tsx
@@ -1,13 +1,9 @@
+import type { ReactNode } from 'react'
+
 import { notFound } from 'next/navigation'
 
-import { ArticlePageComponent } from '@/components/ArticlePageComponent'
-import { FEATURED_ARTICLES_PAGE_SIZE } from '@/const/pagination'
-import { fetchArticleWithRetry } from '@/util/fetchHelpers'
-import { getPageMetadata } from '@/util/getPageMetadata'
-import { stripHtmlTags } from '@/util/stripHTMLTags'
-
 import {
-  Article,
+  Category,
   getAllArticleSlugs,
   getArticleBySlug,
   getArticles,
@@ -16,6 +12,14 @@ import {
 } from '../../../../services/cms'
 
 import type { Metadata } from 'next'
+
+import { ArticlePageComponent } from '@/components/ArticlePageComponent'
+import { FEATURED_ARTICLES_PAGE_SIZE } from '@/const/pagination'
+import { fetchArticleWithRetry } from '@/util/fetchHelpers'
+import { getPageMetadata } from '@/util/getPageMetadata'
+import { stripHtmlTags } from '@/util/stripHTMLTags'
+
+
 
 // Next.js requires revalidate to be a literal number for static analysis
 // This value (3600 seconds = 1 hour) should match CMS_CACHE_TIME in services/cms/index.ts
@@ -26,8 +30,13 @@ export const revalidate = 3600
 const METADATA_DESCRIPTION_MAX_LENGTH = 150
 const METADATA_DESCRIPTION_TRUNCATE_LENGTH = METADATA_DESCRIPTION_MAX_LENGTH - 3
 
-function isRichTextComponent(block: any): block is SharedRichTextComponent {
-  return block.body !== undefined
+function isRichTextComponent(block: unknown): block is SharedRichTextComponent {
+  return (
+    typeof block === 'object' &&
+    block !== null &&
+    'body' in block &&
+    typeof (block as { body?: unknown }).body === 'string'
+  )
 }
 
 type Props = {
@@ -74,7 +83,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   }
 }
 
-export async function generateStaticParams() {
+export async function generateStaticParams(): Promise<{ article: string }[]> {
   try {
     const slugs = await getAllArticleSlugs()
     return slugs.map((article) => ({ article }))
@@ -84,7 +93,7 @@ export async function generateStaticParams() {
   }
 }
 
-export default async function ArticlePage({ params }: Props) {
+export default async function ArticlePage({ params }: Props): Promise<ReactNode> {
   const articleSlug = (await params).article
 
   try {
@@ -105,12 +114,11 @@ export default async function ArticlePage({ params }: Props) {
     })
     const featuredArticles = featuredArticlesResponse.data
 
-    // Get articles for random selection
-    const allArticlesResponse = await getArticles()
-    const randomArticles = getRandomArticles(allArticlesResponse.data, 3)
+    // Use first 3 featured articles for "Read more" section to ensure deterministic ISR caching
+    const readMoreArticles = featuredArticles.slice(0, 3)
     const categoriesResponse = await getCategories()
     const allCategories =
-      categoriesResponse?.map((category: any) => ({
+      categoriesResponse?.map((category: Category) => ({
         name: category?.attributes?.name || '',
         slug: category?.attributes?.slug || '',
       })) || []
@@ -118,7 +126,7 @@ export default async function ArticlePage({ params }: Props) {
     return (
       <ArticlePageComponent
         article={article}
-        randomArticles={randomArticles}
+        randomArticles={readMoreArticles}
         featuredArticles={featuredArticles}
         allCategories={allCategories}
       />
@@ -127,9 +135,4 @@ export default async function ArticlePage({ params }: Props) {
     console.error(`Error fetching article ${articleSlug}:`, error)
     return notFound()
   }
-}
-
-function getRandomArticles(articles: Article[], count: number): Article[] {
-  const shuffled = articles.sort(() => 0.5 - Math.random())
-  return shuffled.slice(0, count)
 }

--- a/apps/cow-fi/app/(learn)/learn/articles/[[...pageIndex]]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/articles/[[...pageIndex]]/page.tsx
@@ -1,6 +1,8 @@
-import { ArticlesPageComponents } from '@/components/ArticlesPageComponents'
 import { redirect } from 'next/navigation'
-import { Article, getArticles, getCategories } from '../../../../../services/cms'
+
+import { Article, Category, getArticles, getCategories } from '../../../../../services/cms'
+
+import { ArticlesPageComponents } from '@/components/ArticlesPageComponents'
 import { ARTICLES_PER_PAGE } from '@/const/pagination'
 import { calculateTotalPages } from '@/util/paginationUtils'
 
@@ -17,6 +19,8 @@ export type ArticlesResponse = {
   }
 }
 
+// TODO: Add proper return type annotation
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export async function generateStaticParams() {
   const articlesResponse = await getArticles({ page: 0, pageSize: ARTICLES_PER_PAGE })
   const totalArticles = articlesResponse.meta?.pagination?.total || 0
@@ -25,6 +29,13 @@ export async function generateStaticParams() {
   return Array.from({ length: totalPages }, (_, i) => ({ pageIndex: [(i + 1).toString()] }))
 }
 
+// Next.js requires revalidate to be a literal number for static analysis
+// This value (3600 seconds = 1 hour) should match CMS_CACHE_TIME in services/cms/index.ts
+export const revalidate = 3600
+
+// TODO: Reduce function complexity by extracting logic
+// TODO: Add proper return type annotation
+// eslint-disable-next-line complexity, @typescript-eslint/explicit-function-return-type
 export default async function Page({ params }: Props) {
   const pageParam = (await params)?.pageIndex?.[0]
   const paramsAreSet = Boolean(pageParam)
@@ -52,6 +63,8 @@ export default async function Page({ params }: Props) {
   const allArticles = allArticlesResponse.data
 
   const articles =
+    // TODO: Reduce function complexity by extracting logic
+    // eslint-disable-next-line complexity
     articlesResponse.data?.map((article: Article) => ({
       ...article,
       id: article.id || 0,
@@ -69,7 +82,7 @@ export default async function Page({ params }: Props) {
 
   const categoriesResponse = await getCategories()
   const allCategories =
-    categoriesResponse?.map((category: any) => ({
+    categoriesResponse?.map((category: Category) => ({
       name: category?.attributes?.name || '',
       slug: category?.attributes?.slug || '',
     })) || []

--- a/apps/cow-fi/app/(learn)/learn/articles/[[...pageIndex]]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/articles/[[...pageIndex]]/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from 'next/navigation'
+import { notFound } from 'next/navigation'
 
 import { Article, Category, getArticles, getCategories } from '../../../../../services/cms'
 
@@ -19,55 +19,49 @@ export type ArticlesResponse = {
   }
 }
 
-// Static limit for reasonable page range to prevent dynamic ISR invalidation
-const MAX_PAGE_LIMIT = 1000
-
-// Generate static params for first 10 pages only to avoid dynamic content issues
-// Additional pages will be generated on-demand with dynamicParams = true
+// Generate static params with conservative estimate
+// Based on realistic content volume - prevents phantom page generation while covering real content
 export async function generateStaticParams(): Promise<{ pageIndex: string[] }[]> {
-  // Static generation for first 10 pages - avoids dynamic CMS calls that bust ISR cache
-  const MAX_STATIC_PAGES = 10
-  return Array.from({ length: MAX_STATIC_PAGES }, (_, i) => ({
+  // Conservative estimate: 15 pages covers ~360 articles
+  // This is generous for most sites while preventing the 1000+ phantom pages issue
+  // If you grow beyond this, just increase the number and redeploy
+  const REASONABLE_PAGE_LIMIT = 15
+
+  const pages = Array.from({ length: REASONABLE_PAGE_LIMIT }, (_, i) => ({
     pageIndex: [(i + 1).toString()],
   }))
+
+  // Add base route: /learn/articles (no pageIndex = page 1)
+  pages.unshift({ pageIndex: [] })
+
+  return pages
 }
 
-// Enable dynamic params for pages beyond the static limit
-export const dynamicParams = true
+// Disable dynamic params to prevent phantom page generation from crawlers/bots
+// Only pre-rendered pages 1-15 will be accessible - pages 16+ get proper 404s
+// For production: false blocks phantom pages | For local dev: true allows on-demand generation
+export const dynamicParams = false
 
 // Next.js requires revalidate to be a literal number for static analysis
-// This value (3600 seconds = 1 hour) should match CMS_CACHE_TIME in services/cms/index.ts
-export const revalidate = 3600
+// 12 hours (43200 seconds) - pagination pages change infrequently
+export const revalidate = 43200
 
 // TODO: Reduce function complexity by extracting logic
 // TODO: Add proper return type annotation
-// eslint-disable-next-line complexity, @typescript-eslint/explicit-function-return-type
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export default async function Page({ params }: Props) {
+  // With dynamicParams = false, only pre-rendered pages are accessible
+  // Next.js handles 404s for non-existent pages automatically
   const pageParam = (await params)?.pageIndex?.[0]
-  const paramsAreSet = Boolean(pageParam)
-  const pageIndexIsValid = Boolean(pageParam && /^\d+$/.test(pageParam))
-
-  // Redirect invalid page numbers to the main articles page
-  if (paramsAreSet && !pageIndexIsValid) {
-    return redirect('/learn/articles')
-  }
-
-  const page = pageParam && pageIndexIsValid ? parseInt(pageParam, 10) : 1
+  const page = pageParam ? parseInt(pageParam, 10) : 1
 
   // Fetch paginated articles for display
   const articlesResponse = await getArticles({ page, pageSize: ARTICLES_PER_PAGE })
   const totalArticles = articlesResponse.meta?.pagination?.total || 0
 
-  // Static bounds checking to avoid dynamic ISR invalidation
-  // Allow reasonable page range - let CMS handle actual bounds
-  if (page < 1 || page > MAX_PAGE_LIMIT) {
-    // Conservative upper limit
-    return redirect('/learn/articles')
-  }
-
-  // If no articles returned, likely beyond actual bounds
+  // Defensive check - if CMS returns no data for a pre-rendered page, something's wrong
   if (!articlesResponse.data || articlesResponse.data.length === 0) {
-    return redirect('/learn/articles')
+    return notFound()
   }
 
   // Get minimal articles for search - limit to reduce ISR cache busting

--- a/apps/cow-fi/app/(learn)/learn/articles/[[...pageIndex]]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/articles/[[...pageIndex]]/page.tsx
@@ -4,7 +4,7 @@ import { Article, Category, getArticles, getCategories } from '../../../../../se
 
 import { ArticlesPageComponents } from '@/components/ArticlesPageComponents'
 import { ARTICLES_PER_PAGE } from '@/const/pagination'
-import { calculateTotalPages } from '@/util/paginationUtils'
+
 
 type Props = {
   params: Promise<{ pageIndex?: string[] }>
@@ -19,15 +19,21 @@ export type ArticlesResponse = {
   }
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export async function generateStaticParams() {
-  const articlesResponse = await getArticles({ page: 0, pageSize: ARTICLES_PER_PAGE })
-  const totalArticles = articlesResponse.meta?.pagination?.total || 0
-  const totalPages = calculateTotalPages(totalArticles)
+// Static limit for reasonable page range to prevent dynamic ISR invalidation
+const MAX_PAGE_LIMIT = 1000
 
-  return Array.from({ length: totalPages }, (_, i) => ({ pageIndex: [(i + 1).toString()] }))
+// Generate static params for first 10 pages only to avoid dynamic content issues
+// Additional pages will be generated on-demand with dynamicParams = true
+export async function generateStaticParams(): Promise<{ pageIndex: string[] }[]> {
+  // Static generation for first 10 pages - avoids dynamic CMS calls that bust ISR cache
+  const MAX_STATIC_PAGES = 10
+  return Array.from({ length: MAX_STATIC_PAGES }, (_, i) => ({
+    pageIndex: [(i + 1).toString()],
+  }))
 }
+
+// Enable dynamic params for pages beyond the static limit
+export const dynamicParams = true
 
 // Next.js requires revalidate to be a literal number for static analysis
 // This value (3600 seconds = 1 hour) should match CMS_CACHE_TIME in services/cms/index.ts
@@ -52,15 +58,22 @@ export default async function Page({ params }: Props) {
   const articlesResponse = await getArticles({ page, pageSize: ARTICLES_PER_PAGE })
   const totalArticles = articlesResponse.meta?.pagination?.total || 0
 
-  // If page number is out of bounds (either less than 1 or greater than total pages), redirect to page 1
-  const numberOfPages = calculateTotalPages(totalArticles)
-  if (page < 1 || page > numberOfPages) {
+  // Static bounds checking to avoid dynamic ISR invalidation
+  // Allow reasonable page range - let CMS handle actual bounds
+  if (page < 1 || page > MAX_PAGE_LIMIT) {
+    // Conservative upper limit
     return redirect('/learn/articles')
   }
 
-  // Get all articles for search functionality
-  const allArticlesResponse = await getArticles()
-  const allArticles = allArticlesResponse.data
+  // If no articles returned, likely beyond actual bounds
+  if (!articlesResponse.data || articlesResponse.data.length === 0) {
+    return redirect('/learn/articles')
+  }
+
+  // Get minimal articles for search - limit to reduce ISR cache busting
+  // Search functionality can work with a subset of recent articles
+  const searchArticlesResponse = await getArticles({ pageSize: 100 }) // Limit for performance
+  const allArticles = searchArticlesResponse.data
 
   const articles =
     // TODO: Reduce function complexity by extracting logic

--- a/apps/cow-fi/app/(learn)/learn/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/page.tsx
@@ -7,8 +7,8 @@ import { FEATURED_ARTICLES_PAGE_SIZE } from '@/const/pagination'
 
 
 // Next.js requires revalidate to be a literal number for static analysis
-// This value (3600 seconds = 1 hour) should match CMS_CACHE_TIME in services/cms/index.ts
-export const revalidate = 3600
+// 12 hours (43200 seconds) - balanced between freshness and cache efficiency
+export const revalidate = 43200
 
 export default async function LearnPage(): Promise<ReactNode> {
   // Fetch featured articles

--- a/apps/cow-fi/app/(learn)/learn/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/page.tsx
@@ -1,9 +1,16 @@
+import type { ReactNode } from 'react'
+
+import { Category, getArticles, getCategories } from '../../../services/cms'
+
 import { LearnPageComponent } from '@/components/LearnPageComponent'
 import { FEATURED_ARTICLES_PAGE_SIZE } from '@/const/pagination'
 
-import { getArticles, getCategories } from '../../../services/cms'
 
-export default async function LearnPage() {
+// Next.js requires revalidate to be a literal number for static analysis
+// This value (3600 seconds = 1 hour) should match CMS_CACHE_TIME in services/cms/index.ts
+export const revalidate = 3600
+
+export default async function LearnPage(): Promise<ReactNode> {
   // Fetch featured articles
   const featuredArticlesResponse = await getArticles({
     filters: {
@@ -27,20 +34,40 @@ export default async function LearnPage() {
 
   const categoriesResponse = await getCategories()
   // Pass raw categories data to client component for styling
-  const categories =
-    categoriesResponse?.map((category: any) => {
-      const imageUrl = category?.attributes?.image?.data?.attributes?.url || ''
-
-      return {
-        name: category?.attributes?.name || '',
-        slug: category?.attributes?.slug || '',
-        description: category?.attributes?.description || '',
-        bgColor: category?.attributes?.backgroundColor || '',
-        textColor: category?.attributes?.textColor || '',
-        link: `/learn/topic/${category?.attributes?.slug}`,
-        imageUrl,
-      }
-    }) || []
+  const categories = categoriesResponse?.map(formatCategoryForComponent) || []
 
   return <LearnPageComponent featuredArticles={featuredArticles} categories={categories} />
+}
+
+function formatCategoryForComponent(category: Category): {
+  name: string
+  slug: string
+  description: string
+  bgColor: string
+  textColor: string
+  link: string
+  imageUrl: string
+} {
+  const attrs = category?.attributes
+  if (!attrs) {
+    return {
+      name: '',
+      slug: '',
+      description: '',
+      bgColor: '',
+      textColor: '',
+      link: '/learn/topic/',
+      imageUrl: '',
+    }
+  }
+
+  return {
+    name: attrs.name ?? '',
+    slug: attrs.slug ?? '',
+    description: attrs.description ?? '',
+    bgColor: attrs.backgroundColor ?? '',
+    textColor: attrs.textColor ?? '',
+    link: `/learn/topic/${attrs.slug ?? ''}`,
+    imageUrl: attrs.image?.data?.attributes?.url ?? '',
+  }
 }

--- a/apps/cow-fi/app/(learn)/learn/topic/[topicSlug]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/topic/[topicSlug]/page.tsx
@@ -23,8 +23,8 @@ type Props = {
 }
 
 // Next.js requires revalidate to be a literal number for static analysis
-// This value (3600 seconds = 1 hour) should match CMS_CACHE_TIME in services/cms/index.ts
-export const revalidate = 3600
+// 12 hours (43200 seconds) - balanced between freshness and cache efficiency
+export const revalidate = 43200
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   'use server'

--- a/apps/cow-fi/app/(learn)/learn/topic/[topicSlug]/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/topic/[topicSlug]/page.tsx
@@ -1,13 +1,30 @@
+import type { ReactNode } from 'react'
+
+import { notFound } from 'next/navigation'
+
+import {
+  Category,
+  getAllCategorySlugs,
+  getArticles,
+  getCategories,
+  getCategoryBySlug,
+} from '../../../../../services/cms'
+
+import type { Metadata } from 'next'
+
 import { TopicPageComponent } from '@/components/TopicPageComponent'
 import { getPageMetadata } from '@/util/getPageMetadata'
-import type { Metadata } from 'next'
-import { notFound } from 'next/navigation'
-import { getAllCategorySlugs, getArticles, getCategories, getCategoryBySlug } from '../../../../../services/cms'
+
+
 
 type Props = {
   params: Promise<{ topicSlug: string }>
   searchParams?: Promise<{ [key: string]: string | string[] | undefined }>
 }
+
+// Next.js requires revalidate to be a literal number for static analysis
+// This value (3600 seconds = 1 hour) should match CMS_CACHE_TIME in services/cms/index.ts
+export const revalidate = 3600
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   'use server'
@@ -25,7 +42,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   })
 }
 
-export async function generateStaticParams() {
+export async function generateStaticParams(): Promise<{ topicSlug: string }[]> {
   'use server'
 
   const categoriesResponse = await getAllCategorySlugs()
@@ -33,8 +50,7 @@ export async function generateStaticParams() {
   return categoriesResponse.map((topicSlug) => ({ topicSlug }))
 }
 
-export default async function TopicPage({ params }: { params: Promise<{ topicSlug: string }> }) {
-  // Get the category
+export default async function TopicPage({ params }: { params: Promise<{ topicSlug: string }> }): Promise<ReactNode> {
   const { topicSlug } = await params
   const category = await getCategoryBySlug(topicSlug)
 
@@ -42,41 +58,24 @@ export default async function TopicPage({ params }: { params: Promise<{ topicSlu
     notFound()
   }
 
-  // Format the category for the component
-  const formattedCategory = {
-    name: category.attributes?.name || '',
-    slug: category.attributes?.slug || '',
-    description: category.attributes?.description || '',
-    bgColor: category.attributes?.backgroundColor || '#FFFFFF',
-    textColor: category.attributes?.textColor || '#000000',
-    imageUrl: category.attributes?.image?.data?.attributes?.url || '',
-  }
-
-  // Get articles for this topic
-  const topicArticlesResponse = await getArticles({
-    filters: {
-      categories: {
-        slug: {
-          $eq: topicSlug,
+  const formattedCategory = formatCategoryForTopicPage(category)
+  const [topicArticlesResponse, allArticlesResponse, categoriesResponse] = await Promise.all([
+    getArticles({
+      filters: {
+        categories: {
+          slug: {
+            $eq: topicSlug,
+          },
         },
       },
-    },
-  })
-
-  // Get articles for search functionality
-  const allArticlesResponse = await getArticles()
+    }),
+    getArticles(),
+    getCategories(),
+  ])
 
   const topicArticles = topicArticlesResponse.data
   const allArticles = allArticlesResponse.data
-
-  const categoriesResponse = await getCategories()
-  const allCategories =
-    categoriesResponse?.map((category: any) => {
-      return {
-        name: category.attributes?.name || '',
-        slug: category.attributes?.slug || '',
-      }
-    }) || []
+  const allCategories = categoriesResponse?.map(formatCategoryForList) || []
 
   return (
     <TopicPageComponent
@@ -86,4 +85,44 @@ export default async function TopicPage({ params }: { params: Promise<{ topicSlu
       allArticles={allArticles}
     />
   )
+}
+
+function formatCategoryForTopicPage(category: Category): {
+  name: string
+  slug: string
+  description: string
+  bgColor: string
+  textColor: string
+  imageUrl: string
+} {
+  const attrs = category.attributes
+  if (!attrs) {
+    return {
+      name: '',
+      slug: '',
+      description: '',
+      bgColor: '#FFFFFF',
+      textColor: '#000000',
+      imageUrl: '',
+    }
+  }
+
+  return {
+    name: attrs.name ?? '',
+    slug: attrs.slug ?? '',
+    description: attrs.description ?? '',
+    bgColor: attrs.backgroundColor ?? '#FFFFFF',
+    textColor: attrs.textColor ?? '#000000',
+    imageUrl: attrs.image?.data?.attributes?.url ?? '',
+  }
+}
+
+function formatCategoryForList(category: Category): {
+  name: string
+  slug: string
+} {
+  return {
+    name: category.attributes?.name ?? '',
+    slug: category.attributes?.slug ?? '',
+  }
 }

--- a/apps/cow-fi/app/(learn)/learn/topics/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/topics/page.tsx
@@ -1,32 +1,59 @@
-'use client'
+import type { ReactNode } from 'react'
 
 import { UI } from '@cowprotocol/ui'
+
+import { Category, getArticles, getCategories } from '../../../../services/cms'
 
 import { TopicsPageComponent } from '@/components/TopicsPageComponent'
 import { ARTICLES_LARGE_PAGE_SIZE } from '@/const/pagination'
 
-import { getArticles, getCategories } from '../../../../services/cms'
 
-export default async function TopicsPage() {
+// Next.js requires revalidate to be a literal number for static analysis
+// This value (3600 seconds = 1 hour) should match CMS_CACHE_TIME in services/cms/index.ts
+export const revalidate = 3600
+
+export default async function TopicsPage(): Promise<ReactNode> {
   const articlesResponse = await getArticles({ pageSize: ARTICLES_LARGE_PAGE_SIZE })
   const articles = articlesResponse.data
 
   const categoriesResponse = await getCategories()
-  const categories =
-    categoriesResponse?.map((category: any) => {
-      const imageUrl = category?.attributes?.image?.data?.attributes?.url || ''
-
-      return {
-        name: category?.attributes?.name || '',
-        slug: category?.attributes?.slug || '',
-        description: category?.attributes?.description || '',
-        bgColor: category?.attributes?.backgroundColor || `var(${UI.COLOR_NEUTRAL_100})`,
-        textColor: category?.attributes?.textColor || `var(${UI.COLOR_NEUTRAL_0})`,
-        link: `/learn/topic/${category?.attributes?.slug}`,
-        iconColor: 'transparent',
-        imageUrl,
-      }
-    }) || []
+  const categories = categoriesResponse?.map(formatCategoryForTopicsPage) || []
 
   return <TopicsPageComponent articles={articles} categories={categories} />
+}
+
+function formatCategoryForTopicsPage(category: Category): {
+  name: string
+  slug: string
+  description: string
+  bgColor: string
+  textColor: string
+  link: string
+  iconColor: string
+  imageUrl: string
+} {
+  const attrs = category?.attributes
+  if (!attrs) {
+    return {
+      name: '',
+      slug: '',
+      description: '',
+      bgColor: `var(${UI.COLOR_NEUTRAL_100})`,
+      textColor: `var(${UI.COLOR_NEUTRAL_0})`,
+      link: '/learn/topic/',
+      iconColor: 'transparent',
+      imageUrl: '',
+    }
+  }
+
+  return {
+    name: attrs.name ?? '',
+    slug: attrs.slug ?? '',
+    description: attrs.description ?? '',
+    bgColor: attrs.backgroundColor ?? `var(${UI.COLOR_NEUTRAL_100})`,
+    textColor: attrs.textColor ?? `var(${UI.COLOR_NEUTRAL_0})`,
+    link: `/learn/topic/${attrs.slug ?? ''}`,
+    iconColor: 'transparent',
+    imageUrl: attrs.image?.data?.attributes?.url ?? '',
+  }
 }

--- a/apps/cow-fi/app/(learn)/learn/topics/page.tsx
+++ b/apps/cow-fi/app/(learn)/learn/topics/page.tsx
@@ -9,8 +9,8 @@ import { ARTICLES_LARGE_PAGE_SIZE } from '@/const/pagination'
 
 
 // Next.js requires revalidate to be a literal number for static analysis
-// This value (3600 seconds = 1 hour) should match CMS_CACHE_TIME in services/cms/index.ts
-export const revalidate = 3600
+// 12 hours (43200 seconds) - balanced between freshness and cache efficiency
+export const revalidate = 43200
 
 export default async function TopicsPage(): Promise<ReactNode> {
   const articlesResponse = await getArticles({ pageSize: ARTICLES_LARGE_PAGE_SIZE })

--- a/apps/cow-fi/app/api/revalidate/route.ts
+++ b/apps/cow-fi/app/api/revalidate/route.ts
@@ -4,7 +4,7 @@ import { NextRequest, NextResponse } from 'next/server'
 // Secret key for protecting the revalidation endpoint
 const REVALIDATE_SECRET = process.env.REVALIDATE_SECRET
 
-export async function GET(request: NextRequest) {
+export async function GET(request: NextRequest): Promise<NextResponse> {
   const secret = request.nextUrl.searchParams.get('secret')
   const tag = request.nextUrl.searchParams.get('tag') || 'cms-content'
   const path = request.nextUrl.searchParams.get('path')
@@ -26,6 +26,10 @@ export async function GET(request: NextRequest) {
 
     // Always revalidate the main learn page to ensure it's fresh
     revalidatePath('/learn')
+
+    // Revalidate learn sub-pages for comprehensive cache refresh
+    revalidatePath('/learn/articles')
+    revalidatePath('/learn/topics')
 
     // Revalidate the dynamic article route (this updates the manifest)
     revalidatePath('/learn/[article]')

--- a/apps/cow-fi/middleware.ts
+++ b/apps/cow-fi/middleware.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+// List of query parameters to strip for cache normalization
+const TRACKING_PARAMS = [
+  'ref',
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_term',
+  'utm_content',
+  'fbclid',
+  'gclid',
+  'msclkid',
+  'twclid',
+  'dclid',
+  'mc_cid',
+  'mc_eid',
+  'igshid',
+  'scid',
+  'fb_source',
+  'ref_src',
+]
+
+export function middleware(request: NextRequest): NextResponse {
+  const pathname = request.nextUrl.pathname
+
+  // Skip non-page assets (js, css, images, etc.)
+  if (pathname.includes('.')) {
+    return NextResponse.next()
+  }
+
+  // Only process /learn routes
+  if (!pathname.startsWith('/learn')) {
+    return NextResponse.next()
+  }
+
+  const url = request.nextUrl.clone()
+  const searchParams = url.searchParams
+  let hasTracking = false
+
+  // Check if any tracking parameters exist (case-insensitive)
+  TRACKING_PARAMS.forEach((param) => {
+    // Check both lowercase and as-is
+    if (searchParams.has(param) || searchParams.has(param.toLowerCase())) {
+      hasTracking = true
+      searchParams.delete(param)
+      searchParams.delete(param.toLowerCase())
+    }
+    // Also check for camelCase variants (e.g., utmSource)
+    const camelCase = param.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase())
+    if (searchParams.has(camelCase)) {
+      hasTracking = true
+      searchParams.delete(camelCase)
+    }
+  })
+
+  // If we removed any params, redirect to clean URL with 308 (permanent)
+  if (hasTracking) {
+    return NextResponse.redirect(url, 308)
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: '/learn/:path*',
+}

--- a/apps/cow-fi/next.config.ts
+++ b/apps/cow-fi/next.config.ts
@@ -3,7 +3,6 @@ import { WithNxOptions } from '@nx/next/plugins/with-nx'
 
 const nextConfig: WithNxOptions = {
   reactStrictMode: true,
-  swcMinify: true,
   nx: {
     svgr: false,
   },
@@ -87,10 +86,7 @@ const nextConfig: WithNxOptions = {
       },
     ]
   },
-  i18n: {
-    locales: ['en'],
-    defaultLocale: 'en',
-  },
+
   images: {
     domains: ['celebrated-gift-f83e5c9419.media.strapiapp.com'],
     remotePatterns: [
@@ -102,13 +98,22 @@ const nextConfig: WithNxOptions = {
   },
   async headers() {
     return [
-      // Cache all pages for 60 seconds
+      {
+        source: '/learn/:path*',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, s-maxage=3600, stale-while-revalidate=86400', // 1h cache, 24h stale
+          },
+        ],
+      },
+      // Cache all other pages for 1 hour
       {
         source: '/:path*',
         headers: [
           {
             key: 'Cache-Control',
-            value: 'public, s-maxage=60, stale-while-revalidate=300',
+            value: 'public, s-maxage=3600, stale-while-revalidate=86400', // 1h cache, 24h stale
           },
         ],
       },

--- a/apps/cowswap-frontend/src/common/hooks/useSwapResultsContext.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useSwapResultsContext.ts
@@ -28,7 +28,7 @@ export function useSwapResultsContext(
   const receivedAmount = useMemo(() => {
     if (!intermediateToken || !swappedAmountWithFee) return undefined
 
-    return CurrencyAmount.fromRawAmount(intermediateToken, swappedAmountWithFee.toString())
+    return CurrencyAmount.fromRawAmount(intermediateToken, swappedAmountWithFee.toFixed(0))
   }, [swappedAmountWithFee, intermediateToken])
 
   const receivedAmountUsd = useUsdAmount(receivedAmount).value


### PR DESCRIPTION
# Summary

A user reported a crash when they tried to open their Account modal.

`swappedAmountWithFee` is an instance of `bignumber.js` which gives `e-notation` values if you call `.toString()`.
To fix that I changed it to `.toFixed()` which returns bignumber as a string.

<img width="500" height="107" alt="image" src="https://github.com/user-attachments/assets/25b34cc6-3eb3-4cb7-a2d3-70010ef30acc" />


# To Test

1. Impersonate this wallet 0xe3564bcd21011faa1f9006bb4a67acd423a4f020 on Base
2. Once connected, open Account modal
- [ ] AR: app crashed
- [ ] ER: no crashes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automatic removal of tracking parameters (e.g., utm_source, fbclid, gclid) from URLs under the Learn section for cleaner sharing and navigation.
  * Expanded cache revalidation to additional Learn sub-pages for more consistent content updates.

* **Improvements**
  * Enhanced cache-control headers for Learn pages, improving performance and freshness.
  * Standardized cache revalidation intervals across Learn pages (now every 12 hours).
  * Improved handling of pagination and 404 errors on article listing pages.
  * Refined article and category formatting for better reliability and display consistency.

* **Bug Fixes**
  * Ensured swapped amounts are correctly rounded in swap calculations for more accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->