### PR TITLE
fix: ondo tokens with bad formatting

### DIFF
--- a/libs/tokens/src/services/fetchTokenList.ts
+++ b/libs/tokens/src/services/fetchTokenList.ts
@@ -97,7 +97,12 @@ function listStateFromSourceConfig(result: ListState, list: ListSourceConfig): L
 
 async function sanitizeList(list: TokenList): Promise<TokenList> {
   // Remove tokens from the list that don't have valid addresses
-  const tokens = list.tokens.filter(({ address }) => isAddress(address))
+  const tokens = list.tokens.reduce<TokenList['tokens']>((acc, token) => {
+    const checksummed = isAddress(token.address.toLowerCase())
+    if (!checksummed) return acc
+    acc.push({ ...token, address: checksummed })
+    return acc
+  }, [])
 
   const cleanedList = { ...list, tokens }
 


### PR DESCRIPTION
# Summary

The list was filtering out around 200 (out of 400) tokens, including American Airlines.
https://cowservices.slack.com/archives/C0361CDG8GP/p1767864872668219?thread_ts=1767100907.055689&cid=C0361CDG8GP

# To Test

1. In incognito, the ondo list should include AALon
