### PR TITLE
fix: allow claiming vesting after due date

### DIFF
--- a/apps/cowswap-frontend/src/pages/Account/LockedGnoVesting/index.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/LockedGnoVesting/index.tsx
@@ -57,10 +57,11 @@ const LockedGnoVesting: React.FC<Props> = ({ openModal, closeModal, vested, allo
   const [status, setStatus] = useState<ClaimStatus>(ClaimStatus.INITIAL)
   const unvested = allocated.subtract(vested)
   const previousAccount = usePrevious(account)
+  const claimableAmount = vested.subtract(claimed)
 
   const canClaim =
     !loading &&
-    unvested.greaterThan(0) &&
+    claimableAmount.greaterThan(0) &&
     status === ClaimStatus.INITIAL &&
     MERKLE_DROP_CONTRACT_ADDRESSES[chainId] &&
     TOKEN_DISTRO_CONTRACT_ADDRESSES[chainId]
@@ -206,7 +207,7 @@ const LockedGnoVesting: React.FC<Props> = ({ openModal, closeModal, vested, allo
               </HoverTooltip>
             </i>
             <b>
-              <TokenAmount amount={vested.subtract(claimed)} defaultValue="0" />
+              <TokenAmount amount={claimableAmount} defaultValue="0" />
             </b>
           </BalanceDisplay>
           {status === ClaimStatus.CONFIRMED ? (


### PR DESCRIPTION
# Summary

1. `unvested` relies on `LOCKED_GNO_VESTING_DURATION`, since the date was yesterday, `unvested` is always zero now
2. The button should not be disabled when `unvested is 0`, it should be disabled when `claimable` is zero

<img width="716" height="687" alt="image" src="https://github.com/user-attachments/assets/91354aeb-705e-4402-8a9d-bbb13407ebcc" />

# To Test

Check an account in Slack


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the calculation and display of claimable vesting amounts for more accurate representation.
  * Updated the claim button logic to correctly reflect when tokens are available for claiming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->