### PR TITLE
chore: run ci on develop and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
 
   notify-failure:
     name: Notify Slack on Failure
-    needs: [setup, build, test, lint, integration-tests]
+    needs: [setup, build, test, lint]
     runs-on: ubuntu-latest
     if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
 

--- a/.gitignore
+++ b/.gitignore
@@ -75,5 +75,4 @@ CLAUDE.md
 .serena/
 
 # Github
-.github/
 /.npmrc


### PR DESCRIPTION
# Summary

1. It's difficult to tell if the build succeds on `develop` because the CI workflow doesn't run on each push to these branch https://github.com/cowprotocol/cowswap/commits/
2. When we merge a PR from an external contributor we usually merge it with a couple of actions failing, e.g.: vercel deployment
3. If vercel deployment fails due to authorization, it might hide a build failing error and get merged, which is why we should run the build step in CI. (or at least have one of the other steps like test or lint also do build)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI updated to run on pushes to main and develop.
  * New automated build job added to the pipeline.
  * New failure notification job sends Slack alerts when builds fail on main/develop.
  * Project ignore rules updated so CI/workflow configuration files are tracked.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->