### PR TITLE
fix(widget): apply theme mode from parameters

### DIFF
--- a/apps/cowswap-frontend/src/theme/ThemeConfigUpdater.test.tsx
+++ b/apps/cowswap-frontend/src/theme/ThemeConfigUpdater.test.tsx
@@ -1,0 +1,162 @@
+import { useSetAtom } from 'jotai'
+
+import { isInjectedWidget } from '@cowprotocol/common-utils'
+
+import { renderHook } from '@testing-library/react'
+
+import { useIsDarkMode } from 'legacy/state/user/hooks'
+
+import { useInjectedWidgetPalette } from 'modules/injectedWidget'
+
+import { getCowswapTheme } from './getCowswapTheme'
+import { mapWidgetTheme } from './mapWidgetTheme'
+import { ThemeConfigUpdater } from './ThemeConfigUpdater'
+
+jest.mock('jotai', () => ({
+  atom: jest.fn(),
+  useSetAtom: jest.fn(),
+}))
+
+jest.mock('@cowprotocol/common-utils', () => ({
+  isInjectedWidget: jest.fn(),
+}))
+
+jest.mock('./getCowswapTheme', () => ({
+  getCowswapTheme: jest.fn(),
+}))
+
+jest.mock('./mapWidgetTheme', () => ({
+  mapWidgetTheme: jest.fn(),
+}))
+
+jest.mock('./themeConfigAtom', () => ({
+  themeConfigAtom: Symbol('themeConfigAtom'),
+}))
+
+jest.mock('../legacy/state/user/hooks', () => ({
+  useIsDarkMode: jest.fn(),
+}))
+
+jest.mock('../modules/injectedWidget', () => ({
+  useInjectedWidgetPalette: jest.fn(),
+}))
+
+const mockedUseSetAtom = useSetAtom as jest.MockedFunction<typeof useSetAtom>
+const mockedIsInjectedWidget = isInjectedWidget as jest.MockedFunction<typeof isInjectedWidget>
+const mockedGetCowswapTheme = getCowswapTheme as jest.MockedFunction<typeof getCowswapTheme>
+const mockedMapWidgetTheme = mapWidgetTheme as jest.MockedFunction<typeof mapWidgetTheme>
+const mockedUseIsDarkMode = useIsDarkMode as jest.MockedFunction<typeof useIsDarkMode>
+const mockedUseInjectedWidgetPalette = useInjectedWidgetPalette as jest.MockedFunction<typeof useInjectedWidgetPalette>
+
+describe('ThemeConfigUpdater', () => {
+  const mockSetThemeConfig = jest.fn()
+  const lightTheme = { bg1: '#fff', isWidget: false } as never
+  const darkTheme = { bg1: '#000', isWidget: false } as never
+  const widgetTheme = { primary: '#f00', isWidget: true } as never
+  const palette = { paper: '#ff0' }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedUseSetAtom.mockReturnValue(mockSetThemeConfig)
+    mockedIsInjectedWidget.mockReturnValue(false)
+    mockedUseIsDarkMode.mockReturnValue(false)
+    mockedUseInjectedWidgetPalette.mockReturnValue(undefined)
+    mockedGetCowswapTheme.mockReturnValue(lightTheme)
+    mockedMapWidgetTheme.mockReturnValue(widgetTheme)
+  })
+
+  describe('non-widget mode', () => {
+    beforeEach(() => {
+      mockedIsInjectedWidget.mockReturnValue(false)
+    })
+
+    it('sets light theme when dark mode is off', () => {
+      mockedUseIsDarkMode.mockReturnValue(false)
+      mockedGetCowswapTheme.mockReturnValue(lightTheme)
+
+      renderHook(() => ThemeConfigUpdater())
+
+      expect(mockedGetCowswapTheme).toHaveBeenCalledWith(false)
+      expect(mockSetThemeConfig).toHaveBeenCalledWith(lightTheme)
+      expect(mockedMapWidgetTheme).not.toHaveBeenCalled()
+    })
+
+    it('sets dark theme when dark mode is on', () => {
+      mockedUseIsDarkMode.mockReturnValue(true)
+      mockedGetCowswapTheme.mockReturnValue(darkTheme)
+
+      renderHook(() => ThemeConfigUpdater())
+
+      expect(mockedGetCowswapTheme).toHaveBeenCalledWith(true)
+      expect(mockSetThemeConfig).toHaveBeenCalledWith(darkTheme)
+    })
+
+    it('updates theme config when dark mode changes', () => {
+      mockedGetCowswapTheme.mockReturnValueOnce(lightTheme).mockReturnValueOnce(darkTheme)
+
+      const { rerender } = renderHook(() => ThemeConfigUpdater())
+
+      expect(mockSetThemeConfig).toHaveBeenLastCalledWith(lightTheme)
+
+      mockedUseIsDarkMode.mockReturnValue(true)
+      rerender()
+
+      expect(mockSetThemeConfig).toHaveBeenLastCalledWith(darkTheme)
+    })
+  })
+
+  describe('widget mode', () => {
+    beforeEach(() => {
+      mockedIsInjectedWidget.mockReturnValue(true)
+    })
+
+    it('calls mapWidgetTheme and sets result when palette is provided', () => {
+      mockedUseInjectedWidgetPalette.mockReturnValue(palette)
+      mockedMapWidgetTheme.mockReturnValue(widgetTheme)
+
+      renderHook(() => ThemeConfigUpdater())
+
+      expect(mockedMapWidgetTheme).toHaveBeenCalledWith(palette, lightTheme)
+      expect(mockSetThemeConfig).toHaveBeenCalledWith(widgetTheme)
+    })
+
+    it('calls mapWidgetTheme with undefined palette when no palette in URL', () => {
+      mockedUseInjectedWidgetPalette.mockReturnValue(undefined)
+      mockedMapWidgetTheme.mockReturnValue(lightTheme)
+
+      renderHook(() => ThemeConfigUpdater())
+
+      expect(mockedMapWidgetTheme).toHaveBeenCalledWith(undefined, lightTheme)
+      expect(mockSetThemeConfig).toHaveBeenCalledWith(lightTheme)
+    })
+
+    it('preserves last non-undefined widgetTheme when palette disappears from URL', () => {
+      mockedUseInjectedWidgetPalette.mockReturnValue(palette)
+
+      const { rerender } = renderHook(() => ThemeConfigUpdater())
+
+      // Palette disappears (e.g. URL changes to null)
+      mockedUseInjectedWidgetPalette.mockReturnValue(undefined)
+      rerender()
+
+      // widgetTheme state should still hold the last non-undefined palette
+      expect(mockedMapWidgetTheme).toHaveBeenLastCalledWith(palette, lightTheme)
+    })
+
+    it('updates widgetTheme state when a new palette arrives', () => {
+      const newPalette = { paper: '#0f0' }
+      const newWidgetTheme = { primary: '#0f0', isWidget: true } as never
+
+      mockedUseInjectedWidgetPalette.mockReturnValue(palette)
+
+      const { rerender } = renderHook(() => ThemeConfigUpdater())
+
+      mockedUseInjectedWidgetPalette.mockReturnValue(newPalette)
+      mockedMapWidgetTheme.mockReturnValue(newWidgetTheme)
+      rerender()
+
+      expect(mockedMapWidgetTheme).toHaveBeenLastCalledWith(newPalette, lightTheme)
+      expect(mockSetThemeConfig).toHaveBeenLastCalledWith(newWidgetTheme)
+    })
+  })
+})

