### PR TITLE
ci: add node-workspace plugin to release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "last-release-sha": "dbf70fcb64ad3255b34779821721fc7b2dab0c31",
+  "plugins": ["node-workspace"],
   "packages": {
     "apps/cowswap-frontend": {
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
# Summary

The plugin is supposed to automatically bump transitive versions

https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#node-workspace


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated release automation configuration to better support multi-package/workspace projects, improving versioning and changelog generation across packages.
  - This change streamlines release workflows and consistency for future releases.
- No User-Facing Changes
  - No impact to application features, behavior, or APIs in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->