### PR TITLE
chore: kill barn

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -32,14 +32,14 @@ jobs:
       app: ${{ matrix.app }}
 
   vercel-pre-prod:
-    # Deploys to Vercel staging and barn environments only when there is a tag for CowSwap or Explorer
+    # Deploys to Vercel staging environment only when there is a tag for CowSwap or Explorer
     name: Vercel pre-prod
     if: startsWith(github.ref, 'refs/tags')
     uses: ./.github/workflows/vercel.yml
     secrets: inherit
     strategy:
       matrix:
-        env_name: [ barn, staging ] # deploys both in parallel
+        env_name: [ staging ] # deploys both in parallel
     with:
       env_name: ${{ matrix.env_name }}
       # Pick app according to published tag
@@ -62,7 +62,7 @@ jobs:
 
   notify-failure:
     name: Notify Slack on Failure
-    needs: [vercel-dev, vercel-pre-prod, vercel-prod]
+    needs: [ vercel-dev, vercel-pre-prod, vercel-prod ]
     runs-on: ubuntu-latest
     if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
 

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       env_name:
-        description: 'Environment to deploy to. Options are: dev, staging, barn and prod'
+        description: 'Environment to deploy to. Options are: dev, staging and prod'
         required: true
         type: string
       app:

--- a/apps/cowswap-frontend/.env
+++ b/apps/cowswap-frontend/.env
@@ -61,7 +61,6 @@
 # AppData, build yours at https://explorer.cow.fi/appdata
 #REACT_APP_FULL_APP_DATA_PRODUCTION=
 #REACT_APP_FULL_APP_DATA_ENS=
-#REACT_APP_FULL_APP_DATA_BARN=
 #REACT_APP_FULL_APP_DATA_STAGING=
 #REACT_APP_FULL_APP_DATA_PR=
 #REACT_APP_FULL_APP_DATA_DEVELOPMENT=
@@ -93,7 +92,6 @@
 #REACT_APP_EXPLORER_URL_DEV=
 #REACT_APP_EXPLORER_URL_STAGING=
 #REACT_APP_EXPLORER_URL_PROD=
-#REACT_APP_EXPLORER_URL_BARN=
 
 #######################################
 # Block Explorer Override
@@ -130,7 +128,6 @@
 # REACT_APP_DOMAIN_REGEX_DEVELOPMENT="^(dev\.swap\.cow\.fi|swap-develop\.vercel\.app)"
 # REACT_APP_DOMAIN_REGEX_STAGING="^(staging\.swap\.cow\.fi|swap-staging\.vercel\.app)"
 # REACT_APP_DOMAIN_REGEX_PRODUCTION="^(swap\.cow\.fi|swap-prod\.vercel\.app)$"
-# REACT_APP_DOMAIN_REGEX_BARN="^(barn\.cow\.fi|swap-barn\.vercel\.app)$"
 # REACT_APP_DOMAIN_REGEX_ENS="(:?^cowswap\.eth|ipfs)"
 
 # Path regex (to detect environment)

