### PR TITLE
fix: move dl provider in tree to avoid ffs reinitialization

### DIFF
--- a/apps/cowswap-frontend/src/cow-react/index.tsx
+++ b/apps/cowswap-frontend/src/cow-react/index.tsx
@@ -51,18 +51,18 @@ export function Main(): ReactNode {
               <ThemeProvider>
                 <HashRouter>
                   <LanguageProvider>
-                    <Web3ProviderInstance>
-                      <BlockNumberProvider>
-                        <WithLDProvider>
+                    <WithLDProvider>
+                      <Web3ProviderInstance>
+                        <BlockNumberProvider>
                           <CowAnalyticsProvider cowAnalytics={cowAnalytics}>
                             <WalletUnsupportedNetworkBanner />
                             <Updaters />
                             <Toasts />
                             <App />
                           </CowAnalyticsProvider>
-                        </WithLDProvider>
-                      </BlockNumberProvider>
-                    </Web3ProviderInstance>
+                        </BlockNumberProvider>
+                      </Web3ProviderInstance>
+                    </WithLDProvider>
                   </LanguageProvider>
                 </HashRouter>
               </ThemeProvider>


### PR DESCRIPTION
# Summary

Fixes blinking "Unsupported Network" banner when connecting Safe wallet on Plasma chain.

## Changes

Moved WithLDProvider  higher in the component tree - before Web3ProviderInstance.


When connecting a wallet, `Web3ProviderInstance` re-renders due to `selectedWallet` state changes. Combined with React StrictMode's double-mounting behavior, this caused LaunchDarkly to re-initialize, temporarily resetting feature flags to `undefined`.

# To Test

1. Open the app on Plasma chain 
2. Connect a Safe wallet via WalletConnect

- [ ] no blinking "Unsupported Network" banner appears
- [ ] wallet connects successfully
- [ ] Plasma chain remains selected after connection


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized provider initialization order to optimize context propagation and component sequencing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->