### PR TITLE
Viem Migration - Fixing e2e tests.

### DIFF
--- a/apps/cowswap-frontend/jest.config.mjs
+++ b/apps/cowswap-frontend/jest.config.mjs
@@ -22,5 +22,6 @@ export default {
   moduleNameMapper: {
     '^wagmi$': require.resolve('wagmi'),
     '^@reown/appkit/react$': '<rootDir>/../../testing/reownMock.ts',
+    '^@reown/appkit-adapter-wagmi$': '<rootDir>/../../testing/reownAdapterMock.ts',
   },
 }

--- a/testing/reownAdapterMock.ts
+++ b/testing/reownAdapterMock.ts
@@ -1,0 +1,13 @@
+import { createConfig, http } from 'wagmi'
+import { mainnet } from 'wagmi/chains'
+
+const mockWagmiConfig = createConfig({
+  chains: [mainnet],
+  transports: { [mainnet.id]: http() },
+})
+
+export class WagmiAdapter {
+  wagmiConfig = mockWagmiConfig
+
+  constructor() {}
+}


### PR DESCRIPTION
# Summary
<img width="785" height="124" alt="image" src="https://github.com/user-attachments/assets/561440db-c77f-4a98-b244-d4a14163859a" />

Fixes #890

Resolves 26 failing test suites caused by the Viem/Wagmi/Reown migration. Jest could not resolve `@reown/appkit-adapter-wagmi` because it was missing from `moduleNameMapper` in `jest.config.mjs`.

Added a `WagmiAdapter` mock that returns a valid `wagmiConfig` built via wagmi's `createConfig`, which is required by `WagmiProvider` in the test wrappers (`WithMockedWeb3`, `Web3Provider`).

# To Test

1. Run the test suite

- [ ] `pnpm test` passes with 115/115 suites and 931/931 tests (previously 26 suites were failing)

# Background

After the Viem/Wagmi/Reown migration, `libs/wallet/src/wagmi/config.ts` introduced an import from `@reown/appkit-adapter-wagmi`. This package was already handled in `transformIgnorePatterns` but was never added to `moduleNameMapper`, so Jest could not resolve it at all — causing every test suite that transitively imported from `@cowprotocol/wallet` to fail with `Cannot find module '@reown/appkit-adapter-wagmi'`.

The mock exports a `WagmiAdapter` class with a minimal but valid `wagmiConfig` (using `createConfig` from wagmi), matching the shape expected by `WagmiProvider` in the test environment.
