### PR TITLE
fix: set order of connectors in Reown

### DIFF
--- a/libs/wallet/src/wagmi/config.ts
+++ b/libs/wallet/src/wagmi/config.ts
@@ -1,4 +1,5 @@
-import { RPC_URLS } from '@cowprotocol/common-const'
+import { RPC_URLS, VIEM_CHAINS } from '@cowprotocol/common-const'
+import { getCurrentChainIdFromUrl } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import { createAppKit } from '@reown/appkit/react'
@@ -83,7 +84,7 @@ export const reownAppKit = createAppKit({
   adapters: [wagmiAdapter],
   allowUnsupportedChain: false,
   customRpcUrls,
-  defaultNetwork: SUPPORTED_REOWN_NETWORKS[0],
+  defaultNetwork: VIEM_CHAINS[getCurrentChainIdFromUrl()],
   enableEIP6963: true,
   enableReconnect: true,
   enableWalletGuide: false,
@@ -92,6 +93,7 @@ export const reownAppKit = createAppKit({
     analytics: false,
     email: false,
     socials: false,
+    connectorTypeOrder: ['injected', 'recent', 'walletConnect'],
   },
   metadata,
   networks: SUPPORTED_REOWN_NETWORKS,


### PR DESCRIPTION
# Summary

Just changed the available wallets order.
Injected wallets should go before WalletConnect.

# To Test

Before

<img width="398" height="512" alt="image" src="https://github.com/user-attachments/assets/3caffb05-eb7e-4587-94ce-2072a7957179" />


After

<img width="399" height="503" alt="image" src="https://github.com/user-attachments/assets/a31cc87e-20c3-4411-a4a8-28cbb5093dd6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Network selection now dynamically adapts to match the current URL, ensuring you're always on the correct blockchain.
  * Wallet connector options are displayed in an optimized order for easier discovery and improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->