### PR TITLE
fix(twap): display part sell amount before all fees

### DIFF
--- a/apps/cowswap-frontend/src/modules/twap/containers/AmountParts/index.test.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/AmountParts/index.test.tsx
@@ -1,0 +1,116 @@
+import { useAtomValue } from 'jotai'
+
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { CurrencyAmount, Token } from '@cowprotocol/currency'
+
+import { render, screen } from '@testing-library/react'
+
+import { useGetReceiveAmountInfo, ReceiveAmountInfo } from 'modules/trade'
+import { useUsdAmount } from 'modules/usdAmount'
+
+import { AmountParts } from '.'
+
+jest.mock('jotai', () => ({
+  ...jest.requireActual('jotai'),
+  useAtomValue: jest.fn(),
+}))
+
+jest.mock('modules/trade', () => ({
+  useGetReceiveAmountInfo: jest.fn(),
+}))
+
+jest.mock('modules/usdAmount', () => ({
+  useUsdAmount: jest.fn().mockReturnValue({ value: null }),
+}))
+
+jest.mock('@lingui/react', () => ({
+  useLingui: () => ({
+    _: (descriptor: { message?: string; id?: string }) => descriptor.message ?? descriptor.id ?? '',
+  }),
+}))
+
+jest.mock('@cowprotocol/ui', () => ({
+  ...jest.requireActual('@cowprotocol/ui'),
+  // Render amount as readable text so we can assert on it
+  TokenAmount: ({ amount }: { amount: CurrencyAmount<Token> | null }) => (
+    <span data-testid="token-amount">{amount ? `${amount.toSignificant(6)} ${amount.currency.symbol}` : ''}</span>
+  ),
+  FiatAmount: () => null,
+  HelpTooltip: () => null,
+  renderTooltip: (x: unknown) => x,
+}))
+
+const useAtomValueMock = useAtomValue as jest.MockedFunction<typeof useAtomValue>
+const useGetReceiveAmountInfoMock = useGetReceiveAmountInfo as jest.MockedFunction<typeof useGetReceiveAmountInfo>
+
+const USDC = new Token(SupportedChainId.MAINNET, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 6, 'USDC', 'USD Coin')
+const WETH = new Token(
+  SupportedChainId.MAINNET,
+  '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+  18,
+  'WETH',
+  'Wrapped Ether',
+)
+
+// Dummy placeholder amounts used as fillers for fields not under test
+const ZERO_USDC = CurrencyAmount.fromRawAmount(USDC, '0')
+const ZERO_WETH = CurrencyAmount.fromRawAmount(WETH, '0')
+
+function buildReceiveAmountInfo(
+  sellAmount: CurrencyAmount<Token>,
+  buyAmount: CurrencyAmount<Token>,
+): ReceiveAmountInfo {
+  const currencies = { sellAmount, buyAmount }
+  return {
+    isSell: true,
+    quotePrice: null as never,
+    costs: {
+      networkFee: { amountInSellCurrency: ZERO_USDC, amountInBuyCurrency: ZERO_WETH },
+      partnerFee: { amount: ZERO_USDC, bps: 0 },
+    },
+    beforeAllFees: currencies,
+    beforeNetworkCosts: currencies,
+    afterNetworkCosts: currencies,
+    afterPartnerFees: currencies,
+    afterSlippage: currencies,
+    amountsToSign: currencies,
+  }
+}
+
+describe('AmountParts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    useAtomValueMock.mockReturnValue({ numberOfPartsValue: 5 })
+    ;(useUsdAmount as jest.Mock).mockReturnValue({ value: null })
+  })
+
+  it('sell amount displays beforeAllFees.sellAmount', () => {
+    const sellAmount = CurrencyAmount.fromRawAmount(USDC, '3000000') // 3 USDC
+    useGetReceiveAmountInfoMock.mockReturnValue({
+      ...buildReceiveAmountInfo(ZERO_USDC, ZERO_WETH),
+      beforeAllFees: { sellAmount, buyAmount: ZERO_WETH },
+      afterPartnerFees: { sellAmount: ZERO_USDC, buyAmount: ZERO_WETH },
+    })
+
+    render(<AmountParts />)
+
+    const [sellAmountEl] = screen.getAllByTestId('token-amount')
+    expect(sellAmountEl.textContent).toBe('3 USDC')
+  })
+
+  it('buy amount displays afterPartnerFees.buyAmount', () => {
+    const sellAmount = CurrencyAmount.fromRawAmount(USDC, '3000000') // 3 USDC
+    const buyAmount = CurrencyAmount.fromRawAmount(WETH, '1500000000000000000') // 1.5 WETH
+
+    useGetReceiveAmountInfoMock.mockReturnValue({
+      ...buildReceiveAmountInfo(ZERO_USDC, ZERO_WETH),
+      beforeAllFees: { sellAmount: ZERO_USDC, buyAmount: ZERO_WETH },
+      afterPartnerFees: { sellAmount, buyAmount },
+    })
+
+    render(<AmountParts />)
+
+    const [, buyAmountEl] = screen.getAllByTestId('token-amount')
+    expect(buyAmountEl.textContent).toBe('1.5 WETH')
+  })
+})

--- a/apps/cowswap-frontend/src/modules/twap/containers/AmountParts/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/AmountParts/index.tsx
@@ -22,9 +22,7 @@ interface TradeAmountPreviewProps {
   children?: ReactNode
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function AmountParts() {
+export function AmountParts(): ReactNode {
   const {
     sellAmount: { label: sellLabel, tooltip: sellTooltip },
     buyAmount: { label: buyLabel, tooltip: buyTooltip },
@@ -34,7 +32,8 @@ export function AmountParts() {
 
   const receiveAmountInfo = useGetReceiveAmountInfo()
 
-  const { sellAmount: inputPartAmount, buyAmount: outputPartAmount } = receiveAmountInfo?.afterPartnerFees || {}
+  const { sellAmount: inputPartAmount } = receiveAmountInfo?.beforeAllFees || {}
+  const { buyAmount: outputPartAmount } = receiveAmountInfo?.afterPartnerFees || {}
 
   const inputPartAmountUsd = useUsdAmount(inputPartAmount).value
   const outputPartAmountUsd = useUsdAmount(outputPartAmount).value
@@ -66,9 +65,7 @@ export function AmountParts() {
   )
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function TradeAmountPreview(props: TradeAmountPreviewProps) {
+function TradeAmountPreview(props: TradeAmountPreviewProps): ReactNode {
   const { amount, usdAmount, label, tooltip, children } = props
 
   return (

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useTwapFormState.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useTwapFormState.ts
@@ -16,7 +16,7 @@ export function useTwapFormState(): TwapFormState | null {
   const twapOrder = useTwapOrder()
 
   const receiveAmountInfo = useGetReceiveAmountInfo()
-  const { sellAmount } = receiveAmountInfo?.afterPartnerFees || {}
+  const { sellAmount } = receiveAmountInfo?.beforeAllFees || {}
   const sellAmountPartFiat = useUsdAmount(sellAmount).value
 
   const partTime = useAtomValue(twapTimeIntervalAtom)


### PR DESCRIPTION
# Summary

<img width="442" height="659" alt="image" src="https://github.com/user-attachments/assets/d08e59b1-a408-4768-9a98-9cc4b3c837cb" />

# To Test

1. Setup a TWAP trade
- [ ] AR: "Sell per part" is less than `sellAmount / num. of parts`
- [ ] ER: "Sell per part" must be `sellAmount / num. of parts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for TWAP amount display functionality.

* **Bug Fixes**
  * Corrected input amount display in TWAP trades to use the appropriate pre-fees data source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->