### PR TITLE
feat(affiliate): 7 - add referral modal controller

### DIFF
--- a/apps/cowswap-frontend/src/modules/affiliate/components/ReferralCodeModal.tsx
+++ b/apps/cowswap-frontend/src/modules/affiliate/components/ReferralCodeModal.tsx
@@ -1,0 +1,45 @@
+import { ReactNode } from 'react'
+
+import { useCowAnalytics } from '@cowprotocol/analytics'
+import { useWalletInfo } from '@cowprotocol/wallet'
+
+import { useToggleWalletModal } from 'legacy/state/application/hooks'
+
+import { useNavigate } from 'common/hooks/useNavigate'
+import { CowModal } from 'common/pure/Modal'
+
+import { ReferralModalContent } from './ReferralCodeModal/content'
+import { useReferralModalController } from './ReferralCodeModal/controller'
+
+import { useReferralActions } from '../hooks/useReferralActions'
+import { useReferralModalState } from '../hooks/useReferralModalState'
+
+export function ReferralCodeModal(): ReactNode {
+  const modalState = useReferralModalState()
+  const actions = useReferralActions()
+  const toggleWalletModal = useToggleWalletModal()
+  const { account } = useWalletInfo()
+  const navigate = useNavigate()
+  const analytics = useCowAnalytics()
+
+  const controller = useReferralModalController({
+    modalState,
+    actions,
+    account,
+    toggleWalletModal,
+    navigate,
+    analytics,
+  })
+
+  return (
+    <CowModal
+      isOpen={controller.referral.modalOpen}
+      onDismiss={controller.handleClose}
+      initialFocusRef={controller.initialFocusRef}
+      padding="0"
+      maxHeight={90}
+    >
+      <ReferralModalContent {...controller.contentProps} onDismiss={controller.handleClose} />
+    </CowModal>
+  )
+}

--- a/apps/cowswap-frontend/src/modules/affiliate/components/ReferralCodeModal/content.tsx
+++ b/apps/cowswap-frontend/src/modules/affiliate/components/ReferralCodeModal/content.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react'
+
+import { ReferralModalContentProps } from './types'
+
+/**
+ * Placeholder modal content for early affiliate UI slices.
+ * Later slices replace this stub with the full referral modal markup.
+ */
+export function ReferralModalContent(_: ReferralModalContentProps): ReactNode {
+  return null
+}

