### PR TITLE
fix: remove bridge banner for BNB and Gnosis chain

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/containers/NetworkBridgeBanner/NetworkBridgeBanner.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/NetworkBridgeBanner/NetworkBridgeBanner.tsx
@@ -53,9 +53,7 @@ const RootWrapper = styled.div`
 
 // TODO: remove once network is supported for cross-chain swaps
 const SHOULD_SHOW_ALERT = {
-  [SupportedChainId.GNOSIS_CHAIN]: true,
   [SupportedChainId.LENS]: true,
-  [SupportedChainId.BNB]: true,
   [SupportedChainId.LINEA]: true,
   [SupportedChainId.PLASMA]: true,
 }


### PR DESCRIPTION
# Summary

Remove network banner from BNB and Gnosis Chain, as both now support bridging.

# To Test

1. Open swap on BNB
* There should not be a bridge banner at the bottom
2. Repeat for Gnosis chain

*Note:* Lens, Linea and Plasma should still show (if applicable).
Plasma doesn't have a native bridge AFAICT: https://github.com/cowprotocol/cow-sdk/blob/main/packages/config/src/chains/details/plasma.ts#L47-L53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated network bridge alert to no longer appear on Gnosis Chain and BNB networks. The alert is now only displayed on Lens, Linea, and Plasma networks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->