### PR TITLE
chore: make across available on Barn

### DIFF
--- a/apps/cowswap-frontend/src/tradingSdk/bridgingSdk.ts
+++ b/apps/cowswap-frontend/src/tradingSdk/bridgingSdk.ts
@@ -1,5 +1,5 @@
 import { bungeeAffiliateCode } from '@cowprotocol/common-const'
-import { isBarn, isDev, isProd, isProdLike, isStaging } from '@cowprotocol/common-utils'
+import { isBarn, isBarnBackendEnv, isDev, isProd, isStaging } from '@cowprotocol/common-utils'
 import {
   AcrossBridgeProvider,
   BridgeProvider,
@@ -27,7 +27,7 @@ const acrossBridgeProvider = new AcrossBridgeProvider()
 export const bridgeProviders: BridgeProvider<BridgeQuoteResult>[] = [bungeeBridgeProvider]
 
 // TODO: Should not enable Across on Prod until it's finalized
-!isProdLike && bridgeProviders.push(acrossBridgeProvider)
+isBarnBackendEnv && bridgeProviders.push(acrossBridgeProvider)
 
 export const bridgingSdk = new BridgingSdk({
   providers: bridgeProviders,


### PR DESCRIPTION
# Summary

Barn is actually an environment where we don't use prod API.
In the same way, Across should be available on Barn, we only disable it on prod.

# To Test

Test it once it on Barn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Across bridge provider availability based on backend environment configuration. The bridge provider is now enabled in specific backend environments rather than production-like environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->