### PR TITLE
fix: don't highlight both hooks and swap tabs when in hooks tab

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidgetLinks/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidgetLinks/index.tsx
@@ -88,7 +88,10 @@ export function TradeWidgetLinks({ isDropdown = false }: TradeWidgetLinksProps) 
           : parameterizeTradeRoute(tradeUrlParams, item.route, !isCurrentPathYield)
 
       const routeBasePath = addChainIdToRoute(item.route, chainId)
-      const isActive = location.pathname.startsWith(routeBasePath)
+      const hooksBasePath = addChainIdToRoute(Routes.HOOKS, chainId)
+      const isActive =
+        location.pathname.startsWith(routeBasePath) &&
+        (item.route === Routes.HOOKS || !location.pathname.startsWith(hooksBasePath))
 
       return (
         <MenuItem


### PR DESCRIPTION
# Summary

Swap and Hooks tabs were highlighted when Hooks tab is open

https://www.loom.com/share/c7fd8f9dcfac42bf9c8f841bad7fc258

# To Test

1. Enable hooks in the settings
2. navigate to the Hooks page
- [ ] AR: it both hooks and swap tabs are highlighted
- [ ] ER: only hooks tab should be highlighted

# Background

Optional: Give background information for changes you've made, that might be difficult to explain via comments
