### PR TITLE
feat: add 'ondo' to allowed token list tags

### DIFF
--- a/libs/tokens/src/updaters/TokensListsTagsUpdater/index.ts
+++ b/libs/tokens/src/updaters/TokensListsTagsUpdater/index.ts
@@ -8,7 +8,7 @@ import { tokenListsTagsAtom } from '../../state/tokenLists/tokenListsTagsAtom'
 import { TokenListTags } from '../../types'
 
 // The list of tag names that we want to support from tokenlists
-const ALLOWED_TOKENLIST_TAGS = ['circle']
+const ALLOWED_TOKENLIST_TAGS = ['circle', 'ondo']
 
 // TODO: Add proper return type annotation
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type


### PR DESCRIPTION
# Summary
Enable Ondo token tags in token selector. Adds "Tokenized by Ondo" tag display similar to USDC's "Issued by Circle" tag.

<img width="642" height="474" alt="Screenshot 2025-08-29 at 08 33 56" src="https://github.com/user-attachments/assets/07426983-193c-4852-ab8c-50cc1435b602" />


# To Test

  1. Open token selector on Mainnet
  2. Enable Ondo token list in Manage Lists
  3. Search for any Ondo token (e.g. `0x9DCf7f739B8C0270E2FC0Cc8D0DaBe355a150dBa`)

  - [ ] Ondo tokens should display "Tokenized by Ondo" tag
  - [ ] Tag should have blue info color and proper tooltip
  - [ ] Tag should appear alongside other token tags (gas-free, etc.)

# Background

  Ondo token list already defines the "ondo" tag with proper metadata, but it wasn't being displayed because only "circle" tags were allowed in the TokensListsTagsUpdater.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for the “ondo” token list tag alongside “circle.” Token lists using this tag are now recognized and surfaced wherever tagged lists appear, with standardized naming, description, and default Info color styling. Behavior for tag handling, de-duplication, and error handling remains unchanged, ensuring backward compatibility and leaving existing “circle” tag functionality intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->