### PR TITLE
fix(widget): enable deeplinks interceptor only in standalone mode

### DIFF
--- a/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
@@ -8,10 +8,6 @@ import { ConfiguratorState } from '../types'
 const vercelSuffix = '-cowswap-dev.vercel.app'
 
 const getBaseUrl = (): string => {
-  const widgetUrlFromSearch = new URLSearchParams(location.search).get('widgetUrl')
-
-  if (widgetUrlFromSearch) return widgetUrlFromSearch
-
   if (typeof window === 'undefined' || !window) return ''
 
   if (isLocalHost) return 'http://localhost:3000'

--- a/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
@@ -8,6 +8,10 @@ import { ConfiguratorState } from '../types'
 const vercelSuffix = '-cowswap-dev.vercel.app'
 
 const getBaseUrl = (): string => {
+  const widgetUrlFromSearch = new URLSearchParams(location.search).get('widgetUrl')
+
+  if (widgetUrlFromSearch) return widgetUrlFromSearch
+
   if (typeof window === 'undefined' || !window) return ''
 
   if (isLocalHost) return 'http://localhost:3000'

--- a/libs/widget-lib/src/cowSwapWidget.ts
+++ b/libs/widget-lib/src/cowSwapWidget.ts
@@ -88,7 +88,20 @@ export function createCowSwapWidget(container: HTMLElement, props: CowSwapWidget
   windowListeners.push(...listenToHeightChanges(iframe, iframeOrigin, params.height, params.maxHeight))
 
   // 5. Intercept deeplinks navigation in the iframe
-  windowListeners.push(interceptDeepLinks(iframeOrigin))
+  let interceptDeepLinksListener: WindowListener | null = null
+
+  function updateInterceptDeepLinks(): void {
+    if (interceptDeepLinksListener) {
+      window.removeEventListener('message', interceptDeepLinksListener)
+    }
+
+    // Enable deeplinks interceptor only in standalone mode
+    // because the mechanism is only needed when connecting wallet inside if the iframe
+    if (!currentParams.standaloneMode) return
+
+    interceptDeepLinksListener = interceptDeepLinks(iframeOrigin)
+    windowListeners.push(interceptDeepLinksListener)
+  }
 
   // 6. Handle two-way communication of widget hooks
   let widgetHooksListener: WindowListener | null = null
@@ -103,6 +116,7 @@ export function createCowSwapWidget(container: HTMLElement, props: CowSwapWidget
     windowListeners.push(widgetHooksListener)
   }
 
+  updateInterceptDeepLinks()
   updateWidgetHooks()
 
   // 7. Handle and forward widget events to the listeners
@@ -124,6 +138,7 @@ export function createCowSwapWidget(container: HTMLElement, props: CowSwapWidget
     updateParams: (newParams: CowSwapWidgetParams) => {
       currentParams = newParams
       updateParams(iframeWindow, iframeOrigin, currentParams, provider)
+      updateInterceptDeepLinks()
       updateWidgetHooks()
     },
     updateListeners: (newListeners?: CowWidgetEventListeners) => iFrameCowEventEmitter.updateListeners(newListeners),
@@ -283,7 +298,7 @@ function listenToReady(contentWindow: Window, iframeOrigin: string, onReady: () 
 /**
  * Since deeplinks are not supported in iframes, this function intercepts the window.open calls from the widget and opens
  */
-function interceptDeepLinks(iframeOrigin: string): (payload: MessageEvent<unknown>) => void {
+function interceptDeepLinks(iframeOrigin: string): WindowListener {
   return widgetIframeTransport.listenToMessageFromWindow(
     window,
     WidgetMethodsEmit.INTERCEPT_WINDOW_OPEN,


### PR DESCRIPTION
# Summary

In Dapp Mode, we don't need to intercept deep links, because this feature is only needed when you connect a wallet inside CoW Swap (standalone mode).

# To Test

1. Open https://widget-configurator-git-fix-window-intercept-9969fe-cowswap-dev.vercel.app/?widgetUrl=https://swap-dev-git-fix-window-intercept-dapp-mode-cowswap-dev.vercel.app
2. Switch to standaloneMode
3. Open the browser console and switch context to the iframe
<img width="464" height="409" alt="image" src="https://github.com/user-attachments/assets/4cfd018a-d0ae-4be2-932a-65660d2191dc" />
4. Run the code snippet
- [ ] ER: it navigates to google
5. Repeat the steps from the beginning, but do not switch to standaloneMode and keep Dapp mode
- [ ] ER: it DOES NOT navigate to google


```
window.parent.postMessage({
    "key": "cowSwapWidget",
    "method": "INTERCEPT_WINDOW_OPEN",
    "href": "https://google.com",
    "target": "_self",
    "rel": "noreferrer noopener"
}, 'https://widget-configurator-git-fix-window-intercept-9969fe-cowswap-dev.vercel.app')
```


https://github.com/user-attachments/assets/19e7adfd-34dc-47be-a4f2-7ee70514ddff

