### PR TITLE
fix(token-search): increase results limit from 10 to 100

### DIFF
--- a/apps/cowswap-frontend/src/modules/tokensList/pure/TokenSearchContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/TokenSearchContent/index.tsx
@@ -11,7 +11,7 @@ import { ImportTokenItem } from '../ImportTokenItem'
 import { TokenListItemContainer } from '../TokenListItemContainer'
 import { TokenSourceTitle } from '../TokenSourceTitle'
 
-const SEARCH_RESULTS_LIMIT = 10
+const SEARCH_RESULTS_LIMIT = 100
 
 interface TokenSearchContentProps {
   searchInput: string

--- a/libs/tokens/src/hooks/tokens/useSearchToken.ts
+++ b/libs/tokens/src/hooks/tokens/useSearchToken.ts
@@ -65,10 +65,11 @@ export function useSearchToken(input: string | null): TokenSearchResponse {
   }, [debouncedInputInList, tokensFromActiveLists, tokensFromInactiveLists])
 
   // Search in external API
-  const { data: apiResultTokens, isLoading: apiIsLoading } = useSearchTokensInApi(
+  // TODO: Temporarily disabled since the API is no longer available. Re-enable when the API is fixed
+  const { data: apiResultTokens, isLoading: apiIsLoading } = { data: null, isLoading: false } /*useSearchTokensInApi(
     debouncedInputInExternals,
     isTokenAlreadyFoundByAddress,
-  )
+  )*/
 
   // Search in Blockchain
   const { data: tokenFromBlockChain, isLoading: blockchainIsLoading } = useFetchTokenFromBlockchain(
@@ -152,6 +153,7 @@ function useSearchTokensInLists(input: string | undefined): FromListsResult {
   return inListsResult || emptyFromListsResult
 }
 
+// eslint-disable-next-line unused-imports/no-unused-vars
 function useSearchTokensInApi(
   input: string | undefined,
   isTokenAlreadyFoundByAddress: boolean,


### PR DESCRIPTION
# Summary

Increase token search results from 10 to 100

# To Test

1. Open SWAP on mainnet
2. Open token selector
3. Search for `ondo`
* There should be 100 results from `inactive` token lists