### PR TITLE
feat(cow-fi): add redirect for MEV blocker to external site

### DIFF
--- a/apps/cow-fi/next.config.ts
+++ b/apps/cow-fi/next.config.ts
@@ -80,6 +80,11 @@ const nextConfig: WithNxOptions = {
         permanent: true,
       },
       {
+        source: '/mev-blocker',
+        destination: 'https://mevblocker.io',
+        permanent: true,
+      },
+      {
         source: '/widget/terms-and-conditions',
         destination: '/legal/integrator-terms',
         permanent: true,


### PR DESCRIPTION
# Summary

  Redirect `/mev-blocker` page to external site `https://mevblocker.io`

  # To Test

  1. Navigate to `/mev-blocker` on cow-fi app

  - [ ] Verify redirect to `https://mevblocker.io` occurs
  - [ ] Verify it's a permanent redirect (301 status)
  - [ ] Check browser URL changes to the external domain

  # Background

  MEV Blocker is now hosted externally. Added redirect in Next.js config
  following existing pattern used for `/report-scam` redirect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Visiting /mev-blocker now automatically redirects to https://mevblocker.io via a permanent redirect. This provides a direct path to the external resource from within the app. The behavior affects only this route; all other redirects and routes remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->