### PR TITLE
fix: enable navigation from widget iframe

### DIFF
--- a/apps/cowswap-frontend/src/modules/injectedWidget/updaters/InjectedWidgetUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/updaters/InjectedWidgetUpdater.tsx
@@ -61,26 +61,6 @@ import {
 
     return window
   }
-
-  document.body.addEventListener('click', (event) => {
-    // Skip clicks already handled by React Router (it calls preventDefault before bubbling)
-    if (event.defaultPrevented) return
-
-    const anchor = (event.target as Element).closest?.('a')
-    if (!(anchor instanceof HTMLAnchorElement)) return
-
-    const { href, target, rel } = anchor
-
-    // Prevent the browser from opening a new tab or navigating the iframe itself
-    event.preventDefault()
-
-    widgetIframeTransport.postMessageToWindow(
-      parent,
-      WidgetMethodsEmit.INTERCEPT_WINDOW_OPEN,
-      { href, target, rel },
-      parentOrigin,
-    )
-  })
 })()
 
 export function InjectedWidgetUpdater(): ReactNode {


### PR DESCRIPTION
# Summary

SInce now the widget iframe has `sandox=allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox` it's allowed to open pages from the iframe and we don't need to intercept `<a>` clicks at all.

# To Test

1. Open the page in Safe apps
2. Go to account orders history
3. Click to `View details`
- [ ] AR: nothing happens
- [ ] ER: it opens the explorer in a new tab

<img width="1648" height="882" alt="image" src="https://github.com/user-attachments/assets/1c6f72d3-5cf2-4ed4-8d81-9ca76cd27974" />

