### PR TITLE
fix(lens): follow up fixes

### DIFF
--- a/apps/explorer/src/api/tenderly/tenderlyApi.ts
+++ b/apps/explorer/src/api/tenderly/tenderlyApi.ts
@@ -79,7 +79,7 @@ export function traceToTransfersAndTrades(trace: Trace): TxTradesAndTransfers {
   const trades: Array<Trade> = []
 
   try {
-    trace.logs.forEach((log) => {
+    trace.logs?.forEach((log) => {
       if (log.name === TypeOfTrace.TRANSFER) {
         const from = log.inputs[IndexTransferInput.from].value
         const to = log.inputs[IndexTransferInput.to].value

--- a/apps/explorer/src/api/tenderly/tenderlyApi.ts
+++ b/apps/explorer/src/api/tenderly/tenderlyApi.ts
@@ -63,17 +63,6 @@ export async function getTransactionContracts(networkId: SupportedChainId, txHas
   return _fetchTradesAccounts(networkId, txHash)
 }
 
-export async function getTradesAndTransfers(
-  networkId: SupportedChainId,
-  txHash: string,
-): Promise<TxTradesAndTransfers> {
-  const trace = await _fetchTrace(networkId, txHash)
-
-  return traceToTransfersAndTrades(trace)
-}
-
-// TODO: Break down this large function into smaller functions
-// eslint-disable-next-line max-lines-per-function
 export function traceToTransfersAndTrades(trace: Trace): TxTradesAndTransfers {
   const transfers: Array<Transfer> = []
   const trades: Array<Trade> = []

--- a/apps/explorer/src/explorer/components/TransanctionBatchGraph/hooks.ts
+++ b/apps/explorer/src/explorer/components/TransanctionBatchGraph/hooks.ts
@@ -71,12 +71,24 @@ export function useCytoscape(params: UseCytoscapeParams): UseCytoscapeReturn {
 
   const stableTxSettlement = JSON.stringify(txSettlement)
 
+  // eslint-disable-next-line complexity
   useEffect(() => {
     try {
       setFailedToLoadGraph(false)
       const cy = cytoscapeRef.current
       setElements([])
-      if (error || isLoading || !networkId || !heightSize || !cy || !txSettlement) return
+      if (
+        error ||
+        isLoading ||
+        !networkId ||
+        !heightSize ||
+        !cy ||
+        !txSettlement ||
+        !txSettlement.trades.length ||
+        !txSettlement.transfers.length
+      ) {
+        return
+      }
 
       const getNodesFn = txSettlement.contractTrades ? buildTokenViewNodes : buildContractViewNodes
       const nodes = getNodesFn(txSettlement, networkId, heightSize, layout.name)
@@ -219,7 +231,7 @@ function useUpdateVisQuery(): (vis: string) => void {
 }
 
 // TODO: Break down this large function into smaller functions
-// eslint-disable-next-line max-lines-per-function
+ 
 export function useTxBatchData(
   networkId: Network | undefined,
   orders: Order[] | undefined,

--- a/libs/common-const/src/tenderly.ts
+++ b/libs/common-const/src/tenderly.ts
@@ -2,5 +2,5 @@ import { mapSupportedNetworks, SupportedChainId } from '@cowprotocol/cow-sdk'
 
 export const TENDERLY_AVAILABLE: Record<SupportedChainId, boolean> = {
   ...mapSupportedNetworks(true),
-  [SupportedChainId.LENS]: false, // Lens is not supported by Tenderly ATM (2025-08)
+  // [SupportedChainId.LENS]: false, // Lens is not supported by Tenderly ATM (2025-08)
 }

--- a/libs/common-const/src/tenderly.ts
+++ b/libs/common-const/src/tenderly.ts
@@ -2,5 +2,5 @@ import { mapSupportedNetworks, SupportedChainId } from '@cowprotocol/cow-sdk'
 
 export const TENDERLY_AVAILABLE: Record<SupportedChainId, boolean> = {
   ...mapSupportedNetworks(true),
-  // [SupportedChainId.LENS]: false, // Lens is not supported by Tenderly ATM (2025-08)
+  [SupportedChainId.LENS]: false, // Lens is not fully supported by Tenderly ATM (2025-08)
 }

--- a/libs/common-const/src/tokens.ts
+++ b/libs/common-const/src/tokens.ts
@@ -618,8 +618,11 @@ const POLYGON_STABLECOINS = [USDC_POLYGON.address, USDT_POLYGON.address, DAI_POL
 
 const AVALANCHE_STABLECOINS = [USDC_AVALANCHE.address, USDT_AVALANCHE.address].map((t) => t.toLowerCase())
 
-// TODO: add more stablecoins for Lens
-const LENS_STABLECOINS = [USDC_LENS.address].map((t) => t.toLowerCase())
+const LENS_STABLECOINS = [
+  USDC_LENS.address,
+  NATIVE_CURRENCIES[SupportedChainId.LENS].address, // GHO
+  WRAPPED_NATIVE_CURRENCIES[SupportedChainId.LENS].address, // WGHO
+].map((t) => t.toLowerCase())
 
 // TODO: add more stablecoins for BNB
 const BNB_STABLECOINS = [USDC_BNB.address].map((t) => t.toLowerCase())

--- a/libs/hook-dapp-lib/src/hookDappsRegistry.ts
+++ b/libs/hook-dapp-lib/src/hookDappsRegistry.ts
@@ -69,6 +69,7 @@ export const hookDappsRegistry = {
     conditions: {
       position: 'pre',
       walletCompatibility: ['EOA'],
+      supportedNetworks: [1, 100, 8453, 42161, 11155111],
     },
   },
   CLAIM_LLAMAPAY_VESTING: {
@@ -131,6 +132,7 @@ export const hookDappsRegistry = {
     conditions: {
       position: 'post',
       walletCompatibility: ['EOA'],
+      supportedNetworks: [1, 100, 8453, 42161, 11155111],
     },
   },
   UNI_V2_DEPOSIT: {

--- a/libs/tokens/src/const/tokensList.json
+++ b/libs/tokens/src/const/tokensList.json
@@ -163,11 +163,6 @@
       "priority": 2,
       "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/CoinGecko.232.json",
       "enabledByDefault": true
-    },
-    {
-      "priority": 3,
-      "enabledByDefault": true,
-      "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/Uniswap.232.json"
     }
   ]
 }


### PR DESCRIPTION
# Summary

Minor fixes for Lens

- Remove uniswap list
- Add GHO and WGHO to the stables list
- Limit CoW AMM hook availability only where it's deployed
- ~Attempt to fix Tenderly~ did not work, disabled it again

## Notes:
- ~Simulations are enabled for hooks. Try it out~ Disabled
- Batch viewer doesn't work because Tenderly doesn't return the needed data, but at least it doesn't crash the page anymore

~If the simulation is not good, I'll disable it completely again.~ Disabled

# To Test

1. Check the fixes mentioned above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Lens: Recognizes additional stablecoins (GHO and WGHO) alongside USDC.
  - Expanded availability for specific hook actions (COW AMM Withdraw, Create LlamaPay Vesting) on Mainnet, Gnosis, Base, Arbitrum, and Sepolia.

- Bug Fixes
  - More robust transaction detail handling when trace/log data is missing.
  - Transaction Batch Graph renders only with complete data, reducing empty or flickering states.

- Chores
  - Streamlined token sources on network 232 by removing the Uniswap list to reduce duplicates and inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->