### PR TITLE
fix (cowswap): show token page if wallet isn't connected

### DIFF
--- a/apps/cowswap-frontend/src/pages/Account/Tokens/TokensOverview.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/Tokens/TokensOverview.tsx
@@ -132,6 +132,7 @@ export default function TokensOverview(): ReactNode {
           <Trans>Deprecated network</Trans>
         ) : (
           <TokensTableContent
+            account={account}
             walletClient={walletClient}
             darkMode={theme.darkMode}
             selectedView={selectedView}
@@ -232,6 +233,7 @@ function TokensOverviewHeader(props: TokensOverviewHeaderProps): ReactNode {
 }
 
 interface TokensTableContentProps {
+  account: string | undefined
   walletClient: WalletClient
   darkMode: boolean
   selectedView: PageViewKeys
@@ -248,6 +250,7 @@ interface TokensTableContentProps {
 
 function TokensTableContent(props: TokensTableContentProps): ReactNode {
   const {
+    account,
     walletClient,
     darkMode,
     selectedView,
@@ -264,7 +267,7 @@ function TokensTableContent(props: TokensTableContentProps): ReactNode {
 
   const tokensData = selectedView === PageViewKeys.ALL_TOKENS ? formattedTokens : favoriteTokens
 
-  if (!walletClient) {
+  if (account && !walletClient) {
     return (
       <TokensLoader>
         <CowLoadingIcon size={120} isDarkMode={darkMode} />


### PR DESCRIPTION
# Summary

Fix the error reported here: https://www.notion.so/cownation/Disconnected-tokens-page-cannot-be-loaded-3428da5f04ca80838bf3fee04e22fe0a

Fixed video: https://www.loom.com/share/e36365f4ffa448dcbcb729e92fbd58cc

Root cause: TokensOverview.tsx:267 had if `(!walletClient)` which showed an infinite loading spinner when no wallet was connected, because walletClient is always undefined without a connected account.

Fix: Changed the condition to if `(account && !walletClient)` — the loading spinner now only shows during the brief initialization period when a wallet IS connected but the client hasn't loaded yet. When no wallet is connected, the TokenTable renders directly, which already handles the disconnected state properly

I'm not totally aware why there was this condition on the first page, so I thought that was better to don't remove it completelly, but let me know if I should do it.
# To Test

1. Open the "tokens" overview page without a wallet connected

- [ ] Check if all token balances and values are filled with 0.
- [ ] Check if "approve" button try to connects your wallet
- [ ] Check if page has the same behavior of the production version


2. Connects your wallet in the page
- [ ] Check if page has the same behavior of the production version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined loading state behavior for the tokens overview, ensuring the loader displays only when actively retrieving wallet data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->