### PR TITLE
fix: call bungee public endpoint when using custom header

### DIFF
--- a/apps/cowswap-frontend/src/tradingSdk/bridgingSdk.ts
+++ b/apps/cowswap-frontend/src/tradingSdk/bridgingSdk.ts
@@ -1,18 +1,13 @@
 import { getRpcProvider } from '@cowprotocol/common-const'
-import { isLocal } from '@cowprotocol/common-utils'
 import { BridgingSdk, BungeeBridgeProvider } from '@cowprotocol/cow-sdk'
 
 import { orderBookApi } from 'cowSdk'
 
 import { tradingSdk } from './tradingSdk'
 
-const bungeeApiBase = getBungeeApiBase()
-
 export const bungeeBridgeProvider = new BungeeBridgeProvider({
   apiOptions: {
     includeBridges: ['across', 'cctp', 'gnosis-native-bridge'],
-    apiBaseUrl: bungeeApiBase ? `${bungeeApiBase}/api/v1/bungee` : undefined,
-    manualApiBaseUrl: bungeeApiBase ? `${bungeeApiBase}/api/v1/bungee-manual` : undefined,
   },
   getRpcProvider,
 })
@@ -23,8 +18,3 @@ export const bridgingSdk = new BridgingSdk({
   tradingSdk,
   orderBookApi,
 })
-
-// returns private endpoint if not local, otherwise undefined
-function getBungeeApiBase(): string | undefined {
-  return isLocal ? undefined : 'https://backend.bungee.exchange'
-}

--- a/apps/cowswap-frontend/src/tradingSdk/bridgingSdk.ts
+++ b/apps/cowswap-frontend/src/tradingSdk/bridgingSdk.ts
@@ -1,5 +1,5 @@
 import { getRpcProvider } from '@cowprotocol/common-const'
-import { isBarn, isDev, isProd, isStaging } from '@cowprotocol/common-utils'
+import { isLocal } from '@cowprotocol/common-utils'
 import { BridgingSdk, BungeeBridgeProvider } from '@cowprotocol/cow-sdk'
 
 import { orderBookApi } from 'cowSdk'
@@ -14,9 +14,11 @@ const bungeeAffiliateCode =
 export const bungeeBridgeProvider = new BungeeBridgeProvider({
   apiOptions: {
     includeBridges: ['across', 'cctp', 'gnosis-native-bridge'],
+    // if undefined, the sdk will default to the public api that allows custom headers
     apiBaseUrl: bungeeApiBase ? `${bungeeApiBase}/api/v1/bungee` : undefined,
+    // if undefined, the sdk will default to the public api that allows custom headers
     manualApiBaseUrl: bungeeApiBase ? `${bungeeApiBase}/api/v1/bungee-manual` : undefined,
-    affiliate: bungeeApiBase ? bungeeAffiliateCode : undefined,
+    affiliate: bungeeApiBase ? undefined : bungeeAffiliateCode,
   },
   getRpcProvider,
 })
@@ -29,9 +31,5 @@ export const bridgingSdk = new BridgingSdk({
 })
 
 function getBungeeApiBase(): string | undefined {
-  if (isProd || isDev || isStaging || isBarn) {
-    return 'https://backend.bungee.exchange'
-  }
-
-  return undefined
+  return isLocal ? 'https://backend.bungee.exchange' : undefined
 }

--- a/apps/cowswap-frontend/src/tradingSdk/bridgingSdk.ts
+++ b/apps/cowswap-frontend/src/tradingSdk/bridgingSdk.ts
@@ -8,17 +8,11 @@ import { tradingSdk } from './tradingSdk'
 
 const bungeeApiBase = getBungeeApiBase()
 
-const bungeeAffiliateCode =
-  '609913096e1a3d62cecd0ffff47aa3e459eaedceb5fef75aad43e6cbff367039708902197e0b2b78b1d76cb0837ad0b318baedceb5fef75aad43e6cb'
-
 export const bungeeBridgeProvider = new BungeeBridgeProvider({
   apiOptions: {
     includeBridges: ['across', 'cctp', 'gnosis-native-bridge'],
-    // if undefined, the sdk will default to the public api that allows custom headers
     apiBaseUrl: bungeeApiBase ? `${bungeeApiBase}/api/v1/bungee` : undefined,
-    // if undefined, the sdk will default to the public api that allows custom headers
     manualApiBaseUrl: bungeeApiBase ? `${bungeeApiBase}/api/v1/bungee-manual` : undefined,
-    affiliate: bungeeApiBase ? undefined : bungeeAffiliateCode,
   },
   getRpcProvider,
 })
@@ -30,6 +24,7 @@ export const bridgingSdk = new BridgingSdk({
   orderBookApi,
 })
 
+// returns private endpoint if not local, otherwise undefined
 function getBungeeApiBase(): string | undefined {
-  return isLocal ? 'https://backend.bungee.exchange' : undefined
+  return isLocal ? undefined : 'https://backend.bungee.exchange'
 }

--- a/apps/explorer/src/sdk/cowSdk.ts
+++ b/apps/explorer/src/sdk/cowSdk.ts
@@ -1,16 +1,11 @@
 import { getRpcProvider } from '@cowprotocol/common-const'
