### PR TITLE
fix(permit): reset appData hooks when sell token changes

### DIFF
--- a/apps/cowswap-frontend/src/modules/appData/updater/AppDataHooksUpdater.ts
+++ b/apps/cowswap-frontend/src/modules/appData/updater/AppDataHooksUpdater.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 
+import { getCurrencyAddress } from '@cowprotocol/common-utils'
 import { cowAppDataLatestScheme } from '@cowprotocol/cow-sdk'
 import { PermitHookData } from '@cowprotocol/permit-utils'
 import { useIsSmartContractWallet } from '@cowprotocol/wallet'
@@ -49,6 +50,18 @@ export function AppDataHooksUpdater(): null {
   const isNativeSell = useIsSellNative()
 
   const [permitHook, setPermitHook] = useState<TypedCowHook | undefined>(undefined)
+
+  const inputCurrencyAddress = tradeState?.inputCurrency ? getCurrencyAddress(tradeState.inputCurrency) : undefined
+
+  /**
+   * Reset appDataHooks every time sellToken changes
+   */
+  useEffect(() => {
+    if (!inputCurrencyAddress) return
+
+    updateAppDataHooks(undefined)
+    setPermitHook(undefined)
+  }, [inputCurrencyAddress, updateAppDataHooks])
 
   useEffect(() => {
     const preInteractionHooks = (preHooks || []).map<TypedCowHook>((hookDetails) =>


### PR DESCRIPTION
# Summary

I don't know where it comes from, but I noticed that appData doesn't get updated in time.
Because of that we use appData generated for previous trade.
To fix that, I added useEffect() which resets `appDataHooksAtom` every time when sellToken changes.

# To Test

1. Have some USDC (permittable) and USDT (non-permittable) on Arbitrum, both with no allowance
2. Go /limit/0xaf88d065e77c8cC2239327C5EDb3A432268e5831/USDT?tab=all&page=1
3. Try to place a limit order, sign permit, but DO NOT sign order, reject the signature
4. Go /swap/USDT/0xaf88d065e77c8cC2239327C5EDb3A432268e5831
5. Approve USDT and swap (place order)
- [ ] AR: the order includes permit in appData hooks
- [ ] ER: there is no hooks in order appData

Please, try to check other cases related to appData updates:
 - slippage
 - volume fee
 - other hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved state handling when changing input currency: app data is reset and pending permits are cleared to ensure consistent behavior after switching currencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->