### PR TITLE
fix(explorer): add more statuses to the Status tooltip

### DIFF
--- a/apps/explorer/src/components/orders/DetailsTable/detailsTableTooltips.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/detailsTableTooltips.tsx
@@ -17,7 +17,7 @@ export const DetailsTableTooltips = {
   hash: 'The onchain settlement transaction for this order. Can be viewed on Etherscan.',
   appData:
     'The AppData hash for this order. It can denote encoded metadata with info on the app, environment and more, although not all interfaces follow the same pattern. Show more will try to decode that information.',
-  status: 'The order status is either Open, Filled, Expired or Canceled.',
+  status: 'The order status is either Signing, Open, Filled, Partially filled, Expired or Canceled.',
   hooks: 'Hooks are interactions before/after order execution.',
   submission:
     'The date and time at which the order was submitted. The timezone is based on the browser locale settings.',


### PR DESCRIPTION
**To test:** 
1. Open an order details (f.e. this [one](https://explorer-dev-git-add-more-statuses-cowswap-dev.vercel.app/orders/0x189979b7c6402bc4cd83e5d68d2eebd14d47b5addf0ef148ade6a0c9d3b0f2899fa3c00a92ec5f96b1ad2527ab41b3932efeda58697a2cb9))
2. Click on the 'Status' field's tooltip --> new orders statuses like 'Signing' and 'Partially filled' are added there
<img width="452" height="109" alt="image" src="https://github.com/user-attachments/assets/1a91450c-b38c-45b7-bd69-b4505be77729" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the order status tooltip to include "Signing" and "Partially filled" alongside "Open", "Filled", "Expired", and "Canceled".
  * Improves clarity in the order details UI, helping users better understand possible order states when reviewing orders.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->