### PR TITLE
fix(tokens): remove mismatched network tokens from localStorage

### DIFF
--- a/libs/tokens/src/index.ts
+++ b/libs/tokens/src/index.ts
@@ -1,3 +1,7 @@
+import { migrateNetworkMismatchUserAddedTokens } from './state/migrations/migrateNetworkMismatchUserAddedTokens'
+
+migrateNetworkMismatchUserAddedTokens()
+
 // Updaters
 export { TokensListsUpdater } from './updaters/TokensListsUpdater'
 export { TokensListsTagsUpdater } from './updaters/TokensListsTagsUpdater'

--- a/libs/tokens/src/state/migrations/migrateNetworkMismatchUserAddedTokens.ts
+++ b/libs/tokens/src/state/migrations/migrateNetworkMismatchUserAddedTokens.ts
@@ -1,0 +1,34 @@
+// TODO: remove after 01.01.2026
+/**
+ * There was a bug which could lead to adding a custom token from a different network
+ * It was fixed in https://github.com/cowprotocol/cowswap/pull/4060
+ * Anyway, some users might have an old localStorage with consequences of the bug
+ * To fix that we have this migration that removes tokens that don't belong to current network
+ */
+export function migrateNetworkMismatchUserAddedTokens(): void {
+  const stateRaw = localStorage.getItem('userAddedTokensAtom:v1')
+
+  if (!stateRaw) return
+
+  try {
+    const state = JSON.parse(stateRaw)
+    let hasChanges = false
+
+    Object.keys(state).forEach((chainId) => {
+      const chainState = state[chainId]
+
+      Object.keys(chainState).forEach((tokenAddress) => {
+        const token = chainState[tokenAddress]
+
+        if (token.chainId && +token.chainId !== +chainId) {
+          hasChanges = true
+          delete chainState[tokenAddress]
+        }
+      })
+    })
+
+    if (hasChanges) {
+      localStorage.setItem('userAddedTokensAtom:v1', JSON.stringify(state))
+    }
+  } catch {}
+}


### PR DESCRIPTION
# Summary

Fixes #6227

There was a bug which could lead to adding a custom token from a different network.
It was fixed in https://github.com/cowprotocol/cowswap/pull/4060.
Anyway, some users might have an old localStorage with consequences of the bug.
To fix that we have this migration that removes tokens that don't belong to the current network.

I wasn't able to reproduce the bug naturaly, my only assumption is that localStorage might contain invalid tokens due to consequences of the mentioned bug.

# To Test

1. Add some custom tokens to different networks
2. Manually edit localStorage of `userAddedTokensAtom:v1` and change some token chainId to a wrong one
3. Reload page
- [ ] `userAddedTokensAtom:v1` should be automatically updated and the token with wrong chainId should be deleted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically cleans up user-added tokens that don’t match the current network, preventing incorrect or stale tokens from appearing after network changes.
  * Improves accuracy of token lists and balances by removing mismatched entries stored from previous sessions.
  * Runs seamlessly on app load with no user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->