### PR TITLE
fix: ensure token selector closes on token selection

### DIFF
--- a/apps/cowswap-frontend/src/modules/tokensList/hooks/useOpenTokenSelectWidget.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/hooks/useOpenTokenSelectWidget.ts
@@ -20,7 +20,6 @@ export function useOpenTokenSelectWidget(): (
   const updateSelectTokenWidget = useUpdateSelectTokenWidgetState()
   const closeTokenSelectWidget = useCloseTokenSelectWidget()
   const isBridgingEnabled = useIsBridgingEnabled()
-  // No need to derive wallet chain id here; selection closes regardless of network
 
   return useCallback(
     (selectedToken, field, oppositeToken, onSelectToken) => {


### PR DESCRIPTION
Addresses https://github.com/cowprotocol/cowswap/issues/6251

 
* Bug Fixes: Token selector now closes immediately after selecting a token (same or cross‑network), fixing cases where it remained open.
* UX Improvements: Consistent, predictable selection flow across INPUT/OUTPUT.
 
-----------

## Notes
- Change: Always call `closeTokenSelectWidget()` on selection.
- Consideration: If wallet network switch fails, the modal is closed; error snackbar is shown and user can reopen. Navigation/state updates are independent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Token selection modal now closes immediately after choosing a token, regardless of network or bridging state, ensuring consistent behavior.

* **Refactor**
  * Simplified internal token selection handling to reduce conditional logic while preserving existing external behavior.

* **Tests**
  * No public API changes; existing integrations remain compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->