### PR TITLE
ci: use latest tag in npm

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -87,4 +87,4 @@ jobs:
 
       # 9️⃣ Publish released packages
       - name: Publish released packages
-        run: pnpm exec nx release publish --tag next --access public
+        run: pnpm exec nx release publish --tag latest --access public


### PR DESCRIPTION
# Summary

CI works well, we can safely use latest now