### PR TITLE
fix(limit-orders): fix partialFillability toggle

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.test.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.test.ts
@@ -1,6 +1,8 @@
+import { useAtom } from 'jotai'
+
 import { useIsTxBundlingSupported } from '@cowprotocol/wallet'
 
-import { renderHook } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 
 import { PriceImpact } from 'legacy/hooks/usePriceImpact'
 
@@ -10,6 +12,7 @@ import { tradeFlow } from 'modules/limitOrders/services/tradeFlow'
 import { TradeFlowContext } from 'modules/limitOrders/services/types'
 import { useNavigateToOrdersTableTab } from 'modules/ordersTable'
 
+import { useIsSafeApprovalBundle } from 'common/hooks/useIsSafeApprovalBundle'
 import { useNeedsApproval } from 'common/hooks/useNeedsApproval'
 import { TradeAmounts } from 'common/types'
 import { WithModalProvider } from 'utils/withModalProvider'
@@ -19,6 +22,7 @@ import { useLimitOrdersRawState, useUpdateLimitOrdersRawState } from './useLimit
 
 import { TradeConfirmActions } from '../../trade'
 import { defaultLimitOrdersSettings } from '../state/limitOrdersSettingsAtom'
+import { partiallyFillableOverrideAtom } from '../state/partiallyFillableOverride'
 
 jest.mock('modules/limitOrders/services/tradeFlow')
 jest.mock('modules/limitOrders/services/safeBundleFlow')
@@ -26,6 +30,7 @@ jest.mock('modules/ordersTable')
 
 jest.mock('modules/limitOrders/hooks/useSafeBundleFlowContext')
 jest.mock('common/hooks/useNeedsApproval')