--- a/apps/cowswap-frontend/src/modules/affiliate/components/ReferralCodeModal/controller.helpers.ts
+++ b/apps/cowswap-frontend/src/modules/affiliate/components/ReferralCodeModal/controller.helpers.ts
@@ -1,0 +1,159 @@
+import { RefObject, useEffect, useMemo, useRef } from 'react'
+
+import { CowAnalytics } from '@cowprotocol/analytics'
+
+import { t } from '@lingui/macro'
+
+import { PrimaryCta, StatusCopyResult } from './types'
+
+import { useReferralModalState, ReferralModalUiState } from '../../hooks/useReferralModalState'
+import { ReferralVerificationStatus } from '../../types'
+
+type VerificationKind = ReturnType<typeof useReferralModalState>['verification']['kind']
+
+export function computePrimaryCta(params: {
+  uiState: ReferralModalUiState
+  hasValidLength: boolean
+  hasCode: boolean
+  verificationKind: VerificationKind
+}): PrimaryCta {
+  const { uiState, hasValidLength, hasCode, verificationKind } = params
+
+  switch (uiState) {
+    case 'empty':
+      return disabledCta(t`Provide a valid referral code.`)
+    case 'unsupported':
+      return disabledCta(t`Unsupported Network.`)
+    case 'checking':
+      return disabledCta(t`Checking code…`)
+    case 'valid':
+    case 'linked':
+      return { label: t`View rewards.`, disabled: false, action: 'viewRewards' }
+    case 'ineligible':
+      return { label: t`Go back.`, disabled: false, action: 'goBack' }
+    case 'invalid':
+    case 'expired':
+      return disabledCta(t`Connect to verify code.`)
+    case 'error':
+      return verifyCta(hasValidLength, hasCode, verificationKind)
+    default:
+      return verifyCta(hasValidLength, hasCode, verificationKind)
+  }
+}
+
+function disabledCta(label: string): PrimaryCta {
+  return { label, disabled: true, action: 'none' }
+}
+
+function verifyCta(
+  hasValidLength: boolean,
+  hasCode: boolean,
+  verificationKind: VerificationKind,
+): PrimaryCta {
+  return {
+    label: t`Connect to verify code.`,
+    disabled: !hasValidLength || !hasCode || verificationKind === 'checking',
+    action: 'verify',
+  }
+}
+
+export function getHelperText(uiState: ReferralModalUiState): string | undefined {
+  return uiState === 'empty' ? t`Provide a valid referral code.` : undefined
+}
+
+export function getStatusCopy(verification: ReferralVerificationStatus): StatusCopyResult {
+  return {
+    shouldShowInfo: verification.kind === 'valid' && verification.eligible,
+    infoMessage: t`Your wallet is eligible for rewards. After your first trade, the referral code will bind and stay active for 90 days.`,
+    expiredMessage: t`Rewards ended for this code. Try another.`,
+    invalidMessage: t`This code is invalid. Try another.`,
+    errorMessage: verification.kind === 'error' ? verification.message : undefined,
+  }
+}
+
+export function useReferralModalFocus(
+  isOpen: boolean,
+  uiState: ReferralModalUiState,
+  inputRef: RefObject<HTMLInputElement | null>,
+  ctaRef: RefObject<HTMLButtonElement | null>,
+): void {
+  useEffect(() => {
+    if (!isOpen) {
+      return
+    }
+
+    if (uiState === 'valid' || uiState === 'linked') {
+      ctaRef.current?.focus()
+      return
+    }
+
+    if (uiState === 'invalid' || uiState === 'expired' || uiState === 'editing' || uiState === 'empty') {
+      inputRef.current?.focus()
+    }
+  }, [ctaRef, inputRef, isOpen, uiState])
+}
+
+export function useReferralModalAnalytics(
+  referral: ReturnType<typeof useReferralModalState>['referral'],
+  uiState: ReferralModalUiState,
+  analytics: CowAnalytics,
+): void {
+  const wasOpenRef = useRef(false)
+  const lastUiStateRef = useRef<ReferralModalUiState | null>(null)
+
+  useEffect(() => {
+    if (referral.modalOpen && !wasOpenRef.current) {
+      analytics.sendEvent({
+        category: 'referral',
+        action: 'modal_opened',
+        label: referral.modalSource ?? 'unknown',
+      })
+    }
+
+    wasOpenRef.current = referral.modalOpen
+
+    if (!referral.modalOpen) {
+      lastUiStateRef.current = null
+    }
+  }, [analytics, referral.modalOpen, referral.modalSource])
+
+  useEffect(() => {
+    if (!referral.modalOpen) {
+      return
+    }
+
+    if (uiState === 'linked' && lastUiStateRef.current !== 'linked') {
+      analytics.sendEvent({
+        category: 'referral',
+        action: 'view_linked',
+        label: referral.modalSource ?? 'unknown',
+      })
+    }
+
+    if (uiState === 'ineligible' && lastUiStateRef.current !== 'ineligible') {
+      analytics.sendEvent({
+        category: 'referral',
+        action: 'view_ineligible',
+        label: referral.modalSource ?? 'unknown',
+      })
+    }
+
+    lastUiStateRef.current = uiState
+  }, [analytics, referral.modalOpen, referral.modalSource, uiState])
+}
+
+export function useReferralMessages(codeForDisplay?: string): { linkedMessage: string; ineligibleMessage: string } {
+  return useMemo(() => {
+    if (!codeForDisplay) {
+      return {
+        linkedMessage: t`Your wallet is already linked to a referral code.`,
+        ineligibleMessage: t`This wallet has already traded and is not eligible for referral rewards.`,
+      }
+    }
+
+    return {
+      linkedMessage: t`The code ${codeForDisplay} from your link wasn’t applied.`,
+      ineligibleMessage: t`The code ${codeForDisplay} from your link wasn’t applied because this wallet has already traded. Referral rewards are for new wallets only.`,
+    }
+  }, [codeForDisplay])
+}

