### PR TITLE
fix: mismatch in order submitted amount for safe wallets

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeFlow/services/safeBundleFlow/safeBundleApprovalFlow.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/services/safeBundleFlow/safeBundleApprovalFlow.ts
@@ -163,7 +163,7 @@ export async function safeBundleApprovalFlow(
       kind,
       receiver: recipientAddressOrName,
       inputAmount,
-      outputAmount,
+      outputAmount: bridgeQuoteAmounts?.bridgeMinReceiveAmount || outputAmount,
       owner: account,
       uiOrderType: UiOrderType.SWAP,
     })

--- a/apps/cowswap-frontend/src/modules/tradeFlow/services/safeBundleFlow/safeBundleEthFlow.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/services/safeBundleFlow/safeBundleEthFlow.ts
@@ -182,7 +182,7 @@ export async function safeBundleEthFlow(
       kind,
       receiver: recipientAddressOrName,
       inputAmount,
-      outputAmount,
+      outputAmount: bridgeQuoteAmounts?.bridgeMinReceiveAmount || outputAmount,
       owner: account,
       uiOrderType: UiOrderType.SWAP,
       isEthFlow: true,


### PR DESCRIPTION
# Summary

> One more issue: Safe, cross-chain: order submitted pop-up shows 'at least' amount that does not match to the bridge 'receive at least' amount, amount on the progress bar and to the order pre-signed pop-up
>
> High-level description of what your changes are accomplishing
>
> Add screenshots if applicable. Images are nice :)


<img width="1115" height="415" alt="image" src="https://github.com/user-attachments/assets/3085aee2-0953-4bb9-9eb1-d7600fdae2b9" />

# To Test

1. Do a safe transaction with approval & bridging
