### PR TITLE
feat: add recipient validation

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/AddressInputPanel/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/AddressInputPanel/index.tsx
@@ -1,93 +1,35 @@
-import { ChangeEvent, ReactNode, useCallback, useEffect, useState } from 'react'
+import { ChangeEvent, ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 
 import { getChainInfo } from '@cowprotocol/common-const'
-import {
-  getBlockExplorerUrl as getExplorerLink,
-  isPrefixedAddress,
-  parsePrefixedAddress,
-} from '@cowprotocol/common-utils'
+import { getBlockExplorerUrl as getExplorerLink } from '@cowprotocol/common-utils'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { useENS } from '@cowprotocol/ens'
-import { ExternalLink, RowBetween, UI } from '@cowprotocol/ui'
+import { ExternalLink, RowBetween } from '@cowprotocol/ui'
 import { useWalletInfo } from '@cowprotocol/wallet'
 
 import { t, Trans } from '@lingui/macro'
-import styled from 'styled-components/macro'
 
 import { AutoColumn } from 'legacy/components/Column'
 import { useIsDarkMode } from 'legacy/state/user/hooks'
 
+import { InputPanel, ContainerRow, InputContainer, Input, ErrorMessage } from './styled'
+import { shouldResolveENS, createValidationResult, processInputValue } from './utils'
+
 import { autofocus } from '../../utils/autofocus'
 import ChainPrefixWarning from '../ChainPrefixWarning'
 
-const InputPanel = styled.div`
-  ${({ theme }) => theme.flexColumnNoWrap}
-  position: relative;
-  border-radius: 16px;
-  background-color: var(${UI.COLOR_PAPER_DARKER});
-  color: inherit;
-  z-index: 1;
-  width: 100%;
-`
+interface AddressInputPanelProps {
+  id?: string
+  className?: string
+  label?: ReactNode
+  placeholder?: string
+  value: string
+  onChange: (value: string) => void
+  customValidation?: (address: string) => string | null
+  currentChainId?: SupportedChainId
+  destinationChainId?: SupportedChainId
+}
 
-const ContainerRow = styled.div<{ error: boolean }>`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  border-radius: 16px;
-  border: 0;
-  color: inherit;
-  background-color: var(${UI.COLOR_PAPER_DARKER});
-`
-
-export const InputContainer = styled.div`
-  flex: 1;
-  padding: 1rem;
-`
-
-const Input = styled.input<{ error?: boolean }>`
-  font-size: 1.25rem;
-  outline: none;
-  border: none;
-  flex: 1 1 auto;
-  background: none;
-  transition: color 0.2s ${({ error }) => (error ? 'step-end' : 'step-start')};
-  color: ${({ error }) => (error ? `var(${UI.COLOR_DANGER})` : 'inherit')};
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-weight: 500;
-  width: 100%;
-
-  &&::placeholder {
-    color: inherit;
-    opacity: 0.5;
-  }
-
-  &:focus::placeholder {
-    color: transparent;
-  }
-
-  padding: 0px;
-  appearance: textfield;
-  -webkit-appearance: textfield;
-
-  ::-webkit-search-decoration {
-    -webkit-appearance: none;
-  }
-
-  ::-webkit-outer-spin-button,
-  ::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-  }
-
-  ::placeholder {
-    color: ${({ theme }) => theme.text4};
-  }
-`
-
-// TODO: Break down this large function into smaller functions
-// TODO: Add proper return type annotation
-// TODO: Reduce function complexity by extracting logic
-// eslint-disable-next-line max-lines-per-function, @typescript-eslint/explicit-function-return-type, complexity
 export function AddressInputPanel({
   id,
   className = 'recipient-address-input',
@@ -95,40 +37,33 @@ export function AddressInputPanel({
   placeholder,
   value,
   onChange,
-}: {
-  id?: string
-  className?: string
-  label?: ReactNode
-  placeholder?: string
-  value: string
-  onChange: (value: string) => void
-}) {
+  customValidation,
+  currentChainId,
+  destinationChainId,
+}: AddressInputPanelProps): ReactNode {
   const { chainId } = useWalletInfo()
   const chainInfo = getChainInfo(chainId)
   const addressPrefix = chainInfo?.addressPrefix
-  const { address, loading, name } = useENS(value)
-  const [chainPrefixWarning, setChainPrefixWarning] = useState('')
   const isDarkMode = useIsDarkMode()
+  const [chainPrefixWarning, setChainPrefixWarning] = useState('')
+
+  // Determine effective chains
+  const effectiveCurrentChain = currentChainId || chainId
+  const effectiveDestinationChain = destinationChainId || effectiveCurrentChain
+
+  // Only resolve ENS when BOTH chains are MAINNET
+  const shouldResolve = shouldResolveENS(effectiveCurrentChain, effectiveDestinationChain)
+
+  // Only call useENS when we should resolve
+  const { address, loading, name } = useENS(shouldResolve ? value : null)
+
+  const validationResult = useMemo(() => {
+    return createValidationResult(value, shouldResolve, address, loading, customValidation)
+  }, [value, shouldResolve, address, loading, customValidation])
 
   const handleInput = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      const input = event.target.value
-      setChainPrefixWarning('')
-      let value = input.replace(/\s+/g, '')
-
-      if (isPrefixedAddress(value)) {
-        const { prefix, address } = parsePrefixedAddress(value)
-
-        if (prefix && addressPrefix !== prefix) {
-          setChainPrefixWarning(prefix)
-        }
-
-        if (address) {
-          value = address
-        }
-      }
-
-      onChange(value)
+      processInputValue(event.target.value, addressPrefix, setChainPrefixWarning, onChange)
     },
     [onChange, addressPrefix],
   )
@@ -140,14 +75,12 @@ export function AddressInputPanel({
     }
   }, [chainId, chainPrefixWarning, addressPrefix])
 