--- a/apps/cowswap-frontend/src/modules/affiliate/components/ReferralCodeModal/controller.ts
+++ b/apps/cowswap-frontend/src/modules/affiliate/components/ReferralCodeModal/controller.ts
@@ -1,0 +1,215 @@
+import { FormEvent, RefObject, useCallback, useMemo, useRef } from 'react'
+
+import { CowAnalytics } from '@cowprotocol/analytics'
+
+import { Routes } from 'common/constants/routes'
+import { NavigateFunction } from 'common/hooks/useNavigate'
+
+import {
+  computePrimaryCta,
+  getHelperText,
+  getStatusCopy,
+  useReferralMessages,
+  useReferralModalAnalytics,
+  useReferralModalFocus,
+} from './controller.helpers'
+import { FocusableElement, PrimaryCta, ReferralModalContentProps } from './types'
+
+import { useReferralActions } from '../../hooks/useReferralActions'
+import { useReferralModalState } from '../../hooks/useReferralModalState'
+import { isReferralCodeLengthValid } from '../../utils/code'
+
+export interface ReferralModalControllerParams {
+  modalState: ReturnType<typeof useReferralModalState>
+  actions: ReturnType<typeof useReferralActions>
+  account?: string
+  toggleWalletModal: () => void
+  navigate: NavigateFunction
+  analytics: CowAnalytics
+}
+
+export interface ReferralModalControllerResult {
+  referral: ReturnType<typeof useReferralModalState>['referral']
+  handleClose(): void
+  initialFocusRef: RefObject<FocusableElement>
+  contentProps: Omit<ReferralModalContentProps, 'onDismiss'>
+}
+
+export function useReferralModalController(params: ReferralModalControllerParams): ReferralModalControllerResult {
+  const { modalState, actions, account, toggleWalletModal, navigate, analytics } = params
+  const { referral, uiState, displayCode, savedCode, hasCode, hasValidLength, verification, incomingCode } = modalState
+
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const ctaRef = useRef<HTMLButtonElement | null>(null)
+
+  const primaryCta = useMemo(
+    () => computePrimaryCta({ uiState, hasValidLength, hasCode, verificationKind: verification.kind }),
+    [hasCode, hasValidLength, uiState, verification.kind],
+  )
+
+  useReferralModalFocus(referral.modalOpen, uiState, inputRef, ctaRef)
+  useReferralModalAnalytics(referral, uiState, analytics)
+
+  const handlers = useReferralModalHandlers({
+    actions,
+    analytics,
+    account,
+    displayCode,
+    primaryCta,
+    toggleWalletModal,
+    navigate,
+    inputRef,
+  })
+
+  const helperText = getHelperText(uiState)
+  const statusCopy = getStatusCopy(verification)
+  const verificationCode = 'code' in verification ? verification.code : undefined
+  const codeForDisplay = incomingCode || verificationCode || savedCode || displayCode
+  const { linkedMessage, ineligibleMessage } = useReferralMessages(codeForDisplay)
+
+  const initialFocusRef =
+    uiState === 'valid' || uiState === 'linked'
+      ? (ctaRef as RefObject<FocusableElement>)
+      : (inputRef as RefObject<FocusableElement>)
+
+  return {
+    referral,
+    handleClose: handlers.onClose,
+    initialFocusRef,
+    contentProps: {
+      uiState,
+      savedCode,
+      displayCode,
+      verification,
+      onPrimaryClick: handlers.onPrimaryClick,
+      onEdit: handlers.onEdit,
+      onRemove: handlers.onRemove,
+      onSave: handlers.onSave,
+      onChange: handlers.onChange,
+      helperText,
+      primaryCta,
+      errorMessage: statusCopy.errorMessage,
+      invalidMessage: statusCopy.invalidMessage,
+      expiredMessage: statusCopy.expiredMessage,
+      linkedMessage,
+      ineligibleMessage,
+      infoMessage: statusCopy.infoMessage,
+      shouldShowInfo: statusCopy.shouldShowInfo,
+      inputRef,
+      ctaRef,
+    },
+  }
+}
+
+interface ReferralModalHandlersParams {
+  actions: ReturnType<typeof useReferralActions>
+  analytics: CowAnalytics
+  account?: string
+  displayCode: string
+  primaryCta: PrimaryCta
+  toggleWalletModal: () => void
+  navigate: NavigateFunction
+  inputRef: RefObject<HTMLInputElement | null>
+}
+
+interface ReferralModalHandlers {
+  onClose(): void
+  onEdit(): void
+  onRemove(): void
+  onSave(): void
+  onPrimaryClick(): void
+  onChange(event: FormEvent<HTMLInputElement>): void
+}
+
+function useReferralModalHandlers(params: ReferralModalHandlersParams): ReferralModalHandlers {
+  const { actions, analytics, account, displayCode, primaryCta, toggleWalletModal, navigate, inputRef } = params
+
+  const focusInput = useCallback(() => {
+    setTimeout(() => inputRef.current?.focus(), 0)
+  }, [inputRef])
+
+  const onClose = useCallback(() => {
+    actions.disableEditMode()
+    actions.closeModal()
+  }, [actions])
+
+  const onEdit = useCallback(() => {
+    actions.enableEditMode()
+    focusInput()
+  }, [actions, focusInput])
+
+  const onRemove = useCallback(() => {
+    actions.removeCode()
+    focusInput()
+  }, [actions, focusInput])
+
+  const onSave = useCallback(() => {
+    if (!displayCode || !isReferralCodeLengthValid(displayCode)) {
+      return
+    }
+
+    actions.saveCode(displayCode)
+    analytics.sendEvent({
+      category: 'referral',
+      action: 'code_saved',
+      label: 'manual',
+      value: displayCode.length,
+    })
+  }, [actions, analytics, displayCode])
+
+  const onPrimaryClick = useCallback(() => {
+    if (primaryCta.disabled) {
+      return
+    }
+
+    if (!account && primaryCta.action === 'verify') {
+      toggleWalletModal()
+      analytics.sendEvent({ category: 'referral', action: 'cta_clicked', label: 'connect_to_verify' })
+      return
+    }
+
+    if (primaryCta.action === 'verify') {
+      analytics.sendEvent({ category: 'referral', action: 'cta_clicked', label: 'connect_to_verify' })
+      actions.requestVerification(displayCode)
+      return
+    }
+
+    if (primaryCta.action === 'viewRewards') {
+      analytics.sendEvent({ category: 'referral', action: 'cta_clicked', label: 'view_rewards' })
+      onClose()
+      navigate(Routes.ACCOUNT)
+      return
+    }
+
+    if (primaryCta.action === 'goBack') {
+      analytics.sendEvent({ category: 'referral', action: 'cta_clicked', label: 'go_back' })
+      onClose()
+    }
+  }, [
+    account,
+    actions,
+    analytics,
+    displayCode,
+    navigate,
+    onClose,
+    primaryCta.action,
+    primaryCta.disabled,
+    toggleWalletModal,
+  ])
+
+  const onChange = useCallback(
+    (event: FormEvent<HTMLInputElement>) => {
+      actions.setInputCode(event.currentTarget.value)
+    },
+    [actions],
+  )
+
+  return {
+    onClose,
+    onEdit,
+    onRemove,
+    onSave,
+    onPrimaryClick,
+    onChange,
+  }
+}

