### PR TITLE
feat(bridge): add feature flag for widget in Safe app

### DIFF
--- a/apps/cowswap-frontend/src/modules/bridge/updaters/BridgingEnabledUpdater.ts
+++ b/apps/cowswap-frontend/src/modules/bridge/updaters/BridgingEnabledUpdater.ts
@@ -1,6 +1,8 @@
 import { useEffect } from 'react'
 
-import { useSetIsBridgingEnabled } from '@cowprotocol/common-hooks'
+import { useFeatureFlags, useSetIsBridgingEnabled } from '@cowprotocol/common-hooks'
+import { isInjectedWidget } from '@cowprotocol/common-utils'
+import { useIsSafeApp } from '@cowprotocol/wallet'
 
 import { useInjectedWidgetParams } from 'modules/injectedWidget'
 import { useTradeTypeInfo } from 'modules/trade'
@@ -10,9 +12,15 @@ import { Routes } from 'common/constants/routes'
 export function BridgingEnabledUpdater(): null {
   const tradeTypeInfo = useTradeTypeInfo()
   const setIsBridgingEnabled = useSetIsBridgingEnabled()
+  const { isBridgingInSafeWidgetEnabled } = useFeatureFlags()
+  const isSafeApp = useIsSafeApp()
   const { disableCrossChainSwap = false } = useInjectedWidgetParams()
 
-  const shouldEnableBridging = tradeTypeInfo?.route === Routes.SWAP && !disableCrossChainSwap
+  const isSwapPage = tradeTypeInfo?.route === Routes.SWAP
+  const widgetInSafeApp = isSafeApp && isInjectedWidget()
+  const shouldEnableInWidgetSafe = isBridgingInSafeWidgetEnabled ? true : !widgetInSafeApp
+
+  const shouldEnableBridging = isSwapPage && !disableCrossChainSwap && shouldEnableInWidgetSafe
 
   useEffect(() => {
     setIsBridgingEnabled(shouldEnableBridging)


### PR DESCRIPTION
# Summary

Added [isBridgingInSafeWidgetEnabled](https://app.launchdarkly.com/projects/default/flags/isBridgingInSafeWidgetEnabled/targeting?env=test&env=staging&env=production&env=local&env=barn&env=develop&selected-env=develop) feature flag to control cross-chain swaps feature in Widget via Safe app.

# To Test

Sorry, I have to trust my demo video, the only way to test it - run both CoW Swap and Safe locally.


https://github.com/user-attachments/assets/473bc390-4be2-4512-b82a-0065dcbb4c38

