### PR TITLE
chore: allow to set orderbook urls using local storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ The API endpoint is configured using the environment variable
 `REACT_APP_ORDER_BOOK_URLS`:
 
 ```ini
-REACT_APP_ORDER_BOOK_URLS='{"1":"https://YOUR_HOST","100":"https://YOUR_HOST","5":"https://YOUR_HOST"}
+REACT_APP_ORDER_BOOK_URLS='{"1":"https://YOUR_HOST","100":"https://YOUR_HOST","5":"https://YOUR_HOST"}'
 ```
 
 ## BFF API Endpoints (Backend for Frontend)

--- a/apps/cowswap-frontend/src/cowSdk.ts
+++ b/apps/cowswap-frontend/src/cowSdk.ts
@@ -7,9 +7,19 @@ import { EthersV5Adapter } from '@cowprotocol/sdk-ethers-v5-adapter'
 import { useWeb3React } from '@web3-react/core'
 
 const chainId = getCurrentChainIdFromUrl()
-const prodBaseUrls = process.env.REACT_APP_ORDER_BOOK_URLS
-  ? JSON.parse(process.env.REACT_APP_ORDER_BOOK_URLS)
-  : undefined
+
+const envBaseUrls = process.env.REACT_APP_ORDER_BOOK_URLS && JSON.parse(process.env.REACT_APP_ORDER_BOOK_URLS)
+
+// To manually set the order book URLs in localStorage, you can use the following command in the browser console:
+// localStorage.setItem('orderBookUrls', JSON.stringify({ "1":"https://YOUR_HOST", "100":"https://YOUR_HOST" }))
+// To clear it, simply run:
+// localStorage.removeItem('orderBookUrls')
+const localStorageBaseUrls =
+  localStorage.getItem('orderBookUrls') && JSON.parse(localStorage.getItem('orderBookUrls') || '{}')
+
+const prodBaseUrls = envBaseUrls || localStorageBaseUrls || undefined
+
+console.log('Order Book URLs:', prodBaseUrls, !!envBaseUrls, !!localStorageBaseUrls)
 
 export const adapter = new EthersV5Adapter({
   provider: getRpcProvider(chainId)!,

--- a/apps/explorer/src/cowSdk.ts
+++ b/apps/explorer/src/cowSdk.ts
@@ -2,9 +2,13 @@ import { MetadataApi } from '@cowprotocol/cow-sdk'
 import { OrderBookApi } from '@cowprotocol/cow-sdk'
 import { SubgraphApi } from '@cowprotocol/sdk-subgraph'
 
-const prodBaseUrls = process.env.REACT_APP_ORDER_BOOK_URLS
-  ? JSON.parse(process.env.REACT_APP_ORDER_BOOK_URLS)
-  : undefined
+// TODO: why is this duplicated? Can this be shared with the instance from CoW Swap?
+
+const envBaseUrls = process.env.REACT_APP_ORDER_BOOK_URLS && JSON.parse(process.env.REACT_APP_ORDER_BOOK_URLS)
+const localStorageBaseUrls =
+  localStorage.getItem('orderBookUrls') && JSON.parse(localStorage.getItem('orderBookUrls') || '{}')
+
+const prodBaseUrls = envBaseUrls || localStorageBaseUrls || undefined
 
 const apiKey = process.env.THEGRAPH_API_KEY || ''
 


### PR DESCRIPTION
# Summary

Use localStorage to set a custom backend endpoint

Supersedes https://github.com/cowprotocol/cowswap/pull/6003

# To Test

1. Pick the url endpoints you'd like to use and set them with:
2. `localStorage.setItem('orderBookUrls', JSON.stringify({ "1":"https://YOUR_HOST", "100":"https://YOUR_HOST" }))`
3. Refresh the page
4. Check the network page
* Requests should be sent to the respective endpoints set above, for the chains specified

5. To clear it:
6. `localStorage.removeItem('orderBookUrls')`
7. Refresh the page
* Usual URLs should be used instead