### PR TITLE
fix: change month in Surplus tooltip for Plasma

### DIFF
--- a/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/SurplusCard.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/SurplusCard.tsx
@@ -29,7 +29,7 @@ const AVALANCHE_START_DATE = 'June 2025'
 const LENS_START_DATE = 'September 2025'
 const BNB_START_DATE = 'September 2025'
 const LINEA_START_DATE = 'November 2025'
-const PLASMA_START_DATE = 'December 2025'
+const PLASMA_START_DATE = 'January 2026'
 
 const START_DATE: Record<SupportedChainId, string> = {
   [SupportedChainId.MAINNET]: DEFAULT_START_DATE,


### PR DESCRIPTION
**To test:** 

1. Connect to a wallet to Plasma network
2. Place some orders if you did not have any filled orders
3. Open Account modal
4. Hover a mouse to the 'Your total surplus' tooltip


**Expected**: start date should be January 2026
<img width="541" height="117" alt="image" src="https://github.com/user-attachments/assets/19fbe429-8803-4e56-be80-d7d41c557b1a" />

5. check the same surplus tooltip in other chains --> no changes should be there. 
6. check translations --> the month should be translated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the PLASMA entry start date from December 2025 to January 2026 in the Surplus Card display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->