### PR TITLE
fix(trade): compare tx approve amount with min amount to swap

### DIFF
--- a/apps/cowswap-frontend/src/modules/erc20Approve/containers/TradeApproveButton/TradeApproveButton.tsx
+++ b/apps/cowswap-frontend/src/modules/erc20Approve/containers/TradeApproveButton/TradeApproveButton.tsx
@@ -20,7 +20,7 @@ import { ApprovalState } from '../../types'
 
 export interface TradeApproveButtonProps {
   amountToApprove: CurrencyAmount<Currency>
-  minAmountToSwap?: CurrencyAmount<Currency>
+  minAmountToSignForSwap?: CurrencyAmount<Currency>
   children?: ReactNode
   isDisabled?: boolean
   enablePartialApprove?: boolean

--- a/apps/cowswap-frontend/src/modules/erc20Approve/hooks/useApproveAndSwap.ts
+++ b/apps/cowswap-frontend/src/modules/erc20Approve/hooks/useApproveAndSwap.ts
@@ -14,7 +14,7 @@ import { getIsTradeApproveResult } from '../utils/getIsTradeApproveResult'
 
 export interface ApproveAndSwapProps {
   amountToApprove: CurrencyAmount<Currency>
-  minAmountToSwap?: CurrencyAmount<Currency>
+  minAmountToSignForSwap?: CurrencyAmount<Currency>
   onApproveConfirm?: (transactionHash?: string) => void
   ignorePermit?: boolean
   useModals?: boolean
@@ -25,7 +25,7 @@ export function useApproveAndSwap({
   useModals,
   ignorePermit,
   onApproveConfirm,
-  minAmountToSwap,
+  minAmountToSignForSwap,
 }: ApproveAndSwapProps): () => Promise<void> {
   const isPartialApproveEnabledByUser = useIsPartialApproveSelectedByUser()
   const handleApprove = useApproveCurrency(amountToApprove, useModals)
@@ -61,8 +61,8 @@ export function useApproveAndSwap({
     if (tx && onApproveConfirm) {
       if (getIsTradeApproveResult(tx)) {
         const approvedAmount = tx.approvedAmount
-        const minAmountToSwapBig = minAmountToSwap ? BigInt(minAmountToSwap.quotient.toString()) : amountToApproveBig
-        const isApprovedAmountSufficient = Boolean(approvedAmount && approvedAmount >= minAmountToSwapBig)
+        const minAmountToSignForSwapBig = minAmountToSignForSwap ? BigInt(minAmountToSignForSwap.quotient.toString()) : amountToApproveBig
+        const isApprovedAmountSufficient = Boolean(approvedAmount && approvedAmount >= minAmountToSignForSwapBig)
 
         if (isApprovedAmountSufficient) {
           const hash =
@@ -83,6 +83,6 @@ export function useApproveAndSwap({
     handleApprove,
     updateTradeApproveState,
     handlePermit,
-    minAmountToSwap,
+    minAmountToSignForSwap,
   ])
 }

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormButtonContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormButtonContext.ts
@@ -25,7 +25,7 @@ export function useTradeFormButtonContext(
   const { standaloneMode } = useInjectedWidgetParams()
   const derivedState = useDerivedTradeState()
   const amountToApprove = useGetAmountToSignApprove()
-  const { maximumSendSellAmount: minSwapAmount } = useAmountsToSignFromQuote() || {}
+  const { maximumSendSellAmount: minAmountToSignForSwap } = useAmountsToSignFromQuote() || {}
   const customTokenError = useTokenCustomTradeError(
     derivedState?.inputCurrency,
     derivedState?.outputCurrency,
@@ -47,7 +47,7 @@ export function useTradeFormButtonContext(
       widgetStandaloneMode: standaloneMode,
       enablePartialApprove,
       customTokenError,
-      minSwapAmount,
+      minAmountToSignForSwap,
     }
   }, [
     defaultText,
@@ -61,6 +61,6 @@ export function useTradeFormButtonContext(
     standaloneMode,
     enablePartialApprove,
     customTokenError,
-    minSwapAmount,
+    minAmountToSignForSwap,
   ])
 }

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
@@ -246,7 +246,7 @@ export const tradeButtonsMap: Record<TradeFormValidation, ButtonErrorConfig | Bu
         amountToApprove={amountToApprove}
         enablePartialApprove={enablePartialApprove}
         onApproveConfirm={context.confirmTrade}
-        minAmountToSwap={context.minSwapAmount}
+        minAmountToSignForSwap={context.minAmountToSignForSwap}
       >
         <TradeFormBlankButton disabled={!enablePartialApprove}>
           <Trans>{defaultText}</Trans>

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/types.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/types.ts
@@ -81,7 +81,7 @@ export interface TradeFormButtonContext {
   widgetStandaloneMode?: boolean
   enablePartialApprove?: boolean
   customTokenError?: string
-  minSwapAmount?: CurrencyAmount<Currency>
+  minAmountToSignForSwap?: CurrencyAmount<Currency>
 
   confirmTrade(): void
 


### PR DESCRIPTION
# Summary

Fix an issue with allowance when user approves less than expected amount, but more than enough for swap. ([details](https://cowservices.slack.com/archives/C0361CDG8GP/p1762525031264299))

Steps to reproduce

Expected: it should not appear as 1>0.1 that is required for trading

# To Test

1. do not enable PA setting
2. Pick not permittable token to sell
3. fill in an amount, for example. 0.1
4. start approving TX, but edit amount in the wallet (f.e., set 1 to approve)
5. sigh the TX
6. Once TX is mined, error message appears on the UI

- [ ] it should not appear as 1>0.1 that is required for trading


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Approval checks now consider a minimum amount required to sign a swap (derived from quotes), reducing failed or insufficient approvals.
  * The trade button and approval flows propagate this minimum-swap amount so approval prompts and UI accurately reflect required amounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->