### PR TITLE
fix(bridging): disable Across bridging provider on prod like envs

### DIFF
--- a/apps/cowswap-frontend/src/tradingSdk/bridgingSdk.ts
+++ b/apps/cowswap-frontend/src/tradingSdk/bridgingSdk.ts
@@ -1,6 +1,12 @@
 import { bungeeAffiliateCode } from '@cowprotocol/common-const'
-import { isBarn, isDev, isProd, isStaging } from '@cowprotocol/common-utils'
-import { AcrossBridgeProvider, BridgingSdk, BungeeBridgeProvider } from '@cowprotocol/sdk-bridging'
+import { isBarn, isDev, isProd, isProdLike, isStaging } from '@cowprotocol/common-utils'
+import {
+  AcrossBridgeProvider,
+  BridgeProvider,
+  BridgeQuoteResult,
+  BridgingSdk,
+  BungeeBridgeProvider,
+} from '@cowprotocol/sdk-bridging'
 
 import { orderBookApi } from 'cowSdk'
 
@@ -19,7 +25,10 @@ const bungeeBridgeProvider = new BungeeBridgeProvider({
 
 const acrossBridgeProvider = new AcrossBridgeProvider()
 
-export const bridgeProviders = [bungeeBridgeProvider, acrossBridgeProvider]
+export const bridgeProviders: BridgeProvider<BridgeQuoteResult>[] = [bungeeBridgeProvider]
+
+// TODO: Should not enable Across on Prod until it's finalized
+isProdLike && bridgeProviders.push(acrossBridgeProvider)
 
 export const bridgingSdk = new BridgingSdk({
   providers: bridgeProviders,

--- a/apps/cowswap-frontend/src/tradingSdk/bridgingSdk.ts
+++ b/apps/cowswap-frontend/src/tradingSdk/bridgingSdk.ts
@@ -28,7 +28,7 @@ const acrossBridgeProvider = new AcrossBridgeProvider()
 export const bridgeProviders: BridgeProvider<BridgeQuoteResult>[] = [bungeeBridgeProvider]
 
 // TODO: Should not enable Across on Prod until it's finalized
-isProdLike && bridgeProviders.push(acrossBridgeProvider)
+!isProdLike && bridgeProviders.push(acrossBridgeProvider)
 
 export const bridgingSdk = new BridgingSdk({
   providers: bridgeProviders,


### PR DESCRIPTION
# Summary

Should not show Across bridging provider on prod like envs (staging, prod, ens, barn).

# To Test

1. Deploy to a prod like env
* Across should not show up
2. On non prod like env (like this PR)
* Across should still be an option

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bridge availability is now environment-aware, showing only supported bridge options per environment (e.g., Across visible in production-like builds).
* **Refactor**
  * Updated bridging configuration to support additional options and improved logging for better observability.
  * Enhanced provider setup to streamline future expansions while maintaining stability.
* **Chores**
  * Expanded environment detection to align bridge activation with production-like deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->