### PR TITLE
fix: use aave token logo from cow cdn for aave img

### DIFF
--- a/libs/hook-dapp-lib/src/hookDappsRegistry.ts
+++ b/libs/hook-dapp-lib/src/hookDappsRegistry.ts
@@ -164,8 +164,7 @@ export const hookDappsRegistry = {
     description: msg`Bungee is a liquidity marketplace that lets you swap into any token on any chain in a fully abstracted manner. Trade any token with the best quotes and a gasless UX!`,
     version: '0.0.1',
     website: 'https://www.bungee.exchange',
-    image:
-      'https://files.cow.fi/cow-sdk/bridging/providers/bungee/bungee-logo.png',
+    image: 'https://files.cow.fi/cow-sdk/bridging/providers/bungee/bungee-logo.png',
     conditions: {
       walletCompatibility: ['EOA'],
     },
@@ -177,8 +176,7 @@ export const hookDappsRegistry = {
     description: msg`Across is the fastest, cheapest and most secure cross-chain bridge for Ethereum, Arbitrum, Optimism, Polygon and other Layer 1 and Layer 2 networks. Transfer tokens with Across.`,
     version: '0.0.1',
     website: 'https://across.to',
-    image:
-      'https://files.cow.fi/cow-sdk/bridging/providers/across/across-logo.png',
+    image: 'https://files.cow.fi/cow-sdk/bridging/providers/across/across-logo.png',
     conditions: {
       walletCompatibility: ['EOA'],
     },
@@ -190,7 +188,7 @@ export const hookDappsRegistry = {
     description: msg`The swap adapter contracts integrate Aave Flash Loans and CoW Swap to facilitate advanced actions like swapping collateral assets when there are borrow positions. Learn more at https://aave.com/docs/developers/smart-contracts/swap-features.`,
     version: '0.0.1',
     website: 'https://aave.com',
-    image: 'https://app.aave.com/icons/tokens/aave.svg',
+    image: 'https://files.cow.fi/token-lists/images/1/0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9/logo.png',
   },
   'cow-sdk://flashloans/aave/v3/debt-swap': {
     name: msg`Aave Debt Swap`,
@@ -199,7 +197,7 @@ export const hookDappsRegistry = {
     description: msg`The swap adapter contracts integrate Aave Flash Loans and CoW Swap to facilitate advanced actions like swapping debt assets. Learn more at https://aave.com/docs/developers/smart-contracts/swap-features.`,
     version: '0.0.1',
     website: 'https://aave.com',
-    image: 'https://app.aave.com/icons/tokens/aave.svg',
+    image: 'https://files.cow.fi/token-lists/images/1/0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9/logo.png',
   },
   'cow-sdk://flashloans/aave/v3/repay-with-collateral': {
     name: msg`Aave Repay`,
@@ -208,6 +206,6 @@ export const hookDappsRegistry = {
     description: msg`The swap adapter contracts integrate Aave Flash Loans and CoW Swap to facilitate advanced actions like repaying borrow positions using collateral. Learn more at https://aave.com/docs/developers/smart-contracts/swap-features.msg`,
     version: '0.0.1',
     website: 'https://aave.com',
-    image: 'https://app.aave.com/icons/tokens/aave.svg',
+    image: 'https://files.cow.fi/token-lists/images/1/0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9/logo.png',
   },
 }


### PR DESCRIPTION
# Summary

Use AAVE token logo from cow cdn for aave img

# To Test

1. Open the explorer with an order that uses any AAVE pre/post hook from a geoblocked country
* The image should load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated image asset hosting paths for hook dapp registry entries to new infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->