### PR TITLE
Feat: add Ondo tokens list

### DIFF
--- a/libs/tokens/src/const/tokensList.json
+++ b/libs/tokens/src/const/tokensList.json
@@ -13,6 +13,10 @@
     {
       "priority": 3,
       "source": "https://curvefi.github.io/curve-assets/ethereum.json"
+    },
+    {
+      "priority": 4,
+      "source": "https://raw.githubusercontent.com/ondoprotocol/cowswap-global-markets-token-list/refs/heads/main/tokenlist.json"
     }
   ],
   "100": [
@@ -133,4 +137,3 @@
     }
   ]
 }
-


### PR DESCRIPTION
# Summary

Add Ondo [tokens list ](https://raw.githubusercontent.com/ondoprotocol/cowswap-global-markets-token-list/refs/heads/main/tokenlist.json) to Mainnet, disabled by default.

<img width="601" height="1090" alt="Screenshot 2025-08-07 at 12 07 59" src="https://github.com/user-attachments/assets/1ea19d13-544e-4238-9b93-4dbfb5ff93ee" />

<img width="650" height="498" alt="Screenshot 2025-08-07 at 12 08 46" src="https://github.com/user-attachments/assets/84008871-5a3a-4195-82b4-b378758fca16" />


# To Test

## Tokens List
1. Wallet is on Ethereum Mainnet
2. Go to Manage Token Lists setting
3.`Ondo Tokenised Stocks List` should be available, disabled by default

## Import token
1. Wallet is on Ethereum Mainnet
2. Open the token selector
3. Paste an address of a Ondo token, for example `0x9DCf7f739B8C0270E2FC0Cc8D0DaBe355a150dBa`
4. The token should be importable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to the latest stable version.
  * Added a new token list source for Ethereum mainnet.
  * Updated default favorite tokens for Polygon by removing a token with no liquidity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->