### PR TITLE
fix(ondo): add ondo list tag

### DIFF
--- a/libs/tokens/src/updaters/TokensListsTagsUpdater/index.ts
+++ b/libs/tokens/src/updaters/TokensListsTagsUpdater/index.ts
@@ -8,7 +8,7 @@ import { tokenListsTagsAtom } from '../../state/tokenLists/tokenListsTagsAtom'
 import { TokenListTags } from '../../types'
 
 // The list of tag names that we want to support from tokenlists
-const ALLOWED_TOKENLIST_TAGS = ['circle']
+const ALLOWED_TOKENLIST_TAGS = ['circle', 'ondo']
 
 // TODO: Add proper return type annotation
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type


### PR DESCRIPTION
# Summary

Add `ondo` token list tag to the allowed list

# To Test

1. On mainnet, enable the Ondo token list
2. In the token selector, search for `ondo`
* Ondo tokens should have the tag