### PR TITLE
fix: prevent input focus when max button is clicked

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
+++ b/apps/cowswap-frontend/src/common/pure/CurrencyInputPanel/CurrencyInputPanel.tsx
@@ -146,17 +146,23 @@ export function CurrencyInputPanel(props: CurrencyInputPanelProps): ReactNode {
     [onUserInput, field, convertUsdToTokenValue, isUsdValuesMode, currency?.decimals],
   )
 
-  const handleMaxInput = useCallback(() => {
-    if (!maxBalance) {
-      return
-    }
+  const handleMaxInput = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.preventDefault()
+      e.stopPropagation()
 
-    const value = isUsdValuesMode ? maxBalanceUsdAmount : maxBalance
+      if (!maxBalance) {
+        return
+      }
 
-    if (value) {
-      onUserInputDispatch(value.toExact(), isUsdValuesMode ? maxBalance.toExact() : undefined)
-    }
-  }, [maxBalance, onUserInputDispatch, isUsdValuesMode, maxBalanceUsdAmount])
+      const value = isUsdValuesMode ? maxBalanceUsdAmount : maxBalance
+
+      if (value) {
+        onUserInputDispatch(value.toExact(), isUsdValuesMode ? maxBalance.toExact() : undefined)
+      }
+    },
+    [maxBalance, onUserInputDispatch, isUsdValuesMode, maxBalanceUsdAmount],
+  )
 
   useEffect(() => {
     // Compare the actual string values to preserve trailing decimals


### PR DESCRIPTION
# Summary

In the Lens deprecation PR, a few fixes around inputs and disabled elements/states were introduced.

One of them replaced the wrapping `div` around the input fields with `label`, so that clicking anywhere in the box that represents the input makes it focus.

However, that also applies to the "Max" button.

This PR makes click in the "Max" button not focus the input.

# To Test

1. Connect a wallet.
2. Click "Max" in the sell input.
3. Verify the input is updated with the max amount, but it is not focused.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal event handling for the maximum balance input functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->