### PR TITLE
feat(account-proxy): add links to cowshed releases

### DIFF
--- a/apps/cowswap-frontend/src/modules/accountProxy/pure/FAQContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/accountProxy/pure/FAQContent/index.tsx
@@ -33,7 +33,15 @@ const FAQ_DATA = [
         {COW_SHED_VERSIONS.length} versions of {ACCOUNT_PROXY_LABEL}:
         <ul>
           {COW_SHED_VERSIONS.map((v) => (
-            <li key={v}>{v}</li>
+            <li key={v}>
+              <Link
+                to={`https://github.com/cowdao-grants/cow-shed/releases/tag/v${v}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {v}
+              </Link>
+            </li>
           ))}
         </ul>
       </>


### PR DESCRIPTION
# Summary

<img width="451" height="173" alt="image" src="https://github.com/user-attachments/assets/b4e474d1-273a-4da2-ad6d-2e7dc2eda5c4" />

# To Test

The links should lead to corresponding releases in https://github.com/cowdao-grants/cow-shed/releases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FAQ version entries are now clickable links to their corresponding GitHub release tags. Clicking a version opens the release page in a new tab, enabling quick access to detailed notes and change logs without disrupting your session. This improves discoverability of release details. No other FAQ content or behavior was modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->