### PR TITLE
fix(swap): select network outside click on mobile (#6603)

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/Header/NetworkSelector/index.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Header/NetworkSelector/index.tsx
@@ -159,6 +159,7 @@ export function NetworkSelector(): ReactNode {
   const { chainId } = useWalletInfo()
   const node = useRef<HTMLDivElement>(null)
   const nodeMobile = useRef<HTMLDivElement>(null)
+  const nodeSelector = useRef<HTMLDivElement>(null)
   const isOpen = useModalIsOpen(ApplicationModal.NETWORK_SELECTOR)
   const toggleModal = useToggleModal(ApplicationModal.NETWORK_SELECTOR)
 
@@ -169,7 +170,7 @@ export function NetworkSelector(): ReactNode {
   const info = getChainInfo(chainId)
   const isUpToMedium = useMediaQuery(Media.upToMedium(false))
 
-  useOnClickOutside(isUpToMedium ? [nodeMobile] : [node], () => {
+  useOnClickOutside(isUpToMedium ? [nodeMobile, nodeSelector] : [node], () => {
     if (isOpen) {
       toggleModal()
     }
@@ -187,7 +188,7 @@ export function NetworkSelector(): ReactNode {
 
   return (
     <SelectorWrapper ref={node} onClick={toggleModal}>
-      <SelectorControls isChainIdUnsupported={isChainIdUnsupported}>
+      <SelectorControls ref={nodeSelector} isChainIdUnsupported={isChainIdUnsupported}>
         {!isChainIdUnsupported ? (
           <>
             <SelectorLogo src={logoUrl} />


### PR DESCRIPTION
# Summary

Fixes #6603

# To Test

1) Switch to mobile mode (screen width <960px)
2) Click Network Selector
3) Click Network Selector again

Network Selector should be closed on the second click

# Background

I'm not sure why `useOnClickOutside` doesn't accept `node ref` in mobile mode. So I've added Control button ref in `useOnClickOutside` arg array on mobile. Now second click doesn't trigger `useOnClickOutside`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network selector's click-outside detection to ensure it reliably closes when clicking outside the component, enhancing the click detection area accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->