### PR TITLE
chore: fix modules order in lint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -99,10 +99,10 @@ module.exports = [
           groups: [
             ['export-interface', 'export-type'],
             'export-enum',
+            ['interface', 'type'],
+            'enum',
             'export-class',
             'export-function',
-            'enum',
-            ['interface', 'type'],
             'class',
             'function',
           ],


### PR DESCRIPTION
# Summary

Types and consts should be defined before functions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized linting configuration for improved code grouping consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->