### PR TITLE
fix: do not poll multicall when document is not focused

### DIFF
--- a/libs/balances-and-allowances/src/consts.ts
+++ b/libs/balances-and-allowances/src/consts.ts
@@ -1,0 +1,11 @@
+import { SWRConfiguration } from 'swr'
+
+export const BASIC_MULTICALL_SWR_CONFIG: SWRConfiguration = {
+  refreshWhenHidden: false,
+  refreshWhenOffline: false,
+  revalidateOnFocus: false,
+  revalidateIfStale: false,
+  isPaused() {
+    return !document.hasFocus()
+  },
+}

--- a/libs/balances-and-allowances/src/hooks/useSwrConfigWithPauseForNetwork.ts
+++ b/libs/balances-and-allowances/src/hooks/useSwrConfigWithPauseForNetwork.ts
@@ -36,6 +36,8 @@ export function useSwrConfigWithPauseForNetwork(
     () => ({
       ...config,
       isPaused: () => {
+        if (config.isPaused?.()) return true
+
         const lastUpdateTimestamp = lastUpdateTimestampRef.current
 
         return !!lastUpdateTimestamp && Date.now() - lastUpdateTimestamp < validityPeriod

--- a/libs/balances-and-allowances/src/updaters/BalancesAndAllowancesUpdater.tsx
+++ b/libs/balances-and-allowances/src/updaters/BalancesAndAllowancesUpdater.tsx
@@ -10,6 +10,7 @@ import { SWRConfiguration } from 'swr'
 import { BalancesCacheUpdater } from './BalancesCacheUpdater'
 import { BalancesResetUpdater } from './BalancesResetUpdater'
 
+import { BASIC_MULTICALL_SWR_CONFIG } from '../consts'
 import { useNativeTokenBalance } from '../hooks/useNativeTokenBalance'
 import { usePersistBalancesAndAllowances } from '../hooks/usePersistBalancesAndAllowances'
 import { useSwrConfigWithPauseForNetwork } from '../hooks/useSwrConfigWithPauseForNetwork'
@@ -17,14 +18,8 @@ import { useUpdateTokenBalance } from '../hooks/useUpdateTokenBalance'
 
 const EMPTY_TOKENS: string[] = []
 
-const BASIC_SWR_CONFIG: SWRConfiguration = {
-  refreshWhenHidden: false,
-  refreshWhenOffline: false,
-  revalidateOnFocus: false,
-  revalidateIfStale: false,
-}
 // A small gap between balances and allowances refresh intervals is needed to avoid high load to the node at the same time
-const BALANCES_SWR_CONFIG: SWRConfiguration = { ...BASIC_SWR_CONFIG, refreshInterval: ms`31s` }
+const BALANCES_SWR_CONFIG: SWRConfiguration = { ...BASIC_MULTICALL_SWR_CONFIG, refreshInterval: ms`31s` }
 
 export interface BalancesAndAllowancesUpdaterProps {
   account: string | undefined

--- a/libs/balances-and-allowances/src/updaters/PriorityTokensUpdater.ts
+++ b/libs/balances-and-allowances/src/updaters/PriorityTokensUpdater.ts
@@ -2,12 +2,13 @@ import type { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import ms from 'ms.macro'
 
+import { BASIC_MULTICALL_SWR_CONFIG } from '../consts'
 import { usePersistBalancesAndAllowances } from '../hooks/usePersistBalancesAndAllowances'
 
 export const PRIORITY_TOKENS_REFRESH_INTERVAL = ms`8s`
 
 // A small gap between balances and allowances refresh intervals is needed to avoid high load to the node at the same time
-const BALANCES_SWR_CONFIG = { revalidateIfStale: false, refreshInterval: PRIORITY_TOKENS_REFRESH_INTERVAL }
+const BALANCES_SWR_CONFIG = { ...BASIC_MULTICALL_SWR_CONFIG, refreshInterval: PRIORITY_TOKENS_REFRESH_INTERVAL }
 
 export interface PriorityTokensUpdaterProps {
   account: string | undefined


### PR DESCRIPTION
# Summary

As we realized, balances multicall work even when the app window is not focused but visible.
It doesn't worth it to do the updates when there is no focus, so we can save RPC calls on that.

<img width="1361" height="121" alt="image" src="https://github.com/user-attachments/assets/637d30e3-f432-4c7f-a6c0-a4ca74ec7c0e" />


# To Test

1. Open the app with a connected wallet
2. Open dev tools and filter logs with `[Multicall]`
3. Wait 20 seconds and keep focus on the app window
4. You should see at least 2 new multicall logs
5. Keep the tab active and switch focus to another window
6. Wait 20 seconds and then switch to the app window again
7. There should not be any new multicall logs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Background balance and allowance updates now pause when the app isn’t focused, and won’t refresh when hidden or offline, improving performance and battery life.
  - Consistent refresh intervals retained (31s for balances/allowances, 8s for priority tokens).

- Refactor
  - Unified refresh behavior across components using a shared configuration for more consistent and predictable updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->