### PR TITLE
fix: handle type for order class data

### DIFF
--- a/apps/explorer/src/utils/getUiOrderType.ts
+++ b/apps/explorer/src/utils/getUiOrderType.ts
@@ -1,5 +1,4 @@
-import { cowAppDataLatestScheme } from '@cowprotocol/cow-sdk'
-import { OrderClass } from '@cowprotocol/cow-sdk'
+import { cowAppDataLatestScheme, OrderClass } from '@cowprotocol/cow-sdk'
 
 import { Order } from 'api/operator'
 import { decodeFullAppData } from 'utils/decodeFullAppData'
@@ -30,8 +29,13 @@ const API_ORDER_CLASS_TO_UI_ORDER_TYPE_MAP: Record<OrderClass, UiOrderType> = {
 export function getUiOrderType({ fullAppData, class: orderClass }: Order): UiOrderType {
   const appData = decodeFullAppData(fullAppData)
 
-  const appDataOrderClass = appData?.metadata?.orderClass as cowAppDataLatestScheme.OrderClass | undefined
-  const typeFromAppData = UiOrderType[appDataOrderClass?.orderClass.toUpperCase() || '']
+  const appDataOrderClass = appData?.metadata?.orderClass as cowAppDataLatestScheme.OrderClass | undefined | string
+  const orderClassAsString =
+    typeof appDataOrderClass === 'string'
+      ? appDataOrderClass.toUpperCase()
+      : appDataOrderClass?.orderClass.toUpperCase() || ''
+
+  const typeFromAppData = UiOrderType[orderClassAsString]
 
   // 1. AppData info has priority as it's what's more precise
   if (typeFromAppData) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "start:omnibridge-hook": "nx run hook-dapp-omnibridge:serve",
     "start:cosmos": "nx run cowswap-frontend:cosmos:run",
     "start:cosmos:explorer": "nx run explorer:cosmos:run",
-    "start:explorer": "nx run explorer:serve",
+    "start:explorer": "cross-env NODE_ENV=development nx run explorer:serve",
     "start:cowfi": "cross-env PORT=3001 nx run cow-fi:dev",
     "start:sdk-tools": "nx run sdk-tools:serve",
     "build": "yarn run build:cowswap",


### PR DESCRIPTION
# Summary

Fixes https://cowservices.slack.com/archives/C036G0J90BU/p1758541883776469

In a user case the sdk returns string value directly, I've added validation for that

# To Test

1. Open [https://explorer.cow.fi/base/orders/0x1a125cc0ed048b704f535a6245aca541e623bbb422b764[…]5f779b31b1cbb51c5e10189099ae4a09860351678bfff374961c068cc0102](https://explorer.cow.fi/base/orders/0x1a125cc0ed048b704f535a6245aca541e623bbb422b764d564b5f779b31b1cbb51c5e10189099ae4a09860351678bfff374961c068cc0102)

- [ ] you should see the order status


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Improved reliability of order type display by correctly handling string-based AppData order classes and preserving existing priority logic.
- Refactor
  - Simplified and consolidated logic for resolving UI order types, reducing lookup complexity.
- Chores
  - Updated start:explorer script to run the Explorer in development mode by default (via NODE_ENV=development).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->