### PR TITLE
fix(swap): adjust swap banner header font size

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/pure/CrossChainUnlockScreen/styled.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/CrossChainUnlockScreen/styled.tsx
@@ -54,7 +54,7 @@ export const Content = styled.div`
 export const Title = styled.h2`
   margin: 0;
   color: inherit;
-  font-size: 36px;
+  font-size: 34px;
   font-weight: 800;
   line-height: 1.2;
 


### PR DESCRIPTION
# Summary

Tiny change to adjust font size.

From 
<img width="512" height="427" alt="image" src="https://github.com/user-attachments/assets/c1ad09b8-261e-49d8-8e35-6393cb0e19b9" />

To
<img width="495" height="385" alt="image" src="https://github.com/user-attachments/assets/d4c281e0-914d-43d2-96cf-8b67bf67fa60" />

# To Test

1. Open SWAP
* Text should NOT wrap in 3 rows, should fit into 2 rows instead