### PR TITLE
chore: deployment v2

### DIFF
--- a/.github/actions/setup-release-sync/action.yml
+++ b/.github/actions/setup-release-sync/action.yml
@@ -1,0 +1,65 @@
+name: Setup Release Sync
+description: Create a GitHub App token, resolve the app bot identity, and checkout the repository
+
+inputs:
+  app-id:
+    description: GitHub App ID
+    required: true
+  private-key:
+    description: GitHub App private key
+    required: true
+  owner:
+    description: Repository owner
+    required: true
+  repository:
+    description: Repository name
+    required: true
+  checkout-ref:
+    description: Optional git ref to checkout
+    required: false
+    default: ''
+  pull-requests-write:
+    description: Whether the app token should include pull request write permission
+    required: false
+    default: 'false'
+
+outputs:
+  token:
+    description: GitHub App installation token
+    value: ${{ steps.app-token.outputs.token }}
+  app-slug:
+    description: GitHub App slug
+    value: ${{ steps.app-token.outputs.app-slug }}
+  app-user-id:
+    description: Numeric GitHub App bot user id
+    value: ${{ steps.app-user.outputs.user-id }}
+
+runs:
+  using: composite
+  steps:
+    - name: Create GitHub App token
+      id: app-token
+      uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.private-key }}
+        owner: ${{ inputs.owner }}
+        repositories: ${{ inputs.repository }}
+        permission-contents: write
+        permission-pull-requests: ${{ inputs.pull-requests-write == 'true' && 'write' || '' }}
+
+    - name: Get GitHub App user ID
+      id: app-user
+      shell: bash
+      run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+      env:
+        APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 0
+        persist-credentials: true
+        token: ${{ steps.app-token.outputs.token }}
+        ref: ${{ inputs.checkout-ref != '' && inputs.checkout-ref || github.ref }}

--- a/.github/workflows/deployment-v2.yml
+++ b/.github/workflows/deployment-v2.yml
@@ -144,7 +144,7 @@ jobs:
           set -euo pipefail
 
           git fetch origin main staging
-          git checkout staging origin/staging
+          git checkout -B staging origin/staging
           git merge --ff-only origin/main
           git push origin staging
 
@@ -187,6 +187,6 @@ jobs:
           set -euo pipefail
 
           git fetch origin main production
-          git checkout production origin/production
+          git checkout -B production origin/production
           git merge --ff-only origin/main
           git push origin production

--- a/.github/workflows/deployment-v2.yml
+++ b/.github/workflows/deployment-v2.yml
@@ -1,4 +1,4 @@
-name: Release Branch Sync
+name: Deployment v2
 
 on:
   push:
@@ -171,7 +171,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/cowswap-') || startsWith(github.ref, 'refs/tags/explorer-')
     needs: [ collect-release-metadata, notify-production-approval ]
     runs-on: ubuntu-latest
-    environment: production
+    environment: production # Env configured in GitHub UI. Requires manual approval before this job can run
     steps:
       - name: Setup release sync
         id: setup

--- a/.github/workflows/deployment-v2.yml
+++ b/.github/workflows/deployment-v2.yml
@@ -2,8 +2,8 @@ name: Deployment v2
 
 on:
   push:
-    branches: [ main ]
-    tags: [ cowswap-*, explorer-* ]
+    branches: [main-copy]
+    tags: [cowswap-*, explorer-*]
 
 concurrency:
   group: release-branch-sync
@@ -48,15 +48,15 @@ jobs:
           echo "release-tags=${release_tags}" >> "$GITHUB_OUTPUT"
 
   sync-develop:
-    name: Sync main to develop
-    if: github.ref == 'refs/heads/main'
+    name: Sync main-copy to develop
+    if: github.ref == 'refs/heads/main-copy'
     runs-on: ubuntu-latest
     env:
       TARGET_BRANCH: develop
-      SYNC_BRANCH: automation/sync-main-to-develop
-      PR_TITLE: 'chore(sync): merge main into develop'
+      SYNC_BRANCH: automation/sync-main-copy-to-develop
+      PR_TITLE: 'chore(sync): merge main-copy into develop'
       PR_BODY: |
