### PR TITLE
fix: explorer environments

### DIFF
--- a/apps/explorer/.env.dev
+++ b/apps/explorer/.env.dev
@@ -1,0 +1,1 @@
+NODE_ENV=production

--- a/apps/explorer/.env.example
+++ b/apps/explorer/.env.example
@@ -15,3 +15,10 @@ REACT_APP_IPFS_READ_URI=https://ipfs.io/ipfs
 
 # The API key to use for the CoW Protocol Subgraph. {@link https://thegraph.com/studio/apikeys/}
 THEGRAPH_API_KEY=
+
+# Domain regex (to detect environment)
+# REACT_APP_DOMAIN_REGEX_LOCAL="^(:?localhost:\d{2,5}|(?:127|192)(?:\.[0-9]{1,3}){3})"
+# REACT_APP_DOMAIN_REGEX_PR="^(dev\.explorer\.cow\.fi|explorer-dev-git-[\w\d-]+cowswap-dev\.vercel\.app)"
+# REACT_APP_DOMAIN_REGEX_DEVELOPMENT="^(dev\.explorer\.cow\.fi|explorer-develop\.vercel\.app)"
+# REACT_APP_DOMAIN_REGEX_STAGING="^(staging\.explorer\.cow\.fi|explorer-staging\.vercel\.app)"
+# REACT_APP_DOMAIN_REGEX_PRODUCTION="^(explorer\.cow\.fi|explorer-prod\.vercel\.app)$"

--- a/apps/explorer/.env.production
+++ b/apps/explorer/.env.production
@@ -1,0 +1,1 @@
+NODE_ENV=production

--- a/apps/explorer/.env.staging
+++ b/apps/explorer/.env.staging
@@ -1,0 +1,1 @@
+NODE_ENV=production

--- a/apps/explorer/project.json
+++ b/apps/explorer/project.json
@@ -6,16 +6,17 @@
   "targets": {
     "build": {
       "executor": "@nx/vite:build",
-      "outputs": [
-        "{options.outputPath}"
-      ],
+      "outputs": ["{options.outputPath}"],
       "defaultConfiguration": "production",
       "options": {
         "outputPath": "build/explorer"
       },
       "configurations": {
-        "development": {
-          "mode": "development"
+        "dev": {
+          "mode": "dev"
+        },
+        "staging": {
+          "mode": "staging"
         },
         "production": {
           "mode": "production"
@@ -24,13 +25,17 @@
     },
     "serve": {
       "executor": "@nx/vite:dev-server",
-      "defaultConfiguration": "development",
+      "defaultConfiguration": "dev",
       "options": {
         "buildTarget": "explorer:build"
       },
       "configurations": {
-        "development": {
-          "buildTarget": "explorer:build:development",
+        "dev": {
+          "buildTarget": "explorer:build:dev",
+          "hmr": true
+        },
+        "staging": {
+          "buildTarget": "explorer:build:staging",
           "hmr": true
         },
         "production": {
@@ -41,13 +46,16 @@
     },
     "preview": {
       "executor": "@nx/vite:preview-server",
-      "defaultConfiguration": "development",
+      "defaultConfiguration": "dev",
       "options": {
         "buildTarget": "explorer:build"
       },
       "configurations": {
-        "development": {
-          "buildTarget": "explorer:build:development"
+        "dev": {
+          "buildTarget": "explorer:build:dev"
+        },
+        "staging": {
+          "buildTarget": "explorer:build:staging"
         },
         "production": {
           "buildTarget": "explorer:build:production"
@@ -63,13 +71,9 @@
     },
     "lint": {
       "executor": "@nx/eslint:lint",
-      "outputs": [
-        "{options.outputFile}"
-      ],
+      "outputs": ["{options.outputFile}"],
       "options": {
-        "lintFilePatterns": [
-          "apps/explorer/**/*.{ts,tsx,js,jsx}"
-        ]
+        "lintFilePatterns": ["apps/explorer/**/*.{ts,tsx,js,jsx}"]
       }
     },
     "serve-static": {

--- a/libs/common-utils/src/environments.ts
+++ b/libs/common-utils/src/environments.ts
@@ -3,9 +3,11 @@ import { registerOnWindow } from './misc'
 const DEFAULT_ENVIRONMENTS_REGEX: Record<EnvironmentName, string> = {
   local: '^(:?localhost:\\d{2,5}|(?:127|192)(?:\\.[0-9]{1,3}){3})',
   pr: '^((?:explorer|swap)-dev-git-[\\w\\d-]+|swap-\\w{9}-)cowswap-dev\\.vercel\\.app',
-  development: '^(dev.swap.cow.fi|swap-develop.vercel.app)',
-  staging: '^(staging.swap.cow.fi|swap-staging.vercel.app)',
-  production: '^(swap.cow.fi|swap-prod.vercel.app)$',
+  development:
+    '^(dev.swap.cow.fi|dev.explorer.cow.fi|swap-develop.vercel.app|explorer-dev-git-develop-cowswap-dev.vercel.app)',
+  staging:
+    '^(staging.swap.cow.fi|staging.explorer.cow.fi|swap-staging.vercel.app|explorer-dev-git-main-cowswap-dev.vercel.app)',
+  production: '^(swap.cow.fi|staging.cow.fi|swap-prod.vercel.app)$',
   barn: '^(barn.cow.fi|swap-barn.vercel.app)$',
   ens: '(:?^cowswap.eth|ipfs)',
 }


### PR DESCRIPTION
# Summary

This fix allows the Explorer to recognise the correct environment is deployed to.
It should fix the incorrect Bungee endpoint it calls (currently it defaults to the public endpoints).

# Test

1. Must be on `Dev`, `Staging`, or `Production` environments
2. Any call to `https://backend.bungee.exchange` should have the `Affiliate` header 
