### PR TITLE
refactor: replace isInjectedWidgetMode with isWidget across components

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/GlobalWarning/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/GlobalWarning/index.tsx
@@ -38,8 +38,8 @@ const Container = styled.div`
   font-size: 12px;
   color: var(${UI.COLOR_BUTTON_TEXT});
   background-color: var(${UI.COLOR_PRIMARY});
-  border-radius: ${({ theme }) => (theme.isInjectedWidgetMode ? '8px' : '')};
-  margin-bottom: ${({ theme }) => (theme.isInjectedWidgetMode ? '10px' : '')};
+  border-radius: ${({ theme }) => (theme.isWidget ? '8px' : '')};
+  margin-bottom: ${({ theme }) => (theme.isWidget ? '10px' : '')};
 
   ${Media.upToSmall()} {
     padding: 12px 8px;

--- a/apps/cowswap-frontend/src/common/pure/LoadingApp/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/LoadingApp/index.tsx
@@ -69,9 +69,7 @@ const LoadingWrapper = styled.div`
   justify-content: center;
   position: fixed;
   background: ${({ theme }) =>
-    theme.isInjectedWidgetMode
-      ? 'transparent'
-      : transparentize(theme.darkMode ? '#0E0F2D' : Color.blue300Primary, 0.1)};
+    theme.isWidget ? 'transparent' : transparentize(theme.darkMode ? '#0E0F2D' : Color.blue300Primary, 0.1)};
   z-index: 99;
   top: 0;
   left: 0;
@@ -80,7 +78,7 @@ const LoadingWrapper = styled.div`
   backdrop-filter: blur(3px);
 
   ${({ theme }) =>
-    !theme.isInjectedWidgetMode &&
+    !theme.isWidget &&
     css`
       &:before {
         content: '';
@@ -122,7 +120,7 @@ const LoadingWrapper = styled.div`
     font-size: 10px;
     font-weight: 400;
     letter-spacing: 4px;
-    margin: ${({ theme }) => (theme.isInjectedWidgetMode ? '0 auto' : '14px auto 0')};
+    margin: ${({ theme }) => (theme.isWidget ? '0 auto' : '14px auto 0')};
     color: ${({ theme }) => theme.text};
   }
 

--- a/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/styled.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/styled.tsx
@@ -44,7 +44,7 @@ export const Wrapper = styled.div<{ active: boolean }>`
   }
 
   ${({ theme }) =>
-    theme.isInjectedWidgetMode &&
+    theme.isWidget &&
     `
     background-color: transparent;
     margin: 0 20px 0 auto!important;

--- a/apps/cowswap-frontend/src/modules/account/containers/OrdersPanel/index.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/OrdersPanel/index.tsx
@@ -42,7 +42,7 @@ const SideBar = styled.div`
     width: 100%;
     height: 100%;
     max-width: 100%;
-    border-radius: ${({ theme }) => (theme.isInjectedWidgetMode ? '24px' : '0')};
+    border-radius: ${({ theme }) => (theme.isWidget ? '24px' : '0')};
     z-index: 10;
   }
 
@@ -58,7 +58,7 @@ const SidebarBackground = styled.div`
   z-index: 4;
   width: 100%;
   height: 100%;
-  background: ${({ theme }) => (theme.isInjectedWidgetMode ? 'transparent' : transparentize(theme.black, 0.1))};
+  background: ${({ theme }) => (theme.isWidget ? 'transparent' : transparentize(theme.black, 0.1))};
   backdrop-filter: blur(3px);
 
   ${Media.upToSmall()} {

--- a/apps/cowswap-frontend/src/modules/application/containers/App/styled.ts
+++ b/apps/cowswap-frontend/src/modules/application/containers/App/styled.ts
@@ -28,8 +28,8 @@ export const AppWrapper = styled.div<Partial<CSS.Properties>>`
   display: flex;
   flex-flow: column;
   align-items: flex-start;
