### PR TITLE
fix: button label in safe operation: wrap & swap & bridge

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/containers/TradeButtons/swapTradeButtonsMap.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/TradeButtons/swapTradeButtonsMap.tsx
@@ -49,6 +49,15 @@ export const swapTradeButtonsMap: Record<SwapFormState, SwapTradeButton> = {
       </div>
     </ButtonError>
   ),
+  [SwapFormState.WrapAndSwapAndBridge]: (props: SwapTradeButtonsContext, isDisabled: boolean) => (
+    <ButtonError buttonSize={ButtonSize.BIG} onClick={props.openSwapConfirm} disabled={isDisabled}>
+      <div>
+        <Trans>
+          Wrap <TokenSymbol token={props.inputCurrency} length={6} /> and Swap and Bridge
+        </Trans>
+      </div>
+    </ButtonError>
+  ),
   [SwapFormState.RegularEthFlowSwap]: (props: SwapTradeButtonsContext, isDisabled: boolean) => (
     <Wrapper>
       <ButtonError buttonSize={ButtonSize.BIG} onClick={props.openSwapConfirm} disabled={isDisabled}>

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useSwapFormState.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useSwapFormState.ts
@@ -11,6 +11,7 @@ export enum SwapFormState {
   SwapWithWrappedToken = 'SwapWithWrappedToken',
   RegularEthFlowSwap = 'EthFlowSwap',
   WrapAndSwap = 'WrapAndSwap',
+  WrapAndSwapAndBridge = 'WrapAndSwapAndBridge',
   SellNativeInHooks = 'SellNativeInHooks',
 }
 
@@ -24,10 +25,13 @@ export function useSwapFormState(): SwapFormState | null {
     if (state.inputCurrency && getIsNativeToken(state.inputCurrency)) {
       if (isHooksStore) return SwapFormState.SellNativeInHooks
 
+      const isBridging =
+        state.inputCurrency && state.outputCurrency && state.inputCurrency.chainId !== state.outputCurrency.chainId
+
       if (!isSmartContractWallet) {
         return SwapFormState.RegularEthFlowSwap
       } else if (isBundlingSupported) {
-        return SwapFormState.WrapAndSwap
+        return isBridging ? SwapFormState.WrapAndSwapAndBridge : SwapFormState.WrapAndSwap
       } else {
         return SwapFormState.SwapWithWrappedToken
       }


### PR DESCRIPTION
# Summary

the button should say 'wrap avax and swap and bridge' when inside safe/connected to Safe with WC

<img width="652" height="687" alt="image" src="https://github.com/user-attachments/assets/2afd602d-573c-4904-a6a5-88743d1c324d" />
