### PR TITLE
feat: rename hook dapp id

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useContract.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useContract.ts
@@ -19,7 +19,7 @@ import {
 } from '@cowprotocol/common-const'
 import { getContract } from '@cowprotocol/common-utils'
 import { isEns, isProd, isStaging } from '@cowprotocol/common-utils'
-import { COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { COW_PROTOCOL_SETTLEMENT_CONTRACT_ADDRESS, CowEnv, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { useWalletInfo } from '@cowprotocol/wallet'
 import { useWalletProvider } from '@cowprotocol/wallet-provider'
 import { Contract, ContractInterface } from '@ethersproject/contracts'
@@ -29,7 +29,7 @@ const WETH_CONTRACT_ADDRESS_MAP = Object.fromEntries(
   Object.entries(WRAPPED_NATIVE_CURRENCIES).map(([chainId, token]) => [chainId, token.address]),
 )
 
-export const ethFlowEnv = isProd || isStaging || isEns ? 'prod' : 'barn'
+export const ethFlowEnv: CowEnv = isProd || isStaging || isEns ? 'prod' : 'staging'
 
 export type UseContractResult<T extends Contract = Contract> = {
   contract: T | null

--- a/apps/cowswap-frontend/src/utils/orderUtils/getOrderFilledAmount.ts
+++ b/apps/cowswap-frontend/src/utils/orderUtils/getOrderFilledAmount.ts
@@ -1,9 +1,10 @@
-import { ZERO_BIG_NUMBER } from '@cowprotocol/common-const'
 import { isSellOrder } from '@cowprotocol/common-utils'
 
 import BigNumber from 'bignumber.js'
 
 import { Order } from 'legacy/state/orders/actions'
+
+const ZERO_BIG_NUMBER = new BigNumber(0)
 
 /**
  * Get order filled amount, both as raw amount (in atoms) and as percentage (from 0 to 1)
@@ -25,7 +26,7 @@ export function getOrderFilledAmount(order: Order): FilledAmountResult {
 
   if (isSellOrder(order.kind)) {
     executedAmount = new BigNumber(order.apiAdditionalInfo.executedSellAmount).minus(
-      order.apiAdditionalInfo?.executedFeeAmount
+      order.apiAdditionalInfo?.executedFeeAmount,
     )
     totalAmount = new BigNumber(order.sellAmount.toString())
   } else {

--- a/apps/cowswap-frontend/src/utils/orderUtils/getOrderSurplus.ts
+++ b/apps/cowswap-frontend/src/utils/orderUtils/getOrderSurplus.ts
@@ -1,5 +1,3 @@
-// Util functions that only pertain to/deal with operator API related stuff
-import { ZERO_BIG_NUMBER } from '@cowprotocol/common-const'
 import { isSellOrder } from '@cowprotocol/common-utils'
 
 import BigNumber from 'bignumber.js'
@@ -8,6 +6,8 @@ import JSBI from 'jsbi'
 import { Order } from 'legacy/state/orders/actions'
 
 import { getOrderExecutedAmounts } from './getOrderExecutedAmounts'
+
+const ZERO_BIG_NUMBER = new BigNumber(0)
 
 type Surplus = {
   amount: BigNumber

--- a/libs/common-const/src/common.ts
+++ b/libs/common-const/src/common.ts
@@ -1,12 +1,14 @@
-import { SupportedChainId, mapSupportedNetworks } from '@cowprotocol/cow-sdk'
+import {
+  SupportedChainId,
+  mapSupportedNetworks,
+  ETH_FLOW_ADDRESS,
+  BARN_ETH_FLOW_ADDRESS,
+  CowEnv,
+} from '@cowprotocol/cow-sdk'
 import { Fraction, Percent } from '@uniswap/sdk-core'
 
-import BigNumber from 'bignumber.js'
 import ms from 'ms.macro'
 
-// TODO: move those consts to src/constants/common
-
-export const ZERO_BIG_NUMBER = new BigNumber(0)
 export const ZERO_FRACTION = new Fraction(0)
 
 export const DEFAULT_SLIPPAGE_BPS = 50 // 0.5%
@@ -18,15 +20,12 @@ export const INITIAL_ALLOWED_SLIPPAGE_PERCENT = new Percent(DEFAULT_SLIPPAGE_BPS
 export const RADIX_DECIMAL = 10
 export const RADIX_HEX = 16
 
-export const DEFAULT_DECIMALS = 18
-export const DEFAULT_PRECISION = 6
 export const AMOUNT_PRECISION = 4
 export const LONG_PRECISION = 10
 export const FULL_PRICE_PRECISION = 20
 export const FIAT_PRECISION = 2
 export const PERCENTAGE_PRECISION = 2
 
-export const SHORT_LOAD_THRESHOLD = 500
 export const LONG_LOAD_THRESHOLD = 2000
 
 export const AVG_APPROVE_COST_GWEI = '50000'
@@ -47,15 +46,8 @@ export const PAGE_TITLES = {
   HOOKS: 'Hooks',
 }
 
-type Env = 'barn' | 'prod'
-
-const NEW_COWSWAP_ETHFLOW_CONTRACT_ADDRESS: Record<Env, string> = {
-  prod: '0xba3cb449bd2b4adddbc894d8697f5170800eadec',
-  barn: '0x04501b9b1d52e67f6862d157e00d13419d2d6e95',
-}
-
-export function getEthFlowContractAddresses(env: Env): string {
-  return NEW_COWSWAP_ETHFLOW_CONTRACT_ADDRESS[env]
+export function getEthFlowContractAddresses(env: CowEnv): string {
+  return env === 'prod' ? ETH_FLOW_ADDRESS : BARN_ETH_FLOW_ADDRESS
 }
 
 export const V_COW_CONTRACT_ADDRESS: Record<SupportedChainId, string | null> = {

--- a/libs/hook-dapp-lib/src/consts.ts
+++ b/libs/hook-dapp-lib/src/consts.ts
@@ -9,3 +9,5 @@ export enum HookDappWalletCompatibility {
 }
 
 export const HOOK_DAPP_ID_LENGTH = 64
+
+export const PERMIT_HOOK_DAPP_ID = 'cow-swap://libs/hook-dapp-lib/permit'

--- a/libs/hook-dapp-lib/src/hookDappsRegistry.ts
+++ b/libs/hook-dapp-lib/src/hookDappsRegistry.ts
@@ -1,3 +1,5 @@
+import { PERMIT_HOOK_DAPP_ID } from './consts'
+
 export const hookDappsRegistry = {
   BUILD_CUSTOM_HOOK: {
     type: 'INTERNAL',
@@ -25,7 +27,7 @@ export const hookDappsRegistry = {
       position: 'pre',
     },
   },
-  PERMIT_TOKEN: {
+  [PERMIT_HOOK_DAPP_ID]: {
     type: 'INTERNAL',
     name: 'Permit a token',
     descriptionShort: 'Infinite permit an address to spend one token on your behalf.',

--- a/libs/hook-dapp-lib/src/utils.ts
+++ b/libs/hook-dapp-lib/src/utils.ts
@@ -1,3 +1,4 @@
+import { PERMIT_HOOK_DAPP_ID } from './consts'
 import { hookDappsRegistry } from './hookDappsRegistry'
 import { CowHook, HookDappBase } from './types'
 
@@ -10,9 +11,7 @@ const hookDapps = Object.keys(hookDappsRegistry).reduce((acc, id) => {
 
 // permit() function selector
 const EIP_2612_PERMIT_SELECTOR = '0xd505accf'
-// TODO: remove it after 01.01.2025
 const DAI_PERMIT_SELECTOR = '0x8fcbaf0c'
-const PERMIT_DAPP_ID = '1db4bacb661a90fb6b475fd5b585acba9745bc373573c65ecc3e8f5bfd5dee1f'
 
 // Before the hooks store the dappId wasn't included in the hook object
 type StrictCowHook = Omit<CowHook, 'dappId'> & { dappId?: string }
@@ -42,13 +41,10 @@ export function matchHooksToDapps(hooks: StrictCowHook[], dapps: HookDappBase[])
         /**
          * Permit token is a special case, as it's not a dapp, but a hook
          */
-        if (
-          (!dapp || hook.dappId === PERMIT_DAPP_ID) &&
-          (hook.callData.startsWith(EIP_2612_PERMIT_SELECTOR) || hook.callData.startsWith(DAI_PERMIT_SELECTOR))
-        ) {
+        if (hook.callData.startsWith(EIP_2612_PERMIT_SELECTOR) || hook.callData.startsWith(DAI_PERMIT_SELECTOR)) {
           return {
             hook,
-            dapp: hookDappsRegistry.PERMIT_TOKEN as HookDappBase,
+            dapp: hookDappsRegistry[PERMIT_HOOK_DAPP_ID] as HookDappBase,
           }
         }
 

--- a/libs/iframe-transport/src/iframeRpcProvider/IframeRpcProviderBridge.ts
+++ b/libs/iframe-transport/src/iframeRpcProvider/IframeRpcProviderBridge.ts
@@ -1,14 +1,14 @@
-import { EIP6963AnnounceProviderEvent, EIP6963ProviderDetail } from '@cowprotocol/types'
+import type { EIP6963AnnounceProviderEvent, EIP6963ProviderDetail } from '@cowprotocol/types'
 
 import {
   IframeRpcProviderEvents,
   iframeRpcProviderTransport,
-  ProviderRpcResponsePayload,
   ProviderRpcRequestPayload,
+  ProviderRpcResponsePayload,
 } from './iframeRpcProviderEvents'
 import { getEip6963ProviderInfo, getProviderWcMetadata } from './utils'
 
-import { EthereumProvider, JsonRpcRequestMessage } from '../types'
+import type { EthereumProvider, JsonRpcRequestMessage } from '../types'
 
 const EVENTS_TO_FORWARD_TO_IFRAME = ['connect', 'disconnect', 'close', 'chainChanged', 'accountsChanged']
 const eip6963Providers: EIP6963ProviderDetail[] = []

--- a/libs/iframe-transport/src/iframeRpcProvider/iframeRpcProviderEvents.ts
+++ b/libs/iframe-transport/src/iframeRpcProvider/iframeRpcProviderEvents.ts
@@ -1,5 +1,6 @@
 import { IframeTransport } from '../IframeTransport'
-import { EIP6963ProviderInfo, JsonRpcRequestMessage, JsonRpcResponse, ProviderWcMetadata } from '../types'
+
+import type { EIP6963ProviderInfo, JsonRpcRequestMessage, JsonRpcResponse, ProviderWcMetadata } from '../types'
 
 export interface ProviderRpcRequestPayload {
   rpcRequest: JsonRpcRequestMessage

--- a/libs/permit-utils/src/lib/generatePermitHook.ts
+++ b/libs/permit-utils/src/lib/generatePermitHook.ts
@@ -1,3 +1,4 @@
+import { PERMIT_HOOK_DAPP_ID } from '@cowprotocol/hook-dapp-lib'
 import { JsonRpcProvider } from '@ethersproject/providers'
 
 import { DEFAULT_PERMIT_GAS_LIMIT, DEFAULT_PERMIT_VALUE, PERMIT_SIGNER } from '../const'
@@ -5,9 +6,6 @@ import { PermitHookData, PermitHookParams } from '../types'
 import { buildDaiLikePermitCallData, buildEip2612PermitCallData } from '../utils/buildPermitCallData'
 import { getPermitDeadline } from '../utils/getPermitDeadline'
 import { isSupportedPermitInfo } from '../utils/isSupportedPermitInfo'
-
-// See hookDappsRegistry.json in @cowprotocol/hook-dapp-lib
-const PERMIT_HOOK_DAPP_ID = 'PERMIT_TOKEN'
 
 const REQUESTS_CACHE: { [permitKey: string]: Promise<PermitHookData | undefined> } = {}
 
@@ -35,8 +33,6 @@ export async function generatePermitHook(params: PermitHookParams): Promise<Perm
   return request
 }
 
-// TODO: Break down this large function into smaller functions
-// eslint-disable-next-line max-lines-per-function
 async function generatePermitHookRaw(params: PermitHookParams): Promise<PermitHookData> {
   const { inputToken, spender, chainId, permitInfo, provider, account, eip2612Utils, nonce: preFetchedNonce } = params
 

--- a/libs/permit-utils/src/types.ts
+++ b/libs/permit-utils/src/types.ts
@@ -1,7 +1,7 @@
-import { latest } from '@cowprotocol/app-data'
-import { JsonRpcProvider } from '@ethersproject/providers'
+import type { latest } from '@cowprotocol/app-data'
+import type { JsonRpcProvider } from '@ethersproject/providers'
 
-import { Eip2612PermitUtils } from '@1inch/permit-signed-approvals-utils'
+import type { Eip2612PermitUtils } from '@1inch/permit-signed-approvals-utils'
 
 export type PermitType = 'dai-like' | 'eip-2612' | 'unsupported'
 


### PR DESCRIPTION
# Summary

1. For better semantics,the  permit hook dappId was renamed to `cow-swap://libs/hook-dapp-lib/permit`
2. Got rid of `bignumber.js` import in `libs/common-consts`. This is cruel to pull this lib into a common lib
3. Got rid of eth-flow contract addresses hardcode. Now they are imported from cow-sdk

# To Test

1. Old orders appData should still be parsed well and display Permit in post-hooks (both Explorer and CoW Swap)
2. In new orders with permit, appData should include `"dappId": "cow-swap://libs/hook-dapp-lib/permit"` (both Explorer and CoW Swap)