### PR TITLE
feat: add ondo token list to bnb

### DIFF
--- a/libs/tokens/src/const/tokensList.json
+++ b/libs/tokens/src/const/tokensList.json
@@ -151,6 +151,10 @@
       "priority": 3,
       "enabledByDefault": true,
       "source": "https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/Uniswap.56.json"
+    },
+    {
+      "priority": 4,
+      "source": "https://raw.githubusercontent.com/ondoprotocol/cowswap-global-markets-token-list/refs/heads/main/tokenlist.json"
     }
   ],
   "232": [


### PR DESCRIPTION
# Summary

Ondo tokens are now available for BNB.
Adding it to BNB chain disabled by default.

# To Test

1. Load the app on BNB
2. Search for Ondo token
* Should show Ondo tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added integration of an additional token source, expanding the pool of available tokens for user interactions within the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->