### PR TITLE
fix: gh issue 6966 re duplicated pending orders

### DIFF
--- a/apps/cowswap-frontend/src/legacy/state/orders/reducer.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/reducer.ts
@@ -253,6 +253,9 @@ export default createReducer(initialState, (builder) =>
 
       order.openSince = CREATING_STATES.includes(order.status) ? undefined : Date.now()
 
+      // Ensure the order doesn't exist in multiple buckets (e.g., creating + pending)
+      deleteOrderById(state, chainId, id)
+
       switch (order.status) {
         // EthFlow or PreSign orders have their respective buckets
         case OrderStatus.CREATING: // ethflow orders


### PR DESCRIPTION
# Summary

Fixes #6966

The order was in both creating and pending order state

# To Test

Described in #6966



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where orders could exist in multiple states simultaneously, ensuring proper order status transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->