### PR TITLE
fix(bridge): fix received amount parsing from executed info

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useSwapResultsContext.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useSwapResultsContext.ts
@@ -28,7 +28,7 @@ export function useSwapResultsContext(
   const receivedAmount = useMemo(() => {
     if (!intermediateToken || !swappedAmountWithFee) return undefined
 
-    return CurrencyAmount.fromRawAmount(intermediateToken, swappedAmountWithFee.toString())
+    return CurrencyAmount.fromRawAmount(intermediateToken, swappedAmountWithFee.toFixed(0))
   }, [swappedAmountWithFee, intermediateToken])
 
   const receivedAmountUsd = useUsdAmount(receivedAmount).value


### PR DESCRIPTION
# Summary

A user reported a crash when they tried to open their Account modal.

`swappedAmountWithFee` is an instance of `bignumber.js` which gives `e-notation` values if you call `.toString()`.
To fix that I changed it to `.toFixed()` which returns bignumber as a string.

<img width="500" height="107" alt="image" src="https://github.com/user-attachments/assets/25b34cc6-3eb3-4cb7-a2d3-70010ef30acc" />


# To Test

1. Impersonate this wallet 0xe3564bcd21011faa1f9006bb4a67acd423a4f020 on Base
2. Once connected, open Account modal
- [ ] AR: app crashed
- [ ] ER: no crashes
