### PR TITLE
fix: page crash when sell token has 0 decimals

### DIFF
--- a/apps/cowswap-frontend/src/legacy/state/orders/utils.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/utils.ts
@@ -1,4 +1,4 @@
-import { ONE_HUNDRED_PERCENT, PENDING_ORDERS_BUFFER, ZERO_FRACTION } from '@cowprotocol/common-const'
+import { ONE_HUNDRED_PERCENT, PENDING_ORDERS_BUFFER, ZERO, ZERO_FRACTION } from '@cowprotocol/common-const'
 import { bpsToPercent, buildPriceFromCurrencyAmounts, getWrappedToken, isSellOrder } from '@cowprotocol/common-utils'
 import type { LatestAppDataDocVersion } from '@cowprotocol/cow-sdk'
 import { EnrichedOrder, getPartnerFeeBps, OrderKind, OrderStatus } from '@cowprotocol/cow-sdk'
@@ -351,7 +351,7 @@ export function getEstimatedExecutionPrice(
     const denominator = remainingSellAmount.subtract(feeWithMargin)
 
     // Just in case when the denominator is <= 0 after subtracting the fee
-    if (!denominator.greaterThan(ZERO_FRACTION)) {
+    if (denominator.quotient <= ZERO) {
       // numerator and denominator are inverted!!!
       // https://github.com/Uniswap/sdk-core/blob/9997e88/src/entities/fractions/price.ts#L26
       return new Price(inputToken, outputToken, '1', '0')

--- a/libs/common-const/src/common.ts
+++ b/libs/common-const/src/common.ts
@@ -8,9 +8,11 @@ import {
 import { Fraction, Percent } from '@uniswap/sdk-core'
 
 import { msg } from '@lingui/core/macro'
+import JSBI from 'jsbi'
 import ms from 'ms.macro'
 
 export const ZERO_FRACTION = new Fraction(0)
+export const ZERO = JSBI.BigInt(0)
 
 export const DEFAULT_SLIPPAGE_BPS = 50 // 0.5%
 export const MAX_SLIPPAGE_BPS = 5000 // 50%


### PR DESCRIPTION
# Summary

Fixes #6669

The page would crash if est fill price could not be computed.

Now, the est. fill price is empty when that happens.

<img width="785" height="937" alt="image" src="https://github.com/user-attachments/assets/7d0f8ceb-fc83-4754-aa78-fc19e23190cc" />


# To Test

1. Open limit orders
2. Connect to Gnosis chain
3. fill in these tokens into the fields https://swap.cow.fi/#/100/limit/MPS/0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83?tab=all&page=1
4. fill in the sell field with 2
5. wait till the quote is loaded

