### PR TITLE
fix: approve & swap bug introduced in #6791

### DIFF
--- a/apps/cowswap-frontend/src/modules/account/containers/OrderPartialApprove/OrderPartialApprove.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/OrderPartialApprove/OrderPartialApprove.tsx
@@ -62,7 +62,7 @@ export function OrderPartialApprove({
         </>
       )}
       <TradeApproveButton
-        enablePartialApprove
+        supportsPartialApprove
         useModals={false}
         amountToApprove={finalAmountToApprove}
         buttonSize={ButtonSize.SMALL}

--- a/apps/cowswap-frontend/src/modules/erc20Approve/containers/TradeApproveButton/TradeApproveButton.tsx
+++ b/apps/cowswap-frontend/src/modules/erc20Approve/containers/TradeApproveButton/TradeApproveButton.tsx
@@ -25,7 +25,7 @@ export interface TradeApproveButtonProps {
   minAmountToSignForSwap?: CurrencyAmount<Currency>
   children?: ReactNode
   isDisabled?: boolean
-  enablePartialApprove?: boolean
+  supportsPartialApprove?: boolean
   onApproveConfirm?: (txHash?: string) => void
   label?: string
   buttonSize?: ButtonSize
@@ -37,7 +37,7 @@ export function TradeApproveButton(props: TradeApproveButtonProps): ReactNode {
   const {
     amountToApprove,
     children,
-    enablePartialApprove,
+    supportsPartialApprove,
     isDisabled,
     buttonSize = ButtonSize.DEFAULT,
     useModals = true,
@@ -51,7 +51,7 @@ export function TradeApproveButton(props: TradeApproveButtonProps): ReactNode {
   const { callback: approveWithPreventedDoubleExecution, isExecuting } = usePreventDoubleExecution(approveAndSwap)
   const { data: cachedPermit, isLoading: cachedPermitLoading } = useHasCachedPermit(amountToApprove)
 
-  if (!enablePartialApprove) {
+  if (!supportsPartialApprove) {
     return (
       <>
         <LegacyApproveButton

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormButtonContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormButtonContext.ts
@@ -48,7 +48,7 @@ export function useTradeFormButtonContext(
       supportsPartialApprove,
       customTokenError,
       minAmountToSignForSwap,
-    }
+    } satisfies TradeFormButtonContext
   }, [
     defaultText,
     amountToApprove,

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
@@ -284,18 +284,18 @@ export const tradeButtonsMap: Record<TradeFormValidation, ButtonErrorConfig | Bu
     )
   },
   [TradeFormValidation.ApproveRequired]: (context, isDisabled = false) => {
-    const { amountToApprove, enablePartialApprove, defaultText } = context
+    const { amountToApprove, supportsPartialApprove, defaultText } = context
     if (!amountToApprove) return null
 
     return (
       <TradeApproveButton
         isDisabled={isDisabled}
         amountToApprove={amountToApprove}
-        enablePartialApprove={enablePartialApprove}
+        supportsPartialApprove={supportsPartialApprove}
         onApproveConfirm={context.confirmTrade}
         minAmountToSignForSwap={context.minAmountToSignForSwap}
       >
-        <TradeFormBlankButton disabled={!enablePartialApprove}>{defaultText}</TradeFormBlankButton>
+        <TradeFormBlankButton disabled={!supportsPartialApprove}>{defaultText}</TradeFormBlankButton>
       </TradeApproveButton>
     )
   },

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/types.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/types.ts
@@ -83,7 +83,7 @@ export interface TradeFormButtonContext {
   quote: TradeQuoteState
   isSupportedWallet: boolean
   widgetStandaloneMode?: boolean
-  enablePartialApprove?: boolean
+  supportsPartialApprove?: boolean
   customTokenError?: string
   minAmountToSignForSwap?: CurrencyAmount<Currency>
 


### PR DESCRIPTION
# Summary

I introduced a bug in #6791 because [I renamed `enablePartialApprove` to `supportsPartialApprove`.](https://github.com/cowprotocol/cowswap/pull/6791/changes#diff-0d55e51ec6c15e97428eacbd4cdaabd21d5ce87a173091c0f77107c839c53e9c)

Thinking that is a better name and that typescript will catch any issues.

Introduced a safety check `satisfies TradeFormButtonContext` when returning the object so this thing doesn't happen again.

## Testing

Ensure Approve & Swap is one button.

<img width="1657" height="707" alt="image" src="https://github.com/user-attachments/assets/8fceb7ac-e446-4d99-83ec-fc110756a337" />
