### PR TITLE
fix: add pluralization for TWAP 'parts'

### DIFF
--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/TwapStatusAndToggle/index.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/TwapStatusAndToggle/index.tsx
@@ -77,7 +77,7 @@ export function TwapStatusAndToggle({
       <styledEl.ToggleExpandButton onClick={onToggle} isCollapsed={isCollapsed}>
         {childrenLength && (
           <i>
-            {childrenLength} {childrenLength > 1 ? <Trans>parts</Trans> : <Trans>parts</Trans>}
+            {childrenLength} {childrenLength > 1 ? <Trans>parts</Trans> : <Trans>part</Trans>}
           </i>
         )}
         <button />


### PR DESCRIPTION
**To test:** 
1. Open https://app.safe.global/apps/open?safe=base:0x17a40f2F463d360FbF1769c3fFF9520c259F69F4&appUrl=https%3A%2F%2Fswap-dev-git-parts-in-plural-cowswap-dev.vercel.app/ and go to the orders history
2. Check that 'parts' is in plural
<img width="441" height="186" alt="image" src="https://github.com/user-attachments/assets/dcfde760-a34b-4b45-8f18-791102ce6bb1" />
<img width="450" height="368" alt="image" src="https://github.com/user-attachments/assets/83201df8-74d0-4df2-94e7-1eaea4bc156c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pluralization in the order status display so labels now read "part" or "parts" appropriately based on item count, ensuring consistent and clear messaging across the UI. This improves readability and prevents confusion when viewing multi-part orders.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->