### PR TITLE
fix(explorer): do not add tx row when there's no tx hash

### DIFF
--- a/apps/explorer/src/components/orders/DetailsTable/BaseDetailsTable.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/BaseDetailsTable.tsx
@@ -155,10 +155,8 @@ export function BaseDetailsTable({
           </tr>
           {(!partiallyFillable || txHash) && areTradesLoading ? (
             <Spinner />
-          ) : txHash ? (
-            <TxHashItem chainId={chainId} txHash={txHash} onCopy={onCopy} isLoading={areTradesLoading} />
           ) : (
-            '-'
+            <TxHashItem chainId={chainId} txHash={txHash} onCopy={onCopy} isLoading={areTradesLoading} />
           )}
           <tr>
             <td>


### PR DESCRIPTION
# Summary

Fix bug where there's a dangling `-` in the explorer order details
<img width="485" height="377" alt="image" src="https://github.com/user-attachments/assets/2cd9839b-49fa-4c1a-9b86-22c2fd035994" />


# To Test

1. Pick an order that have not been executed (no tx hash yet)
2. Load it into explorer
* There should NOT be a dangling `-`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated transaction hash display in trade details to consistently show the transaction hash component instead of a placeholder dash when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->