### PR TITLE
fix(account-modal): prevent crash with unexpected empty appData.metadata

### DIFF
--- a/apps/cowswap-frontend/src/common/containers/OrderHooksDetails/index.tsx
+++ b/apps/cowswap-frontend/src/common/containers/OrderHooksDetails/index.tsx
@@ -42,7 +42,8 @@ export function OrderHooksDetails({ appData, children, margin, isTradeConfirmati
     if (isTradeConfirmation) mutate()
   }, [isTradeConfirmation, mutate])
 
-  if (!appDataDoc) return null
+  // Not all versions of appData have metadata
+  if (!appDataDoc?.metadata) return null
 
   const metadata = appDataDoc.metadata as cowAppDataLatestScheme.Metadata
 


### PR DESCRIPTION
# Summary

There's a crash due to an order with appData contents set to `{}`

At this point, the code expects orders to follow the appData schema, which is not the case here.

# To Test

1. On prod/staging, impersonate `0x2dB8323b3766b868AAF6a967E55eEb35C233DE9d`
2. Open the account modal
* Should NOT crash