-        This PR contains an automated merge commit from `main` into `develop`.
+        This PR contains an automated merge commit from `main-copy` into `develop`.
 
         Requested reviewers:
         - @cowprotocol/frontend
@@ -79,11 +79,11 @@ jobs:
           git config user.name "${APP_SLUG}[bot]"
           git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
 
-          git fetch origin main "${TARGET_BRANCH}"
+          git fetch origin main-copy "${TARGET_BRANCH}"
           git checkout -B "${SYNC_BRANCH}" "origin/${TARGET_BRANCH}"
 
           before_sha="$(git rev-parse HEAD)"
-          git merge --no-ff --no-edit -m "${PR_TITLE}" origin/main
+          git merge --no-ff --no-edit -m "${PR_TITLE}" origin/main-copy
           after_sha="$(git rev-parse HEAD)"
 
           if [ "${before_sha}" = "${after_sha}" ]; then
@@ -125,7 +125,7 @@ jobs:
           PR_URL: ${{ steps.create-pr.outputs.pull-request-url }}
 
   sync-staging:
-    name: Fast-forward staging to main
+    name: Fast-forward staging to main-copy
     if: startsWith(github.ref, 'refs/tags/cowswap-') || startsWith(github.ref, 'refs/tags/explorer-')
     needs: collect-release-metadata
     runs-on: ubuntu-latest
@@ -143,15 +143,15 @@ jobs:
         run: |
           set -euo pipefail
 
-          git fetch origin main staging
+          git fetch origin main-copy staging
           git checkout -B staging origin/staging
-          git merge --ff-only origin/main
+          git merge --ff-only origin/main-copy
           git push origin staging
 
   notify-production-approval:
     name: Notify Slack for production approval
     if: startsWith(github.ref, 'refs/tags/cowswap-') || startsWith(github.ref, 'refs/tags/explorer-')
-    needs: [ collect-release-metadata, sync-staging ]
+    needs: [collect-release-metadata, sync-staging]
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack
@@ -167,9 +167,9 @@ jobs:
           RUN_ID: ${{ github.run_id }}
 
   sync-production:
-    name: Fast-forward production to main
+    name: Fast-forward production to main-copy
     if: startsWith(github.ref, 'refs/tags/cowswap-') || startsWith(github.ref, 'refs/tags/explorer-')
-    needs: [ collect-release-metadata, notify-production-approval ]
+    needs: [collect-release-metadata, notify-production-approval]
     runs-on: ubuntu-latest
     environment: production # Env configured in GitHub UI. Requires manual approval before this job can run
     steps:
@@ -186,7 +186,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          git fetch origin main production
+          git fetch origin main-copy production
           git checkout -B production origin/production
-          git merge --ff-only origin/main
+          git merge --ff-only origin/main-copy
           git push origin production

--- a/.github/workflows/release-branch-sync.yml
+++ b/.github/workflows/release-branch-sync.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     tags: [cowswap-*, explorer-*]
 
+concurrency:
+  group: release-branch-sync
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/release-branch-sync.yml
+++ b/.github/workflows/release-branch-sync.yml
@@ -2,8 +2,8 @@ name: Release Branch Sync
 
 on:
   push:
-    branches: [ main ]
-    tags: [ cowswap-*, explorer-* ]
+    branches: [main]
+    tags: [cowswap-*, explorer-*]
 
 permissions:
   contents: write
@@ -102,13 +102,13 @@ jobs:
           git push origin staging
 
   sync-production:
-    name: Sync main to production
+    name: Fast-forward production to main
     if: startsWith(github.ref, 'refs/tags/cowswap-') || startsWith(github.ref, 'refs/tags/explorer-')
+    needs: sync-staging
     runs-on: ubuntu-latest
+    environment: production
     env:
       RELEASE_TAG: ${{ github.ref_name }}
-      TARGET_BRANCH: production
-      SYNC_BRANCH: automation/sync-main-to-production
     steps:
       - name: Setup release sync
         id: setup
