### PR TITLE
fix: recommended slippage styling

### DIFF
--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -1231,6 +1231,10 @@ msgstr "How it works"
 msgid "any token into CoW AMM pools to start benefiting from attractive APRs."
 msgstr "any token into CoW AMM pools to start benefiting from attractive APRs."
 
+#: apps/cowswap-frontend/src/modules/application/containers/App/menuConsts.tsx
+msgid "Solvers"
+msgstr "Solvers"
+
 #: apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTableContainer/NoOrdersContent.tsx
 #~ msgid "You don't have any {orderStatusText} orders at the moment."
 #~ msgstr "You don't have any {orderStatusText} orders at the moment."
@@ -4097,8 +4101,8 @@ msgstr "Request cancellations"
 #~ msgstr "Left to next $10"
 
 #: apps/cowswap-frontend/src/modules/tradeWidgetAddons/pure/Row/RowSlippageContent/index.tsx
-msgid "Recommended"
-msgstr "Recommended"
+#~ msgid "Recommended"
+#~ msgstr "Recommended"
 
 #: apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateTraderModalCodeLinking.tsx
 msgid "Start trading"
@@ -6234,6 +6238,10 @@ msgstr "Something went wrong"
 #: apps/cowswap-frontend/src/modules/affiliate/pure/AffiliatePartner/AffiliatePartnerCodeForm.tsx
 #~ msgid "Type or generate a code (subject to availability). Saving locks this code to your wallet and cannot be changed. Links/codes don't reveal your wallet."
 #~ msgstr "Type or generate a code (subject to availability). Saving locks this code to your wallet and cannot be changed. Links/codes don't reveal your wallet."
+
+#: apps/cowswap-frontend/src/modules/tradeWidgetAddons/pure/Row/RowSlippageContent/index.tsx
+msgid "Suggested"
+msgstr "Suggested"
 
 #: apps/cowswap-frontend/src/modules/hooksStore/pure/AddCustomHookForm/index.tsx
 msgid "Add the app at your own risk"

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/pure/Row/RowSlippageContent/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/pure/Row/RowSlippageContent/index.tsx
@@ -89,7 +89,7 @@ export function RowSlippageContent(props: RowSlippageContentProps): ReactNode {
         ) : (
           <>
             <LinkStyledButton onClick={setAutoSlippage}>
-              (<Trans>Recommended</Trans>: {smartSlippage})
+              (<Trans>Suggested</Trans>: {smartSlippage})
             </LinkStyledButton>
             <HoverTooltip wrapInContainer content={SUGGESTED_SLIPPAGE_TOOLTIP}>
               <StyledInfoIcon size={16} />


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/recommended-slippage-is-hardly-visible-3138da5f04ca8074b70df2b3192d9b71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined slippage display: removed strikethrough and small-font styling, and adjusted button padding.
* **Content**
  * Updated slippage label from "Recommended" to "Suggested".
* **Localization**
  * Added translation entries for "Suggested" and "Solvers"; deprecated the previous "Recommended" entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->