### PR TITLE
Bruno/cow 872 Remaining issues from Ethers -> Viem migration

### DIFF
--- a/apps/cowswap-frontend/src/common/updaters/WalletChainUrlSyncUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/WalletChainUrlSyncUpdater.ts
@@ -1,24 +1,28 @@
 import { useEffect, useRef } from 'react'
 
-import { useWalletInfo } from '@cowprotocol/wallet'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import { useConnection } from 'wagmi'
 
 import { useLegacySetChainIdToUrl } from 'common/hooks/useLegacySetChainIdToUrl'
 
 /**
  * Syncs the URL when the connected wallet changes chain externally (e.g. via MetaMask).
- * Without this, disconnecting after an external chain switch would revert to the stale URL chain.
+ * Uses the raw provider chain from useConnection() to avoid the fallback logic in useWalletInfo()
+ * that masks unsupported chains with the URL chain.
  */
 export function WalletChainUrlSyncUpdater(): null {
-  const { chainId, active } = useWalletInfo()
+  const { chainId, isConnected } = useConnection()
   const setChainIdToUrl = useLegacySetChainIdToUrl()
   const prevChainIdRef = useRef(chainId)
 
   useEffect(() => {
-    if (active && chainId !== prevChainIdRef.current) {
-      setChainIdToUrl(chainId)
+    // Only sync supported chains from a connected wallet
+    if (isConnected && chainId && chainId in SupportedChainId && chainId !== prevChainIdRef.current) {
+      setChainIdToUrl(chainId as SupportedChainId)
     }
     prevChainIdRef.current = chainId
-  }, [active, chainId, setChainIdToUrl])
+  }, [isConnected, chainId, setChainIdToUrl])
 
   return null
 }

--- a/apps/cowswap-frontend/src/common/updaters/WalletChainUrlSyncUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/WalletChainUrlSyncUpdater.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from 'react'
+
+import { useWalletInfo } from '@cowprotocol/wallet'
+
+import { useLegacySetChainIdToUrl } from 'common/hooks/useLegacySetChainIdToUrl'
+
+/**
+ * Syncs the URL when the connected wallet changes chain externally (e.g. via MetaMask).
+ * Without this, disconnecting after an external chain switch would revert to the stale URL chain.
+ */
+export function WalletChainUrlSyncUpdater(): null {
+  const { chainId, active } = useWalletInfo()
+  const setChainIdToUrl = useLegacySetChainIdToUrl()
+  const prevChainIdRef = useRef(chainId)
+
+  useEffect(() => {
+    if (active && chainId !== prevChainIdRef.current) {
+      setChainIdToUrl(chainId)
+    }
+    prevChainIdRef.current = chainId
+  }, [active, chainId, setChainIdToUrl])
+
+  return null
+}

--- a/apps/cowswap-frontend/src/common/updaters/WalletChainUrlSyncUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/WalletChainUrlSyncUpdater.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 
-import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { isSupportedChainId } from '@cowprotocol/common-utils'
 
 import { useConnection } from 'wagmi'
 
