### PR TITLE
fix(multicall): build fix (#6776)

### DIFF
--- a/libs/multicall/vite.config.mts
+++ b/libs/multicall/vite.config.mts
@@ -2,6 +2,7 @@
 import { lingui } from '@lingui/vite-plugin'
 import react from '@vitejs/plugin-react-swc'
 import { defineConfig } from 'vite'
+import macrosPlugin from 'vite-plugin-babel-macros'
 import dts from 'vite-plugin-dts'
 import viteTsConfigPaths from 'vite-tsconfig-paths'
 
@@ -12,6 +13,7 @@ export default defineConfig({
   cacheDir: '../../node_modules/.vite/multicall',
 
   plugins: [
+    macrosPlugin(), // required for @cowprotocol/ui
     dts({
       entryRoot: 'src',
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),


### PR DESCRIPTION
# Summary

Fixes #6776

`libs/multicall` imports `libs/ui` which uses `styled-components/macro` - it requires `vite-plugin-babel-macros` setup.

# To Test

`npx nx build multicall` should work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to support babel macros, enabling more flexible code transformations during the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->