### PR TITLE
fix(linea): add USDT as a favourite token

### DIFF
--- a/libs/common-const/src/tokens.ts
+++ b/libs/common-const/src/tokens.ts
@@ -492,7 +492,6 @@ export const BTCB_BNB = new TokenWithLogo(
 
 // Linea
 
-// TODO: verify and add more tokens for Linea
 export const USDC_LINEA = new TokenWithLogo(
   USDC_MAINNET.logoURI,
   SupportedChainId.LINEA,
@@ -501,6 +500,16 @@ export const USDC_LINEA = new TokenWithLogo(
   6,
   'USDC',
   'USD Coin',
+)
+
+export const USDT_LINEA = new TokenWithLogo(
+  USDT.logoURI,
+  SupportedChainId.LINEA,
+  // https://lineascan.build/address/0xA219439258ca9da29E9Cc4cE5596924745e12B93
+  '0xa219439258ca9da29e9cc4ce5596924745e12b93',
+  6,
+  'USDT',
+  'Tether USD',
 )
 
 // Plasma

--- a/libs/tokens/src/const/defaultFavoriteTokens.ts
+++ b/libs/tokens/src/const/defaultFavoriteTokens.ts
@@ -31,6 +31,7 @@ import {
   USDT_AVALANCHE,
   USDT_BASE,
   USDT_BNB,
+  USDT_LINEA,
   USDT_PLASMA,
   USDT_POLYGON,
   WBTC,
@@ -120,6 +121,10 @@ export const DEFAULT_FAVORITE_TOKENS: Record<SupportedChainId, TokensMap> = {
     DAI_BNB,
     BTCB_BNB,
   ]),
-  [SupportedChainId.LINEA]: tokensListToMap([WRAPPED_NATIVE_CURRENCIES[SupportedChainId.LINEA], USDC_LINEA]),
+  [SupportedChainId.LINEA]: tokensListToMap([
+    WRAPPED_NATIVE_CURRENCIES[SupportedChainId.LINEA],
+    USDC_LINEA,
+    USDT_LINEA,
+  ]),
   [SupportedChainId.PLASMA]: tokensListToMap([WRAPPED_NATIVE_CURRENCIES[SupportedChainId.PLASMA], USDT_PLASMA]),
 }


### PR DESCRIPTION
# Summary

Add USDT as a favourite token on Linea

# To Test

1. Connect to Linea
2. Open token selector
* USDT should be one of the favourite tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added USDT (Tether USD) support on the Linea blockchain with full token configuration
  * USDT is now a default favorite token for Linea users for convenient access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->