### PR TITLE
fix: from & to labels for near bridging

### DIFF
--- a/apps/explorer/src/components/orders/BridgeDetailsTable/BridgeDetailsContent/index.tsx
+++ b/apps/explorer/src/components/orders/BridgeDetailsTable/BridgeDetailsContent/index.tsx
@@ -31,6 +31,10 @@ export function BridgeDetailsContent({ crossChainOrder }: BridgeDetailsContentPr
   } = crossChainOrder
   const bridgeProvider = crossChainOrder.provider
   const { sourceToken, destinationToken } = useCrossChainTokens(crossChainOrder)
+  const fromTooltipText =
+    bridgeProvider.type === 'HookBridgeProvider'
+      ? BridgeDetailsTooltips.accountFromProxy
+      : BridgeDetailsTooltips.accountOrderSigner
 
   const RecipientAddress = recipient ? (
     <AddressLink address={recipient} chainId={destinationChainId} bridgeProvider={bridgeProvider} showNetworkName />
@@ -45,7 +49,7 @@ export function BridgeDetailsContent({ crossChainOrder }: BridgeDetailsContentPr
         </ProviderDisplayWrapper>
       </DetailRow>
 
-      <DetailRow label="From" tooltipText={BridgeDetailsTooltips.accountFromProxy}>
+      <DetailRow label="From" tooltipText={fromTooltipText}>
         <RowWithCopyButton
           textToCopy={owner}
           contentsToDisplay={<AddressLink address={owner} chainId={sourceChainId} showNetworkName />}

--- a/apps/explorer/src/components/orders/BridgeDetailsTable/bridgeDetailsTooltips.tsx
+++ b/apps/explorer/src/components/orders/BridgeDetailsTable/bridgeDetailsTooltips.tsx
@@ -17,5 +17,6 @@ export const BridgeDetailsTooltips = {
       amount of the Swap before the bridge is initiated.
     </span>
   ),
+  accountOrderSigner: 'The account address which signed the order.',
   receiverAddress: 'The account address to which the tokens are bridged on the destination chain.',
 }

--- a/apps/explorer/src/components/orders/DetailsTable/BaseDetailsTable.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/BaseDetailsTable.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { useCowAnalytics } from '@cowprotocol/analytics'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { BridgeProviderType } from '@cowprotocol/sdk-bridging'
 import { Icon, UI } from '@cowprotocol/ui'
 import { TruncatedText } from '@cowprotocol/ui/pure/TruncatedText'
 
@@ -32,6 +33,7 @@ export interface BaseDetailsTableProps {
   order: Order
   showFillsButton: boolean | undefined
   areTradesLoading: boolean
+  bridgeProviderType?: BridgeProviderType
   children?: React.ReactNode
 }
 
@@ -44,6 +46,7 @@ export function BaseDetailsTable({
   order,
   showFillsButton,
   areTradesLoading,
+  bridgeProviderType,
   children,
 }: BaseDetailsTableProps): React.ReactNode | null {
   const cowAnalytics = useCowAnalytics()
@@ -76,6 +79,12 @@ export function BaseDetailsTable({
   }
   const isSigning = status === 'signing'
   const isBridging = !!order?.bridgeProviderId
+  const toTooltip = isBridging
+    ? bridgeProviderType === 'ReceiverAccountBridgeProvider'
+      ? DetailsTableTooltips.toBridgeReceiver
+      : DetailsTableTooltips.toBridgeProxy
+    : DetailsTableTooltips.to
+
 
   return (
     <SimpleTable
@@ -132,11 +141,7 @@ export function BaseDetailsTable({
           <tr>
             <td>
               <span>
-                <HelpTooltip
-                  placement="bottom"
-                  tooltip={isBridging ? DetailsTableTooltips.toBridge : DetailsTableTooltips.to}
-                />{' '}
-                To
+                <HelpTooltip placement="bottom" tooltip={toTooltip} /> To
               </span>
             </td>
             <td>

--- a/apps/explorer/src/components/orders/DetailsTable/FullDetailsTable.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/FullDetailsTable.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react'
 
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { BridgeProviderType } from '@cowprotocol/sdk-bridging'
 
 import { Order } from 'api/operator'
 
@@ -11,6 +12,7 @@ export interface FullDetailsTableProps {
   order: Order
   showFillsButton: boolean | undefined
   areTradesLoading: boolean
+  bridgeProviderType?: BridgeProviderType
   children: ReactNode
 }
 
@@ -19,6 +21,7 @@ export function FullDetailsTable({
   order,
   showFillsButton,
   areTradesLoading,
+  bridgeProviderType,
   children,
 }: FullDetailsTableProps): ReactNode {
   const { buyToken, sellToken } = order
@@ -33,6 +36,7 @@ export function FullDetailsTable({
       order={order}
       showFillsButton={showFillsButton}
       areTradesLoading={areTradesLoading}
+      bridgeProviderType={bridgeProviderType}
     >
       {children}
     </BaseDetailsTable>

--- a/apps/explorer/src/components/orders/DetailsTable/detailsTableTooltips.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/detailsTableTooltips.tsx
@@ -1,3 +1,5 @@
+
+
 import { ACCOUNT_PROXY_LABEL_EXPLORER } from '@cowprotocol/common-const'
 
 import { AccountProxyLink } from '../shared/AccountProxyLink'
@@ -6,12 +8,13 @@ export const DetailsTableTooltips = {
   orderID: 'A unique identifier ID for this order.',
   from: 'The account address which signed the order.',
   to: 'The account address which will/did receive the bought amount.',
-  toBridge: (
+  toBridgeProxy: (
     <span>
       The <AccountProxyLink>{ACCOUNT_PROXY_LABEL_EXPLORER}</AccountProxyLink> address which will/did receive bought
       amount of the Swap before the bridge is initiated.
     </span>
   ),
+  toBridgeReceiver: 'This bridge provider uses special receiver address to bridge funds. This address is deterministic for a quote and has been verified by CoW Swap.',
   hash: 'The onchain settlement transaction for this order. Can be viewed on Etherscan.',
   appData:
     'The AppData hash for this order. It can denote encoded metadata with info on the app, environment and more, although not all interfaces follow the same pattern. Show more will try to decode that information.',

--- a/apps/explorer/src/components/orders/OrderDetails/index.tsx
+++ b/apps/explorer/src/components/orders/OrderDetails/index.tsx
@@ -80,7 +80,13 @@ const tabItems = (
 
   const defaultDetails =
     order && areTokensLoaded ? (
-      <FullDetailsTable chainId={chainId} order={order} showFillsButton={showFills} areTradesLoading={areTradesLoading}>
+      <FullDetailsTable
+        chainId={chainId}
+        order={order}
+        showFillsButton={showFills}
+        areTradesLoading={areTradesLoading}
+        bridgeProviderType={crossChainOrder?.provider.type}
+      >
         <VerboseDetails
           order={order}
           showFillsButton={showFills}


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/124-Explorer-Near-Tooltip-says-that-an-address-is-account-proxy-however-it-is-not-2aa8da5f04ca80aaaddcec6e006f4581

The from and to labels being wrong.

# To Test

Try the `0x7588bfccea67661c99013c6798f402343998b3ffb6027df48464385ee938ff5e3de0a3f95eb59dc208fbedeaac43f5197c39709d6939630d` order and compare the to and from labels.

They should say
<img width="742" height="411" alt="image" src="https://github.com/user-attachments/assets/524cc14d-e5f1-4c11-8552-3adb1000acad" />


<img width="764" height="396" alt="image" src="https://github.com/user-attachments/assets/bbf3d1f7-8138-43c8-b2a2-56603b71785c" />

    
instead of   `The Account proxy  address which will/did receive bought amount of the Swap before the bridge is initiated.`
