### PR TITLE
refactor: update quote ID formatting to support ellipsis for long IDs

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/RowQuoteId/RowQuoteId.utils.ts
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/RowQuoteId/RowQuoteId.utils.ts
@@ -1,7 +1,7 @@
 export type QuoteIdInput = string | number | null | undefined
 export type QuoteExpirationInput = string | null | undefined
 
-const QUOTE_REF_LENGTH = 8
+const QUOTE_REF_MAX_VISIBLE_LENGTH = 16
 
 export function getQuoteIdString(quoteId: QuoteIdInput): string | null {
   if (quoteId === null || quoteId === undefined) return null
@@ -12,7 +12,13 @@ export function getQuoteIdString(quoteId: QuoteIdInput): string | null {
 }
 
 export function formatQuoteIdReference(quoteId: string): string {
-  return `Q-${quoteId.slice(0, QUOTE_REF_LENGTH).toUpperCase()}`
+  const normalizedQuoteId = quoteId.toUpperCase()
+
+  if (normalizedQuoteId.length <= QUOTE_REF_MAX_VISIBLE_LENGTH) {
+    return `Q-${normalizedQuoteId}`
+  }
+
+  return `Q-${normalizedQuoteId.slice(0, QUOTE_REF_MAX_VISIBLE_LENGTH)}...`
 }
 
 export function getQuoteExpiresInLabel(expiration: QuoteExpirationInput, nowMs = Date.now()): string | null {

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/RowQuoteId/index.test.ts
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/RowQuoteId/index.test.ts
@@ -2,8 +2,8 @@ import { formatQuoteIdReference, getQuoteExpiresInLabel, getQuoteIdString } from
 
 describe('RowQuoteId', () => {
   describe('formatQuoteIdReference()', () => {
-    it('formats UUID-like ids into support-friendly references', () => {
-      expect(formatQuoteIdReference('a3f2b91e-4d7c-8f21-b0c1-5f31e29b1111')).toBe('Q-A3F2B91E')
+    it('caps long ids and adds ellipsis', () => {
+      expect(formatQuoteIdReference('a3f2b91e-4d7c-8f21-b0c1-5f31e29b1111')).toBe('Q-A3F2B91E-4D7C-8F...')
     })
 
     it('works with short ids', () => {


### PR DESCRIPTION
# Summary

  Update Quote ID display formatting to improve readability for long IDs:

  - Show as Q-<first 16 chars>... when Quote ID is longer than 16 chars
  - Keep full Quote ID unchanged for copy action (copy still uses the complete ID)

  # To Test

  1. Open Swap and generate a quote with a long Quote ID.

  - [ ] Quote ID text is shown as Q-<first 16 chars>...
  - [ ] Short Quote IDs are still shown fully (with Q- prefix)

  2. Click the copy icon next to Quote ID.

  - [ ] Copied value is the full Quote ID (not truncated)

  # Background

  This keeps the Quote ID compact in UI while preserving full value for support/debug copy workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quote ID reference display with enhanced truncation logic that shows full references when short and truncates with ellipsis when exceeding maximum length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->