### PR TITLE
fix: token lists missing after migration

### DIFF
--- a/libs/tokens/src/updaters/TokensListsUpdater/index.tsx
+++ b/libs/tokens/src/updaters/TokensListsUpdater/index.tsx
@@ -23,7 +23,7 @@ const LAST_UPDATE_TIME_DEFAULT = 0
 
 const { atom: lastUpdateTimeAtom, updateAtom: updateLastUpdateTimeAtom } = atomWithPartialUpdate(
   atomWithStorage<PersistentStateByChain<number>>(
-    'tokens:lastUpdateTimeAtom:v5',
+    'tokens:lastUpdateTimeAtom:v6',
     mapSupportedNetworks(LAST_UPDATE_TIME_DEFAULT),
     getJotaiMergerStorage(),
     {


### PR DESCRIPTION
# Summary

Fixes https://github.com/cowprotocol/cowswap/issues/6702

Token lists are missing for users that have visited CoWSwap in the last 6 hours before the release. E.g.: Elena visited CoWSwap prod before the release and used the polygon, avalanche and gnosis chain lists and our logic prevents her to refetch any tokens lists for 6 hours. 
