### PR TITLE
fix: fix window.open widget logic opening twice

### DIFF
--- a/apps/cowswap-frontend/src/modules/injectedWidget/updaters/InjectedWidgetUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/updaters/InjectedWidgetUpdater.tsx
@@ -44,10 +44,11 @@ import {
 
   /**
    * Intercept window.open and anchor clicks to send a message to the parent window
-   * to handle the opening of deeplinks in the parent window
+   * to handle the opening of deeplinks in the parent window.
+   *
+   * IMPORTANT: Do not call the native window.open here: createCowSwapWidget registers interceptDeepLinks
+   * which opens in the parent; calling both would open two tabs / popups.
    */
-  const originalWinOpen = window.open
-
   window.open = function (...args) {
     const [href = '', target = '', rel = ''] = args
 
@@ -58,7 +59,7 @@ import {
       parentOrigin,
     )
 
-    return originalWinOpen.apply(this, args)
+    return window
   }
 
   document.body.addEventListener('click', (event) => {


### PR DESCRIPTION
# Summary

Closes https://github.com/cowprotocol/cowswap/issues/7310.

The original `window.open` was being called inside the widget app, at the same time that `INTERCEPT_WINDOW_OPEN` was being sent to the parent, which would call `window.open` again.

# To Test

Make a transaction and try to share on X. Only one tab should open.
