### PR TITLE
feat(cow-fi): add redirect for MEV blocker to external site

### DIFF
--- a/apps/cow-fi/next.config.ts
+++ b/apps/cow-fi/next.config.ts
@@ -80,6 +80,11 @@ const nextConfig: WithNxOptions = {
         permanent: true,
       },
       {
+        source: '/mev-blocker',
+        destination: 'https://mevblocker.io',
+        permanent: true,
+      },
+      {
         source: '/widget/terms-and-conditions',
         destination: '/legal/integrator-terms',
         permanent: true,


### PR DESCRIPTION
Redirect `/mev-blocker` page to external site `https://mevblocker.io`

# To Test

1. Navigate to `/mev-blocker` on cow-fi app

- [ ] Verify redirect to `https://mevblocker.io` occurs
- [ ] Verify it's a permanent redirect (301 status)
- [ ] Check browser URL changes to the external domain

# Background

MEV Blocker is now hosted externally. Added redirect in Next.js config
following existing pattern used for `/report-scam` redirect.