### PR TITLE
fix: remove feature flags

### DIFF
--- a/libs/common-hooks/src/useAvailableChains.ts
+++ b/libs/common-hooks/src/useAvailableChains.ts
@@ -3,8 +3,6 @@ import { useMemo } from 'react'
 import { getAvailableChains } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
-import { useFeatureFlags } from './useFeatureFlags'
-
 /**
  * Hook to get a list of SupportedChainId currently available/enabled
  *
@@ -14,20 +12,20 @@ import { useFeatureFlags } from './useFeatureFlags'
  */
 export function useAvailableChains(): SupportedChainId[] {
   // 1. Load feature flag for chain being enabled
-  const { isBnbEnabled } = useFeatureFlags()
+  // const { isBnbEnabled } = useFeatureFlags()
 
   return useMemo(
     // 2. Conditionally build a list of chain ids to exclude
     // () => getAvailableChains(isBaseEnabled ? undefined : [SupportedChainId.BASE]),  <-- example usage, kept for reference
     () => {
-      const chainsToSkip: SupportedChainId[] = []
+      // const chainsToSkip: SupportedChainId[] = []
+      //
+      // if (!isBnbEnabled) {
+      //   chainsToSkip.push(SupportedChainId.BNB)
+      // }
 
-      if (!isBnbEnabled) {
-        chainsToSkip.push(SupportedChainId.BNB)
-      }
-
-      return getAvailableChains(chainsToSkip)
+      return getAvailableChains()
     },
-    [isBnbEnabled],
+    [],
   )
 }

--- a/libs/common-hooks/src/useAvailableChains.ts
+++ b/libs/common-hooks/src/useAvailableChains.ts
@@ -14,7 +14,7 @@ import { useFeatureFlags } from './useFeatureFlags'
  */
 export function useAvailableChains(): SupportedChainId[] {
   // 1. Load feature flag for chain being enabled
-  const { isLensEnabled, isBnbEnabled } = useFeatureFlags()
+  const { isBnbEnabled } = useFeatureFlags()
 
   return useMemo(
     // 2. Conditionally build a list of chain ids to exclude
@@ -22,16 +22,12 @@ export function useAvailableChains(): SupportedChainId[] {
     () => {
       const chainsToSkip: SupportedChainId[] = []
 
-      if (!isLensEnabled) {
-        chainsToSkip.push(SupportedChainId.LENS)
-      }
-
       if (!isBnbEnabled) {
         chainsToSkip.push(SupportedChainId.BNB)
       }
 
       return getAvailableChains(chainsToSkip)
     },
-    [isLensEnabled, isBnbEnabled],
+    [isBnbEnabled],
   )
 }


### PR DESCRIPTION
# Summary

Remove feature flags for Lens and BNB as soon both will be live

# To Test

1. Lens and BNB should work as usual

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * All supported chains are now always available in the app.
  * Previously gated networks (e.g., Lens and BNB) are enabled by default, removing variability based on feature flags.
  * Simplifies chain selection for users by presenting the complete list consistently across sessions and environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->