@@ -18,8 +18,8 @@ export function WalletChainUrlSyncUpdater(): null {
 
   useEffect(() => {
     // Only sync supported chains from a connected wallet
-    if (isConnected && chainId && chainId in SupportedChainId && chainId !== prevChainIdRef.current) {
-      setChainIdToUrl(chainId as SupportedChainId)
+    if (isConnected && isSupportedChainId(chainId) && chainId !== prevChainIdRef.current) {
+      setChainIdToUrl(chainId)
     }
     prevChainIdRef.current = chainId
   }, [isConnected, chainId, setChainIdToUrl])

--- a/apps/cowswap-frontend/src/modules/application/containers/App/Updaters.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/App/Updaters.tsx
@@ -54,6 +54,7 @@ import { SentryUpdater } from 'common/updaters/SentryUpdater'
 import { SolversInfoUpdater } from 'common/updaters/SolversInfoUpdater'
 import { ThemeFromUrlUpdater } from 'common/updaters/ThemeFromUrlUpdater'
 import { UserUpdater } from 'common/updaters/UserUpdater'
+import { WalletChainUrlSyncUpdater } from 'common/updaters/WalletChainUrlSyncUpdater'
 import { WalletSessionDurationUpdater } from 'common/updaters/WalletSessionDurationUpdater'
 import { WidgetTokensUpdater } from 'common/updaters/WidgetTokensUpdater'
 
@@ -82,6 +83,7 @@ export function Updaters(): ReactNode {
       <TradingSdkUpdater />
       {/*Set custom chainId only when it differs from the wallet chainId*/}
       <WalletUpdater standaloneMode={standaloneMode} />
+      <WalletChainUrlSyncUpdater />
       <UserUpdater />
       <FinalizeTxUpdater />
       <PendingOrdersUpdater />

--- a/libs/common-utils/src/getCurrentChainIdFromUrl.ts
+++ b/libs/common-utils/src/getCurrentChainIdFromUrl.ts
@@ -1,12 +1,21 @@
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 /**
- * Maps chain names used in URL query parameters to SupportedChainId
- * Those networks are the ones that existed before we started using chain IDs in the URL
+ * Maps chain names used in URL query parameters to SupportedChainId.
+ * The names here must match the `name` field in CHAIN_INFO (libs/common-const/src/chainInfo.ts).
  */
 const chainNameToIdMap: { [key: string]: SupportedChainId } = {
   mainnet: SupportedChainId.MAINNET,
+  ethereum: SupportedChainId.MAINNET,
+  bnb: SupportedChainId.BNB,
+  base: SupportedChainId.BASE,
+  arbitrum_one: SupportedChainId.ARBITRUM_ONE,
+  polygon: SupportedChainId.POLYGON,
+  avalanche: SupportedChainId.AVALANCHE,
   gnosis_chain: SupportedChainId.GNOSIS_CHAIN,
+  linea: SupportedChainId.LINEA,
+  plasma: SupportedChainId.PLASMA,
+  ink: SupportedChainId.INK,
   sepolia: SupportedChainId.SEPOLIA,
 }
 

--- a/libs/wallet/src/wagmi/Web3Provider.tsx
+++ b/libs/wallet/src/wagmi/Web3Provider.tsx
@@ -3,7 +3,6 @@ import { useEffect, type ReactNode } from 'react'
 import { SafeProvider } from '@safe-global/safe-apps-react-sdk'
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { reconnect } from '@wagmi/core'
 import { WagmiProvider } from 'wagmi'
 
 import { config, reownAppKit } from './config'
@@ -12,19 +11,6 @@ import { SafeConnectionHandler } from './SafeConnectionHandler'
 import { OPEN_WALLET_MODAL_EVENT } from '../constants'
 
 const queryClient = new QueryClient()
-
-function ReconnectOnMount(): null {
-  useEffect(() => {
-    void reconnect(config)
-      .then((res) => {
-        console.debug('[ReconnectOnMount] result', res)
-      })
-      .catch((error) => {
-        console.error('[ReconnectOnMount] error', error)
-      })
-  }, [])
-  return null
-}
 
 function OpenWalletModalOnCustomEvent(): null {
   useEffect(() => {
@@ -43,8 +29,7 @@ interface Web3ProviderProps {
 
 export function Web3Provider({ children }: Web3ProviderProps): ReactNode {
   return (
-    <WagmiProvider config={config}>
-      <ReconnectOnMount />
+    <WagmiProvider config={config} reconnectOnMount>
       <OpenWalletModalOnCustomEvent />
       <QueryClientProvider client={queryClient}>
         <SafeProvider>

--- a/libs/wallet/src/wagmi/hooks/useSwitchNetwork.ts
+++ b/libs/wallet/src/wagmi/hooks/useSwitchNetwork.ts
@@ -1,16 +1,25 @@
+import { useSetAtom } from 'jotai'
 import { useCallback } from 'react'
 
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
-import { useSwitchChain } from 'wagmi'
+import { useConnection, useSwitchChain } from 'wagmi'
+
+import { walletInfoAtom } from '../../api/state'
 
 export function useSwitchNetwork(): (chainId: SupportedChainId) => Promise<void> {
   const { mutateAsync: switchChain } = useSwitchChain()
+  const { isConnected } = useConnection()
+  const setWalletInfo = useSetAtom(walletInfoAtom)
 
   return useCallback(
     async (chainId: SupportedChainId) => {
-      await switchChain({ chainId })
+      if (isConnected) {
+        await switchChain({ chainId })
+      } else {
+        setWalletInfo((prev) => ({ ...prev, chainId }))
+      }
     },
-    [switchChain],
+    [switchChain, isConnected, setWalletInfo],
   )
 }

--- a/libs/wallet/src/wagmi/updater.ts
+++ b/libs/wallet/src/wagmi/updater.ts
@@ -1,7 +1,7 @@
 import { useAtomValue, useSetAtom } from 'jotai'
 import { useEffect, useMemo, useState, useSyncExternalStore } from 'react'
 
-import { getCurrentChainIdFromUrl } from '@cowprotocol/common-utils'
+import { getCurrentChainIdFromUrl, getRawCurrentChainIdFromUrl } from '@cowprotocol/common-utils'
 import { getSafeInfo } from '@cowprotocol/core'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
@@ -44,6 +44,7 @@ function useWalletInfo(): WalletInfo {
   const { address, chainId, isConnected } = useConnection()
   const isChainIdUnsupported = !!chainId && !(chainId in SupportedChainId)
   const [lastStableChainId, setLastStableChainId] = useState<SupportedChainId | undefined>(undefined)
+  const [lastResolvedChainId, setLastResolvedChainId] = useState<SupportedChainId>(() => getCurrentChainIdFromUrl())
 
   useEffect(() => {
     if (!isConnected) {
@@ -55,12 +56,14 @@ function useWalletInfo(): WalletInfo {
     }
   }, [isConnected, chainId, isChainIdUnsupported])
 
-  return useMemo(() => {
+  const walletInfo = useMemo(() => {
     void urlKey
 
     let resolvedChainId: SupportedChainId
     if (!isConnected) {
-      resolvedChainId = getCurrentChainIdFromUrl()
+      // Use chain from URL if present; otherwise preserve the last resolved chainId
+      // (e.g. when navigating from a path-based route like /56/swap to /account which has no chain in URL)
+      resolvedChainId = getRawCurrentChainIdFromUrl() ?? lastResolvedChainId
     } else if (isChainIdUnsupported) {
       resolvedChainId = getCurrentChainIdFromUrl()
     } else if (chainId) {
@@ -74,7 +77,13 @@ function useWalletInfo(): WalletInfo {
       active: isConnected,
       account: address,
     }
-  }, [address, chainId, isConnected, isChainIdUnsupported, lastStableChainId, urlKey])
+  }, [address, chainId, isConnected, isChainIdUnsupported, lastStableChainId, lastResolvedChainId, urlKey])
+
+  useEffect(() => {
+    setLastResolvedChainId(walletInfo.chainId)
+  }, [walletInfo.chainId])
+
+  return walletInfo
 }
 
 // Smart contract wallets are filtered out by default, no need to add them to this list


### PR DESCRIPTION
# Summary

This branch is for resolving comments/bugs/removing legacy code from Ethers -> Viem migration.

Fixes https://nomevlabs.slack.com/archives/C07FQTUKLJC/p1776163606828179?thread_ts=1776154503.425239&cid=C07FQTUKLJC

# To Test

1. Disconnect wallet
2. Switch chain on the button near Connect Wallet
- [ ] AR: it doesn't switch chainId on URL
- [ ] ER: it switches the chainId on URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for more chain name aliases in URL parsing.
  * Introduced a background updater that syncs the app URL with the connected wallet chain.

* **Bug Fixes**
  * Prevented network switch attempts when the wallet is disconnected by deferring chain changes until connected.

* **Refactor**
  * Rely on built-in provider reconnection and simplified wallet chain-resolution with a URL-based fallback to reduce noise and complexity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->