### PR TITLE
feat(bridge): add bridge appzi nps survey

### DIFF
--- a/apps/cowswap-frontend/.env
+++ b/apps/cowswap-frontend/.env
@@ -41,7 +41,6 @@
 # Appzi NPS feedback
 #REACT_APP_FEEDBACK_ENABLED_DEV=false
 #REACT_APP_APPZI_FEEDBACK_KEY=
-#REACT_APP_APPZI_NPS_KEY=
 
 # Launch darkly
 #REACT_APP_LAUNCH_DARKLY_KEY=your-launch-darkly-key

--- a/apps/cowswap-frontend/src/appzi.ts
+++ b/apps/cowswap-frontend/src/appzi.ts
@@ -25,7 +25,7 @@ export const isAppziEnabled =
 const PROD_FEEDBACK_KEY = 'f7591eca-72f7-4888-b15f-e7ff5fcd60cd'
 const TEST_FEEDBACK_KEY = '6da8bf10-4904-4952-9a34-12db70e9194e'
 
-const FEEDBACK_KEY = process.env.REACT_APP_APPZI_FEEDBACK_KEY || isProdLike ? PROD_FEEDBACK_KEY : TEST_FEEDBACK_KEY
+const FEEDBACK_KEY = process.env.REACT_APP_APPZI_FEEDBACK_KEY || (isProdLike ? PROD_FEEDBACK_KEY : TEST_FEEDBACK_KEY)
 
 const APPZI_TOKEN = process.env.REACT_APP_APPZI_TOKEN || '5ju0G'
 

--- a/apps/cowswap-frontend/src/appzi.ts
+++ b/apps/cowswap-frontend/src/appzi.ts
@@ -29,7 +29,8 @@ const FEEDBACK_KEY = process.env.REACT_APP_APPZI_FEEDBACK_KEY || isProdLike ? PR
 
 const APPZI_TOKEN = process.env.REACT_APP_APPZI_TOKEN || '5ju0G'
 
