### PR TITLE
fix(widget-react): use react from peer deps

### DIFF
--- a/libs/widget-react/package.json
+++ b/libs/widget-react/package.json
@@ -12,10 +12,12 @@
   "dependencies": {
     "@cowprotocol/events": "workspace:*",
     "@cowprotocol/types": "workspace:*",
-    "@cowprotocol/widget-lib": "workspace:*",
-    "react": "19.1.2"
+    "@cowprotocol/widget-lib": "workspace:*"
   },
   "devDependencies": {
     "@types/react": "19.1.3"
+  },
+  "peerDependencies": {
+    "react": "19.1.2"
   }
 }


### PR DESCRIPTION
# Summary

>Also a bit of feedback that might be useful to the CowSwap team: currently @cowprotocol/widget-react bundles React 19 as a hard dep instead of a peer dep, which crashes in React 18 apps. We worked around it by using widget-lib directly.
