### PR TITLE
fix(balances): skip balances update from old blocks

### DIFF
--- a/apps/cowswap-frontend/src/modules/ordersTable/hooks/useTokenAllowances.ts
+++ b/apps/cowswap-frontend/src/modules/ordersTable/hooks/useTokenAllowances.ts
@@ -40,16 +40,18 @@ export function useTokenAllowances(tokenAddresses: string[]): {
     account,
   )
 
+  const results = data?.results
+
   const state = useMemo(() => {
-    if (!data) return
+    if (!results) return
 
     const res = tokenAddresses.reduce<AllowancesState>((acc, address, index) => {
-      acc[address.toLowerCase()] = data[index]?.[0]
+      acc[address.toLowerCase()] = results[index]?.[0]
       return acc
     }, {})
 
     return res
-  }, [tokenAddresses, data])
+  }, [tokenAddresses, results])
 
   return useMemo(() => ({ state, isLoading }), [state, isLoading])
 }

--- a/apps/cowswap-frontend/src/modules/ordersTable/hooks/useTokenAllowances.ts
+++ b/apps/cowswap-frontend/src/modules/ordersTable/hooks/useTokenAllowances.ts
@@ -43,14 +43,12 @@ export function useTokenAllowances(tokenAddresses: string[]): {
   const results = data?.results
 
   const state = useMemo(() => {
-    if (!results) return
+    if (!results?.length) return
 
-    const res = tokenAddresses.reduce<AllowancesState>((acc, address, index) => {
+    return tokenAddresses.reduce<AllowancesState>((acc, address, index) => {
       acc[address.toLowerCase()] = results[index]?.[0]
       return acc
     }, {})
-
-    return res
   }, [tokenAddresses, results])
 
   return useMemo(() => ({ state, isLoading }), [state, isLoading])

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useTwapOrdersAuthMulticall.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useTwapOrdersAuthMulticall.ts
@@ -14,19 +14,20 @@ const SWR_CONFIG = { refreshInterval: ms`30s` }
 export function useTwapOrdersAuthMulticall(
   safeAddress: string,
   composableCowContract: ComposableCoW,
-  ordersInfo: TwapOrderInfo[]
+  ordersInfo: TwapOrderInfo[],
 ): TwapOrdersAuthResult | null {
   const input = useMemo(() => {
     return ordersInfo.map(({ id }) => [safeAddress, id])
   }, [safeAddress, ordersInfo])
 
-  const { data: loadedResults, isLoading } = useSingleContractMultipleData<[boolean]>(
+  const { data, isLoading } = useSingleContractMultipleData<[boolean]>(
     composableCowContract,
     'singleOrders',
     input,
     MULTICALL_OPTIONS,
-    SWR_CONFIG
+    SWR_CONFIG,
   )
+  const loadedResults = data?.results
 
   return useMemo(() => {
     if (ordersInfo.length === 0) return EMPTY_AUTH_RESULT

--- a/apps/cowswap-frontend/src/modules/wallet/containers/AccountSelectorModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/wallet/containers/AccountSelectorModal/index.tsx
@@ -1,5 +1,5 @@
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 
 import { useNativeTokensBalances } from '@cowprotocol/balances-and-allowances'
 import { NATIVE_CURRENCIES } from '@cowprotocol/common-const'
@@ -24,10 +24,7 @@ import * as styledEl from './styled'
 
 const EMPTY_BALANCES = {}
 
-// TODO: Break down this large function into smaller functions
-// TODO: Add proper return type annotation
-// eslint-disable-next-line max-lines-per-function, @typescript-eslint/explicit-function-return-type
-export function AccountSelectorModal() {
+export function AccountSelectorModal(): ReactNode {
   const { chainId } = useWalletInfo()
   const { isOpen } = useAtomValue(accountSelectorModalAtom)
   const closeModal = useSetAtom(toggleAccountSelectorModalAtom)
@@ -43,7 +40,7 @@ export function AccountSelectorModal() {
 
   const [accountsList, setAccountsList] = useState<string[] | null>(null)
 
-  const nativeTokensBalances = useNativeTokensBalances(accountsList || undefined)
+  const nativeTokensBalances = useNativeTokensBalances(chainId, accountsList || undefined)
 
   const balances = useMemo(() => {
     if (!nativeTokensBalances) return EMPTY_BALANCES
@@ -57,7 +54,7 @@ export function AccountSelectorModal() {
         }
         return acc
       },
-      {}
+      {},
     )
   }, [nativeTokensBalances, nativeToken])
 
@@ -76,7 +73,7 @@ export function AccountSelectorModal() {
 
       addSnackbar({ content: <Trans>{walletName} account changed</Trans>, id: 'account-changed', icon: 'success' })
     },
-    [walletName, addSnackbar, setHwAccountIndex, closeModal]
+    [walletName, addSnackbar, setHwAccountIndex, closeModal],
   )
 
   useEffect(() => {

--- a/apps/cowswap-frontend/src/pages/error/AnySwapAffectedUsers/useIsAnySwapAffectedUser.ts
+++ b/apps/cowswap-frontend/src/pages/error/AnySwapAffectedUsers/useIsAnySwapAffectedUser.ts
@@ -31,7 +31,7 @@ const SWR_CONFIG: SWRConfiguration = {
 
 export function useIsAnySwapAffectedUser(): boolean {
   const { chainId, account } = useWalletInfo()
-  const { data: allowances } = useMultipleContractSingleData<[BigNumber]>(
+  const { data } = useMultipleContractSingleData<[BigNumber]>(
     chainId,
     AFFECTED_TOKENS,
     ERC20_INTERFACE,
@@ -41,6 +41,8 @@ export function useIsAnySwapAffectedUser(): boolean {
     SWR_CONFIG,
     `useIsAnySwapAffectedUser`,
   )
+
+  const allowances = data?.results
 
   return useMemo(() => {
     // The error affects Mainnet

--- a/libs/abis/src/abis/Multicall3.json
+++ b/libs/abis/src/abis/Multicall3.json
@@ -1,5 +1,18 @@
 [
   {
+    "inputs": [],
+    "name": "getBlockNumber",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "blockNumber",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",

--- a/libs/abis/src/generated/custom/Multicall3.ts
+++ b/libs/abis/src/generated/custom/Multicall3.ts
@@ -40,18 +40,21 @@ export declare namespace Multicall3 {
 
 export interface Multicall3Interface extends utils.Interface {
   functions: {
+    'getBlockNumber()': FunctionFragment
     'getEthBalance(address)': FunctionFragment
     'tryAggregate(bool,(address,bytes)[])': FunctionFragment
   }
 
   getFunction(nameOrSignatureOrTopic: 'getEthBalance' | 'tryAggregate'): FunctionFragment
 
+  encodeFunctionData(functionFragment: 'getBlockNumber'): string
   encodeFunctionData(functionFragment: 'getEthBalance', values: [PromiseOrValue<string>]): string
   encodeFunctionData(
     functionFragment: 'tryAggregate',
-    values: [PromiseOrValue<boolean>, Multicall3.CallStruct[]]
+    values: [PromiseOrValue<boolean>, Multicall3.CallStruct[]],
   ): string
 
+  decodeFunctionResult(functionFragment: 'getBlockNumber', data: BytesLike): Result
   decodeFunctionResult(functionFragment: 'getEthBalance', data: BytesLike): Result
   decodeFunctionResult(functionFragment: 'tryAggregate', data: BytesLike): Result
 
@@ -68,7 +71,7 @@ export interface Multicall3 extends BaseContract {
   queryFilter<TEvent extends TypedEvent>(
     event: TypedEventFilter<TEvent>,
     fromBlockOrBlockhash?: string | number | undefined,
-    toBlock?: string | number | undefined
+    toBlock?: string | number | undefined,
   ): Promise<Array<TEvent>>
 
   listeners<TEvent extends TypedEvent>(eventFilter?: TypedEventFilter<TEvent>): Array<TypedListener<TEvent>>
@@ -81,55 +84,65 @@ export interface Multicall3 extends BaseContract {
   removeListener: OnEvent<this>
 
   functions: {
+    getBlockNumber(overrides?: CallOverrides): Promise<[BigNumber] & { blockNumber: BigNumber }>
+
     getEthBalance(
       addr: PromiseOrValue<string>,
-      overrides?: CallOverrides
+      overrides?: CallOverrides,
     ): Promise<[BigNumber] & { balance: BigNumber }>
 
     tryAggregate(
       requireSuccess: PromiseOrValue<boolean>,
       calls: Multicall3.CallStruct[],
-      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> },
     ): Promise<ContractTransaction>
   }
+
+  getBlockNumber(overrides?: CallOverrides): Promise<BigNumber>
 
   getEthBalance(addr: PromiseOrValue<string>, overrides?: CallOverrides): Promise<BigNumber>
 
   tryAggregate(
     requireSuccess: PromiseOrValue<boolean>,
     calls: Multicall3.CallStruct[],
-    overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+    overrides?: PayableOverrides & { from?: PromiseOrValue<string> },
   ): Promise<ContractTransaction>
 
   callStatic: {
+    getBlockNumber(overrides?: CallOverrides): Promise<BigNumber>
+
     getEthBalance(addr: PromiseOrValue<string>, overrides?: CallOverrides): Promise<BigNumber>
 
     tryAggregate(
       requireSuccess: PromiseOrValue<boolean>,
       calls: Multicall3.CallStruct[],
-      overrides?: CallOverrides
+      overrides?: CallOverrides,
     ): Promise<Multicall3.ResultStructOutput[]>
   }
 
   filters: {}
 
   estimateGas: {
+    getBlockNumber(overrides?: CallOverrides): Promise<BigNumber>
+
     getEthBalance(addr: PromiseOrValue<string>, overrides?: CallOverrides): Promise<BigNumber>
 
     tryAggregate(
       requireSuccess: PromiseOrValue<boolean>,
       calls: Multicall3.CallStruct[],
-      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> },
     ): Promise<BigNumber>
   }
 
   populateTransaction: {
+    getBlockNumber(overrides?: CallOverrides): Promise<PopulatedTransaction>
+
     getEthBalance(addr: PromiseOrValue<string>, overrides?: CallOverrides): Promise<PopulatedTransaction>
 
     tryAggregate(
       requireSuccess: PromiseOrValue<boolean>,
       calls: Multicall3.CallStruct[],
-      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> },
     ): Promise<PopulatedTransaction>
   }
 }

--- a/libs/balances-and-allowances/src/hooks/useIsBlockNumberRelevant.ts
+++ b/libs/balances-and-allowances/src/hooks/useIsBlockNumberRelevant.ts
@@ -1,0 +1,20 @@
+import { usePrevious } from '@cowprotocol/common-hooks'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
+export function useIsBlockNumberRelevant(chainId: SupportedChainId, blockNumber: number | undefined): boolean {
+  const prevBlockNumber = usePrevious(blockNumber)
+  const prevChainId = usePrevious(chainId)
+  const isChainChanged = prevChainId !== chainId
+
+  return isChainChanged || getIsBlockNumberRelevant({ prevBlockNumber, blockNumber })
+}
+
+function getIsBlockNumberRelevant<T = number | undefined>({
+  blockNumber,
+  prevBlockNumber,
+}: {
+  blockNumber: T
+  prevBlockNumber: T
+}): boolean {
+  return typeof prevBlockNumber === 'number' && typeof blockNumber === 'number' ? blockNumber > prevBlockNumber : true
+}

--- a/libs/balances-and-allowances/src/hooks/useNativeTokensBalances.ts
+++ b/libs/balances-and-allowances/src/hooks/useNativeTokensBalances.ts
@@ -1,15 +1,18 @@
 import { useMemo } from 'react'
 
-import { usePrevious } from '@cowprotocol/common-hooks'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { getMulticallContract, useSingleContractMultipleData } from '@cowprotocol/multicall'
 import { useWalletProvider } from '@cowprotocol/wallet-provider'
 import { BigNumber } from '@ethersproject/bignumber'
 
-import { getIsBlockNumberRelevant } from '../utils/getIsBlockNumberRelevant'
+import { useIsBlockNumberRelevant } from './useIsBlockNumberRelevant'
 
 type NativeBalances = { [account: string]: BigNumber | undefined }
 
-export function useNativeTokensBalances(accounts: string[] | undefined): NativeBalances | undefined {
+export function useNativeTokensBalances(
+  chainId: SupportedChainId,
+  accounts: string[] | undefined,
+): NativeBalances | undefined {
   const provider = useWalletProvider()
   const contract = provider ? getMulticallContract(provider) : undefined
   const params = useMemo(() => accounts?.map((account) => [account]), [accounts])
@@ -17,10 +20,9 @@ export function useNativeTokensBalances(accounts: string[] | undefined): NativeB
   const { data } = useSingleContractMultipleData<[BigNumber]>(contract, 'getEthBalance', params)
   const results = data?.results
   const blockNumber = data?.blockNumber
-  const prevBlockNumber = usePrevious(blockNumber)
 
   // Skip multicall results from outdated block if there is a result from newer one
-  const isNewBlockNumber = getIsBlockNumberRelevant({ prevBlockNumber, blockNumber })
+  const isNewBlockNumber = useIsBlockNumberRelevant(chainId, blockNumber)
 
   return useMemo(() => {
     if (!results || !accounts || !isNewBlockNumber) return undefined

--- a/libs/balances-and-allowances/src/hooks/useNativeTokensBalances.ts
+++ b/libs/balances-and-allowances/src/hooks/useNativeTokensBalances.ts
@@ -1,8 +1,11 @@
 import { useMemo } from 'react'
 
+import { usePrevious } from '@cowprotocol/common-hooks'
 import { getMulticallContract, useSingleContractMultipleData } from '@cowprotocol/multicall'
 import { useWalletProvider } from '@cowprotocol/wallet-provider'
 import { BigNumber } from '@ethersproject/bignumber'
+
+import { getIsBlockNumberRelevant } from '../utils/getIsBlockNumberRelevant'
 
 type NativeBalances = { [account: string]: BigNumber | undefined }
 
@@ -13,14 +16,19 @@ export function useNativeTokensBalances(accounts: string[] | undefined): NativeB
 
   const { data } = useSingleContractMultipleData<[BigNumber]>(contract, 'getEthBalance', params)
   const results = data?.results
+  const blockNumber = data?.blockNumber
+  const prevBlockNumber = usePrevious(blockNumber)
+
+  // Skip multicall results from outdated block if there is a result from newer one
+  const isNewBlockNumber = getIsBlockNumberRelevant({ prevBlockNumber, blockNumber })
 
   return useMemo(() => {
-    if (!results || !accounts) return undefined
+    if (!results || !accounts || !isNewBlockNumber) return undefined
 
     return results.reduce<NativeBalances>((acc, result, index) => {
       acc[accounts[index]] = result?.[0]
 
       return acc
     }, {})
-  }, [results, accounts])
+  }, [results, accounts, isNewBlockNumber])
 }

--- a/libs/balances-and-allowances/src/hooks/useNativeTokensBalances.ts
+++ b/libs/balances-and-allowances/src/hooks/useNativeTokensBalances.ts
@@ -11,7 +11,8 @@ export function useNativeTokensBalances(accounts: string[] | undefined): NativeB
   const contract = provider ? getMulticallContract(provider) : undefined
   const params = useMemo(() => accounts?.map((account) => [account]), [accounts])
 
-  const { data: results } = useSingleContractMultipleData<[BigNumber]>(contract, 'getEthBalance', params)
+  const { data } = useSingleContractMultipleData<[BigNumber]>(contract, 'getEthBalance', params)
+  const results = data?.results
 
   return useMemo(() => {
     if (!results || !accounts) return undefined

--- a/libs/balances-and-allowances/src/hooks/usePersistBalancesAndAllowances.ts
+++ b/libs/balances-and-allowances/src/hooks/usePersistBalancesAndAllowances.ts
@@ -2,7 +2,6 @@ import { useSetAtom } from 'jotai'
 import { useEffect, useMemo } from 'react'
 
 import { ERC_20_INTERFACE } from '@cowprotocol/abis'
-import { usePrevious } from '@cowprotocol/common-hooks'
 import { getIsNativeToken } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { MultiCallOptions, useMultipleContractSingleData } from '@cowprotocol/multicall'
@@ -10,8 +9,9 @@ import { BigNumber } from '@ethersproject/bignumber'
 
 import { SWRConfiguration } from 'swr'
 
+import { useIsBlockNumberRelevant } from './useIsBlockNumberRelevant'
+
 import { balancesAtom, BalancesState, balancesUpdateAtom } from '../state/balancesAtom'
-import { getIsBlockNumberRelevant } from '../utils/getIsBlockNumberRelevant'
 
 const MULTICALL_OPTIONS = {}
 
@@ -53,10 +53,9 @@ export function usePersistBalancesAndAllowances(params: PersistBalancesAndAllowa
   )
   const balances = data?.results
   const blockNumber = data?.blockNumber
-  const prevBlockNumber = usePrevious(blockNumber)
 
   // Skip multicall results from outdated block if there is a result from newer one
-  const isNewBlockNumber = getIsBlockNumberRelevant({ prevBlockNumber, blockNumber })
+  const isNewBlockNumber = useIsBlockNumberRelevant(chainId, blockNumber)
 
   // Set balances loading state
   useEffect(() => {

--- a/libs/balances-and-allowances/src/hooks/usePersistBalancesAndAllowances.ts
+++ b/libs/balances-and-allowances/src/hooks/usePersistBalancesAndAllowances.ts
@@ -11,6 +11,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { SWRConfiguration } from 'swr'
 
 import { balancesAtom, BalancesState, balancesUpdateAtom } from '../state/balancesAtom'
+import { getIsBlockNumberRelevant } from '../utils/getIsBlockNumberRelevant'
 
 const MULTICALL_OPTIONS = {}
 
@@ -55,8 +56,7 @@ export function usePersistBalancesAndAllowances(params: PersistBalancesAndAllowa
   const prevBlockNumber = usePrevious(blockNumber)
 
   // Skip multicall results from outdated block if there is a result from newer one
-  const isNewBlockNumber =
-    typeof prevBlockNumber === 'number' && typeof blockNumber === 'number' ? blockNumber > prevBlockNumber : true
+  const isNewBlockNumber = getIsBlockNumberRelevant({ prevBlockNumber, blockNumber })
 
   // Set balances loading state
   useEffect(() => {

--- a/libs/balances-and-allowances/src/utils/getIsBlockNumberRelevant.ts
+++ b/libs/balances-and-allowances/src/utils/getIsBlockNumberRelevant.ts
@@ -1,0 +1,9 @@
+export function getIsBlockNumberRelevant<T = number | undefined>({
+  blockNumber,
+  prevBlockNumber,
+}: {
+  blockNumber: T
+  prevBlockNumber: T
+}): boolean {
+  return typeof prevBlockNumber === 'number' && typeof blockNumber === 'number' ? blockNumber > prevBlockNumber : true
+}

--- a/libs/balances-and-allowances/src/utils/getIsBlockNumberRelevant.ts
+++ b/libs/balances-and-allowances/src/utils/getIsBlockNumberRelevant.ts
@@ -1,9 +1,0 @@
-export function getIsBlockNumberRelevant<T = number | undefined>({
-  blockNumber,
-  prevBlockNumber,
-}: {
-  blockNumber: T
-  prevBlockNumber: T
-}): boolean {
-  return typeof prevBlockNumber === 'number' && typeof blockNumber === 'number' ? blockNumber > prevBlockNumber : true
-}

--- a/libs/multicall/src/hooks/useMultipleContractSingleData.ts
+++ b/libs/multicall/src/hooks/useMultipleContractSingleData.ts
@@ -10,8 +10,7 @@ import useSWR, { SWRConfiguration, SWRResponse } from 'swr'
 import { useMultiCallRpcProvider } from './useMultiCallRpcProvider'
 
 import { multiCall, MultiCallOptions } from '../multicall'
-
-type MulticallResponse<T> = { results: (T | undefined)[]; blockNumber: number } | null
+import { MulticallResponseOptional } from '../types'
 
 export function useMultipleContractSingleData<T = Result>(
   chainId: SupportedChainId,
@@ -22,7 +21,7 @@ export function useMultipleContractSingleData<T = Result>(
   multicallOptions: MultiCallOptions = {},
   swrConfig?: SWRConfiguration,
   cacheKey?: string,
-): SWRResponse<MulticallResponse<T>> {
+): SWRResponse<MulticallResponseOptional<T>> {
   const provider = useMultiCallRpcProvider()
 
   const callData = useMemo(() => {
@@ -42,7 +41,7 @@ export function useMultipleContractSingleData<T = Result>(
     })
   }, [addresses, callData])
 
-  return useSWR<MulticallResponse<T>>(
+  return useSWR<MulticallResponseOptional<T>>(
     !calls?.length || !provider
       ? null
       : [

--- a/libs/multicall/src/hooks/useMultipleContractSingleData.ts
+++ b/libs/multicall/src/hooks/useMultipleContractSingleData.ts
@@ -11,6 +11,8 @@ import { useMultiCallRpcProvider } from './useMultiCallRpcProvider'
 
 import { multiCall, MultiCallOptions } from '../multicall'
 
+type MulticallResponse<T> = { results: (T | undefined)[]; blockNumber: number } | null
+
 export function useMultipleContractSingleData<T = Result>(
   chainId: SupportedChainId,
   addresses: string[],
@@ -20,7 +22,7 @@ export function useMultipleContractSingleData<T = Result>(
   multicallOptions: MultiCallOptions = {},
   swrConfig?: SWRConfiguration,
   cacheKey?: string,
-): SWRResponse<(T | undefined)[] | null> {
+): SWRResponse<MulticallResponse<T>> {
   const provider = useMultiCallRpcProvider()
 
   const callData = useMemo(() => {
@@ -40,7 +42,7 @@ export function useMultipleContractSingleData<T = Result>(
     })
   }, [addresses, callData])
 
-  return useSWR<(T | undefined)[] | null>(
+  return useSWR<MulticallResponse<T>>(
     !calls?.length || !provider
       ? null
       : [
@@ -77,14 +79,17 @@ export function useMultipleContractSingleData<T = Result>(
       })
 
       return multiCall(provider, calls, multicallOptions)
-        .then((results) => {
-          return results.map((result) => {
-            try {
-              return contractInterface.decodeFunctionResult(methodName, result.returnData) as T
-            } catch {
-              return undefined
-            }
-          })
+        .then(({ results, blockNumber }) => {
+          return {
+            results: results.map((result) => {
+              try {
+                return contractInterface.decodeFunctionResult(methodName, result.returnData) as T
+              } catch {
+                return undefined
+              }
+            }),
+            blockNumber,
+          }
         })
         .catch((error) => {
           console.error('Could not make a multicall (SingleData)', error)

--- a/libs/multicall/src/hooks/useSingleContractMultipleData.ts
+++ b/libs/multicall/src/hooks/useSingleContractMultipleData.ts
@@ -10,8 +10,7 @@ import useSWR, { SWRConfiguration, SWRResponse } from 'swr'
 import { useMultiCallRpcProvider } from './useMultiCallRpcProvider'
 
 import { multiCall, MultiCallOptions } from '../multicall'
-
-type MulticallResponse<T> = { results: (T | undefined)[]; blockNumber: number } | null
+import { MulticallResponseOptional } from '../types'
 
 export function useSingleContractMultipleData<T = Result, P = unknown>(
   contract: BaseContract | undefined,
@@ -19,7 +18,7 @@ export function useSingleContractMultipleData<T = Result, P = unknown>(
   params: P[] | undefined,
   options: MultiCallOptions = {},
   swrConfig?: SWRConfiguration,
-): SWRResponse<MulticallResponse<T>> {
+): SWRResponse<MulticallResponseOptional<T>> {
   const provider = useMultiCallRpcProvider()
 
   const chainId = provider?.network?.chainId
@@ -35,7 +34,7 @@ export function useSingleContractMultipleData<T = Result, P = unknown>(
     })
   }, [contract, methodName, params])
 
-  return useSWR<MulticallResponse<T>>(
+  return useSWR<MulticallResponseOptional<T>>(
     !contract || !calls || calls.length === 0 || !provider
       ? null
       : [provider, calls, options, methodName, contract, chainId, 'useSingleContractMultipleData'],

--- a/libs/multicall/src/multicall.ts
+++ b/libs/multicall/src/multicall.ts
@@ -2,6 +2,7 @@ import type { Multicall3 } from '@cowprotocol/abis'
 import type { JsonRpcProvider } from '@ethersproject/providers'
 
 import { DEFAULT_BATCH_SIZE } from './const'
+import { MulticallResponse } from './types'
 import { getMulticallContract } from './utils/getMulticallContract'
 
 export interface MultiCallOptions {
@@ -18,7 +19,7 @@ export async function multiCall(
   provider: JsonRpcProvider,
   calls: Multicall3.CallStruct[],
   options: MultiCallOptions = {},
-): Promise<{ results: Multicall3.ResultStructOutput[]; blockNumber: number }> {
+): Promise<MulticallResponse<Multicall3.ResultStructOutput>> {
   const { batchSize = DEFAULT_BATCH_SIZE, consequentExecution } = options
 
   const multicall = getMulticallContract(provider)

--- a/libs/multicall/src/multicall.ts
+++ b/libs/multicall/src/multicall.ts
@@ -52,7 +52,15 @@ export async function multiCall(
       ).then((res) => res.flat())
 
   return result.then(([blockNumberRaw, ...results]) => {
+    if (!blockNumberRaw.success) {
+      throw new Error('Failed to get block number from multicall')
+    }
+
     const blockNumber = +blockNumberRaw.returnData.toString()
+
+    if (isNaN(blockNumber)) {
+      throw new Error('Invalid block number received from multicall')
+    }
     return {
       blockNumber,
       results,

--- a/libs/multicall/src/types.ts
+++ b/libs/multicall/src/types.ts
@@ -1,0 +1,3 @@
+export type MulticallResponse<T> = { results: T[]; blockNumber: number }
+
+export type MulticallResponseOptional<T> = MulticallResponse<T | undefined> | null

--- a/libs/tokens/src/state/tokens/allTokensAtom.ts
+++ b/libs/tokens/src/state/tokens/allTokensAtom.ts
@@ -31,39 +31,42 @@ const tokensStateAtom = atom(async (get) => {
   const listsStatesList = await get(listsStatesListAtom)
   const listsEnabledState = await get(listsEnabledStateAtom)
 
-  return listsStatesList.reduce<TokensState>(
-    (acc, list) => {
-      const isListEnabled = listsEnabledState[list.source]
-      const lpTokenProvider = list.lpTokenProvider
-      list.list.tokens.forEach((token) => {
-        const tokenInfo = parseTokenInfo(chainId, token)
-        const tokenAddressKey = tokenInfo?.address.toLowerCase()
+  return {
+    listsCount: listsStatesList.length,
+    tokensState: listsStatesList.reduce<TokensState>(
+      (acc, list) => {
+        const isListEnabled = listsEnabledState[list.source]
+        const lpTokenProvider = list.lpTokenProvider
+        list.list.tokens.forEach((token) => {
+          const tokenInfo = parseTokenInfo(chainId, token)
+          const tokenAddressKey = tokenInfo?.address.toLowerCase()
 
-        if (!tokenInfo || !tokenAddressKey) return
+          if (!tokenInfo || !tokenAddressKey) return
 
-        if (lpTokenProvider) {
-          tokenInfo.lpTokenProvider = lpTokenProvider
-        }
-
-        if (isListEnabled) {
-          if (!acc.activeTokens[tokenAddressKey]) {
-            acc.activeTokens[tokenAddressKey] = tokenInfo
+          if (lpTokenProvider) {
+            tokenInfo.lpTokenProvider = lpTokenProvider
           }
-        } else {
-          if (!acc.inactiveTokens[tokenAddressKey]) {
-            acc.inactiveTokens[tokenAddressKey] = tokenInfo
-          }
-        }
-      })
 
-      return acc
-    },
-    { activeTokens: {}, inactiveTokens: {} },
-  )
+          if (isListEnabled) {
+            if (!acc.activeTokens[tokenAddressKey]) {
+              acc.activeTokens[tokenAddressKey] = tokenInfo
+            }
+          } else {
+            if (!acc.inactiveTokens[tokenAddressKey]) {
+              acc.inactiveTokens[tokenAddressKey] = tokenInfo
+            }
+          }
+        })
+
+        return acc
+      },
+      { activeTokens: {}, inactiveTokens: {} },
+    ),
+  }
 })
 
 export const activeTokensMapAtom = atom(async (get) => {
-  return (await get(tokensStateAtom)).activeTokens
+  return (await get(tokensStateAtom)).tokensState.activeTokens
 })
 
 /**
@@ -75,15 +78,14 @@ export const allActiveTokensAtom = atom(async (get) => {
   const { chainId, enableLpTokensByDefault } = get(environmentAtom)
   const userAddedTokens = get(userAddedTokensAtom)
   const favoriteTokensState = get(favoriteTokensAtom)
-  const listsStatesList = await get(listsStatesListAtom)
 
-  const tokensMap = await get(tokensStateAtom)
+  const { tokensState: tokensMap, listsCount } = await get(tokensStateAtom)
   const nativeToken = NATIVE_CURRENCIES[chainId]
 
   /**
    * Wait till token lists loaded
    */
-  if (listsStatesList.length === 0) {
+  if (listsCount === 0) {
     return { tokens: [], chainId }
   }
 
@@ -120,7 +122,7 @@ export const allActiveTokensAtom = atom(async (get) => {
 
 export const inactiveTokensAtom = atom(async (get) => {
   const { chainId } = get(environmentAtom)
-  const tokensMap = await get(tokensStateAtom)
+  const { tokensState: tokensMap } = await get(tokensStateAtom)
 
   return tokenMapToListWithLogo([tokensMap.inactiveTokens], chainId)
 })


### PR DESCRIPTION
# Summary

Fixes #6096

As I assumed, there are multicall responses from previous blocks.
To fix that, I added `blockNumber` to the multicall (as described in [Multicall3 docs](https://github.com/EthereumClassicDAO/multicall3)) and compared it with the previous blockNumber.
If another multicall blockNumber is outdated, then we skip the balances update.

<img width="894" height="300" alt="image" src="https://github.com/user-attachments/assets/33494465-030e-4499-84be-3650a36cce88" />


# To Test

See #6096


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Balances are now chain-scoped and update based on the latest network block.
- Bug Fixes
  - Prevented stale on-chain data from displaying; balances and allowances now reflect the most recent block and network switches accurately.
- Refactor
  - Improved multicall data handling for fresher results and better performance.
  - Enhanced token list state management for more reliable loading of active/inactive tokens.
- Chores
  - Minor type and formatting cleanups to improve maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->