@@ -118,59 +118,12 @@ jobs:
           private-key: ${{ secrets.COWSWAP_RELEASE_SYNC_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repository: ${{ github.event.repository.name }}
-          pull-requests-write: 'true'
 
-      - name: Prepare merge branch
-        id: prepare
+      - name: Fast-forward production
         run: |
           set -euo pipefail
 
-          git config user.name "${APP_SLUG}[bot]"
-          git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
-
-          pr_title="chore(release): merge main into production for ${RELEASE_TAG}"
-
-          git fetch origin main "${TARGET_BRANCH}"
-          git checkout -B "${SYNC_BRANCH}" "origin/${TARGET_BRANCH}"
-
-          before_sha="$(git rev-parse HEAD)"
-          git merge --no-ff --no-edit -m "${pr_title}" origin/main
-          after_sha="$(git rev-parse HEAD)"
-
-          if [ "${before_sha}" = "${after_sha}" ]; then
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            echo "pr_title=${pr_title}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "has_changes=true" >> "$GITHUB_OUTPUT"
-          echo "pr_title=${pr_title}" >> "$GITHUB_OUTPUT"
-        env:
-          APP_SLUG: ${{ steps.setup.outputs.app-slug }}
-          APP_USER_ID: ${{ steps.setup.outputs.app-user-id }}
-
-      - name: Create or update pull request
-        if: steps.prepare.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v8
-        with:
-          token: ${{ steps.setup.outputs.token }}
-          branch: ${{ env.SYNC_BRANCH }}
-          base: ${{ env.TARGET_BRANCH }}
-          title: ${{ env.PR_TITLE }}
-          body: |
-            This PR contains an automated merge commit from `main` into `${{ env.TARGET_BRANCH }}`.
-
-            Release tag: `${{ env.RELEASE_TAG }}`
-
-            Requested reviewers:
-            - @alfetopito
-            - @anxolin
-          commit-message: ${{ env.PR_TITLE }}
-          delete-branch: false
-          draft: false
-          reviewers: |
-            alfetopito
-            anxolin
-        env:
-          PR_TITLE: ${{ steps.prepare.outputs.pr_title }}
-          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          git fetch origin main production
+          git checkout production origin/production
+          git merge --ff-only origin/main
+          git push origin production

--- a/.github/workflows/release-branch-sync.yml
+++ b/.github/workflows/release-branch-sync.yml
@@ -2,8 +2,8 @@ name: Release Branch Sync
 
 on:
   push:
-    branches: [main]
-    tags: [cowswap-*, explorer-*]
+    branches: [ main ]
+    tags: [ cowswap-*, explorer-* ]
 
 concurrency:
   group: release-branch-sync
@@ -14,6 +14,39 @@ permissions:
   pull-requests: write
 
 jobs:
+  collect-release-metadata:
+    name: Collect release metadata
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    outputs:
+      release-tags: ${{ steps.collect.outputs.release-tags }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Collect tags for release commit
+        id: collect
+        run: |
+          set -euo pipefail
+
+          git fetch --tags origin
+
+          release_commit="$(git rev-list -n 1 "${GITHUB_REF}")"
+          release_tags="$(
+            git tag --points-at "${release_commit}" \
+              | sort \
+              | paste -sd ', ' -
+          )"
+
+          if [ -z "${release_tags}" ]; then
+            release_tags="${GITHUB_REF_NAME}"
+          fi
+
+          echo "release-tags=${release_tags}" >> "$GITHUB_OUTPUT"
+
   sync-develop:
     name: Sync main to develop
     if: github.ref == 'refs/heads/main'
@@ -83,9 +116,8 @@ jobs:
   sync-staging:
     name: Fast-forward staging to main
     if: startsWith(github.ref, 'refs/tags/cowswap-') || startsWith(github.ref, 'refs/tags/explorer-')
+    needs: collect-release-metadata
     runs-on: ubuntu-latest
-    env:
-      RELEASE_TAG: ${{ github.ref_name }}
     steps:
       - name: Setup release sync
         id: setup
@@ -108,17 +140,17 @@ jobs:
   notify-production-approval:
     name: Notify Slack for production approval
     if: startsWith(github.ref, 'refs/tags/cowswap-') || startsWith(github.ref, 'refs/tags/explorer-')
-    needs: sync-staging
+    needs: [ collect-release-metadata, sync-staging ]
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack
         run: |
           curl -X POST -H "Content-type: application/json" \
-            --data "{\"text\": \"Production release for \`${RELEASE_TAG}\` is waiting for approval. <$SERVER_URL/$REPOSITORY/actions/runs/$RUN_ID|Review the workflow run>.\"}" \
+            --data "{\"text\": \"⏳ Production release for tag(s) \`${RELEASE_TAGS}\` is waiting for approval. <$SERVER_URL/$REPOSITORY/actions/runs/$RUN_ID|Review the workflow run>.\"}" \
             "$SLACK_WEBHOOK_URL"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAGS: ${{ needs.collect-release-metadata.outputs.release-tags }}
           SERVER_URL: ${{ github.server_url }}
           REPOSITORY: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
@@ -126,11 +158,9 @@ jobs:
   sync-production:
     name: Fast-forward production to main
     if: startsWith(github.ref, 'refs/tags/cowswap-') || startsWith(github.ref, 'refs/tags/explorer-')
-    needs: notify-production-approval
+    needs: [ collect-release-metadata, notify-production-approval ]
     runs-on: ubuntu-latest
     environment: production
-    env:
-      RELEASE_TAG: ${{ github.ref_name }}
     steps:
       - name: Setup release sync
         id: setup

--- a/.github/workflows/release-branch-sync.yml
+++ b/.github/workflows/release-branch-sync.yml
@@ -1,0 +1,215 @@
+name: Release Branch Sync
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ cowswap-*, explorer-* ]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync-develop:
+    name: Sync main to develop
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    env:
+      TARGET_BRANCH: develop
+      SYNC_BRANCH: automation/sync-main-to-develop
+      PR_TITLE: 'chore(sync): merge main into develop'
+      PR_BODY: |
+        This PR contains an automated merge commit from `main` into `develop`.
+
+        Requested reviewers:
+        - @cowprotocol/frontend
+        - @cowprotocol/qa
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ vars.COWSWAP_RELEASE_SYNC_APP_ID }}
+          private-key: ${{ secrets.COWSWAP_RELEASE_SYNC_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Get GitHub App user ID
+        id: app-user
+        run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Prepare merge branch
+        id: prepare
+        run: |
+          set -euo pipefail
+
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+
+          git fetch origin main "${TARGET_BRANCH}"
+          git checkout -B "${SYNC_BRANCH}" "origin/${TARGET_BRANCH}"
+
+          before_sha="$(git rev-parse HEAD)"
+          git merge --no-ff --no-edit -m "${PR_TITLE}" origin/main
+          after_sha="$(git rev-parse HEAD)"
+
+          if [ "${before_sha}" = "${after_sha}" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          APP_USER_ID: ${{ steps.app-user.outputs.user-id }}
+
+      - name: Create or update pull request
+        if: steps.prepare.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: ${{ env.SYNC_BRANCH }}
+          base: ${{ env.TARGET_BRANCH }}
+          title: ${{ env.PR_TITLE }}
+          body: ${{ env.PR_BODY }}
+          commit-message: ${{ env.PR_TITLE }}
+          delete-branch: false
+          draft: false
+          reviewers: ''
+          team-reviewers: |
+            frontend
+            qa
+
+  sync-staging:
+    name: Fast-forward staging to main
+    if: startsWith(github.ref, 'refs/tags/cowswap-') || startsWith(github.ref, 'refs/tags/explorer-')
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.ref_name }}
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ vars.COWSWAP_RELEASE_SYNC_APP_ID }}
+          private-key: ${{ secrets.COWSWAP_RELEASE_SYNC_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Fast-forward staging
+        run: |
+          set -euo pipefail
+
+          git fetch origin main staging
+          git checkout staging origin/staging
+          git merge --ff-only origin/main
+          git push origin staging
+
+  sync-production:
+    name: Sync main to production
+    if: startsWith(github.ref, 'refs/tags/cowswap-') || startsWith(github.ref, 'refs/tags/explorer-')
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.ref_name }}
+      TARGET_BRANCH: production
+      SYNC_BRANCH: automation/sync-main-to-production
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ vars.COWSWAP_RELEASE_SYNC_APP_ID }}
+          private-key: ${{ secrets.COWSWAP_RELEASE_SYNC_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Get GitHub App user ID
+        id: app-user
+        run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Prepare merge branch
+        id: prepare
+        run: |
+          set -euo pipefail
+
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+
+          pr_title="chore(release): merge main into production for ${RELEASE_TAG}"
+
+          git fetch origin main "${TARGET_BRANCH}"
+          git checkout -B "${SYNC_BRANCH}" "origin/${TARGET_BRANCH}"
+
+          before_sha="$(git rev-parse HEAD)"
+          git merge --no-ff --no-edit -m "${pr_title}" origin/main
+          after_sha="$(git rev-parse HEAD)"
+
+          if [ "${before_sha}" = "${after_sha}" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "pr_title=${pr_title}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          echo "pr_title=${pr_title}" >> "$GITHUB_OUTPUT"
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          APP_USER_ID: ${{ steps.app-user.outputs.user-id }}
+
+      - name: Create or update pull request
+        if: steps.prepare.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: ${{ env.SYNC_BRANCH }}
+          base: ${{ env.TARGET_BRANCH }}
+          title: ${{ env.PR_TITLE }}
+          body: |
+            This PR contains an automated merge commit from `main` into `${{ env.TARGET_BRANCH }}`.
+
+            Release tag: `${{ env.RELEASE_TAG }}`
+
+            Requested reviewers:
+            - @alfetopito
+            - @anxolin
+          commit-message: ${{ env.PR_TITLE }}
+          delete-branch: false
+          draft: false
+          reviewers: |
+            alfetopito
+            anxolin
+        env:
+          PR_TITLE: ${{ steps.prepare.outputs.pr_title }}
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}

--- a/.github/workflows/release-branch-sync.yml
+++ b/.github/workflows/release-branch-sync.yml
@@ -98,6 +98,7 @@ jobs:
 
       - name: Create or update pull request
         if: steps.prepare.outputs.has_changes == 'true'
+        id: create-pr
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ steps.setup.outputs.token }}
@@ -112,6 +113,16 @@ jobs:
           team-reviewers: |
             frontend
             qa
