### PR TITLE
fix: make slippage editable while dynamic is loading

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/TransactionSlippageInput/Input.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/TransactionSlippageInput/Input.tsx
@@ -1,0 +1,65 @@
+import { ReactNode, RefObject } from 'react'
+
+import { RowBetween } from '@cowprotocol/ui'
+
+import { t } from '@lingui/core/macro'
+
+import { SlippageWarningParams } from './hooks/types'
+import { SlippageError } from './hooks/useSlippageInput'
+import * as styledEl from './styled'
+
+interface InputProps {
+  isSlippageModified: boolean
+  slippageError: false | SlippageError
+  focusOnInput: () => void
+  isQuoteLoading: boolean
+  isInputFocused: boolean
+  slippageWarningParams: SlippageWarningParams | null
+  inputRef: RefObject<HTMLInputElement | null>
+  slippageViewValue: string
+  parseSlippageInput: (value: string) => void
+  onSlippageInputBlur: () => void
+  placeholderSlippage: string
+}
+export function Input({
+  isSlippageModified,
+  slippageError,
+  focusOnInput,
+  isQuoteLoading,
+  isInputFocused,
+  slippageWarningParams,
+  inputRef,
+  slippageViewValue,
+  parseSlippageInput,
+  onSlippageInputBlur,
+  placeholderSlippage,
+}: InputProps): ReactNode {
+  return (
+    <styledEl.OptionCustom active={isSlippageModified} warning={!!slippageError} tabIndex={-1} onClick={focusOnInput}>
+      {!isSlippageModified && isQuoteLoading && !isInputFocused ? (
+        <styledEl.SlippageLoader size="16px" />
+      ) : (
+        <RowBetween>
+          {slippageWarningParams &&
+          !isQuoteLoading &&
+          (slippageWarningParams.tooLow || slippageWarningParams?.tooHigh) ? (
+            <styledEl.SlippageEmojiContainer>
+              <span role="img" aria-label={t`warning`}>
+                ⚠️
+              </span>
+            </styledEl.SlippageEmojiContainer>
+          ) : null}
+          <styledEl.Input
+            ref={inputRef}
+            autoFocus={isInputFocused}
+            placeholder={placeholderSlippage}
+            value={slippageViewValue}
+            onChange={(e) => parseSlippageInput(e.target.value)}
+            onBlur={onSlippageInputBlur}
+          />
+          %
+        </RowBetween>
+      )}
+    </styledEl.OptionCustom>
+  )
+}

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/TransactionSlippageInput/hooks/useSlippageAnalytics.ts
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/TransactionSlippageInput/hooks/useSlippageAnalytics.ts
@@ -1,0 +1,35 @@
+import { useCallback } from 'react'
+
+import { useCowAnalytics } from '@cowprotocol/analytics'
+
+import { CowSwapAnalyticsCategory } from 'common/analytics/types'
+
+type TxSettingAction = 'Default' | 'Custom'
+
+interface SlippageAnalyticsEvent {
+  category: CowSwapAnalyticsCategory.TRADE
+  action: `${TxSettingAction} Slippage Tolerance`
+  value: number
+}
+
+interface ReturnType {
+  sendSlippageAnalytics: (action: TxSettingAction, value: string | number) => void
+}
+
+export function useSlippageAnalytics(): ReturnType {
+  const analytics = useCowAnalytics()
+
+  const sendSlippageAnalytics = useCallback(
+    (action: TxSettingAction, value: string | number) => {
+      const analyticsEvent: SlippageAnalyticsEvent = {
+        category: CowSwapAnalyticsCategory.TRADE,
+        action: `${action} Slippage Tolerance`,
+        value: typeof value === 'string' ? parseFloat(value) : value,
+      }
+      analytics.sendEvent(analyticsEvent)
+    },
+    [analytics],
+  )
+
+  return { sendSlippageAnalytics }
+}

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/TransactionSlippageInput/hooks/useSlippageInput.ts
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/TransactionSlippageInput/hooks/useSlippageInput.ts
@@ -1,6 +1,5 @@
 import { RefObject, useCallback, useMemo, useRef, useState } from 'react'
 
-import { useCowAnalytics } from '@cowprotocol/analytics'
 import { useOnClickOutside } from '@cowprotocol/common-hooks'
 import { isValidIntegerFactory, percentToBps } from '@cowprotocol/common-utils'
 import { Percent } from '@uniswap/sdk-core'
@@ -13,18 +12,10 @@ import {
   useTradeSlippage,
 } from 'modules/tradeSlippage'
 
-import { CowSwapAnalyticsCategory } from 'common/analytics/types'
+import { useSlippageAnalytics } from './useSlippageAnalytics'
 
