### PR TITLE
fix: message for balances error

### DIFF
--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -5510,6 +5510,10 @@ msgstr "is required"
 msgid "Operation in progress!"
 msgstr "Operation in progress!"
 
+#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+msgid "Request is being rate limited"
+msgstr "Request is being rate limited"
+
 #: libs/hook-dapp-lib/src/hookDappsRegistry.ts
 #~ msgid "The Morpho Borrow hook enables users to seamlessly combine swaps with borrow-related actions. Users can enter new positions, leave existing ones, or move between different markets through a unified, streamlined process."
 #~ msgstr "The Morpho Borrow hook enables users to seamlessly combine swaps with borrow-related actions. Users can enter new positions, leave existing ones, or move between different markets through a unified, streamlined process."

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
@@ -266,7 +266,7 @@ export const tradeButtonsMap: Record<TradeFormValidation, ButtonErrorConfig | Bu
     let errorMessage: string | undefined = undefined
 
     if (context.balancesError?.includes('rate limit')) {
-      errorMessage = 'Request is being rate limited'
+      errorMessage = t`Request is being rate limited`
     }
 
     return (


### PR DESCRIPTION
# Summary

Fixing this error message, now it should show `'Request is being rate limited'` or no tooltip.


<img width="1313" height="885" alt="image" src="https://github.com/user-attachments/assets/12f83476-2806-482a-887f-0fb002767ebb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messaging for rate-limited requests during balance loading. Users now receive a clearer, more informative notification when rate limiting occurs, replacing generic error text with actionable feedback ("Request is being rate limited").

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->