### PR TITLE
feat: disable analytics for widget

### DIFF
--- a/apps/cowswap-frontend/src/cow-react/index.tsx
+++ b/apps/cowswap-frontend/src/cow-react/index.tsx
@@ -3,8 +3,8 @@ import { Provider as AtomProvider } from 'jotai'
 import { ReactNode, StrictMode } from 'react'
 import './sentry'
 
-import { CowAnalyticsProvider, initGtm } from '@cowprotocol/analytics'
-import { nodeRemoveChildFix } from '@cowprotocol/common-utils'
+import { CowAnalyticsProvider, createNoopCowAnalytics, initGtm } from '@cowprotocol/analytics'
+import { isInjectedWidget, nodeRemoveChildFix } from '@cowprotocol/common-utils'
 import { jotaiStore } from '@cowprotocol/core'
 import { SnackbarsWidget } from '@cowprotocol/snackbars'
 import { LegacyWeb3Provider, Web3Provider } from '@cowprotocol/wallet'
@@ -38,7 +38,7 @@ import { APP_HEADER_ELEMENT_ID } from '../common/constants/common'
 import { WalletUnsupportedNetworkBanner } from '../common/containers/WalletUnsupportedNetworkBanner'
 import { BlockNumberProvider } from '../common/hooks/useBlockNumber'
 
-const cowAnalytics = initGtm()
+const cowAnalytics = isInjectedWidget() ? createNoopCowAnalytics() : initGtm()
 const helmetContext = {}
 
 // Node removeChild hackaround

--- a/apps/cowswap-frontend/src/modules/application/containers/AppContainer/AppContainer.container.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/AppContainer/AppContainer.container.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useMemo, useState } from 'react'
 
-import { initPixelAnalytics, useAnalyticsReporter, useCowAnalytics, WebVitalsAnalytics } from '@cowprotocol/analytics'
+import { useAnalyticsReporter } from '@cowprotocol/analytics'
 import { useFeatureFlags, useMediaQuery } from '@cowprotocol/common-hooks'
 import { isInjectedWidget } from '@cowprotocol/common-utils'
 import type { NotificationModel } from '@cowprotocol/core'
@@ -32,9 +32,6 @@ import { isChristmasTheme as isChristmasThemeHelper } from '../App/styled'
 import { AppMenu } from '../AppMenu'
 import { NetworkAndAccountControls } from '../NetworkAndAccountControls/NetworkAndAccountControls.container'
 
-// Initialize static analytics instance
-const pixel = initPixelAnalytics()
-
 interface AppContainerProps {
   children: ReactNode | ReactNode[]
 }
@@ -60,17 +57,12 @@ interface FooterSectionProps {
 export function AppContainer({ children }: AppContainerProps): ReactNode {
   const { chainId, account } = useWalletInfo()
   const { walletName } = useWalletDetails()
-  const cowAnalytics = useCowAnalytics()
-  const webVitals = useMemo(() => new WebVitalsAnalytics(cowAnalytics), [cowAnalytics])
   const { isYieldEnabled, isAffiliateProgramEnabled } = useFeatureFlags()
 
   useAnalyticsReporter({
     account,
     chainId,
     walletName,
-    cowAnalytics,
-    pixelAnalytics: pixel,
-    webVitalsAnalytics: webVitals,
     marketDimension: useGetMarketDimension() || undefined,
     injectedWidgetAppId: useInjectedWidgetMetaData()?.appCode,
   })

--- a/apps/cowswap-frontend/src/modules/application/containers/WithLDProvider.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/WithLDProvider.tsx
@@ -1,6 +1,7 @@
 import { JSX, PropsWithChildren, ReactNode } from 'react'
 
 import { LAUNCH_DARKLY_CLIENT_KEY } from '@cowprotocol/common-const'
+import { isInjectedWidget } from '@cowprotocol/common-utils'
 
 import { withLDProvider } from 'launchdarkly-react-client-sdk'
 
@@ -17,5 +18,6 @@ export const WithLDProvider = withLDProvider<PropsWithChildren & JSX.IntrinsicAt
   },
   options: {
     bootstrap: 'localStorage',
+    sendEvents: !isInjectedWidget(),
   },
 })(InnerWithLDProvider)

--- a/apps/cowswap-frontend/src/modules/utm/hooks.ts
+++ b/apps/cowswap-frontend/src/modules/utm/hooks.ts
@@ -2,7 +2,7 @@ import { useAtomValue, useSetAtom } from 'jotai'
 import { useLayoutEffect, useRef } from 'react'
 
 import { waitForAnalytics } from '@cowprotocol/analytics'
-import { getUtmParams, cleanUpUtmParams, UtmParams } from '@cowprotocol/common-utils'
+import { getUtmParams, cleanUpUtmParams, isInjectedWidget, UtmParams } from '@cowprotocol/common-utils'
 
 import { useLocation } from 'react-router'
 
@@ -187,6 +187,12 @@ function processUtmParams(
     })
 
     handleUrlNavigation(newSearch, hasQueryParamsOutOfHashbang, navigate, pathname, hash)
