### PR TITLE
fix: order fill notification - wrong amount & token for buy orders

### DIFF
--- a/apps/cowswap-frontend/src/modules/orders/containers/FulfilledOrderInfo/index.tsx
+++ b/apps/cowswap-frontend/src/modules/orders/containers/FulfilledOrderInfo/index.tsx
@@ -39,10 +39,17 @@ export function FulfilledOrderInfo({ chainId, orderUid }: ExecutedSummaryProps):
 
   const { formattedFilledAmount, formattedSwappedAmount } = useGetExecutedBridgeSummary(order) || {}
 
-  if (!order || !formattedSwappedAmount) return null
+  if (!order || !formattedSwappedAmount || !formattedFilledAmount) return null
 
   const inputToken = isSellOrder(order.kind) ? order.inputToken : formattedSwappedAmount.currency
-  const outputToken = isSellOrder(order.kind) ? formattedSwappedAmount.currency : order.inputToken
+  const outputToken = isSellOrder(order.kind) ? formattedSwappedAmount.currency : order.outputToken
+
+  const sellAmount = isSellOrder(order.kind)
+    ? formattedFilledAmount.quotient.toString()
+    : formattedSwappedAmount.quotient.toString()
+  const buyAmount = isSellOrder(order.kind)
+    ? formattedSwappedAmount.quotient.toString()
+    : formattedFilledAmount.quotient.toString()
 
   return (
     <>
@@ -51,8 +58,8 @@ export function FulfilledOrderInfo({ chainId, orderUid }: ExecutedSummaryProps):
           kind={order.kind}
           inputToken={inputToken as TokenInfo}
           outputToken={outputToken as TokenInfo}
-          sellAmount={formattedFilledAmount.quotient.toString()}
-          buyAmount={formattedSwappedAmount.quotient.toString()}
+          sellAmount={sellAmount}
+          buyAmount={buyAmount}
           customTemplate={FulfilledSummaryTemplate}
         />
       )}


### PR DESCRIPTION
# Summary

Fixes an issue introduced in #6670 , in [this file](https://github.com/cowprotocol/cowswap/pull/6670/changes#diff-ca5b1e5ce2d7cf449304a879b637f0dfaa646ca25aebb7e3aabe1af024661de3), causing a wrong token and a wrong amount for buy orders in the filled order notification.

<img width="1297" height="598" alt="image" src="https://github.com/user-attachments/assets/55f1e3f5-3ac6-4093-a3c4-2b8fdc627748" />

## Testing

1. Place a buy order from USDC to DAI
2. Both the amount and the tickers should be correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Corrected fulfilled order information display**: Fixed the calculation and selection of order amounts to accurately reflect buy and sell values based on order type, ensuring proper token and amount visibility in order summaries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->