-  min-height: ${({ theme }) => (theme.isInjectedWidgetMode ? '400px' : '100vh')};
-  height: ${({ theme }) => (theme.isInjectedWidgetMode ? 'initial' : '100%')};
+  min-height: ${({ theme }) => (theme.isWidget ? '400px' : '100vh')};
+  height: ${({ theme }) => (theme.isWidget ? 'initial' : '100%')};
 `
 
 export const Marginer = styled.div`
@@ -46,13 +46,13 @@ export const BodyWrapper = styled.div<{ customTheme?: CowSwapTheme }>`
   flex: 1 1 auto;
   z-index: 2;
   color: inherit;
-  padding: ${({ theme }) => (theme.isInjectedWidgetMode ? '16px 16px 0' : '150px 16px 76px')};
-  margin: ${({ theme }) => (theme.isInjectedWidgetMode ? '0' : '-76px auto calc(var(--marginBottomOffset) * -1);')};
-  border-bottom-left-radius: ${({ theme }) => (theme.isInjectedWidgetMode ? '0' : 'var(--marginBottomOffset)')};
-  border-bottom-right-radius: ${({ theme }) => (theme.isInjectedWidgetMode ? '0' : 'var(--marginBottomOffset)')};
-  min-height: ${({ theme }) => (theme.isInjectedWidgetMode ? 'initial' : 'calc(100vh - 200px)')};
+  padding: ${({ theme }) => (theme.isWidget ? '16px 16px 0' : '150px 16px 76px')};
+  margin: ${({ theme }) => (theme.isWidget ? '0' : '-76px auto calc(var(--marginBottomOffset) * -1);')};
+  border-bottom-left-radius: ${({ theme }) => (theme.isWidget ? '0' : 'var(--marginBottomOffset)')};
+  border-bottom-right-radius: ${({ theme }) => (theme.isWidget ? '0' : 'var(--marginBottomOffset)')};
+  min-height: ${({ theme }) => (theme.isWidget ? 'initial' : 'calc(100vh - 200px)')};
   background: ${({ theme, customTheme }) => {
-    if (theme.isInjectedWidgetMode) {
+    if (theme.isWidget) {
       return 'transparent'
     } else {
       const backgroundColor = theme.darkMode ? '#0E0F2D' : `var(${UI.COLOR_BLUE_300_PRIMARY})`
@@ -73,9 +73,9 @@ export const BodyWrapper = styled.div<{ customTheme?: CowSwapTheme }>`
   }};
 
   ${Media.upToMedium()} {
-    padding: ${({ theme }) => (theme.isInjectedWidgetMode ? '0 0 16px' : '150px 16px 76px')};
+    padding: ${({ theme }) => (theme.isWidget ? '0 0 16px' : '150px 16px 76px')};
     flex: none;
-    min-height: ${({ theme }) => (theme.isInjectedWidgetMode ? 'initial' : 'calc(100vh - 200px)')};
+    min-height: ${({ theme }) => (theme.isWidget ? 'initial' : 'calc(100vh - 200px)')};
     background-size: auto;
 
     ${({ customTheme }) =>
@@ -86,15 +86,15 @@ export const BodyWrapper = styled.div<{ customTheme?: CowSwapTheme }>`
 
     ${({ customTheme, theme }) =>
       isChristmasTheme(customTheme) &&
-      !theme.isInjectedWidgetMode &&
+      !theme.isWidget &&
       `
         background-image: url(${theme.darkMode ? IMAGE_BACKGROUND_DARK_CHRISTMAS_MEDIUM : IMAGE_BACKGROUND_LIGHT_CHRISTMAS_MEDIUM});
       `}
   }
 
   ${Media.upToSmall()} {
-    padding: ${({ theme }) => (theme.isInjectedWidgetMode ? '0 0 16px' : '90px 16px 76px')};
-    min-height: ${({ theme }) => (theme.isInjectedWidgetMode ? 'initial' : 'calc(100vh - 100px)')};
+    padding: ${({ theme }) => (theme.isWidget ? '0 0 16px' : '90px 16px 76px')};
+    min-height: ${({ theme }) => (theme.isWidget ? 'initial' : 'calc(100vh - 100px)')};
 
     ${({ customTheme }) =>
       customTheme === 'darkHalloween' &&
@@ -104,7 +104,7 @@ export const BodyWrapper = styled.div<{ customTheme?: CowSwapTheme }>`
 
     ${({ customTheme, theme }) =>
       isChristmasTheme(customTheme) &&
-      !theme.isInjectedWidgetMode &&
+      !theme.isWidget &&
       `
         background-image: url(${theme.darkMode ? IMAGE_BACKGROUND_DARK_CHRISTMAS_SMALL : IMAGE_BACKGROUND_LIGHT_CHRISTMAS_SMALL});
       `}

--- a/apps/cowswap-frontend/src/modules/notifications/containers/NotificationBell.tsx
+++ b/apps/cowswap-frontend/src/modules/notifications/containers/NotificationBell.tsx
@@ -14,7 +14,7 @@ const Icon = styled.div<{ hasNotification?: boolean }>`
   width: var(--size);
   height: var(--size);
   position: relative;
-  display: ${({ theme }) => (theme.isInjectedWidgetMode ? 'none' : 'flex')};
+  display: ${({ theme }) => (theme.isWidget ? 'none' : 'flex')};
   align-items: center;
   justify-content: center;
   cursor: pointer;

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/styled.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/styled.tsx
@@ -19,7 +19,7 @@ export const ContainerBox = styled.div`
   color: var(${UI.COLOR_TEXT_PAPER});
   border: none;
   border-radius: var(${UI.BORDER_RADIUS_NORMAL});
-  box-shadow: ${({ theme }) => (theme.isInjectedWidgetMode ? theme.boxShadow1 : 'none')};
+  box-shadow: ${({ theme }) => (theme.isWidget ? theme.boxShadow1 : 'none')};
   padding: 10px;
   position: relative;
 
@@ -37,7 +37,7 @@ export const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: ${({ theme }) => (theme.isInjectedWidgetMode ? '0 7px' : '0 5px 0 0')};
+  padding: ${({ theme }) => (theme.isWidget ? '0 7px' : '0 5px 0 0')};
   margin: 0;
   color: inherit;
 `

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidgetLinks/styled.ts
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidgetLinks/styled.ts
@@ -83,10 +83,10 @@ export const MenuItem = styled.div<{ isActive?: boolean; isDropdownVisible: bool
     align-items: center;
     justify-content: flex-start;
     text-align: left;
-    font-size: ${({ theme }) => (theme.isInjectedWidgetMode ? '16px' : '14px')};
-    font-weight: ${({ theme }) => (theme.isInjectedWidgetMode ? '600' : '500')};
+    font-size: ${({ theme }) => (theme.isWidget ? '16px' : '14px')};
+    font-weight: ${({ theme }) => (theme.isWidget ? '600' : '500')};
     border-radius: var(${UI.BORDER_RADIUS_NORMAL});
-    padding: ${({ theme }) => (theme.isInjectedWidgetMode ? '7px' : '5px 10px')};
+    padding: ${({ theme }) => (theme.isWidget ? '7px' : '5px 10px')};
     background: transparent;
     transition: background var(${UI.ANIMATION_DURATION}) ease-in-out;
     color: inherit;
@@ -131,7 +131,7 @@ export const SelectMenu = styled.div`
   border-radius: var(${UI.BORDER_RADIUS_NORMAL});
 
   > div:first-child {
-    margin-bottom: ${({ theme }) => (theme.isInjectedWidgetMode ? '16px' : '24px')};
+    margin-bottom: ${({ theme }) => (theme.isWidget ? '16px' : '24px')};
   }
 `
 

--- a/apps/cowswap-frontend/src/modules/wallet/pure/Web3StatusInner/styled.ts
+++ b/apps/cowswap-frontend/src/modules/wallet/pure/Web3StatusInner/styled.ts
@@ -6,11 +6,11 @@ export const Web3StatusGeneric = styled(ButtonSecondary)``
 
 export const Web3StatusConnect = styled(Web3StatusGeneric)<{ faded?: boolean }>`
   > svg {
-    display: ${({ theme }) => (theme.isInjectedWidgetMode ? '' : 'none')};
+    display: ${({ theme }) => (theme.isWidget ? '' : 'none')};
   }
 
   ${({ theme }) =>
-    theme.isInjectedWidgetMode &&
+    theme.isWidget &&
     css`
       margin: 0;
       padding: 6px 12px;
@@ -67,14 +67,14 @@ export const Text = styled.p`
   text-overflow: ellipsis;
   white-space: nowrap;
   margin: 0;
-  font-size: ${({ theme }) => (theme.isInjectedWidgetMode ? '15px' : '16px')};
+  font-size: ${({ theme }) => (theme.isWidget ? '15px' : '16px')};
   width: fit-content;
   font-weight: 500;
 `
 
 export const Wrapper = styled.div`
   color: inherit;
-  height: ${({ theme }) => (theme.isInjectedWidgetMode ? 'initial' : '100%')};
+  height: ${({ theme }) => (theme.isWidget ? 'initial' : '100%')};
   max-height: 100%;
   display: flex;
   padding: 0;

--- a/apps/cowswap-frontend/src/theme/ThemedGlobalStyle.tsx
+++ b/apps/cowswap-frontend/src/theme/ThemedGlobalStyle.tsx
@@ -52,8 +52,7 @@ export const ThemedGlobalStyle = createGlobalStyle`
   }
 
   html {
-    background-color: ${({ theme }) =>
-      theme.isInjectedWidgetMode ? 'transparent' : `var(${UI.COLOR_CONTAINER_BG_02})`};
+    background-color: ${({ theme }) => (theme.isWidget ? 'transparent' : `var(${UI.COLOR_CONTAINER_BG_02})`)};
   }
 
   *, *:after, *:before {
@@ -61,8 +60,8 @@ export const ThemedGlobalStyle = createGlobalStyle`
   }
 
   body {
-    background: ${({ theme }) => (theme?.isInjectedWidgetMode ? 'transparent' : `var(${UI.COLOR_NEUTRAL_98})`)};
-    min-height: ${({ theme }) => (theme.isInjectedWidgetMode ? 'auto' : '100vh')};
+    background: ${({ theme }) => (theme.isWidget ? 'transparent' : `var(${UI.COLOR_NEUTRAL_98})`)};
+    min-height: ${({ theme }) => (theme.isWidget ? 'auto' : '100vh')};
 
     &.noScroll {
       overflow: hidden;

--- a/apps/cowswap-frontend/src/theme/getCowswapTheme.ts
+++ b/apps/cowswap-frontend/src/theme/getCowswapTheme.ts
@@ -8,9 +8,6 @@ const isWidget = isInjectedWidget()
 const widgetMode = {
   isWidget,
   isIframe: isIframe(),
-  // TODO: isInjectedWidgetMode is deprecated, use isWidget instead
-  // This alias is kept for backward compatibility with styled components
-  isInjectedWidgetMode: isWidget,
 }
 
 export function getCowswapTheme(darkmode: boolean): CoWSwapTheme {

--- a/apps/cowswap-frontend/src/theme/types.ts
+++ b/apps/cowswap-frontend/src/theme/types.ts
@@ -9,9 +9,6 @@ declare module 'styled-components' {
     /** Properties specific to CoWSwap widget functionality */
     isWidget: boolean
     isIframe: boolean
-
-    /** @deprecated Use isWidget instead */
-    isInjectedWidgetMode: boolean
   }
 
   // Use CoWSwapTheme as the default theme for styled-components in this app


### PR DESCRIPTION
# Summary

  Removed the deprecated `isInjectedWidgetMode` theme flag so components now rely solely on `isWidget`.

  # To Test

  1. Open the widget build (e.g. embedded widget preview)
     - [ ] Body/background styling matches previous widget appearance
     - [ ] Header/account elements render with widget-specific layout

  2. Open the standard app shell
     - [ ] Full-page background and minimum height behave as before
     - [ ] Theme-driven components (menus, loaders, notifications) still render correctly

  # Background

  Cleaning up the leftover alias now that all references have been migrated to `isWidget`.