### PR TITLE
fix(tokens): check lists instead of tokens to prevent flickering

### DIFF
--- a/libs/tokens/src/state/tokens/allTokensAtom.ts
+++ b/libs/tokens/src/state/tokens/allTokensAtom.ts
@@ -75,16 +75,15 @@ export const allActiveTokensAtom = atom(async (get) => {
   const { chainId, enableLpTokensByDefault } = get(environmentAtom)
   const userAddedTokens = get(userAddedTokensAtom)
   const favoriteTokensState = get(favoriteTokensAtom)
+  const listsStatesList = await get(listsStatesListAtom)
 
   const tokensMap = await get(tokensStateAtom)
   const nativeToken = NATIVE_CURRENCIES[chainId]
 
-  const activeTokensCount = Object.keys(tokensMap.activeTokens).length
-
   /**
-   * Wait till active tokens are loaded
+   * Wait till token lists loaded
    */
-  if (activeTokensCount === 0) {
+  if (listsStatesList.length === 0) {
     return { tokens: [], chainId }
   }
 

--- a/libs/tokens/src/updaters/TokensListsUpdater/index.tsx
+++ b/libs/tokens/src/updaters/TokensListsUpdater/index.tsx
@@ -26,6 +26,9 @@ const { atom: lastUpdateTimeAtom, updateAtom: updateLastUpdateTimeAtom } = atomW
     'tokens:lastUpdateTimeAtom:v5',
     mapSupportedNetworks(LAST_UPDATE_TIME_DEFAULT),
     getJotaiMergerStorage(),
+    {
+      unstable_getOnInit: true,
+    },
   ),
 )
 


### PR DESCRIPTION
# Summary

Fixes #6114

There are two fixes:
1. I realized that `lastUpdateTimeAtom` in `TokensListsUpdater` doesn't work properly. It was loading tokens on every page load, but we expect them to be updated no often than once every 6 hours. To fix that, I added `unstable_getOnInit: true`. See https://github.com/pmndrs/jotai/discussions/1999 for more details
2. The actual fix of #6114. In #6093 I added `activeTokensCount === 0` check to prevent excessive balances updates. But there is an edge case, when all token lists are disabled, and `activeTokensCount` is always 0. To fix that, I check `listsStatesList` instead, because there is at least one list in `tokensList.json`.

# To Test

See #6114


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the logic for determining when token lists are loaded, resulting in more accurate readiness checks.
  * Updated initialization behavior for token list update tracking to enhance reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->