### PR TITLE
fix(cowswap): infinite loop on cow account token balance

### DIFF
--- a/apps/cowswap-frontend/src/pages/Account/Balances.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/Balances.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import ArrowIcon from '@cowprotocol/assets/cow-swap/arrow.svg'
 import CowImage from '@cowprotocol/assets/cow-swap/cow_token.svg'
 import vCOWImage from '@cowprotocol/assets/images/vCOW.svg'
-import { useCurrencyAmountBalance } from '@cowprotocol/balances-and-allowances'
+import { useCurrencyAmountBalance, useTokensBalances } from '@cowprotocol/balances-and-allowances'
 import {
   COW_TOKEN_TO_CHAIN,
   COW_CONTRACT_ADDRESS,
@@ -99,16 +99,13 @@ export default function Profile() {
     !hasVestedBalance || !isSwapInitial || isSwapPending || isSwapConfirmed || shouldUpdate,
   )
 
+  const { hasFirstLoad: hasBalancesLoaded } = useTokensBalances()
+
   const isCardsLoading = useMemo(() => {
-    let output = isVCowLoading || isLockedGnoLoading || !walletClient
+    if (!account) return false
 
-    // remove loader after 5 sec in any case
-    setTimeout(() => {
-      output = false
-    }, 5000)
-
-    return output
-  }, [isLockedGnoLoading, isVCowLoading, walletClient])
+    return isVCowLoading || isLockedGnoLoading || !walletClient || !hasBalancesLoaded
+  }, [account, isLockedGnoLoading, isVCowLoading, walletClient, hasBalancesLoaded])
 
   // Init modal hooks
   const { handleSetError, handleCloseError, ErrorModal } = useErrorModal()


### PR DESCRIPTION
# Summary

Fix infinite loading state and balance flickering on the Account Overview page (/account).

The COW balance card was stuck in an infinite loading spinner when no wallet was connected, and showed a
 brief flash of "0" balance before displaying the actual balance when a wallet was connected.

Root cause: The isCardsLoading logic in Balances.tsx had three issues:
1. !walletClient was used as a loading condition, which is always true when no wallet is connected —
causing an infinite loading state.
2. account was missing from the useMemo dependency array, so disconnection was never reflected.
3. The loading state didn't wait for token balances to be fetched, causing cards to render with a "0"
fallback before the real balance arrived.
4. A broken setTimeout hack inside useMemo attempted to force-clear loading after 5s by setting a local
variable — this never triggered a re-render and was dead code.

https://www.loom.com/share/04ecfd94aebf4f10b3fdf18c4fb4d20c

# To Test

1. Open /account without a wallet connected

- COW balance card should render immediately (no infinite loading spinner)
- Balance should display as 0

2. Connect a wallet that holds COW tokens

- Loading spinner should display while data is being fetched
- Once loaded, the actual COW balance should appear without a brief flash of "0"

3. Disconnect the wallet while on /account

- Cards should transition from showing balances to showing 0 without getting stuck on a loading spinner

# Background

isCardsLoading was rewritten to:
- Return false immediately when no account is connected (no data to load).
- Include !hasBalancesLoaded (from useTokensBalances()) so the loading spinner stays until balances have
 been fetched at least once, preventing the "0" flash.
- Remove the broken setTimeout workaround.
