### PR TITLE
fix: sort chains according to the rest of the UI

### DIFF
--- a/libs/common-const/src/getAvailableChainsText.ts
+++ b/libs/common-const/src/getAvailableChainsText.ts
@@ -1,9 +1,15 @@
-import { ALL_SUPPORTED_CHAINS } from '@cowprotocol/cow-sdk'
+import { ALL_SUPPORTED_CHAINS_MAP } from '@cowprotocol/cow-sdk'
+
+import { SORTED_CHAIN_IDS } from './chainInfo'
 
 export function getAvailableChainsText(): string {
-  return ALL_SUPPORTED_CHAINS.filter(({ isUnderDevelopment }) => !isUnderDevelopment)
-    .map(({ label, isTestnet }) => `${label}${isTestnet ? ' (testnet)' : ''}`)
-    .sort()
+  return SORTED_CHAIN_IDS.reduce((acc, chainId) => {
+    const { label, isTestnet, isUnderDevelopment } = ALL_SUPPORTED_CHAINS_MAP[chainId]
+    if (!isUnderDevelopment) {
+      acc.push(`${label}${isTestnet ? ' (testnet)' : ''}`)
+    }
+    return acc
+  }, [] as string[])
     .join(', ')
     .replace(/, ([^,]*)$/, ' and $1')
 }


### PR DESCRIPTION
# Summary

Minor fix sorting chains in the same order as the UI.

# To Test

1. Open cow.fi on cowprotocol page and check the FAQ where all the chains are defined
* Should list them in the same order as CoW Swap UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency of chain display ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->