### PR TITLE
fix(bridge): hide receiver when swap part of bridge is filled

### DIFF
--- a/apps/cowswap-frontend/src/modules/orders/pure/OrderNotificationContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/orders/pure/OrderNotificationContent/index.tsx
@@ -25,6 +25,7 @@ export interface OrderNotificationContentProps {
   actionTitle?: string
   customTemplate?: typeof SellForAtLeastTemplate
   skipExplorerLink?: boolean
+  hideReceiver?: boolean
   transactionHash?: string
   bottomContent?: ReactNode
   children?: ReactNode
@@ -41,6 +42,7 @@ export function OrderNotificationContent({
   transactionHash,
   skipExplorerLink,
   bottomContent,
+  hideReceiver,
   children,
 }: OrderNotificationContentProps): ReactNode {
   const ref = useToastRenderRef(orderInfo.orderUid, messageType, orderInfo.orderType)
@@ -63,7 +65,7 @@ export function OrderNotificationContent({
           dstChainData={dstChainData}
         />
       )}
-      <ReceiverInfo receiver={orderInfo.receiver} owner={orderInfo.owner} />
+      {!hideReceiver && <ReceiverInfo receiver={orderInfo.receiver} owner={orderInfo.owner} />}
       {bottomContent}
     </div>
   )

--- a/apps/cowswap-frontend/src/modules/orders/updaters/OrdersNotificationsUpdater/handlers.tsx
+++ b/apps/cowswap-frontend/src/modules/orders/updaters/OrdersNotificationsUpdater/handlers.tsx
@@ -61,6 +61,8 @@ export const ORDERS_NOTIFICATION_HANDLERS: Record<OrderStatusEvents, OrdersNotif
           chainId={chainId}
           orderUid={order.uid}
           messageType={ToastMessageType.ORDER_FULFILLED}
+          // Do not display a receiver for bridge order, because it will always by a proxy address
+          hideReceiver={!!bridgeOrder}
         >
           <FulfilledOrderInfo chainId={chainId} orderUid={order.uid} />
         </OrderNotification>


### PR DESCRIPTION
# Summary

<img width="1266" height="696" alt="image" src="https://github.com/user-attachments/assets/c0a00b05-6a20-4cbf-88b5-c9a314a2807d" />

# To Test

1. Make a cross-chain order
2. Wait till swap part is finished
- [ ] There should not be "Receiver" filed in `Swap order filled` banner
- [ ] For regular swaps, when custom recipient is specified, there should be "Receiver" filed in `Order filled` banner
