### PR TITLE
fix(widget): revert iframe detection changes

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useCustomTheme.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useCustomTheme.ts
@@ -26,9 +26,10 @@ export function resolveCowSwapTheme(darkMode: boolean, featureFlags?: FeatureFla
 export function useCustomTheme(): CowSwapTheme | undefined {
   const [darkMode] = useDarkModeManager()
   const featureFlags = useAtomValue(featureFlagsAtom)
+  const isWidget = isInjectedWidget()
 
   // We don't want to set any custom theme for the widget
-  if (isInjectedWidget()) {
+  if (isWidget) {
     return undefined
   }
 

--- a/libs/common-utils/src/isInjectedWidget.ts
+++ b/libs/common-utils/src/isInjectedWidget.ts
@@ -1,13 +1,9 @@
-import { isIframe } from './isIframe'
-
 /**
  * Detects if the current page is running in widget mode
  * by checking for '/widget' in the URL hash
  */
 export function isInjectedWidget(): boolean {
   if (typeof window === 'undefined') return false
-
-  if (isIframe()) return true
 
   try {
     const hash = new URL(window.location.href).hash


### PR DESCRIPTION



# Summary

This reverts commit 9817a4e4d4d648d09366d8a33e9a8874a62f6473.

Safe is broken currently as the widget detection is too broad.
The app fails to load https://app.safe.global/apps/open?safe=gno%3A0x7b22232698Aeb07dB39278982E68263Ac4655Dd9&appUrl=https%3A%2F%2Fswap.cow.fi
<img width="810" height="364" alt="image" src="https://github.com/user-attachments/assets/faa451aa-7f24-4f4b-bae1-5ebfc80738c0" />


# To Test

1. Load the all as a custom Safe app https://swap-dev-git-fix-widget-again-cowswap-dev.vercel.app/
* Should load and work as expected

