### PR TITLE
ci: fix and speed up e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
         run: npx cypress install
 
       - name: Start server in the background
-        run: pnpm run start &
+        run: pnpm run preview &
 
       # Actually run tests, building repo
       - name: Cypress run

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useGetConfirmButtonLabel.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useGetConfirmButtonLabel.ts
@@ -9,5 +9,5 @@ export function useGetConfirmButtonLabel(variant: ConfirmButtonLabelVariant, isB
     return isBridging ? t`Approve, Swap & Bridge` : t`Approve and Swap`
   }
 
-  return isBridging ? t`Swap and Bridge` : t`Swap`
+  return isBridging ? t`Confirm Swap and Bridge` : t`Confirm Swap`
 }


### PR DESCRIPTION
# Summary

1. Changed `pnpm start` to `pnpm run preview` to speed up e2e tests running. Preview runs production opimized bundle
2. Fixed `Swap` -> `Confirm Swap` renaming
3. Reverted #6746 and fixed it in another way

# To Test

1. Retest #6746
2. "Swap" was renamed to "Confirm Swap" on confirm modal
3. "wap and Bridge" -> "Confirm Swap and Bridge"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Swap confirmation button labels now display "Confirm Swap" and "Confirm Swap and Bridge"
  * Improved URL parameter handling in trading flows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->