### PR TITLE
fix: improve swap UI when network costs round to 0

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/ReceiveAmountInfo/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/ReceiveAmountInfo/index.tsx
@@ -51,7 +51,6 @@ export function ReceiveAmountInfoTooltip(props: ReceiveAmountInfoTooltipProps): 
   const hasProtocolFee = hasValidFee(protocolFeeAmount, protocolFeeBps)
   const hasAnyFee = hasPartnerFee || hasProtocolFee
   const hasNetworkFee = !isFractionFalsy(networkFeeAmount)
-  const hasFee = hasNetworkFee || hasAnyFee
 
   const isEoaNotEthFlow = allowsOffchainSigning && !isEoaEthFlow
 
@@ -72,7 +71,9 @@ export function ReceiveAmountInfoTooltip(props: ReceiveAmountInfoTooltipProps): 
 
       {hasPartnerFee && <FeeItem title={t`Partner fee`} isSell={isSell} feeAmount={partnerFeeAmount} />}
 
-      <NetworkFeeItem discount={discount} networkFeeAmount={networkFeeAmount} isSell={isSell} hasFee={hasFee} />
+      {hasNetworkFee && (
+        <NetworkFeeItem discount={discount} networkFeeAmount={networkFeeAmount} isSell={isSell} hasFee={hasAnyFee} />
+      )}
 
       {!hasAnyFee && !isEoaNotEthFlow && <FeeItem title={t`Fee`} isSell={isSell} feeAmount={undefined} />}
 

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeFeesAndCosts/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeFeesAndCosts/index.tsx
@@ -61,7 +61,7 @@ export function TradeFeesAndCosts(props: TradeFeesAndCostsProps): ReactNode {
         showTotalRow={showTotalRow}
       />
 
-      {hasNetworkCosts && networkFeeAmount && (
+      {networkFeeAmount && (
         <NetworkCostsRow
           networkFeeAmount={networkFeeAmount}
           networkFeeAmountUsd={networkFeeAmountUsd}
@@ -69,6 +69,7 @@ export function TradeFeesAndCosts(props: TradeFeesAndCostsProps): ReactNode {
           amountSuffix={networkCostsSuffix}
           tooltipSuffix={networkCostsTooltipSuffix}
           isLast
+          showFreeLabel={!hasNetworkCosts}
         />
       )}
     </>

--- a/apps/cowswap-frontend/src/modules/trade/pure/NetworkCostsRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/NetworkCostsRow/index.tsx
@@ -13,6 +13,7 @@ interface NetworkCostsRowProps {
   amountSuffix?: ReactNode
   tooltipSuffix?: ReactNode
   isLast?: boolean
+  showFreeLabel?: boolean
 }
 
 export function NetworkCostsRow({
@@ -22,6 +23,7 @@ export function NetworkCostsRow({
   amountSuffix,
   tooltipSuffix,
   isLast = false,
+  showFreeLabel = false,
 }: NetworkCostsRowProps): ReactNode {
   const { t } = useLingui()
 
@@ -42,6 +44,7 @@ export function NetworkCostsRow({
       }
       label={t`Network costs (est.)`}
       isLast={isLast}
+      showFreeLabel={showFreeLabel}
     />
   )
 }

--- a/apps/cowswap-frontend/src/modules/trade/pure/ReviewOrderModalAmountRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/ReviewOrderModalAmountRow/index.tsx
@@ -1,14 +1,20 @@
 import { ReactElement, ReactNode } from 'react'
 
-import { FiatAmount, InfoTooltip, TokenAmount } from '@cowprotocol/ui'
+import { FiatAmount, InfoTooltip, TokenAmount, UI } from '@cowprotocol/ui'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
+import { Trans } from '@lingui/react/macro'
+import styled from 'styled-components/macro'
 import { Nullish } from 'types'
 
 import { Content, Label } from 'modules/trade/pure/ConfirmDetailsItem/styled'
 
 import { ConfirmDetailsItem } from '../ConfirmDetailsItem'
 import { ReceiveAmountTitle } from '../ReceiveAmountTitle'
+
+const GreenText = styled.span`
+  color: var(${UI.COLOR_GREEN});
+`
 
 export type ReviewOrderAmountRowProps = {
   amount?: Nullish<CurrencyAmount<Currency>>
@@ -21,6 +27,7 @@ export type ReviewOrderAmountRowProps = {
   withTimelineDot?: boolean
   highlighted?: boolean
   isLast?: boolean
+  showFreeLabel?: boolean
 }
 
 export function ReviewOrderModalAmountRow({
@@ -34,17 +41,26 @@ export function ReviewOrderModalAmountRow({
   withTimelineDot = false,
   highlighted = false,
   isLast = false,
+  showFreeLabel = false,
 }: ReviewOrderAmountRowProps): ReactElement {
   const Amount = (
     <Content highlighted={highlighted}>
-      {children}
-      {!isAmountAccurate && '≈ '}
-      <TokenAmount amount={amount} defaultValue="-" tokenSymbol={amount?.currency} />
-      {amountSuffix}
-      {fiatAmount && (
+      {showFreeLabel ? (
+        <GreenText>
+          <Trans>FREE</Trans>
+        </GreenText>
+      ) : (
         <>
-          &nbsp;
-          <FiatAmount amount={fiatAmount} withParentheses />
+          {children}
+          {!isAmountAccurate && '≈ '}
+          <TokenAmount amount={amount} defaultValue="-" tokenSymbol={amount?.currency} />
+          {amountSuffix}
+          {fiatAmount && (
+            <>
+              &nbsp;
+              <FiatAmount amount={fiatAmount} withParentheses />
+            </>
+          )}
         </>
       )}
     </Content>


### PR DESCRIPTION
# Summary

Fixes #6826 

Sometimes, there is no "network costs" field on the swap order estimation. This PR makes sure the field is present everytime even if the cost is zero. The word, "free", is shown when the cost is zero.

## Screenshots

### Before

<img width="397" height="404" alt="Screenshot 2026-01-18 at 17 04 13" src="https://github.com/user-attachments/assets/1456c220-fe95-4988-8091-1a2c16240751" />

### After
<img width="331" height="355" alt="Screenshot 2026-01-18 at 17 09 51" src="https://github.com/user-attachments/assets/983dfa60-3d55-4825-9e11-aa7bb63bba5b" />

# To Test

1. Go to the [swap page](https://swap.cow.fi/#/1/swap/WETH/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48)
2. Switch to any L2 chain with a general low gas fee (Gnosis, Plasma)
3. Swap tokens
4. Check the network costs field (present with the "free" word if the cost is zero)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Free" label to indicate when network costs are absent.

* **Improvements**
  * Network cost row now appears whenever a network fee amount exists, clarifying when costs apply.
  * Fee labeling and propagation across review screens improved for clearer, more consistent fee breakdowns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->