### PR TITLE
fix: add user context on launch darkly initialization

### DIFF
--- a/apps/cowswap-frontend/src/modules/application/containers/WithLDProvider.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/WithLDProvider.tsx
@@ -1,17 +1,20 @@
-import { JSX, PropsWithChildren } from 'react'
+import { JSX, PropsWithChildren, ReactNode } from 'react'
 
 import { LAUNCH_DARKLY_CLIENT_KEY } from '@cowprotocol/common-const'
 
 import { withLDProvider } from 'launchdarkly-react-client-sdk'
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function InnerWithLDProvider({ children }: PropsWithChildren) {
+function InnerWithLDProvider({ children }: PropsWithChildren): ReactNode {
   return children
 }
 
 export const WithLDProvider = withLDProvider<PropsWithChildren & JSX.IntrinsicAttributes>({
   clientSideID: LAUNCH_DARKLY_CLIENT_KEY,
+  context: {
+    kind: 'user',
+    key: 'cowswap',
+    name: 'cowswap',
+  },
   options: {
     bootstrap: 'localStorage',
   },

--- a/apps/explorer/src/explorer/components/common/WithLDProvider/index.tsx
+++ b/apps/explorer/src/explorer/components/common/WithLDProvider/index.tsx
@@ -1,4 +1,4 @@
-import { JSX, PropsWithChildren } from 'react'
+import { JSX, PropsWithChildren, ReactNode } from 'react'
 
 import { LAUNCH_DARKLY_CLIENT_KEY } from '@cowprotocol/common-const'
 
@@ -6,14 +6,17 @@ import { withLDProvider } from 'launchdarkly-react-client-sdk'
 
 // TODO: remove duplicated component with app/cowswap-frontend/src/modules/application/containers/WithLDProvider
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function InnerWithLDProvider({ children }: PropsWithChildren) {
+function InnerWithLDProvider({ children }: PropsWithChildren): ReactNode {
   return children
 }
 
 export const WithLDProvider = withLDProvider<PropsWithChildren & JSX.IntrinsicAttributes>({
   clientSideID: LAUNCH_DARKLY_CLIENT_KEY,
+  context: {
+    kind: 'user',
+    key: 'explorer',
+    name: 'explorer',
+  },
   options: {
     bootstrap: 'localStorage',
   },

--- a/apps/widget-configurator/src/WithLDProvider.ts
+++ b/apps/widget-configurator/src/WithLDProvider.ts
@@ -1,4 +1,4 @@
-import { JSX, PropsWithChildren } from 'react'
+import { JSX, PropsWithChildren, ReactNode } from 'react'
 
 import { LAUNCH_DARKLY_CLIENT_KEY } from '@cowprotocol/common-const'
 
@@ -6,15 +6,17 @@ import { withLDProvider } from 'launchdarkly-react-client-sdk'
 
 // TODO: remove duplicated component with app/cowswap-frontend/src/modules/application/containers/WithLDProvider
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function InnerWithLDProvider({ children }: PropsWithChildren) {
+function InnerWithLDProvider({ children }: PropsWithChildren): ReactNode {
   return children
 }
 
-//
 export const WithLDProvider = withLDProvider<PropsWithChildren & JSX.IntrinsicAttributes>({
   clientSideID: LAUNCH_DARKLY_CLIENT_KEY,
+  context: {
+    kind: 'user',
+    key: 'widget-configurator',
+    name: 'widget-configurator',
+  },
   options: {
     bootstrap: 'localStorage',
   },


### PR DESCRIPTION
# Summary

Attempt to fix metric tracking on LaunchDarkly and capture a more realistic MAU (https://launchdarkly.com/docs/home/account/calculating-billing#monthly-active-users-mau).

With this change, we should use a single user for all requests, instead of one unique anonymous user for all requests. See https://launchdarkly.com/docs/home/flags/anonymous-contexts

# To Test

1. Load the app
2. Check a currently enabled feature flag is working, turn a flag on and off
* Should work as usual
3. Check the network requests and filter for launchdarkly related queries
* Should work as usual
4. Inspect the launchdarkly dashboard and see usage (not actually sure about this one, need to check how soon the events will be captured and displayed on their side)

Actually, I don't see an easy way to test from this PR alone.
We can merge it to develop and observe whether it makes any impact in the count for the dev env.
<img width="1399" height="1024" alt="image" src="https://github.com/user-attachments/assets/216a95c6-42a0-4a9c-b163-0b6ad528435a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety by adding explicit return type annotations across multiple provider components.
  * Enhanced metadata configuration for improved system integration and tracking consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->