### PR TITLE
chore(cow-fi): sitemap - cache getAllArticleSlugsWithDates() value

### DIFF
--- a/apps/cow-fi/next-sitemap.config.js
+++ b/apps/cow-fi/next-sitemap.config.js
@@ -22,7 +22,7 @@ module.exports = {
     if (url.startsWith('/learn/')) {
       try {
         console.log(`Transforming learn page: ${url}`)
-        const articles = await getAllArticleSlugsWithDates()
+        const articles = await getAllArticleSlugsWithDatesCached()
         const article = articles.find(({ slug }) => `/learn/${slug}` === url)
 
         if (article) {
@@ -50,6 +50,25 @@ module.exports = {
     }
   },
 }
+
+function cacheAsyncFunction(fn) {
+  const EMPTY = Symbol()
+  let result = EMPTY
+
+  return async function (...args) {
+    if (result !== EMPTY) return result
+
+    result = fn(...args).catch((err) => {
+      result = EMPTY
+      throw err
+    })
+
+    return result
+  }
+}
+
+/** @type {typeof getAllArticleSlugsWithDates} */
+const getAllArticleSlugsWithDatesCached = cacheAsyncFunction(getAllArticleSlugsWithDates)
 
 /**
  * Function to fetch all article slugs with lastModified dates from the CMS API


### PR DESCRIPTION
# Summary

next-sitemap's `transform` functions calls `getAllArticleSlugsWithDates` for every `/learn/**` slug, so it lasts a long time

Fix:
- added infinite cache for `getAllArticleSlugsWithDates()` call

# To Test

1. `yarn build:cowfi`

`sitemap.xml` should be generated very quickly



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced sitemap generation performance through implementation of efficient caching for article data retrieval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->