### PR TITLE
chore: remove Cow token from Polygon's favorite tokens and Account page

### DIFF
--- a/libs/common-const/src/common.ts
+++ b/libs/common-const/src/common.ts
@@ -74,8 +74,9 @@ export const COW_CONTRACT_ADDRESS: Record<SupportedChainId, string | null> = {
   [SupportedChainId.ARBITRUM_ONE]: '0xcb8b5cd20bdcaea9a010ac1f8d835824f5c87a04',
   [SupportedChainId.BASE]: '0xc694a91e6b071bF030A18BD3053A7fE09B6DaE69',
   [SupportedChainId.SEPOLIA]: '0x0625aFB445C3B6B7B929342a04A22599fd5dBB59',
+  // the token is deployed but there's no liquidity at the moment
   // https://polygonscan.com/token/0x2f4efd3aa42e15a1ec6114547151b63ee5d39958
-  [SupportedChainId.POLYGON]: '0x2f4efd3aa42e15a1ec6114547151b63ee5d39958',
+  [SupportedChainId.POLYGON]: null,
   [SupportedChainId.AVALANCHE]: null,
 }
 

--- a/libs/common-const/src/common.ts
+++ b/libs/common-const/src/common.ts
@@ -74,9 +74,8 @@ export const COW_CONTRACT_ADDRESS: Record<SupportedChainId, string | null> = {
   [SupportedChainId.ARBITRUM_ONE]: '0xcb8b5cd20bdcaea9a010ac1f8d835824f5c87a04',
   [SupportedChainId.BASE]: '0xc694a91e6b071bF030A18BD3053A7fE09B6DaE69',
   [SupportedChainId.SEPOLIA]: '0x0625aFB445C3B6B7B929342a04A22599fd5dBB59',
-  // the token is deployed but there's no liquidity at the moment
   // https://polygonscan.com/token/0x2f4efd3aa42e15a1ec6114547151b63ee5d39958
-  [SupportedChainId.POLYGON]: null,
+  [SupportedChainId.POLYGON]: '0x2f4efd3aa42e15a1ec6114547151b63ee5d39958',
   [SupportedChainId.AVALANCHE]: null,
 }
 

--- a/libs/tokens/src/const/defaultFavoriteTokens.ts
+++ b/libs/tokens/src/const/defaultFavoriteTokens.ts
@@ -4,7 +4,6 @@ import {
   COW_TOKEN_ARBITRUM,
   COW_TOKEN_BASE,
   COW_TOKEN_MAINNET,
-  COW_TOKEN_POLYGON,
   COW_TOKEN_SEPOLIA,
   COW_TOKEN_XDAI,
   DAI,
@@ -98,7 +97,7 @@ export const DEFAULT_FAVORITE_TOKENS: Record<SupportedChainId, TokensMap> = {
     USDC_POLYGON,
     USDT_POLYGON,
     DAI_POLYGON,
-    COW_TOKEN_POLYGON,
+    // Cow Token is deployed but there's no liquidity at the moment
     WRAPPED_NATIVE_CURRENCIES[SupportedChainId.POLYGON],
   ]),
   [SupportedChainId.AVALANCHE]: tokensListToMap([


### PR DESCRIPTION
# Summary

Removing `CoW` token from Polygon's favorite tokens and Account page, as there's no liquidity at the moment.

# To Test

1. Switch Wallet to Polygon and open token selector
2. CoW token should not be in the favorite token list
3. Navigate to `Account` page
4. CoW token balance shouldn't be displayed, and a message is shown that the token is not available

