### PR TITLE
fix: update quote when wallet is not connected

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useQuoteParams.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useQuoteParams.ts
@@ -10,7 +10,6 @@ import { useWalletInfo } from '@cowprotocol/wallet'
 
 import ms from 'ms.macro'
 import { Nullish } from 'types'
-import { useWalletClient } from 'wagmi'
 
 import { AppDataInfo, useAppData } from 'modules/appData'
 import { useIsWrapOrUnwrap, useDerivedTradeState } from 'modules/trade'
@@ -38,7 +37,6 @@ export interface QuoteParams {
 
 export function useQuoteParams(amount: Nullish<string>, partiallyFillable = false): QuoteParams | undefined {
   const { account } = useWalletInfo()
-  const { data: _walletClient } = useWalletClient() // kept for memo dep – triggers re-quote on wallet change
   const appData = useAppData()
   const isWrapOrUnwrap = useIsWrapOrUnwrap()
   const isProviderNetworkUnsupported = useIsProviderNetworkUnsupported()
@@ -58,7 +56,7 @@ export function useQuoteParams(amount: Nullish<string>, partiallyFillable = fals
 
   const params = useSafeMemo(() => {
     if (isWrapOrUnwrap || isProviderNetworkUnsupported || isProviderNetworkDeprecated) return
-    if (!inputCurrency || !outputCurrency || !orderKind || !_walletClient) return
+    if (!inputCurrency || !outputCurrency || !orderKind) return
     return buildQuoteParams({
       amount,
       partiallyFillable,
@@ -73,7 +71,6 @@ export function useQuoteParams(amount: Nullish<string>, partiallyFillable = fals
       smartSlippageBpsRef,
     })
   }, [
-    _walletClient,
     inputCurrency,
     outputCurrency,
     amount,


### PR DESCRIPTION
# Summary

Fixed quote fetching problem with wallet is not connected.

# To Test

1. Disconnect wallet
2. Change sell amount
- [ ] AR: it doesn't fetch quote
- [ ] ER: it fetches quote and update values


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized quote parameter calculation to improve performance. Quote updates now depend exclusively on currency selection and order type, eliminating unnecessary recalculations previously triggered by wallet connectivity changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->