--- a/apps/cowswap-frontend/src/modules/affiliate/components/ReferralCodeModal/styles.ts
+++ b/apps/cowswap-frontend/src/modules/affiliate/components/ReferralCodeModal/styles.ts
@@ -1,0 +1,25 @@
+import styled from 'styled-components/macro'
+
+// Minimal structural styles to keep early slices compiling; replaced with
+// full design tokens in later branches of the affiliate UI stack.
+export const ModalContainer = styled.div``
+export const Body = styled.div``
+export const Illustration = styled.div``
+export const Subtitle = styled.p``
+export const FormGroup = styled.form``
+export const LabelRow = styled.div``
+export const Label = styled.label``
+export const TagGroup = styled.div``
+export const EditButton = styled.button``
+export const InputWrapper = styled.div``
+export const StyledInput = styled.input``
+export const TrailingActions = styled.div``
+export const InlineAction = styled.button``
+export const StatusMessage = styled.div``
+export const SpinnerRow = styled.div``
+export const Footer = styled.div``
+export const HelperText = styled.div``
+export const InlineAlert = styled.div``
+export const ErrorInline = styled.div``
+export const LinkedLock = styled.div``
+export const TrailingIcon = styled.div``

--- a/apps/cowswap-frontend/src/modules/affiliate/components/ReferralCodeModal/types.ts
+++ b/apps/cowswap-frontend/src/modules/affiliate/components/ReferralCodeModal/types.ts
@@ -1,0 +1,44 @@
+import { FormEvent, RefObject } from 'react'
+
+import { ReferralModalUiState } from '../../hooks/useReferralModalState'
+import { ReferralVerificationStatus } from '../../types'
+
+export type FocusableElement = HTMLElement | HTMLInputElement | HTMLButtonElement | null
+
+export interface PrimaryCta {
+  label: string
+  disabled: boolean
+  action: 'none' | 'verify' | 'viewRewards' | 'goBack'
+}
+
+export interface ReferralModalContentProps {
+  uiState: ReferralModalUiState
+  savedCode?: string
+  displayCode: string
+  verification: ReferralVerificationStatus
+  onPrimaryClick(): void
+  onEdit(): void
+  onRemove(): void
+  onSave(): void
+  onChange(event: FormEvent<HTMLInputElement>): void
+  helperText?: string
+  primaryCta: PrimaryCta
+  errorMessage?: string
+  invalidMessage: string
+  expiredMessage: string
+  linkedMessage: string
+  ineligibleMessage: string
+  infoMessage: string
+  shouldShowInfo: boolean
+  inputRef: RefObject<HTMLInputElement | null>
+  ctaRef: RefObject<HTMLButtonElement | null>
+  onDismiss(): void
+}
+
+export interface StatusCopyResult {
+  shouldShowInfo: boolean
+  infoMessage: string
+  expiredMessage: string
+  invalidMessage: string
+  errorMessage?: string
+}


