### PR TITLE
fix: update tgData assignment to use nullish coalescing operator

### DIFF
--- a/apps/cowswap-frontend/src/modules/notifications/hooks/useTgSubscription.tsx
+++ b/apps/cowswap-frontend/src/modules/notifications/hooks/useTgSubscription.tsx
@@ -133,7 +133,7 @@ export function useTgSubscription(account: string | undefined, authorization: Tg
     callSubscriptionApi,
     setTgSubscribed,
     skipNextCheckRef,
-    tgData: tgData || undefined,
+    tgData: tgData ?? undefined,
   })
 
   const addTgSubscription = useCallback(


### PR DESCRIPTION
# Summary

  Make `useSubscriptionCheckEffects` accept optional Telegram data and fix the type narrowing to avoid passing `null`.

  # To Test

  1. Run `yarn nx cowswap-frontend:build`
  - [ ] Command completes without TS2322 error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Telegram subscription data in notifications, ensuring valid but falsy values are recognized correctly. This reduces false prompts and improves reliability when checking subscription status.
* **Chores**
  * Minor internal logic cleanup to align value handling with expected behavior, with no changes to visible UI or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->