### PR TITLE
feat: gate SCW chains by runtime capabilities and block unsupported self-recipient destinations

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useShouldHideNetworkSelector.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useShouldHideNetworkSelector.ts
@@ -1,11 +1,16 @@
-import { useIsRabbyWallet, useIsSafeViaWc, useIsSmartContractWallet } from '@cowprotocol/wallet'
+import { useIsCoinbaseWallet, useIsRabbyWallet, useIsSafeViaWc, useIsSmartContractWallet } from '@cowprotocol/wallet'
 
 export function useShouldHideNetworkSelector(): boolean {
-  const isSafeViaWc = useIsSafeViaWc()
   const isSmartContractWallet = useIsSmartContractWallet()
+  const isSafeViaWc = useIsSafeViaWc()
   const isRabbyWallet = useIsRabbyWallet()
+  const isCoinbaseWallet = useIsCoinbaseWallet()
 
   if (isRabbyWallet) return false
+
+  // Coinbase SCW is multi-chain — show the selector.
+  // Other SCWs (Safe, unknown) keep the hidden selector.
+  if (isSmartContractWallet && isCoinbaseWallet) return false
 
   return isSmartContractWallet || isSafeViaWc
 }

--- a/apps/cowswap-frontend/src/common/pure/NetworksList/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/NetworksList/index.tsx
@@ -5,7 +5,7 @@ import { getExplorerBaseUrl } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { Badge, BadgeTypes } from '@cowprotocol/ui'
 
-import { Trans } from '@lingui/react/macro'
+import { Trans, useLingui } from '@lingui/react/macro'
 
 import * as styledEl from './styled'
 
@@ -15,31 +15,43 @@ export interface NetworksListProps {
   currentChainId: SupportedChainId | null
   isDarkMode: boolean
   availableChains: SupportedChainId[]
+  disabledChainIds?: Set<number>
 
   onSelectChain(targetChainId: SupportedChainId): void
 }
 