### PR DESCRIPTION
# Summary

  Introduces the referral modal shell and controller layer, wiring the previously added state machine into a reusable `ReferralCodeModal`. The controller handles CTA logic, focus management, analytics, navigation, and verification requests, while the modal itself mounts a placeholder content/styling stub so downstream slices can drop in the full UI without breaking this PR. Support files (`controller.helpers.ts`, `types.ts`, `styles.ts`, `content.tsx`) keep the slice self-contained and lint-compliant.

  # To Test

  1. `yarn lint`
     - [ ] Lint passes; modal controller satisfies TS/ESLint rules

  2. Runtime sanity (temporary instrumentation)
     - [ ] Render `<ReferralCodeModal />` inside `ReferralProvider` in Storybook or a sandbox page: component mounts without runtime errors
     - [ ] Trigger `referral.actions.openModal('header')` via DevTools; modal opens and `useReferralModalController` returns CTA props
     - [ ] Call `actions.disableEditMode()` or `actions.requestVerification()` while open; controller updates focus refs without crashes

  3. Analytics smoke (optional)
     - [ ] With analytics mocked (e.g., `jest.spyOn(useCowAnalytics(), 'sendEvent')`), opening the modal fires `modal_opened`

  # Background

  This slice keeps the modal headless on purpose: content markup and full styling land in subsequent PRs. The placeholder stubs ensure consumers can compile the branch today while the controller work is incrementally reviewed.