### PR TITLE
fix: update schema reference for app data

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ metadata JSON containing some information about the trade (using `keccak256` on
 the `UTF-8` bytes).
 
 The format of the JSON follows the format defined in
-[@cowprotocol/sdk-app-data](https://github.com/cowprotocol/cow-sdk/tree/main/packages/app-data).
+[@cowprotocol/sdk-app-data](https://www.npmjs.com/package/@cowprotocol/sdk-app-data).
 
 To set your own `AppData`, change `REACT_APP_FULL_APP_DATA_<environment>`
 environment variable. For more details, check out the environment file (<.env>)

--- a/apps/cowswap-frontend/.env
+++ b/apps/cowswap-frontend/.env
@@ -54,7 +54,7 @@
 #
 # This metadata will be sent to the smart contract as a hexadecimal value in an order field called `AppData`.
 # This value comes from hashing the content of a metadata JSON containing some information about the trade (using `keccak256` on the `UTF-8` bytes).
-# The format of the JSON follows the format defined in https://github.com/cowprotocol/app-data
+# The format of the JSON follows the format defined in https://www.npmjs.com/package/@cowprotocol/sdk-app-data
 #
 # To set your own `AppData`, change `REACT_APP_FULL_APP_DATA_<environment>`
 

--- a/apps/cowswap-frontend/src/modules/appData/appData-module.drawio.svg
+++ b/apps/cowswap-frontend/src/modules/appData/appData-module.drawio.svg
@@ -344,7 +344,7 @@
                         <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; font-weight: bold; white-space: normal; overflow-wrap: normal;">
                                 <font color="#000000">
-                                    @cowprotocol/app-data
+                                    @cowprotocol/sdk-app-data
                                     <br/>
                                     <span style="font-weight: 400;">
                                         metadata API
@@ -356,7 +356,7 @@
                     </div>
                 </foreignObject>
                 <text x="685" y="104" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle" font-weight="bold">
-                    @cowprotocol/app-data...
+                    @cowprotocol/sdk-app-data...
                 </text>
             </switch>
         </g>

--- a/apps/cowswap-frontend/src/modules/appData/appData-module.md
+++ b/apps/cowswap-frontend/src/modules/appData/appData-module.md
@@ -15,7 +15,7 @@ This module will facilitate to get this information, both in a object format, an
 
 ## App-data project
 
-This module depends on the library https://github.com/cowprotocol/app-data
+This module depends on the library https://www.npmjs.com/package/@cowprotocol/sdk-app-data
 
 # Details
 

--- a/apps/explorer/src/explorer/pages/AppData/EncodePage.tsx
+++ b/apps/explorer/src/explorer/pages/AppData/EncodePage.tsx
@@ -182,7 +182,7 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData /* handleTabCha
             JSON schema
           </a>
           defined on app-data
-          <a target="_blank" href="https://github.com/cowprotocol/app-data" rel="noreferrer">
+          <a target="_blank" href="https://www.npmjs.com/package/@cowprotocol/sdk-app-data" rel="noreferrer">
             repo.
           </a>
         </p>
@@ -285,7 +285,7 @@ const EncodePage: React.FC<EncodeProps> = ({ tabData, setTabData /* handleTabCha
                 <p>
                   This CID is derived from the <strong>AppData hex</strong> (
                   <a
-                    href="https://github.com/cowprotocol/app-data/blob/main/src/api/appDataHexToCid.ts#L30"
+                    href="https://github.com/cowprotocol/cow-sdk/blob/main/packages/app-data/src/api/appDataHexToCid.ts"
                     target="_blank"
                     rel="noreferrer"
                   >

--- a/libs/permit-utils/README.md
+++ b/libs/permit-utils/README.md
@@ -111,7 +111,7 @@ const hookData = await generatePermitHook({
 })
 
 // Add the hookData to the order's appData
-// See the full reference on https://github.com/cowprotocol/app-data/
+// See the full reference on https://www.npmjs.com/package/@cowprotocol/sdk-app-data?activeTab=code
 const appData = { version: '0.10.0', metadata: { hooks: { pre: [hookData] } } }
 
 // The order expects the stringified JSON doc


### PR DESCRIPTION
# Summary

I was looking for the app data schema [here](https://explorer.cow.fi/appdata) and I noticed that the reference link is outdated.
In this PR I changed all outdated references with updated ones.

# To Test

- [ ] Links in project readmes work.
- [ ] Link in env file works.
- [ ] Updated SVG file is valid (I don't know where it's used but the overall image size doesn't change anyway).
- In http://localhost:4200/appdata
  - [ ] Text "defined on app-data repo" doesn't link to an archived repo anymore but to the right NPM package.
  - [ ] Text "AppData hex (see here how)" links to a current repository and to a relevant file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated AppData package references across README, docs, and environment guidance to point to the npm package location.
  * Corrected UI and documentation links related to AppData utilities and hex-to-CID references to reflect new locations.
  * No functional changes; documentation-only updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->