### PR TITLE
fix: use ff to hide partial approve block

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
@@ -190,7 +190,7 @@ export function SwapWidget({ topContent, bottomContent }: SwapWidgetProps): Reac
           <>
             {bottomContent}
             <SwapRateDetails rateInfoParams={rateInfoParams} deadline={deadlineState[0]} />
-            {isPrimaryValidationPassed && <TradeApproveWithAffectedOrderList />}
+            {isPrimaryValidationPassed && isPartialApproveEnabled && <TradeApproveWithAffectedOrderList />}
             <Warnings buyingFiatAmount={buyingFiatAmount} />
             {tradeWarnings}
             <TradeButtons
@@ -215,6 +215,7 @@ export function SwapWidget({ topContent, bottomContent }: SwapWidgetProps): Reac
         toBeImported,
         intermediateBuyToken,
         isPrimaryValidationPassed,
+        isPartialApproveEnabled,
       ],
     ),
   }


### PR DESCRIPTION
# Summary

Fixes showing partial approve details if the FF is turned off

<img width="813" height="813" alt="image" src="https://github.com/user-attachments/assets/26e48e5c-714d-49f6-b056-323a93e17f17" />


# To Test

1. Switch off the ff for partial approve 

- [ ] There aren't partial approve actions on trade widget form