--- a/apps/cowswap-frontend/src/theme/ThemeConfigUpdater.ts
+++ b/apps/cowswap-frontend/src/theme/ThemeConfigUpdater.ts
@@ -1,5 +1,5 @@
 import { useSetAtom } from 'jotai'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 import { isInjectedWidget } from '@cowprotocol/common-utils'
 
@@ -15,18 +15,26 @@ export function ThemeConfigUpdater(): null {
 
   const darkMode = useIsDarkMode()
   const injectedWidgetTheme = useInjectedWidgetPalette()
+  const [widgetTheme, setWidgetTheme] = useState(injectedWidgetTheme)
+
+  /**
+   * Save widgetTheme from URL to state only if it's present
+   */
+  useEffect(() => {
+    if (injectedWidgetTheme) {
+      setWidgetTheme(injectedWidgetTheme)
+    }
+  }, [injectedWidgetTheme])
 
   useEffect(() => {
     const defaultTheme = getCowswapTheme(darkMode)
 
     if (isInjectedWidget()) {
-      if (injectedWidgetTheme) {
-        setThemeConfig(mapWidgetTheme(injectedWidgetTheme, defaultTheme))
-      }
+      setThemeConfig(mapWidgetTheme(widgetTheme, defaultTheme))
     } else {
       setThemeConfig(defaultTheme)
     }
-  }, [setThemeConfig, darkMode, injectedWidgetTheme])
+  }, [setThemeConfig, darkMode, widgetTheme])
 
   return null
 }


### PR DESCRIPTION
# Summary

In #7071 I didn't consider the case of light/dark mode switching.

<img width="269" height="314" alt="image" src="https://github.com/user-attachments/assets/dccc5b10-79e8-45e2-b1c8-86c5129e3cdb" />

# To Test

1. Open widget configurator
2. Change theme to light/dark many times
- [ ] AR: widget content ignores the theme mode changes
- [ ] ER: widget follows the selected theme mode
3. #7071 should still be fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for theme configuration handling, covering both standard and widget modes with various theme scenarios.

* **Bug Fixes**
  * Improved theme synchronization to ensure proper theme application in widget mode, addressing edge cases where palette availability changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->