-  const error = Boolean(value.length > 0 && !loading && !address)
-
   return (
     <InputPanel id={id}>
       {chainPrefixWarning && (
         <ChainPrefixWarning chainPrefixWarning={chainPrefixWarning} chainInfo={chainInfo} isDarkMode={isDarkMode} />
       )}
-      <ContainerRow error={error}>
+      <ContainerRow error={validationResult.hasError}>
         <InputContainer>
           <AutoColumn gap="md">
             <RowBetween>
@@ -166,12 +99,15 @@ export function AddressInputPanel({
               autoCapitalize="off"
               spellCheck="false"
               placeholder={placeholder ?? t`Wallet Address or ENS name`}
-              error={error}
+              error={validationResult.hasError}
               pattern="^(0x[a-fA-F0-9]{40})$"
               onChange={handleInput}
               value={value}
               onFocus={autofocus}
             />
+            {(validationResult.ensError || validationResult.customError) && (
+              <ErrorMessage>{validationResult.ensError || validationResult.customError}</ErrorMessage>
+            )}
           </AutoColumn>
         </InputContainer>
       </ContainerRow>

--- a/apps/cowswap-frontend/src/common/pure/AddressInputPanel/styled.ts
+++ b/apps/cowswap-frontend/src/common/pure/AddressInputPanel/styled.ts
@@ -1,0 +1,74 @@
+import { UI } from '@cowprotocol/ui'
+
+import styled from 'styled-components/macro'
+
+export const InputPanel = styled.div`
+  ${({ theme }) => theme.flexColumnNoWrap}
+  position: relative;
+  border-radius: 16px;
+  background-color: var(${UI.COLOR_PAPER_DARKER});
+  color: inherit;
+  z-index: 1;
+  width: 100%;
+`
+
+export const ContainerRow = styled.div<{ error: boolean }>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 16px;
+  border: 0;
+  color: inherit;
+  background-color: var(${UI.COLOR_PAPER_DARKER});
+`
+
+export const InputContainer = styled.div`
+  flex: 1;
+  padding: 1rem;
+`
+
+export const Input = styled.input<{ error?: boolean }>`
+  font-size: 1.25rem;
+  outline: none;
+  border: none;
+  flex: 1 1 auto;
+  background: none;
+  transition: color 0.2s ${({ error }) => (error ? 'step-end' : 'step-start')};
+  color: ${({ error }) => (error ? `var(${UI.COLOR_DANGER})` : 'inherit')};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 500;
+  width: 100%;
+
+  &&::placeholder {
+    color: inherit;
+    opacity: 0.5;
+  }
+
+  &:focus::placeholder {
+    color: transparent;
+  }
+
+  padding: 0px;
+  appearance: textfield;
+  -webkit-appearance: textfield;
+
+  ::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+
+  ::-webkit-outer-spin-button,
+  ::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+  }
+
+  ::placeholder {
+    color: ${({ theme }) => theme.text4};
+  }
+`
+
+export const ErrorMessage = styled.div`
+  color: var(${UI.COLOR_DANGER_TEXT});
+  font-size: 12px;
+  margin-top: 4px;
+`

--- a/apps/cowswap-frontend/src/common/pure/AddressInputPanel/utils.ts
+++ b/apps/cowswap-frontend/src/common/pure/AddressInputPanel/utils.ts
@@ -1,0 +1,61 @@
+import { isAddress, isPrefixedAddress, parsePrefixedAddress } from '@cowprotocol/common-utils'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import { hasEnsEnding, getMainnetEnsError } from '../../utils/recipientValidation'
+
+interface ValidationResult {
+  ensError: string | null
+  customError: string | null
+  hasError: boolean
+}
+
+// Helper function to determine if ENS should be resolved
+export function shouldResolveENS(currentChain: SupportedChainId, destinationChain: SupportedChainId): boolean {
+  return currentChain === SupportedChainId.MAINNET && destinationChain === SupportedChainId.MAINNET
+}
+
+// Helper function to create validation result
+export function createValidationResult(
+  value: string,
+  shouldResolve: boolean,
+  address: string | null,
+  loading: boolean,
+  customValidation?: (address: string) => string | null,
+): ValidationResult {
+  const ensError = hasEnsEnding(value) && !shouldResolve ? getMainnetEnsError() : null
+  const customError = customValidation && address ? customValidation(address) : null
+
+  return {
+    ensError,
+    customError,
+    hasError: Boolean((value.length > 0 && !loading && !address && !isAddress(value)) || ensError || customError),
+  }
+}
+
+// Helper function to handle input processing
+export function processInputValue(
+  input: string,
+  addressPrefix: string | undefined,
+  setChainPrefixWarning: (warning: string) => void,
+  onChange: (value: string) => void,
+): void {
+  setChainPrefixWarning('')
+  const cleanValue = input.replace(/\s+/g, '')
+
+  if (isPrefixedAddress(cleanValue)) {
+    const { prefix, address } = parsePrefixedAddress(cleanValue)
+
+    if (prefix && addressPrefix !== prefix) {
+      setChainPrefixWarning(prefix)
+    }
+
+    if (address) {
+      onChange(address)
+      return
+    }
+  }
+
+  onChange(cleanValue)
+}
+
+export type { ValidationResult }

--- a/apps/cowswap-frontend/src/common/utils/recipientValidation.ts
+++ b/apps/cowswap-frontend/src/common/utils/recipientValidation.ts
@@ -1,0 +1,34 @@
+import { getChainInfo } from '@cowprotocol/common-const'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
+const ENS_ENDING = '.eth'
+
+export function getMainnetEnsError(): string {
+  const mainnetLabel = getChainInfo(SupportedChainId.MAINNET)?.label || 'Mainnet'
+  return `ENS names are only supported when sending from ${mainnetLabel} to ${mainnetLabel}`
+}
+
+export function hasEnsEnding(value: string): boolean {
+  return value.toLowerCase().endsWith(ENS_ENDING)
+}
+
+// Check if address is dangerous (token contracts, etc)
+export function isDangerousRecipient(
+  recipient: string,
+  sellTokenAddress?: string,
+  buyTokenAddress?: string,
+): string | null {
+  const normalized = recipient.toLowerCase()
+
+  if (sellTokenAddress && normalized === sellTokenAddress.toLowerCase()) {
+    return 'Cannot send to the sell token contract address'
+  }
+
+  if (buyTokenAddress && normalized === buyTokenAddress.toLowerCase()) {
+    return 'Cannot send to the buy token contract address'
+  }
+
+  return null
+}
+
+export { ENS_ENDING }

--- a/apps/cowswap-frontend/src/modules/limitOrders/pure/LimitOrdersDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/pure/LimitOrdersDetails/index.tsx
@@ -61,7 +61,7 @@ export function LimitOrdersDetails(props: LimitOrdersDetailsProps): ReactNode {
     partiallyFillableOverride,
     children,
   } = props
-  const { account, recipient, recipientAddressOrName, partiallyFillable } = tradeContext.postOrderParams
+  const { recipient, recipientAddressOrName, partiallyFillable } = tradeContext.postOrderParams
   const { feeAmount, activeRate, marketRate } = limitRateState
 
   const validTo = calculateLimitOrdersDeadline(settingsState, tradeContext.quoteState)
@@ -127,7 +127,7 @@ export function LimitOrdersDetails(props: LimitOrdersDetailsProps): ReactNode {
         <span>{expiryDate.toLocaleString(undefined, DEFAULT_DATE_FORMAT)}</span>
       </styledEl.DetailsRow>
       <OrderType isPartiallyFillable={partiallyFillable} partiallyFillableOverride={partiallyFillableOverride} />
-      <RecipientRow chainId={tradeContext.chainId} recipient={recipientAddressOrName || recipient} account={account} />
+      <RecipientRow chainId={tradeContext.chainId} recipient={recipientAddressOrName || recipient} />
     </Wrapper>
   )
 }

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapRateDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapRateDetails/index.tsx
@@ -1,4 +1,7 @@
-import { ReactNode, useCallback } from 'react'
+import { ReactNode, useCallback, useMemo } from 'react'
+
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { useWalletInfo } from '@cowprotocol/wallet'
 
 import {
   BridgeAccordionSummary,
@@ -7,10 +10,21 @@ import {
   useShouldDisplayBridgeDetails,
   QuoteDetails,
 } from 'modules/bridge'
+import { useTradeState } from 'modules/trade'
+import { RecipientRow } from 'modules/trade/pure/RecipientRow'
 import { useTradeQuote } from 'modules/tradeQuote'
 import { TradeRateDetails } from 'modules/tradeWidgetAddons'
 
 import { RateInfoParams } from 'common/pure/RateInfo'
+
+// Helper to resolve recipient chain ID safely
+function getRecipientChainId(
+  bridgeContext: ReturnType<typeof useQuoteBridgeContext>,
+  fallbackChainId: SupportedChainId,
+): SupportedChainId {
+  const bridgeChainId = bridgeContext?.buyAmount?.currency?.chainId
+  return bridgeChainId && bridgeChainId in SupportedChainId ? (bridgeChainId as SupportedChainId) : fallbackChainId
+}
 
 export interface SwapRateDetailsProps {
   rateInfoParams: RateInfoParams
@@ -19,14 +33,22 @@ export interface SwapRateDetailsProps {
 
 export function SwapRateDetails({ rateInfoParams, deadline }: SwapRateDetailsProps): ReactNode {
   const { isLoading: isRateLoading, bridgeQuote } = useTradeQuote()
+  const { chainId } = useWalletInfo()
+  const { state } = useTradeState()
 
   const shouldDisplayBridgeDetails = useShouldDisplayBridgeDetails()
-
   const providerDetails = bridgeQuote?.providerInfo
   const bridgeEstimatedTime = bridgeQuote?.expectedFillTimeSeconds
 
   const swapContext = useQuoteSwapContext()
   const bridgeContext = useQuoteBridgeContext()
+
+  const recipientChainId = getRecipientChainId(bridgeContext, chainId)
+  const recipientRow = useMemo(() => {
+    if (!state?.recipient) return null
+
+    return <RecipientRow chainId={recipientChainId} recipient={state.recipientAddress || state.recipient} />
+  }, [recipientChainId, state?.recipient, state?.recipientAddress])
 
   const feeWrapper = useCallback(
     (feeElement: ReactNode, isOpen: boolean) => {
@@ -56,9 +78,8 @@ export function SwapRateDetails({ rateInfoParams, deadline }: SwapRateDetailsPro
         swapContext &&
         bridgeContext && (
           <>
-            <QuoteDetails bridgeProvider={providerDetails}
-                          swapContext={swapContext}
-                          bridgeContext={bridgeContext}/>
+            <QuoteDetails bridgeProvider={providerDetails} swapContext={swapContext} bridgeContext={bridgeContext} />
+            {recipientRow}
           </>
         )
       }

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeBasicConfirmDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeBasicConfirmDetails/index.tsx
@@ -61,7 +61,6 @@ export function TradeBasicConfirmDetails(props: Props) {
     withTimelineDot = true,
     children,
     recipient,
-    account,
   } = props
   const isInvertedState = useState(false)
   const { amountAfterFees, amountAfterSlippage } = getOrderTypeReceiveAmounts(receiveAmountInfo)
@@ -149,7 +148,7 @@ export function TradeBasicConfirmDetails(props: Props) {
       )}
 
       {/*Recipient*/}
-      <RecipientRow chainId={rateInfoParams.chainId} recipient={recipient} account={account} />
+      <RecipientRow chainId={rateInfoParams.chainId} recipient={recipient} />
       {children}
     </styledEl.Wrapper>
   )

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
@@ -115,6 +115,10 @@ export function TradeWidgetForm(props: TradeWidgetProps): ReactNode {
   const buyToken = outputCurrencyInfo.currency
   const areCurrenciesLoading = !sellToken && !buyToken
   const bothCurrenciesSet = !!sellToken && !!buyToken
+  const isOutputTokenUnsupported = !!buyToken && !(buyToken.chainId in SupportedChainId)
+  const supportedDestinationChainId = buyToken?.chainId && buyToken.chainId in SupportedChainId 
+    ? (buyToken.chainId as SupportedChainId) 
+    : undefined
 
   const hasRecipientInUrl = !!tradeStateFromUrl?.recipient
   const withRecipient = !isWrapOrUnwrap && (showRecipient || hasRecipientInUrl)
@@ -178,8 +182,6 @@ export function TradeWidgetForm(props: TradeWidgetProps): ReactNode {
       scrollToMyOrders()
     }
   }, [isMarketOrderWidget, toggleAccountModal])
-
-  const isOutputTokenUnsupported = !!buyToken && !(buyToken.chainId in SupportedChainId)
 
   return (
     <>
@@ -258,7 +260,15 @@ export function TradeWidgetForm(props: TradeWidgetProps): ReactNode {
                     {...currencyInputCommonProps}
                   />
                 </div>
-                {withRecipient && <SetRecipient recipient={recipient || ''} onChangeRecipient={onChangeRecipient} />}
+                {withRecipient && (
+                  <SetRecipient 
+                    recipient={recipient || ''} 
+                    onChangeRecipient={onChangeRecipient}
+                    sellTokenAddress={sellToken?.isToken ? sellToken.address : undefined}
+                    buyTokenAddress={buyToken?.isToken ? buyToken.address : undefined}
+                    destinationChainId={supportedDestinationChainId}
+                  />
+                )}
 
                 {isWrapOrUnwrap ? (
                   sellToken ? (

--- a/apps/cowswap-frontend/src/modules/trade/pure/RecipientRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/RecipientRow/index.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react'
 
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { InfoTooltip } from '@cowprotocol/ui'
+import { InfoTooltip, NetworkLogo } from '@cowprotocol/ui'
 
 import styled from 'styled-components/macro'
 import { Nullish } from 'types'
@@ -18,31 +18,35 @@ const Row = styled.div`
   gap: 3px;
 `
 
+const AddressWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+`
+
 interface RecipientRowProps {
   chainId: SupportedChainId
   recipient: Nullish<string>
-  account: Nullish<string>
 }
 
 export function RecipientRow(props: RecipientRowProps): ReactNode {
-  const { chainId, recipient, account } = props
+  const { chainId, recipient } = props
+
+  // Always show recipient if provided (even if same as account)
+  if (!recipient) {
+    return null
+  }
+
   return (
-    <>
-      {recipient && recipient.toLowerCase() !== account?.toLowerCase() && (
-        <Row>
-          <div>
-            <span>Recipient</span>{' '}
-            <InfoTooltip
-              content={
-                'The tokens received from this order will automatically be sent to this address. No need to do a second transaction!'
-              }
-            />
-          </div>
-          <div>
-            <AddressLink address={recipient} chainId={chainId} />
-          </div>
-        </Row>
-      )}
-    </>
+    <Row>
+      <div>
+        <span>Recipient</span>{' '}
+        <InfoTooltip content="The tokens received from this order will automatically be sent to this address. No need to do a second transaction!" />
+      </div>
+      <AddressWrapper>
+        <NetworkLogo chainId={chainId} size={16} />
+        <AddressLink address={recipient} chainId={chainId} />
+      </AddressWrapper>
+    </Row>
   )
 }

--- a/apps/cowswap-frontend/src/modules/trade/pure/SetRecipient/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/SetRecipient/index.tsx
@@ -1,26 +1,47 @@
+import { ReactNode, useCallback } from 'react'
+
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { AutoRow } from '@cowprotocol/ui'
+import { useWalletInfo } from '@cowprotocol/wallet'
 
 import { ArrowDown } from 'react-feather'
 
 import { AddressInputPanel } from 'common/pure/AddressInputPanel'
+import { isDangerousRecipient } from 'common/utils/recipientValidation'
 
 export interface SetRecipientProps {
   recipient: string
   onChangeRecipient(recipient: string | null): void
   className?: string
+  sellTokenAddress?: string
+  buyTokenAddress?: string
+  destinationChainId?: SupportedChainId
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function SetRecipient(props: SetRecipientProps) {
-  const { recipient, onChangeRecipient, className } = props
+export function SetRecipient(props: SetRecipientProps): ReactNode {
+  const { recipient, onChangeRecipient, className, sellTokenAddress, buyTokenAddress, destinationChainId } = props
+  const { chainId } = useWalletInfo()
+
+  const customValidation = useCallback(
+    (address: string) => {
+      return isDangerousRecipient(address, sellTokenAddress, buyTokenAddress)
+    },
+    [sellTokenAddress, buyTokenAddress],
+  )
 
   return (
     <>
       <AutoRow className={className} justify="center">
         <ArrowDown size="16" />
       </AutoRow>
-      <AddressInputPanel id="recipient" value={recipient} onChange={onChangeRecipient} />
+      <AddressInputPanel
+        id="recipient"
+        value={recipient}
+        onChange={onChangeRecipient}
+        customValidation={customValidation}
+        currentChainId={chainId}
+        destinationChainId={destinationChainId}
+      />
     </>
   )
 }


### PR DESCRIPTION
 # Summary

  Implements recipient validation for swap and bridge transactions with ENS support and security checks.

  - ENS resolution restricted to Ethereum → Ethereum transactions only
  - Token contract address validation to prevent dangerous sends
  - Chain badges for recipient display clarity
  - Basic recipient display in expanded bridge accordion

  # To Test

  1. **ENS Validation** - Navigate to swap page on Ethereum

  - [ ] Enter `vitalik.eth` in recipient field → should resolve to address
  - [ ] Switch to Arbitrum, enter `vitalik.eth` → should show "ENS names are only supported when sending from Ethereum to Ethereum"
  - [ ] Bridge from Ethereum to Arbitrum, enter `vitalik.eth` → should show same error

  2. **Token Contract Protection** - On any swap page

  - [ ] Enter sell token contract address as recipient → should show "Cannot send to the sell token contract address"
  - [ ] Enter buy token contract address as recipient → should show "Cannot send to the buy token contract address"
  - [ ] Enter valid wallet address → should accept without error

  3. **Chain Badge Display** - With custom recipient set

  - [ ] Recipient row should display network logo next to address
  - [ ] Bridge transactions should show recipient when accordion is expanded
  - [ ] Regular swaps should show recipient normally

  # Background

  This is **Phase 1** of recipient validation implementation focusing on core security and UX improvements for swaps and
  bridges.

  **Upcoming phases** will extend validation to Limit Orders and TWAP orders, add user confirmation checkboxes for non-expert mode, and implement conditional recipient row display when the bridge fee accordion is collapsed to ensure custom recipients remain visible at all times.