### PR TITLE
fix: tooltips descriptions

### DIFF
--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -701,8 +701,8 @@ msgid "Unsupported Token"
 msgstr "Unsupported Token"
 
 #: apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/index.tsx
-msgid "Limit price (incl. costs)"
-msgstr "Limit price (incl. costs)"
+#~ msgid "Limit price (incl. costs)"
+#~ msgstr "Limit price (incl. costs)"
 
 #: apps/cowswap-frontend/src/modules/ordersTable/containers/OrderRow/OrderContextMenu.tsx
 msgid "Order receipt"
@@ -1319,8 +1319,8 @@ msgid "COW vesting from locked GNO"
 msgstr "COW vesting from locked GNO"
 
 #: apps/cowswap-frontend/src/modules/ordersTable/pure/ReceiptModal/index.tsx
-msgid "Limit price (incl.costs)"
-msgstr "Limit price (incl.costs)"
+#~ msgid "Limit price (incl.costs)"
+#~ msgstr "Limit price (incl.costs)"
 
 #: apps/cowswap-frontend/src/modules/twap/containers/SetupFallbackHandlerWarning/index.tsx
 msgid "Update fallback handler"
@@ -1677,8 +1677,8 @@ msgid "Receiver"
 msgstr "Receiver"
 
 #: apps/cowswap-frontend/src/modules/ordersTable/pure/ReceiptModal/index.tsx
-msgid "An order’s actual execution price will vary based on the market price and network costs."
-msgstr "An order’s actual execution price will vary based on the market price and network costs."
+#~ msgid "An order’s actual execution price will vary based on the market price and network costs."
+#~ msgstr "An order’s actual execution price will vary based on the market price and network costs."
 
 #: apps/cowswap-frontend/src/modules/hooksStore/dapps/AirdropHookApp/index.tsx
 msgid "You have already claimed this airdrop"
@@ -1867,6 +1867,10 @@ msgstr "To continue, click SWAP below to use your existing {wrappedSymbol} balan
 msgid "Effortless Airdrop Claims! The Claim COW Airdrop feature simplifies the process of collecting free COW tokens before or after your swap, seamlessly integrating into the CoW Swap platform. Whether you're claiming new airdrops or exploring CoW on a new network, this tool ensures you get your rewards quickly and easily."
 msgstr "Effortless Airdrop Claims! The Claim COW Airdrop feature simplifies the process of collecting free COW tokens before or after your swap, seamlessly integrating into the CoW Swap platform. Whether you're claiming new airdrops or exploring CoW on a new network, this tool ensures you get your rewards quickly and easily."
 
+#: apps/cowswap-frontend/src/modules/ordersTable/pure/ReceiptModal/index.tsx
+msgid "An order's actual execution price will vary based on the market price and network fees and costs."
+msgstr "An order's actual execution price will vary based on the market price and network fees and costs."
+
 #: apps/cowswap-frontend/src/modules/ethFlow/pure/EthFlowModalContent/configs.ts
 #: apps/cowswap-frontend/src/modules/ethFlow/pure/EthFlowModalContent/configs.ts
 #: apps/cowswap-frontend/src/modules/ethFlow/pure/EthFlowModalContent/configs.ts
@@ -1922,6 +1926,11 @@ msgstr "minutes"
 #: apps/cowswap-frontend/src/common/containers/InvalidLocalTimeWarning/index.tsx
 msgid "Local device time is not accurate, CoW Swap most likely will not work correctly. Please adjust your device's time."
 msgstr "Local device time is not accurate, CoW Swap most likely will not work correctly. Please adjust your device's time."
+
+#: apps/cowswap-frontend/src/modules/ordersTable/pure/ReceiptModal/index.tsx
+#: apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/index.tsx
+msgid "Limit price (incl. fees)"
+msgstr "Limit price (incl. fees)"
 
 #: apps/cowswap-frontend/src/modules/bridge/pure/StopStatus/index.tsx
 msgid "Bridging via"
@@ -6297,10 +6306,3 @@ msgstr "Learn more"
 #: apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/HighFeeWarning/highFeeWarningHelpers.ts
 msgid "Swap and bridge costs are at least {formattedFeePercentage}% of the swap amount"
 msgstr "Swap and bridge costs are at least {formattedFeePercentage}% of the swap amount"
-
-# Notifications / jobs aria labels
-msgid "Trade alert settings"
-msgstr "Trade alert settings"
-
-msgid "View jobs (opens in a new tab)"
-msgstr "View jobs (opens in a new tab)"

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/ReceiptModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/ReceiptModal/index.tsx
@@ -62,7 +62,7 @@ interface ReceiptProps {
 
 const TOOLTIPS_MSG: Record<string, MessageDescriptor> = {
   LIMIT_PRICE: msg`You will receive this price or better for your tokens.`,
-  EXECUTION_PRICE: msg`An order’s actual execution price will vary based on the market price and network costs.`,
+  EXECUTION_PRICE: msg`An order's actual execution price will vary based on the market price and network fees and costs.`,
   EXECUTES_AT: msg`Network costs (incl. gas) are covered by filling your order when the market price is better than your limit price.`,
   FILLED_TWAP: msg`How much of the order has been filled.`,
   SURPLUS: msg`The amount of extra tokens you get on top of your limit price.`,
@@ -210,7 +210,7 @@ export function ReceiptModal({
             )}
 
             <styledEl.Field>
-              <FieldLabel label={t`Limit price (incl.costs)`} tooltip={i18n._(TOOLTIPS_MSG.LIMIT_PRICE)} />
+              <FieldLabel label={t`Limit price (incl. fees)`} tooltip={i18n._(TOOLTIPS_MSG.LIMIT_PRICE)} />
               <PriceField order={order} price={limitPrice} />
             </styledEl.Field>
 

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/index.tsx
@@ -52,7 +52,7 @@ const getConfirmModalConfig = (): {
       </p>
     </>
   ),
-  limitPriceLabel: t`Limit price (incl. costs)`,
+  limitPriceLabel: t`Limit price (incl. fees)`,
   limitPriceTooltip: (
     <Trans>
       If CoW Swap cannot get this price or better (taking into account fees and price protection tolerance), your TWAP


### PR DESCRIPTION
# Summary

Addressed [this](https://github.com/cowprotocol/cowswap/pull/6548#issuecomment-3575481232) comment for fee components

<img width="523" height="546" alt="image" src="https://github.com/user-attachments/assets/52a2d1a8-c28f-4b50-96c5-964610883a3f" />
<img width="523" height="546" alt="image" src="https://github.com/user-attachments/assets/3969ab4d-a796-4a74-8734-e08764e6e040" />


# To Test

1. Open swap and see the list of fees

- [ ] The last fee element always should have only dot (without line)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated limit price labels to clarify "fees" terminology in order receipt and confirmation dialogs
  * Enhanced tooltip messaging to explain how market prices and network fees impact order execution prices
  * Refreshed translation strings for improved user clarity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->