### PR TITLE
fix: incorrect twap slippage

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/hooks/useGetSwapReceiveAmountInfo.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useGetSwapReceiveAmountInfo.ts
@@ -31,6 +31,7 @@ export function useSwapReceiveAmountInfoParams(): ReceiveAmountInfoParams | null
   const tradeQuote = useTradeQuote()
   const volumeFeeBps = useVolumeFee()?.volumeBps
   const orderKind = derivedTradeState?.orderKind
+  const derivedSlippage = derivedTradeState?.slippage
 
   const quoteResults = tradeQuote?.quote?.quoteResults
   const quoteResponse = quoteResults?.quoteResponse
@@ -50,11 +51,11 @@ export function useSwapReceiveAmountInfoParams(): ReceiveAmountInfoParams | null
       orderParams,
       inputCurrency,
       outputCurrency,
-      slippagePercent: bpsToPercent(slippage),
+      slippagePercent: derivedSlippage || bpsToPercent(slippage),
       partnerFeeBps: volumeFeeBps,
       protocolFeeBps,
     }
-  }, [orderKind, orderParams, volumeFeeBps, inputCurrency, outputCurrency, slippage, protocolFeeBps])
+  }, [orderKind, orderParams, volumeFeeBps, inputCurrency, outputCurrency, slippage, protocolFeeBps, derivedSlippage])
 }
 
 function useQuoteCurrencies(): ReceiveAmountCurrencies {


### PR DESCRIPTION
# Summary

Fix the TWAP price protection bug we introduced in #6974.

TWAP was set to use the global swap slippage (0.5% default) instead of TWAP slippage (10% default), so price protection and min receive were wrong.

# To Test

Open TWAP swap form and change price protection value

https://nomevlabs.slack.com/archives/C0361CDG8GP/p1771337719308939

