### PR TITLE
feat: implement solver details feature across order components

### DIFF
--- a/apps/explorer/src/components/common/MenuDropdown/mainMenu.ts
+++ b/apps/explorer/src/components/common/MenuDropdown/mainMenu.ts
@@ -5,7 +5,7 @@ import IMAGE_DOC from 'assets/img/doc.svg'
 import IMAGE_ANALYTICS from 'assets/img/pie.svg'
 import { PiMathOperationsFill } from 'react-icons/pi'
 
-import { MenuItemKind, MenuTreeItem } from './types'
+import { MenuItemKind, MenuLink, MenuTreeItem } from './types'
 
 import {
   DOCS_LINK,
@@ -16,71 +16,81 @@ import {
   Routes,
 } from '../../../explorer/const'
 
-export const MAIN_MENU: MenuTreeItem[] = [
-  {
-    title: 'Home',
-    url: Routes.HOME,
-  },
-  {
-    kind: MenuItemKind.DROP_DOWN,
-    title: 'More',
-    items: [
-      {
-        sectionTitle: 'OVERVIEW',
-        links: [
-          {
-            title: 'CoW Swap',
-            url: COWSWAP_LINK,
-            kind: MenuItemKind.EXTERNAL_LINK,
-            iconSVG: IMAGE_COW,
-          },
-          {
-            title: 'CoW Protocol',
-            url: PROTOCOL_LINK,
-            kind: MenuItemKind.EXTERNAL_LINK,
-            iconSVG: IMAGE_COW,
-          },
-          {
-            title: 'Documentation',
-            url: DOCS_LINK,
-            kind: MenuItemKind.EXTERNAL_LINK,
-            iconSVG: IMAGE_DOC,
-          },
-          {
-            title: 'Analytics',
-            url: DUNE_DASHBOARD_LINK,
-            kind: MenuItemKind.EXTERNAL_LINK,
-            iconSVG: IMAGE_ANALYTICS,
-          },
-        ],
-      },
-      {
-        sectionTitle: 'COMMUNITY',
-        links: [
-          {
-            title: 'Discord',
-            url: DISCORD_LINK,
-            iconSVG: IMAGE_DISCORD, // If icon is a <SVG> inline component
-            kind: MenuItemKind.EXTERNAL_LINK,
-          },
-        ],
-      },
-      {
-        sectionTitle: 'OTHER',
-        links: [
+export function getMainMenu(isSolversEnabled = true): MenuTreeItem[] {
+  const otherLinks: MenuLink[] = [
+    ...(isSolversEnabled
+      ? [
           {
             title: 'Solvers',
             url: Routes.SOLVERS,
             iconComponent: PiMathOperationsFill,
             noPrefix: true,
-          },
-          {
-            title: 'AppData',
-            url: Routes.APPDATA,
-            iconSVG: IMAGE_APPDATA,
-          },
-        ],
-      },
-    ],
-  },
-]
+          } satisfies MenuLink,
+        ]
+      : []),
+    {
+      title: 'AppData',
+      url: Routes.APPDATA,
+      iconSVG: IMAGE_APPDATA,
+    },
+  ]
+
+  return [
+    {
+      title: 'Home',
+      url: Routes.HOME,
+    },
+    {
+      kind: MenuItemKind.DROP_DOWN,
+      title: 'More',
+      items: [
+        {
+          sectionTitle: 'OVERVIEW',
+          links: [
+            {
+              title: 'CoW Swap',
+              url: COWSWAP_LINK,
+              kind: MenuItemKind.EXTERNAL_LINK,
+              iconSVG: IMAGE_COW,
+            },
+            {
+              title: 'CoW Protocol',
+              url: PROTOCOL_LINK,
+              kind: MenuItemKind.EXTERNAL_LINK,
+              iconSVG: IMAGE_COW,
+            },
+            {
+              title: 'Documentation',
+              url: DOCS_LINK,
+              kind: MenuItemKind.EXTERNAL_LINK,
+              iconSVG: IMAGE_DOC,
+            },
+            {
+              title: 'Analytics',
+              url: DUNE_DASHBOARD_LINK,
+              kind: MenuItemKind.EXTERNAL_LINK,
+              iconSVG: IMAGE_ANALYTICS,
+            },
+          ],
+        },
+        {
+          sectionTitle: 'COMMUNITY',
+          links: [
+            {
+              title: 'Discord',
+              url: DISCORD_LINK,
+              iconSVG: IMAGE_DISCORD, // If icon is a <SVG> inline component
+              kind: MenuItemKind.EXTERNAL_LINK,
+            },
+          ],
+        },
+        {
+          sectionTitle: 'OTHER',
+          links: otherLinks,
+        },
+      ],
+    },
+  ]
+}
+
+export const MAIN_MENU = getMainMenu()

--- a/apps/explorer/src/components/orders/DetailsTable/VerboseDetails.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/VerboseDetails.tsx
@@ -21,19 +21,10 @@ import { OrderHooksDetails } from '../OrderHooksDetails'
 import { OrderPriceDisplay } from '../OrderPriceDisplay'
 import { OrderSurplusDisplay } from '../OrderSurplusDisplay'
 