+
+      - name: Notify Slack for develop review
+        if: steps.prepare.outputs.has_changes == 'true'
+        run: |
+          curl -X POST -H "Content-type: application/json" \
+            --data "{\"text\": \"➡️ Develop sync PR is ready for review. <$PR_URL|Open pull request>.\"}" \
+            "$SLACK_WEBHOOK_URL"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          PR_URL: ${{ steps.create-pr.outputs.pull-request-url }}
 
   sync-staging:
     name: Fast-forward staging to main

--- a/.github/workflows/release-branch-sync.yml
+++ b/.github/workflows/release-branch-sync.yml
@@ -23,32 +23,16 @@ jobs:
 
         Requested reviewers:
         - @cowprotocol/frontend
-        - @cowprotocol/qa
     steps:
-      - name: Create GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+      - name: Setup release sync
+        id: setup
+        uses: ./.github/actions/setup-release-sync
         with:
           app-id: ${{ vars.COWSWAP_RELEASE_SYNC_APP_ID }}
           private-key: ${{ secrets.COWSWAP_RELEASE_SYNC_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-          permission-contents: write
-          permission-pull-requests: write
-
-      - name: Get GitHub App user ID
-        id: app-user
-        run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
-        env:
-          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: true
-          token: ${{ steps.app-token.outputs.token }}
+          repository: ${{ github.event.repository.name }}
+          pull-requests-write: 'true'
 
       - name: Prepare merge branch
         id: prepare
@@ -72,14 +56,14 @@ jobs:
 
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
         env:
-          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
-          APP_USER_ID: ${{ steps.app-user.outputs.user-id }}
+          APP_SLUG: ${{ steps.setup.outputs.app-slug }}
+          APP_USER_ID: ${{ steps.setup.outputs.app-user-id }}
 
       - name: Create or update pull request
         if: steps.prepare.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.setup.outputs.token }}
           branch: ${{ env.SYNC_BRANCH }}
           base: ${{ env.TARGET_BRANCH }}
           title: ${{ env.PR_TITLE }}