+  }
+
+  if (isInjectedWidget()) {
+    // Widget mode does not load GTM; avoid long waitForAnalytics polling.
+    timeoutId = window.setTimeout(performUtmCleanup, 0)
+    return cleanup
   }
 
   // Wait for analytics to be ready before cleaning up UTM parameters

--- a/apps/explorer/src/explorer/ExplorerApp.tsx
+++ b/apps/explorer/src/explorer/ExplorerApp.tsx
@@ -1,12 +1,6 @@
 import React from 'react'
 
-import {
-  CowAnalyticsProvider,
-  initGtm,
-  initPixelAnalytics,
-  useAnalyticsReporter,
-  WebVitalsAnalytics,
-} from '@cowprotocol/analytics'
+import { CowAnalyticsProvider, initGtm, useAnalyticsReporter } from '@cowprotocol/analytics'
 import { CHAIN_INFO_ARRAY } from '@cowprotocol/common-const'
 
 import * as Sentry from '@sentry/react'
@@ -29,8 +23,6 @@ import { environmentName } from '../utils/env'
 
 // Initialize analytics instances
 const cowAnalytics = initGtm()
-const pixelAnalytics = initPixelAnalytics()
-const webVitalsAnalytics = new WebVitalsAnalytics(cowAnalytics)
 
 const SENTRY_DSN = process.env.REACT_APP_EXPLORER_SENTRY_DSN
 const SENTRY_TRACES_SAMPLE_RATE = process.env.REACT_APP_SENTRY_TRACES_SAMPLE_RATE
@@ -137,9 +129,6 @@ const AppContent = (): React.ReactNode => {
     account: undefined, // Explorer doesn't have wallet functionality
     walletName: undefined, // Explorer doesn't have wallet functionality
     chainId: chainId || undefined,
-    cowAnalytics,
-    pixelAnalytics,
-    webVitalsAnalytics,
   })
 
   const location = useLocation()

--- a/libs/analytics/src/gtm/CowAnalyticsGtm.ts
+++ b/libs/analytics/src/gtm/CowAnalyticsGtm.ts
@@ -35,7 +35,8 @@ function sanitizeRecord(record: Record<string, unknown>): Record<string, unknown
 declare global {
   interface Window {
     dataLayer: unknown[]
-    cowAnalyticsInstance?: CowAnalyticsGtm // For singleton pattern
+    /** GTM or noop implementation; widened from CowAnalyticsGtm so both can register. */
+    cowAnalyticsInstance?: CowAnalytics
   }
 }
 

--- a/libs/analytics/src/hooks/useAnalyticsReporter.ts
+++ b/libs/analytics/src/hooks/useAnalyticsReporter.ts
@@ -1,4 +1,7 @@
+import { useMemo } from 'react'
+
 import { usePrevious } from '@cowprotocol/common-hooks'
+import { isInjectedWidget } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import { useLocation } from 'react-router'
@@ -14,8 +17,8 @@ import {
   useUserContext,
 } from './useAnalyticsReporter.effects'
 
