### PR TITLE
fix(tokens): check token lists loading state

### DIFF
--- a/libs/tokens/src/state/tokens/allTokensAtom.ts
+++ b/libs/tokens/src/state/tokens/allTokensAtom.ts
@@ -11,7 +11,7 @@ import { lowerCaseTokensMap } from '../../utils/lowerCaseTokensMap'
 import { parseTokenInfo } from '../../utils/parseTokenInfo'
 import { tokenMapToListWithLogo } from '../../utils/tokenMapToListWithLogo'
 import { environmentAtom } from '../environmentAtom'
-import { listsEnabledStateAtom, listsStatesListAtom } from '../tokenLists/tokenListsStateAtom'
+import { listsEnabledStateAtom, listsStatesListAtom, tokenListsUpdatingAtom } from '../tokenLists/tokenListsStateAtom'
 
 export interface TokensByAddress {
   [address: string]: TokenWithLogo | undefined
@@ -78,6 +78,7 @@ export const allActiveTokensAtom = atom(async (get) => {
   const { chainId, enableLpTokensByDefault } = get(environmentAtom)
   const userAddedTokens = get(userAddedTokensAtom)
   const favoriteTokensState = get(favoriteTokensAtom)
+  const isTokenListsUpdating = get(tokenListsUpdatingAtom)
 
   const { tokensState: tokensMap, listsCount } = await get(tokensStateAtom)
   const nativeToken = NATIVE_CURRENCIES[chainId]
@@ -85,7 +86,7 @@ export const allActiveTokensAtom = atom(async (get) => {
   /**
    * Wait till token lists loaded
    */
-  if (listsCount === 0) {
+  if (!isTokenListsUpdating ? false : listsCount === 0) {
     return { tokens: [], chainId }
   }
 


### PR DESCRIPTION
# Summary

There is a check in `allActiveTokensAtom` to prevent excessive multicall calls:
```
if (listsCount === 0) {
    return { tokens: [], chainId }
}
```

It doesn't work properly, when there is a list but it doesn't contain any tokens. This is a case of Lens token list:
https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/CoinGecko.232.json

To prevent that problem, I added additional `isTokenListsUpdating` check. This value signals us that token lists are processed and loaded.

<img width="1291" height="831" alt="image" src="https://github.com/user-attachments/assets/ea3ba46a-4e3b-47ff-98c7-ee7005769685" />

# To Test

1. Open the app from US location
2. Open `/#/232/swap/0xB0588f9A9cADe7CD5f194a5fe77AcD6A58250f82/0x88F08E304EC4f90D644Cec3Fb69b8aD414acf884`
3. It should propose to you import tokens
- [ ] AR: nothing happens when you click "Import"
- [ ] ER: token gets imported


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevents the token list from appearing empty when not actively updating, reducing false “no tokens” states.
  - Improves reliability of token display during list refreshes for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->