-enum SlippageError {
+export enum SlippageError {
   InvalidInput = 'InvalidInput',
-}
-
-type TxSettingAction = 'Default' | 'Custom'
-
-interface SlippageAnalyticsEvent {
-  category: CowSwapAnalyticsCategory.TRADE
-  action: `${TxSettingAction} Slippage Tolerance`
-  value: number
 }
 
 interface ReturnType {
@@ -43,7 +34,6 @@ function getSlippageForView(slippageInput: string, isSlippageModified: boolean, 
   return slippageInput.length > 0 ? slippageInput : !isSlippageModified ? '' : swapSlippage.toFixed(2)
 }
 
-// eslint-disable-next-line max-lines-per-function
 export function useSlippageInput(): ReturnType {
   const inputRef = useRef<HTMLInputElement>(null)
   const [slippageInput, setSlippageInput] = useState('')
@@ -53,25 +43,13 @@ export function useSlippageInput(): ReturnType {
   const { min, max } = useSlippageConfig()
 
   const setSwapSlippage = useSetSlippage()
-  const analytics = useCowAnalytics()
+  const { sendSlippageAnalytics } = useSlippageAnalytics()
 
   const defaultSwapSlippage = useDefaultTradeSlippage()
   const swapSlippage = useTradeSlippage()
   const isSlippageModified = useIsSlippageModified()
 
   const placeholderSlippage = isSlippageModified ? defaultSwapSlippage : swapSlippage
-
-  const sendSlippageAnalytics = useCallback(
-    (action: TxSettingAction, value: string | number) => {
-      const analyticsEvent: SlippageAnalyticsEvent = {
-        category: CowSwapAnalyticsCategory.TRADE,
-        action: `${action} Slippage Tolerance`,
-        value: typeof value === 'string' ? parseFloat(value) : value,
-      }
-      analytics.sendEvent(analyticsEvent)
-    },
-    [analytics],
-  )
 
   const slippageViewValue = getSlippageForView(slippageInput, isSlippageModified, swapSlippage)
 

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/TransactionSlippageInput/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/TransactionSlippageInput/index.tsx
@@ -2,7 +2,6 @@ import { JSX, useContext } from 'react'
 
 import { HelpTooltip, RowBetween, RowFixed } from '@cowprotocol/ui'
 
-import { t } from '@lingui/core/macro'
 import { Trans } from '@lingui/react/macro'
 import { ThemeContext } from 'styled-components/macro'
 
@@ -12,12 +11,11 @@ import { SlippageWarningMessage } from 'modules/tradeWidgetAddons/pure/SlippageW
 
 import { useSlippageInput } from './hooks/useSlippageInput'
 import { useSlippageWarningParams } from './hooks/useSlippageWarningParams'
+import { Input } from './Input'
 import * as styledEl from './styled'
-import { SlippageLoader } from './styled'
 
 import { SlippageTooltip } from '../SlippageTooltip'
 
-// eslint-disable-next-line max-lines-per-function
 export function TransactionSlippageInput(): JSX.Element {
   const theme = useContext(ThemeContext)
 
@@ -51,37 +49,19 @@ export function TransactionSlippageInput(): JSX.Element {
         <styledEl.Option onClick={setAutoSlippage} active={!isSlippageModified}>
           <Trans>Auto</Trans>
         </styledEl.Option>
-        <styledEl.OptionCustom
-          active={isSlippageModified}
-          warning={!!slippageError}
-          tabIndex={-1}
-          onClick={focusOnInput}
-        >
-          {!isSlippageModified && isQuoteLoading && !isInputFocused ? (
-            <SlippageLoader size="16px" />
-          ) : (
-            <RowBetween>
-              {slippageWarningParams &&
-              !isQuoteLoading &&
-              (slippageWarningParams.tooLow || slippageWarningParams?.tooHigh) ? (
-                <styledEl.SlippageEmojiContainer>
-                  <span role="img" aria-label={t`warning`}>
-                    ⚠️
-                  </span>
-                </styledEl.SlippageEmojiContainer>
-              ) : null}
-              <styledEl.Input
-                ref={inputRef}
-                autoFocus={isInputFocused}
-                placeholder={placeholderSlippage.toFixed(2)}
-                value={slippageViewValue}
-                onChange={(e) => parseSlippageInput(e.target.value)}
-                onBlur={onSlippageInputBlur}
-              />
-              %
-            </RowBetween>
-          )}
-        </styledEl.OptionCustom>
+        <Input
+          isSlippageModified={isSlippageModified}
+          slippageError={slippageError}
+          focusOnInput={focusOnInput}
+          isQuoteLoading={isQuoteLoading}
+          isInputFocused={isInputFocused}
+          slippageWarningParams={slippageWarningParams}
+          inputRef={inputRef}
+          slippageViewValue={slippageViewValue}
+          parseSlippageInput={parseSlippageInput}
+          onSlippageInputBlur={onSlippageInputBlur}
+          placeholderSlippage={placeholderSlippage.toFixed(2)}
+        />
       </RowBetween>
       {slippageWarningParams && !isQuoteLoading && (
         <SlippageWarningMessage error={!!slippageError} theme={theme} slippageWarningParams={slippageWarningParams} />


### PR DESCRIPTION
# Summary

Fixes #6800 

Makes sure the slippage input field is editable when the dynamic is loading

## Screenshot
<img width="463" height="449" alt="Screenshot 2026-01-21 at 04 56 51" src="https://github.com/user-attachments/assets/153e9cb7-a0bf-477d-8081-b40e29e7d1f1" />

# To Test
- Go to the swap tab
- Open the settings while the quote is loading
- Change slippage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced inline slippage UI with a dedicated slippage input component that shows placeholder, current value, and a trailing "%" and supports programmatic focus.
  * Input now surfaces focus state so clicking the loader/container focuses the field and editing programmatically focuses it.

* **Bug Fixes**
  * Loading indicator and warning visuals behave correctly with focus and modification state, avoiding obstruction and confusing displays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->