### PR TITLE
fix(trade): do not reset output token for regular swap

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/hooks/useNavigateOnCurrencySelection.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useNavigateOnCurrencySelection.ts
@@ -125,7 +125,11 @@ export function useNavigateOnCurrencySelection(): CurrencySelectionCallback {
           ? { inputCurrencyId: outputCurrencyId, outputCurrencyId: inputCurrencyId }
           : {
               inputCurrencyId: targetInputCurrencyId,
-              outputCurrencyId: isOutputCurrencyBridgeSupported ? targetOutputCurrencyId : null,
+              outputCurrencyId: isBridgeTrade
+                ? isOutputCurrencyBridgeSupported
+                  ? targetOutputCurrencyId
+                  : null
+                : targetOutputCurrencyId,
             },
         searchParams,
       )


### PR DESCRIPTION
# Summary

token selection may be reset when I pick different tokens in one chain in safe:
 - Open limit orders (the form does not matter, actually)
 - pick GNO-COW
 - open Buy token selector and change token to WETH --> it is reset
