### PR TITLE
fix(bridging): disable bridging when there are no configured providers

### DIFF
--- a/apps/cowswap-frontend/src/entities/bridgeProvider/bridgeProvidersAtom.ts
+++ b/apps/cowswap-frontend/src/entities/bridgeProvider/bridgeProvidersAtom.ts
@@ -5,3 +5,5 @@ import { DefaultBridgeProvider } from '@cowprotocol/sdk-bridging'
 import { bungeeBridgeProvider } from 'tradingSdk/bridgingSdk'
 
 export const bridgeProvidersAtom = atom(new Set<DefaultBridgeProvider>([bungeeBridgeProvider]))
+
+export const hasBridgeProvidersAtom = atom((get) => get(bridgeProvidersAtom).size > 0)

--- a/apps/cowswap-frontend/src/entities/bridgeProvider/index.ts
+++ b/apps/cowswap-frontend/src/entities/bridgeProvider/index.ts
@@ -2,4 +2,5 @@ export { useBridgeSupportedNetworks, useBridgeSupportedNetwork } from './useBrid
 export { useBridgeSupportedTokens } from './useBridgeSupportedTokens'
 export { useRoutesAvailability } from './useRoutesAvailability'
 export { useHasHookBridgeProvidersEnabled } from './useHasHookBridgeProvidersEnabled'
+export { useHasBridgeProviders } from './useHasBridgeProviders'
 export { BridgeProvidersUpdater } from './BridgeProvidersUpdater'

--- a/apps/cowswap-frontend/src/entities/bridgeProvider/useHasBridgeProviders.ts
+++ b/apps/cowswap-frontend/src/entities/bridgeProvider/useHasBridgeProviders.ts
@@ -1,0 +1,7 @@
+import { useAtomValue } from 'jotai'
+
+import { hasBridgeProvidersAtom } from './bridgeProvidersAtom'
+
+export function useHasBridgeProviders(): boolean {
+  return useAtomValue(hasBridgeProvidersAtom)
+}

--- a/apps/cowswap-frontend/src/modules/bridge/updaters/BridgingEnabledUpdater.ts
+++ b/apps/cowswap-frontend/src/modules/bridge/updaters/BridgingEnabledUpdater.ts
@@ -4,6 +4,8 @@ import { useFeatureFlags, useSetIsBridgingEnabled } from '@cowprotocol/common-ho
 import { isInjectedWidget } from '@cowprotocol/common-utils'
 import { useIsSafeApp } from '@cowprotocol/wallet'
 
+import { useHasBridgeProviders } from 'entities/bridgeProvider'
+
 import { useInjectedWidgetParams } from 'modules/injectedWidget'
 import { useTradeTypeInfo } from 'modules/trade'
 
@@ -20,7 +22,9 @@ export function BridgingEnabledUpdater(): null {
   const widgetInSafeApp = isSafeApp && isInjectedWidget()
   const shouldEnableInWidgetSafe = isBridgingInSafeWidgetEnabled ? true : !widgetInSafeApp
 
-  const shouldEnableBridging = isSwapPage && !disableCrossChainSwap && shouldEnableInWidgetSafe
+  const hasBridgeProviders = useHasBridgeProviders()
+
+  const shouldEnableBridging = isSwapPage && !disableCrossChainSwap && shouldEnableInWidgetSafe && hasBridgeProviders
 
   useEffect(() => {
     setIsBridgingEnabled(shouldEnableBridging)


### PR DESCRIPTION
# Summary

Despite we checking and not enabling providers based on feature flags and wallet type, we were not checking whether there were any providers enabled in order to enable bridging.

# To Test

1. Load app on Safe
2. Disable NEAR provider
* Bridging should not be enabled
* There should not be 1click nor bungee related queries
3. Enable NEAR provider
* Bridging should be enabled
* There should be 1click requests, no bungee requests
4. Load app and connect with EOA
5. Disable all bridge providers
* Bridging should not be enabled
* There should not be 1click nor bungee related queries
6. Enable all bridge providers
* Should work as usual

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced bridge feature with improved availability detection to ensure bridging is only enabled when bridge providers are present and operational.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->