### PR TITLE
fix: getAppDataHooks Crash when metadata is undefined

### DIFF
--- a/apps/cowswap-frontend/src/modules/appData/utils/getAppDataHooks.ts
+++ b/apps/cowswap-frontend/src/modules/appData/utils/getAppDataHooks.ts
@@ -14,7 +14,7 @@ import { AppDataHooks } from '../types'
 export function getAppDataHooks(fullAppData: Nullish<AnyAppDataDocVersion | string>): AppDataHooks | undefined {
   const decodedAppData = typeof fullAppData === 'string' ? decodeAppData(fullAppData) : fullAppData
 
-  if (!decodedAppData || !('hooks' in decodedAppData.metadata)) return undefined
+  if (!decodedAppData || !decodedAppData.metadata || !('hooks' in decodedAppData.metadata)) return undefined
 
   // TODO: this requires app-data v0.9.0. Might not work for newer versions...
   return decodedAppData.metadata.hooks as AppDataHooks


### PR DESCRIPTION
# Summary

 getAppDataHooks make the App Crash when metadata is undefined

Add screensh
<img width="912" height="494" alt="cowswaperror" src="https://github.com/user-attachments/assets/eeb6f42d-f238-43e7-a1a7-b2fa75b0ea0a" />
ots if applicable. Images are nice :)

# To Test

1. <<Step one>> Open the page `about`

- [ ] Go to https://swap.cow.fi/#/1/limit/
- [ ] Connect your wallet and enable hooks 
- [ ] Disconnect wallet, connect again 
- [ ] Go to https://swap.cow.fi/#/1/limit/ , the app should crash 


# Background

Metadata object is not always  present , just evaluate it 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when processing app data by verifying metadata presence before accessing hooks, preventing runtime errors when metadata is missing.
  * No changes to user-facing behavior or APIs; existing flows continue to work as before.
  * Reduces sporadic crashes and edge-case failures when dealing with incomplete app data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->