### PR TITLE
fix(limit-orders): display correct protocol fee amount

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useLimitOrderProtocolFeeAmount.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useLimitOrderProtocolFeeAmount.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 
+import { bpsToPercent } from '@cowprotocol/common-utils'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 
 import { useDerivedTradeState } from 'modules/trade'
@@ -16,7 +17,7 @@ export function useLimitOrderProtocolFeeAmount(): CurrencyAmount<Currency> | nul
     if (!outputCurrencyAmount) return null
 
     return !!protocolFeeBps && protocolFeeBps > 0
-      ? outputCurrencyAmount.multiply(protocolFeeBps * PROTOCOL_FEE_SCALE).divide(PROTOCOL_FEE_SCALE)
+      ? outputCurrencyAmount.multiply(bpsToPercent(protocolFeeBps * PROTOCOL_FEE_SCALE)).divide(PROTOCOL_FEE_SCALE)
       : CurrencyAmount.fromRawAmount(outputCurrencyAmount.currency, 0)
   }, [outputCurrencyAmount, protocolFeeBps])
 }


### PR DESCRIPTION
# Summary
Fixes #6953 


<img width="469" height="477" alt="image" src="https://github.com/user-attachments/assets/ccd39905-1ec7-4da7-a1b8-abcb34beec98" />


# To Test

1. Open Limit orders
2. Setup USDT/USDC on mainnet

- [ ] Protocol fee is 0.003%
- [ ] Protocol fee amounts corresponds to the protocol fee percent and trade amounts