### PR TITLE
fix: do not theme the widget

### DIFF
--- a/apps/cowswap-frontend/src/modules/application/containers/App/styled.ts
+++ b/apps/cowswap-frontend/src/modules/application/containers/App/styled.ts
@@ -107,9 +107,10 @@ export const BodyWrapper = styled.div<{ customTheme?: CowSwapTheme; backgroundVa
     min-height: ${({ theme }) => (theme.isWidget ? 'initial' : 'calc(100vh - 200px)')};
     background-size: ${({ customTheme }) => (customTheme === 'darkHalloween' ? 'contain' : 'auto')};
 
-    ${({ customTheme, backgroundVariant }) =>
+    ${({ customTheme, backgroundVariant, theme }) =>
       backgroundVariant !== 'nocows' &&
       customTheme === 'darkHalloween' &&
+      !theme.isWidget &&
       `
         background-image: url(${IMAGE_BACKGROUND_DARK_HALLOWEEN_MEDIUM});
       `}
@@ -128,9 +129,10 @@ export const BodyWrapper = styled.div<{ customTheme?: CowSwapTheme; backgroundVa
     min-height: ${({ theme }) => (theme.isWidget ? 'initial' : 'calc(100vh - 100px)')};
     background-size: ${({ customTheme }) => (customTheme === 'darkHalloween' ? 'contain' : 'auto')};
 
-    ${({ customTheme, backgroundVariant }) =>
+    ${({ customTheme, backgroundVariant, theme }) =>
       backgroundVariant !== 'nocows' &&
       customTheme === 'darkHalloween' &&
+      !theme.isWidget &&
       `
         background-image: url(${IMAGE_BACKGROUND_DARK_HALLOWEEN_MEDIUM});
       `}


### PR DESCRIPTION
# Summary

@fairlighteth fixed the issue that shows halloween themes even when CoW Swap is in widget mode.

This PR just cherry-pick the commit and applies it in main
https://github.com/cowprotocol/cowswap/pull/6449