### PR TITLE
fix: display price even while it's being loaded

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
@@ -156,7 +156,7 @@ export function SwapWidget({ topContent, bottomContent }: SwapWidgetProps): Reac
     label: isSellTrade ? t`Receive (before fees)` : t`Buy exactly`,
   }
 
-  const rateInfoParams = useRateInfoParams(inputCurrencyInfo.amount, outputCurrencyInfo.amount)
+  const rateInfoParams = useRateInfoParams(inputCurrencyAmount, outputCurrencyAmount)
 
   const buyingFiatAmount = useMemo(
     () => (isSellTrade ? outputCurrencyInfo.fiatAmount : inputCurrencyInfo.fiatAmount),


### PR DESCRIPTION
# Summary

After #6819 , input/output amounts are cleared while the rate is being loaded.
This makes so the rateInfo is reset as well, leading to the UI not showing the previously existing price.

This change uses input/outputCurrencyAmount for calculating rateInfo which won't be reset while loading.

# To Test

1. Load a price
2. Wait for it to reload/change amounts so the re-fetch is triggered
* Price should be displayed while loading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal rate information handling in the swap interface to improve data flow efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->