-import { CowAnalytics } from '../CowAnalytics'
-import { PixelAnalytics } from '../pixels/PixelAnalytics'
+import { useCowAnalytics } from '../context/CowAnalyticsContext'
+import { initPixelAnalytics } from '../pixels/initPixelAnalytics'
 import { WebVitalsAnalytics } from '../webVitals/WebVitalsAnalytics'
 
 export {
@@ -28,9 +31,6 @@ interface UseAnalyticsReporterProps {
   account: string | undefined
   walletName: string | undefined
   chainId: SupportedChainId | undefined
-  cowAnalytics: CowAnalytics
-  pixelAnalytics?: PixelAnalytics
-  webVitalsAnalytics?: WebVitalsAnalytics
   marketDimension?: string
   injectedWidgetAppId?: string
 }
@@ -39,17 +39,19 @@ interface UseAnalyticsReporterProps {
  * Common hook used by all apps to report some basic data to analytics
  * @param props
  */
-export function useAnalyticsReporter(props: UseAnalyticsReporterProps): void {
-  const {
-    account,
-    walletName,
-    chainId,
-    cowAnalytics,
-    pixelAnalytics,
-    webVitalsAnalytics,
-    marketDimension,
-    injectedWidgetAppId,
-  } = props
+export function useAnalyticsReporter({
+  account,
+  walletName,
+  chainId,
+  marketDimension,
+  injectedWidgetAppId,
+}: UseAnalyticsReporterProps): void {
+  const cowAnalytics = useCowAnalytics()
+  const webVitalsAnalytics = useMemo(
+    () => (isInjectedWidget() ? undefined : new WebVitalsAnalytics(cowAnalytics)),
+    [cowAnalytics],
+  )
+  const pixelAnalytics = useMemo(() => (isInjectedWidget() ? undefined : initPixelAnalytics()), [])
   const { pathname, search } = useLocation()
 
   const prevAccount = usePrevious(account)

--- a/libs/analytics/src/index.ts
+++ b/libs/analytics/src/index.ts
@@ -1,5 +1,6 @@
 // Core analytics initialization
 export { initGtm } from './gtm/initGtm'
+export { createNoopCowAnalytics } from './noop/createNoopCowAnalytics'
 export { initPixelAnalytics } from './pixels/initPixelAnalytics'
 export { WebVitalsAnalytics } from './webVitals/WebVitalsAnalytics'
 

--- a/libs/analytics/src/noop/createNoopCowAnalytics.test.ts
+++ b/libs/analytics/src/noop/createNoopCowAnalytics.test.ts
@@ -1,0 +1,46 @@
+import { __resetNoopCowAnalyticsInstance, createNoopCowAnalytics } from './createNoopCowAnalytics'
+
+import { AnalyticsContext } from '../CowAnalytics'
+
+describe('createNoopCowAnalytics', () => {
+  afterEach(() => {
+    __resetNoopCowAnalyticsInstance()
+    delete (window as unknown as { cowAnalyticsInstance?: unknown }).cowAnalyticsInstance
+    delete (window as unknown as { dataLayer?: unknown }).dataLayer
+  })
+
+  it('returns the same singleton', () => {
+    const a = createNoopCowAnalytics()
+    const b = createNoopCowAnalytics()
+    expect(a).toBe(b)
+  })
+
+  it('registers on window without creating dataLayer', () => {
+    expect(window.dataLayer).toBeUndefined()
+    createNoopCowAnalytics()
+    expect(window.dataLayer).toBeUndefined()
+    expect(window.cowAnalyticsInstance).toBeDefined()
+  })
+
+  it('exposes safe no-op methods', () => {
+    const analytics = createNoopCowAnalytics()
+    expect(() => {
+      analytics.setUserAccount('0xabc')
+      analytics.sendPageView('/x')
+      analytics.sendEvent({ category: 'c', action: 'a' })
+      analytics.sendTiming('cat', 'var', 1, 'label')
+      analytics.sendError(new Error('e'))
+      analytics.setContext(AnalyticsContext.chainId, '1')
+    }).not.toThrow()
+  })
+
+  it('invokes outbound hitCallback asynchronously', (done) => {
+    const analytics = createNoopCowAnalytics()
+    analytics.outboundLink({
+      label: 'x',
+      hitCallback: () => {
+        done()
+      },
+    })
+  })
+})

--- a/libs/analytics/src/noop/createNoopCowAnalytics.ts
+++ b/libs/analytics/src/noop/createNoopCowAnalytics.ts
@@ -1,0 +1,65 @@
+/**
+ * No-op analytics implementation for environments where third-party scripts must not load (e.g. embedded widget).
+ */
+
+import { AnalyticsContext, CowAnalytics, EventOptions, OutboundLinkParams } from '../CowAnalytics'
+
+const state = {
+  instance: null as CowAnalytics | null,
+}
+
+class CowAnalyticsNoop implements CowAnalytics {
+  private cleanup(): void {
+    if (typeof window !== 'undefined') {
+      window.cowAnalyticsInstance = undefined
+    }
+  }
+
+  constructor() {
+    if (typeof window !== 'undefined') {
+      if (window.cowAnalyticsInstance) {
+        throw new Error('Cow analytics instance already exists — use initGtm() or createNoopCowAnalytics() once')
+      }
+
+      window.cowAnalyticsInstance = this
+      window.addEventListener('unload', this.cleanup)
+    }
+  }
+
+  setUserAccount(_account: string | undefined, _walletName?: string): void {}
+
+  sendPageView(_path?: string, _params?: string[], _title?: string): void {}
+
+  sendEvent(_event: string | EventOptions, _params?: unknown): void {}
+
+  sendTiming(_timingCategory: string, _timingVar: string, _timingValue: number, _timingLabel: string): void {}
+
+  sendError(_error: Error, _errorInfo?: string): void {}
+
+  outboundLink({ hitCallback }: OutboundLinkParams): void {
+    if (hitCallback && typeof window !== 'undefined') {
+      window.setTimeout(hitCallback, 0)
+    }
+  }
+
+  setContext(_key: AnalyticsContext, _value?: string): void {}
+}
+
+/**
+ * Returns a singleton no-op CowAnalytics and registers it on window when in the browser.
+ */
+export function createNoopCowAnalytics(): CowAnalytics {
+  if (state.instance) {
+    return state.instance
+  }
+
+  state.instance = new CowAnalyticsNoop()
+  return state.instance
+}
+
+/** @internal Testing only */
+export function __resetNoopCowAnalyticsInstance(): void {
+  if (process.env.NODE_ENV === 'test') {
+    state.instance = null
+  }
+}


### PR DESCRIPTION
# Summary

Disable analytics for widget.

# To Test

1. Go to widget configurator: DevTools → Network → filter googletagmanager → reload iframe → no GTM requests.
2. Go to the standalone CoW Swap page: Same filter → reload → GTM still loads (as before).
3. Widget: Quick smoke: connect wallet + get quote / small flow → works, no new hard failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic analytics optimization for embedded widget contexts.

* **Improvements**
  * Simplified analytics initialization by centralizing configuration.
  * LaunchDarkly event tracking now respects embedded widget contexts.
  * Enhanced UTM parameter processing for embedded widgets.
  * Improved performance for embedded widgets by conditionally disabling analytics overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->