### PR TITLE
fix: display network selector for Safe via WC

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/Header/NetworkSelector/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Header/NetworkSelector/index.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { ReactNode, useRef } from 'react'
 
 import { getChainInfo } from '@cowprotocol/common-const'
 import { useAvailableChains } from '@cowprotocol/common-hooks'
@@ -6,7 +6,7 @@ import { useOnClickOutside } from '@cowprotocol/common-hooks'
 import { useMediaQuery } from '@cowprotocol/common-hooks'
 import { UI } from '@cowprotocol/ui'
 import { Media } from '@cowprotocol/ui'
-import { useIsRabbyWallet, useIsSmartContractWallet, useWalletInfo } from '@cowprotocol/wallet'
+import { useIsRabbyWallet, useIsSmartContractWallet, useWalletInfo, useIsSafeViaWc } from '@cowprotocol/wallet'
 import { useWalletProvider } from '@cowprotocol/wallet-provider'
 
 import { Trans } from '@lingui/macro'
@@ -154,10 +154,7 @@ const NetworkAlertLabel = styled.div`
   }
 `
 
-// TODO: Break down this large function into smaller functions
-// TODO: Add proper return type annotation
-// eslint-disable-next-line max-lines-per-function, @typescript-eslint/explicit-function-return-type
-export function NetworkSelector() {
+export function NetworkSelector(): ReactNode {
   const provider = useWalletProvider()
   const { chainId } = useWalletInfo()
   const node = useRef<HTMLDivElement>(null)
@@ -165,6 +162,7 @@ export function NetworkSelector() {
   const isOpen = useModalIsOpen(ApplicationModal.NETWORK_SELECTOR)
   const toggleModal = useToggleModal(ApplicationModal.NETWORK_SELECTOR)
 
+  const isSafeViaWc = useIsSafeViaWc()
   const isSmartContractWallet = useIsSmartContractWallet()
   const isRabbyWallet = useIsRabbyWallet()
   const isChainIdUnsupported = useIsProviderNetworkUnsupported()
@@ -183,7 +181,7 @@ export function NetworkSelector() {
 
   const availableChains = useAvailableChains()
 
-  if (!provider || (isSmartContractWallet && !isRabbyWallet)) {
+  if (!provider || (isSmartContractWallet && !isRabbyWallet && !isSafeViaWc)) {
     return null
   }
 


### PR DESCRIPTION
# Summary

Fixes #5806

The network selector must be displayed when connected to a Safe via WalletConnect.

# To Test

See #5806


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded compatibility for the Network Selector: now available for Safe wallets connected via WalletConnect, enabling network switching for more smart contract wallet setups.
  * Improved wallet detection ensures the selector appears when appropriate, reducing unnecessary restrictions and enhancing consistency.
  * Smoother experience for supported wallets with more reliable rendering of the selector across scenarios, without impacting behavior for other wallet types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->