### PR TITLE
fix: remember deleted token lists

### DIFF
--- a/apps/cowswap-frontend/src/modules/tokensList/containers/SelectTokenWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/containers/SelectTokenWidget/index.tsx
@@ -85,13 +85,17 @@ export function SelectTokenWidget({ displayLpTokenLists, standalone }: SelectTok
   const { account } = useWalletInfo()
 
   const cowAnalytics = useCowAnalytics()
-  const addCustomTokenLists = useAddList((source) => {
-    cowAnalytics.sendEvent({
-      category: CowSwapAnalyticsCategory.LIST,
-      action: 'Add List Success',
-      label: source,
-    })
-  })
+  const trackAddListAnalytics = useCallback(
+    (source: string) => {
+      cowAnalytics.sendEvent({
+        category: CowSwapAnalyticsCategory.LIST,
+        action: 'Add List Success',
+        label: source,
+      })
+    },
+    [cowAnalytics],
+  )
+  const addCustomTokenLists = useAddList(trackAddListAnalytics)
   const importTokenCallback = useAddUserToken()
 
   const {

--- a/apps/cowswap-frontend/src/modules/tokensList/hooks/useAddListImport.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/hooks/useAddListImport.ts
@@ -4,9 +4,7 @@ import { ListState } from '@cowprotocol/tokens'
 
 import { useUpdateSelectTokenWidgetState } from './useUpdateSelectTokenWidgetState'
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function useAddListImport() {
+export function useAddListImport(): (listToImport: ListState) => void {
   const updateSelectTokenWidget = useUpdateSelectTokenWidgetState()
 
   return useCallback(
@@ -15,6 +13,6 @@ export function useAddListImport() {
         listToImport,
       })
     },
-    [updateSelectTokenWidget]
+    [updateSelectTokenWidget],
   )
 }

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/ImportListModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/ImportListModal/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { ReactNode, useState } from 'react'
 
 import { getTokenListViewLink, ListState, TokenLogo } from '@cowprotocol/tokens'
 import { ButtonPrimary, ModalHeader } from '@cowprotocol/ui'
@@ -18,9 +18,7 @@ export interface ImportListModalProps {
   onDismiss(): void
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function ImportListModal(props: ImportListModalProps) {
+export function ImportListModal(props: ImportListModalProps): ReactNode {
   const { list, onBack, onDismiss, onImport } = props
 
   const [isAccepted, setIsAccepted] = useState(false)

--- a/libs/tokens/src/hooks/lists/useAddList.ts
+++ b/libs/tokens/src/hooks/lists/useAddList.ts
@@ -24,16 +24,16 @@ Tokens in update: ${updateCount}.
   `
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function useAddList(onAddList: (source: string) => void) {
+export function useAddList(onAddList: (source: string) => void): (state: ListState) => void {
   const { chainId } = useAtomValue(environmentAtom)
   const listsStatesByChain = useAtomValue(listsStatesByChainAtom)
   const addList = useSetAtom(addListAtom)
 
   return useCallback(
     (state: ListState) => {
-      const currentStateCount = getTokenListsStateCount(Object.values(listsStatesByChain[chainId] || {}))
+      const currentStateCount = getTokenListsStateCount(
+        Object.values(listsStatesByChain[chainId] || {}).filter((value) => value !== 'deleted'),
+      )
       const updateCount = getTokenListsStateCount([state])
       const totalCount = currentStateCount + updateCount
 

--- a/libs/tokens/src/state/tokenLists/tokenListsActionsAtom.ts
+++ b/libs/tokens/src/state/tokenLists/tokenListsActionsAtom.ts
@@ -17,9 +17,12 @@ export const upsertListsAtom = atom(null, async (get, set, chainId: SupportedCha
   const chainState = globalState[chainId]
 
   const update = listsStates.reduce<{ [listId: string]: ListState }>((acc, list) => {
+    const listState = chainState?.[list.source]
+    const defaultEnabledState = listState === 'deleted' ? true : listState?.isEnabled
+
     acc[list.source] = {
       ...list,
-      isEnabled: typeof list.isEnabled === 'boolean' ? list.isEnabled : chainState?.[list.source]?.isEnabled,
+      isEnabled: typeof list.isEnabled === 'boolean' ? list.isEnabled : defaultEnabledState,
     }
 
     return acc
@@ -71,7 +74,7 @@ export const removeListAtom = atom(null, async (get, set, source: string) => {
   const networkState = stateCopy[chainId]
 
   if (networkState) {
-    delete networkState[source]
+    networkState[source] = 'deleted'
   }
 
   set(listsStatesByChainAtom, stateCopy)

--- a/libs/tokens/src/state/tokenLists/tokenListsStateAtom.test.ts
+++ b/libs/tokens/src/state/tokenLists/tokenListsStateAtom.test.ts
@@ -1,0 +1,244 @@
+import { createStore } from 'jotai'
+
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import { removeListAtom, upsertListsAtom } from './tokenListsActionsAtom'
+import { listsStatesByChainAtom, listsStatesMapAtom } from './tokenListsStateAtom'
+
+import { ListState, TokenListsByChainState } from '../../types'
+import { environmentAtom } from '../environmentAtom'
+
+const DEFAULT_LISTS_STATE = {
+  [SupportedChainId.MAINNET]: {},
+  [SupportedChainId.GNOSIS_CHAIN]: {},
+  [SupportedChainId.ARBITRUM_ONE]: {},
+  [SupportedChainId.BASE]: {},
+  [SupportedChainId.SEPOLIA]: {},
+  [SupportedChainId.POLYGON]: {},
+  [SupportedChainId.AVALANCHE]: {},
+  [SupportedChainId.LENS]: {},
+  [SupportedChainId.BNB]: {},
+  [SupportedChainId.LINEA]: {},
+  [SupportedChainId.PLASMA]: {},
+}
+const MOCK_CHAIN_ID = SupportedChainId.MAINNET
+
+const MOCK_LIST_STATE: ListState = {
+  source: 'https://example.com/tokenlist.json',
+  priority: 1,
+  list: {
+    name: 'Test List',
+    timestamp: '2024-01-01T00:00:00Z',
+    version: { major: 1, minor: 0, patch: 0 },
+    tokens: [
+      {
+        chainId: 1,
+        address: '0x1234567890123456789012345678901234567890',
+        name: 'Test Token',
+        symbol: 'TEST',
+        decimals: 18,
+      },
+    ],
+  },
+  isEnabled: true,
+}
+
+const MOCK_LIST_STATE_2: ListState = {
+  source: 'https://example.com/tokenlist2.json',
+  priority: 2,
+  list: {
+    name: 'Test List 2',
+    timestamp: '2024-01-01T00:00:00Z',
+    version: { major: 1, minor: 0, patch: 0 },
+    tokens: [
+      {
+        chainId: 1,
+        address: '0x2234567890123456789012345678901234567890',
+        name: 'Test Token 2',
+        symbol: 'TEST2',
+        decimals: 18,
+      },
+    ],
+  },
+  isEnabled: true,
+}
+
+describe('listsStatesByChainAtom - token lists state', () => {
+  describe('listsStatesMapAtom', () => {
+    it('filters out deleted entries from the list state', async () => {
+      const store = createStore()
+
+      const stateWithDeleted: TokenListsByChainState = {
+        ...DEFAULT_LISTS_STATE,
+        [MOCK_CHAIN_ID]: {
+          [MOCK_LIST_STATE.source]: MOCK_LIST_STATE,
+          [MOCK_LIST_STATE_2.source]: 'deleted',
+        },
+      }
+
+      store.set(environmentAtom, {
+        chainId: MOCK_CHAIN_ID,
+        useCuratedListOnly: false,
+        isYieldEnabled: false,
+      })
+      store.set(listsStatesByChainAtom, stateWithDeleted)
+
+      const listsStatesMap = await store.get(listsStatesMapAtom)
+
+      expect(listsStatesMap[MOCK_LIST_STATE.source]).toEqual(MOCK_LIST_STATE)
+      expect(listsStatesMap[MOCK_LIST_STATE_2.source]).toBeUndefined()
+    })
+
+    it('returns all entries when none are deleted', async () => {
+      const store = createStore()
+
+      const stateWithoutDeleted: TokenListsByChainState = {
+        ...DEFAULT_LISTS_STATE,
+        [MOCK_CHAIN_ID]: {
+          [MOCK_LIST_STATE.source]: MOCK_LIST_STATE,
+          [MOCK_LIST_STATE_2.source]: MOCK_LIST_STATE_2,
+        },
+      }
+
+      store.set(environmentAtom, {
+        chainId: MOCK_CHAIN_ID,
+        useCuratedListOnly: false,
+        isYieldEnabled: false,
+      })
+      store.set(listsStatesByChainAtom, stateWithoutDeleted)
+
+      const listsStatesMap = await store.get(listsStatesMapAtom)
+
+      expect(Object.keys(listsStatesMap)).toHaveLength(2)
+      expect(listsStatesMap[MOCK_LIST_STATE.source]).toEqual(MOCK_LIST_STATE)
+      expect(listsStatesMap[MOCK_LIST_STATE_2.source]).toEqual(MOCK_LIST_STATE_2)
+    })
+
+    it('returns empty object when all entries are deleted', async () => {
+      const store = createStore()
+
+      const stateAllDeleted: TokenListsByChainState = {
+        ...DEFAULT_LISTS_STATE,
+        [MOCK_CHAIN_ID]: {
+          [MOCK_LIST_STATE.source]: 'deleted',
+          [MOCK_LIST_STATE_2.source]: 'deleted',
+        },
+      }
+
+      store.set(environmentAtom, {
+        chainId: MOCK_CHAIN_ID,
+        useCuratedListOnly: false,
+        isYieldEnabled: false,
+      })
+      store.set(listsStatesByChainAtom, stateAllDeleted)
+
+      const listsStatesMap = await store.get(listsStatesMapAtom)
+
+      expect(Object.keys(listsStatesMap)).toHaveLength(0)
+    })
+  })
+
+  describe('removeListAtom', () => {
+    it('sets the list state to "deleted" when removing a list', async () => {
+      const store = createStore()
+
+      const initialState: TokenListsByChainState = {
+        ...DEFAULT_LISTS_STATE,
+        [MOCK_CHAIN_ID]: {
+          [MOCK_LIST_STATE.source]: MOCK_LIST_STATE,
+        },
+      }
+
+      store.set(environmentAtom, {
+        chainId: MOCK_CHAIN_ID,
+        useCuratedListOnly: false,
+        isYieldEnabled: false,
+      })
+      store.set(listsStatesByChainAtom, initialState)
+
+      await store.set(removeListAtom, MOCK_LIST_STATE.source)
+
+      const updatedState = await store.get(listsStatesByChainAtom)
+
+      expect(updatedState?.[MOCK_CHAIN_ID]?.[MOCK_LIST_STATE.source]).toBe('deleted')
+    })
+  })
+
+  describe('upsertListsAtom', () => {
+    it('restores a list that was marked as deleted with isEnabled defaulting to true', async () => {
+      const store = createStore()
+
+      const initialState: TokenListsByChainState = {
+        ...DEFAULT_LISTS_STATE,
+        [MOCK_CHAIN_ID]: {
+          [MOCK_LIST_STATE.source]: 'deleted',
+        },
+      }
+
+      store.set(listsStatesByChainAtom, initialState)
+
+      const listWithoutEnabled = { ...MOCK_LIST_STATE }
+      delete listWithoutEnabled.isEnabled
+
+      await store.set(upsertListsAtom, MOCK_CHAIN_ID, [listWithoutEnabled])
+
+      const updatedState = await store.get(listsStatesByChainAtom)
+
+      // Should be restored with isEnabled defaulting to true
+      expect(updatedState?.[MOCK_CHAIN_ID]?.[MOCK_LIST_STATE.source]).toEqual({
+        ...listWithoutEnabled,
+        isEnabled: true,
+      })
+    })
+
+    it('upserts a new list that does not exist in state', async () => {
+      const store = createStore()
+
+      const initialState: TokenListsByChainState = {
+        ...DEFAULT_LISTS_STATE,
+        [MOCK_CHAIN_ID]: {},
+      }
+
+      store.set(listsStatesByChainAtom, initialState)
+
+      await store.set(upsertListsAtom, MOCK_CHAIN_ID, [MOCK_LIST_STATE])
+
+      const updatedState = await store.get(listsStatesByChainAtom)
+
+      expect(updatedState?.[MOCK_CHAIN_ID]?.[MOCK_LIST_STATE.source]).toEqual(MOCK_LIST_STATE)
+    })
+  })
+
+  describe('integration: delete and restore workflow', () => {
+    it('allows deleted list to be restored via upsert with isEnabled defaulting to true', async () => {
+      const store = createStore()
+
+      const initialState: TokenListsByChainState = {
+        ...DEFAULT_LISTS_STATE,
+        [MOCK_CHAIN_ID]: {
+          [MOCK_LIST_STATE.source]: MOCK_LIST_STATE,
+        },
+      }
+
+      store.set(environmentAtom, {
+        chainId: MOCK_CHAIN_ID,
+        useCuratedListOnly: false,
+        isYieldEnabled: false,
+      })
+      store.set(listsStatesByChainAtom, initialState)
+
+      // Remove the list (sets to deleted)
+      await store.set(removeListAtom, MOCK_LIST_STATE.source)
+
+      const state = await store.get(listsStatesByChainAtom)
+      expect(state?.[MOCK_CHAIN_ID]?.[MOCK_LIST_STATE.source]).toBe('deleted')
+
+      // Upsert the same list - should restore it
+      await store.set(upsertListsAtom, MOCK_CHAIN_ID, [MOCK_LIST_STATE])
+
+      const stateUpdate = await store.get(listsStatesByChainAtom)
+      // Should be restored with the list data
+      expect(stateUpdate?.[MOCK_CHAIN_ID]?.[MOCK_LIST_STATE.source]).toEqual(MOCK_LIST_STATE)
+    })
+  })
+})

--- a/libs/tokens/src/state/tokenLists/tokenListsStateAtom.ts
+++ b/libs/tokens/src/state/tokenLists/tokenListsStateAtom.ts
@@ -14,26 +14,20 @@ import {
 } from '../../types'
 import { environmentAtom } from '../environmentAtom'
 
+const TOKEN_LIST_SRC = 'https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public'
+
 const UNISWAP_TOKEN_LIST_URL: Record<SupportedChainId, string> = {
   [SupportedChainId.MAINNET]: UNISWAP_TOKENS_LIST,
-  [SupportedChainId.GNOSIS_CHAIN]:
-    'https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/Uniswap.100.json',
-  [SupportedChainId.ARBITRUM_ONE]:
-    'https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/Uniswap.42161.json',
-  [SupportedChainId.BASE]:
-    'https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/Uniswap.8453.json',
+  [SupportedChainId.GNOSIS_CHAIN]: `${TOKEN_LIST_SRC}/Uniswap.100.json`,
+  [SupportedChainId.ARBITRUM_ONE]: `${TOKEN_LIST_SRC}/Uniswap.42161.json`,
+  [SupportedChainId.BASE]: `${TOKEN_LIST_SRC}/Uniswap.8453.json`,
   [SupportedChainId.SEPOLIA]: UNISWAP_TOKENS_LIST,
-  [SupportedChainId.POLYGON]:
-    'https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/Uniswap.137.json',
-  [SupportedChainId.AVALANCHE]:
-    'https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/Uniswap.43114.json',
-  [SupportedChainId.LENS]:
-    'https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/CoinGecko.232.json', // There's no Uniswap list for Lens, using Coingecko as a fallback
-  [SupportedChainId.BNB]: 'https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/Uniswap.56.json',
-  [SupportedChainId.LINEA]:
-    'https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/Uniswap.59144.json', // TODO: create lists if possible
-  [SupportedChainId.PLASMA]:
-    'https://raw.githubusercontent.com/cowprotocol/token-lists/main/src/public/Uniswap.9745.json', // TODO: create lists if possible
+  [SupportedChainId.POLYGON]: `${TOKEN_LIST_SRC}/Uniswap.137.json`,
+  [SupportedChainId.AVALANCHE]: `${TOKEN_LIST_SRC}/Uniswap.43114.json`,
+  [SupportedChainId.LENS]: `${TOKEN_LIST_SRC}/CoinGecko.232.json`, // There's no Uniswap list for Lens, using Coingecko as a fallback
+  [SupportedChainId.BNB]: `${TOKEN_LIST_SRC}/Uniswap.56.json`,
+  [SupportedChainId.LINEA]: `${TOKEN_LIST_SRC}/Uniswap.59144.json`, // TODO: create lists if possible
+  [SupportedChainId.PLASMA]: `${TOKEN_LIST_SRC}/Uniswap.9745.json`, // TODO: create lists if possible
 }
 
 const curatedListSourceAtom = atom((get) => {
@@ -88,13 +82,23 @@ export const virtualListsStateAtom = atom<TokenListsState>({})
 
 export const listsStatesMapAtom = atom(async (get) => {
   const { chainId, widgetAppCode, selectedLists, useCuratedListOnly } = get(environmentAtom)
-  const allTokenListsInfo = await get(listsStatesByChainAtom)
   const virtualListsState = get(virtualListsStateAtom)
   const userAddedTokenLists = get(userAddedListsSourcesAtom)
   const useeAddedTokenListsForChain = userAddedTokenLists[chainId] || []
 
+  const allTokenListsInfo = await get(listsStatesByChainAtom)
+  const listsState = allTokenListsInfo[chainId] || {}
+
   const currentNetworkLists = {
-    ...allTokenListsInfo[chainId],
+    ...Object.keys(listsState).reduce<TokenListsState>((acc, key) => {
+      const val = listsState[key]
+
+      if (val !== 'deleted') {
+        acc[key] = val
+      }
+
+      return acc
+    }, {}),
     ...virtualListsState,
   }
 

--- a/libs/tokens/src/types.ts
+++ b/libs/tokens/src/types.ts
@@ -43,7 +43,7 @@ export interface ListState extends Pick<ListSourceConfig, 'source' | 'priority' 
 
 export type TokenListsState = { [source: string]: ListState }
 
-export type TokenListsByChainState = PersistentStateByChain<TokenListsState>
+export type TokenListsByChainState = PersistentStateByChain<{ [source: string]: ListState | 'deleted' }>
 
 export type TagInfo = {
   id: string


### PR DESCRIPTION
# Summary

Fixes #6238

1. `listsStatesByChainAtom` state type has been changed from `{ [source: string]: ListState }` to `{ [source: string]: ListState | 'deleted' }`
2. With the new `deleted` value, we explicitly mark deleted token lists, which prevents using the default tokens lists once they are deleted
3. There is no need to bump `listsStatesByChainAtom` localStorage version because the state change is backward compatible

# To Test

See #6238


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - Exclude lists marked "deleted" from user-visible lists and counts; removal now marks lists as deleted consistently.

* **Refactor**
  - Stabilized callbacks and added explicit return typing and clearer configuration for token list sources and defaults.

* **Tests**
  - Added comprehensive tests covering deletion, restoration, and state behaviors for token lists.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->