### PR TITLE
feat: customize get a wallet button and hide "explore all"

### DIFF
--- a/libs/wallet/src/wagmi/config.ts
+++ b/libs/wallet/src/wagmi/config.ts
@@ -1,6 +1,7 @@
 import { RPC_URLS, VIEM_CHAINS } from '@cowprotocol/common-const'
 import { getCurrentChainIdFromUrl } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { Color } from '@cowprotocol/ui'
 
 import { createAppKit } from '@reown/appkit/react'
 import { WagmiAdapter } from '@reown/appkit-adapter-wagmi'
@@ -82,18 +83,34 @@ export const config = wagmiAdapter.wagmiConfig
 
 export const reownAppKit = createAppKit({
   adapters: [wagmiAdapter],
-  allowUnsupportedChain: false,
+  allowUnsupportedChain: true,
   customRpcUrls,
   defaultNetwork: VIEM_CHAINS[getCurrentChainIdFromUrl()],
   enableEIP6963: true,
   enableReconnect: true,
   enableWalletGuide: false,
-  featuredWalletIds: ['fd20dc426fb37566d803205b19bbc1d4096b248ac04548e3cfb6b3a38bd033aa'],
+  featuredWalletIds: [
+    '18388be9ac2d02726dbac9777c96efaac06d744b2f6d580fccdd4127a6d01fd1', // Rabby Wallet
+    'fd20dc426fb37566d803205b19bbc1d4096b248ac04548e3cfb6b3a38bd033aa', // Coinbase Wallet
+    'c57ca95b47569778a828d19178114f4db188b89b763c899ba0be274e97267d96', // MetaMask
+  ],
   features: {
     analytics: false,
     email: false,
     socials: false,
     connectorTypeOrder: ['injected', 'recent', 'walletConnect'],
+  },
+  // Match CoW Swap's ButtonPrimary styling
+  themeMode: 'light',
+  themeVariables: {
+    '--apkt-accent': Color.blue300Primary,
+    '--w3m-accent': Color.blue300Primary,
+    '--apkt-border-radius-master': '4px',
+    '--w3m-border-radius-master': '4px',
+    '--apkt-font-family': "'studiofeixen', 'Inter var', 'Inter', Arial, sans-serif",
+    '--w3m-font-family': "'studiofeixen', 'Inter var', 'Inter', Arial, sans-serif",
+    '--apkt-font-size-master': '11px',
+    '--w3m-font-size-master': '11px',
   },
   metadata,
   networks: SUPPORTED_REOWN_NETWORKS,
@@ -101,3 +118,103 @@ export const reownAppKit = createAppKit({
   termsConditionsUrl:
     'https://cow.fi/legal/cowswap-terms?utm_source=swap.cow.fi&utm_medium=web&utm_content=wallet-modal-terms-link',
 })
+
+// TODO: AppKit v1.8.19 has broken theming — themeVariables don't propagate to button backgrounds,
+// theme gets overwritten on mount, and "Explore all" is hardcoded with a dead URL.
+// These workarounds should be removed once AppKit fixes its theming API.
+// See: https://github.com/reown-com/appkit/issues (file issues for broken theming)
+if (typeof window !== 'undefined') {
+  const COW_FONT = "'studiofeixen', 'Inter var', 'Inter', Arial, sans-serif"
+
+  /** Detect dark/light mode from CoW Swap's CSS variables */
+  function getAppThemeMode(): 'dark' | 'light' {
+    const bg = getComputedStyle(document.documentElement).getPropertyValue('--cow-color-background').trim()
+    return bg === '#000000' || bg === '#000' ? 'dark' : 'light'
+  }
+
+  /** Apply CoW Swap theming to AppKit modal */
+  function applyCowTheme(): void {
+    reownAppKit.setThemeMode(getAppThemeMode())
+    reownAppKit.setThemeVariables({
+      '--w3m-accent': Color.blue300Primary,
+      '--w3m-font-family': COW_FONT,
+      '--w3m-border-radius-master': '4px',
+      '--w3m-font-size-master': '11px',
+    })
+
+    // AppKit doesn't propagate accent to internal token variables — override directly
+    const el = document.getElementById('cow-appkit-overrides') || document.createElement('style')
+    el.id = 'cow-appkit-overrides'
+    el.textContent = `:root {
+      --apkt-tokens-core-backgroundAccentPrimary-base: var(--cow-color-primary, ${Color.blue300Primary}) !important;
+      --apkt-tokens-core-backgroundAccentPrimary: var(--cow-color-primary, ${Color.blue300Primary}) !important;
+      --apkt-fontFamily-regular: ${COW_FONT} !important;
+      --apkt-fontFamily-mono: ${COW_FONT} !important;
+      --apkt-fontWeight-regular: 500 !important;
+    }`
+    if (!el.parentNode) document.head.appendChild(el)
+  }
+
+  /** Hide "Explore all" (hardcoded 404 link) inside AppKit's nested shadow DOMs */
+  function hideExploreAll(): void {
+    const modal = document.querySelector('w3m-modal')
+    if (!modal?.shadowRoot) return
+    const walk = (root: ShadowRoot | Element): void => {
+      for (const el of Array.from(root.querySelectorAll('*'))) {
+        if (el.getAttribute('name') === 'Explore all') (el as HTMLElement).style.display = 'none'
+        if (el.shadowRoot) walk(el.shadowRoot)
+      }
+    }
+    walk(modal.shadowRoot)
+  }
+
+  // Wait for AppKit to finish initializing its theme (inserts <style> tags in <head>),
+  // then override with CoW Swap theme
+  let themeApplied = false
+  const headObs = new MutationObserver(() => {
+    // AppKit's initializeTheming creates style tags with --apkt- variables
+    const hasAppKitStyles = Array.from(document.head.querySelectorAll('style')).some((s) =>
+      s.textContent?.includes('--apkt-colors-'),
+    )
+    if (hasAppKitStyles && !themeApplied) {
+      themeApplied = true
+      applyCowTheme()
+      headObs.disconnect()
+    }
+  })
+  headObs.observe(document.head, { childList: true })
+
+  // Observe the modal for view changes and recursively watch new shadow roots
+  function observeModalForExploreAll(): void {
+    const modal = document.querySelector('w3m-modal')
+    if (!modal?.shadowRoot) return
+
+    const observed = new WeakSet<ShadowRoot>()
+
+    function observeShadowRoot(root: ShadowRoot): void {
+      if (observed.has(root)) return
+      observed.add(root)
+      new MutationObserver(() => {
+        hideExploreAll()
+        // Watch any newly added shadow roots
+        for (const el of Array.from(root.querySelectorAll('*'))) {
+          if (el.shadowRoot) observeShadowRoot(el.shadowRoot)
+        }
+      }).observe(root, { childList: true, subtree: true })
+    }
+
+    observeShadowRoot(modal.shadowRoot)
+  }
+
+  // Start observing once the modal exists
+  const waitForModal = new MutationObserver(() => {
+    if (document.querySelector('w3m-modal')) {
+      observeModalForExploreAll()
+      waitForModal.disconnect()
+    }
+  })
+  waitForModal.observe(document.documentElement, { childList: true, subtree: true })
+  if (document.querySelector('w3m-modal')) {
+    observeModalForExploreAll()
+  }
+}


### PR DESCRIPTION
# Summary

This PR resolves the [customization](https://www.notion.so/cownation/What-is-wallet-issues-with-customisation-3428da5f04ca80b3ab9bf1c29bf75fc3?v=2fc8da5f04ca81ada4ca000c320d51ef&source=copy_link) for "Get a wallet" button on "What is a wallet" page on Reown/Appkit modal and hides the "Explore all" button from "Get a wallet page on Reown/Appkit modal since it is redirecting to a 404 page.

Before:
https://www.loom.com/share/0411699c68254ac8af4267a074b5df2d

Now:
https://www.loom.com/share/97cb3c87054f459ab83cc61d65c59dd8

# To Test

1. Click on Connect wallet
2. Click on the "?" symbol on the top left corner button
- [ ] AR: "Get a wallet" button was using Reown/Appkit default customization.
- [ ] ER: "Get a wallet" button now is customized with CoW fonts and colors.
3. Click on "Get a wallet" button
4. "Click on "Explore all" button
- [ ] AR: Reown/Appkit redirects the user to a 404 page
- [ ] ER: Should not redirect the user to a 404 page, so I removed the button since this is an internal redirection from Reown/Appkit.

# Background

Optional: Give background information for changes you've made, that might be difficult to explain via comments
