### PR TITLE
fix: wallet connect v2 reconnection

### DIFF
--- a/libs/wallet/src/index.ts
+++ b/libs/wallet/src/index.ts
@@ -42,7 +42,6 @@ export { Web3Provider } from './web3-react/Web3Provider'
 export { injectedWalletConnection } from './web3-react/connection/injectedWallet'
 export { networkConnection } from './web3-react/connection/network'
 export { gnosisSafeConnection } from './web3-react/connection/safe'
-export { walletConnectConnectionV2 } from './web3-react/connection/walletConnectV2'
 
 // Connect options
 export { InjectedOption, Eip6963Option } from './web3-react/connection/injectedOptions'

--- a/libs/wallet/src/web3-react/connection/walletConnectV2.tsx
+++ b/libs/wallet/src/web3-react/connection/walletConnectV2.tsx
@@ -1,22 +1,21 @@
-import { useState, useSyncExternalStore } from 'react'
+import { ReactNode } from 'react'
 
 import { RPC_URLS } from '@cowprotocol/common-const'
 import { getCurrentChainIdFromUrl } from '@cowprotocol/common-utils'
 import { ALL_SUPPORTED_CHAIN_IDS, SupportedChainId } from '@cowprotocol/cow-sdk'
-import { Command } from '@cowprotocol/types'
-import { initializeConnector, Web3ReactHooks } from '@web3-react/core'
-import { Web3ReactStore } from '@web3-react/types'
+import { initializeConnector } from '@web3-react/core'
 
-import { ASYNC_CUSTOM_PROVIDER_EVENT, AsyncConnector } from './asyncConnector'
 import { onError } from './onError'
 
-import { default as WalletConnectV2Image } from '../../api/assets/walletConnectIcon.svg'
+import WalletConnectV2Image from '../../api/assets/walletConnectIcon.svg'
 import { ConnectWalletOption } from '../../api/pure/ConnectWalletOption'
 import { ConnectionType } from '../../api/types'
 import { getConnectionName } from '../../api/utils/connection'
 import { WC_PROJECT_ID } from '../../constants'
+import { WalletConnectV2Connector } from '../connectors/WalletConnectV2Connector'
 import { useIsActiveConnection } from '../hooks/useIsActiveConnection'
