### PR TITLE
fix: preserve widget theme

### DIFF
--- a/apps/cowswap-frontend/src/theme/ThemeConfigUpdater.ts
+++ b/apps/cowswap-frontend/src/theme/ThemeConfigUpdater.ts
@@ -20,7 +20,9 @@ export function ThemeConfigUpdater(): null {
     const defaultTheme = getCowswapTheme(darkMode)
 
     if (isInjectedWidget()) {
-      setThemeConfig(mapWidgetTheme(injectedWidgetTheme, defaultTheme))
+      if (injectedWidgetTheme) {
+        setThemeConfig(mapWidgetTheme(injectedWidgetTheme, defaultTheme))
+      }
     } else {
       setThemeConfig(defaultTheme)
     }


### PR DESCRIPTION
# Summary

Simplification of https://github.com/cowprotocol/cowswap/pull/7070.

I think there is no case of dynamic theme change, so we can set it once and just do not reset in the future.

# To Test

Same as https://github.com/cowprotocol/cowswap/pull/7070


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme handling to ensure the default theme is properly preserved when no custom theme configuration is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->