### PR TITLE
hotfix: update protocol fee description

### DIFF
--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -1637,8 +1637,8 @@ msgid "Order type"
 msgstr "Order type"
 
 #: apps/cowswap-frontend/src/modules/trade/pure/ProtocolFeeRow/index.tsx
-msgid "The fee is {protocolFeeAsPercent}%, applied only if the trade is executed, in order to incentivize a strong solver competition that provides ecosystem leading prices."
-msgstr "The fee is {protocolFeeAsPercent}%, applied only if the trade is executed, in order to incentivize a strong solver competition that provides ecosystem leading prices."
+#~ msgid "The fee is {protocolFeeAsPercent}%, applied only if the trade is executed, in order to incentivize a strong solver competition that provides ecosystem leading prices."
+#~ msgstr "The fee is {protocolFeeAsPercent}%, applied only if the trade is executed, in order to incentivize a strong solver competition that provides ecosystem leading prices."
 
 #: apps/cowswap-frontend/src/modules/hooksStore/containers/HooksStoreWidget/index.tsx
 msgid "Learn more."
@@ -3295,6 +3295,10 @@ msgstr "Connect wallet"
 #: apps/cowswap-frontend/src/modules/ordersTable/containers/OrderRow/OrderWarning.tsx
 msgid "Approve the token to proceed."
 msgstr "Approve the token to proceed."
+
+#: apps/cowswap-frontend/src/modules/trade/pure/ProtocolFeeRow/index.tsx
+msgid "This {protocolFeeBps} BPS fee incentivizes solvers to find better prices for users. It is only applied if the trade is executed."
+msgstr "This {protocolFeeBps} BPS fee incentivizes solvers to find better prices for users. It is only applied if the trade is executed."
 
 #: apps/cowswap-frontend/src/modules/accountProxy/pure/AccountCard/DefaultAccountContent.tsx
 msgid "Recoverable value"

--- a/apps/cowswap-frontend/src/modules/trade/pure/ProtocolFeeRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/ProtocolFeeRow/index.tsx
@@ -38,8 +38,8 @@ export function ProtocolFeeRow({
       fiatAmount={protocolFeeUsd}
       tooltip={
         <Trans>
-          The fee, applied only if the trade is executed, in order to incentivize a strong
-          solver competition that provides ecosystem leading prices.
+          This {protocolFeeBps} BPS fee incentivizes solvers to find better prices for users. It is only applied if the
+          trade is executed.
         </Trans>
       }
       label={t`Protocol fee (${protocolFeeAsPercent}%)`}


### PR DESCRIPTION
# Summary

Update the protocol fee tooltip description

<img width="510" height="633" alt="image" src="https://github.com/user-attachments/assets/8f4f1c44-8479-4513-aac0-f061b25abaa4" />


# To Test

1. Check the fee description on the swap/limit order form

- [ ] description should be "This {protocolFeeBps} BPS fee incentivizes solvers to find better prices for users. It is only applied if the trade is executed."
