### PR TITLE
fix: switch to sell order if wallet changed from safe to EOA

### DIFF
--- a/apps/cowswap-frontend/project.json
+++ b/apps/cowswap-frontend/project.json
@@ -35,7 +35,8 @@
       "executor": "@nx/vite:dev-server",
       "defaultConfiguration": "development",
       "options": {
-        "buildTarget": "cowswap-frontend:build"
+        "buildTarget": "cowswap-frontend:build",
+        "host": true
       },
       "configurations": {
         "dev": {

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
@@ -12,11 +12,13 @@ import { useHooksEnabledManager } from 'legacy/state/user/hooks'
 import { useTryFindIntermediateToken } from 'modules/bridge'
 import { TradeApproveWithAffectedOrderList } from 'modules/erc20Approve'
 import { EthFlowModal, EthFlowProps } from 'modules/ethFlow'
+import { SELL_ETH_RESET_STATE } from 'modules/swap/consts'
 import { AddIntermediateTokenModal } from 'modules/tokensList'
 import {
   TradeWidget,
   TradeWidgetSlots,
   useGetReceiveAmountInfo,
+  useIsEoaEthFlow,
   useTradePriceImpact,
   useWrapNativeFlow,
 } from 'modules/trade'
@@ -97,11 +99,18 @@ export function SwapWidget({ topContent, bottomContent }: SwapWidgetProps): Reac
   const [isHydrated, setIsHydrated] = useState(false)
   const handleUnlock = useCallback(() => updateSwapState({ isUnlocked: true }), [updateSwapState])
   const isPrimaryValidationPassed = useIsTradeFormValidationPassed()
+  const isEoaEthFlow = useIsEoaEthFlow()
 
   useEffect(() => {
     // Hydration guard: defer lock-screen until persisted state (isUnlocked) loads to prevent initial flash.
     setIsHydrated(true)
   }, [])
+
+  useEffect(() => {
+    if (isEoaEthFlow && !isSellOrder(orderKind)) {
+      updateSwapState(SELL_ETH_RESET_STATE)
+    }
+  }, [isEoaEthFlow, orderKind, updateSwapState])
 
   const isSellTrade = isSellOrder(orderKind)
 


### PR DESCRIPTION
# Summary

Fixes #6394

# To Test

1. connect to Rabby+safe
2. specify a buy order with selling eth
3. change an account in Rabby from Safe to EOA
4. notice the form getting cleared and order kind being set to sell

# Background

Before this change, the output would get disabled, but you were still able to click swap and place an invalid buy order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ETH flow handling in the swap widget to ensure the swap state resets appropriately when entering the EOA ETH flow.

* **Chores**
  * Development server updated to listen on all network interfaces for easier local network testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->