### PR TITLE
fix(bridge): resolve recipient for bridge quote

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useQuoteParamsRecipient.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useQuoteParamsRecipient.ts
@@ -20,6 +20,7 @@ export function useQuoteParamsRecipient(): string | undefined {
   const { account } = useWalletInfo()
 
   const { recipient, recipientAddress } = state || {}
+
   const isReceiverAccountBridgeProvider = bridgeQuote?.providerInfo.type === 'ReceiverAccountBridgeProvider'
 
   return useMemo(() => {
@@ -29,6 +30,6 @@ export function useQuoteParamsRecipient(): string | undefined {
       }
     }
 
-    return recipientAddress && isAddress(recipientAddress) ? recipientAddress : account
+    return (isAddress(recipientAddress) ? recipientAddress : isAddress(recipient) ? recipient : null) || account
   }, [isReceiverAccountBridgeProvider, account, recipient, recipientAddress])
 }


### PR DESCRIPTION
# Summary

`return recipientAddress && isAddress(recipientAddress) ? recipientAddress : account` - this was wrong. `recipientAddress` is present in case when recipient is an ENS address, otherwise we should use `recipient`.
 
# To Test

1. Setup `/#/1/swap/ETH/0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE?targetChainId=100`
2. Enter custom recipient
- [ ] AR: quote refetches with no reason
- [ ] ER: quote refetches only when parameters are actualy changes or by timer
