### PR TITLE
feat: add aave hooks to registry

### DIFF
--- a/libs/hook-dapp-lib/src/hookDappsRegistry.ts
+++ b/libs/hook-dapp-lib/src/hookDappsRegistry.ts
@@ -196,29 +196,38 @@ export const hookDappsRegistry = {
   },
   'cow-sdk://flashloans/aave/v3/collateral-swap': {
     name: 'Aave',
-    type: 'INTERNAL',
+    type: 'EXTERNAL',
     descriptionShort: 'Aave Collateral Swap Flashloan',
     description: 'The swap adapter contracts integrate Aave Flash Loans and CoW Swap to facilitate advanced actions like swapping collateral assets when there are borrow positions. Learn more at https://aave.com/docs/developers/smart-contracts/swap-features.',
     version: '0.0.1',
     website: 'https://aave.com',
     image: 'https://app.aave.com/icons/tokens/aave.svg',
+    conditions: {
+      supportedNetworks: [11155111],
+    },
   },
   'cow-sdk://flashloans/aave/v3/debt-swap': {
     name: 'Aave',
-    type: 'INTERNAL',
+    type: 'EXTERNAL',
     descriptionShort: 'Aave Debt Swap Flashloan',
     description: 'The swap adapter contracts integrate Aave Flash Loans and CoW Swap to facilitate advanced actions like swapping debt assets. Learn more at https://aave.com/docs/developers/smart-contracts/swap-features.',
     version: '0.0.1',
     website: 'https://aave.com',
     image: 'https://app.aave.com/icons/tokens/aave.svg',
+    conditions: {
+      supportedNetworks: [11155111],
+    },
   },
   'cow-sdk://flashloans/aave/v3/repay-with-collateral': {
     name: 'Aave',
-    type: 'INTERNAL',
+    type: 'EXTERNAL',
     descriptionShort: 'Aave Repay with Collateral Flashloan',
     description: 'The swap adapter contracts integrate Aave Flash Loans and CoW Swap to facilitate advanced actions like repaying borrow positions using collateral. Learn more at https://aave.com/docs/developers/smart-contracts/swap-features.',
     version: '0.0.1',
     website: 'https://aave.com',
     image: 'https://app.aave.com/icons/tokens/aave.svg',
+    conditions: {
+      supportedNetworks: [11155111],
+    },
   },
 }


### PR DESCRIPTION
Adds aave hooks info to hooks registry.

Testing: try use a hook with some of the dapp ids included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three Aave v3 flashloan options in the app: collateral-swap, debt-swap, and repay-with-collateral.
  * Each option is listed with descriptive metadata and is available on supported networks (v3 entry added, versioned).
  * Enhances UI discoverability for Aave v3 flashloan flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->