-import { isLocal } from '@cowprotocol/common-utils'
 import { AcrossBridgeProvider, BungeeBridgeProvider, OrderBookApi } from '@cowprotocol/cow-sdk'
 
 export const orderBookApi = new OrderBookApi()
 
-const bungeeAffiliateCode =
-  '609913096e1a3d62cecd0ffff47aa3e459eaedceb5fef75aad43e6cbff367039708902197e0b2b78b1d76cb0837ad0b318baedceb5fef75aad43e6cb'
-
 export const bungeeBridgeProvider = new BungeeBridgeProvider({
   apiOptions: {
     includeBridges: ['across', 'cctp', 'gnosis-native-bridge'],
-    affiliate: isLocal ? undefined : bungeeAffiliateCode,
   },
   getRpcProvider,
 })

--- a/apps/explorer/src/sdk/cowSdk.ts
+++ b/apps/explorer/src/sdk/cowSdk.ts
@@ -3,7 +3,6 @@ import { isLocal } from '@cowprotocol/common-utils'
 import { AcrossBridgeProvider, BungeeBridgeProvider, OrderBookApi } from '@cowprotocol/cow-sdk'
 
 export const orderBookApi = new OrderBookApi()
-const bungeeApiBase = getBungeeApiBase()
 
 const bungeeAffiliateCode =
   '609913096e1a3d62cecd0ffff47aa3e459eaedceb5fef75aad43e6cbff367039708902197e0b2b78b1d76cb0837ad0b318baedceb5fef75aad43e6cb'
@@ -11,11 +10,7 @@ const bungeeAffiliateCode =
 export const bungeeBridgeProvider = new BungeeBridgeProvider({
   apiOptions: {
     includeBridges: ['across', 'cctp', 'gnosis-native-bridge'],
-    // if undefined, the sdk will default to the public api that allows custom headers
-    apiBaseUrl: bungeeApiBase ? `${bungeeApiBase}/api/v1/bungee` : undefined,
-    // if undefined, the sdk will default to the public api that allows custom headers
-    manualApiBaseUrl: bungeeApiBase ? `${bungeeApiBase}/api/v1/bungee-manual` : undefined,
-    affiliate: bungeeApiBase ? undefined : bungeeAffiliateCode,
+    affiliate: isLocal ? undefined : bungeeAffiliateCode,
   },
   getRpcProvider,
 })
@@ -23,7 +18,3 @@ export const bungeeBridgeProvider = new BungeeBridgeProvider({
 export const acrossBridgeProvider = new AcrossBridgeProvider({ getRpcProvider })
 
 export const knownBridgeProviders = [bungeeBridgeProvider, acrossBridgeProvider]
-
-function getBungeeApiBase(): string | undefined {
-  return isLocal ? 'https://backend.bungee.exchange' : undefined
-}

--- a/apps/explorer/src/sdk/cowSdk.ts
+++ b/apps/explorer/src/sdk/cowSdk.ts
@@ -1,5 +1,5 @@
 import { getRpcProvider } from '@cowprotocol/common-const'
-import { isBarn, isDev, isProd, isStaging } from '@cowprotocol/common-utils'
+import { isLocal } from '@cowprotocol/common-utils'
 import { AcrossBridgeProvider, BungeeBridgeProvider, OrderBookApi } from '@cowprotocol/cow-sdk'
 
 export const orderBookApi = new OrderBookApi()
@@ -11,9 +11,11 @@ const bungeeAffiliateCode =
 export const bungeeBridgeProvider = new BungeeBridgeProvider({
   apiOptions: {
     includeBridges: ['across', 'cctp', 'gnosis-native-bridge'],
+    // if undefined, the sdk will default to the public api that allows custom headers
     apiBaseUrl: bungeeApiBase ? `${bungeeApiBase}/api/v1/bungee` : undefined,
+    // if undefined, the sdk will default to the public api that allows custom headers
     manualApiBaseUrl: bungeeApiBase ? `${bungeeApiBase}/api/v1/bungee-manual` : undefined,
-    affiliate: bungeeApiBase ? bungeeAffiliateCode : undefined,
+    affiliate: bungeeApiBase ? undefined : bungeeAffiliateCode,
   },
   getRpcProvider,
 })
@@ -23,9 +25,5 @@ export const acrossBridgeProvider = new AcrossBridgeProvider({ getRpcProvider })
 export const knownBridgeProviders = [bungeeBridgeProvider, acrossBridgeProvider]
 
 function getBungeeApiBase(): string | undefined {
-  if (isProd || isDev || isStaging || isBarn) {
-    return 'https://backend.bungee.exchange'
-  }
-
-  return undefined
+  return isLocal ? 'https://backend.bungee.exchange' : undefined
 }


### PR DESCRIPTION
# Summary

Use Bungee public endpoint `https://public-backend.bungee.exchange/api/v1/bungee` if Swap or Explorer aren't running locally.

# To Test

1. Perform a Bridge transaction
2. In the dev tools, any request's header to `https://public-backend.bungee.exchange` should have an `Affiliate` key 

# Background

This is necessary as we're using a custom header to send the `affiliate` field
