### PR TITLE
fix(cow-fi): show affiliate link in footer behind feature flag

### DIFF
--- a/apps/cow-fi/app/(main)/affiliate-program/page.tsx
+++ b/apps/cow-fi/app/(main)/affiliate-program/page.tsx
@@ -45,16 +45,14 @@ import {
 } from '@/styles/styled'
 
 const FooterCtaLinkOuter = styled.div`
-  width: fit-content;
-  display: flex;
-  aligh-items: center;
-  justify-content: center;
-  margin: auto;
-
   ${Media.upToExtraSmall()} {
+    width: 100%;
+    box-sizing: border-box;
     align-self: stretch;
+    margin: 0;
 
     a {
+      display: block;
       width: 100%;
       box-sizing: border-box;
       line-height: 1.35;

--- a/apps/cow-fi/app/(main)/affiliate-program/page.tsx
+++ b/apps/cow-fi/app/(main)/affiliate-program/page.tsx
@@ -6,9 +6,10 @@ import IMG_ICON_COW_LENS from '@cowprotocol/assets/images/icon-cow-lens.svg'
 import IMG_ICON_FAQ from '@cowprotocol/assets/images/icon-faq.svg'
 import IMG_COWSWAP_HERO from '@cowprotocol/assets/images/image-affiliate-hero.svg'
 import { useFeatureFlags } from '@cowprotocol/common-hooks'
-import { ProductLogo, ProductVariant, UI } from '@cowprotocol/ui'
+import { Media, ProductLogo, ProductVariant, UI } from '@cowprotocol/ui'
 
 import { CowFiCategory } from 'src/common/analytics/types'
+import styled from 'styled-components/macro'
 
 import FAQ from '@/components/FAQ'
 import LazySVG from '@/components/LazySVG'
@@ -42,6 +43,25 @@ import {
   TopicList,
   TopicTitle,
 } from '@/styles/styled'
+
+const FooterCtaLinkOuter = styled.div`
+  width: fit-content;
+  display: flex;
+  aligh-items: center;
+  justify-content: center;
+  margin: auto;
+
+  ${Media.upToExtraSmall()} {
+    align-self: stretch;
+
+    a {
+      width: 100%;
+      box-sizing: border-box;
+      line-height: 1.35;
+      padding: 14px 16px;
+    }
+  }
+`
 
 type SendEvent = (action: string) => void
 function AffiliateHero({ sendEvent }: { sendEvent: SendEvent }): ReactNode {
@@ -217,17 +237,19 @@ function FooterCtaSection({ sendEvent }: { sendEvent: SendEvent }): ReactNode {
           <SectionTitleDescription fontSize={28} color={`var(${UI.COLOR_NEUTRAL_30})`}>
             Generate your link. Share it. Earn USDC - every week.
           </SectionTitleDescription>
-          <Link
-            bgColor={`var(${UI.COLOR_YELLOW_300_PRIMARY})`}
-            color={`var(${UI.COLOR_YELLOW_800_PRIMARY})`}
-            href={AFFILIATE_PROGRAM_CTA.href}
-            external
-            linkType={LinkType.SectionTitleButton}
-            utmContent="affiliate-program-footer-generate-link"
-            onClick={() => sendEvent('click-generate-referral-link')}
-          >
-            Generate your referral link &#8594;
-          </Link>
+          <FooterCtaLinkOuter>
+            <Link
+              bgColor={`var(${UI.COLOR_YELLOW_300_PRIMARY})`}
+              color={`var(${UI.COLOR_YELLOW_800_PRIMARY})`}
+              href={AFFILIATE_PROGRAM_CTA.href}
+              external
+              linkType={LinkType.SectionTitleButton}
+              utmContent="affiliate-program-footer-generate-link"
+              onClick={() => sendEvent('click-generate-referral-link')}
+            >
+              Generate your referral link &#8594;
+            </Link>
+          </FooterCtaLinkOuter>
         </SectionTitleWrapper>
       </ContainerCardSection>
     </ContainerCard>

--- a/apps/cow-fi/components/Layout/const.ts
+++ b/apps/cow-fi/components/Layout/const.ts
@@ -105,7 +105,7 @@ function getAboutNavItem(isAffiliateProgramEnabled: boolean): MenuItem {
         external: true,
       },
       { label: 'Careers', href: '/careers' },
-      ...(isAffiliateProgramEnabled ? [{ label: 'Affiliate program', href: '/affiliate-program' }] : []),
+      ...(isAffiliateProgramEnabled ? [{ label: 'Affiliate Program', href: '/affiliate-program' }] : []),
     ],
   }
 }

--- a/apps/cow-fi/components/Layout/index.tsx
+++ b/apps/cow-fi/components/Layout/index.tsx
@@ -3,7 +3,7 @@
 import { PropsWithChildren, ReactNode } from 'react'
 
 import { useFeatureFlags } from '@cowprotocol/common-hooks'
-import { Footer, GlobalCoWDAOStyles, Media, MenuBar, baseTheme } from '@cowprotocol/ui'
+import { Footer, GlobalCoWDAOStyles, Media, MenuBar, baseTheme, getGlobalFooterNavItems } from '@cowprotocol/ui'
 
 import Link from 'next/link'
 import styled, { createGlobalStyle, css, ThemeProvider } from 'styled-components/macro'
@@ -77,6 +77,7 @@ export function Layout({ children, bgColor, host, showCowSaucer, contentMinHeigh
         <Footer
           maxWidth={PAGE_MAX_WIDTH}
           productVariant={PRODUCT_VARIANT}
+          navItems={getGlobalFooterNavItems(!!isAffiliateProgramEnabled)}
           host={host ?? process.env.NEXT_PUBLIC_SITE_URL!}
           expanded
           hasTouchFooter

--- a/libs/ui/src/containers/Footer/index.tsx
+++ b/libs/ui/src/containers/Footer/index.tsx
@@ -130,96 +130,124 @@ const PRODUCT_LOGO_LINKS: {
 const GLOBAL_FOOTER_DESCRIPTION =
   'CoW DAO is an open collective of developers, market makers, and community contributors on a mission to protect users from the dangers of DeFi.'
 
-const GLOBAL_FOOTER_NAV_ITEMS: Array<NavItemProps> = [
-  {
-    label: 'About',
-    children: [
-      {
-        href: 'https://docs.cow.fi/governance',
-        label: 'Governance',
-        external: true,
-        utmContent: 'footer-about-governance',
-      },
-      {
-        href: 'https://dune.com/cowprotocol/cow-revenue',
-        label: 'Revenue',
-        external: true,
-        utmContent: 'footer-about-revenue',
-      },
-      { href: 'https://grants.cow.fi/', label: 'Grants', external: true, utmContent: 'footer-about-grants' },
-      { href: 'https://cow.fi/careers', label: 'Careers', external: true, utmContent: 'footer-about-careers' },
-      {
-        href: 'https://cownation.notion.site/CoW-DAO-Brand-Kit-dad6212f182f49d38683e8410bfb37d2',
-        label: 'Brand Kit',
-        external: true,
-        utmContent: 'footer-about-brand-kit',
-      },
-      { href: 'https://cow.fi/legal', label: 'Legal', external: true, utmContent: 'footer-about-legal' },
-      {
-        label: 'Bug Bounty',
-        href: 'https://immunefi.com/bug-bounty/cowprotocol/information/',
-        external: true,
-        utmContent: 'footer-misc-bug-bounty',
-      },
-    ],
-  },
-  {
-    label: 'Products',
-    children: [
-      {
-        label: 'CoW Swap',
-        href: 'https://cow.fi/cow-swap',
-        external: true,
-        utmContent: 'footer-products-cow-swap',
-      },
-      {
-        label: 'CoW Protocol',
-        href: 'https://cow.fi/cow-protocol',
-        external: true,
-        utmContent: 'footer-products-cow-protocol',
-      },
-      { label: 'CoW AMM', href: 'https://cow.fi/cow-amm', external: true, utmContent: 'footer-products-cow-amm' },
-      {
-        label: 'MEV Blocker',
-        href: 'https://cow.fi/mev-blocker',
-        external: true,
-        utmContent: 'footer-products-mev-blocker',
-      },
-      {
-        label: 'CoW Explorer',
-        href: 'https://explorer.cow.fi/',
-        external: true,
-        utmContent: 'footer-products-cow-explorer',
-      },
-      { label: 'CoW Widget', href: 'https://cow.fi/widget', external: true, utmContent: 'footer-products-cow-widget' },
-    ],
-  },
-  {
-    label: 'Help',
-    children: [
-      { label: 'Docs', href: 'https://docs.cow.fi/', external: true, utmContent: 'footer-help-docs' },
-      {
-        label: 'Knowledge Base',
-        href: 'https://cow.fi/learn',
-        external: true,
-        utmContent: 'footer-help-knowledge-base',
-      },
-      {
-        label: 'Report Scams',
-        href: 'https://cow.fi/report-scam',
-        external: true,
-        utmContent: 'footer-help-report-scams',
-      },
-    ],
-  },
-  {
-    label: 'Misc.',
-    children: [
-      { label: 'For DAOs', href: 'https://cow.fi/daos', external: true, utmContent: 'footer-misc-for-daos' },
-      { label: 'Token Charts', href: 'https://cow.fi/tokens', external: true, utmContent: 'footer-misc-token-charts' },
-    ],
-  },
-]
+const FOOTER_NAV_GROUP_PRODUCTS: NavItemProps = {
+  label: 'Products',
+  children: [
+    {
+      label: 'CoW Swap',
+      href: 'https://cow.fi/cow-swap',
+      external: true,
+      utmContent: 'footer-products-cow-swap',
+    },
+    {
+      label: 'CoW Protocol',
+      href: 'https://cow.fi/cow-protocol',
+      external: true,
+      utmContent: 'footer-products-cow-protocol',
+    },
+    { label: 'CoW AMM', href: 'https://cow.fi/cow-amm', external: true, utmContent: 'footer-products-cow-amm' },
+    {
+      label: 'MEV Blocker',
+      href: 'https://cow.fi/mev-blocker',
+      external: true,
+      utmContent: 'footer-products-mev-blocker',
+    },
+    {
+      label: 'CoW Explorer',
+      href: 'https://explorer.cow.fi/',
+      external: true,
+      utmContent: 'footer-products-cow-explorer',
+    },
+    {
+      label: 'CoW Widget',
+      href: 'https://cow.fi/widget',
+      external: true,
+      utmContent: 'footer-products-cow-widget',
+    },
+  ],
+}
+
+const FOOTER_NAV_GROUP_HELP: NavItemProps = {
+  label: 'Help',
+  children: [
+    { label: 'Docs', href: 'https://docs.cow.fi/', external: true, utmContent: 'footer-help-docs' },
+    {
+      label: 'Knowledge Base',
+      href: 'https://cow.fi/learn',
+      external: true,
+      utmContent: 'footer-help-knowledge-base',
+    },
+    {
+      label: 'Report Scams',
+      href: 'https://cow.fi/report-scam',
+      external: true,
+      utmContent: 'footer-help-report-scams',
+    },
+  ],
+}
+
+const FOOTER_NAV_GROUP_MISC: NavItemProps = {
+  label: 'Misc.',
+  children: [
+    { label: 'For DAOs', href: 'https://cow.fi/daos', external: true, utmContent: 'footer-misc-for-daos' },
+    {
+      label: 'Token Charts',
+      href: 'https://cow.fi/tokens',
+      external: true,
+      utmContent: 'footer-misc-token-charts',
+    },
+  ],
+}
+
+function getAboutFooterNavChildren(isAffiliateProgramEnabled: boolean): NonNullable<MenuItem['children']> {
+  return [
+    {
+      href: 'https://docs.cow.fi/governance',
+      label: 'Governance',
+      external: true,
+      utmContent: 'footer-about-governance',
+    },
+    {
+      href: 'https://dune.com/cowprotocol/cow-revenue',
+      label: 'Revenue',
+      external: true,
+      utmContent: 'footer-about-revenue',
+    },
+    { href: 'https://grants.cow.fi/', label: 'Grants', external: true, utmContent: 'footer-about-grants' },
+    { href: 'https://cow.fi/careers', label: 'Careers', external: true, utmContent: 'footer-about-careers' },
+    {
+      href: 'https://cownation.notion.site/CoW-DAO-Brand-Kit-dad6212f182f49d38683e8410bfb37d2',
+      label: 'Brand Kit',
+      external: true,
+      utmContent: 'footer-about-brand-kit',
+    },
+    { href: 'https://cow.fi/legal', label: 'Legal', external: true, utmContent: 'footer-about-legal' },
+    {
+      label: 'Bug Bounty',
+      href: 'https://immunefi.com/bug-bounty/cowprotocol/information/',
+      external: true,
+      utmContent: 'footer-misc-bug-bounty',
+    },
+    ...(isAffiliateProgramEnabled
+      ? [
+          {
+            label: 'Affiliate Program',
+            href: '/affiliate-program',
+            utmContent: 'footer-about-affiliate-program',
+          },
+        ]
+      : []),
+  ]
+}
+
+export function getGlobalFooterNavItems(isAffiliateProgramEnabled: boolean): Array<NavItemProps> {
+  return [
+    { label: 'About', children: getAboutFooterNavChildren(isAffiliateProgramEnabled) },
+    FOOTER_NAV_GROUP_PRODUCTS,
+    FOOTER_NAV_GROUP_HELP,
+    FOOTER_NAV_GROUP_MISC,
+  ]
+}
 
 interface FooterLinkProps {
   href: string
@@ -261,8 +289,8 @@ const FooterLink = ({ href, external, label, utmSource: _utmSource, utmContent, 
   )
 }
 
-// TODO: Break down this large function into smaller functions
-// eslint-disable-next-line max-lines-per-function
+export const GLOBAL_FOOTER_NAV_ITEMS = getGlobalFooterNavItems(false)
+
 export const Footer = ({
   description = GLOBAL_FOOTER_DESCRIPTION,
   navItems = GLOBAL_FOOTER_NAV_ITEMS,


### PR DESCRIPTION
## Summary

Fixes #7273

Aligns cow.fi with the affiliate feature: the footer **About** section can show **Affiliate Program** when the same **feature flag** as the header is on, keeps **Affiliate Program** casing in the nav, and improves the affiliate program page footer CTA on narrow screens when the button label wraps.

---

## To test

- [ ] **Flag off:** Header **About** and footer **About** do **not** show **Affiliate Program**.
- [ ] **Flag on:** Header and footer **About** both show **Affiliate Program** (footer after **Bug Bounty**), linking to `/affiliate-program` as expected.
- [ ] **Affiliate program page:** Bottom CTA (“Generate your referral link”) looks good on narrow width (~320–500px) and on desktop.
- [ ] **Regression:** Apps using default `Footer` `navItems` still behave as before (no unexpected affiliate link).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Footer navigation now conditionally includes the Affiliate Program link based on feature enablement.

* **Style**
  * Improved mobile responsiveness and spacing for the affiliate CTA/footer link.

* **Documentation**
  * Updated navigation label capitalization for consistency ("Affiliate Program").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->