### PR TITLE
fix: to address tooltip for bridge orders

### DIFF
--- a/apps/explorer/src/components/orders/OrderDetails/index.tsx
+++ b/apps/explorer/src/components/orders/OrderDetails/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react'
 
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import type { CrossChainOrder } from '@cowprotocol/sdk-bridging'
+import type { BridgeProviderType, CrossChainOrder } from '@cowprotocol/sdk-bridging'
 import { Command } from '@cowprotocol/types'
 import { TruncatedText } from '@cowprotocol/ui/pure/TruncatedText'
 
@@ -15,6 +15,7 @@ import { TableState } from 'explorer/components/TokensTableWidget/useTable'
 import { TAB_QUERY_PARAM_KEY } from 'explorer/const'
 import { useQuery, useUpdateQueryString } from 'hooks/useQuery'
 import { useLocation } from 'react-router'
+import { knownBridgeProviders } from 'sdk/cowSdk'
 import { useNetworkId } from 'state/network'
 import { SWRResponse } from 'swr'
 import { Errors } from 'types'
@@ -81,6 +82,9 @@ const tabItems = (
   const showFills = order?.partiallyFillable && !order.txHash && hasMultipleTrades
 
   const { data: crossChainOrder, isLoading: crossChainOrderLoading } = crossChainOrderResponse
+  const bridgeProviderType: BridgeProviderType | undefined =
+    crossChainOrder?.provider.type ||
+    knownBridgeProviders.find((provider) => provider.info.dappId === order?.bridgeProviderId)?.type
 
   const noTokens = Boolean(!isOrderLoading && order && !areTokensLoaded)
 
@@ -91,7 +95,7 @@ const tabItems = (
         order={order}
         showFillsButton={showFills}
         areTradesLoading={areTradesLoading}
-        bridgeProviderType={crossChainOrder?.provider.type}
+        bridgeProviderType={bridgeProviderType}
       >
         <VerboseDetails
           order={order}


### PR DESCRIPTION
# Summary

Fixes https://github.com/cowprotocol/cowswap/issues/6749

The label was wrong for these orders using Near:

[Expired](https://explorer-dev-git-fix-explorer-order-to-tooltip-cowswap-dev.vercel.app/orders/0xa7ebf586ccf86aecbc582263996e056590c41253ae22c055fa2e829aa86730bf9fa3c00a92ec5f96b1ad2527ab41b3932efeda58694a6d5d)
[Cancelled](https://explorer-dev-git-fix-explorer-order-to-tooltip-cowswap-dev.vercel.app/orders/0xb2f7fe7d83587e20190cf0bac3bdef7518aaa7cb0d2ffd0c3a0a019acf889eeb9fa3c00a92ec5f96b1ad2527ab41b3932efeda58694a66d5)
Signing
Open

<img width="1123" height="627" alt="image" src="https://github.com/user-attachments/assets/0f73d562-5716-45c1-8d3c-2f061209f2a4" />

<img width="452" height="153" alt="image" src="https://github.com/user-attachments/assets/64ff5989-dd80-41f5-a7f2-71198e3aa932" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Order details now reliably show bridge provider info even when primary order data is missing or still loading by using a fallback lookup, ensuring consistent display across states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->