### PR TITLE
fix: use GH url for AAVE icons for explorer Hooks

### DIFF
--- a/libs/hook-dapp-lib/src/hookDappsRegistry.ts
+++ b/libs/hook-dapp-lib/src/hookDappsRegistry.ts
@@ -201,7 +201,7 @@ export const hookDappsRegistry = {
     description: 'The swap adapter contracts integrate Aave Flash Loans and CoW Swap to facilitate advanced actions like swapping collateral assets when there are borrow positions. Learn more at https://aave.com/docs/developers/smart-contracts/swap-features.',
     version: '0.0.1',
     website: 'https://aave.com',
-    image: 'https://app.aave.com/icons/tokens/aave.svg',
+    image: 'https://raw.githubusercontent.com/aave/interface/refs/heads/main/public/icons/tokens/aave.svg',
     conditions: {
       supportedNetworks: [11155111],
     },
@@ -213,7 +213,7 @@ export const hookDappsRegistry = {
     description: 'The swap adapter contracts integrate Aave Flash Loans and CoW Swap to facilitate advanced actions like swapping debt assets. Learn more at https://aave.com/docs/developers/smart-contracts/swap-features.',
     version: '0.0.1',
     website: 'https://aave.com',
-    image: 'https://app.aave.com/icons/tokens/aave.svg',
+    image: 'https://raw.githubusercontent.com/aave/interface/refs/heads/main/public/icons/tokens/aave.svg',
     conditions: {
       supportedNetworks: [11155111],
     },
@@ -225,7 +225,7 @@ export const hookDappsRegistry = {
     description: 'The swap adapter contracts integrate Aave Flash Loans and CoW Swap to facilitate advanced actions like repaying borrow positions using collateral. Learn more at https://aave.com/docs/developers/smart-contracts/swap-features.',
     version: '0.0.1',
     website: 'https://aave.com',
-    image: 'https://app.aave.com/icons/tokens/aave.svg',
+    image: 'https://raw.githubusercontent.com/aave/interface/refs/heads/main/public/icons/tokens/aave.svg',
     conditions: {
       supportedNetworks: [11155111],
     },


### PR DESCRIPTION
Elena raised that from Aave we were blocking some requests for the AAVE icon on the explorer. Let's use the public one in GH so we don't need to change our internal policies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Three new Aave v3 flashloan integrations are now available to all users: collateral swap enables seamless collateral exchanges, debt swap facilitates flexible debt position management, and repay with collateral provides enhanced options for collateral based repayments. These new integrations expand overall platform functionality and are live on the Sepolia testnet.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->