+jest.mock('common/hooks/useIsSafeApprovalBundle')
 jest.mock('@cowprotocol/wallet', () => {
   const actual = jest.requireActual('@cowprotocol/wallet')
 
@@ -52,6 +57,7 @@ const mockUseNavigateToOpenOrdersTable = useNavigateToOrdersTableTab as jest.Moc
 const mockUseSafeBundleFlowContext = useSafeBundleFlowContext as jest.MockedFunction<typeof useSafeBundleFlowContext>
 const mockUseNeedsApproval = useNeedsApproval as jest.MockedFunction<typeof useNeedsApproval>
 const mockIsBundlingSupported = useIsTxBundlingSupported as jest.MockedFunction<typeof useIsTxBundlingSupported>
+const mockUseIsSafeApprovalBundle = useIsSafeApprovalBundle as jest.MockedFunction<typeof useIsSafeApprovalBundle>
 
 // TODO: Replace any with proper type definitions
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -84,12 +90,13 @@ const tradeConfirmActions: TradeConfirmActions = {
 
 describe('useHandleOrderPlacement', () => {
   beforeEach(() => {
-    mockTradeFlow.mockImplementation(() => Promise.resolve(''))
-    mockSafeBundleFlow.mockImplementation(() => Promise.resolve(''))
+    mockTradeFlow.mockImplementation(() => Promise.resolve('0xOrderHash'))
+    mockSafeBundleFlow.mockImplementation(() => Promise.resolve('0xOrderHash'))
     mockUseSafeBundleFlowContext.mockImplementation(() => null)
     mockUseNeedsApproval.mockImplementation(() => false)
     mockIsBundlingSupported.mockImplementation(() => true)
     mockUseNavigateToOpenOrdersTable.mockImplementation(() => () => {})
+    mockUseIsSafeApprovalBundle.mockImplementation(() => false)
   })
 
   it('When a limit order placed, then the recipient value should be deleted', async () => {
@@ -121,5 +128,292 @@ describe('useHandleOrderPlacement', () => {
       wrapper: WithModalProvider,
     })
     expect(limitOrdersStateResultAfter.current.recipient).toBe(null)
+  })
+
+  describe('partiallyFillableOverride', () => {
+    it('When partiallyFillableOverride is undefined, then no override should be passed to tradeFlow', async () => {
+      // Arrange
+      const { result: atomResult } = renderHook(() => useAtom(partiallyFillableOverrideAtom), {
+        wrapper: WithModalProvider,
+      })
+      // Set override to undefined
+      act(() => {
+        atomResult.current[1](undefined)
+      })
+
+      // Act
+      const { result } = renderHook(
+        () =>
+          useHandleOrderPlacement(tradeContextMock, priceImpactMock, defaultLimitOrdersSettings, tradeConfirmActions),
+        { wrapper: WithModalProvider },
+      )
+      await act(async () => {
+        await result.current()
+      })
+
+      // Assert - tradeFlow should be called without partiallyFillable in params
+      expect(mockTradeFlow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          postOrderParams: expect.objectContaining({
+            partiallyFillable: true, // Original value from tradeContextMock
+          }),
+        }),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      )
+    })
+
+    it('When partiallyFillableOverride is true, then it should be passed to tradeFlow', async () => {
+      // Arrange
+      const { result: atomResult } = renderHook(() => useAtom(partiallyFillableOverrideAtom), {
+        wrapper: WithModalProvider,
+      })
+      // Set override to true
+      act(() => {
+        atomResult.current[1](true)
+      })
+
+      // Act
+      const { result } = renderHook(
+        () =>
+          useHandleOrderPlacement(tradeContextMock, priceImpactMock, defaultLimitOrdersSettings, tradeConfirmActions),
+        { wrapper: WithModalProvider },
+      )
+      await act(async () => {
+        await result.current()
+      })
+
+      // Assert - tradeFlow should be called with partiallyFillable: true
+      expect(mockTradeFlow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          postOrderParams: expect.objectContaining({
+            partiallyFillable: true,
+          }),
+        }),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      )
+    })
+
+    it('When partiallyFillableOverride is false, then it should be passed to tradeFlow', async () => {
+      // Arrange
+      const { result: atomResult } = renderHook(() => useAtom(partiallyFillableOverrideAtom), {
+        wrapper: WithModalProvider,
+      })
+      // Set override to false
+      act(() => {
+        atomResult.current[1](false)
+      })
+
+      // Act
+      const { result } = renderHook(
+        () =>
+          useHandleOrderPlacement(tradeContextMock, priceImpactMock, defaultLimitOrdersSettings, tradeConfirmActions),
+        { wrapper: WithModalProvider },
+      )
+      await act(async () => {
+        await result.current()
+      })
+
+      // Assert - tradeFlow should be called with partiallyFillable: false
+      expect(mockTradeFlow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          postOrderParams: expect.objectContaining({
+            partiallyFillable: false,
+          }),
+        }),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      )
+    })
+
+    it('When order is successfully placed, then partiallyFillableOverride should be reset to undefined', async () => {
+      // Arrange
+      const { result: atomResult } = renderHook(() => useAtom(partiallyFillableOverrideAtom), {
+        wrapper: WithModalProvider,
+      })
+      // Set override to true initially
+      act(() => {
+        atomResult.current[1](true)
+      })
+      expect(atomResult.current[0]).toBe(true)
+
+      // Act
+      const { result } = renderHook(
+        () =>
+          useHandleOrderPlacement(tradeContextMock, priceImpactMock, defaultLimitOrdersSettings, tradeConfirmActions),
+        { wrapper: WithModalProvider },
+      )
+      await act(async () => {
+        await result.current()
+      })
+
+      // Assert - override should be reset to undefined after successful placement
+      await waitFor(() => {
+        expect(atomResult.current[0]).toBe(undefined)
+      })
+    })
+
+    it('When using safeBundleFlow and partiallyFillableOverride is true, then it should be passed to safeBundleFlow', async () => {
+      // Arrange
+      // TODO: Replace any with proper type definitions
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const safeBundleContext = { postOrderParams: { partiallyFillable: false } } as any
+      mockUseSafeBundleFlowContext.mockImplementation(() => safeBundleContext)
+      mockUseIsSafeApprovalBundle.mockImplementation(() => true) // Trigger safe bundle flow
+
+      const { result: atomResult } = renderHook(() => useAtom(partiallyFillableOverrideAtom), {
+        wrapper: WithModalProvider,
+      })
+      // Set override to true
+      act(() => {
+        atomResult.current[1](true)
+      })
+
+      // Act
+      const { result } = renderHook(
+        () =>
+          useHandleOrderPlacement(tradeContextMock, priceImpactMock, defaultLimitOrdersSettings, tradeConfirmActions),
+        { wrapper: WithModalProvider },
+      )
+      await act(async () => {
+        await result.current()
+      })
+
+      // Assert - safeBundleFlow should be called with partiallyFillable: true
+      expect(mockSafeBundleFlow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          postOrderParams: expect.objectContaining({
+            partiallyFillable: true,
+          }),
+        }),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      )
+    })
+
+    it('When using safeBundleFlow and partiallyFillableOverride is false, then it should be passed to safeBundleFlow', async () => {
+      // Arrange
+      // TODO: Replace any with proper type definitions
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const safeBundleContext = { postOrderParams: { partiallyFillable: true } } as any
+      mockUseSafeBundleFlowContext.mockImplementation(() => safeBundleContext)
+      mockUseIsSafeApprovalBundle.mockImplementation(() => true) // Trigger safe bundle flow
+
+      const { result: atomResult } = renderHook(() => useAtom(partiallyFillableOverrideAtom), {
+        wrapper: WithModalProvider,
+      })
+      // Set override to false
+      act(() => {
+        atomResult.current[1](false)
+      })
+
+      // Act
+      const { result } = renderHook(
+        () =>
+          useHandleOrderPlacement(tradeContextMock, priceImpactMock, defaultLimitOrdersSettings, tradeConfirmActions),
+        { wrapper: WithModalProvider },
+      )
+      await act(async () => {
+        await result.current()
+      })
+
+      // Assert - safeBundleFlow should be called with partiallyFillable: false
+      expect(mockSafeBundleFlow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          postOrderParams: expect.objectContaining({
+            partiallyFillable: false,
+          }),
+        }),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      )
+    })
+
+    it('When using safeBundleFlow and partiallyFillableOverride is undefined, then no override should be passed', async () => {
+      // Arrange
+      // TODO: Replace any with proper type definitions
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const safeBundleContext = { postOrderParams: { partiallyFillable: true } } as any
+      mockUseSafeBundleFlowContext.mockImplementation(() => safeBundleContext)
+      mockUseIsSafeApprovalBundle.mockImplementation(() => true) // Trigger safe bundle flow
+
+      const { result: atomResult } = renderHook(() => useAtom(partiallyFillableOverrideAtom), {
+        wrapper: WithModalProvider,
+      })
+      // Set override to undefined
+      act(() => {
+        atomResult.current[1](undefined)
+      })
+
+      // Act
+      const { result } = renderHook(
+        () =>
+          useHandleOrderPlacement(tradeContextMock, priceImpactMock, defaultLimitOrdersSettings, tradeConfirmActions),
+        { wrapper: WithModalProvider },
+      )
+      await act(async () => {
+        await result.current()
+      })
+
+      // Assert - safeBundleFlow should be called with original partiallyFillable value
+      expect(mockSafeBundleFlow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          postOrderParams: expect.objectContaining({
+            partiallyFillable: true, // Original value from safeBundleContext
+          }),
+        }),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      )
+    })
+
+    it('When order fails, then partiallyFillableOverride should NOT be reset', async () => {
+      // Arrange
+      mockTradeFlow.mockImplementation(() => Promise.reject(new Error('Order failed')))
+
+      const { result: atomResult } = renderHook(() => useAtom(partiallyFillableOverrideAtom), {
+        wrapper: WithModalProvider,
+      })
+      // Set override to true initially
+      act(() => {
+        atomResult.current[1](true)
+      })
+      expect(atomResult.current[0]).toBe(true)
+
+      // Act
+      const { result } = renderHook(
+        () =>
+          useHandleOrderPlacement(tradeContextMock, priceImpactMock, defaultLimitOrdersSettings, tradeConfirmActions),
+        { wrapper: WithModalProvider },
+      )
+      await act(async () => {
+        await result.current()
+      })
+
+      // Assert - override should remain true after failure
+      expect(atomResult.current[0]).toBe(true)
+    })
   })
 })

