### PR TITLE
fix: get relevant provider network for multicall

### DIFF
--- a/libs/multicall/src/hooks/useMultiCallRpcProvider.ts
+++ b/libs/multicall/src/hooks/useMultiCallRpcProvider.ts
@@ -1,29 +1,46 @@
 import { useAtomValue } from 'jotai/index'
+import { useMemo } from 'react'
 
 import { getRpcProvider } from '@cowprotocol/common-const'
+import { useDebounce } from '@cowprotocol/common-hooks'
 import { Nullish } from '@cowprotocol/types'
 import { useWalletProvider } from '@cowprotocol/wallet-provider'
 import { JsonRpcProvider } from '@ethersproject/providers'
 
+import ms from 'ms.macro'
 import { useAsyncMemo } from 'use-async-memo'
 
 import { multiCallContextAtom } from '../state/multiCallContextAtom'
+
+const PROVIDER_DEBOUNCE = ms`500ms`
 
 export function useMultiCallRpcProvider(): Nullish<JsonRpcProvider> {
   const provider = useWalletProvider()
   const context = useAtomValue(multiCallContextAtom)
 
-  return useAsyncMemo(async () => {
-    if (!context || !provider) return null
+  const contextChainId = context?.chainId
 
-    const walletChainId = +(await provider.getNetwork()).chainId
+  const walletChainId = useAsyncMemo(async () => {
+    if (!provider) return undefined
+
+    return +(await provider.getNetwork()).chainId
+  }, [provider])
+
+  const multicallProvider = useMemo(() => {
+    if (!contextChainId || !walletChainId) return null
 
     // Use wallet provider if current network matches the wallet network
-    if (walletChainId === context.chainId) {
+    if (walletChainId === contextChainId) {
       return provider
     }
 
     // Otherwise use RPC node
-    return getRpcProvider(context.chainId)
-  }, [context, provider])
+    return getRpcProvider(contextChainId)
+  }, [contextChainId, walletChainId, provider])
+
+  /**
+   * Due to network changes, there might a race condition between walletChainId and contextChainId
+   * To avoid flickering, we debounce the result provider for 0.5s, it's more than enough for a moment of network change
+   */
+  return useDebounce(multicallProvider, PROVIDER_DEBOUNCE)
 }

--- a/libs/multicall/src/hooks/useMultiCallRpcProvider.ts
+++ b/libs/multicall/src/hooks/useMultiCallRpcProvider.ts
@@ -1,20 +1,22 @@
 import { useAtomValue } from 'jotai/index'
-import { useMemo } from 'react'
 
 import { getRpcProvider } from '@cowprotocol/common-const'
+import { Nullish } from '@cowprotocol/types'
 import { useWalletProvider } from '@cowprotocol/wallet-provider'
 import { JsonRpcProvider } from '@ethersproject/providers'
 
+import { useAsyncMemo } from 'use-async-memo'
+
 import { multiCallContextAtom } from '../state/multiCallContextAtom'
 
-export function useMultiCallRpcProvider(): JsonRpcProvider | null {
+export function useMultiCallRpcProvider(): Nullish<JsonRpcProvider> {
   const provider = useWalletProvider()
   const context = useAtomValue(multiCallContextAtom)
 
-  return useMemo(() => {
+  return useAsyncMemo(async () => {
     if (!context || !provider) return null
 
-    const walletChainId = provider.network?.chainId
+    const walletChainId = +(await provider.getNetwork()).chainId
 
     // Use wallet provider if current network matches the wallet network
     if (walletChainId === context.chainId) {


### PR DESCRIPTION
# Summary

This is a consequence of #6057

`useMultiCallRpcProvider()` was `network` property which might return undefined in some cases (there is a race condition). If it returns undefined first time, the hook will take 

<img width="813" height="220" alt="image" src="https://github.com/user-attachments/assets/4875199c-0f43-4de7-aa17-e2afb4928528" />

<img width="756" height="367" alt="image" src="https://github.com/user-attachments/assets/734f8489-7ea3-45fb-b444-1ab2abddc7be" />


# To Test

1. <<Step one>> Open the page `about`

- [ ] <<What to expect?>> Verify it contains about information...
- [ ] Checkbox Style list of things a QA person could verify, i.e.
- [ ] Should display Text Input our storybook
- [ ] Input should not accept Numbers

2. <<Step two>> ...

# Background

Optional: Give background information for changes you've made, that might be difficult to explain via comments
