### PR TITLE
fix: remove available chains from unsupported networks warning

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useUnsupportedNetworksText.tsx
+++ b/apps/cowswap-frontend/src/common/hooks/useUnsupportedNetworksText.tsx
@@ -1,9 +1,9 @@
 import { ReactElement } from 'react'
 
-import { getChainInfo } from '@cowprotocol/common-const'
 import { Trans } from '@lingui/macro'
 
 export function useUnsupportedNetworksText(): ReactElement {
+  // TODO: turn into a pure component now that it doesn't need additional info
   return (
     <Trans>
       Please connect your wallet to one of our supported networks.


### PR DESCRIPTION
Fixes https://www.notion.so/cownation/Remove-list-of-supported-networks-from-unsupported-network-message-2a18da5f04ca807a83ded41002a52161

**To test:** 
1. connect the app to an unsupported network
2. check the warning and the message on the Account modal --> supported chains should not be listed.
<img width="410" height="102" alt="image" src="https://github.com/user-attachments/assets/a07006e6-0871-4cef-be5c-37d328dbe84b" />
<img width="533" height="126" alt="image" src="https://github.com/user-attachments/assets/f7206dc2-a819-4906-925b-0f6c44dc9cbe" />