--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.ts
@@ -85,7 +85,8 @@ export function useHandleOrderPlacement(
   }, [tradeContext, tradeConfirmActions])
 
   const tradeFn = useCallback(async () => {
-    const partiallyFillableState = partiallyFillableOverride ? { partiallyFillable: partiallyFillableOverride } : null
+    const partiallyFillableState =
+      typeof partiallyFillableOverride === 'boolean' ? { partiallyFillable: partiallyFillableOverride } : null
 
     if (isSafeBundle) {
       if (!safeBundleFlowContext) throw new Error('safeBundleFlowContext is not set!')

--- a/apps/cowswap-frontend/src/modules/limitOrders/pure/OrderType/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/pure/OrderType/index.tsx
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react'
+
 import IMAGE_CARET_DOWN from '@cowprotocol/assets/cow-swap/carret-down.svg'
 import { InfoTooltip, RowFixed } from '@cowprotocol/ui'
 
@@ -14,9 +16,7 @@ export type OrderTypeProps = {
   className?: string
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function OrderType(props: OrderTypeProps) {
+export function OrderType(props: OrderTypeProps): ReactNode {
   const {
     isPartiallyFillable,
     className,
@@ -40,18 +40,16 @@ export function OrderType(props: OrderTypeProps) {
 
 const LABELS = ['Partially fillable', 'Fill or kill']
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function OrderTypePicker({ isPartiallyFillable, partiallyFillableOverride }: OrderTypeProps) {
+function OrderTypePicker({ isPartiallyFillable, partiallyFillableOverride }: OrderTypeProps): ReactNode {
   const [override, setOverride] = partiallyFillableOverride
 
   const showPartiallyFillable = override ?? isPartiallyFillable
 
   const [labelText] = showPartiallyFillable ? LABELS : [...LABELS].reverse()
 
-  // TODO: Add proper return type annotation
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  const onSelect = (label: string) => setOverride(label === LABELS[0])
+  const onSelect = (label: string): void => {
+    setOverride(label === LABELS[0])
+  }
 
   return (
     <Menu>


### PR DESCRIPTION
# Summary

I broke it in #6352, sorry...

<img width="972" height="507" alt="image" src="https://github.com/user-attachments/assets/d83e4e9b-31dc-4064-b8f6-30e57d08fe67" />

# To Test

The partailFill toggle in the limit orders confirm screen should give impact on the signing order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for order placement and partially fillable order override scenarios.

* **Refactor**
  * Improved type safety in component signatures and refined partially fillable override parameter handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->