### PR TITLE
fix: empty space on the bridge confirm modal

### DIFF
--- a/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateTraderRewardsRow.tsx
+++ b/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateTraderRewardsRow.tsx
@@ -6,8 +6,6 @@ import { HoverTooltip, LinkStyledButton, RowFixed, UI } from '@cowprotocol/ui'
 import { Trans } from '@lingui/react/macro'
 
 import { StyledInfoIcon, StyledRowBetween, TextWrapper } from '../../tradeWidgetAddons/pure/Row/styled'
-import { AFFILIATE_HIDE_REWARDS_ROW_IF_INELIGIBLE } from '../config/affiliateProgram.const'
-import { TraderWalletStatus, useAffiliateTraderWallet } from '../hooks/useAffiliateTraderWallet'
 import { toggleTraderModalAtom } from '../state/affiliateTraderModalAtom'
 import { affiliateTraderSavedCodeAtom } from '../state/affiliateTraderSavedCodeAtom'
 
@@ -15,11 +13,6 @@ export function AffiliateTraderRewardsRow(): ReactNode {
   const toggleAffiliateModal = useSetAtom(toggleTraderModalAtom)
 
   const { savedCode, isLinked } = useAtomValue(affiliateTraderSavedCodeAtom)
-  const walletStatus = useAffiliateTraderWallet()
-
-  if (AFFILIATE_HIDE_REWARDS_ROW_IF_INELIGIBLE && walletStatus === TraderWalletStatus.INELIGIBLE) {
-    return null
-  }
 
   return (
     <StyledRowBetween>

--- a/apps/cowswap-frontend/src/modules/affiliate/hooks/useIsRewardsRowEnabled.ts
+++ b/apps/cowswap-frontend/src/modules/affiliate/hooks/useIsRewardsRowEnabled.ts
@@ -1,8 +1,17 @@
 import { useFeatureFlags } from '@cowprotocol/common-hooks'
 import { isInjectedWidget } from '@cowprotocol/common-utils'
 
+import { TraderWalletStatus, useAffiliateTraderWallet } from './useAffiliateTraderWallet'
+
+import { AFFILIATE_HIDE_REWARDS_ROW_IF_INELIGIBLE } from '../config/affiliateProgram.const'
+
 export function useIsRewardsRowEnabled(): boolean {
   const { isAffiliateProgramEnabled } = useFeatureFlags()
+  const walletStatus = useAffiliateTraderWallet()
+
+  if (AFFILIATE_HIDE_REWARDS_ROW_IF_INELIGIBLE && walletStatus === TraderWalletStatus.INELIGIBLE) {
+    return false
+  }
 
   return isAffiliateProgramEnabled && !isInjectedWidget()
 }


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Empty-space-on-the-confirm-modal-when-code-is-hidden-3048da5f04ca8002a430f1bb42793294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized affiliate rewards eligibility logic by centralizing checks for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->