-import { ConnectionOptionProps, Web3ReactConnection } from '../types'
+import { ConnectionOptionProps } from '../types'
+import { Web3ReactConnection } from '../types'
 
 export const walletConnectV2Option = {
   color: '#4196FC',
@@ -24,127 +23,56 @@ export const walletConnectV2Option = {
   id: 'wallet-connect-v2',
 }
 
-function createWalletConnectV2Connector(chainId: SupportedChainId): [AsyncConnector, Web3ReactHooks, Web3ReactStore] {
-  return initializeConnector<AsyncConnector>(
+const wc2Connections = new Map<SupportedChainId, Web3ReactConnection>()
+
+function createWalletConnectV2Connection(chainId: SupportedChainId): Web3ReactConnection {
+  const [connector, hooks] = initializeConnector<WalletConnectV2Connector>(
     (actions) =>
-      new AsyncConnector(
-        () =>
-          import('../connectors/WalletConnectV2Connector').then(
-            (m) =>
-              new m.WalletConnectV2Connector({
-                actions,
-                onError(error) {
-                  console.error('WalletConnect2 ERROR:', error)
-                },
-                options: {
-                  projectId: WC_PROJECT_ID,
-                  chains: [chainId],
-                  optionalChains: ALL_SUPPORTED_CHAIN_IDS,
-                  showQrModal: true,
-                  rpcMap: RPC_URLS,
-                },
-              }),
-          ),
+      new WalletConnectV2Connector({
         actions,
         onError,
-      ),
+        options: {
+          projectId: WC_PROJECT_ID,
+          chains: [chainId],
+          optionalChains: ALL_SUPPORTED_CHAIN_IDS,
+          rpcMap: RPC_URLS,
+          showQrModal: true,
+        },
+      }),
   )
-}
-
-/**
- * Copy-pasted solution from https://github.com/Uniswap/interface/blob/36986579dc413ff57bfe48ff209d96a13d4666ec/src/connection/index.ts#L85
- *
- * Why do we need this:
- * WC2 connector can be created once per network
- *
- * Let's consider the case:
- *
- *  - Connect via WC2 to Mainnet
- *  - Disconnect
- *  - Try to connect to Gnosis Chain via WC2
- *
- * In this case, the connection won't be established, because at step 1 the WC2 connector was created for chainId=1.
- * To overcome this problem we proxy WC2 connection and change it's implementation on flight on network changes.
- */
-// TODO: Break down this large function into smaller functions
-
-function createWc2Connection(chainId = getCurrentChainIdFromUrl()): Web3ReactConnection {
-  let [web3WalletConnectV2, web3WalletConnectV2Hooks] = createWalletConnectV2Connector(chainId)
-
-  web3WalletConnectV2Hooks.useProvider = function useProvider<T>() {
-    const [customProvider, setCustomProvider] = useState<T | undefined>(undefined)
-
-    web3WalletConnectV2.events.on(ASYNC_CUSTOM_PROVIDER_EVENT, setCustomProvider)
-
-    return customProvider
-  }
-
-  let onActivate: Command | undefined
-
-  const proxyConnector = new Proxy(
-    {},
-    {
-      get: (target, p, receiver) => Reflect.get(web3WalletConnectV2, p, receiver),
-      getOwnPropertyDescriptor: (target, p) => Reflect.getOwnPropertyDescriptor(web3WalletConnectV2, p),
-      getPrototypeOf: () => AsyncConnector.prototype,
-      set: (target, p, receiver) => Reflect.set(web3WalletConnectV2, p, receiver),
-    },
-  ) as typeof web3WalletConnectV2
-
-  const proxyHooks = new Proxy(
-    {},
-    {
-      get: (target, p, receiver) => {
-        return () => {
-          // Because our connectors are referentially stable (through proxying), we need a way to trigger React renders
-          // from outside of the React lifecycle when our connector is re-initialized. This is done via 'change' events
-          // with `useSyncExternalStore`:
-          const hooks = useSyncExternalStore(
-            (onChange) => {
-              onActivate = onChange
-              return () => (onActivate = undefined)
-            },
-            () => web3WalletConnectV2Hooks,
-          )
-          return Reflect.get(hooks, p, receiver)()
-        }
-      },
-    },
-  ) as typeof web3WalletConnectV2Hooks
 
   return {
-    get connector() {
-      return proxyConnector
-    },
-    get hooks() {
-      return proxyHooks
-    },
+    connector,
+    hooks,
     type: ConnectionType.WALLET_CONNECT_V2,
-    overrideActivate(chainId: SupportedChainId) {
-      return false
-      const update = createWalletConnectV2Connector(chainId)
-      web3WalletConnectV2 = update[0]
-      web3WalletConnectV2Hooks = update[1]
-
-      onActivate?.()
-      return false
-    },
   }
 }
 
-export const walletConnectConnectionV2 = createWc2Connection()
+export function getWalletConnectV2Connection(
+  chainId: SupportedChainId = getCurrentChainIdFromUrl(),
+): Web3ReactConnection {
+  let connection = wc2Connections.get(chainId)
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function WalletConnectV2Option({ selectedWallet, tryActivation }: ConnectionOptionProps) {
-  const isActive = useIsActiveConnection(selectedWallet, walletConnectConnectionV2)
+  if (!connection) {
+    connection = createWalletConnectV2Connection(chainId)
+    wc2Connections.set(chainId, connection)
+  }
+
+  return connection
+}
+
+export function WalletConnectV2Option({ selectedWallet, tryActivation }: ConnectionOptionProps): ReactNode {
+  const chainId = getCurrentChainIdFromUrl()
+  const connection = getWalletConnectV2Connection(chainId)
+
+  const isActive = useIsActiveConnection(selectedWallet, connection)
 
   return (
     <ConnectWalletOption
       {...walletConnectV2Option}
       isActive={isActive}
       clickable={!isActive}
-      onClick={() => tryActivation(walletConnectConnectionV2.connector)}
+      onClick={() => tryActivation(connection.connector)}
       header={getConnectionName(ConnectionType.WALLET_CONNECT_V2)}
     />
   )

--- a/libs/wallet/src/web3-react/utils/getWeb3ReactConnection.ts
+++ b/libs/wallet/src/web3-react/utils/getWeb3ReactConnection.ts
@@ -1,3 +1,4 @@
+import { getCurrentChainIdFromUrl } from '@cowprotocol/common-utils'
 import { Connector } from '@web3-react/types'
 
 import { ConnectionType } from '../../api/types'
@@ -7,23 +8,30 @@ import { metaMaskSdkConnection } from '../connection/metaMaskSdk'
 import { networkConnection } from '../connection/network'
 import { gnosisSafeConnection } from '../connection/safe'
 import { trezorConnection } from '../connection/trezor'
-import { walletConnectConnectionV2 } from '../connection/walletConnectV2'
+import { getWalletConnectV2Connection } from '../connection/walletConnectV2'
+import { WalletConnectV2Connector } from '../connectors/WalletConnectV2Connector'
 import { Web3ReactConnection } from '../types'
 
-const connectionTypeToConnection: Record<ConnectionType, Web3ReactConnection> = {
+const connectionTypeToConnection: Record<
+  Exclude<ConnectionType, ConnectionType.WALLET_CONNECT_V2>,
+  Web3ReactConnection
+> = {
   [ConnectionType.INJECTED]: injectedWalletConnection,
   [ConnectionType.METAMASK]: metaMaskSdkConnection,
   [ConnectionType.COINBASE_WALLET]: coinbaseWalletConnection,
-  [ConnectionType.WALLET_CONNECT_V2]: walletConnectConnectionV2,
   [ConnectionType.NETWORK]: networkConnection,
   [ConnectionType.GNOSIS_SAFE]: gnosisSafeConnection,
   [ConnectionType.TREZOR]: trezorConnection,
 }
-const CONNECTIONS: Web3ReactConnection[] = Object.values(connectionTypeToConnection)
+const STATIC_CONNECTIONS: Web3ReactConnection[] = Object.values(connectionTypeToConnection)
 
 export function getWeb3ReactConnection(c: Connector | ConnectionType): Web3ReactConnection {
+  if (c instanceof WalletConnectV2Connector || c === ConnectionType.WALLET_CONNECT_V2) {
+    return getWalletConnectV2Connection(getCurrentChainIdFromUrl())
+  }
+
   if (c instanceof Connector) {
-    const connection = CONNECTIONS.find((connection) => connection.connector === c)
+    const connection = STATIC_CONNECTIONS.find((connection) => connection.connector === c)
     if (!connection) {
       throw Error('unsupported connector')
     }


### PR DESCRIPTION
# Summary

Fixes #5709

The solution was to refactor `getWeb3ReactConnection` and add a special case for wallet connect which is a dynamic, not static connection. I believe the static "referentially stable" workaround is incompatible with web3-react: it causes it to not re-render on reconnection.

## Extra Context

~This is a draft because it's still a tricky issue for me.~

What I noticed is that the bug is fixed by removing `overrideActivate` in wallet connect v2:

```ts
    get connector() {
      return proxyConnector
    },
    get hooks() {
      return proxyHooks
    },
    type: ConnectionType.WALLET_CONNECT_V2,
    overrideActivate(chainId: SupportedChainId) {
      const update = createWalletConnectV2Connector(chainId)
      web3WalletConnectV2 = update[0]
      web3WalletConnectV2Hooks = update[1]

      onActivate?.()
      return false
    },
``` 

And this is why we need that code:

> Why do we need this:
> WC2 connector can be created once per network
>
> Let's consider the case:
>
>  - Connect via WC2 to Mainnet
>  - Disconnect
>  - Try to connect to Gnosis Chain via WC2
>
> In this case, the connection won't be established, because at step 1 the WC2 connector was created for chainId=1.
> To overcome this problem we proxy WC2 connection and change it's implementation on flight on network changes.

A change introduced in #3047.
Related issue https://github.com/Uniswap/web3-react/issues/843.

## Testing

Bug reproduction steps: https://github.com/cowprotocol/cowswap/pull/6830#issuecomment-3750519304


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined WalletConnect V2: switched to on-demand, per-chain cached connections and a simpler activation flow for faster, more reliable wallet connections; removed an older public export from the module API.
* **Bug Fixes**
  * Fixed inconsistent WalletConnect V2 activation and resolution across chains, improving connection stability and user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->