### PR TITLE
fix: return back missing spaces on 'Cannot sell native token' warning

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/SellNativeWarningBanner/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/SellNativeWarningBanner/index.tsx
@@ -50,12 +50,15 @@ export function SellNativeWarningBanner() {
         <Button onClick={() => navigateOnCurrencySelection(Field.INPUT, wrapped)}>
           <Trans>Switch to {wrappedNativeSymbol}</Trans>
         </Button>
+        {' '}
         <Trans>or</Trans>
+        {' '}
         <Button onClick={() => navigateOnCurrencySelection(Field.OUTPUT, wrapped, undefined, queryParams)}>
           <Trans>
             Wrap {nativeSymbol} to {wrappedNativeSymbol}
           </Trans>
         </Button>
+        {' '}
         <Trans>first.</Trans>
       </p>
     </InlineBanner>


### PR DESCRIPTION
Fixes missing spaces on the warning 
<img width="677" height="185" alt="Screenshot_9" src="https://github.com/user-attachments/assets/49ffa8d0-1326-41ea-8356-daba524862fd" />


**To test:** 
1. Open [Limit order page](https://swap-dev-git-return-spaces-cowswap-dev.vercel.app/#/1/limit/ETH/USDC?tab=open&page=1)
2. Connect to a wallet
3. Pick ETH token to sell
4. Check the warning message at the bottom of the form

**ER**: the message should contain spaces between links




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing between UI elements in the warning banner for better visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->