### PR TITLE
fix: add plural to partial approvals text

### DIFF
--- a/apps/cowswap-frontend/src/modules/erc20Approve/containers/ActiveOrdersWithAffectedPermit/ActiveOrdersWithAffectedPermit.tsx
+++ b/apps/cowswap-frontend/src/modules/erc20Approve/containers/ActiveOrdersWithAffectedPermit/ActiveOrdersWithAffectedPermit.tsx
@@ -28,9 +28,12 @@ export function ActiveOrdersWithAffectedPermit({ currency, orderId }: ActiveOrde
 
   if (!ordersWithPermit.length) return null
 
+  const isPlural = ordersWithPermit.length > 1
+  const orderWord = isPlural ? 'orders' : 'order'
+
   const titleContent = (
     <>
-      Partial approval may block <span className={'font-bold'}>{ordersWithPermit.length}</span> other orders
+      Partial approval may block <span className={'font-bold'}>{ordersWithPermit.length}</span> other {orderWord}
     </>
   )
 
@@ -40,9 +43,10 @@ export function ActiveOrdersWithAffectedPermit({ currency, orderId }: ActiveOrde
         <AffectedPermitOrdersTable orders={ordersWithPermit} />
       </styledEl.DropdownList>
       <styledEl.DropdownFooter>
-        There are <span className={'font-bold'}>{ordersWithPermit.length}</span> existing orders using a{' '}
-        <TokenSymbol className={'font-bold'} token={currency} /> token approval. If you sign a new one, only one order
-        can fill. Continue with current permit amount or choose full approval so all orders can be filled.
+        There {isPlural ? 'are' : 'is'} <span className={'font-bold'}>{ordersWithPermit.length}</span> existing{' '}
+        {orderWord} using a <TokenSymbol className={'font-bold'} token={currency} /> token approval. If you sign a new
+        one, only one order can fill. Continue with current permit amount or choose full approval so all orders can be
+        filled.
       </styledEl.DropdownFooter>
     </AccordionBanner>
   )


### PR DESCRIPTION
# Summary

Fix plural for partial approvals

# To Test

1. See on https://www.notion.so/cownation/1-affected-order-is-in-plural-2878da5f04ca807ab875e1f7c0858de6
<img width="486" height="276" alt="image" src="https://github.com/user-attachments/assets/232c721b-707c-4ac9-b0c3-2bc489991efe" />

<img width="476" height="207" alt="image" src="https://github.com/user-attachments/assets/5d4b31e7-6f13-4d48-9dc4-b4183687ab8a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grammar in order-related messages by implementing proper pluralization for singular and multiple orders, ensuring correct verb agreement and message formatting across the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->