@@ -99,22 +83,14 @@ jobs:
     env:
       RELEASE_TAG: ${{ github.ref_name }}
     steps:
-      - name: Create GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+      - name: Setup release sync
+        id: setup
+        uses: ./.github/actions/setup-release-sync
         with:
           app-id: ${{ vars.COWSWAP_RELEASE_SYNC_APP_ID }}
           private-key: ${{ secrets.COWSWAP_RELEASE_SYNC_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-          permission-contents: write
-
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: true
-          token: ${{ steps.app-token.outputs.token }}
+          repository: ${{ github.event.repository.name }}
 
       - name: Fast-forward staging
         run: |
@@ -134,30 +110,15 @@ jobs:
       TARGET_BRANCH: production
       SYNC_BRANCH: automation/sync-main-to-production
     steps:
-      - name: Create GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+      - name: Setup release sync
+        id: setup
+        uses: ./.github/actions/setup-release-sync
         with:
           app-id: ${{ vars.COWSWAP_RELEASE_SYNC_APP_ID }}
           private-key: ${{ secrets.COWSWAP_RELEASE_SYNC_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-          permission-contents: write
-          permission-pull-requests: write
-
-      - name: Get GitHub App user ID
-        id: app-user
-        run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
-        env:
-          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: true
-          token: ${{ steps.app-token.outputs.token }}
+          repository: ${{ github.event.repository.name }}
+          pull-requests-write: 'true'
 
       - name: Prepare merge branch
         id: prepare
@@ -185,14 +146,14 @@ jobs:
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
           echo "pr_title=${pr_title}" >> "$GITHUB_OUTPUT"
         env:
-          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
-          APP_USER_ID: ${{ steps.app-user.outputs.user-id }}
+          APP_SLUG: ${{ steps.setup.outputs.app-slug }}
+          APP_USER_ID: ${{ steps.setup.outputs.app-user-id }}
 
       - name: Create or update pull request
         if: steps.prepare.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.setup.outputs.token }}
           branch: ${{ env.SYNC_BRANCH }}
           base: ${{ env.TARGET_BRANCH }}
           title: ${{ env.PR_TITLE }}

--- a/.github/workflows/release-branch-sync.yml
+++ b/.github/workflows/release-branch-sync.yml
@@ -101,10 +101,28 @@ jobs:
           git merge --ff-only origin/main
           git push origin staging
 
+  notify-production-approval:
+    name: Notify Slack for production approval
+    if: startsWith(github.ref, 'refs/tags/cowswap-') || startsWith(github.ref, 'refs/tags/explorer-')
+    needs: sync-staging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack
+        run: |
+          curl -X POST -H "Content-type: application/json" \
+            --data "{\"text\": \"Production release for \`${RELEASE_TAG}\` is waiting for approval. <$SERVER_URL/$REPOSITORY/actions/runs/$RUN_ID|Review the workflow run>.\"}" \
+            "$SLACK_WEBHOOK_URL"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+
   sync-production:
     name: Fast-forward production to main
     if: startsWith(github.ref, 'refs/tags/cowswap-') || startsWith(github.ref, 'refs/tags/explorer-')
-    needs: sync-staging
+    needs: notify-production-approval
     runs-on: ubuntu-latest
     environment: production
     env:


### PR DESCRIPTION
# Summary

Adding a new workflow that will be the new deployment flow.

It automates 3 things:

1. Merging `main` to `develop`

Regular pain we have for a long time. This should create a new PR once there are changes merged to `main`.
Will post to slack when PR is created.

2. Syncing `main` to `staging`

New branch part of the new release strategy.
Uses a dedicated GH app to perform the sync a new `cowswap` or `explorer` tag is created.

3. Syncing `main` to `production`

Like the staging branch, whenever there's a new tag, create a commit to sync main to production.
The approval flow will remain similar to what we have right now: an approval workflow.
When it's ready to review, it'll post a message to slack.

# To Test

Only after merging it?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated deployment workflow that responds to main and release tag pushes, coordinates releases across develop, staging, and production, and exposes release tag metadata.
  * Added notifications to Slack and a manual approval gate for production deployments.

* **Chores**
  * Introduced a secure setup step to obtain deployment credentials and identity for automation.
  * Automated branch syncs with PR creation for develop and fast-forward updates for staging/production.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->