### PR TITLE
feat: enable sourcemaps

### DIFF
--- a/apps/cowswap-frontend/vite.config.mts
+++ b/apps/cowswap-frontend/vite.config.mts
@@ -159,7 +159,7 @@ export default defineConfig(({ mode }) => {
     build: {
       assetsInlineLimit: 0, // prevent inlining assets
       assetsDir: 'static', // All assets go to /static/ directory
-      // sourcemap: true, // disabled for now, as this is causing vercel builds to fail
+      sourcemap: true,
       rollupOptions: {
         output: {
           // Remove hash for font files to enable preloading


### PR DESCRIPTION
## Summary

Improves error debugging. Reverts a change from #3077, enabling source maps.

## To Test

1. If you go to https://swap-o6brr0prl-cowswap-dev.vercel.app, you can trigger a error by chosing a buy token in a limit order
2. That error should point to index.tsx:194:48
<img width="1437" height="412" alt="image" src="https://github.com/user-attachments/assets/4d74a5cf-fba5-4220-bd3a-3d8bfbb16a22" />

3. Sources tab should also allow you to inspect src
<img width="489" height="258" alt="image" src="https://github.com/user-attachments/assets/755b56e9-ffea-4269-9e82-29ca3d7ab4d1" />

4. Sentry should resolve the sourcemaps from prod e.g.: https://cowprotocol.sentry.io/issues/7218915271/ and provide helpful stack traces

## Background

Source maps are only loaded when dev tools are opened, you can test this by serving the build locally using `serve`:
<details>

<summary>Serve logs</summary>

```sh
daniel in cowswap on  feat/source-maps [$!] via ⬢ v22.19.0 is 📦 2.0.0 
➜ serve build/cowswap

   ┌───────────────────────────────────────────┐
   │                                           │
   │   Serving!                                │
   │                                           │
   │   - Local:    http://localhost:3000       │
   │   - Network:  http://192.168.0.132:3000   │
   │                                           │
   │   Copied local address to clipboard!      │
   │                                           │
   └───────────────────────────────────────────┘

 HTTP  1/26/2026 3:25:37 PM ::1 GET /
 HTTP  1/26/2026 3:25:37 PM ::1 Returned 200 in 21 ms
 HTTP  1/26/2026 3:25:37 PM ::1 GET /emergency.js
 HTTP  1/26/2026 3:25:37 PM ::1 GET /static/Inter-roman.var.woff2
 HTTP  1/26/2026 3:25:37 PM ::1 GET /static/index-Db82kXku.css
 HTTP  1/26/2026 3:25:37 PM ::1 GET /static/Inter-italic.var.woff2
 HTTP  1/26/2026 3:25:37 PM ::1 Returned 200 in 6 ms
 HTTP  1/26/2026 3:25:37 PM ::1 GET /static/StudioFeixenSans-Regular.woff2
 HTTP  1/26/2026 3:25:37 PM ::1 GET /static/StudioFeixenSans-Medium.woff2
 HTTP  1/26/2026 3:25:37 PM ::1 Returned 200 in 7 ms
 HTTP  1/26/2026 3:25:37 PM ::1 Returned 200 in 6 ms
 HTTP  1/26/2026 3:25:37 PM ::1 Returned 200 in 12 ms
 HTTP  1/26/2026 3:25:37 PM ::1 GET /static/StudioFeixenSans-Semibold.woff2
 HTTP  1/26/2026 3:25:37 PM ::1 Returned 200 in 7 ms
 HTTP  1/26/2026 3:25:37 PM ::1 Returned 200 in 12 ms
 HTTP  1/26/2026 3:25:37 PM ::1 GET /static/StudioFeixenSans-Bold.woff2
 HTTP  1/26/2026 3:25:37 PM ::1 Returned 200 in 8 ms
 HTTP  1/26/2026 3:25:37 PM ::1 GET /static/StudioFeixenMono-Regular.woff2
 HTTP  1/26/2026 3:25:37 PM ::1 GET /static/index-D6UfCSdh.js
 HTTP  1/26/2026 3:25:37 PM ::1 GET /static/web3-BMegh8Q9.js
 HTTP  1/26/2026 3:25:37 PM ::1 Returned 200 in 8 ms
 HTTP  1/26/2026 3:25:37 PM ::1 GET /static/@1inch-hQ971-1m.js
 HTTP  1/26/2026 3:25:37 PM ::1 GET /static/@safe-global-BSfd5xOQ.js
 HTTP  1/26/2026 3:25:37 PM ::1 Returned 200 in 7 ms
 HTTP  1/26/2026 3:25:37 PM ::1 GET /static/@sentry-ChUjQtYO.js
 HTTP  1/26/2026 3:25:37 PM ::1 GET /static/@uniswap-Bq2IDTnp.js
 HTTP  1/26/2026 3:25:37 PM ::1 Returned 200 in 5 ms
 HTTP  1/26/2026 3:25:37 PM ::1 Returned 200 in 4 ms
 HTTP  1/26/2026 3:25:37 PM ::1 Returned 200 in 18 ms
 HTTP  1/26/2026 3:25:37 PM ::1 Returned 200 in 21 ms
 HTTP  1/26/2026 3:25:37 PM ::1 Returned 200 in 19 ms
 HTTP  1/26/2026 3:25:37 PM ::1 GET /static/lottie-react-DmOP8yhW.js
 HTTP  1/26/2026 3:25:37 PM ::1 Returned 200 in 4 ms
 HTTP  1/26/2026 3:25:37 PM ::1 Returned 200 in 34 ms
 HTTP  1/26/2026 3:25:37 PM ::1 GET /static/cow-no-connection-s1SqaxsV.png
 HTTP  1/26/2026 3:25:37 PM ::1 GET /static/ajv-3WvWos9i.js
 HTTP  1/26/2026 3:25:37 PM ::1 GET /static/index-C148XJoK.js
 HTTP  1/26/2026 3:25:37 PM ::1 Returned 200 in 2 ms
 HTTP  1/26/2026 3:25:37 PM ::1 Returned 200 in 2 ms
 HTTP  1/26/2026 3:25:37 PM ::1 Returned 200 in 3 ms
 HTTP  1/26/2026 3:25:38 PM ::1 GET /static/en-US-Dj5QQVNp.js
 HTTP  1/26/2026 3:25:38 PM ::1 Returned 200 in 1 ms
 HTTP  1/26/2026 3:25:38 PM ::1 GET /static/background-cowswap-darkmode-BEnOnXSg.svg
 HTTP  1/26/2026 3:25:38 PM ::1 Returned 200 in 2 ms
 HTTP  1/26/2026 3:25:38 PM ::1 GET /static/background-cowswap-lightmode-oHG5WLOn.svg
 HTTP  1/26/2026 3:25:38 PM ::1 Returned 200 in 1 ms
 HTTP  1/26/2026 3:25:38 PM ::1 GET /static/menu-grid-dots-CmmsNWFO.svg
 HTTP  1/26/2026 3:25:38 PM ::1 Returned 200 in 1 ms
 HTTP  1/26/2026 3:25:38 PM ::1 GET /static/carret-down-D9sN-8LQ.svg
 HTTP  1/26/2026 3:25:38 PM ::1 GET /static/wallet-uulSsO0j.svg
 HTTP  1/26/2026 3:25:38 PM ::1 GET /static/settings-global-C3HunjHi.svg
 HTTP  1/26/2026 3:25:38 PM ::1 GET /static/logo-cowswap-DGTX7LSW.svg
 HTTP  1/26/2026 3:25:38 PM ::1 GET /static/logo-cowprotocol-DhVeK_6C.svg
 HTTP  1/26/2026 3:25:38 PM ::1 GET /static/logo-mevblocker-Byos9g5k.svg
 HTTP  1/26/2026 3:25:38 PM ::1 Returned 200 in 3 ms
 HTTP  1/26/2026 3:25:38 PM ::1 Returned 200 in 2 ms
 HTTP  1/26/2026 3:25:38 PM ::1 Returned 200 in 2 ms
 HTTP  1/26/2026 3:25:38 PM ::1 Returned 200 in 2 ms
 HTTP  1/26/2026 3:25:38 PM ::1 Returned 200 in 2 ms
 HTTP  1/26/2026 3:25:38 PM ::1 Returned 200 in 3 ms
 HTTP  1/26/2026 3:25:38 PM ::1 GET /static/logo-cowamm-BGn4X3_q.svg
 HTTP  1/26/2026 3:25:38 PM ::1 GET /static/icon-fortune-cookie-IVS84_Sa.svg
 HTTP  1/26/2026 3:25:38 PM ::1 GET /static/feedback-BppUuyg8.svg
 HTTP  1/26/2026 3:25:38 PM ::1 GET /static/arrow-right-circular-BDAFETA8.svg
 HTTP  1/26/2026 3:25:38 PM ::1 GET /static/check-JJpmiuP3.svg
 HTTP  1/26/2026 3:25:38 PM ::1 GET /static/wallet-plus-3-dsHsgB.svg
 HTTP  1/26/2026 3:25:38 PM ::1 Returned 200 in 3 ms
 HTTP  1/26/2026 3:25:38 PM ::1 Returned 200 in 2 ms
 HTTP  1/26/2026 3:25:38 PM ::1 Returned 200 in 2 ms
 HTTP  1/26/2026 3:25:38 PM ::1 Returned 200 in 2 ms
 HTTP  1/26/2026 3:25:38 PM ::1 Returned 200 in 2 ms
 HTTP  1/26/2026 3:25:38 PM ::1 Returned 200 in 2 ms
 HTTP  1/26/2026 3:25:38 PM ::1 GET /service-worker.js
 HTTP  1/26/2026 3:25:38 PM ::1 Returned 200 in 2 ms
 HTTP  1/26/2026 3:25:39 PM ::1 GET /service-worker.js
 HTTP  1/26/2026 3:25:39 PM ::1 Returned 304 in 1 ms
 HTTP  1/26/2026 3:25:39 PM ::1 GET /451.html
 HTTP  1/26/2026 3:25:39 PM ::1 Returned 301 in 0 ms
 HTTP  1/26/2026 3:25:39 PM ::1 GET /451
 HTTP  1/26/2026 3:25:39 PM ::1 Returned 200 in 2 ms
 HTTP  1/26/2026 3:25:39 PM ::1 GET /android-chrome-192x192.png
 HTTP  1/26/2026 3:25:39 PM ::1 Returned 200 in 1 ms
 HTTP  1/26/2026 3:25:39 PM ::1 GET /android-chrome-512x512.png
 HTTP  1/26/2026 3:25:39 PM ::1 Returned 200 in 2 ms
 HTTP  1/26/2026 3:25:39 PM ::1 GET /apple-touch-icon-darkmode.png
 HTTP  1/26/2026 3:25:39 PM ::1 Returned 200 in 1 ms
 HTTP  1/26/2026 3:25:39 PM ::1 GET /apple-touch-icon.png
 HTTP  1/26/2026 3:25:39 PM ::1 Returned 200 in 1 ms
 HTTP  1/26/2026 3:25:39 PM ::1 GET /favicon-dark-mode.png
 HTTP  1/26/2026 3:25:39 PM ::1 Returned 200 in 1 ms
 HTTP  1/26/2026 3:25:39 PM ::1 GET /favicon-light-mode.png
 HTTP  1/26/2026 3:25:39 PM ::1 Returned 200 in 1 ms
 HTTP  1/26/2026 3:25:39 PM ::1 GET /images/og-meta-cowswap.png
 HTTP  1/26/2026 3:25:39 PM ::1 Returned 200 in 1 ms
 HTTP  1/26/2026 3:25:39 PM ::1 GET /index.html
 HTTP  1/26/2026 3:25:39 PM ::1 Returned 301 in 0 ms
 HTTP  1/26/2026 3:25:39 PM ::1 GET /index
 HTTP  1/26/2026 3:25:39 PM ::1 Returned 301 in 0 ms
 HTTP  1/26/2026 3:25:39 PM ::1 GET /
 HTTP  1/26/2026 3:25:39 PM ::1 Returned 200 in 2 ms
 HTTP  1/26/2026 3:25:39 PM ::1 GET /manifest.json
 HTTP  1/26/2026 3:25:39 PM ::1 Returned 200 in 2 ms
 HTTP  1/26/2026 3:25:39 PM ::1 GET /mstile-150x150.png
 HTTP  1/26/2026 3:25:39 PM ::1 Returned 200 in 2 ms
 HTTP  1/26/2026 3:25:39 PM ::1 GET /package.json
 HTTP  1/26/2026 3:25:39 PM ::1 Returned 200 in 1 ms
 HTTP  1/26/2026 3:25:39 PM ::1 GET /safari-pinned-tab.svg
 HTTP  1/26/2026 3:25:39 PM ::1 Returned 200 in 1 ms
 HTTP  1/26/2026 3:25:39 PM ::1 GET /manifest.webmanifest
 HTTP  1/26/2026 3:25:39 PM ::1 Returned 200 in 2 ms







 HTTP  1/26/2026 3:25:57 PM ::1 GET /static/index-Db82kXku.css
 HTTP  1/26/2026 3:25:57 PM ::1 Returned 304 in 1 ms
 HTTP  1/26/2026 3:25:57 PM ::1 GET /.well-known/appspecific/com.chrome.devtools.json
 HTTP  1/26/2026 3:25:57 PM ::1 Returned 404 in 3 ms
 HTTP  1/26/2026 3:25:57 PM ::1 GET /service-worker.js.map
 HTTP  1/26/2026 3:25:57 PM ::1 Returned 200 in 2 ms
 HTTP  1/26/2026 3:25:58 PM ::1 GET /static/@sentry-ChUjQtYO.js.map
 HTTP  1/26/2026 3:25:58 PM ::1 GET /static/@uniswap-Bq2IDTnp.js.map
 HTTP  1/26/2026 3:25:58 PM ::1 GET /static/lottie-react-DmOP8yhW.js.map
 HTTP  1/26/2026 3:25:58 PM ::1 GET /static/@1inch-hQ971-1m.js.map
 HTTP  1/26/2026 3:25:58 PM ::1 GET /static/@safe-global-BSfd5xOQ.js.map
 HTTP  1/26/2026 3:25:58 PM ::1 GET /static/web3-BMegh8Q9.js.map
 HTTP  1/26/2026 3:25:58 PM ::1 Returned 200 in 6 ms
 HTTP  1/26/2026 3:25:58 PM ::1 Returned 200 in 10 ms
 HTTP  1/26/2026 3:25:58 PM ::1 Returned 200 in 12 ms
 HTTP  1/26/2026 3:25:58 PM ::1 GET /static/index-D6UfCSdh.js.map
 HTTP  1/26/2026 3:25:58 PM ::1 Returned 200 in 33 ms
 HTTP  1/26/2026 3:25:58 PM ::1 Returned 200 in 40 ms
 HTTP  1/26/2026 3:25:58 PM ::1 Returned 200 in 41 ms
 HTTP  1/26/2026 3:25:58 PM ::1 GET /static/index-C148XJoK.js.map
 HTTP  1/26/2026 3:25:58 PM ::1 Returned 200 in 2 ms
 HTTP  1/26/2026 3:25:58 PM ::1 GET /static/ajv-3WvWos9i.js.map
 HTTP  1/26/2026 3:25:58 PM ::1 Returned 200 in 4 ms
 HTTP  1/26/2026 3:25:58 PM ::1 GET /static/en-US-Dj5QQVNp.js.map
 HTTP  1/26/2026 3:25:58 PM ::1 Returned 200 in 4 ms
 HTTP  1/26/2026 3:25:58 PM ::1 Returned 200 in 96 ms
```
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled generation of source maps to improve debugging and build diagnostics, making it easier to trace issues during development and review.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->