### PR TITLE
fix(bridge): allow bridging when wallet not connected

### DIFF
--- a/apps/cowswap-frontend/src/common/updaters/BridgingEnabledUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/BridgingEnabledUpdater.ts
@@ -1,13 +1,14 @@
 import { useEffect } from 'react'
 
 import { useFeatureFlags, useSetIsBridgingEnabled } from '@cowprotocol/common-hooks'
-import { useIsSmartContractWallet } from '@cowprotocol/wallet'
+import { useIsSmartContractWallet, useWalletInfo } from '@cowprotocol/wallet'
 
 import { useTradeTypeInfo } from 'modules/trade'
 
 import { Routes } from '../constants/routes'
 
 export function BridgingEnabledUpdater(): null {
+  const { account } = useWalletInfo()
   const { isBridgingEnabled } = useFeatureFlags()
   const tradeTypeInfo = useTradeTypeInfo()
   const isSmartContractWallet = useIsSmartContractWallet()
@@ -15,18 +16,12 @@ export function BridgingEnabledUpdater(): null {
 
   const isSwapRoute = tradeTypeInfo?.route === Routes.SWAP
 
-  function shouldEnableBridging(
-    featureFlagEnabled: boolean,
-    scWallet: boolean | undefined,
-    swapRoute: boolean,
-  ): boolean {
-    // Only enable bridging once we definitively know it's an EOA (strict false)
-    return featureFlagEnabled && scWallet === false && swapRoute
-  }
+  const isWalletCompatible = Boolean(account ? isSmartContractWallet === false : true)
+  const shouldEnableBridging = isBridgingEnabled && isWalletCompatible && isSwapRoute
 
   useEffect(() => {
-    setIsBridgingEnabled(shouldEnableBridging(isBridgingEnabled, isSmartContractWallet, isSwapRoute))
-  }, [setIsBridgingEnabled, isBridgingEnabled, isSmartContractWallet, isSwapRoute])
+    setIsBridgingEnabled(shouldEnableBridging)
+  }, [setIsBridgingEnabled, shouldEnableBridging])
 
   return null
 }


### PR DESCRIPTION
# Summary

Fixes #6273

We check `isSmartContractWallet === false`, but when wallet is not connected the value is `undefined`.

# To Test

1. Bridging should be available when the wallet is not connected
2. Bridging should NOT be available for smart-contract wallets
