### PR TITLE
fix: bump tokens limit on import

### DIFF
--- a/libs/tokens/src/hooks/lists/useAddList.ts
+++ b/libs/tokens/src/hooks/lists/useAddList.ts
@@ -6,23 +6,7 @@ import { addListAtom } from '../../state/tokenLists/tokenListsActionsAtom'
 import { listsStatesByChainAtom } from '../../state/tokenLists/tokenListsStateAtom'
 import { ListState } from '../../types'
 
-const TOKEN_LISTS_CONTENT_LIMIT = 5000
-
-function getTokenListsStateCount(states: ListState[]): number {
-  return states
-    .map((item) => (item ? item.list.tokens.length : 0))
-    .flat()
-    .reduce((acc, count) => acc + count, 0)
-}
-
-function getTokenListsLimitError(currentStateCount: number, updateCount: number): string {
-  return `
-Cannot add token list.
-Token lists content limit exceeded: ${TOKEN_LISTS_CONTENT_LIMIT}.
-Current tokens count: ${currentStateCount}.
-Tokens in update: ${updateCount}.
-  `
-}
+const TOKEN_LISTS_CONTENT_LIMIT = 10_000
 
 export function useAddList(onAddList: (source: string) => void): (state: ListState) => void {
   const { chainId } = useAtomValue(environmentAtom)
@@ -37,7 +21,7 @@ export function useAddList(onAddList: (source: string) => void): (state: ListSta
       const updateCount = getTokenListsStateCount([state])
       const totalCount = currentStateCount + updateCount
 
-      // Due to localStorage limit, we need to limit the amount of tokens we can store
+      // Limit token lists volume to control app performance
       if (totalCount > TOKEN_LISTS_CONTENT_LIMIT) {
         throw new Error(getTokenListsLimitError(currentStateCount, updateCount))
       }
@@ -47,4 +31,20 @@ export function useAddList(onAddList: (source: string) => void): (state: ListSta
     },
     [addList, listsStatesByChain, chainId, onAddList],
   )
+}
+
+function getTokenListsLimitError(currentStateCount: number, updateCount: number): string {
+  return `
+Cannot add token list.
+Token lists content limit exceeded: ${TOKEN_LISTS_CONTENT_LIMIT}.
+Current tokens count: ${currentStateCount}.
+Tokens in update: ${updateCount}.
+  `
+}
+
+function getTokenListsStateCount(states: ListState[]): number {
+  return states
+    .map((item) => (item ? item.list.tokens.length : 0))
+    .flat()
+    .reduce((acc, count) => acc + count, 0)
 }


### PR DESCRIPTION
# Summary

There is a request from one of the widget users.
They are using token lists which are exceeding the 5000 tokens limit.
Since we don't use localStorage anymore (IndexedDB instead), we can increase the limit.

<img width="465" height="485" alt="image" src="https://github.com/user-attachments/assets/f4c5e23e-51ad-4634-8d5e-1b06c233070f" />


# To Test

1. Import different token lists
2. Once you've imported too many of lists, you should see the error, but with 10000.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased token list content capacity from 5,000 to 10,000 tokens, enabling users to work with larger collections.

* **Chores**
  * Reorganized internal code structure for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->