### PR TITLE
feat: add fallback for restricted ondo token list

### DIFF
--- a/libs/core/src/cms/consts.ts
+++ b/libs/core/src/cms/consts.ts
@@ -1,5 +1,7 @@
 import ms from 'ms.macro'
 
+import type { RestrictedTokenList } from './types'
+
 export const DEFAULT_CMS_REQUEST_TTL = ms`1h`
 
 export const ONDO_TOKEN_LIST_URL =
@@ -57,3 +59,9 @@ export const ONDO_RESTRICTED_COUNTRIES = [
   'LI',
   'NO',
 ] as const
+
+export const ONDO_FALLBACK_TOKEN_LIST: RestrictedTokenList = {
+  name: 'Ondo Tokenized Stocks List',
+  tokenListUrl: ONDO_TOKEN_LIST_URL,
+  restrictedCountries: [...ONDO_RESTRICTED_COUNTRIES],
+}

--- a/libs/core/src/cms/utils/getRestrictedTokenLists.ts
+++ b/libs/core/src/cms/utils/getRestrictedTokenLists.ts
@@ -2,7 +2,7 @@ import { TTLCache } from '@cowprotocol/cow-sdk'
 
 import { querySerializer } from './querySerializer'
 
-import { DEFAULT_CMS_REQUEST_TTL, ONDO_RESTRICTED_COUNTRIES, ONDO_TOKEN_LIST_URL } from '../consts'
+import { DEFAULT_CMS_REQUEST_TTL, ONDO_FALLBACK_TOKEN_LIST } from '../consts'
 import { RestrictedTokenList, RestrictedTokenLists } from '../types'
 import { getCmsClient } from '../utils'
 
@@ -68,12 +68,6 @@ async function fetchRestrictedTokenLists(): Promise<RestrictedTokenLists | null>
     })
     .catch((error: Error) => {
       console.error('Failed to fetch restricted token lists', error)
-      return [
-        {
-          name: 'Ondo Tokenized Stocks List',
-          tokenListUrl: ONDO_TOKEN_LIST_URL,
-          restrictedCountries: [...ONDO_RESTRICTED_COUNTRIES],
-        },
-      ]
+      return [ONDO_FALLBACK_TOKEN_LIST]
     })
 }


### PR DESCRIPTION
# Summary

Adds hardcoded fallback for Ondo tokenized list when CMS fetch fails

# To Test

1. **Test fallback behavior**
   - [ ] Simulate CMS failure (block cms request)
   - [ ] Verify that the Ondo token list is returned as fallback - restricted list should require the consent


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a built-in Ondo token list fallback so the app has a predefined token list available.

* **Bug Fixes**
  * Improved token list retrieval: on fetch failures the app now falls back to the Ondo token list instead of returning null, improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->