-// TODO: Break down this large function into smaller functions
 export function NetworksList(props: NetworksListProps): ReactNode {
-  const { currentChainId, isDarkMode, availableChains, onSelectChain } = props
+  const { currentChainId, isDarkMode, availableChains, onSelectChain, disabledChainIds } = props
+  const { t } = useLingui()
 
   return (
     <>
-      {/* TODO: Break down this large function into smaller functions */}
       {availableChains.map((targetChainId: SupportedChainId) => {
         const info = getChainInfo(targetChainId)
-        const { label, logo, bridge, explorer, explorerTitle, helpCenterUrl } = info
+        const { label, logo } = info
 
         const isActive = targetChainId === currentChainId
+        const isDisabled = disabledChainIds?.has(targetChainId) ?? false
         const logoUrl = getLogo(isDarkMode, isActive, logo.dark, logo.light)
         const isNewNetwork = NEW_NETWORK_IDS.has(targetChainId)
+
+        const handleClick = (): void => {
+          if (!isDisabled) {
+            onSelectChain(targetChainId)
+          }
+        }
 
         const rowContent = (
           <styledEl.FlyoutRow
             key={targetChainId}
             type="button"
-            onClick={() => onSelectChain(targetChainId)}
+            onClick={handleClick}
             active={isActive}
+            disabled$={isDisabled}
+            title={
+              isDisabled ? t`This chain is not supported by your connected wallet (Coinbase Smart Wallet)` : undefined
+            }
+            aria-disabled={isDisabled}
           >
             <styledEl.Logo src={logoUrl} />
             <styledEl.NetworkLabel color={info.color}>{label}</styledEl.NetworkLabel>
@@ -59,49 +71,62 @@ export function NetworksList(props: NetworksListProps): ReactNode {
         return (
           <styledEl.ActiveRowWrapper key={targetChainId}>
             {rowContent}
-            <styledEl.ActiveRowLinkList>
-              {bridge && (
-                <styledEl.ActiveRowLink href={bridge}>
-                  <styledEl.ActiveRowLinkLabel>
-                    <Trans>Bridge</Trans>
-                  </styledEl.ActiveRowLinkLabel>
-                  <styledEl.LinkOutIconWrapper>
-                    <styledEl.LinkOutCircle aria-hidden="true" />
-                  </styledEl.LinkOutIconWrapper>
-                </styledEl.ActiveRowLink>
-              )}
-              {explorer && (
-                <styledEl.ActiveRowLink href={explorer}>
-                  <styledEl.ActiveRowLinkLabel>{explorerTitle}</styledEl.ActiveRowLinkLabel>
-                  <styledEl.LinkOutIconWrapper>
-                    <styledEl.LinkOutCircle aria-hidden="true" />
-                  </styledEl.LinkOutIconWrapper>
-                </styledEl.ActiveRowLink>
-              )}
-              {helpCenterUrl && (
-                <styledEl.ActiveRowLink href={helpCenterUrl}>
-                  <styledEl.ActiveRowLinkLabel>
-                    <Trans>Help Center</Trans>
-                  </styledEl.ActiveRowLinkLabel>
-                  <styledEl.LinkOutIconWrapper>
-                    <styledEl.LinkOutCircle aria-hidden="true" />
-                  </styledEl.LinkOutIconWrapper>
-                </styledEl.ActiveRowLink>
-              )}
-
-              <styledEl.ActiveRowLink href={getExplorerBaseUrl(targetChainId)}>
-                <styledEl.ActiveRowLinkLabel>
-                  <Trans>CoW Protocol Explorer</Trans>
-                </styledEl.ActiveRowLinkLabel>
-                <styledEl.LinkOutIconWrapper>
-                  <styledEl.LinkOutCircle aria-hidden="true" />
-                </styledEl.LinkOutIconWrapper>
-              </styledEl.ActiveRowLink>
-            </styledEl.ActiveRowLinkList>
+            <ActiveRowLinks info={info} targetChainId={targetChainId} />
           </styledEl.ActiveRowWrapper>
         )
       })}
     </>
+  )
+}
+
+function ActiveRowLinks({
+  info,
+  targetChainId,
+}: {
+  info: ReturnType<typeof getChainInfo>
+  targetChainId: SupportedChainId
+}): ReactNode {
+  const { bridge, explorer, explorerTitle, helpCenterUrl } = info
+
+  return (
+    <styledEl.ActiveRowLinkList>
+      {bridge && (
+        <styledEl.ActiveRowLink href={bridge}>
+          <styledEl.ActiveRowLinkLabel>
+            <Trans>Bridge</Trans>
+          </styledEl.ActiveRowLinkLabel>
+          <styledEl.LinkOutIconWrapper>
+            <styledEl.LinkOutCircle aria-hidden="true" />
+          </styledEl.LinkOutIconWrapper>
+        </styledEl.ActiveRowLink>
+      )}
+      {explorer && (
+        <styledEl.ActiveRowLink href={explorer}>
+          <styledEl.ActiveRowLinkLabel>{explorerTitle}</styledEl.ActiveRowLinkLabel>
+          <styledEl.LinkOutIconWrapper>
+            <styledEl.LinkOutCircle aria-hidden="true" />
+          </styledEl.LinkOutIconWrapper>
+        </styledEl.ActiveRowLink>
+      )}
+      {helpCenterUrl && (
+        <styledEl.ActiveRowLink href={helpCenterUrl}>
+          <styledEl.ActiveRowLinkLabel>
+            <Trans>Help Center</Trans>
+          </styledEl.ActiveRowLinkLabel>
+          <styledEl.LinkOutIconWrapper>
+            <styledEl.LinkOutCircle aria-hidden="true" />
+          </styledEl.LinkOutIconWrapper>
+        </styledEl.ActiveRowLink>
+      )}
+      <styledEl.ActiveRowLink href={getExplorerBaseUrl(targetChainId)}>
+        <styledEl.ActiveRowLinkLabel>
+          <Trans>CoW Protocol Explorer</Trans>
+        </styledEl.ActiveRowLinkLabel>
+        <styledEl.LinkOutIconWrapper>
+          <styledEl.LinkOutCircle aria-hidden="true" />
+        </styledEl.LinkOutIconWrapper>
+      </styledEl.ActiveRowLink>
+    </styledEl.ActiveRowLinkList>
   )
 }
 

--- a/apps/cowswap-frontend/src/common/pure/NetworksList/styled.tsx
+++ b/apps/cowswap-frontend/src/common/pure/NetworksList/styled.tsx
@@ -98,12 +98,12 @@ export const LinkOutCircle = styled(ArrowDownCircle)`
   height: 16px;
   flex-shrink: 0;
 `
-export const FlyoutRow = styled.button<{ active: boolean }>`
+export const FlyoutRow = styled.button<{ active: boolean; disabled$?: boolean }>`
   align-items: center;
   background-color: ${({ active, theme }) => (active ? theme.bg2 : 'transparent')};
   border-radius: 8px;
   border: 0;
-  cursor: pointer;
+  cursor: ${({ disabled$ }) => (disabled$ ? 'not-allowed' : 'pointer')};
   display: flex;
   font-weight: 400;
   justify-content: space-between;
@@ -112,10 +112,11 @@ export const FlyoutRow = styled.button<{ active: boolean }>`
   width: 100%;
   color: ${({ active, theme }) => (active ? theme.white : `var(${UI.COLOR_TEXT})`)};
   appearance: none;
+  opacity: ${({ disabled$ }) => (disabled$ ? 0.5 : 1)};
 
   &:hover {
-    color: ${({ theme, active }) => !active && theme.text1};
-    background: ${({ theme, active }) => !active && transparentize(theme.text, 0.9)};
+    color: ${({ theme, active, disabled$ }) => !active && !disabled$ && theme.text1};
+    background: ${({ theme, active, disabled$ }) => !active && !disabled$ && transparentize(theme.text, 0.9)};
   }
 
   &:focus-visible {

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
@@ -166,6 +166,10 @@ export function SwapWidget({ topContent, bottomContent, allowSwapSameToken }: Sw
     [isSellTrade, outputCurrencyInfo.fiatAmount, inputCurrencyInfo.fiatAmount],
   )
 
+  const enableCustomRecipient = useCallback(() => {
+    recipientToggleState[1](true)
+  }, [recipientToggleState])
+
   const handleImport = useCallback(() => {
     setShowAddIntermediateTokenModal(false)
   }, [])
@@ -205,7 +209,11 @@ export function SwapWidget({ topContent, bottomContent, allowSwapSameToken }: Sw
             {bottomContent}
             {!isRateLoading && <SwapRateDetails rateInfoParams={rateInfoParams} deadline={deadlineState[0]} />}
             {isPrimaryValidationPassed && <TradeApproveWithAffectedOrderList />}
-            <Warnings buyingFiatAmount={buyingFiatAmount} hideQuoteAmount={hideQuoteAmount} />
+            <Warnings
+              buyingFiatAmount={buyingFiatAmount}
+              hideQuoteAmount={hideQuoteAmount}
+              onEnableCustomRecipient={enableCustomRecipient}
+            />
             {tradeWarnings}
             <TradeButtons
               isTradeContextReady={doTrade.contextIsReady}
@@ -231,6 +239,7 @@ export function SwapWidget({ topContent, bottomContent, allowSwapSameToken }: Sw
         isPrimaryValidationPassed,
         hideQuoteAmount,
         isRateLoading,
+        enableCustomRecipient,
       ],
     ),
   }

--- a/apps/cowswap-frontend/src/modules/swap/containers/TradeButtons/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/TradeButtons/index.tsx
@@ -25,6 +25,8 @@ import { useSafeMemoObject } from 'common/hooks/useSafeMemo'
 import { swapTradeButtonsMap } from './swapTradeButtonsMap'
 
 import { useOnCurrencySelection } from '../../hooks/useOnCurrencySelection'
+// Used by both Warnings (banner visibility) and TradeButtons (isDisabled). Keep in sync.
+import { useShouldBlockUnsupportedDestination } from '../../hooks/useShouldBlockUnsupportedDestination'
 import {
   useShouldCheckBridgingRecipient,
   useSmartContractRecipientConfirmed,
@@ -64,6 +66,7 @@ export function TradeButtons({
   const isCurrentTradeBridging = useIsCurrentTradeBridging()
   const shouldCheckBridgingRecipient = useShouldCheckBridgingRecipient()
   const smartContractRecipientConfirmed = useSmartContractRecipientConfirmed()
+  const shouldBlockUnsupportedDestination = useShouldBlockUnsupportedDestination()
   const isSafeWallet = useIsSafeWallet()
 
   const { confirmTrade } = useConfirmTradeWithRwaCheck()
@@ -110,6 +113,7 @@ export function TradeButtons({
     !isTradeContextReady ||
     !feeWarningAccepted ||
     !isNoImpactWarningAccepted ||
+    shouldBlockUnsupportedDestination ||
     (shouldCheckBridgingRecipient ? !smartContractRecipientConfirmed : false)
 
   if (!tradeFormButtonContext) return null

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useShouldBlockUnsupportedDestination.test.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useShouldBlockUnsupportedDestination.test.ts
@@ -1,0 +1,180 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { useIsCoinbaseWallet, useWalletInfo, useWalletSupportedChainIds } from '@cowprotocol/wallet'
+import type { WalletInfo } from '@cowprotocol/wallet'
+
+import { renderHook } from '@testing-library/react'
+
+import { useIsCurrentTradeBridging } from 'modules/trade/hooks/useIsCurrentTradeBridging'
+
+import { useShouldBlockUnsupportedDestination } from './useShouldBlockUnsupportedDestination'
+import { useSwapDerivedState } from './useSwapDerivedState'
+
+import type { SwapDerivedState } from '../state/swapRawStateAtom'
+
+jest.mock('@cowprotocol/wallet', () => ({
+  useIsCoinbaseWallet: jest.fn(),
+  useWalletInfo: jest.fn(),
+  useWalletSupportedChainIds: jest.fn(),
+}))
+
+jest.mock('modules/trade/hooks/useIsCurrentTradeBridging', () => ({
+  useIsCurrentTradeBridging: jest.fn(),
+}))
+
+jest.mock('./useSwapDerivedState', () => ({
+  useSwapDerivedState: jest.fn(),
+}))
+
+const mockUseIsCoinbaseWallet = useIsCoinbaseWallet as jest.MockedFunction<typeof useIsCoinbaseWallet>
+const mockUseWalletInfo = useWalletInfo as jest.MockedFunction<typeof useWalletInfo>
+const mockUseWalletSupportedChainIds = useWalletSupportedChainIds as jest.MockedFunction<
+  typeof useWalletSupportedChainIds
+>
+const mockUseIsCurrentTradeBridging = useIsCurrentTradeBridging as jest.MockedFunction<typeof useIsCurrentTradeBridging>
+const mockUseSwapDerivedState = useSwapDerivedState as jest.MockedFunction<typeof useSwapDerivedState>
+
+const ACCOUNT = '0xCoinbaseScwAddress'
+const EXTERNAL_RECIPIENT = '0xExternalAddress'
+
+function setupDefaults(overrides?: {
+  isCoinbaseWallet?: boolean
+  walletSupportedChainIds?: Set<number> | null // null = use default, undefined = pass undefined
+  isBridging?: boolean
+  account?: string
+  recipient?: string | null
+  recipientAddress?: string | null
+  outputChainId?: number
+}): void {
+  const {
+    isCoinbaseWallet = true,
+    isBridging = true,
+    account = ACCOUNT,
+    recipient = undefined,
+    recipientAddress = undefined,
+    outputChainId = SupportedChainId.GNOSIS_CHAIN,
+  } = overrides ?? {}
+
+  // Use null sentinel to distinguish "not specified" (use default Set) from "explicitly undefined"
+  const walletSupportedChainIds =
+    overrides && 'walletSupportedChainIds' in overrides
+      ? (overrides.walletSupportedChainIds ?? undefined)
+      : new Set([SupportedChainId.MAINNET, SupportedChainId.BASE])
+
+  mockUseIsCoinbaseWallet.mockReturnValue(isCoinbaseWallet)
+  mockUseWalletSupportedChainIds.mockReturnValue(walletSupportedChainIds)
+  mockUseIsCurrentTradeBridging.mockReturnValue(isBridging)
+  mockUseWalletInfo.mockReturnValue({ account } as WalletInfo)
+  mockUseSwapDerivedState.mockReturnValue({
+    recipient,
+    recipientAddress,
+    outputCurrency:
+      outputChainId !== undefined
+        ? ({ chainId: outputChainId } as unknown as SwapDerivedState['outputCurrency'])
+        : null,
+  } as SwapDerivedState)
+}
+
+describe('useShouldBlockUnsupportedDestination', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  // --- Coinbase scoping ---
+
+  it('returns true for Coinbase SCW bridging to unsupported chain with no external recipient', () => {
+    setupDefaults()
+
+    const { result } = renderHook(() => useShouldBlockUnsupportedDestination())
+    expect(result.current).toBe(true)
+  })
+
+  it('returns false for non-Coinbase wallet even with unsupported destination', () => {
+    setupDefaults({ isCoinbaseWallet: false })
+
+    const { result } = renderHook(() => useShouldBlockUnsupportedDestination())
+    expect(result.current).toBe(false)
+  })
+
+  it('returns false for Coinbase EOA (walletSupportedChainIds undefined)', () => {
+    setupDefaults({ walletSupportedChainIds: undefined })
+
+    const { result } = renderHook(() => useShouldBlockUnsupportedDestination())
+    expect(result.current).toBe(false)
+  })
+
+  // --- Basic conditions ---
+
+  it('returns false when not bridging', () => {
+    setupDefaults({ isBridging: false })
+
+    const { result } = renderHook(() => useShouldBlockUnsupportedDestination())
+    expect(result.current).toBe(false)
+  })
+
+  it('returns false when destination is supported', () => {
+    // BASE is in the supported set
+    setupDefaults({ outputChainId: SupportedChainId.BASE })
+
+    const { result } = renderHook(() => useShouldBlockUnsupportedDestination())
+    expect(result.current).toBe(false)
+  })
+
+  it('returns false when walletSupportedChainIds is undefined (loading/EOA fallback)', () => {
+    setupDefaults({ walletSupportedChainIds: undefined })
+
+    const { result } = renderHook(() => useShouldBlockUnsupportedDestination())
+    expect(result.current).toBe(false)
+  })
+
+  // --- Recipient logic (using resolved state, not UI toggle) ---
+
+  it('returns true when unsupported dest + no recipient (recipient=undefined)', () => {
+    setupDefaults({ recipient: undefined, recipientAddress: undefined })
+
+    const { result } = renderHook(() => useShouldBlockUnsupportedDestination())
+    expect(result.current).toBe(true)
+  })
+
+  it('returns true when unsupported dest + recipient is own address', () => {
+    setupDefaults({ recipient: ACCOUNT })
+
+    const { result } = renderHook(() => useShouldBlockUnsupportedDestination())
+    expect(result.current).toBe(true)
+  })
+
+  it('returns true when unsupported dest + recipient is own address (case-insensitive)', () => {
+    setupDefaults({ recipient: ACCOUNT.toUpperCase() })
+
+    const { result } = renderHook(() => useShouldBlockUnsupportedDestination())
+    expect(result.current).toBe(true)
+  })
+
+  it('returns false when unsupported dest + external recipient', () => {
+    setupDefaults({ recipient: EXTERNAL_RECIPIENT })
+
+    const { result } = renderHook(() => useShouldBlockUnsupportedDestination())
+    expect(result.current).toBe(false)
+  })
+
+  it('returns false when unsupported dest + external recipientAddress (ENS-resolved)', () => {
+    setupDefaults({ recipientAddress: EXTERNAL_RECIPIENT })
+
+    const { result } = renderHook(() => useShouldBlockUnsupportedDestination())
+    expect(result.current).toBe(false)
+  })
+
+  it('returns false when URL recipient (external recipientAddress, showRecipient=false)', () => {
+    // URL provides ?recipient=0xDIFFERENT — recipientAddress is resolved, showRecipient may be false
+    setupDefaults({ recipientAddress: EXTERNAL_RECIPIENT, recipient: undefined })
+
+    const { result } = renderHook(() => useShouldBlockUnsupportedDestination())
+    expect(result.current).toBe(false)
+  })
+
+  it('returns true when URL recipient is own address', () => {
+    setupDefaults({ recipientAddress: ACCOUNT, recipient: undefined })
+
+    const { result } = renderHook(() => useShouldBlockUnsupportedDestination())
+    expect(result.current).toBe(true)
+  })
+})

--- a/apps/cowswap-frontend/src/modules/swap/hooks/useShouldBlockUnsupportedDestination.ts
+++ b/apps/cowswap-frontend/src/modules/swap/hooks/useShouldBlockUnsupportedDestination.ts
@@ -1,0 +1,41 @@
+import { useIsCoinbaseWallet, useWalletInfo, useWalletSupportedChainIds } from '@cowprotocol/wallet'
+
+import { useIsCurrentTradeBridging } from 'modules/trade/hooks/useIsCurrentTradeBridging'
+
+import { useSwapDerivedState } from './useSwapDerivedState'
+
+/**
+ * Returns true when the trade should be hard-blocked because the Coinbase Smart Wallet
+ * doesn't exist on the destination chain and no external recipient is set.
+ *
+ * Used by both Warnings (banner visibility) and TradeButtons (isDisabled). Keep in sync.
+ */
+export function useShouldBlockUnsupportedDestination(): boolean {
+  const isCoinbaseWallet = useIsCoinbaseWallet()
+  const walletSupportedChainIds = useWalletSupportedChainIds()
+  const isBridging = useIsCurrentTradeBridging()
+  const { account } = useWalletInfo()
+  const { recipient, recipientAddress, outputCurrency } = useSwapDerivedState()
+
+  const outputChainId = outputCurrency?.chainId
+
+  // Scope to Coinbase wallets only — Safe/other SCWs have separate restriction flows.
+  // walletSupportedChainIds being defined already implies SCW (only set when atomic caps detected).
+  // Coinbase EOAs won't trigger this because their walletSupportedChainIds is undefined.
+  const isUnsupportedDestination =
+    isCoinbaseWallet &&
+    walletSupportedChainIds !== undefined &&
+    isBridging &&
+    outputChainId !== undefined &&
+    !walletSupportedChainIds.has(outputChainId)
+
+  if (!isUnsupportedDestination) return false
+
+  // Recipient check is based on resolved state, NOT on showRecipient UI toggle.
+  // Recipients can arrive via URL (?recipient=0x...) with showRecipient=false.
+  const effectiveRecipient = recipientAddress || recipient
+  const hasExternalRecipient =
+    !!effectiveRecipient && !!account && effectiveRecipient.toLowerCase() !== account.toLowerCase()
+
+  return !hasExternalRecipient
+}

--- a/apps/cowswap-frontend/src/modules/swap/pure/UnsupportedDestinationWarning/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/pure/UnsupportedDestinationWarning/index.tsx
@@ -1,0 +1,55 @@
+import { ReactNode } from 'react'
+
+import { CHAIN_INFO } from '@cowprotocol/common-const'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { BannerOrientation, InlineBanner, NetworkLogo, StatusColorVariant } from '@cowprotocol/ui'
+
+import { Trans } from '@lingui/react/macro'
+import styled from 'styled-components/macro'
+
+const NetworkLogoStyled = styled(NetworkLogo)`
+  margin: 0 4px;
+  top: 3px;
+  position: relative;
+`
+
+const EnableRecipientLink = styled.button`
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+  color: inherit;
+`
+
+interface UnsupportedDestinationWarningProps {
+  destinationChainId: SupportedChainId
+  onEnableCustomRecipient: () => void
+}
+
+export function UnsupportedDestinationWarning({
+  destinationChainId,
+  onEnableCustomRecipient,
+}: UnsupportedDestinationWarningProps): ReactNode {
+  const chainName = CHAIN_INFO[destinationChainId]?.label ?? 'this chain'
+
+  return (
+    <InlineBanner bannerType={StatusColorVariant.Alert} orientation={BannerOrientation.Horizontal} breakWord>
+      <div>
+        <div>
+          <Trans>
+            Your smart wallet doesn&apos;t exist on
+            <NetworkLogoStyled chainId={destinationChainId} size={16} />
+            {chainName}. Bridged funds sent to your address on this chain would be lost.
+          </Trans>
+        </div>
+        <div>
+          <EnableRecipientLink type="button" onClick={onEnableCustomRecipient}>
+            <Trans>Send to a different address instead</Trans>
+          </EnableRecipientLink>
+        </div>
+      </div>
+    </InlineBanner>
+  )
+}

--- a/apps/cowswap-frontend/src/modules/tokensList/hooks/useChainsToSelect.test.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/hooks/useChainsToSelect.test.ts
@@ -1,12 +1,16 @@
 import { TokenWithLogo } from '@cowprotocol/common-const'
+import { useIsBridgingEnabled, useAvailableChains } from '@cowprotocol/common-hooks'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { useWalletInfo, WalletInfo } from '@cowprotocol/wallet'
+import { useWalletInfo, useIsCoinbaseWallet, useWalletSupportedChainIds, WalletInfo } from '@cowprotocol/wallet'
 
 import { renderHook } from '@testing-library/react'
+import { useBridgeSupportedNetworks, useRoutesAvailability } from 'entities/bridgeProvider'
 
 import { Field } from 'legacy/state/types'
 
 import { TradeType } from 'modules/trade'
+
+import { useShouldHideNetworkSelector } from 'common/hooks/useShouldHideNetworkSelector'
 
 import { useChainsToSelect, createInputChainsState, createOutputChainsState } from './useChainsToSelect'
 import { useSelectTokenWidgetState } from './useSelectTokenWidgetState'
@@ -21,9 +25,18 @@ const DEFAULT_ROUTES_AVAILABILITY = {
   isLoading: false,
 }
 
+// Minimal SWR response shape for mocking — omits mutate/error/isValidating which aren't used in tests
+function mockSWR(
+  data: ReturnType<typeof useBridgeSupportedNetworks>['data'],
+): ReturnType<typeof useBridgeSupportedNetworks> {
+  return { data, isLoading: false, error: undefined, isValidating: false, mutate: jest.fn() }
+}
+
 jest.mock('@cowprotocol/wallet', () => ({
   ...jest.requireActual('@cowprotocol/wallet'),
   useWalletInfo: jest.fn(),
+  useIsCoinbaseWallet: jest.fn().mockReturnValue(false),
+  useWalletSupportedChainIds: jest.fn().mockReturnValue(undefined),
 }))
 
 jest.mock('@cowprotocol/common-hooks', () => ({
@@ -49,18 +62,16 @@ jest.mock('common/hooks/useShouldHideNetworkSelector', () => ({
 
 const mockUseWalletInfo = useWalletInfo as jest.MockedFunction<typeof useWalletInfo>
 const mockUseSelectTokenWidgetState = useSelectTokenWidgetState as jest.MockedFunction<typeof useSelectTokenWidgetState>
-
-const { useIsBridgingEnabled, useAvailableChains } = require('@cowprotocol/common-hooks')
+const mockUseIsCoinbaseWallet = useIsCoinbaseWallet as jest.MockedFunction<typeof useIsCoinbaseWallet>
+const mockUseWalletSupportedChainIds = useWalletSupportedChainIds as jest.MockedFunction<
+  typeof useWalletSupportedChainIds
+>
 const mockUseIsBridgingEnabled = useIsBridgingEnabled as jest.MockedFunction<typeof useIsBridgingEnabled>
 const mockUseAvailableChains = useAvailableChains as jest.MockedFunction<typeof useAvailableChains>
-
-const { useBridgeSupportedNetworks, useRoutesAvailability } = require('entities/bridgeProvider')
 const mockUseBridgeSupportedNetworks = useBridgeSupportedNetworks as jest.MockedFunction<
   typeof useBridgeSupportedNetworks
 >
 const mockUseRoutesAvailability = useRoutesAvailability as jest.MockedFunction<typeof useRoutesAvailability>
-
-const { useShouldHideNetworkSelector } = require('common/hooks/useShouldHideNetworkSelector')
 const mockUseShouldHideNetworkSelector = useShouldHideNetworkSelector as jest.MockedFunction<
   typeof useShouldHideNetworkSelector
 >
@@ -332,10 +343,7 @@ describe('useChainsToSelect hook', () => {
     mockUseWalletInfo.mockReturnValue({ chainId: SupportedChainId.MAINNET } as WalletInfo)
     mockUseIsBridgingEnabled.mockReturnValue(true)
     mockUseAvailableChains.mockReturnValue([SupportedChainId.MAINNET, SupportedChainId.GNOSIS_CHAIN])
-    mockUseBridgeSupportedNetworks.mockReturnValue({
-      data: [createChainInfoForTests(SupportedChainId.GNOSIS_CHAIN)],
-      isLoading: false,
-    })
+    mockUseBridgeSupportedNetworks.mockReturnValue(mockSWR([createChainInfoForTests(SupportedChainId.GNOSIS_CHAIN)]))
     mockUseRoutesAvailability.mockReturnValue(DEFAULT_ROUTES_AVAILABILITY)
     mockUseShouldHideNetworkSelector.mockReturnValue(false)
   })
@@ -399,10 +407,12 @@ describe('useChainsToSelect hook', () => {
   it('returns chains for SWAP + OUTPUT (buy token)', () => {
     // Include Mainnet in bridge data to exercise bridge destinations path
     // Use mockReturnValueOnce for test isolation
-    mockUseBridgeSupportedNetworks.mockReturnValueOnce({
-      data: [createChainInfoForTests(SupportedChainId.MAINNET), createChainInfoForTests(SupportedChainId.GNOSIS_CHAIN)],
-      isLoading: false,
-    })
+    mockUseBridgeSupportedNetworks.mockReturnValueOnce(
+      mockSWR([
+        createChainInfoForTests(SupportedChainId.MAINNET),
+        createChainInfoForTests(SupportedChainId.GNOSIS_CHAIN),
+      ]),
+    )
 
     mockUseSelectTokenWidgetState.mockReturnValue(
       createWidgetState({
@@ -467,5 +477,163 @@ describe('useChainsToSelect hook', () => {
     // Verify it returns supported chains (Mainnet, Gnosis)
     expect(result.current?.chains?.some((chain) => chain.id === SupportedChainId.MAINNET)).toBe(true)
     expect(result.current?.chains?.some((chain) => chain.id === SupportedChainId.GNOSIS_CHAIN)).toBe(true)
+  })
+
+  it('disables Coinbase SCW unsupported chains for buy token when isCoinbaseWallet is true', () => {
+    mockUseIsCoinbaseWallet.mockReturnValue(true)
+    // Simulate Coinbase SCW capabilities: only Mainnet supported, Gnosis not
+    mockUseWalletSupportedChainIds.mockReturnValue(new Set([SupportedChainId.MAINNET]))
+    mockUseAvailableChains.mockReturnValue([SupportedChainId.MAINNET, SupportedChainId.GNOSIS_CHAIN])
+    mockUseBridgeSupportedNetworks.mockReturnValueOnce(
+      mockSWR([
+        createChainInfoForTests(SupportedChainId.MAINNET),
+        createChainInfoForTests(SupportedChainId.GNOSIS_CHAIN),
+      ]),
+    )
+
+    mockUseSelectTokenWidgetState.mockReturnValue(
+      createWidgetState({
+        field: Field.OUTPUT,
+        tradeType: TradeType.SWAP,
+        selectedTargetChainId: SupportedChainId.MAINNET,
+      }),
+    )
+
+    const { result } = renderHook(() => useChainsToSelect())
+
+    expect(result.current).toBeDefined()
+    // Gnosis should be disabled as a bridge destination for Coinbase SCW
+    expect(result.current?.disabledChainIds?.has(SupportedChainId.GNOSIS_CHAIN)).toBe(true)
+    // Source chain (Mainnet) should not be disabled
+    expect(result.current?.disabledChainIds?.has(SupportedChainId.MAINNET)).toBeFalsy()
+    // walletUnsupportedChainIds should be set for tooltip differentiation
+    expect(result.current?.walletUnsupportedChainIds?.has(SupportedChainId.GNOSIS_CHAIN)).toBe(true)
+  })
+
+  it('does not disable chains when isCoinbaseWallet is false', () => {
+    mockUseIsCoinbaseWallet.mockReturnValue(false)
+    mockUseWalletSupportedChainIds.mockReturnValue(undefined)
+    mockUseAvailableChains.mockReturnValue([SupportedChainId.MAINNET, SupportedChainId.GNOSIS_CHAIN])
+    mockUseBridgeSupportedNetworks.mockReturnValueOnce(
+      mockSWR([
+        createChainInfoForTests(SupportedChainId.MAINNET),
+        createChainInfoForTests(SupportedChainId.GNOSIS_CHAIN),
+      ]),
+    )
+
+    mockUseSelectTokenWidgetState.mockReturnValue(
+      createWidgetState({
+        field: Field.OUTPUT,
+        tradeType: TradeType.SWAP,
+        selectedTargetChainId: SupportedChainId.MAINNET,
+      }),
+    )
+
+    const { result } = renderHook(() => useChainsToSelect())
+
+    expect(result.current).toBeDefined()
+    // No wallet-based chain restrictions for non-Coinbase wallets
+    expect(result.current?.disabledChainIds?.has(SupportedChainId.GNOSIS_CHAIN)).toBeFalsy()
+  })
+
+  it('does not disable chains when isCoinbaseWallet is true but walletSupportedChainIds is undefined (EOA)', () => {
+    mockUseIsCoinbaseWallet.mockReturnValue(true)
+    mockUseWalletSupportedChainIds.mockReturnValue(undefined)
+    mockUseAvailableChains.mockReturnValue([SupportedChainId.MAINNET, SupportedChainId.GNOSIS_CHAIN])
+    mockUseBridgeSupportedNetworks.mockReturnValueOnce(
+      mockSWR([
+        createChainInfoForTests(SupportedChainId.MAINNET),
+        createChainInfoForTests(SupportedChainId.GNOSIS_CHAIN),
+      ]),
+    )
+
+    mockUseSelectTokenWidgetState.mockReturnValue(
+      createWidgetState({
+        field: Field.OUTPUT,
+        tradeType: TradeType.SWAP,
+        selectedTargetChainId: SupportedChainId.MAINNET,
+      }),
+    )
+
+    const { result } = renderHook(() => useChainsToSelect())
+
+    expect(result.current).toBeDefined()
+    // Coinbase EOA: no atomic capabilities -> no chain filtering
+    expect(result.current?.walletUnsupportedChainIds).toBeUndefined()
+  })
+
+  it('disables Coinbase SCW unsupported chains in sell token (INPUT) list', () => {
+    mockUseIsCoinbaseWallet.mockReturnValue(true)
+    // Simulate Coinbase SCW capabilities: only Mainnet supported
+    mockUseWalletSupportedChainIds.mockReturnValue(new Set([SupportedChainId.MAINNET]))
+    mockUseAvailableChains.mockReturnValue([SupportedChainId.MAINNET, SupportedChainId.GNOSIS_CHAIN])
+
+    mockUseSelectTokenWidgetState.mockReturnValue(
+      createWidgetState({
+        field: Field.INPUT,
+        tradeType: TradeType.SWAP,
+        selectedTargetChainId: SupportedChainId.MAINNET,
+      }),
+    )
+
+    const { result } = renderHook(() => useChainsToSelect())
+
+    expect(result.current).toBeDefined()
+    // Mainnet (supported) should be in the list and not disabled
+    expect(result.current?.chains?.some((chain) => chain.id === SupportedChainId.MAINNET)).toBe(true)
+    expect(result.current?.disabledChainIds?.has(SupportedChainId.MAINNET)).toBeFalsy()
+    // Gnosis (unsupported) should be in the list but disabled
+    expect(result.current?.chains?.some((chain) => chain.id === SupportedChainId.GNOSIS_CHAIN)).toBe(true)
+    expect(result.current?.disabledChainIds?.has(SupportedChainId.GNOSIS_CHAIN)).toBe(true)
+    // walletUnsupportedChainIds should be set for tooltip differentiation
+    expect(result.current?.walletUnsupportedChainIds?.has(SupportedChainId.GNOSIS_CHAIN)).toBe(true)
+  })
+
+  it('shows all chains in sell token (INPUT) list for non-Coinbase wallets', () => {
+    mockUseIsCoinbaseWallet.mockReturnValue(false)
+    mockUseAvailableChains.mockReturnValue([SupportedChainId.MAINNET, SupportedChainId.GNOSIS_CHAIN])
+
+    mockUseSelectTokenWidgetState.mockReturnValue(
+      createWidgetState({
+        field: Field.INPUT,
+        tradeType: TradeType.SWAP,
+        selectedTargetChainId: SupportedChainId.MAINNET,
+      }),
+    )
+
+    const { result } = renderHook(() => useChainsToSelect())
+
+    expect(result.current).toBeDefined()
+    expect(result.current?.chains?.some((chain) => chain.id === SupportedChainId.MAINNET)).toBe(true)
+    expect(result.current?.chains?.some((chain) => chain.id === SupportedChainId.GNOSIS_CHAIN)).toBe(true)
+  })
+
+  it('excludes source chain from Coinbase SCW disabled set', () => {
+    mockUseIsCoinbaseWallet.mockReturnValue(true)
+    // Simulate Coinbase SCW capabilities: only Mainnet supported
+    mockUseWalletSupportedChainIds.mockReturnValue(new Set([SupportedChainId.MAINNET]))
+    // Connect on Gnosis (unsupported by Coinbase SCW) — bridging FROM it should still work
+    mockUseWalletInfo.mockReturnValue({ chainId: SupportedChainId.GNOSIS_CHAIN } as WalletInfo)
+    mockUseAvailableChains.mockReturnValue([SupportedChainId.MAINNET, SupportedChainId.GNOSIS_CHAIN])
+    mockUseBridgeSupportedNetworks.mockReturnValueOnce(
+      mockSWR([
+        createChainInfoForTests(SupportedChainId.MAINNET),
+        createChainInfoForTests(SupportedChainId.GNOSIS_CHAIN),
+      ]),
+    )
+
+    mockUseSelectTokenWidgetState.mockReturnValue(
+      createWidgetState({
+        field: Field.OUTPUT,
+        tradeType: TradeType.SWAP,
+        selectedTargetChainId: SupportedChainId.MAINNET,
+      }),
+    )
+
+    const { result } = renderHook(() => useChainsToSelect())
+
+    expect(result.current).toBeDefined()
+    // Source chain (Gnosis) should NOT be disabled even though it's not in wallet supported chains
+    expect(result.current?.disabledChainIds?.has(SupportedChainId.GNOSIS_CHAIN)).toBeFalsy()
   })
 })

--- a/apps/cowswap-frontend/src/modules/tokensList/hooks/useChainsToSelect.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/hooks/useChainsToSelect.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react'
 import { CHAIN_INFO } from '@cowprotocol/common-const'
 import { useAvailableChains, useIsBridgingEnabled } from '@cowprotocol/common-hooks'
 import { ChainInfo, SupportedChainId } from '@cowprotocol/cow-sdk'
-import { useWalletInfo } from '@cowprotocol/wallet'
+import { useIsCoinbaseWallet, useWalletSupportedChainIds, useWalletInfo } from '@cowprotocol/wallet'
 
 import { useBridgeSupportedNetworks, useRoutesAvailability } from 'entities/bridgeProvider'
 
@@ -38,6 +38,8 @@ export function useChainsToSelect(): ChainsToSelectState | undefined {
   const availableChains = useAvailableChains()
   const isAdvancedTradeType = tradeType === TradeType.LIMIT_ORDER || tradeType === TradeType.ADVANCED_ORDERS
   const shouldHideNetworkSelector = useShouldHideNetworkSelector()
+  const isCoinbaseWallet = useIsCoinbaseWallet()
+  const walletSupportedChainIds = useWalletSupportedChainIds()
 
   const supportedChains = useMemo(() => {
     return availableChains.reduce((acc, id) => {
@@ -51,6 +53,15 @@ export function useChainsToSelect(): ChainsToSelectState | undefined {
   // not necessarily the wallet network. This keeps chain availability accurate when wallet network != trade network.
   const sourceChainId =
     field === Field.OUTPUT && oppositeToken?.chainId ? (oppositeToken.chainId as SupportedChainId) : chainId
+
+  // Only restrict chains for Coinbase SDK wallets with detected SCW capabilities.
+  // For Coinbase SCW, capability keys = chains where the smart contract is deployed.
+  // Coinbase EOA (no atomic capabilities) -> walletSupportedChainIds is undefined -> no filtering.
+  const walletUnsupportedChainIds = useMemo(() => {
+    if (!isCoinbaseWallet || !walletSupportedChainIds) return undefined
+    // Exclude source chain (chainId) — user is connected to it, bridging FROM it is valid
+    return new Set(availableChains.filter((id) => id !== chainId && !walletSupportedChainIds.has(id)))
+  }, [isCoinbaseWallet, walletSupportedChainIds, availableChains, chainId])
 
   const destinationChainIds = useMemo(() => supportedChains.map((c) => c.id), [supportedChains])
   const isBuyField = field === Field.OUTPUT
@@ -71,6 +82,8 @@ export function useChainsToSelect(): ChainsToSelectState | undefined {
         defaultChainId: selectedTargetChainId,
         chains: shouldHideNetworkSelector ? [] : sortChainsByDisplayOrder(supportedChains),
         isLoading: false,
+        disabledChainIds: walletUnsupportedChainIds,
+        walletUnsupportedChainIds,
       }
     }
 
@@ -83,6 +96,7 @@ export function useChainsToSelect(): ChainsToSelectState | undefined {
       supportedChains,
       isLoading,
       routesAvailability,
+      walletUnsupportedChainIds,
     })
   }, [
     field,
@@ -96,5 +110,6 @@ export function useChainsToSelect(): ChainsToSelectState | undefined {
     isAdvancedTradeType,
     routesAvailability,
     shouldHideNetworkSelector,
+    walletUnsupportedChainIds,
   ])
 }

--- a/apps/cowswap-frontend/src/modules/tokensList/hooks/useChainsToSelect.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/hooks/useChainsToSelect.ts
@@ -88,6 +88,9 @@ export function useChainsToSelect(): ChainsToSelectState | undefined {
     }
 
     // BUY token selection - include disabled chains info
+    // Note: walletUnsupportedChainIds is intentionally NOT passed for OUTPUT.
+    // Instead of disabling destination chains, we show a blocking warning in the swap form
+    // when the user tries to bridge to an unsupported chain (see useShouldBlockUnsupportedDestination).
     return createOutputChainsState({
       selectedTargetChainId,
       chainId: sourceChainId,
@@ -96,7 +99,7 @@ export function useChainsToSelect(): ChainsToSelectState | undefined {
       supportedChains,
       isLoading,
       routesAvailability,
-      walletUnsupportedChainIds,
+      walletUnsupportedChainIds: undefined,
     })
   }, [
     field,

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/ChainPanel/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/ChainPanel/index.tsx
@@ -74,6 +74,7 @@ export function ChainPanel({
           onSelectChain={onSelectChain}
           disabledChainIds={chainsState?.disabledChainIds}
           loadingChainIds={chainsState?.loadingChainIds}
+          walletUnsupportedChainIds={chainsState?.walletUnsupportedChainIds}
           tradeType={tradeType}
           field={field}
           counterChainId={counterChainId}

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/ChainsSelector/ChainButton.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/ChainsSelector/ChainButton.tsx
@@ -16,6 +16,7 @@ export interface ChainButtonProps {
   onSelectChain(chain: ChainInfo): void
   isDisabled: boolean
   isLoading: boolean
+  isWalletUnsupported?: boolean
   clickEvent?: string
 }
 
@@ -26,12 +27,16 @@ export function ChainButton({
   onSelectChain,
   isDisabled,
   isLoading,
+  isWalletUnsupported,
   clickEvent,
 }: ChainButtonProps): ReactNode {
   const { t } = useLingui()
   const logoSrc = isDarkMode ? chain.logo.dark : chain.logo.light
   const accent = getChainAccent(chain.id)
-  const disabledTooltip = t`This destination is not supported for this source chain`
+  const walletUnsupportedTooltip = t`This chain is not supported by your connected wallet (Coinbase Smart Wallet)`
+  const disabledTooltip = isWalletUnsupported
+    ? walletUnsupportedTooltip
+    : t`This destination is not supported for this source chain`
   const loadingTooltip = t`Checking route availability...`
 
   const handleClick = (): void => {

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/ChainsSelector/ChainsList.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/ChainsSelector/ChainsList.tsx
@@ -12,6 +12,7 @@ export interface ChainsListProps {
   isDarkMode: boolean
   disabledChainIds?: Set<number>
   loadingChainIds?: Set<number>
+  walletUnsupportedChainIds?: Set<number>
   buildClickEvent?: (chain: ChainInfo) => string
   isSwapMode?: boolean
 }
@@ -23,6 +24,7 @@ export function ChainsList({
   isDarkMode,
   disabledChainIds,
   loadingChainIds,
+  walletUnsupportedChainIds,
   buildClickEvent,
   isSwapMode = false,
 }: ChainsListProps): ReactNode {
@@ -31,6 +33,7 @@ export function ChainsList({
       {chains.map((chain) => {
         const isDisabled = disabledChainIds?.has(chain.id) ?? false
         const isLoading = loadingChainIds?.has(chain.id) ?? false
+        const isWalletUnsupported = walletUnsupportedChainIds?.has(chain.id) ?? false
         const clickEvent =
           isSwapMode && buildClickEvent && !isDisabled && !isLoading ? buildClickEvent(chain) : undefined
 
@@ -43,6 +46,7 @@ export function ChainsList({
             isDarkMode={isDarkMode}
             isDisabled={isDisabled}
             isLoading={isLoading}
+            isWalletUnsupported={isWalletUnsupported}
             clickEvent={clickEvent}
           />
         )

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/ChainsSelector/ChainsSelector.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/ChainsSelector/ChainsSelector.tsx
@@ -18,6 +18,7 @@ export interface ChainsSelectorProps {
   isLoading: boolean
   disabledChainIds?: Set<number>
   loadingChainIds?: Set<number>
+  walletUnsupportedChainIds?: Set<number>
   tradeType?: TradeType
   field?: Field
   counterChainId?: ChainInfo['id']

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/SelectTokenModal/ChainChip.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/SelectTokenModal/ChainChip.tsx
@@ -16,6 +16,7 @@ export interface ChainChipProps {
   onSelectChain(chain: ChainInfo): void
   isDisabled: boolean
   isLoading: boolean
+  isWalletUnsupported?: boolean
   isTooltipVisible: boolean
   onDisabledClick(chainId: number): void
   onHideTooltip(): void
@@ -28,6 +29,7 @@ export function ChainChip({
   onSelectChain,
   isDisabled,
   isLoading,
+  isWalletUnsupported,
   isTooltipVisible,
   onDisabledClick,
   onHideTooltip,
@@ -37,7 +39,10 @@ export function ChainChip({
   const { darkMode } = useTheme()
   const accent = getChainAccent(chain.id)
   const logoSrc = darkMode ? chain.logo.dark : chain.logo.light
-  const disabledTooltip = t`This destination is not supported for this source chain`
+  const walletUnsupportedTooltip = t`This chain is not supported by your connected wallet (Coinbase Smart Wallet)`
+  const disabledTooltip = isWalletUnsupported
+    ? walletUnsupportedTooltip
+    : t`This destination is not supported for this source chain`
   const loadingTooltip = t`Checking route availability...`
   const chipRef = useRef<HTMLButtonElement | null>(null)
 

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/SelectTokenModal/MobileChainSelector.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/SelectTokenModal/MobileChainSelector.tsx
@@ -55,6 +55,7 @@ function ChainChipList({
       {orderedChains.map((chain) => {
         const isDisabled = chainsState.disabledChainIds?.has(chain.id) ?? false
         const isLoading = chainsState.loadingChainIds?.has(chain.id) ?? false
+        const isWalletUnsupported = chainsState.walletUnsupportedChainIds?.has(chain.id) ?? false
         const clickEvent =
           isSwapMode && buildClickEvent && !isDisabled && !isLoading ? buildClickEvent(chain) : undefined
 
@@ -66,6 +67,7 @@ function ChainChipList({
             onSelectChain={onSelectChain}
             isDisabled={isDisabled}
             isLoading={isLoading}
+            isWalletUnsupported={isWalletUnsupported}
             isTooltipVisible={activeTooltipChainId === chain.id}
             onDisabledClick={onDisabledClick}
             onHideTooltip={onHideTooltip}

--- a/apps/cowswap-frontend/src/modules/tokensList/types.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/types.ts
@@ -22,4 +22,5 @@ export interface ChainsToSelectState {
   isLoading?: boolean
   disabledChainIds?: Set<number>
   loadingChainIds?: Set<number>
+  walletUnsupportedChainIds?: Set<number>
 }

--- a/apps/cowswap-frontend/src/modules/tokensList/utils/chainsState.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/utils/chainsState.ts
@@ -16,6 +16,7 @@ export interface CreateOutputChainsOptions {
     loadingChainIds: Set<number>
     isLoading: boolean
   }
+  walletUnsupportedChainIds?: Set<number>
 }
 
 export function filterDestinationChains(bridgeSupportedNetworks: ChainInfo[] | undefined): ChainInfo[] | undefined {
@@ -78,6 +79,7 @@ export function createOutputChainsState({
   supportedChains,
   isLoading,
   routesAvailability,
+  walletUnsupportedChainIds,
 }: CreateOutputChainsOptions): ChainsToSelectState {
   const chainSet = new Set(supportedChains.map((c) => c.id))
   const chainsWithCurrent = chainSet.has(chainId) ? supportedChains : [...supportedChains, currentChainInfo]
@@ -94,7 +96,11 @@ export function createOutputChainsState({
     isLoading,
   )
 
-  const disabledChainIds = new Set([...baseDisabledChainIds, ...routesAvailability.unavailableChainIds])
+  const disabledChainIds = new Set([
+    ...baseDisabledChainIds,
+    ...routesAvailability.unavailableChainIds,
+    ...(walletUnsupportedChainIds ?? []),
+  ])
 
   const resolvedDefaultChainId = resolveDefaultChainId(orderedChains, selectedTargetChainId, chainId, disabledChainIds)
 
@@ -104,5 +110,6 @@ export function createOutputChainsState({
     isLoading,
     disabledChainIds: disabledChainIds.size > 0 ? disabledChainIds : undefined,
     loadingChainIds: routesAvailability.loadingChainIds.size > 0 ? routesAvailability.loadingChainIds : undefined,
+    walletUnsupportedChainIds,
   }
 }

--- a/libs/wallet/src/api/hooks.ts
+++ b/libs/wallet/src/api/hooks.ts
@@ -6,6 +6,7 @@ import { LAUNCH_DARKLY_VIEM_MIGRATION } from '@cowprotocol/common-const'
 import { useConnection } from 'wagmi'
 
 import { useWalletCapabilities } from './hooks/useWalletCapabilities'
+export { useWalletSupportedChainIds } from './hooks/useWalletSupportedChainIds'
 import {
   gnosisSafeInfoAtom,
   walletDetailsAtom,

--- a/libs/wallet/src/api/hooks/useWalletSupportedChainIds.ts
+++ b/libs/wallet/src/api/hooks/useWalletSupportedChainIds.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react'
+
+import { useWalletCapabilities, WalletCapabilities } from './useWalletCapabilities'
+
+function hasAtomicBatchSupport(capabilities: WalletCapabilities | undefined): boolean {
+  const status = capabilities?.atomic?.status
+  return status === 'supported' || status === 'ready'
+}
+
+export function useWalletSupportedChainIds(): Set<number> | undefined {
+  const { allChains, isLoading } = useWalletCapabilities()
+
+  return useMemo(() => {
+    if (!allChains || isLoading) return undefined
+
+    const ids = Object.entries(allChains)
+      .filter(([, caps]) => hasAtomicBatchSupport(caps))
+      .map(([id]) => Number(id))
+
+    return ids.length > 0 ? new Set(ids) : undefined
+  }, [allChains, isLoading])
+}

--- a/libs/wallet/src/index.ts
+++ b/libs/wallet/src/index.ts
@@ -8,6 +8,8 @@ export * from './constants'
 // Hooks
 export * from './api/hooks'
 export { useWalletCapabilities } from './api/hooks/useWalletCapabilities'
+export type { WalletCapabilities, CapabilitiesPerChain } from './api/hooks/useWalletCapabilities'
+export { useWalletSupportedChainIds } from './api/hooks/useWalletSupportedChainIds'
 export { useWidgetProviderMetaInfo } from './api/hooks/useWidgetProviderMetaInfo'
 export { useSendBatchTransactions } from './api/hooks/useSendBatchTransactions'
 export type { SendBatchTxCallback } from './api/hooks/useSendBatchTransactions'

--- a/libs/wallet/src/versionResolver.ts
+++ b/libs/wallet/src/versionResolver.ts
@@ -2,9 +2,11 @@ import { LAUNCH_DARKLY_VIEM_MIGRATION } from '@cowprotocol/common-const'
 import { AccountType } from '@cowprotocol/types'
 import { Connector as LegacyConnector } from '@web3-react/types'
 
+import * as newUseIsCoinbaseWallet from './wagmi/hooks/useIsCoinbaseWallet'
 import * as newUseIsSmartContract from './wagmi/hooks/useIsSmartContractWallet'
 import * as newUseIsWalletConnect from './wagmi/hooks/useIsWalletConnect'
 import * as newUseWalletMetadata from './wagmi/hooks/useWalletMetadata'
+import * as legacyUseIsCoinbaseWallet from './web3-react/hooks/useIsCoinbaseWallet'
 import * as legacyUseIsSmartContractWallet from './web3-react/hooks/useIsSmartContractWallet'
 import * as legacyUseIsWalletConnect from './web3-react/hooks/useIsWalletConnect'
 import * as legacyUseWalletMetadata from './web3-react/hooks/useWalletMetadata'
@@ -24,6 +26,12 @@ export function useIsSmartContractWallet(): boolean | undefined {
   const newIsSmartContractWallet = newUseIsSmartContract.useIsSmartContractWallet()
   const legacyIsSmartContractWallet = legacyUseIsSmartContractWallet.useIsSmartContractWallet()
   return LAUNCH_DARKLY_VIEM_MIGRATION ? newIsSmartContractWallet : legacyIsSmartContractWallet
+}
+
+export function useIsCoinbaseWallet(): boolean {
+  const newResult = newUseIsCoinbaseWallet.useIsCoinbaseWallet()
+  const legacyResult = legacyUseIsCoinbaseWallet.useIsCoinbaseWallet()
+  return LAUNCH_DARKLY_VIEM_MIGRATION ? newResult : legacyResult
 }
 
 export function getIsWalletConnect(connector: LegacyConnector): boolean {

--- a/libs/wallet/src/wagmi/hooks/useIsCoinbaseWallet.ts
+++ b/libs/wallet/src/wagmi/hooks/useIsCoinbaseWallet.ts
@@ -1,0 +1,9 @@
+import { useConnection } from 'wagmi'
+
+import { ConnectorType } from '../../api/types'
+
+export function useIsCoinbaseWallet(): boolean {
+  const { connector } = useConnection()
+
+  return connector?.type === ConnectorType.COINBASE_WALLET
+}

--- a/libs/wallet/src/web3-react/hooks/useIsCoinbaseWallet.ts
+++ b/libs/wallet/src/web3-react/hooks/useIsCoinbaseWallet.ts
@@ -1,0 +1,7 @@
+import { useConnectionType } from './useConnectionType'
+
+import { ConnectionType } from '../../api/types'
+
+export function useIsCoinbaseWallet(): boolean {
+  return useConnectionType() === ConnectionType.COINBASE_WALLET
+}


### PR DESCRIPTION
# Summary

  This PR combines Coinbase runtime chain capability handling with the destination-guard UX policy: 
  
  1. Runtime capability-based Coinbase chain handling (SCW vs EOA)

  - Adds wallet capability plumbing (wallet_getCapabilities usage via useWalletCapabilities / useWalletSupportedChainIds).
  - Adds Coinbase wallet detection hooks (useIsCoinbaseWallet) for wagmi and web3-react.
  - Applies Coinbase chain restrictions only when runtime capabilities indicate SCW support.
  - Avoids over-restricting Coinbase EOA users (no SCW capability set => no SCW chain restriction).

  2. Final destination safety policy for Coinbase SCW bridging

  - BUY-side destination chain selector remains broadly selectable (no hard disable for unsupported destination on OUTPUT side).
  - Swap execution is guarded:
      - block when destination chain is unsupported and recipient is self/default wallet
      - allow when recipient is external/custom
  - Shows dedicated warning banner and blocks submit for unsafe self-recipient path.

  This matches the agreed UX:

  - let users pick destination chains on BUY side
  - prevent unsafe self-recipient routing to unsupported SCW chains
  - still allow explicit external recipient flow.

  # To Test

  1. Coinbase SCW runtime chain behavior

  - [ ] Connect Coinbase Smart Wallet (SCW).
  - [ ] Open sell-side chain selector (INPUT path).
  - [ ] Verify unsupported SCW chains are shown as wallet-unsupported/disabled where applicable.
  - [ ] Verify supported SCW chains remain selectable.

  2. Coinbase EOA behavior is not over-restricted

  - [ ] Connect Coinbase EOA (no SCW atomic capability map).
  - [ ] Open chain selectors.
  - [ ] Verify chains are not restricted by SCW-only gating logic.

  3. BUY-side chain selection policy (agreed UX)

  - [ ] With Coinbase SCW, go to BUY/output-side chain selection.
  - [ ] Select a destination chain that is unsupported for SCW.
  - [ ] Verify selection is allowed in selector (not hard-disabled at selection step).

  4. Unsupported destination guard in swap flow

  - [ ] Keep recipient as self/default.
  - [ ] Verify warning banner appears for unsupported destination.
  - [ ] Verify trade/submit is blocked.
  - [ ] Set an external/custom recipient address.
  - [ ] Verify guard is lifted and submit path is allowed.

  5. Regression tests

  - [ ] pnpm exec jest --watchman=false --config apps/cowswap-frontend/jest.config.ts --runInBand --runTestsByPath apps/cowswap-frontend/src/modules/tokensList/hooks/useChainsToSelect.test.ts
  - [ ] pnpm exec jest --watchman=false --config apps/cowswap-frontend/jest.config.ts --runInBand --runTestsByPath apps/cowswap-frontend/src/modules/tokensList/utils/chainsState.test.ts
  - [ ] pnpm exec jest --watchman=false --config apps/cowswap-frontend/jest.config.ts --runInBand --runTestsByPath apps/cowswap-frontend/src/modules/swap/hooks/
    useShouldBlockUnsupportedDestination.test.ts

  # Background

  Previously, Coinbase SCW handling and destination safety were split across separate steps, which could produce intermediate behavior that did not fully reflect the intended final UX.

  This PR intentionally combines:

  - capability-based SCW chain intelligence, and
  - destination guardrail logic with recipient-aware blocking,

  so reviewers and QA can validate the final product behavior in one isolated PR against develop.