### PR TITLE
fix(trade): do not close auto-import modal when account changes

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetModals.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetModals.tsx
@@ -54,10 +54,12 @@ export function TradeWidgetModals({
   const updateTradeApproveState = useUpdateTradeApproveState()
 
   const resetAllScreens = useCallback(
-    (closeTokenSelectWidget = true) => {
+    (closeTokenSelectWidget = true, shouldCloseAutoImportModal = true) => {
       closeTradeConfirm()
       closeZeroApprovalModal()
-      closeAutoImportModal()
+      if (shouldCloseAutoImportModal) {
+        closeAutoImportModal()
+      }
       if (closeTokenSelectWidget) {
         updateSelectTokenWidgetState({ open: false })
       }
@@ -79,11 +81,11 @@ export function TradeWidgetModals({
   const error = tokenListAddingError || approveError || confirmError
 
   /**
-   * Close modals on chainId/account change
+   * Close all modals besides auto-import on account change
    */
   useEffect(() => {
-    resetAllScreens()
-  }, [chainId, account, resetAllScreens])
+    resetAllScreens(true, false)
+  }, [account, resetAllScreens])
 
   /**
    * Close all modals besides token select widget on chain change


### PR DESCRIPTION
# Summary

Fixed an issue with imToken wallet injected browser.

# To Test

1. Open CoW Swap in the imToken wallet injected browser with URL: /#/1/swap/USDT/NVDAon
2. It should display `NVDAon` token importing modal
3. It should display CoWSwap wallet access request on the wallet side
4. Click "Confirm"

- [ ] AR: The token importing modal disappears
- [ ] ER: You can proceed with the token importing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved modal behavior during account changes: AutoImport remains open while other trade modals and the token selector close appropriately.
  - Refined behavior on network changes: AutoImport now closes while the token selector remains open.
  - Overall, modal resets are more predictable, reducing accidental dismissals and interruptions during trading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->