### PR TITLE
fix: skip trade if order valid time is non-positive

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowContext.ts
@@ -108,7 +108,8 @@ export function useTradeFlowContext({ deadline }: TradeFlowParams): TradeFlowCon
         tradeQuote.fetchParams?.priceQuality === PriceQuality.OPTIMAL &&
         orderKind &&
         settlementContract &&
-        uiOrderType
+        uiOrderType &&
+        validTo > 0
         ? [
             account,
             allowsOffchainSigning,


### PR DESCRIPTION
# Summary

In some rare cases, the value of `deadline` passed to a hook is `0`. This fix prevent an order to be executed if the value is non-positive.

# To Test

N/A: I couldn't find a reliable way to reproduce the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents data fetches for expired or invalid orders in the trading flow, reducing errors and edge-case failures.
  * Improves stability by ensuring requests only occur when orders have a valid expiration.

* **Performance**
  * Reduces unnecessary network calls and UI flicker by gating fetches until order validity is confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->