### PR TITLE
feat: improve form validation regarding loading balances

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
@@ -28,7 +28,6 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
     customTokenError,
     isRestrictedForCountry,
     isBalancesLoading,
-    balancesError,
   } = context
 
   const {
@@ -121,16 +120,16 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
     }
 
     if (!canPlaceOrderWithoutBalance && !!account) {
-      if (isBalancesLoading) {
+      if (!inputCurrencyBalance && isBalancesLoading) {
         validations.push(TradeFormValidation.BalancesLoading)
-      } else {
-        if (!inputCurrencyBalance && balancesError) {
-          validations.push(TradeFormValidation.BalancesNotLoaded)
-        }
+      }
 
-        if (inputCurrencyBalance && inputCurrencyAmount && inputCurrencyBalance.lessThan(inputCurrencyAmount)) {
-          validations.push(TradeFormValidation.BalanceInsufficient)
-        }
+      if (!inputCurrencyBalance && !isBalancesLoading) {
+        validations.push(TradeFormValidation.BalancesNotLoaded)
+      }
+
+      if (inputCurrencyBalance && inputCurrencyAmount && inputCurrencyBalance.lessThan(inputCurrencyAmount)) {
+        validations.push(TradeFormValidation.BalanceInsufficient)
       }
     }
 


### PR DESCRIPTION
# Summary

1. Now we don't show `Fetching balanes...` if we have them already (cached)
2. We show the `Couldn't load balances` error even if we don't have a fetch error - but everytime the input balance is missing.