### PR TITLE
fix(approve): change 'affected orders' message to a more generic one

### DIFF
--- a/apps/cowswap-frontend/src/modules/erc20Approve/containers/ActiveOrdersWithAffectedPermit/ActiveOrdersWithAffectedPermit.tsx
+++ b/apps/cowswap-frontend/src/modules/erc20Approve/containers/ActiveOrdersWithAffectedPermit/ActiveOrdersWithAffectedPermit.tsx
@@ -33,7 +33,7 @@ export function ActiveOrdersWithAffectedPermit({ currency, orderId }: ActiveOrde
 
   const titleContent = (
     <>
-      Partial approval may block <span className={'font-bold'}>{ordersWithPermit.length}</span> other {orderWord}
+      Partial approval may block <span className={'font-bold'}>{ordersWithPermit.length}</span> other {orderWord}.
     </>
   )
 
@@ -44,9 +44,8 @@ export function ActiveOrdersWithAffectedPermit({ currency, orderId }: ActiveOrde
       </styledEl.DropdownList>
       <styledEl.DropdownFooter>
         There {isPlural ? 'are' : 'is'} <span className={'font-bold'}>{ordersWithPermit.length}</span> existing{' '}
-        {orderWord} using a <TokenSymbol className={'font-bold'} token={currency} /> token approval. If you sign a new
-        one, only one order can fill. Continue with current permit amount or choose full approval so all orders can be
-        filled.
+        {orderWord} using a <TokenSymbol className={'font-bold'} token={currency} /> token approval. Partial approval  
+        may affect the execution of other orders. Adjust the amount or choose full approval to proceed.
       </styledEl.DropdownFooter>
     </AccordionBanner>
   )


### PR DESCRIPTION
Fixes https://www.notion.so/cownation/Unfillable-order-message-says-sign-permit-for-onchain-transaction-28e8da5f04ca80e986b2f496f97b3a85

Discussion https://cowservices.slack.com/archives/C0361CDG8GP/p1760541040817869

Affected order section is displayed inside the Account modal for unfillable orders. 
When there is an unfillable order inside the Account modal, only onchain approval may work to enable an order execution.
In this PR I'm proposing to change the text to more generic one without mentioning an approval method before approving a token.

**To test:** 
1. Enable Partial approvals feature-flag and setting ON
2. Place a limit order with an approved token
3. Place a swap order with the same token in the sell field
4. While the order is pending, revoke the sell token approval
5. Wait till the TX is mined
6. Open Account modal and expand the 'unfillable' warning
7. Check the text in the 'affected orders' section --> 
<img width="589" height="204" alt="image" src="https://github.com/user-attachments/assets/45d9afff-c02b-47b2-a67b-110df86ec8a5" />

8. go to the swap form and specify an order with this token in the sell field
9. Expand the affected orders section and check the text --> 
<img width="455" height="196" alt="image" src="https://github.com/user-attachments/assets/a58a0d06-58c5-4f68-b0c3-f01b122b83b1" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated on-screen messaging with improved punctuation and clarified warning about how partial approvals may affect other orders.
  * Streamlined notification text to provide concise, actionable guidance on approval options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->