### PR TITLE
fix(swap): replace swap unlock screen banner header

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/pure/CrossChainUnlockScreen/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/CrossChainUnlockScreen/index.tsx
@@ -20,7 +20,7 @@ export function CrossChainUnlockScreen({ handleUnlock }: CrossChainUnlockScreenP
     <>
       <styledEl.Container darkMode={darkMode}>
         <styledEl.Content>
-          <styledEl.Title>Swaps just got smarter</styledEl.Title>
+          <styledEl.Title>Cross-chain swaps are here</styledEl.Title>
           <styledEl.Subtitle>
             Mooove between <br /> any chain, hassle-free
           </styledEl.Subtitle>


### PR DESCRIPTION
# Summary

As per marketing's request, replace the unlock screen banner header from

> Swaps just got smarter

<img width="520" height="403" alt="image" src="https://github.com/user-attachments/assets/1c3a31b6-0ddb-4294-8821-0f512f5f74bc" />

To

> Cross-chain swaps are here

<img width="517" height="436" alt="image" src="https://github.com/user-attachments/assets/080019ba-3292-4292-8096-f52b005f5601" />


# To Test

1. Open CoW Swap
* Swap page text should be shown as above