### PR TITLE
fix: change 'order' back to English

### DIFF
--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -3922,7 +3922,7 @@ msgstr "This is the recommended slippage tolerance based on current gas prices &
 #: apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
 #: apps/cowswap-frontend/src/modules/ordersTable/pure/ReceiptModal/OrderTypeField.tsx
 msgid "buy"
-msgstr "comprar"
+msgstr "buy"
 
 #: apps/cowswap-frontend/src/pages/Account/Balances.tsx
 msgid "Converting vCOW to COW"


### PR DESCRIPTION
An attempt to fix https://www.notion.so/cownation/124-Limit-TWAP-Order-type-is-in-Spanish-in-receipt-2bf8da5f04ca80bc9f43eef362376ac0

To test: 
1. Open [Limit orders page](https://swap-dev-git-fix-order-translation-cowswap-dev.vercel.app/#/1/limit/)
2. Connect to a wallet
3. Place an limit order (if there are no any in the history)
4. Open limit order receipt
5. Check the Order type field --> order details should not be in Spanish (type)
6. Check in other languages --> it should be translatable. 