### PR TITLE
chore/add bungee affiliate link to explorer

### DIFF
--- a/apps/explorer/src/sdk/cowSdk.ts
+++ b/apps/explorer/src/sdk/cowSdk.ts
@@ -1,11 +1,19 @@
 import { getRpcProvider } from '@cowprotocol/common-const'
+import { isBarn, isDev, isProd, isStaging } from '@cowprotocol/common-utils'
 import { AcrossBridgeProvider, BungeeBridgeProvider, OrderBookApi } from '@cowprotocol/cow-sdk'
 
 export const orderBookApi = new OrderBookApi()
+const bungeeApiBase = getBungeeApiBase()
+
+const bungeeAffiliateCode =
+  '609913096e1a3d62cecd0ffff47aa3e459eaedceb5fef75aad43e6cbff367039708902197e0b2b78b1d76cb0837ad0b318baedceb5fef75aad43e6cb'
 
 export const bungeeBridgeProvider = new BungeeBridgeProvider({
   apiOptions: {
     includeBridges: ['across', 'cctp', 'gnosis-native-bridge'],
+    apiBaseUrl: bungeeApiBase ? `${bungeeApiBase}/api/v1/bungee` : undefined,
+    manualApiBaseUrl: bungeeApiBase ? `${bungeeApiBase}/api/v1/bungee-manual` : undefined,
+    affiliate: bungeeApiBase ? bungeeAffiliateCode : undefined,
   },
   getRpcProvider,
 })
@@ -13,3 +21,11 @@ export const bungeeBridgeProvider = new BungeeBridgeProvider({
 export const acrossBridgeProvider = new AcrossBridgeProvider({ getRpcProvider })
 
 export const knownBridgeProviders = [bungeeBridgeProvider, acrossBridgeProvider]
+
+function getBungeeApiBase(): string | undefined {
+  if (isProd || isDev || isStaging || isBarn) {
+    return 'https://backend.bungee.exchange'
+  }
+
+  return undefined
+}


### PR DESCRIPTION
# Summary

Add Bungee's affiliate code to any request's header towards `https://backend.bungee.exchange` 

# To Test

0. It works only on `prod`, `staging`, `barn`, or `dev` environments
1. Select a token pair to be bridged
2. In the dev tools, in all requests to `https://backend.bungee.exchange`, the header should contain the key `affiliate` and the value `609913096e1a3d62cecd0ffff47aa3e459eaedceb5fef75aad43e6cbff367039708902197e0b2b78b1d76cb0837ad0b318baedceb5fef75aad43e6cb` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enables Bungee bridging in supported environments (production, dev, staging, barn), automatically selecting the correct API endpoints.
  - Applies affiliate tagging when Bungee is enabled.

- Behavior Changes
  - Bungee integration is disabled in unsupported environments, ensuring no impact where not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->