--- a/apps/cowswap-frontend/src/modules/appData/utils/fullAppData.ts
+++ b/apps/cowswap-frontend/src/modules/appData/utils/fullAppData.ts
@@ -11,7 +11,6 @@ const DEFAULT_FULL_APP_DATA = JSON.stringify(DEFAULT_FULL_APP_DATA_OBJ)
 const APP_DATA_PER_ENV: Record<EnvironmentName, string> = {
   production: process.env.REACT_APP_FULL_APP_DATA_PRODUCTION || addEnvToDefaultAppData('production'),
   ens: process.env.REACT_APP_FULL_APP_DATA_ENS || addEnvToDefaultAppData('ens'),
-  barn: process.env.REACT_APP_FULL_APP_DATA_BARN || addEnvToDefaultAppData('barn'),
   staging: process.env.REACT_APP_FULL_APP_DATA_STAGING || addEnvToDefaultAppData('staging'),
   pr: process.env.REACT_APP_FULL_APP_DATA_PR || addEnvToDefaultAppData('pr'),
   development: process.env.REACT_APP_FULL_APP_DATA_DEVELOPMENT || addEnvToDefaultAppData('development'),

--- a/apps/cowswap-frontend/src/tradingSdk/bridgingSdk.ts
+++ b/apps/cowswap-frontend/src/tradingSdk/bridgingSdk.ts
@@ -1,5 +1,5 @@
 import { bungeeAffiliateCode } from '@cowprotocol/common-const'
-import { isBarn, isDev, isProd, isStaging } from '@cowprotocol/common-utils'
+import { isDev, isProd, isStaging } from '@cowprotocol/common-utils'
 import {
   AcrossBridgeProvider,
   BridgingSdk,
@@ -37,7 +37,7 @@ export const bridgingSdk = new BridgingSdk({
 bridgingSdk.setAvailableProviders([bungeeBridgeProvider.info.dappId])
 
 function getBungeeApiBase(): string | undefined {
-  if (isProd || isDev || isStaging || isBarn) {
+  if (isProd || isDev || isStaging) {
     return 'https://backend.bungee.exchange'
   }
 

--- a/apps/explorer/src/sdk/cowSdk.ts
+++ b/apps/explorer/src/sdk/cowSdk.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 
 import { bungeeAffiliateCode, RPC_URLS, VIEM_CHAINS } from '@cowprotocol/common-const'
-import { isBarn, isDev, isProd, isStaging } from '@cowprotocol/common-utils'
+import { isDev, isProd, isStaging } from '@cowprotocol/common-utils'
 import { AbstractProviderAdapter, OrderBookApi, setGlobalAdapter, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { AcrossBridgeProvider, BungeeBridgeProvider, NearIntentsBridgeProvider } from '@cowprotocol/sdk-bridging'
 import { ViemAdapter } from '@cowprotocol/sdk-viem-adapter'
@@ -48,7 +48,7 @@ const nearIntentsBridgeProvider = new NearIntentsBridgeProvider({ apiKey: proces
 export const knownBridgeProviders = [bungeeBridgeProvider, acrossBridgeProvider, nearIntentsBridgeProvider]
 
 function getBungeeApiBase(): string | undefined {
-  if (isProd || isDev || isStaging || isBarn) {
+  if (isProd || isDev || isStaging) {
     return 'https://backend.bungee.exchange'
   }
 

--- a/apps/explorer/src/utils/env.ts
+++ b/apps/explorer/src/utils/env.ts
@@ -2,7 +2,6 @@ type EnvsFlags = {
   isDev: boolean
   isStaging: boolean
   isProd: boolean
-  isBarn: boolean
 }
 
 const getRegex = (regex: string | undefined): RegExp | undefined => (regex ? new RegExp(regex) : undefined)
@@ -11,25 +10,21 @@ function checkEnvironment(host: string): EnvsFlags {
   const domainDevRegex = getRegex(process.env.EXPLORER_APP_DOMAIN_REGEX_DEV)
   const domainStagingRegex = getRegex(process.env.EXPLORER_APP_DOMAIN_REGEX_STAGING)
   const domainProdRegex = getRegex(process.env.EXPLORER_APP_DOMAIN_REGEX_PROD)
-  const domainBarnRegex = getRegex(process.env.EXPLORER_APP_DOMAIN_REGEX_BARN)
 
   return {
     isDev: domainDevRegex?.test(host) || false,
     isStaging: domainStagingRegex?.test(host) || false,
     isProd: domainProdRegex?.test(host) || false,
-    isBarn: domainBarnRegex?.test(host) || false,
   }
 }
 
-const { isDev, isStaging, isProd, isBarn } = checkEnvironment(window.location.host)
+const { isDev, isStaging, isProd } = checkEnvironment(window.location.host)
 
 export type Envs = 'production' | 'barn' | 'staging' | 'development'
 
 export const environmentName = (function (): Envs | undefined {
   if (isProd) {
     return 'production'
-  } else if (isBarn) {
-    return 'barn'
   } else if (isStaging) {
     return 'staging'
   } else if (isDev) {
@@ -39,4 +34,4 @@ export const environmentName = (function (): Envs | undefined {
   }
 })()
 
-export { isDev, isStaging, isProd, isBarn }
+export { isDev, isStaging, isProd }

--- a/libs/common-utils/src/environments.test.ts
+++ b/libs/common-utils/src/environments.test.ts
@@ -3,7 +3,6 @@ import { checkEnvironment, EnvironmentChecks } from './environments'
 const DEFAULT_ENVIRONMENTS_CHECKS: EnvironmentChecks = {
   isProd: false,
   isEns: false,
-  isBarn: false,
   isStaging: false,
   isPr: false,
   isDev: false,
@@ -85,14 +84,6 @@ describe('Detect environments using host and path', () => {
       expect(checkEnvironment('gateway.pinata.cloud', '/ipfs/QmZW5abzempvhyPvSMbLhnmZ6d6SEGgGQd3paaHRK7CSfm')).toEqual(
         isEns,
       )
-    })
-  })
-
-  describe('Is Barn', () => {
-    const isBarn = { ...DEFAULT_ENVIRONMENTS_CHECKS, isBarn: true }
-
-    it('barn.cow.fi', () => {
-      expect(checkEnvironment('barn.cow.fi', '')).toEqual(isBarn)
     })
   })
 

--- a/libs/common-utils/src/environments.ts
+++ b/libs/common-utils/src/environments.ts
@@ -44,6 +44,10 @@ export function checkEnvironment(host: string, path: string): EnvironmentChecks 
 const forceProdApi = typeof window !== 'undefined' && !!window.localStorage.getItem('forceProdApi')
 const forceStagingApi = typeof window !== 'undefined' && !!window.localStorage.getItem('forceStagingApi')
 
+if (forceProdApi || forceStagingApi) {
+  console.debug('[BackendApiOverwrite]', `forceProdApi: ${forceProdApi}, forceStagingApi: ${forceStagingApi}`)
+}
+
 // Default values for environments
 let isLocal = false
 let isDev = false

--- a/libs/common-utils/src/environments.ts
+++ b/libs/common-utils/src/environments.ts
@@ -7,7 +7,6 @@ const DEFAULT_ENVIRONMENTS_REGEX: Record<EnvironmentName, string> = {
   staging: '^(staging.swap.cow.fi|staging.explorer.cow.fi|swap-staging.vercel.app|explorer-staging.vercel.app)',
   production:
     '^(swap.cow.fi|explorer.cow.fi|swap-prod.vercel.app|explorer-prod-seven.vercel.app|cow.trade|cowswap.exchange)$',
-  barn: '^(barn.cow.fi|barn.explorer.cow.fi|swap-barn.vercel.app|explorer-barn.vercel.app|barn.cowswap.exchange)$',
   ens: '(:?^cowswap.eth|ipfs)',
 }
 
@@ -21,7 +20,6 @@ function getRegex(env: EnvironmentName) {
 export interface EnvironmentChecks {
   isProd: boolean
   isEns: boolean
-  isBarn: boolean
   isStaging: boolean
   isPr: boolean
   isDev: boolean
@@ -39,24 +37,20 @@ export function checkEnvironment(host: string, path: string): EnvironmentChecks 
     isStaging: getRegex('staging').test(host),
     isProd: getRegex('production').test(host),
     isEns: ensRegex.test(host) || ensRegex.test(path),
-
-    // Environment used for Backend workflow
-    // The latest stable version pointing to the DEV api
-    isBarn: getRegex('barn').test(host),
   }
 }
 
 // A hack to test against prod API
 const forceProdApi = typeof window !== 'undefined' && !!window.localStorage.getItem('forceProdApi')
+const forceStagingApi = typeof window !== 'undefined' && !!window.localStorage.getItem('forceStagingApi')
 
 // Default values for environments
 let isLocal = false
 let isDev = false
 let isPr = false
-let isStaging = false
+let isStaging = forceStagingApi
 let isProd = forceProdApi
 let isEns = false
-let isBarn = false
 
 if (typeof window !== 'undefined') {
   const envChecks = checkEnvironment(window.location.host, window.location.pathname)
@@ -66,25 +60,14 @@ if (typeof window !== 'undefined') {
   isStaging = envChecks.isStaging
   isProd = envChecks.isProd
   isEns = envChecks.isEns
-  isBarn = envChecks.isBarn
 }
 
-export const ALL_ENVIRONMENTS: EnvironmentName[] = [
-  'local',
-  'development',
-  'pr',
-  'staging',
-  'production',
-  'barn',
-  'ens',
-]
-export type EnvironmentName = 'local' | 'development' | 'pr' | 'staging' | 'production' | 'barn' | 'ens'
+export const ALL_ENVIRONMENTS: EnvironmentName[] = ['local', 'development', 'pr', 'staging', 'production', 'ens']
+export type EnvironmentName = 'local' | 'development' | 'pr' | 'staging' | 'production' | 'ens'
 
 export const environmentName: EnvironmentName | undefined = (function () {
   if (isProd) {
     return 'production'
-  } else if (isBarn) {
-    return 'barn'
   } else if (isEns) {
     return 'ens'
   } else if (isStaging) {
@@ -100,9 +83,9 @@ export const environmentName: EnvironmentName | undefined = (function () {
   }
 })()
 
-const isProdLike = isProd || isEns || isStaging || isBarn
-const isBarnBackendEnv = forceProdApi ? false : isLocal || isDev || isPr || isBarn
+const isProdLike = isProd || isEns || isStaging
+const isBarnBackendEnv = forceProdApi ? false : isLocal || isDev || isPr || forceStagingApi
 
 registerOnWindow({ environment: environmentName })
 
-export { isLocal, isDev, isPr, isBarn, isStaging, isProd, isEns, isProdLike, isBarnBackendEnv }
+export { isLocal, isDev, isPr, isStaging, isProd, isEns, isProdLike, isBarnBackendEnv }

--- a/libs/common-utils/src/explorer.ts
+++ b/libs/common-utils/src/explorer.ts
@@ -1,6 +1,6 @@
 import { SupportedChainId as ChainId, UID } from '@cowprotocol/cow-sdk'
 
-import { isBarn, isDev, isLocal, isPr, isStaging } from './environments'
+import { isDev, isLocal, isPr, isStaging } from './environments'
 
 function _getExplorerUrlByEnvironment(): Record<ChainId, string> {
   let baseUrl: string | undefined
@@ -8,8 +8,6 @@ function _getExplorerUrlByEnvironment(): Record<ChainId, string> {
     baseUrl = process.env.REACT_APP_EXPLORER_URL_DEV || 'https://dev.explorer.cow.fi'
   } else if (isStaging) {
     baseUrl = process.env.REACT_APP_EXPLORER_URL_STAGING || 'https://staging.explorer.cow.fi'
-  } else if (isBarn) {
-    baseUrl = process.env.REACT_APP_EXPLORER_URL_BARN || 'https://barn.explorer.cow.fi'
   } else {
     // Production by default
     baseUrl = process.env.REACT_APP_EXPLORER_URL_PROD || 'https://explorer.cow.fi'

--- a/libs/common-utils/src/swap.ts
+++ b/libs/common-utils/src/swap.ts
@@ -4,7 +4,6 @@ const DEFAULT_SWAP_URL = 'https://swap.cow.fi'
 
 const swapUrlByEnvironment: Record<EnvironmentName, string> = {
   production: 'https://swap.cow.fi',
-  barn: 'https://barn.swap.cow.fi',
   ens: 'https://ens.swap.cow.fi',
   staging: 'https://staging.swap.cow.fi',
   pr: 'https://dev.swap.cow.fi',


### PR DESCRIPTION
# Summary

Remove Barn env

Also, add the option to force any env to use staging backend URLs by setting the localStorage key `forceStagingApi`, similar to `forceProdApi`.
The prod setting takes precedence.

# To Test

1. App should work as usual
2. Once promoted to main/next deployment, should not trigger the barn build

## Enable the backend api overwrite 

1. Open the console
2. Insert: `localStorage.setItem('forceStagingApi', 'true')`
3. Reload the page
* Staging endpoint should be used 
* Note: this won't have any effect in the PR, which already points to backend staging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed support for the Barn environment configuration across the application and deployment workflows
  * Updated slippage tolerance tooltip messages for improved clarity and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->