### PR TITLE
fix(affiliate): conflict in prod & staging dashboards

### DIFF
--- a/apps/cowswap-frontend/src/modules/affiliate/misc/affiliate_data_issues.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/affiliate_data_issues.sql
@@ -12,6 +12,8 @@ params as (
 select
   base.block_time,
   base.environment,
+  base.app_data_app_code,
+  base.order_class,
   base.protocol_fee_volume_bps,
   base.referrer_code,
   base.blockchain,
@@ -22,6 +24,7 @@ from (
   select
     trades.*,
     coalesce(ad.environment, ad.widget_environment) as environment,
+    ad.app_code as app_data_app_code,
     lower(cast(trades.trader as varchar)) as trader_address
   from dune.cowprotocol.result_fac_trades as trades
   left join query_5172256 as ad
@@ -31,6 +34,7 @@ from (
   where
     trades.block_time >= cast(params.start_date as timestamp)
     and (not params.has_referrer or trades.referrer_code is not null)
+    and lower(coalesce(trades.swap_source, '')) != 'integrations'
 ) base
 cross join params
 where

--- a/apps/cowswap-frontend/src/modules/affiliate/misc/affiliate_data_issues.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/affiliate_data_issues.sql
@@ -1,0 +1,45 @@
+with
+params as (
+  select
+    case
+      when '{{start_date}}' in ('', 'default value') then date '2026-04-01'
+      else cast('{{start_date}}' as date)
+    end as start_date,
+    case when '{{has_referrer}}' = 'true' then true else false end as has_referrer,
+    case when '{{show_missing_env}}' = 'true' then true else false end as show_missing_env,
+    case when '{{show_missing_fee}}' = 'true' then true else false end as show_missing_fee
+)
+select
+  base.block_time,
+  base.environment,
+  base.protocol_fee_volume_bps,
+  base.referrer_code,
+  base.blockchain,
+  base.order_uid,
+  base.trader_address,
+  base.*
+from (
+  select
+    trades.*,
+    coalesce(ad.environment, ad.widget_environment) as environment,
+    lower(cast(trades.trader as varchar)) as trader_address
+  from dune.cowprotocol.result_fac_trades as trades
+  left join query_5172256 as ad
+    on ad.blockchain = trades.blockchain
+    and ad.app_hash = trades.app_data
+  cross join params
+  where
+    trades.block_time >= cast(params.start_date as timestamp)
+    and (not params.has_referrer or trades.referrer_code is not null)
+) base
+cross join params
+where
+  (
+    params.show_missing_env
+    and base.environment is null
+  )
+  or (
+    params.show_missing_fee
+    and base.protocol_fee_volume_bps is null
+  )
+order by base.block_time desc, base.order_uid desc;

--- a/apps/cowswap-frontend/src/modules/affiliate/misc/affiliates.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/affiliates.sql
@@ -4,6 +4,10 @@ params as (
     split('{{blockchain}}', ',') as blockchains,
     case when '{{is_staging_env}}' = 'true' then true else false end as is_staging_env,
     case
+      when '{{start_date}}' in ('', 'default value') then date '2026-01-01'
+      else cast('{{start_date}}' as date)
+    end as start_date,
+    case
       when '{{affiliate_payout_sources}}' in ('', 'default value') then cast(array[] as array(varchar))
       else transform(split('{{affiliate_payout_sources}}', ','), x -> lower(trim(x)))
     end as affiliate_payout_sources
@@ -61,6 +65,7 @@ trades_with_referrer as (
   cross join constants
   where
     if(array_position(params.blockchains, '-=All=-') > 0, true, array_position(params.blockchains, dune.cowprotocol.result_fac_trades.blockchain) > 0)
+    and dune.cowprotocol.result_fac_trades.block_time >= cast(params.start_date as timestamp)
 ),
 first_trade as (
   select trader, min(block_time) as first_trade_time
@@ -144,7 +149,7 @@ payouts as (
   cross join unnest(params.affiliate_payout_sources) as ps(payout_source)
   where lower(to_hex("from")) = replace(ps.payout_source, '0x', '')
     and contract_address = 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48
-    and evt_block_time >= date '2026-01-01'
+    and evt_block_time >= cast(params.start_date as timestamp)
   group by 1
 )
 select

--- a/apps/cowswap-frontend/src/modules/affiliate/misc/affiliates.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/affiliates.sql
@@ -52,10 +52,9 @@ trades_with_referrer as (
     dune.cowprotocol.result_fac_trades.usd_value as usd_value,
     dune.cowprotocol.result_fac_trades.referrer_code as referrer_code,
     dune.cowprotocol.result_fac_trades.swap_source as swap_source,
-    dune.cowprotocol.result_fac_trades.protocol_fee_bps,
     dune.cowprotocol.result_fac_trades.protocol_fee_volume_bps,
     (
-      coalesce(dune.cowprotocol.result_fac_trades.protocol_fee_volume_bps, 1e9) < constants.min_fee_bps
+      coalesce(dune.cowprotocol.result_fac_trades.protocol_fee_volume_bps, 0) < constants.min_fee_bps
     ) as is_excluded_low_fee,
     (
       lower(coalesce(dune.cowprotocol.result_fac_trades.swap_source, '')) = 'integrations'

--- a/apps/cowswap-frontend/src/modules/affiliate/misc/affiliates.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/affiliates.sql
@@ -134,6 +134,7 @@ affiliate_rewards as (
       distinct case
         when (bound_time + time_cap_days * interval '1' day) > now() and (volume_cap = 0 or cum_volume < volume_cap)
           then trader
+        else null
       end
     ) as active_traders
   from capped_trades

--- a/apps/cowswap-frontend/src/modules/affiliate/misc/affiliates.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/affiliates.sql
@@ -73,10 +73,8 @@ trades_with_referrer as (
     if(array_position(params.blockchains, '-=All=-') > 0, true, array_position(params.blockchains, dune.cowprotocol.result_fac_trades.blockchain) > 0)
     and if(
       params.is_staging_env,
-      app_data.environment is not null
-        and app_data.environment <> 'production',
-      app_data.environment is null
-        or app_data.environment = 'production'
+      app_data.environment in ('local', 'development', 'pr'),
+      app_data.environment in ('production', 'staging', 'ens')
     )
 ),
 first_trade as (

--- a/apps/cowswap-frontend/src/modules/affiliate/misc/affiliates.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/affiliates.sql
@@ -4,13 +4,16 @@ params as (
     split('{{blockchain}}', ',') as blockchains,
     case when '{{is_staging_env}}' = 'true' then true else false end as is_staging_env,
     case
-      when '{{start_date}}' in ('', 'default value') then date '2026-01-01'
-      else cast('{{start_date}}' as date)
-    end as start_date,
-    case
       when '{{affiliate_payout_sources}}' in ('', 'default value') then cast(array[] as array(varchar))
       else transform(split('{{affiliate_payout_sources}}', ','), x -> lower(trim(x)))
     end as affiliate_payout_sources
+),
+app_data as (
+  select
+    blockchain,
+    app_hash,
+    coalesce(environment, widget_environment) as environment
+  from query_5172256
 ),
 constants as (
   -- Exclude very low fee swaps from counting towards affiliate eligible volume.
@@ -53,6 +56,7 @@ trades_with_referrer as (
     dune.cowprotocol.result_fac_trades.referrer_code as referrer_code,
     dune.cowprotocol.result_fac_trades.swap_source as swap_source,
     dune.cowprotocol.result_fac_trades.protocol_fee_volume_bps,
+    app_data.environment,
     (
       coalesce(dune.cowprotocol.result_fac_trades.protocol_fee_volume_bps, 0) < constants.min_fee_bps
     ) as is_excluded_low_fee,
@@ -60,11 +64,20 @@ trades_with_referrer as (
       lower(coalesce(dune.cowprotocol.result_fac_trades.swap_source, '')) = 'integrations'
     ) as is_excluded_integrators_source
   from dune.cowprotocol.result_fac_trades
+  left join app_data
+    on app_data.blockchain = dune.cowprotocol.result_fac_trades.blockchain
+    and app_data.app_hash = dune.cowprotocol.result_fac_trades.app_data
   cross join params
   cross join constants
   where
     if(array_position(params.blockchains, '-=All=-') > 0, true, array_position(params.blockchains, dune.cowprotocol.result_fac_trades.blockchain) > 0)
-    and dune.cowprotocol.result_fac_trades.block_time >= cast(params.start_date as timestamp)
+    and if(
+      params.is_staging_env,
+      app_data.environment is not null
+        and app_data.environment <> 'production',
+      app_data.environment is null
+        or app_data.environment = 'production'
+    )
 ),
 first_trade as (
   select trader, min(block_time) as first_trade_time
@@ -149,7 +162,6 @@ payouts as (
   cross join unnest(params.affiliate_payout_sources) as ps(payout_source)
   where lower(to_hex("from")) = replace(ps.payout_source, '0x', '')
     and contract_address = 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48
-    and evt_block_time >= cast(params.start_date as timestamp)
   group by 1
 )
 select

--- a/apps/cowswap-frontend/src/modules/affiliate/misc/ethflow_debug.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/ethflow_debug.sql
@@ -1,0 +1,50 @@
+with
+app_data as (
+  select
+    blockchain,
+    app_hash,
+    coalesce(environment, widget_environment) as environment
+  from query_5172256
+),
+native_sell_symbols as (
+  select * from (
+    values
+      ('ethereum', 'ETH'),
+      ('ethereum', 'WETH'),
+      ('gnosis', 'XDAI'),
+      ('gnosis', 'WXDAI'),
+      ('arbitrum', 'ETH'),
+      ('arbitrum', 'WETH'),
+      ('base', 'ETH'),
+      ('base', 'WETH'),
+      ('linea', 'ETH'),
+      ('linea', 'WETH'),
+      ('sepolia', 'ETH'),
+      ('sepolia', 'WETH'),
+      ('bnb', 'BNB'),
+      ('bnb', 'WBNB'),
+      ('avalanche_c', 'AVAX'),
+      ('avalanche_c', 'WAVAX'),
+      ('polygon', 'POL'),
+      ('polygon', 'WPOL'),
+      ('polygon', 'MATIC'),
+      ('polygon', 'WMATIC')
+  ) as s(blockchain, sell_token_symbol)
+),
+trades as (
+  select
+    app_data.environment,
+    t.*
+  from dune.cowprotocol.result_fac_trades t
+  left join app_data
+    on app_data.blockchain = t.blockchain
+    and app_data.app_hash = t.app_data
+)
+select t.*
+from trades t
+join native_sell_symbols s
+  on s.blockchain = t.blockchain
+ and s.sell_token_symbol = upper(coalesce(t.sell_token, ''))
+where t.block_time >= timestamp '2026-01-01 00:00:00'
+  and nullif(trim(t.referrer_code), '') is not null
+order by t.block_time desc;

--- a/apps/cowswap-frontend/src/modules/affiliate/misc/fac_trades.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/fac_trades.sql
@@ -1,0 +1,165 @@
+-- this query returns detailed information about each trade
+-- the fee conversions to usd and eth are made by taking the amounts in native token (using protocol_fee_native_price*) and using the daily native token prices 
+-- *the protocol_fee_native_price value comes from the backend db (query_4364122) and is never null
+
+with
+-- swap level info, with fees data in native token
+prep as (
+    select
+        t.block_time
+        ,'{{blockchain}}' as blockchain
+        ,b.name as dst_chain
+        ,if(b.name is not null and ad.bridging_provider is null and t.block_time < date('2025-11-15'), 'socket', ad.bridging_provider) as bridging_provider
+        ,t.usd_value
+        ,t.surplus_usd
+        ,t.order_type
+        ,ad.order_class
+        ,ad.referrer_code
+        ,if(replace(lower(ad.app_code),' ','') in ('cowswap', 'cowswap-safeapp'), 'UI', 'Integrations') as swap_source
+        ,t.partial_fill
+        ,t.fill_proportion
+        ,t.sell_token
+        ,t.units_sold
+        ,t.buy_token
+        ,t.units_bought
+        ,t.token_pair
+        ,s.name as solver_name
+        ,t.sell_price
+        ,t.buy_price
+        ,if(rod.protocol_fee_token = t.buy_token_address, t.buy_price, t.sell_price) as fee_token_price
+        ,coalesce((protocol_fee - coalesce(partner_fee, 0)) * protocol_fee_native_price/1e18, 0) as protocol_fee_native
+        -- protocol fee = volume fee + price improv. fee from market orders + price improv. fee from limit orders + UI fee (experiment run in gnosis and arb1 for a short time)
+        ,coalesce(protocol_volume_fee * protocol_fee_native_price/1e18, 0) as volume_fee_native
+        ,if(t.block_time < timestamp '2024-04-01 23:58' or protocol_fee_kind = 'surplus'
+            , coalesce((protocol_fee - coalesce(partner_fee, 0) - coalesce(protocol_volume_fee, 0)) * protocol_fee_native_price/1e18, 0)
+            , 0
+        )   as limit_pi_fee_native
+        ,if(protocol_fee_kind = 'priceimprovement'
+            , coalesce((protocol_fee - coalesce(partner_fee, 0) - coalesce(protocol_volume_fee, 0)) * protocol_fee_native_price/1e18, 0)
+            , 0
+        ) as market_pi_fee_native
+        ,if(ui_fee.ui_fee_recipient is not null
+            , partner_fee * protocol_fee_native_price/1e18 
+            , 0
+        ) as ui_fee_native
+        ,if(ui_fee.ui_fee_recipient is null
+            ,(1- coalesce(partner_split.partner_share, if(t.block_time < timestamp '2025-11-25', 0.5, 0.75))) * coalesce(partner_fee, 0) * coalesce(protocol_fee_native_price, 0)/1e18 
+            ,0
+        ) as partner_fee_cow_cut_native
+        ,if(ui_fee.ui_fee_recipient is null
+            ,coalesce(partner_split.partner_share, if(t.block_time < timestamp '2025-11-25', 0.5, 0.75)) * coalesce(partner_fee, 0) * coalesce(protocol_fee_native_price, 0)/1e18 
+            ,0
+        ) as partner_fee_partner_cut_native
+
+/*
+        ,if(ui_fee.ui_fee_recipient is null
+            ,coalesce(partner_split.partner_share, if(t.block_time < timestamp '2025-11-25', 0.5, 0.75)) *  coalesce( ad.partner_bps/1e4 * if(order_type='SELL', t.atoms_bought, t.atoms_sold) * protocol_fee_native_price/1e18, 0 )
+            ,0
+        ) as partner_vol_fee_partner_cut_native
+        ,if(ui_fee.ui_fee_recipient is null
+            ,coalesce(partner_split.partner_share, if(t.block_time < timestamp '2025-11-25', 0.5, 0.75)) * (coalesce(rod.partner_fee*protocol_fee_native_price/1e18, 0) - coalesce( ad.partner_bps/1e4 * if(order_type='SELL', t.atoms_bought, t.atoms_sold) * protocol_fee_native_price/1e18, 0 ))
+            ,0
+        ) as partner_pi_fee_partner_cut_native
+        ,coalesce(rod.partner_fee, 0) as total_partner_fee
+        ,coalesce( ad.partner_bps/1e4 * if(order_type='SELL', t.atoms_bought, t.atoms_sold) * protocol_fee_native_price/1e18, 0 ) as partner_fee_vol
+        ,coalesce(rod.partner_fee, 0) - coalesce( ad.partner_bps/1e4 * if(order_type='SELL', t.atoms_bought, t.atoms_sold) * protocol_fee_native_price/1e18, 0 ) as partner_fee_pi
+*/       
+        ,1e4 * cast(coalesce(rod.protocol_fee, 0) - coalesce(rod.partner_fee, 0) as double) / if(rod.protocol_fee_token = t.buy_token_address, t.atoms_bought+rod.protocol_fee, t.atoms_sold+rod.protocol_fee) as protocol_fee_bps  
+        ,1e4 * cast(coalesce(rod.protocol_fee, 0) - coalesce(rod.partner_fee, 0) - coalesce(rod.protocol_volume_fee, 0) as double) / if(rod.protocol_fee_token = t.buy_token_address, t.atoms_bought+rod.protocol_fee, t.atoms_sold+rod.protocol_fee) as protocol_fee_pi_bps  
+        ,1e4 * cast(coalesce(rod.protocol_volume_fee, 0) as double) / if(rod.protocol_fee_token = t.buy_token_address, t.atoms_bought+rod.protocol_fee, t.atoms_sold+rod.protocol_fee) as protocol_fee_volume_bps  
+        ,1e4 * cast(if(ui_fee.ui_fee_recipient is null,
+                        (1- coalesce(partner_split.partner_share, if(t.block_time < timestamp '2025-11-25', 0.5, 0.75))) * coalesce(partner_fee, 0),
+                        0) as double) / if(rod.protocol_fee_token = t.buy_token_address, t.atoms_bought+rod.protocol_fee, t.atoms_sold+rod.protocol_fee) as partner_fee_cow_cut_bps  
+        ,t.buy_token_address
+        ,t.sell_token_address
+        ,rod.protocol_fee_token as fee_token_address
+        ,rod.solver as solver_address
+        ,rod.partner_fee_recipient
+        ,t.order_uid
+        ,t.tx_hash
+        ,t.trader
+        ,t.receiver
+        ,t.app_data
+    from 
+        cow_protocol_{{blockchain}}.trades as t
+    left join
+        (select distinct * from "query_4364122(blockchain='{{blockchain}}')") as rod -- currently multiple duplicates in this table
+        on rod.order_uid = t.order_uid
+        and rod.tx_hash = t.tx_hash
+    left join 
+        dune.cowprotocol.result_cow_protocol_{{blockchain}}_app_data as ad
+        on t.app_data = ad.app_hash
+    left join (select * from dune.blockchains where name not in ('optimism_legacy_ovm1', 'beacon')) b 
+        on ad.destination_chain_id = b.chain_id
+    left join query_6434256 as ui_fee
+        on ui_fee.blockchain = '{{blockchain}}'
+        and ui_fee.ui_fee_recipient = rod.partner_fee_recipient
+    left join query_5333695 as partner_split
+        on partner_split.blockchain = '{{blockchain}}'
+        and partner_split.partner_recipient = rod.partner_fee_recipient
+        and partner_split.app_code_to_excl != ad.app_code 
+    left join query_6376342 as s
+        on rod.solver = s.address
+        and s.blockchain = '{{blockchain}}'
+    left join query_3639473 as excl
+        on excl.order_uid = t.order_uid
+    left join query_3490353 as excl2
+        on excl2.tx_hash = t.tx_hash
+    where
+        excl.order_uid is null
+        and excl2.tx_hash is null
+)
+, daily_native_token_prices as  (
+    select
+        p.timestamp as day
+        ,p.blockchain
+        ,p.symbol
+        ,p.price
+    from prices.day as p
+    join dune.blockchains as b
+        on p.blockchain = b.name
+        and p.contract_address = b.token_address
+    where
+        p.timestamp >= timestamp '2024-01-01'
+)
+-- adding usd and eth conversions based on daily prices
+, fees_with_conversions as (
+    select
+        prep.*
+        
+        ,protocol_fee_native  * p_native.price as protocol_fee_usd
+        ,volume_fee_native    * p_native.price as volume_fee_usd
+        ,limit_pi_fee_native  * p_native.price as limit_pi_fee_usd
+        ,market_pi_fee_native * p_native.price as market_pi_fee_usd
+        ,ui_fee_native        * p_native.price as ui_fee_usd
+        
+        ,partner_fee_cow_cut_native     * p_native.price as partner_fee_cow_cut_usd
+        ,partner_fee_partner_cut_native * p_native.price as partner_fee_partner_cut_usd
+        --,partner_vol_fee_partner_cut_native * p_native.price as partner_vol_fee_partner_cut_usd
+        --,partner_pi_fee_partner_cut_native * p_native.price as partner_pi_fee_partner_cut_usd
+        
+    
+        ,protocol_fee_native  * p_native.price / p_eth.price as protocol_fee_eth
+        ,volume_fee_native    * p_native.price / p_eth.price as volume_fee_eth
+        ,limit_pi_fee_native  * p_native.price / p_eth.price as limit_pi_fee_eth
+        ,market_pi_fee_native * p_native.price / p_eth.price as market_pi_fee_eth
+        ,ui_fee_native        * p_native.price / p_eth.price as ui_fee_eth
+        
+        ,partner_fee_cow_cut_native     * p_native.price / p_eth.price as partner_fee_cow_cut_eth
+        ,partner_fee_partner_cut_native * p_native.price / p_eth.price as partner_fee_partner_cut_eth
+        --,partner_vol_fee_partner_cut_native * p_native.price / p_eth.price as partner_vol_fee_partner_cut_eth
+        --,partner_pi_fee_partner_cut_native * p_native.price / p_eth.price as partner_pi_fee_partner_cut_eth         
+    from 
+        prep      
+    left join
+        daily_native_token_prices as p_native
+        on date(prep.block_time) = p_native.day
+        and prep.blockchain = p_native.blockchain 
+    left join
+        daily_native_token_prices as p_eth
+        on date(prep.block_time) = p_eth.day 
+        and p_eth.blockchain = 'ethereum'
+)
+select *   
+from fees_with_conversions
+where (coalesce(protocol_fee_usd,0)+coalesce(partner_fee_cow_cut_usd,0)+coalesce(partner_fee_partner_cut_usd,0)) <= coalesce(usd_value,500000) -- to eliminate big price errors from be

--- a/apps/cowswap-frontend/src/modules/affiliate/misc/payouts.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/payouts.sql
@@ -2,7 +2,11 @@ with
 params as (
   select
     case when '{{is_staging_env}}' = 'true' then true else false end as is_staging_env,
-    lower('{{payout_type}}') as payout_type
+    lower('{{payout_type}}') as payout_type,
+    case
+      when '{{denied_addresses}}' in ('', 'default value') then cast(array[] as array(varchar))
+      else transform(split('{{denied_addresses}}', ','), x -> lower(trim(x)))
+    end as denied_addresses
 ),
 affiliate_base as (
   select affiliate_address, next_payout
@@ -43,5 +47,6 @@ select
 from base
 where next_payout > 0
   and payout_type = (select payout_type from params)
+  and not contains((select denied_addresses from params), receiver)
 group by 1,2,3
 order by amount desc;

--- a/apps/cowswap-frontend/src/modules/affiliate/misc/trader_debug.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/trader_debug.sql
@@ -9,7 +9,6 @@ select
   lower(cast(dune.cowprotocol.result_fac_trades.trader as varchar)) as trader_address,
   dune.cowprotocol.result_fac_trades.usd_value,
   dune.cowprotocol.result_fac_trades.referrer_code,
-  dune.cowprotocol.result_fac_trades.protocol_fee_bps,
   dune.cowprotocol.result_fac_trades.protocol_fee_volume_bps
 from dune.cowprotocol.result_fac_trades
 cross join params

--- a/apps/cowswap-frontend/src/modules/affiliate/misc/traders.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/traders.sql
@@ -4,6 +4,10 @@ params as (
     split('{{blockchain}}', ',') as blockchains,
     case when '{{is_staging_env}}' = 'true' then true else false end as is_staging_env,
     case
+      when '{{start_date}}' in ('', 'default value') then date '2026-01-01'
+      else cast('{{start_date}}' as date)
+    end as start_date,
+    case
       when '{{trader_payout_sources}}' in ('', 'default value') then cast(array[] as array(varchar))
       else transform(split('{{trader_payout_sources}}', ','), x -> lower(trim(x)))
     end as trader_payout_sources
@@ -61,6 +65,7 @@ trades_with_referrer as (
   cross join constants
   where
     if(array_position(params.blockchains, '-=All=-') > 0, true, array_position(params.blockchains, dune.cowprotocol.result_fac_trades.blockchain) > 0)
+    and dune.cowprotocol.result_fac_trades.block_time >= cast(params.start_date as timestamp)
 ),
 first_trade as (
   select trader, min(block_time) as first_trade_time
@@ -127,7 +132,7 @@ payouts as (
   cross join unnest(params.trader_payout_sources) as ps(payout_source)
   where lower(to_hex("from")) = replace(ps.payout_source, '0x', '')
     and contract_address = 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48
-    and evt_block_time >= date '2026-01-01'
+    and evt_block_time >= cast(params.start_date as timestamp)
   group by 1
 )
 select

--- a/apps/cowswap-frontend/src/modules/affiliate/misc/traders.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/traders.sql
@@ -52,10 +52,9 @@ trades_with_referrer as (
     dune.cowprotocol.result_fac_trades.usd_value as usd_value,
     dune.cowprotocol.result_fac_trades.referrer_code as referrer_code,
     dune.cowprotocol.result_fac_trades.swap_source as swap_source,
-    dune.cowprotocol.result_fac_trades.protocol_fee_bps,
     dune.cowprotocol.result_fac_trades.protocol_fee_volume_bps,
     (
-      coalesce(dune.cowprotocol.result_fac_trades.protocol_fee_volume_bps, 1e9) < constants.min_fee_bps
+      coalesce(dune.cowprotocol.result_fac_trades.protocol_fee_volume_bps, 0) < constants.min_fee_bps
     ) as is_excluded_low_fee,
     (
       lower(coalesce(dune.cowprotocol.result_fac_trades.swap_source, '')) = 'integrations'

--- a/apps/cowswap-frontend/src/modules/affiliate/misc/traders.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/traders.sql
@@ -73,10 +73,8 @@ trades_with_referrer as (
     if(array_position(params.blockchains, '-=All=-') > 0, true, array_position(params.blockchains, dune.cowprotocol.result_fac_trades.blockchain) > 0)
     and if(
       params.is_staging_env,
-      app_data.environment is not null
-        and app_data.environment <> 'production',
-      app_data.environment is null
-        or app_data.environment = 'production'
+      app_data.environment in ('local', 'development', 'pr'),
+      app_data.environment in ('production', 'staging', 'ens')
     )
 ),
 first_trade as (

--- a/apps/cowswap-frontend/src/modules/affiliate/misc/traders.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/traders.sql
@@ -4,13 +4,16 @@ params as (
     split('{{blockchain}}', ',') as blockchains,
     case when '{{is_staging_env}}' = 'true' then true else false end as is_staging_env,
     case
-      when '{{start_date}}' in ('', 'default value') then date '2026-01-01'
-      else cast('{{start_date}}' as date)
-    end as start_date,
-    case
       when '{{trader_payout_sources}}' in ('', 'default value') then cast(array[] as array(varchar))
       else transform(split('{{trader_payout_sources}}', ','), x -> lower(trim(x)))
     end as trader_payout_sources
+),
+app_data as (
+  select
+    blockchain,
+    app_hash,
+    coalesce(environment, widget_environment) as environment
+  from query_5172256
 ),
 constants as (
   -- Exclude very low fee swaps from counting towards trader eligible volume.
@@ -53,6 +56,7 @@ trades_with_referrer as (
     dune.cowprotocol.result_fac_trades.referrer_code as referrer_code,
     dune.cowprotocol.result_fac_trades.swap_source as swap_source,
     dune.cowprotocol.result_fac_trades.protocol_fee_volume_bps,
+    app_data.environment,
     (
       coalesce(dune.cowprotocol.result_fac_trades.protocol_fee_volume_bps, 0) < constants.min_fee_bps
     ) as is_excluded_low_fee,
@@ -60,11 +64,20 @@ trades_with_referrer as (
       lower(coalesce(dune.cowprotocol.result_fac_trades.swap_source, '')) = 'integrations'
     ) as is_excluded_integrators_source
   from dune.cowprotocol.result_fac_trades
+  left join app_data
+    on app_data.blockchain = dune.cowprotocol.result_fac_trades.blockchain
+    and app_data.app_hash = dune.cowprotocol.result_fac_trades.app_data
   cross join params
   cross join constants
   where
     if(array_position(params.blockchains, '-=All=-') > 0, true, array_position(params.blockchains, dune.cowprotocol.result_fac_trades.blockchain) > 0)
-    and dune.cowprotocol.result_fac_trades.block_time >= cast(params.start_date as timestamp)
+    and if(
+      params.is_staging_env,
+      app_data.environment is not null
+        and app_data.environment <> 'production',
+      app_data.environment is null
+        or app_data.environment = 'production'
+    )
 ),
 first_trade as (
   select trader, min(block_time) as first_trade_time
@@ -131,7 +144,6 @@ payouts as (
   cross join unnest(params.trader_payout_sources) as ps(payout_source)
   where lower(to_hex("from")) = replace(ps.payout_source, '0x', '')
     and contract_address = 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48
-    and evt_block_time >= cast(params.start_date as timestamp)
   group by 1
 )
 select

--- a/apps/cowswap-frontend/src/modules/affiliate/misc/traders_activity.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/traders_activity.sql
@@ -40,6 +40,8 @@ trades as (
     lower(cast(dune.cowprotocol.result_fac_trades.trader as varchar)) as trader_address,
     lower(cast(dune.cowprotocol.result_fac_trades.sell_token_address as varchar)) as sell_token,
     lower(cast(dune.cowprotocol.result_fac_trades.buy_token_address as varchar)) as buy_token,
+    cast(dune.cowprotocol.result_fac_trades.sell_token as varchar) as sell_token_symbol,
+    cast(dune.cowprotocol.result_fac_trades.buy_token as varchar) as buy_token_symbol,
     dune.cowprotocol.result_fac_trades.units_sold as executed_sell_amount,
     dune.cowprotocol.result_fac_trades.units_bought as executed_buy_amount,
     dune.cowprotocol.result_fac_trades.usd_value as usd_value,
@@ -187,6 +189,8 @@ select
   trades.order_uid,
   trades.sell_token,
   trades.buy_token,
+  trades.sell_token_symbol,
+  trades.buy_token_symbol,
   trades.executed_sell_amount,
   trades.executed_buy_amount
 from trades

--- a/apps/cowswap-frontend/src/modules/affiliate/misc/traders_activity.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/traders_activity.sql
@@ -1,0 +1,188 @@
+with
+params as (
+  select
+    case when '{{is_staging_env}}' = 'true' then true else false end as is_staging_env,
+    case
+      when '{{start_date}}' in ('', 'default value') then date '2026-01-01'
+      else cast('{{start_date}}' as date)
+    end as start_date
+),
+affiliate_program_data as (
+  select
+    cast(code as varchar) as code,
+    trigger_volume,
+    time_cap_days,
+    volume_cap
+  from dune.cowprotocol.dataset_affiliate_program_data
+  where not (select is_staging_env from params)
+  union all
+  select
+    cast(code as varchar) as code,
+    trigger_volume,
+    time_cap_days,
+    volume_cap
+  from dune.cowprotocol.dataset_affiliate_program_data_staging
+  where (select is_staging_env from params)
+),
+constants as (
+  select
+    cast(1.9 as double) as min_fee_bps
+),
+trades as (
+  select
+    dune.cowprotocol.result_fac_trades.blockchain,
+    dune.cowprotocol.result_fac_trades.block_time,
+    dune.cowprotocol.result_fac_trades.tx_hash,
+    dune.cowprotocol.result_fac_trades.order_uid,
+    lower(cast(dune.cowprotocol.result_fac_trades.trader as varchar)) as trader_address,
+    lower(cast(dune.cowprotocol.result_fac_trades.sell_token_address as varchar)) as sell_token,
+    lower(cast(dune.cowprotocol.result_fac_trades.buy_token_address as varchar)) as buy_token,
+    dune.cowprotocol.result_fac_trades.units_sold as executed_sell_amount,
+    dune.cowprotocol.result_fac_trades.units_bought as executed_buy_amount,
+    dune.cowprotocol.result_fac_trades.usd_value as usd_value,
+    dune.cowprotocol.result_fac_trades.referrer_code as referrer_code,
+    dune.cowprotocol.result_fac_trades.swap_source as swap_source,
+    dune.cowprotocol.result_fac_trades.protocol_fee_volume_bps,
+    (
+      coalesce(dune.cowprotocol.result_fac_trades.protocol_fee_volume_bps, 0) < constants.min_fee_bps
+    ) as is_excluded_low_fee,
+    (
+      lower(coalesce(dune.cowprotocol.result_fac_trades.swap_source, '')) = 'integrations'
+    ) as is_excluded_integrators_source
+  from dune.cowprotocol.result_fac_trades
+  cross join params
+  cross join constants
+  where
+    if(array_position(split('{{blockchain}}', ','), '-=All=-') > 0, true, array_position(split('{{blockchain}}', ','), dune.cowprotocol.result_fac_trades.blockchain) > 0)
+    and dune.cowprotocol.result_fac_trades.block_time >= cast(params.start_date as timestamp)
+),
+first_trade as (
+  select
+    ranked.trader_address,
+    ranked.block_time as first_trade_time,
+    ranked.order_uid as first_trade_order_uid,
+    ranked.tx_hash as first_trade_tx_hash
+  from (
+    select
+      trades.trader_address,
+      trades.block_time,
+      trades.order_uid,
+      trades.tx_hash,
+      row_number()
+        over (partition by trades.trader_address order by trades.block_time, trades.order_uid, trades.tx_hash) as rn
+    from trades
+    where not trades.is_excluded_integrators_source
+  ) ranked
+  where ranked.rn = 1
+),
+first_ref_trade as (
+  select
+    ranked.trader_address,
+    ranked.referrer_code as bound_code,
+    ranked.block_time as first_ref_trade_time,
+    ranked.order_uid as first_ref_trade_order_uid,
+    ranked.tx_hash as first_ref_trade_tx_hash
+  from (
+    select
+      trades.trader_address,
+      trades.referrer_code,
+      trades.block_time,
+      trades.order_uid,
+      trades.tx_hash,
+      row_number()
+        over (partition by trades.trader_address order by trades.block_time, trades.order_uid, trades.tx_hash) as rn
+    from trades
+    where trades.referrer_code is not null and not trades.is_excluded_integrators_source
+  ) ranked
+  where ranked.rn = 1
+),
+bound_ref as (
+  select
+    first_ref_trade.trader_address,
+    first_ref_trade.bound_code,
+    first_ref_trade.first_ref_trade_time as bound_time
+  from first_ref_trade
+),
+eligible_trades as (
+  select
+    trades.trader_address,
+    trades.tx_hash,
+    trades.order_uid,
+    trades.referrer_code,
+    trades.block_time,
+    trades.usd_value,
+    affiliate_program_data.time_cap_days,
+    affiliate_program_data.volume_cap,
+    sum(trades.usd_value)
+      over (partition by trades.trader_address, trades.referrer_code order by trades.block_time, trades.order_uid, trades.tx_hash) as cum_volume
+  from trades
+  join bound_ref
+    on bound_ref.trader_address = trades.trader_address
+    and bound_ref.bound_code = trades.referrer_code
+  join first_trade on first_trade.trader_address = trades.trader_address
+  join first_ref_trade on first_ref_trade.trader_address = trades.trader_address
+  join affiliate_program_data on affiliate_program_data.code = trades.referrer_code
+  where
+    first_trade.first_trade_time = first_ref_trade.first_ref_trade_time
+    and trades.block_time <= bound_ref.bound_time + affiliate_program_data.time_cap_days * interval '1' day
+    and not trades.is_excluded_low_fee
+    and not trades.is_excluded_integrators_source
+),
+capped_trades as (
+  select
+    trader_address,
+    tx_hash,
+    block_time,
+    order_uid,
+    volume_cap,
+    time_cap_days,
+    cum_volume,
+    case
+      when volume_cap = 0 then usd_value
+      when cum_volume <= volume_cap then usd_value
+      when cum_volume - usd_value >= volume_cap then 0
+      else volume_cap - (cum_volume - usd_value)
+    end as eligible_volume_usd
+  from eligible_trades
+)
+select
+  trades.blockchain,
+  trades.block_time as creation_date,
+  trades.tx_hash,
+  trades.order_uid,
+  trades.trader_address,
+  trades.sell_token,
+  trades.buy_token,
+  trades.executed_sell_amount,
+  trades.executed_buy_amount,
+  trades.usd_value,
+  coalesce(capped_trades.eligible_volume_usd, cast(0 as double)) as eligible_volume_usd,
+  trades.referrer_code,
+  bound_ref.bound_code as bound_referrer_code,
+  trades.order_uid = first_trade.first_trade_order_uid
+    and trades.tx_hash = first_trade.first_trade_tx_hash as is_first_trade,
+  trades.order_uid = first_ref_trade.first_ref_trade_order_uid
+    and trades.tx_hash = first_ref_trade.first_ref_trade_tx_hash as is_first_ref_trade,
+  case
+    when affiliate_program_data.code is null then 'code_not_found'
+    when trades.is_excluded_integrators_source then 'integrator_ignored'
+    when first_trade.first_trade_time <> first_ref_trade.first_ref_trade_time then 'ref_after_first_trade'
+    when coalesce(bound_ref.bound_code, '') <> trades.referrer_code then 'code_mismatch_after_binding'
+    when trades.is_excluded_low_fee then 'low_fee_excluded'
+    when capped_trades.order_uid is not null and capped_trades.eligible_volume_usd = 0 and capped_trades.volume_cap > 0 then 'volume_cap_reached'
+    else 'eligible'
+  end as eligibility_reason,
+  coalesce(bound_ref.bound_code = trades.referrer_code, false) as is_bound_to_code,
+  coalesce(capped_trades.eligible_volume_usd, cast(0 as double)) > 0 as is_eligible
+from trades
+left join first_trade on first_trade.trader_address = trades.trader_address
+left join first_ref_trade on first_ref_trade.trader_address = trades.trader_address
+left join bound_ref on bound_ref.trader_address = trades.trader_address
+left join affiliate_program_data on affiliate_program_data.code = trades.referrer_code
+left join capped_trades
+  on capped_trades.trader_address = trades.trader_address
+  and capped_trades.tx_hash = trades.tx_hash
+  and capped_trades.block_time = trades.block_time
+  and capped_trades.order_uid = trades.order_uid
+where trades.referrer_code is not null
+order by trades.block_time desc, trades.order_uid desc;

--- a/apps/cowswap-frontend/src/modules/affiliate/misc/traders_activity.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/traders_activity.sql
@@ -65,10 +65,8 @@ trades as (
     if(array_position(split('{{blockchain}}', ','), '-=All=-') > 0, true, array_position(split('{{blockchain}}', ','), dune.cowprotocol.result_fac_trades.blockchain) > 0)
     and if(
       (select is_staging_env from params),
-      app_data.environment is not null
-        and app_data.environment <> 'production',
-      app_data.environment is null
-        or app_data.environment = 'production'
+      app_data.environment in ('local', 'development', 'pr'),
+      app_data.environment in ('production', 'staging', 'ens')
     )
 ),
 first_trade as (

--- a/apps/cowswap-frontend/src/modules/affiliate/misc/traders_activity.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/traders_activity.sql
@@ -1,11 +1,14 @@
 with
 params as (
   select
-    case when '{{is_staging_env}}' = 'true' then true else false end as is_staging_env,
-    case
-      when '{{start_date}}' in ('', 'default value') then date '2026-01-01'
-      else cast('{{start_date}}' as date)
-    end as start_date
+    case when '{{is_staging_env}}' = 'true' then true else false end as is_staging_env
+),
+app_data as (
+  select
+    blockchain,
+    app_hash,
+    coalesce(environment, widget_environment) as environment
+  from query_5172256
 ),
 affiliate_program_data as (
   select
@@ -40,6 +43,7 @@ trades as (
     dune.cowprotocol.result_fac_trades.units_sold as executed_sell_amount,
     dune.cowprotocol.result_fac_trades.units_bought as executed_buy_amount,
     dune.cowprotocol.result_fac_trades.usd_value as usd_value,
+    app_data.environment,
     dune.cowprotocol.result_fac_trades.referrer_code as referrer_code,
     dune.cowprotocol.result_fac_trades.swap_source as swap_source,
     dune.cowprotocol.result_fac_trades.protocol_fee_volume_bps,
@@ -50,11 +54,20 @@ trades as (
       lower(coalesce(dune.cowprotocol.result_fac_trades.swap_source, '')) = 'integrations'
     ) as is_excluded_integrators_source
   from dune.cowprotocol.result_fac_trades
+  left join app_data
+    on app_data.blockchain = dune.cowprotocol.result_fac_trades.blockchain
+    and app_data.app_hash = dune.cowprotocol.result_fac_trades.app_data
   cross join params
   cross join constants
   where
     if(array_position(split('{{blockchain}}', ','), '-=All=-') > 0, true, array_position(split('{{blockchain}}', ','), dune.cowprotocol.result_fac_trades.blockchain) > 0)
-    and dune.cowprotocol.result_fac_trades.block_time >= cast(params.start_date as timestamp)
+    and if(
+      (select is_staging_env from params),
+      app_data.environment is not null
+        and app_data.environment <> 'production',
+      app_data.environment is null
+        or app_data.environment = 'production'
+    )
 ),
 first_trade as (
   select
@@ -146,6 +159,7 @@ capped_trades as (
   from eligible_trades
 )
 select
+  trades.environment,
   trades.blockchain,
   trades.block_time as creation_date,
   trades.tx_hash,

--- a/apps/cowswap-frontend/src/modules/affiliate/misc/traders_activity.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/traders_activity.sql
@@ -162,15 +162,10 @@ select
   trades.environment,
   trades.blockchain,
   trades.block_time as creation_date,
-  trades.tx_hash,
-  trades.order_uid,
   trades.trader_address,
-  trades.sell_token,
-  trades.buy_token,
-  trades.executed_sell_amount,
-  trades.executed_buy_amount,
   trades.usd_value,
   coalesce(capped_trades.eligible_volume_usd, cast(0 as double)) as eligible_volume_usd,
+  coalesce(capped_trades.eligible_volume_usd, cast(0 as double)) > 0 as is_eligible,
   trades.referrer_code,
   bound_ref.bound_code as bound_referrer_code,
   trades.order_uid = first_trade.first_trade_order_uid
@@ -187,7 +182,12 @@ select
     else 'eligible'
   end as eligibility_reason,
   coalesce(bound_ref.bound_code = trades.referrer_code, false) as is_bound_to_code,
-  coalesce(capped_trades.eligible_volume_usd, cast(0 as double)) > 0 as is_eligible
+  trades.tx_hash,
+  trades.order_uid,
+  trades.sell_token,
+  trades.buy_token,
+  trades.executed_sell_amount,
+  trades.executed_buy_amount
 from trades
 left join first_trade on first_trade.trader_address = trades.trader_address
 left join first_ref_trade on first_ref_trade.trader_address = trades.trader_address

--- a/apps/cowswap-frontend/src/modules/affiliate/misc/traders_activity.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/traders_activity.sql
@@ -177,6 +177,7 @@ select
     when trades.is_excluded_integrators_source then 'integrator_ignored'
     when first_trade.first_trade_time <> first_ref_trade.first_ref_trade_time then 'ref_after_first_trade'
     when coalesce(bound_ref.bound_code, '') <> trades.referrer_code then 'code_mismatch_after_binding'
+    when trades.block_time > bound_ref.bound_time + affiliate_program_data.time_cap_days * interval '1' day then 'time_cap_exceeded'
     when trades.is_excluded_low_fee then 'low_fee_excluded'
     when capped_trades.order_uid is not null and capped_trades.eligible_volume_usd = 0 and capped_trades.volume_cap > 0 then 'volume_cap_reached'
     else 'eligible'

--- a/apps/cowswap-frontend/src/modules/affiliate/misc/traders_debug.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/traders_debug.sql
@@ -16,10 +16,9 @@ trades as (
     dune.cowprotocol.result_fac_trades.usd_value as usd_value,
     dune.cowprotocol.result_fac_trades.referrer_code as referrer_code,
     dune.cowprotocol.result_fac_trades.swap_source as swap_source,
-    dune.cowprotocol.result_fac_trades.protocol_fee_bps,
     dune.cowprotocol.result_fac_trades.protocol_fee_volume_bps,
     (
-      coalesce(dune.cowprotocol.result_fac_trades.protocol_fee_volume_bps, 1e9) < constants.min_fee_bps
+      coalesce(dune.cowprotocol.result_fac_trades.protocol_fee_volume_bps, 0) < constants.min_fee_bps
     ) as is_excluded_low_fee,
     (
       lower(coalesce(dune.cowprotocol.result_fac_trades.swap_source, '')) = 'integrations'

--- a/apps/cowswap-frontend/src/modules/affiliate/misc/traders_debug.sql
+++ b/apps/cowswap-frontend/src/modules/affiliate/misc/traders_debug.sql
@@ -12,6 +12,7 @@ trades as (
     dune.cowprotocol.result_fac_trades.blockchain,
     dune.cowprotocol.result_fac_trades.block_time,
     dune.cowprotocol.result_fac_trades.tx_hash,
+    dune.cowprotocol.result_fac_trades.order_uid,
     lower(cast(dune.cowprotocol.result_fac_trades.trader as varchar)) as trader,
     dune.cowprotocol.result_fac_trades.usd_value as usd_value,
     dune.cowprotocol.result_fac_trades.referrer_code as referrer_code,
@@ -32,6 +33,7 @@ trades as (
 first_trade as (
   select trader, min(block_time) as first_trade_time
   from trades
+  where not is_excluded_integrators_source
   group by 1
 ),
 first_ref_trade as (
@@ -54,6 +56,7 @@ select
   trades.blockchain,
   trades.block_time,
   trades.tx_hash,
+  trades.order_uid,
   trades.trader as trader_address,
   trades.usd_value,
   trades.referrer_code,


### PR DESCRIPTION
# Summary

Fixes:
1. `fix` a loophole allowing you to create a code that was used on staging and get those rewards. Now the 2 environments are separated by appData's environment value. 
```
production, staging, ens -> affiliate prod
local, development, pr -> affiliate staging
barn -> excluded
```
2. `fix` handle fee bps being null in SQL queries
3. `fix` active traders being computed wrongly
4. `feat` allow to deny addresses in payouts
5. `feat` new dashboard to check for missing fee & missing env
6. `chore` new query to analyze [ETH-flow orders are not included into referral volume](https://www.notion.so/cownation/ETH-flow-orders-are-not-included-into-referral-volume-3298da5f04ca80dc9fa6f22c95c77b39)

Context:

1. If you review commit by commit you will see that I tried to fix the prod & staging conflict using a start_date param, cutting of trades done before the prod lauch date. This was naive and cause the check for "traders to not have previous cowswap trades" to fail. The proper fix was to check the environment in the app data.
2. I already updated the [dashboards in prod & staging](https://www.notion.so/cownation/Affiliate-program-internal-docs-3358da5f04ca808baf92f6d9d761e038).
3. I added fac_trades.sql for reference, and imported traders activity from #7164 as it can be used for debugging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced affiliate eligibility tracking with volume-capping, detailed reason codes, new trade/activity reports, and debugging/data-inspection views.
  * Payouts can now exclude specified denied addresses.

* **Bug Fixes**
  * Missing fee volumes now treated as zero (fixes low-fee handling).
  * Tightened first-trade/referrer logic and improved environment-based filtering.
  * Removed an outdated fixed date filter affecting payouts.

* **Chores**
  * Added richer per-trade fee breakdowns with daily USD/ETH conversions; removed unused fee column from outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cowprotocol/cowswap/pull/7188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->