-interface VerboseDetailsProps {
-  order: Order
-  solvedBy?: OrderSolverInfo
-  isSolvedByLoading?: boolean
-  isPriceInverted: boolean
-  invertPrice: Command
-  showFillsButton: boolean | undefined
-  viewFills: Command
-}
-
 // eslint-disable-next-line max-lines-per-function
 export function VerboseDetails({
   order,
+  showSolverDetails,
   solvedBy,
   isSolvedByLoading,
   invertPrice,
@@ -95,17 +86,19 @@ export function VerboseDetails({
       <DetailRow label="Costs & Fees" tooltipText={DetailsTableTooltips.fees}>
         <GasFeeDisplay order={order} />
       </DetailRow>
-      <DetailRow label="Solved by" tooltipText={DetailsTableTooltips.solvedBy}>
-        {showFillsButton ? (
-          <TextLink onClickOptional={viewFills} to={`/orders/${uid}/?${TAB_QUERY_PARAM_KEY}=fills`}>
-            View all solvers
-          </TextLink>
-        ) : isSolvedByLoading ? (
-          <Spinner spin size="1x" />
-        ) : (
-          <SolvedByBadge solvedBy={solvedBy} />
-        )}
-      </DetailRow>
+      {showSolverDetails && (
+        <DetailRow label="Solved by" tooltipText={DetailsTableTooltips.solvedBy}>
+          {showFillsButton ? (
+            <TextLink onClickOptional={viewFills} to={`/orders/${uid}/?${TAB_QUERY_PARAM_KEY}=fills`}>
+              View all solvers
+            </TextLink>
+          ) : isSolvedByLoading ? (
+            <Spinner spin size="1x" />
+          ) : (
+            <SolvedByBadge solvedBy={solvedBy} />
+          )}
+        </DetailRow>
+      )}
       <OrderHooksDetails appData={appData} fullAppData={fullAppData ?? undefined}>
         {(content) => (
           <DetailRow label="Hooks" tooltipText={DetailsTableTooltips.hooks}>
@@ -118,4 +111,15 @@ export function VerboseDetails({
       </DetailRow>
     </>
   )
+}
+
+interface VerboseDetailsProps {
+  order: Order
+  showSolverDetails: boolean
+  solvedBy?: OrderSolverInfo
+  isSolvedByLoading?: boolean
+  isPriceInverted: boolean
+  invertPrice: Command
+  showFillsButton: boolean | undefined
+  viewFills: Command
 }

--- a/apps/explorer/src/components/orders/OrderDetails/FillsTable.tsx
+++ b/apps/explorer/src/components/orders/OrderDetails/FillsTable.tsx
@@ -13,27 +13,26 @@ import { FillsTableRow } from './FillsTableRow'
 import { SimpleTable, SimpleTableProps } from '../../common/SimpleTable'
 import { FilledProgress } from '../FilledProgress'
 
-type FillsTableProps = SimpleTableProps & {
-  trades: Trade[] | undefined
-  order: Order | null
-  tableState: TableState
-  isPriceInverted: boolean
-  invertPrice: Command
-}
-
 export function FillsTable(props: FillsTableProps): ReactNode {
-  const { trades, order, isPriceInverted, invertPrice } = props
+  const { trades, order, isPriceInverted, invertPrice, showSolverDetails } = props
 
   const invertButton = useMemo(() => <Icon icon={faExchangeAlt} onClick={invertPrice} />, [invertPrice])
 
   const tradeItems = !trades?.length ? (
     <tr className="row-empty">
-      <td className="row-td-empty">
+      <td className="row-td-empty" colSpan={showSolverDetails ? 7 : 6}>
         No results found. <br /> Please try another search.
       </td>
     </tr>
   ) : (
-    trades.map((item) => <FillsTableRow key={item.txHash} trade={item} isPriceInverted={isPriceInverted} />)
+    trades.map((item) => (
+      <FillsTableRow
+        key={item.txHash}
+        trade={item}
+        isPriceInverted={isPriceInverted}
+        showSolverDetails={showSolverDetails}
+      />
+    ))
   )
 
   return (
@@ -53,11 +52,20 @@ export function FillsTable(props: FillsTableProps): ReactNode {
               <span>Execution price {invertButton}</span>
             </th>
             <th>Execution time</th>
-            <th>Solver</th>
+            {showSolverDetails && <th>Solver</th>}
           </tr>
         }
         body={tradeItems}
       />
     </>
   )
+}
+
+type FillsTableProps = SimpleTableProps & {
+  trades: Trade[] | undefined
+  order: Order | null
+  tableState: TableState
+  isPriceInverted: boolean
+  invertPrice: Command
+  showSolverDetails: boolean
 }

--- a/apps/explorer/src/components/orders/OrderDetails/FillsTableRow.tsx
+++ b/apps/explorer/src/components/orders/OrderDetails/FillsTableRow.tsx
@@ -25,20 +25,7 @@ const StyledShimmerBar = styled(ShimmerBar)`
   min-width: 10rem;
 `
 
-function TradeSolverCell({ txHash }: { txHash: string }): React.ReactNode {
-  const { solver, isLoading } = useTradeSolver(txHash)
-
-  if (isLoading) return <Spinner spin size="1x" />
-
-  return <SolvedByBadge solvedBy={solver} />
-}
-
-interface FillsTableRowProps {
-  trade: Trade
-  isPriceInverted: boolean
-}
-
-export function FillsTableRow({ trade, isPriceInverted }: FillsTableRowProps): React.ReactNode {
+export function FillsTableRow({ trade, isPriceInverted, showSolverDetails }: FillsTableRowProps): React.ReactNode {
   const network = useNetworkId() ?? undefined
   const {
     txHash,
@@ -99,9 +86,25 @@ export function FillsTableRow({ trade, isPriceInverted }: FillsTableRowProps): R
       <td>{surplus ? <SurplusComponent icon={faIcon} surplus={surplus} token={surplusToken} /> : '-'}</td>
       <td>{executionPrice && <TokenAmount amount={executionPrice} token={executionToken} />}</td>
       <td>{executionTime ? <DateDisplay date={executionTime} showIcon={true} /> : <StyledShimmerBar />}</td>
-      <td>
-        <TradeSolverCell txHash={txHash} />
-      </td>
+      {showSolverDetails && (
+        <td>
+          <TradeSolverCell txHash={txHash} />
+        </td>
+      )}
     </tr>
   )
+}
+
+interface FillsTableRowProps {
+  trade: Trade
+  isPriceInverted: boolean
+  showSolverDetails: boolean
+}
+
+function TradeSolverCell({ txHash }: { txHash: string }): React.ReactNode {
+  const { solver, isLoading } = useTradeSolver(txHash)
+
+  if (isLoading) return <Spinner spin size="1x" />
+
+  return <SolvedByBadge solvedBy={solver} />
 }

--- a/apps/explorer/src/components/orders/OrderDetails/FillsTableWithData.tsx
+++ b/apps/explorer/src/components/orders/OrderDetails/FillsTableWithData.tsx
@@ -15,6 +15,7 @@ export type FillsTableWithDataProps = {
   order: Order | null
   isPriceInverted: boolean
   invertPrice: Command
+  showSolverDetails: boolean
 }
 
 export const FillsTableWithData: React.FC<FillsTableWithDataProps> = ({
@@ -22,6 +23,7 @@ export const FillsTableWithData: React.FC<FillsTableWithDataProps> = ({
   order,
   isPriceInverted,
   invertPrice,
+  showSolverDetails,
 }) => {
   const { data: trades, tableState } = useContext(FillsTableContext)
   const isFirstRender = useFirstRender()
@@ -35,6 +37,7 @@ export const FillsTableWithData: React.FC<FillsTableWithDataProps> = ({
       tableState={tableState}
       isPriceInverted={isPriceInverted}
       invertPrice={invertPrice}
+      showSolverDetails={showSolverDetails}
     />
   )
 }

--- a/apps/explorer/src/components/orders/OrderDetails/index.tsx
+++ b/apps/explorer/src/components/orders/OrderDetails/index.tsx
@@ -15,6 +15,7 @@ import { TableState } from 'explorer/components/TokensTableWidget/useTable'
 import { TAB_QUERY_PARAM_KEY } from 'explorer/const'
 import { OrderSolverInfo, useOrderSolver } from 'hooks/useOrderSolver'
 import { useQuery, useUpdateQueryString } from 'hooks/useQuery'
+import { useSolversFeatureFlag } from 'hooks/useSolversFeatureFlag'
 import { useLocation } from 'react-router'
 import { knownBridgeProviders } from 'sdk/cowSdk'
 import { useNetworkId } from 'state/network'
@@ -75,6 +76,7 @@ const tabItems = (
   isPriceInverted: boolean,
   invertPrice: Command,
   hasMultipleTrades: boolean,
+  showSolverDetails: boolean,
   solvedBy?: OrderSolverInfo,
   isSolvedByLoading?: boolean,
 ): TabItemInterface[] => {
@@ -102,6 +104,7 @@ const tabItems = (
       >
         <VerboseDetails
           order={order}
+          showSolverDetails={showSolverDetails}
           solvedBy={solvedBy}
           isSolvedByLoading={isSolvedByLoading}
           showFillsButton={showFills}
@@ -134,7 +137,13 @@ const tabItems = (
     return [overviewTab]
   }
 
-  const fillsTab = getFillsTab(filledPercentage, { order, areTokensLoaded, isPriceInverted, invertPrice })
+  const fillsTab = getFillsTab(filledPercentage, {
+    order,
+    areTokensLoaded,
+    isPriceInverted,
+    invertPrice,
+    showSolverDetails,
+  })
 
   return [overviewTab, fillsTab]
 }
@@ -149,6 +158,10 @@ function getOrderWithTxHash(order: Order | null, trades: Trade[], hasMultipleTra
     return { ...order, txHash: trades[0].txHash || undefined, executionDate: trades[0].executionTime || undefined }
   }
   return order
+}
+
+function hasMultipleTradesForOrder(trades: Trade[], tableState: TableState): boolean {
+  return trades.length > 1 || (!!tableState.pageIndex && tableState.pageIndex > 1) || !!tableState.hasNextPage
 }
 
 // TODO: Break down this large function into smaller functions
@@ -167,6 +180,7 @@ export const OrderDetails: React.FC<Props> = (props) => {
     handlePreviousPage,
   } = props
   const chainId = useNetworkId()
+  const showSolverDetails = useSolversFeatureFlag()
   const tab = useQueryViewParams()
   const [tabViewSelected, setTabViewSelected] = useState<TabView>(TabView[tab] || TabView[DEFAULT_TAB]) // use DEFAULT when URL param is outside the enum
 
@@ -176,11 +190,12 @@ export const OrderDetails: React.FC<Props> = (props) => {
   const [redirectTo, setRedirectTo] = useState(false)
   const updateQueryString = useUpdateQueryString()
   const crossChainOrderResponse = useCrossChainOrder(order?.uid)
-  const hasMultipleTrades =
-    trades.length > 1 || (!!tableState.pageIndex && tableState.pageIndex > 1) || !!tableState.hasNextPage
+  const hasMultipleTrades = hasMultipleTradesForOrder(trades, tableState)
   const isMultiFill = order?.partiallyFillable && !order.txHash && hasMultipleTrades
   const orderWithTxHash = getOrderWithTxHash(order, trades, hasMultipleTrades)
-  const { solver: solvedBy, isLoading: isSolvedByLoading } = useOrderSolver(isMultiFill ? null : orderWithTxHash)
+  const { solver: solvedBy, isLoading: isSolvedByLoading } = useOrderSolver(
+    showSolverDetails && !isMultiFill ? orderWithTxHash : null,
+  )
 
   const ExtraComponentNode: React.ReactNode = (
     <WrapperExtraComponents>
@@ -258,6 +273,7 @@ export const OrderDetails: React.FC<Props> = (props) => {
             isPriceInverted,
             invertPrice,
             hasMultipleTrades,
+            showSolverDetails,
             solvedBy,
             isSolvedByLoading,
           )}

--- a/apps/explorer/src/explorer/ExplorerApp.tsx
+++ b/apps/explorer/src/explorer/ExplorerApp.tsx
@@ -21,6 +21,7 @@ import { GlobalStyle, MainWrapper } from './styled'
 import { version } from '../../package.json'
 import { GenericLayout } from '../components/layout'
 import { withGlobalContext } from '../hooks/useGlobalState'
+import { useSolversFeatureFlag } from '../hooks/useSolversFeatureFlag'
 import { CowSdkUpdater } from '../sdk/cowSdk'
 import { RedirectMainnet, RedirectXdai, useNetworkId } from '../state/network'
 import { NetworkUpdater } from '../state/network/NetworkUpdater'
@@ -131,6 +132,7 @@ const networkPrefixes = CHAIN_INFO_ARRAY.map((info) => info.urlAlias)
 
 const AppContent = (): React.ReactNode => {
   const chainId = useNetworkId()
+  const isSolversEnabled = useSolversFeatureFlag()
   useAnalyticsReporter({
     account: undefined, // Explorer doesn't have wallet functionality
     walletName: undefined, // Explorer doesn't have wallet functionality
@@ -146,25 +148,23 @@ const AppContent = (): React.ReactNode => {
   const pathPrefix = networkPrefixes.includes(prefix) ? `/${prefix}` : '/'
 
   return (
-    <WithLDProvider>
-      <GenericLayout header={<Header />}>
-        <React.Suspense fallback={null}>
-          <Routes>
-            <Route path={pathPrefix + '/'} element={<Home />} />
-            <Route path={pathPrefix + '/address/'} element={<Navigate to={pathPrefix + '/search/'} />} />
-            <Route path={pathPrefix + '/orders/'} element={<Navigate to={pathPrefix + '/search/'} />} />
-            <Route path={pathPrefix + '/tx/'} element={<Navigate to={pathPrefix + '/search/'} />} />
-            <Route path={pathPrefix + '/orders/:orderId'} element={<Order />} />
-            <Route path={pathPrefix + '/address/:address'} element={<UserDetails />} />
-            <Route path={pathPrefix + '/tx/:txHash'} element={<TransactionDetails />} />
-            <Route path={pathPrefix + '/solvers'} element={<Solvers />} />
-            <Route path={pathPrefix + '/search/:searchString?'} element={<SearchNotFound />} />
-            <Route path={pathPrefix + '/appdata'} element={<AppDataDetails />} />
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-        </React.Suspense>
-      </GenericLayout>
-    </WithLDProvider>
+    <GenericLayout header={<Header />}>
+      <React.Suspense fallback={null}>
+        <Routes>
+          <Route path={pathPrefix + '/'} element={<Home />} />
+          <Route path={pathPrefix + '/address/'} element={<Navigate to={pathPrefix + '/search/'} />} />
+          <Route path={pathPrefix + '/orders/'} element={<Navigate to={pathPrefix + '/search/'} />} />
+          <Route path={pathPrefix + '/tx/'} element={<Navigate to={pathPrefix + '/search/'} />} />
+          <Route path={pathPrefix + '/orders/:orderId'} element={<Order />} />
+          <Route path={pathPrefix + '/address/:address'} element={<UserDetails />} />
+          <Route path={pathPrefix + '/tx/:txHash'} element={<TransactionDetails />} />
+          {isSolversEnabled && <Route path={pathPrefix + '/solvers'} element={<Solvers />} />}
+          <Route path={pathPrefix + '/search/:searchString?'} element={<SearchNotFound />} />
+          <Route path={pathPrefix + '/appdata'} element={<AppDataDetails />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </React.Suspense>
+    </GenericLayout>
   )
 }
 
@@ -176,15 +176,17 @@ export const ExplorerApp: React.FC = () => {
     <CowAnalyticsProvider cowAnalytics={cowAnalytics}>
       <GlobalStyle />
       <MainWrapper>
-        <Router basename={process.env.BASE_URL}>
-          <StateUpdaters />
-          <CowSdkUpdater />
-          <Routes>
-            <Route path="/mainnet" element={<RedirectMainnet />} />
-            <Route path="/xdai" element={<RedirectXdai />} />
-            <Route path="*" element={<AppContent />} />
-          </Routes>
-        </Router>
+        <WithLDProvider>
+          <Router basename={process.env.BASE_URL}>
+            <StateUpdaters />
+            <CowSdkUpdater />
+            <Routes>
+              <Route path="/mainnet" element={<RedirectMainnet />} />
+              <Route path="/xdai" element={<RedirectXdai />} />
+              <Route path="*" element={<AppContent />} />
+            </Routes>
+          </Router>
+        </WithLDProvider>
       </MainWrapper>
     </CowAnalyticsProvider>
   )

--- a/apps/explorer/src/explorer/layout/Header.container.tsx
+++ b/apps/explorer/src/explorer/layout/Header.container.tsx
@@ -4,14 +4,17 @@ import { CHAIN_INFO } from '@cowprotocol/common-const'
 import { useBodyScrollbarLocker, useMediaQuery } from '@cowprotocol/common-hooks'
 import { Media } from '@cowprotocol/ui'
 
+import { getMainMenu } from '../../components/common/MenuDropdown/mainMenu'
 import { MenuTree } from '../../components/common/MenuDropdown/MenuTree'
 import { Header as GenericHeader } from '../../components/layout/GenericLayout/Header'
 import { NetworkSelector } from '../../components/NetworkSelector/NetworkSelector.container'
+import { useSolversFeatureFlag } from '../../hooks/useSolversFeatureFlag'
 import { useNetworkId } from '../../state/network'
 import { FlexWrap } from '../pages/styled'
 
 export const Header: React.FC = () => {
   const isMobile = useMediaQuery(Media.upToSmall(false))
+  const isSolversEnabled = useSolversFeatureFlag()
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false)
 
   useBodyScrollbarLocker(isMobileMenuOpen && isMobile)
@@ -26,6 +29,7 @@ export const Header: React.FC = () => {
   }
 
   const prefixNetwork = CHAIN_INFO[networkId].urlAlias
+  const menuList = getMainMenu(isSolversEnabled)
 
   return (
     <GenericHeader
@@ -38,6 +42,7 @@ export const Header: React.FC = () => {
           isMobile={isMobile}
           isMobileMenuOpen={isMobileMenuOpen}
           handleMobileMenuOnClick={handleMobileMenuOnClick}
+          menuList={menuList}
         />
       </FlexWrap>
     </GenericHeader>

--- a/apps/explorer/src/explorer/pages/Solvers.tsx
+++ b/apps/explorer/src/explorer/pages/Solvers.tsx
@@ -55,10 +55,7 @@ const Solvers = (): React.ReactNode => {
       </Helmet>
       <StyledSearch />
       <h1>Solvers</h1>
-      <Subtitle>
-        Discover solver teams, supported networks, environments, and deployment addresses. Expand any solver row for
-        per-network payout details.
-      </Subtitle>
+      <Subtitle>Discover solver teams, supported networks, environments, and deployment addresses.</Subtitle>
       <Section>
         <SnapshotAccordion $expanded={isSnapshotExpanded}>
           <SectionHeader $expanded={isSnapshotExpanded} onClick={(): void => setIsSnapshotExpanded((state) => !state)}>

--- a/apps/explorer/src/explorer/pages/SolversDirectoryTable.helpers.tsx
+++ b/apps/explorer/src/explorer/pages/SolversDirectoryTable.helpers.tsx
@@ -32,16 +32,19 @@ export function filterDeploymentsByActiveStatus(
   return deployments
 }
 
-export function getNetworkOptions(solversInfo: SolverInfo[]): [number, string][] {
-  const entries = new Map<number, string>()
+export function filterSolvers(
+  solversInfo: SolverInfo[],
+  query: string,
+  networkFilter: string,
+  environmentFilter: string,
+  activeFilter: string,
+): SolverInfo[] {
+  return solversInfo.filter((solver) => {
+    const scopedDeployments = filterDeployments(solver.deployments, networkFilter, environmentFilter)
+    const visibleDeployments = filterDeploymentsByActiveStatus(scopedDeployments, activeFilter)
 
-  solversInfo.forEach((solver) => {
-    solver.deployments.forEach((deployment) => {
-      entries.set(deployment.chainId, deployment.chainName)
-    })
+    return visibleDeployments.length > 0 && matchesSearch(solver, query, visibleDeployments)
   })
-
-  return [...entries.entries()].sort((a, b) => a[1].localeCompare(b[1]))
 }
 
 export function getEnvironmentOptions(solversInfo: SolverInfo[]): string[] {
@@ -58,19 +61,16 @@ export function getEnvironmentOptions(solversInfo: SolverInfo[]): string[] {
   return [...environments].sort()
 }
 
-export function filterSolvers(
-  solversInfo: SolverInfo[],
-  query: string,
-  networkFilter: string,
-  environmentFilter: string,
-  activeFilter: string,
-): SolverInfo[] {
-  return solversInfo.filter((solver) => {
-    const scopedDeployments = filterDeployments(solver.deployments, networkFilter, environmentFilter)
-    const visibleDeployments = filterDeploymentsByActiveStatus(scopedDeployments, activeFilter)
+export function getNetworkOptions(solversInfo: SolverInfo[]): [number, string][] {
+  const entries = new Map<number, string>()
 
-    return visibleDeployments.length > 0 && matchesSearch(solver, query, visibleDeployments)
+  solversInfo.forEach((solver) => {
+    solver.deployments.forEach((deployment) => {
+      entries.set(deployment.chainId, deployment.chainName)
+    })
   })
+
+  return [...entries.entries()].sort((a, b) => a[1].localeCompare(b[1]))
 }
 
 function matchesSearch(solver: SolverInfo, query: string, deployments: SolverDeployment[]): boolean {
@@ -80,9 +80,7 @@ function matchesSearch(solver: SolverInfo, query: string, deployments: SolverDep
   const searchableFields = [
     solver.displayName,
     solver.solverId,
-    solver.description || '',
-    solver.website || '',
-    deployments.map((deployment) => `${deployment.address || ''} ${deployment.payoutAddress || ''}`).join(' '),
+    deployments.map((deployment) => deployment.address || '').join(' '),
   ]
 
   return searchableFields.join(' ').toLowerCase().includes(normalizedQuery)

--- a/apps/explorer/src/explorer/pages/SolversDirectoryTable.styles.tsx
+++ b/apps/explorer/src/explorer/pages/SolversDirectoryTable.styles.tsx
@@ -4,8 +4,8 @@ import styled from 'styled-components/macro'
 
 import { SimpleTable } from '../../components/common/SimpleTable'
 
-const DEPLOYMENTS_GRID_TEMPLATE_COLUMNS = '12rem 8rem 1fr 1fr'
-const DEPLOYMENTS_GRID_MIN_WIDTH = '72rem'
+const DEPLOYMENTS_GRID_TEMPLATE_COLUMNS = '12rem 8rem minmax(0, 1fr)'
+const DEPLOYMENTS_GRID_MIN_WIDTH = '48rem'
 
 type EnvTagPalette = {
   color: string
@@ -93,7 +93,7 @@ export const Select = styled.select`
 `
 
 export const Table = styled(SimpleTable)`
-  min-width: 98rem;
+  min-width: 76rem;
 
   tbody tr.solver-summary-row td {
     transition: background-color 0.14s ease;
@@ -116,17 +116,8 @@ export const Table = styled(SimpleTable)`
     min-width: 16rem;
   }
 
-  td.website {
-    min-width: 11rem;
-  }
-
-  td.description {
-    min-width: 18rem;
-    white-space: normal;
-  }
-
   ${Media.upToMedium()} {
-    min-width: 92rem;
+    min-width: 72rem;
   }
 `
 
@@ -302,8 +293,7 @@ export const DeploymentsGridRow = styled.div`
     background: ${Color.explorer_bg2};
   }
 
-  > :nth-child(3),
-  > :nth-child(4) {
+  > :nth-child(3) {
     min-width: 22rem;
   }
 `

--- a/apps/explorer/src/explorer/pages/SolversDirectoryTable.tsx
+++ b/apps/explorer/src/explorer/pages/SolversDirectoryTable.tsx
@@ -1,6 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
-import { ALL_FILTER, filterSolvers, getEnvironmentOptions, getNetworkOptions } from './SolversDirectoryTable.helpers'
+import {
+  ACTIVE_FILTER_ACTIVE,
+  ALL_FILTER,
+  filterSolvers,
+  getEnvironmentOptions,
+  getNetworkOptions,
+} from './SolversDirectoryTable.helpers'
 import { Table, TableScrollHint } from './SolversDirectoryTable.styles'
 import { SolversDirectoryTableBody } from './SolversDirectoryTableBody'
 import { SolversDirectoryTableFilters } from './SolversDirectoryTableFilters'
@@ -15,23 +21,27 @@ interface SolversDirectoryTableProps {
 
 const SOLVER_SUFFIX_REGEX = /-solve$/i
 
-function normalizeSolverIdentifier(value: string): string {
-  return value.trim().toLowerCase().replace(SOLVER_SUFFIX_REGEX, '')
-}
-
-function findMatchingSolverId(solversInfo: SolverInfo[], solverDeeplink?: string | null): string | null {
+function findMatchingSolver(solversInfo: SolverInfo[], solverDeeplink?: string | null): SolverInfo | null {
   if (!solverDeeplink) return null
 
   const normalizedSolverDeeplink = normalizeSolverIdentifier(solverDeeplink)
 
-  const matchingSolver = solversInfo.find((solver) => {
-    const normalizedSolverId = normalizeSolverIdentifier(solver.solverId)
-    const normalizedDisplayName = normalizeSolverIdentifier(solver.displayName)
+  return (
+    solversInfo.find((solver) => {
+      const normalizedSolverId = normalizeSolverIdentifier(solver.solverId)
+      const normalizedDisplayName = normalizeSolverIdentifier(solver.displayName)
 
-    return normalizedSolverId === normalizedSolverDeeplink || normalizedDisplayName === normalizedSolverDeeplink
-  })
+      return normalizedSolverId === normalizedSolverDeeplink || normalizedDisplayName === normalizedSolverDeeplink
+    }) || null
+  )
+}
 
-  return matchingSolver?.solverId || null
+function normalizeSolverIdentifier(value: string): string {
+  return value.trim().toLowerCase().replace(SOLVER_SUFFIX_REGEX, '')
+}
+
+function shouldShowAllStatusesForSolverDeeplink(solver: SolverInfo | null): boolean {
+  return !!solver && !solver.deployments.some((deployment) => deployment.active)
 }
 
 const SOLVERS_TABLE_HEADER = (
@@ -39,8 +49,6 @@ const SOLVERS_TABLE_HEADER = (
     <th>Solver</th>
     <th>Networks</th>
     <th>Environments</th>
-    <th>Website</th>
-    <th>Description</th>
   </tr>
 )
 
@@ -52,7 +60,10 @@ export function SolversDirectoryTable({
   const [searchQuery, setSearchQuery] = useState('')
   const [networkFilter, setNetworkFilter] = useState(ALL_FILTER)
   const [environmentFilter, setEnvironmentFilter] = useState(ALL_FILTER)
-  const [activeFilter, setActiveFilter] = useState(ALL_FILTER)
+  const deeplinkedSolver = useMemo(() => findMatchingSolver(solversInfo, solverDeeplink), [solverDeeplink, solversInfo])
+  const deeplinkedSolverId = deeplinkedSolver?.solverId || null
+  const shouldShowAllStatuses = shouldShowAllStatusesForSolverDeeplink(deeplinkedSolver)
+  const [activeFilter, setActiveFilter] = useState(() => (shouldShowAllStatuses ? ALL_FILTER : ACTIVE_FILTER_ACTIVE))
   const [expandedRows, setExpandedRows] = useState<Record<string, boolean>>({})
   const [scrolledSolverId, setScrolledSolverId] = useState<string | null>(null)
 
@@ -62,14 +73,16 @@ export function SolversDirectoryTable({
     () => filterSolvers(solversInfo, searchQuery, networkFilter, environmentFilter, activeFilter),
     [activeFilter, environmentFilter, networkFilter, searchQuery, solversInfo],
   )
-  const deeplinkedSolverId = useMemo(
-    () => findMatchingSolverId(solversInfo, solverDeeplink),
-    [solverDeeplink, solversInfo],
-  )
 
   const toggleExpandedRow = useCallback((solverId: string): void => {
     setExpandedRows((current) => ({ ...current, [solverId]: !current[solverId] }))
   }, [])
+
+  useEffect(() => {
+    if (!deeplinkedSolverId || !shouldShowAllStatuses) return
+
+    setActiveFilter((current) => (current === ACTIVE_FILTER_ACTIVE ? ALL_FILTER : current))
+  }, [deeplinkedSolverId, shouldShowAllStatuses])
 
   useEffect(() => {
     onFilteredCountChange?.(filteredSolvers.length)
@@ -109,7 +122,7 @@ export function SolversDirectoryTable({
       />
       <TableScrollHint>
         <Table
-          numColumns={5}
+          numColumns={3}
           header={SOLVERS_TABLE_HEADER}
           body={
             <SolversDirectoryTableBody

--- a/apps/explorer/src/explorer/pages/SolversDirectoryTable.utils.ts
+++ b/apps/explorer/src/explorer/pages/SolversDirectoryTable.utils.ts
@@ -1,29 +1,8 @@
 import { SolverDeployment } from '../../utils/fetchSolversInfo'
 
-export function formatWebsiteUrl(url: string): string {
-  try {
-    const { hostname } = new URL(url)
-    return hostname.replace(/^www\./, '')
-  } catch {
-    return url
-  }
-}
-
 export type SummaryNetwork = {
   chainId: number
   chainName: string
-}
-
-export function mapSummaryNetworks(deployments: SolverDeployment[]): SummaryNetwork[] {
-  const byChainId = new Map<number, string>()
-
-  deployments.forEach((deployment) => {
-    byChainId.set(deployment.chainId, deployment.chainName)
-  })
-
-  return [...byChainId.entries()]
-    .map(([chainId, chainName]) => ({ chainId, chainName }))
-    .sort((a, b) => a.chainName.localeCompare(b.chainName))
 }
 
 export function mapSummaryEnvironments(deployments: SolverDeployment[]): string[] {
@@ -36,4 +15,16 @@ export function mapSummaryEnvironments(deployments: SolverDeployment[]): string[
   })
 
   return [...environments].sort()
+}
+
+export function mapSummaryNetworks(deployments: SolverDeployment[]): SummaryNetwork[] {
+  const byChainId = new Map<number, string>()
+
+  deployments.forEach((deployment) => {
+    byChainId.set(deployment.chainId, deployment.chainName)
+  })
+
+  return [...byChainId.entries()]
+    .map(([chainId, chainName]) => ({ chainId, chainName }))
+    .sort((a, b) => a.chainName.localeCompare(b.chainName))
 }

--- a/apps/explorer/src/explorer/pages/SolversDirectoryTableBody.tsx
+++ b/apps/explorer/src/explorer/pages/SolversDirectoryTableBody.tsx
@@ -6,15 +6,6 @@ import { SolverDetailsRow, SolverSummaryRow } from './SolversDirectoryTableRows'
 
 import { SolverInfo } from '../../utils/fetchSolversInfo'
 
-type SolversDirectoryTableBodyProps = {
-  filteredSolvers: SolverInfo[]
-  expandedRows: Record<string, boolean>
-  networkFilter: string
-  environmentFilter: string
-  activeFilter: string
-  onToggle: (solverId: string) => void
-}
-
 export function SolversDirectoryTableBody({
   filteredSolvers,
   expandedRows,
@@ -26,7 +17,7 @@ export function SolversDirectoryTableBody({
   if (!filteredSolvers.length) {
     return (
       <tr>
-        <td colSpan={5}>
+        <td colSpan={3}>
           <Placeholder>No solvers match your current filters.</Placeholder>
         </td>
       </tr>
@@ -53,6 +44,15 @@ export function SolversDirectoryTableBody({
       return [summary]
     }
 
-    return [summary, <SolverDetailsRow key={`${solver.solverId}-details`} solver={solver} deployments={deployments} />]
+    return [summary, <SolverDetailsRow key={`${solver.solverId}-details`} deployments={deployments} />]
   })
+}
+
+type SolversDirectoryTableBodyProps = {
+  filteredSolvers: SolverInfo[]
+  expandedRows: Record<string, boolean>
+  networkFilter: string
+  environmentFilter: string
+  activeFilter: string
+  onToggle: (solverId: string) => void
 }

--- a/apps/explorer/src/explorer/pages/SolversDirectoryTableComponents.tsx
+++ b/apps/explorer/src/explorer/pages/SolversDirectoryTableComponents.tsx
@@ -28,17 +28,47 @@ type ChainInfoEntry = {
 
 const CHAIN_INFO_BY_ID = CHAIN_INFO as Partial<Record<number, ChainInfoEntry>>
 
-function getChainIcon(chainId: number): string | undefined {
-  if (!Object.prototype.hasOwnProperty.call(CHAIN_INFO_BY_ID, chainId)) {
-    return undefined
-  }
-
-  return CHAIN_INFO_BY_ID[chainId]?.logo?.light || undefined
+export function DeploymentsSectionRows({ deployments }: { deployments: SolverDeployment[] }): React.ReactNode {
+  return (
+    <>
+      <DeploymentsGridHeader>
+        <span>Chain</span>
+        <span>Env</span>
+        <span>Solver address</span>
+      </DeploymentsGridHeader>
+      {deployments.map((deployment, index) => (
+        <DeploymentsGridRow
+          key={`${deployment.chainId}-${deployment.environment || 'na'}-${deployment.address || 'na'}-${index}`}
+        >
+          <span>{deployment.chainName}</span>
+          <span>{deployment.environment || '-'}</span>
+          {deployment.address ? (
+            <AddressLink address={deployment.address} chainId={deployment.chainId} showIcon showNetworkName={false} />
+          ) : (
+            <Mono>-</Mono>
+          )}
+        </DeploymentsGridRow>
+      ))}
+    </>
+  )
 }
 
-export function SolverIcon({ solver }: { solver: SolverInfo }): React.ReactNode {
-  if (solver.image) return <SolverLogo src={solver.image} alt={`${solver.displayName} logo`} />
-  return <SolverLogoFallback>{solver.displayName.charAt(0).toUpperCase()}</SolverLogoFallback>
+export function EnvironmentTags({
+  solverId,
+  environments,
+}: {
+  solverId: string
+  environments: string[]
+}): React.ReactNode {
+  return (
+    <EnvTags>
+      {environments.map((environment) => (
+        <EnvTag key={`${solverId}-${environment}`} $environment={environment}>
+          {environment}
+        </EnvTag>
+      ))}
+    </EnvTags>
+  )
 }
 
 export function NetworkChips({
@@ -65,60 +95,15 @@ export function NetworkChips({
   )
 }
 
-export function EnvironmentTags({
-  solverId,
-  environments,
-}: {
-  solverId: string
-  environments: string[]
-}): React.ReactNode {
-  return (
-    <EnvTags>
-      {environments.map((environment) => (
-        <EnvTag key={`${solverId}-${environment}`} $environment={environment}>
-          {environment}
-        </EnvTag>
-      ))}
-    </EnvTags>
-  )
+export function SolverIcon({ solver }: { solver: SolverInfo }): React.ReactNode {
+  if (solver.image) return <SolverLogo src={solver.image} alt={`${solver.displayName} logo`} />
+  return <SolverLogoFallback>{solver.displayName.charAt(0).toUpperCase()}</SolverLogoFallback>
 }
 
-export function DeploymentsSectionRows({
-  solver,
-  deployments,
-}: {
-  solver: SolverInfo
-  deployments: SolverDeployment[]
-}): React.ReactNode {
-  return (
-    <>
-      <DeploymentsGridHeader>
-        <span>Chain</span>
-        <span>Env</span>
-        <span>Solver address</span>
-        <span>Payout address</span>
-      </DeploymentsGridHeader>
-      {deployments.map((deployment, index) => (
-        <DeploymentsGridRow key={`${solver.solverId}-${deployment.chainId}-${deployment.environment || 'na'}-${index}`}>
-          <span>{deployment.chainName}</span>
-          <span>{deployment.environment || '-'}</span>
-          {deployment.address ? (
-            <AddressLink address={deployment.address} chainId={deployment.chainId} showIcon showNetworkName={false} />
-          ) : (
-            <Mono>-</Mono>
-          )}
-          {deployment.payoutAddress ? (
-            <AddressLink
-              address={deployment.payoutAddress}
-              chainId={deployment.chainId}
-              showIcon
-              showNetworkName={false}
-            />
-          ) : (
-            <Mono>-</Mono>
-          )}
-        </DeploymentsGridRow>
-      ))}
-    </>
-  )
+function getChainIcon(chainId: number): string | undefined {
+  if (!Object.prototype.hasOwnProperty.call(CHAIN_INFO_BY_ID, chainId)) {
+    return undefined
+  }
+
+  return CHAIN_INFO_BY_ID[chainId]?.logo?.light || undefined
 }

--- a/apps/explorer/src/explorer/pages/SolversDirectoryTableFilters.tsx
+++ b/apps/explorer/src/explorer/pages/SolversDirectoryTableFilters.tsx
@@ -5,19 +5,6 @@ import { FiX } from 'react-icons/fi'
 import { ACTIVE_FILTER_ACTIVE, ACTIVE_FILTER_INACTIVE, ALL_FILTER } from './SolversDirectoryTable.helpers'
 import { ClearInputButton, Controls, Input, SearchInputWrapper, Select } from './SolversDirectoryTable.styles'
 
-interface FiltersBarProps {
-  searchQuery: string
-  networkFilter: string
-  environmentFilter: string
-  activeFilter: string
-  networkOptions: [number, string][]
-  environmentOptions: string[]
-  setSearchQuery: (value: string) => void
-  setNetworkFilter: (value: string) => void
-  setEnvironmentFilter: (value: string) => void
-  setActiveFilter: (value: string) => void
-}
-
 export function SolversDirectoryTableFilters(props: FiltersBarProps): React.ReactNode {
   const {
     searchQuery,
@@ -38,7 +25,7 @@ export function SolversDirectoryTableFilters(props: FiltersBarProps): React.Reac
         <Input
           value={searchQuery}
           onChange={(event): void => setSearchQuery(event.target.value)}
-          placeholder="Search solver, backend ID, description, address, payout..."
+          placeholder="Search solver, backend ID, address..."
         />
         {searchQuery && (
           <ClearInputButton type="button" onClick={(): void => setSearchQuery('')} aria-label="Clear search">
@@ -69,4 +56,17 @@ export function SolversDirectoryTableFilters(props: FiltersBarProps): React.Reac
       </Select>
     </Controls>
   )
+}
+
+interface FiltersBarProps {
+  searchQuery: string
+  networkFilter: string
+  environmentFilter: string
+  activeFilter: string
+  networkOptions: [number, string][]
+  environmentOptions: string[]
+  setSearchQuery: (value: string) => void
+  setNetworkFilter: (value: string) => void
+  setEnvironmentFilter: (value: string) => void
+  setActiveFilter: (value: string) => void
 }

--- a/apps/explorer/src/explorer/pages/SolversDirectoryTableRows.tsx
+++ b/apps/explorer/src/explorer/pages/SolversDirectoryTableRows.tsx
@@ -1,8 +1,5 @@
 import React from 'react'
 
-import { ExternalLink } from '@cowprotocol/ui'
-
-import { Placeholder } from './Solvers.styles'
 import {
   DeploymentsEmpty,
   DeploymentsPanel,
@@ -14,16 +11,45 @@ import {
   SolverDetails,
   SolverId,
 } from './SolversDirectoryTable.styles'
-import { formatWebsiteUrl, mapSummaryEnvironments, mapSummaryNetworks } from './SolversDirectoryTable.utils'
+import { mapSummaryEnvironments, mapSummaryNetworks } from './SolversDirectoryTable.utils'
 import { DeploymentsSectionRows, EnvironmentTags, NetworkChips, SolverIcon } from './SolversDirectoryTableComponents'
 
 import { SolverDeployment, SolverInfo } from '../../utils/fetchSolversInfo'
 
-type SolverSummaryRowProps = {
-  solver: SolverInfo
-  deployments: SolverDeployment[]
-  isExpanded: boolean
-  onToggle: (solverId: string) => void
+export function SolverDetailsRow({ deployments }: SolverDetailsRowProps): React.ReactNode {
+  const activeDeployments = deployments.filter((deployment) => deployment.active)
+  const inactiveDeployments = deployments.filter((deployment) => !deployment.active)
+  const hasActiveDeployments = activeDeployments.length > 0
+  const hasInactiveDeployments = inactiveDeployments.length > 0
+  const hasAnyDeployments = hasActiveDeployments || hasInactiveDeployments
+
+  return (
+    <tr className="solver-details-row">
+      <td colSpan={3}>
+        <DeploymentsPanel>
+          <DeploymentsPanelTitle>Solver addresses by chain/environment</DeploymentsPanelTitle>
+          {hasAnyDeployments ? (
+            <>
+              {hasActiveDeployments && (
+                <DeploymentsSection>
+                  <DeploymentsSectionTitle>Active</DeploymentsSectionTitle>
+                  <DeploymentsSectionRows deployments={activeDeployments} />
+                </DeploymentsSection>
+              )}
+              {hasInactiveDeployments && (
+                <DeploymentsSection $muted>
+                  <DeploymentsSectionTitle $muted>Inactive</DeploymentsSectionTitle>
+                  <DeploymentsSectionRows deployments={inactiveDeployments} />
+                </DeploymentsSection>
+              )}
+            </>
+          ) : (
+            <DeploymentsEmpty>No deployments match the current filters.</DeploymentsEmpty>
+          )}
+        </DeploymentsPanel>
+      </td>
+    </tr>
+  )
 }
 
 export function SolverSummaryRow({
@@ -60,57 +86,17 @@ export function SolverSummaryRow({
       <td className="envs">
         <EnvironmentTags solverId={solver.solverId} environments={environments} />
       </td>
-      <td className="website">
-        {solver.website ? (
-          <ExternalLink href={solver.website} target="_blank">
-            {formatWebsiteUrl(solver.website)} ↗
-          </ExternalLink>
-        ) : (
-          <Placeholder>-</Placeholder>
-        )}
-      </td>
-      <td className="description">{solver.description || <Placeholder>-</Placeholder>}</td>
     </tr>
   )
 }
 
 type SolverDetailsRowProps = {
-  solver: SolverInfo
   deployments: SolverDeployment[]
 }
 
-export function SolverDetailsRow({ solver, deployments }: SolverDetailsRowProps): React.ReactNode {
-  const activeDeployments = deployments.filter((deployment) => deployment.active)
-  const inactiveDeployments = deployments.filter((deployment) => !deployment.active)
-  const hasActiveDeployments = activeDeployments.length > 0
-  const hasInactiveDeployments = inactiveDeployments.length > 0
-  const hasAnyDeployments = hasActiveDeployments || hasInactiveDeployments
-
-  return (
-    <tr className="solver-details-row">
-      <td colSpan={5}>
-        <DeploymentsPanel>
-          <DeploymentsPanelTitle>Solver and payout addresses by chain/environment</DeploymentsPanelTitle>
-          {hasAnyDeployments ? (
-            <>
-              {hasActiveDeployments && (
-                <DeploymentsSection>
-                  <DeploymentsSectionTitle>Active</DeploymentsSectionTitle>
-                  <DeploymentsSectionRows solver={solver} deployments={activeDeployments} />
-                </DeploymentsSection>
-              )}
-              {hasInactiveDeployments && (
-                <DeploymentsSection $muted>
-                  <DeploymentsSectionTitle $muted>Inactive</DeploymentsSectionTitle>
-                  <DeploymentsSectionRows solver={solver} deployments={inactiveDeployments} />
-                </DeploymentsSection>
-              )}
-            </>
-          ) : (
-            <DeploymentsEmpty>No deployments match the current filters.</DeploymentsEmpty>
-          )}
-        </DeploymentsPanel>
-      </td>
-    </tr>
-  )
+type SolverSummaryRowProps = {
+  solver: SolverInfo
+  deployments: SolverDeployment[]
+  isExpanded: boolean
+  onToggle: (solverId: string) => void
 }

--- a/apps/explorer/src/hooks/useSolversFeatureFlag.ts
+++ b/apps/explorer/src/hooks/useSolversFeatureFlag.ts
@@ -1,0 +1,11 @@
+import { useFlags } from 'launchdarkly-react-client-sdk'
+
+export function useSolversFeatureFlag(): boolean {
+  const flags = useFlags() as SolversFeatureFlags
+
+  return flags.isSolversEnabled ?? false
+}
+
+type SolversFeatureFlags = {
+  isSolversEnabled?: boolean
+}

--- a/apps/explorer/src/test/components/fillsTable.test.tsx
+++ b/apps/explorer/src/test/components/fillsTable.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+
+import { render, screen } from '@testing-library/react'
+
+jest.mock('../../components/orders/OrderDetails/FillsTableRow', () => ({
+  FillsTableRow: (): React.ReactNode => (
+    <tr>
+      <td>Mock fill row</td>
+    </tr>
+  ),
+}))
+
+import { FillsTable } from '../../components/orders/OrderDetails/FillsTable'
+
+const TABLE_STATE = {
+  pageSize: 10,
+  pageOffset: 0,
+}
+
+describe('FillsTable', () => {
+  it('shows the solver column when solver details are enabled', () => {
+    render(
+      <FillsTable
+        trades={[]}
+        order={null}
+        tableState={TABLE_STATE}
+        isPriceInverted={false}
+        invertPrice={jest.fn()}
+        showSolverDetails
+      />,
+    )
+
+    expect(screen.getByText('Solver')).not.toBeNull()
+  })
+
+  it('hides the solver column when solver details are disabled', () => {
+    render(
+      <FillsTable
+        trades={[]}
+        order={null}
+        tableState={TABLE_STATE}
+        isPriceInverted={false}
+        invertPrice={jest.fn()}
+        showSolverDetails={false}
+      />,
+    )
+
+    expect(screen.queryByText('Solver')).toBeNull()
+  })
+})

--- a/apps/explorer/src/test/components/mainMenu.test.ts
+++ b/apps/explorer/src/test/components/mainMenu.test.ts
@@ -1,0 +1,23 @@
+import { getMainMenu } from '../../components/common/MenuDropdown/mainMenu'
+import { MenuItemKind } from '../../components/common/MenuDropdown/types'
+
+function getOtherSectionLinkTitles(isSolversEnabled: boolean): string[] {
+  const menu = getMainMenu(isSolversEnabled)
+  const moreItem = menu.find((item) => item.kind === MenuItemKind.DROP_DOWN)
+
+  if (!moreItem || moreItem.kind !== MenuItemKind.DROP_DOWN) {
+    return []
+  }
+
+  return moreItem.items.find((item) => item.sectionTitle === 'OTHER')?.links.map((link) => link.title) || []
+}
+
+describe('getMainMenu', () => {
+  it('includes the Solvers link when the feature is enabled', () => {
+    expect(getOtherSectionLinkTitles(true)).toEqual(['Solvers', 'AppData'])
+  })
+
+  it('removes the Solvers link when the feature is disabled', () => {
+    expect(getOtherSectionLinkTitles(false)).toEqual(['AppData'])
+  })
+})

--- a/apps/explorer/src/test/components/verboseDetails.test.tsx
+++ b/apps/explorer/src/test/components/verboseDetails.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+
+import { render, screen } from '@testing-library/react'
+
+import { VerboseDetails } from '../../components/orders/DetailsTable/VerboseDetails'
+import { RICH_ORDER } from '../data/operator'
+
+jest.mock('../../components/orders/DetailsTable/SolvedByBadge', () => ({
+  SolvedByBadge: ({ solvedBy }: { solvedBy?: { displayName?: string } }): React.ReactNode => (
+    <span>{solvedBy?.displayName || '-'}</span>
+  ),
+}))
+
+jest.mock('../../components/common/DetailRow', () => ({
+  DetailRow: ({ label, children }: { label: string; children: React.ReactNode }): React.ReactNode => (
+    <div>
+      <span>{label}</span>
+      {children}
+    </div>
+  ),
+}))
+
+jest.mock('../../components/orders/FilledProgress', () => ({
+  FilledProgress: (): React.ReactNode => <span>FilledProgress</span>,
+}))
+
+jest.mock('../../components/orders/GasFeeDisplay', () => ({
+  GasFeeDisplay: (): React.ReactNode => <span>GasFeeDisplay</span>,
+}))
+
+jest.mock('../../components/orders/OrderPriceDisplay', () => ({
+  OrderPriceDisplay: (): React.ReactNode => <span>OrderPriceDisplay</span>,
+}))
+
+jest.mock('../../components/orders/OrderSurplusDisplay', () => ({
+  OrderSurplusDisplay: (): React.ReactNode => <span>OrderSurplusDisplay</span>,
+}))
+
+jest.mock('../../components/orders/OrderHooksDetails', () => ({
+  OrderHooksDetails: ({ children }: { children: (content: React.ReactNode) => React.ReactNode }): React.ReactNode => (
+    <>{children('Hooks content')}</>
+  ),
+}))
+
+jest.mock('../../components/AppData/DecodeAppData', () => ({
+  DecodeAppData: (): React.ReactNode => <span>DecodeAppData</span>,
+}))
+
+jest.mock('../../components/common/Spinner', () => ({
+  __esModule: true,
+  default: (): React.ReactNode => <span>Spinner</span>,
+}))
+
+describe('VerboseDetails', () => {
+  const defaultProps = {
+    order: RICH_ORDER,
+    solvedBy: {
+      solverId: 'alpha-solver',
+      displayName: 'Alpha Solver',
+      image: undefined,
+    },
+    isSolvedByLoading: false,
+    isPriceInverted: false,
+    invertPrice: jest.fn(),
+    showFillsButton: false,
+    viewFills: jest.fn(),
+  }
+
+  it('shows the solved by row when solver details are enabled', () => {
+    render(<VerboseDetails {...defaultProps} showSolverDetails />)
+
+    expect(screen.getByText('Solved by')).not.toBeNull()
+    expect(screen.getByText('Alpha Solver')).not.toBeNull()
+  })
+
+  it('hides the solved by row when solver details are disabled', () => {
+    render(<VerboseDetails {...defaultProps} showSolverDetails={false} />)
+
+    expect(screen.queryByText('Solved by')).toBeNull()
+    expect(screen.queryByText('Alpha Solver')).toBeNull()
+  })
+})

--- a/apps/explorer/src/test/hooks/useSolversFeatureFlag.test.tsx
+++ b/apps/explorer/src/test/hooks/useSolversFeatureFlag.test.tsx
@@ -1,0 +1,33 @@
+import { renderHook } from '@testing-library/react'
+
+import { useSolversFeatureFlag } from '../../hooks/useSolversFeatureFlag'
+
+jest.mock('launchdarkly-react-client-sdk', () => ({
+  useFlags: jest.fn(),
+}))
+
+const { useFlags } = jest.requireMock('launchdarkly-react-client-sdk') as {
+  useFlags: jest.Mock
+}
+
+describe('useSolversFeatureFlag', () => {
+  beforeEach(() => {
+    useFlags.mockReset()
+  })
+
+  it('defaults to disabled when the LaunchDarkly flag is missing', () => {
+    useFlags.mockReturnValue({})
+
+    const { result } = renderHook(() => useSolversFeatureFlag())
+
+    expect(result.current).toBe(false)
+  })
+
+  it('returns the LaunchDarkly flag value when provided', () => {
+    useFlags.mockReturnValue({ isSolversEnabled: false })
+
+    const { result } = renderHook(() => useSolversFeatureFlag())
+
+    expect(result.current).toBe(false)
+  })
+})

--- a/apps/explorer/src/test/pages/solversDirectoryTable.deeplink.test.tsx
+++ b/apps/explorer/src/test/pages/solversDirectoryTable.deeplink.test.tsx
@@ -38,6 +38,22 @@ const SOLVERS_INFO: SolversInfo = [
       },
     ],
   },
+  {
+    solverId: 'gamma',
+    displayName: 'Gamma Solver',
+    description: 'Gamma description',
+    website: 'https://gamma.example',
+    image: undefined,
+    networks: [{ chainId: 1, chainName: 'Ethereum', environments: ['staging'] }],
+    deployments: [
+      {
+        chainId: 1,
+        chainName: 'Ethereum',
+        environment: 'staging',
+        active: false,
+      },
+    ],
+  },
 ]
 
 describe('SolversDirectoryTable deeplink', () => {
@@ -63,7 +79,9 @@ describe('SolversDirectoryTable deeplink', () => {
     })
 
     expect(scrollIntoViewMock).toHaveBeenCalled()
-    expect(screen.getByText('Solver and payout addresses by chain/environment')).not.toBeNull()
+    expect(screen.getByText('Solver addresses by chain/environment')).not.toBeNull()
+    expect(screen.getAllByText('Active')).toHaveLength(2)
+    expect(screen.queryByText('Payout address')).toBeNull()
   })
 
   it('matches deeplink by normalized identifier', async () => {
@@ -76,5 +94,22 @@ describe('SolversDirectoryTable deeplink', () => {
     await waitFor(() => {
       expect(toggleButton.getAttribute('aria-expanded')).toBe('true')
     })
+  })
+
+  it('shows inactive deeplinked solvers by widening the status filter', async () => {
+    render(<SolversDirectoryTable solversInfo={SOLVERS_INFO} solverDeeplink="gamma" />)
+
+    expect(screen.getByDisplayValue('All statuses')).not.toBeNull()
+
+    const toggleButton = screen.getByRole('button', {
+      name: 'Toggle deployments for solver Gamma Solver (gamma)',
+    })
+
+    await waitFor(() => {
+      expect(toggleButton.getAttribute('aria-expanded')).toBe('true')
+    })
+
+    expect(screen.getByText('Gamma Solver')).not.toBeNull()
+    expect(screen.getByRole('heading', { name: 'Inactive' })).not.toBeNull()
   })
 })

--- a/apps/explorer/src/test/pages/solversDirectoryTable.defaultActive.test.tsx
+++ b/apps/explorer/src/test/pages/solversDirectoryTable.defaultActive.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+
+import { render, screen } from '@testing-library/react'
+
+import { SolversDirectoryTable } from '../../explorer/pages/SolversDirectoryTable'
+import { SolversInfo } from '../../utils/fetchSolversInfo'
+
+const SOLVERS_INFO: SolversInfo = [
+  {
+    solverId: 'active-solver',
+    displayName: 'Active Solver',
+    description: 'Active description',
+    website: 'https://active.example',
+    image: undefined,
+    networks: [{ chainId: 1, chainName: 'Ethereum', environments: ['prod'] }],
+    deployments: [
+      {
+        chainId: 1,
+        chainName: 'Ethereum',
+        environment: 'prod',
+        active: true,
+      },
+    ],
+  },
+  {
+    solverId: 'inactive-solver',
+    displayName: 'Inactive Solver',
+    description: 'Inactive description',
+    website: 'https://inactive.example',
+    image: undefined,
+    networks: [{ chainId: 1, chainName: 'Ethereum', environments: ['prod'] }],
+    deployments: [
+      {
+        chainId: 1,
+        chainName: 'Ethereum',
+        environment: 'prod',
+        active: false,
+      },
+    ],
+  },
+]
+
+describe('SolversDirectoryTable default active filter', () => {
+  it('shows only active solvers on initial render', () => {
+    render(<SolversDirectoryTable solversInfo={SOLVERS_INFO} />)
+
+    expect(screen.getByDisplayValue('Active')).not.toBeNull()
+    expect(screen.getByText('Active Solver')).not.toBeNull()
+    expect(screen.queryByText('Inactive Solver')).toBeNull()
+    expect(screen.queryByText('Website')).toBeNull()
+    expect(screen.queryByText('Description')).toBeNull()
+  })
+})

--- a/apps/explorer/src/test/pages/solversDirectoryTable.helpers.test.ts
+++ b/apps/explorer/src/test/pages/solversDirectoryTable.helpers.test.ts
@@ -82,7 +82,7 @@ const SOLVERS_INFO: SolversInfo = [
   },
 ]
 
-describe('filterSolvers active filter', () => {
+describe('SolversDirectoryTable helpers', () => {
   it('returns all matching solvers when status filter is All', () => {
     const result = filterSolvers(SOLVERS_INFO, '', ALL_FILTER, ALL_FILTER, ALL_FILTER)
 
@@ -107,13 +107,13 @@ describe('filterSolvers active filter', () => {
     expect(result).toEqual([])
   })
 
-  it('does not match addresses from deployments hidden by active filter', () => {
+  it('does not match addresses from inactive deployments', () => {
     const result = filterSolvers(SOLVERS_INFO, '0xalpha2', ALL_FILTER, ALL_FILTER, ACTIVE_FILTER_ACTIVE)
 
     expect(result).toEqual([])
   })
 
-  it('matches addresses from deployments visible under current filters', () => {
+  it('matches addresses from active deployments', () => {
     const result = filterSolvers(SOLVERS_INFO, '0xalpha1', ALL_FILTER, ALL_FILTER, ACTIVE_FILTER_ACTIVE)
 
     expect(result.map((solver) => solver.solverId)).toEqual(['alpha'])

--- a/apps/explorer/src/test/pages/solversDirectoryTableFilters.test.tsx
+++ b/apps/explorer/src/test/pages/solversDirectoryTableFilters.test.tsx
@@ -46,4 +46,11 @@ describe('SolversDirectoryTableFilters', () => {
 
     expect(screen.queryByRole('button', { name: 'Clear search' })).toBeNull()
   })
+
+  it('renders status select', () => {
+    renderFilters()
+
+    expect(screen.getAllByRole('combobox')).toHaveLength(3)
+    expect(screen.getByText('All statuses')).not.toBeNull()
+  })
 })


### PR DESCRIPTION
 # Summary

  Adds a feature-flagged solver directory experience in Explorer and tightens the solver-related UI across the app.

  This PR:

  - gates the /solvers page, header navigation entry, and solver details in order/transaction views behind isSolversEnabled
  - makes the LaunchDarkly check fail closed while flags are still uninitialized
  - updates the solvers directory to focus on deployment data only by removing Website, Description, and payout addresses
  - keeps the status filter available, defaults the directory to Active, and preserves deeplinks for inactive historical solvers by widening to All when needed
  - updates the expanded deployments table to the new three-column layout and refreshes targeted Explorer tests

  # To Test

  1. Solvers page with the feature flag enabled

  - [ ] Open /solvers
  - [ ] Verify the page loads and the Solvers menu item is visible in the header
  - [ ] Verify the directory defaults to the Active status filter
  - [ ] Verify the table only shows Solver, Networks, and Environments
  - [ ] Verify Website and Description are not shown
  - [ ] Expand a solver row and verify payout addresses are not shown
  - [ ] Verify expanded deployments still separate Active and Inactive rows when applicable
  - [ ] Verify the status dropdown still lets you switch between All, Active, and Inactive

  2. Historical solver deeplink behavior

  - [ ] Open a solver deeplink for an inactive-only solver, for example from a historical order’s Solved by link
  - [ ] Verify the target solver row is visible, expanded, and scrolled into view
  - [ ] Verify the page does not hide that solver behind the default Active filter
  - [ ] Verify the status filter shows All statuses for that deeplinked case

  3. Solvers feature flag disabled

  - [ ] Turn off isSolversEnabled in LaunchDarkly and reload Explorer
  - [ ] Verify the Solvers menu item is hidden
  - [ ] Verify /solvers is no longer directly routable
  - [ ] Open an order/transaction details page
  - [ ] Verify the Solved by row is hidden
  - [ ] Verify the fills table does not show the Solver column

  # Background

  The main follow-up fixes here were around rollout safety and historical navigation:

  - the LaunchDarkly solver flag now defaults to disabled until flags are available, so the gated UI does not flash on before initialization completes
  - the solvers directory still defaults to Active for normal visits, but deeplinks to inactive historical solvers stay functional by automatically widening the status filter when required