### PR TITLE
fix(ga): rename bridging events

### DIFF
--- a/apps/cowswap-frontend/src/modules/bridge/updaters/PendingBridgeOrdersUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/updaters/PendingBridgeOrdersUpdater.tsx
@@ -70,7 +70,7 @@ function PendingOrderUpdater({ chainId, orderUid }: PendingOrderUpdaterProps): R
 
       analytics.sendEvent({
         category: CowSwapAnalyticsCategory.Bridge,
-        action: 'Bridging succeeded',
+        action: 'bridging_succeeded',
         label: analyticsSummary,
         orderId: orderUid,
         chainId: sourceChainId,
@@ -80,7 +80,7 @@ function PendingOrderUpdater({ chainId, orderUid }: PendingOrderUpdaterProps): R
 
       analytics.sendEvent({
         category: CowSwapAnalyticsCategory.Bridge,
-        action: 'Bridging failed',
+        action: 'bridging_failed',
         label: analyticsSummary,
         orderId: orderUid,
         chainId: sourceChainId,


### PR DESCRIPTION
# Summary

Rename bridging events.
No other changes.

# To Test

1. Google analytics events related to bridging should be renamed
* From `Bridging succeeded` to `bridging_succeeded`
* From `Bridging failed` to `bridging_failed` (this will likely not be easy to test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardized analytics event naming for bridge order outcomes, switching to consistent snake_case identifiers for succeeded and failed events.
  - Preserves existing trigger conditions and event metadata; only action names are adjusted.
  - Improves telemetry consistency, reporting accuracy, and reduces fragmentation in analytics dashboards.
  - No user-facing behavior or UI changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->