### PR TITLE
fix(wallet): add disconnect button to injected browsers

### DIFF
--- a/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/index.tsx
@@ -156,24 +156,20 @@ export function AccountDetails({
         <AccountGroupingRow>
           <AccountControl>
             <WalletSecondaryActions>
-              {!isInjectedMobileBrowser && (
-                <>
-                  {account && !isChainIdUnsupported && (
-                    <AddressLink
-                      hasENS={!!ENSName}
-                      isENS={!!ENSName}
-                      href={getEtherscanLink(chainId, 'address', ENSName ? ENSName : account)}
-                    >
-                      {explorerLabel} ↗
-                    </AddressLink>
-                  )}
+              {!isInjectedMobileBrowser && account && !isChainIdUnsupported && (
+                <AddressLink
+                  hasENS={!!ENSName}
+                  isENS={!!ENSName}
+                  href={getEtherscanLink(chainId, 'address', ENSName ? ENSName : account)}
+                >
+                  {explorerLabel} ↗
+                </AddressLink>
+              )}
 
-                  {standaloneMode !== false && connectionType !== ConnectionType.GNOSIS_SAFE && (
-                    <WalletAction onClick={handleDisconnectClick}>
-                      <Trans>Disconnect</Trans>
-                    </WalletAction>
-                  )}
-                </>
+              {standaloneMode !== false && connectionType !== ConnectionType.GNOSIS_SAFE && (
+                <WalletAction onClick={handleDisconnectClick}>
+                  <Trans>Disconnect</Trans>
+                </WalletAction>
               )}
             </WalletSecondaryActions>
           </AccountControl>


### PR DESCRIPTION
# Summary

Fixes #6030

I'm not really sure if it is needed. In practice, in injected mobile browsers, there should be only one provider, and you don't need to switch it.

<img width="275" height="247" alt="image" src="https://github.com/user-attachments/assets/a293ee62-00e2-43a8-b5b6-41534e1a6274" />


# To Test

See #6030

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disconnect option now displays more reliably across devices, including mobile in-app browsers, when eligible.
  * Account address link is shown only when connected on a supported network and outside in-app browser contexts, reducing confusion.
  * Improved behavior in standalone mode and for Safe connections to ensure correct visibility of actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->