### PR TITLE
ci: disable nx cloud in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ env:
   REACT_APP_CMS_BASE_URL: ${{ secrets.CMS_BASE_URL }}
   NEXT_PUBLIC_CMS_BASE_URL: ${{ secrets.CMS_BASE_URL }}
   PACKAGE_READ_AUTH_TOKEN: ${{ secrets.PACKAGE_READ_AUTH_TOKEN }}
+  NX_DISABLE_REMOTE_CACHE: true
 
 jobs:
   setup:


### PR DESCRIPTION
# Summary

Nx Cloud is still working in Vercel.
In this PR I only excluded it from Lint, Test, E2E.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI configuration updated to disable remote caching during automated runs.
  * No application code, UI, or user-facing behavior changed as part of this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->