-const PENDING_TOO_LONG_TIME = ms`5 min`
+const PENDING_TOO_LONG_TIME_SWAP = ms`5 min`
+const PENDING_TOO_LONG_TIME_BRIDGE = ms`7 min`
 
 declare global {
   interface Window {
@@ -102,10 +103,11 @@ export function openFeedbackAppzi(params: { account?: string; walletName?: strin
   }
 }
 
-export function isOrderInPendingTooLong(openSince: number | undefined): boolean {
+export function isOrderInPendingTooLong(openSince: number | undefined, isBridging?: boolean): boolean {
   const now = Date.now()
+  const pendingTime = isBridging ? PENDING_TOO_LONG_TIME_BRIDGE : PENDING_TOO_LONG_TIME_SWAP
 
-  return !!openSince && now - openSince > PENDING_TOO_LONG_TIME
+  return !!openSince && now - openSince > pendingTime
 }
 
 // Different triggers for each NPS survey.

--- a/apps/cowswap-frontend/src/appzi.ts
+++ b/apps/cowswap-frontend/src/appzi.ts
@@ -24,11 +24,8 @@ export const isAppziEnabled =
 
 const PROD_FEEDBACK_KEY = 'f7591eca-72f7-4888-b15f-e7ff5fcd60cd'
 const TEST_FEEDBACK_KEY = '6da8bf10-4904-4952-9a34-12db70e9194e'
-const PROD_NPS_KEY = '55872789-593b-4c6c-9e49-9b5c7693e90a'
-const TEST_NPS_KEY = '5b794318-f81c-4dac-83ba-15a6e4c9353d'
 
 const FEEDBACK_KEY = process.env.REACT_APP_APPZI_FEEDBACK_KEY || isProdLike ? PROD_FEEDBACK_KEY : TEST_FEEDBACK_KEY
-const NPS_KEY = process.env.REACT_APP_APPZI_NPS_KEY || isProdLike ? PROD_NPS_KEY : TEST_NPS_KEY
 
 const APPZI_TOKEN = process.env.REACT_APP_APPZI_TOKEN || '5ju0G'
 
@@ -102,14 +99,6 @@ export function openFeedbackAppzi(params: { account?: string; walletName?: strin
   if (typeof window !== 'undefined') {
     updateAppziSettings({ data: { account, chainId, walletName } })
     window.appzi?.openWidget(FEEDBACK_KEY)
-  }
-}
-
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function openNpsAppzi() {
-  if (typeof window !== 'undefined') {
-    window.appzi?.openWidget(NPS_KEY)
   }
 }
 

--- a/apps/cowswap-frontend/src/appzi.ts
+++ b/apps/cowswap-frontend/src/appzi.ts
@@ -52,7 +52,7 @@ type AppziCustomSettings = {
   waitedTooLong?: true
   expired?: true
   traded?: true
-  bridged?: true
+  isBridging?: true
   created?: true
   cancelled?: true
   openedLimitPage?: true

--- a/apps/cowswap-frontend/src/common/updaters/orders/PendingOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/PendingOrdersUpdater.ts
@@ -29,7 +29,7 @@ import {
   useFulfillOrdersBatch,
   useInvalidateOrdersBatch,
   usePresignOrders,
-  useUpdatePresignGnosisSafeTx,
+  useUpdatePresignGnosisSafeTx
 } from 'legacy/state/orders/hooks'
 import { OrderTransitionStatus } from 'legacy/state/orders/utils'
 
@@ -37,7 +37,7 @@ import {
   emitCancelledOrderEvent,
   emitExpiredOrderEvent,
   emitFulfilledOrderEvent,
-  emitPresignedOrderEvent,
+  emitPresignedOrderEvent
 } from 'modules/orders'
 
 import { getOrder } from 'api/cowProtocol'
@@ -353,8 +353,9 @@ function _triggerNps(pending: Order[], chainId: ChainId, account: string): void 
   for (const order of pending) {
     const { openSince, id: orderId } = order
     const orderType = getUiOrderType(order)
+    const isBridging = getIsBridgeOrder(order) || undefined
     // Check if there's any SWAP pending for more than `PENDING_TOO_LONG_TIME`
-    if (orderType === UiOrderType.SWAP && isOrderInPendingTooLong(openSince)) {
+    if (orderType === UiOrderType.SWAP && isOrderInPendingTooLong(openSince, isBridging)) {
       const explorerUrl = getExplorerOrderLink(chainId, orderId)
       // Trigger NPS display, controlled by Appzi
       triggerAppziSurvey({
@@ -364,6 +365,7 @@ function _triggerNps(pending: Order[], chainId: ChainId, account: string): void 
         chainId,
         orderType,
         account,
+        isBridging,
       })
       // Break the loop, don't need to show more than once
       break

--- a/apps/cowswap-frontend/src/modules/bridge/updaters/PendingBridgeOrdersUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/updaters/PendingBridgeOrdersUpdater.tsx
@@ -120,7 +120,7 @@ function PendingOrderUpdater({ chainId, orderUid, openSince }: PendingOrderUpdat
         chainId: sourceChainId,
       } as GtmEvent<CowSwapAnalyticsCategory.Bridge>)
     }
-  }, [crossChainOrder, updateBridgeOrderQuote, addOrderToSurplusQueue, analytics, openSince])
+  }, [crossChainOrder, updateBridgeOrderQuote, addOrderToSurplusQueue, analytics])
 
   return null
 }

--- a/apps/cowswap-frontend/src/modules/bridge/updaters/PendingBridgeOrdersUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/updaters/PendingBridgeOrdersUpdater.tsx
@@ -26,7 +26,7 @@ function processExecutedBridging(crossChainOrder: CrossChainOrder): void {
   // Trigger Appzi survey
   triggerAppziSurvey(
     {
-      bridged: true,
+      isBridging: true,
       explorerUrl: crossChainOrder.explorerUrl,
       chainId: crossChainOrder.chainId,
       orderType: UiOrderType.SWAP,

--- a/apps/cowswap-frontend/src/modules/bridge/updaters/PendingBridgeOrdersUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/bridge/updaters/PendingBridgeOrdersUpdater.tsx
@@ -15,6 +15,8 @@ import { getCowSoundError, getCowSoundSuccess } from 'modules/sounds'
 
 import { CowSwapAnalyticsCategory } from 'common/analytics/types'
 
+const APPZI_CHECK_INTERVAL = 60_000
+
 function processExecutedBridging(crossChainOrder: CrossChainOrder): void {
   const { provider: _, ...eventPayload } = crossChainOrder
 
@@ -75,7 +77,7 @@ function PendingOrderUpdater({ chainId, orderUid, openSince }: PendingOrderUpdat
         })
         waitingTooLongNpsTriggeredRef.current = true
       }
-    }, 60_000)
+    }, APPZI_CHECK_INTERVAL)
 
     return () => clearInterval(interval)
   }, [crossChainOrder, openSince])


### PR DESCRIPTION
# Summary

Add Appzi survey for bridges, that trigger independently from pure swaps/limits.

It triggers when a bridge finishes and when it has been pending for > 7min.

# To Test

1. Make sure the local storage doesn't have any appzi keys (`azat-*`)

2. Place a bridge and swap that takes less than 7 min to complete
* Once bridge is complete, the new survey nps should be displayed
3. Place a regular SWAP
* Once swap is complete, the swap nps should be displayed
4. Place a regular LIMIT
* Once limit is placed, the limit nps should be displayed

5. Repeat `1`

6. Place a bridge that takes longer than 7 min to complete
* After 7+ min pending, the new survey should be displayed
7. Place a swap that takes longer than 5min to complete
* After 5+ min pending, the swap survey should be displayed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NPS prompts now differentiate swaps vs. bridges: surveys trigger after ~5 minutes for swaps and ~7 minutes for bridges.
  * Bridge-related surveys now include explicit "isBridging" context for more relevant feedback and analytics.
  * Automatic survey triggering added for long-pending bridge orders.

* **Chores**
  * Removed an obsolete NPS placeholder comment from environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->