### PR TITLE
fix: load pnpm before starting vercel build

### DIFF
--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -29,6 +29,15 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
+      - name: Set up node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+      
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
 


### PR DESCRIPTION
# Summary

Vercel prod builds have been broken since the pnpm migration, as pnpm is not found https://github.com/cowprotocol/cowswap/actions/runs/21449610979/job/61774570198
<img width="1118" height="572" alt="image" src="https://github.com/user-attachments/assets/ad67eb46-2f98-4b0e-aa05-66a180c5f774" />

# To Test

Merge to `develop` and observe build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and deployment workflow configuration to optimize package manager and Node environment setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->