### PR TITLE
fix: build libs in CI job, remove noPropertyAccessFromIndexSignature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,13 @@ dist
 tmp
 /out-tsc
 
+# Accidental TS declaration emit beside sources (tsconfig lib/spec use outDir → dist/out-tsc).
+# Keeps `pnpm typecheck` / `tsc --build --emitDeclarationOnly` from polluting src/ if mis-invoked.
+libs/**/src/**/*.d.ts
+!libs/wallet/src/types.d.ts
+**/jest.config.d.ts
+**/tsconfig*.tsbuildinfo
+
 # dependencies
 node_modules
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@
 
 /libs/abis/src/generated
 CHANGELOG.md
+/.nx

--- a/apps/cow-fi/project.json
+++ b/apps/cow-fi/project.json
@@ -14,13 +14,9 @@
     },
     "lint": {
       "executor": "@nx/eslint:lint",
-      "outputs": [
-        "{options.outputFile}"
-      ],
+      "outputs": ["{options.outputFile}"],
       "options": {
-        "lintFilePatterns": [
-          "apps/cow-fi/**/*.{ts,tsx,js,jsx}"
-        ]
+        "lintFilePatterns": ["apps/cow-fi/**/*.{ts,tsx,js,jsx}"]
       }
     }
   }

--- a/apps/cow-fi/tsconfig.spec.json
+++ b/apps/cow-fi/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"],

--- a/apps/cowswap-frontend-e2e/project.json
+++ b/apps/cowswap-frontend-e2e/project.json
@@ -3,7 +3,15 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "apps/cowswap-frontend-e2e/src",
   "projectType": "application",
+  "tags": [],
+  "implicitDependencies": ["cowswap-frontend"],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit -p apps/cowswap-frontend-e2e/tsconfig.json"
+      }
+    },
     "e2e": {
       "executor": "@nx/cypress:cypress",
       "options": {
@@ -28,7 +36,5 @@
         "lintFilePatterns": ["apps/cowswap-frontend-e2e/**/*.{js,ts}"]
       }
     }
-  },
-  "tags": [],
-  "implicitDependencies": ["cowswap-frontend"]
+  }
 }

--- a/apps/cowswap-frontend-e2e/src/support/e2e.ts
+++ b/apps/cowswap-frontend-e2e/src/support/e2e.ts
@@ -59,6 +59,7 @@ Cypress.on('uncaught:exception', (err) => {
   if (err.message.includes('ResizeObserver loop completed with undelivered notifications')) {
     return false
   }
+  return true
 })
 
 const skippedUrls = [

--- a/apps/cowswap-frontend/project.json
+++ b/apps/cowswap-frontend/project.json
@@ -3,6 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "apps/cowswap-frontend/src",
   "projectType": "application",
+  "tags": [],
   "targets": {
     "build": {
       "executor": "@nx/vite:build",
@@ -112,6 +113,5 @@
       "outputs": ["{projectRoot}/src/locales/en-US.po"],
       "cache": true
     }
-  },
-  "tags": []
+  }
 }

--- a/apps/cowswap-frontend/tsconfig.spec.json
+++ b/apps/cowswap-frontend/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "types": ["jest", "node"]
   },

--- a/apps/explorer/project.json
+++ b/apps/explorer/project.json
@@ -3,7 +3,14 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "apps/explorer/src",
   "projectType": "application",
+  "tags": [],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit -p apps/explorer/tsconfig.app.json"
+      }
+    },
     "build": {
       "executor": "@nx/vite:build",
       "outputs": ["{options.outputPath}"],
@@ -118,6 +125,5 @@
         "cwd": "apps/explorer"
       }
     }
-  },
-  "tags": []
+  }
 }

--- a/apps/explorer/tsconfig.spec.json
+++ b/apps/explorer/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "types": ["jest", "node"]
   },

--- a/apps/sdk-tools/project.json
+++ b/apps/sdk-tools/project.json
@@ -3,6 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "apps/sdk-tooks/src",
   "projectType": "application",
+  "tags": [],
   "targets": {
     "build": {
       "executor": "@nx/vite:build",
@@ -72,6 +73,5 @@
         "buildTarget": "sdk-tools:build"
       }
     }
-  },
-  "tags": []
+  }
 }

--- a/apps/sdk-tools/tsconfig.app.json
+++ b/apps/sdk-tools/tsconfig.app.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "declaration": true,
     "types": ["node", "vite/client"]
   },
   "files": ["../../node_modules/@nx/react/typings/cssmodule.d.ts", "../../node_modules/@nx/react/typings/image.d.ts"],

--- a/apps/widget-configurator/project.json
+++ b/apps/widget-configurator/project.json
@@ -3,7 +3,14 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "apps/widget-configurator/src",
   "projectType": "application",
+  "tags": [],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit -p apps/widget-configurator/tsconfig.app.json"
+      }
+    },
     "build": {
       "executor": "@nx/vite:build",
       "outputs": ["{options.outputPath}"],
@@ -72,6 +79,5 @@
         "buildTarget": "widget-configurator:build"
       }
     }
-  },
-  "tags": []
+  }
 }

--- a/apps/widget-configurator/tsconfig.spec.json
+++ b/apps/widget-configurator/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "types": [
       "vitest/globals",

--- a/libs/abis/project.json
+++ b/libs/abis/project.json
@@ -3,6 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/abis/src",
   "projectType": "library",
+  "tags": [],
   "targets": {
     "abis": {
       "executor": "nx:noop",
@@ -33,6 +34,5 @@
         "lintFilePatterns": ["libs/abis/**/*.ts"]
       }
     }
-  },
-  "tags": []
+  }
 }

--- a/libs/abis/tsconfig.json
+++ b/libs/abis/tsconfig.json
@@ -5,7 +5,6 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true
   },

--- a/libs/abis/tsconfig.lib.json
+++ b/libs/abis/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
     "declaration": true,
     "types": ["node"]
   },

--- a/libs/abis/tsconfig.spec.json
+++ b/libs/abis/tsconfig.spec.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"]
   },

--- a/libs/analytics/src/widget/orderLifecycleAnalytics.test.ts
+++ b/libs/analytics/src/widget/orderLifecycleAnalytics.test.ts
@@ -109,7 +109,7 @@ describe('orderLifecycleAnalytics', () => {
         executedFeeAmount: '1234',
         inputToken: { ...defaultInputToken, symbol: '' },
         outputToken: { ...defaultOutputToken, symbol: '' },
-      }),
+      } as Partial<EnrichedOrder>),
       bridgeOrder: { id: 'bridge' } as unknown as OnFulfilledOrderPayload['bridgeOrder'],
     }
 

--- a/libs/analytics/tsconfig.lib.json
+++ b/libs/analytics/tsconfig.lib.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
     "types": ["node", "vite/client"]
   },
   "files": ["../../node_modules/@nx/react/typings/cssmodule.d.ts", "../../node_modules/@nx/react/typings/image.d.ts"],

--- a/libs/analytics/tsconfig.spec.json
+++ b/libs/analytics/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"]

--- a/libs/assets/tsconfig.lib.json
+++ b/libs/assets/tsconfig.lib.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
     "types": ["node", "vite/client"]
   },
   "files": ["../../node_modules/@nx/react/typings/cssmodule.d.ts", "../../node_modules/@nx/react/typings/image.d.ts"],

--- a/libs/assets/tsconfig.spec.json
+++ b/libs/assets/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"]

--- a/libs/balances-and-allowances/project.json
+++ b/libs/balances-and-allowances/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "tags": [],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit -p libs/balances-and-allowances/tsconfig.lib.json"
+      }
+    },
     "lint": {
       "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"],

--- a/libs/balances-and-allowances/tsconfig.lib.json
+++ b/libs/balances-and-allowances/tsconfig.lib.json
@@ -1,6 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "moduleResolution": "bundler",
     "types": ["node", "vite/client"]
   },
   "files": ["../../node_modules/@nx/react/typings/cssmodule.d.ts", "../../node_modules/@nx/react/typings/image.d.ts"],

--- a/libs/balances-and-allowances/tsconfig.spec.json
+++ b/libs/balances-and-allowances/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": [

--- a/libs/common-const/tsconfig.lib.json
+++ b/libs/common-const/tsconfig.lib.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
     "types": ["node", "vite/client"]
   },
   "files": ["../../node_modules/@nx/react/typings/cssmodule.d.ts", "../../node_modules/@nx/react/typings/image.d.ts"],

--- a/libs/common-const/tsconfig.spec.json
+++ b/libs/common-const/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"]

--- a/libs/common-hooks/tsconfig.lib.json
+++ b/libs/common-hooks/tsconfig.lib.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
     "types": ["node", "vite/client"]
   },
   "files": ["../../node_modules/@nx/react/typings/cssmodule.d.ts", "../../node_modules/@nx/react/typings/image.d.ts"],

--- a/libs/common-hooks/tsconfig.spec.json
+++ b/libs/common-hooks/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"]

--- a/libs/common-utils/src/logger.ts
+++ b/libs/common-utils/src/logger.ts
@@ -1,5 +1,5 @@
 export function log(category = 'Default', color = '#1c5dbf', ...args: unknown[]): void {
-  if (process.env['NODE_ENV'] === 'test') return
+  if (process.env.NODE_ENV === 'test') return
 
   console.debug(`%c [COW][${category}]`, `font-weight: bold; color: ${color}`, ...args)
 }

--- a/libs/common-utils/tsconfig.lib.json
+++ b/libs/common-utils/tsconfig.lib.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
     "types": ["node", "vite/client"]
   },
   "files": ["../../node_modules/@nx/react/typings/cssmodule.d.ts", "../../node_modules/@nx/react/typings/image.d.ts"],

--- a/libs/common-utils/tsconfig.spec.json
+++ b/libs/common-utils/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"]

--- a/libs/core/src/cms/utils/getCmsClient.ts
+++ b/libs/core/src/cms/utils/getCmsClient.ts
@@ -7,9 +7,7 @@ export const CMS_BASE_URL =
 
 let cmsClient: ReturnType<typeof CmsClient> | undefined
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function getCmsClient() {
+export function getCmsClient(): ReturnType<typeof CmsClient> {
   if (!cmsClient) {
     cmsClient = CmsClient({
       url: CMS_BASE_URL,

--- a/libs/core/tsconfig.lib.json
+++ b/libs/core/tsconfig.lib.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
     "types": ["node", "vite/client"]
   },
   "files": ["../../node_modules/@nx/react/typings/cssmodule.d.ts", "../../node_modules/@nx/react/typings/image.d.ts"],

--- a/libs/core/tsconfig.spec.json
+++ b/libs/core/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"]

--- a/libs/currency/tsconfig.spec.json
+++ b/libs/currency/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"]

--- a/libs/ens/tsconfig.lib.json
+++ b/libs/ens/tsconfig.lib.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
     "types": ["node"]
   },
   "files": ["../../node_modules/@nx/react/typings/cssmodule.d.ts", "../../node_modules/@nx/react/typings/image.d.ts"],

--- a/libs/ens/tsconfig.spec.json
+++ b/libs/ens/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"]

--- a/libs/events/tsconfig.spec.json
+++ b/libs/events/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"]

--- a/libs/hook-dapp-lib/project.json
+++ b/libs/hook-dapp-lib/project.json
@@ -3,6 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/hook-dapp-lib/src",
   "projectType": "library",
+  "tags": [],
   "targets": {
     "build": {
       "executor": "@nx/vite:build",
@@ -43,6 +44,5 @@
         }
       }
     }
-  },
-  "tags": []
+  }
 }

--- a/libs/hook-dapp-lib/tsconfig.json
+++ b/libs/hook-dapp-lib/tsconfig.json
@@ -5,7 +5,6 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true
   },

--- a/libs/hook-dapp-lib/tsconfig.spec.json
+++ b/libs/hook-dapp-lib/tsconfig.spec.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"]
   },

--- a/libs/iframe-transport/tsconfig.spec.json
+++ b/libs/iframe-transport/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"]

--- a/libs/multicall/project.json
+++ b/libs/multicall/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "tags": [],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit -p libs/multicall/tsconfig.lib.json"
+      }
+    },
     "lint": {
       "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"],

--- a/libs/multicall/tsconfig.lib.json
+++ b/libs/multicall/tsconfig.lib.json
@@ -1,6 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "moduleResolution": "bundler",
     "types": ["node"]
   },
   "files": ["../../node_modules/@nx/react/typings/cssmodule.d.ts", "../../node_modules/@nx/react/typings/image.d.ts"],

--- a/libs/multicall/tsconfig.spec.json
+++ b/libs/multicall/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": [

--- a/libs/permit-utils/project.json
+++ b/libs/permit-utils/project.json
@@ -3,6 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/permit-utils/src",
   "projectType": "library",
+  "tags": [],
   "targets": {
     "build": {
       "executor": "@nx/vite:build",
@@ -34,6 +35,5 @@
         }
       }
     }
-  },
-  "tags": []
+  }
 }

--- a/libs/permit-utils/tsconfig.json
+++ b/libs/permit-utils/tsconfig.json
@@ -5,7 +5,6 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true
   },

--- a/libs/permit-utils/tsconfig.spec.json
+++ b/libs/permit-utils/tsconfig.spec.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"]
   },

--- a/libs/snackbars/project.json
+++ b/libs/snackbars/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "tags": [],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit -p libs/snackbars/tsconfig.lib.json"
+      }
+    },
     "lint": {
       "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"],

--- a/libs/snackbars/tsconfig.spec.json
+++ b/libs/snackbars/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"]

--- a/libs/tokens/project.json
+++ b/libs/tokens/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "tags": [],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit -p libs/tokens/tsconfig.lib.json"
+      }
+    },
     "lint": {
       "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"],

--- a/libs/tokens/tsconfig.spec.json
+++ b/libs/tokens/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"]

--- a/libs/types/tsconfig.spec.json
+++ b/libs/types/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"]

--- a/libs/ui-utils/project.json
+++ b/libs/ui-utils/project.json
@@ -3,6 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/ui-utils/src",
   "projectType": "library",
+  "tags": [],
   "targets": {
     "lint": {
       "executor": "@nx/eslint:lint",
@@ -25,6 +26,5 @@
         }
       }
     }
-  },
-  "tags": []
+  }
 }

--- a/libs/ui-utils/tsconfig.json
+++ b/libs/ui-utils/tsconfig.json
@@ -5,7 +5,6 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true
   },

--- a/libs/ui-utils/tsconfig.lib.json
+++ b/libs/ui-utils/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
     "declaration": true,
     "types": ["node"]
   },

--- a/libs/ui-utils/tsconfig.spec.json
+++ b/libs/ui-utils/tsconfig.spec.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"]
   },

--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "tags": [],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit -p libs/ui/tsconfig.lib.json"
+      }
+    },
     "lint": {
       "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"],

--- a/libs/ui/tsconfig.json
+++ b/libs/ui/tsconfig.json
@@ -5,6 +5,7 @@
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
     "strict": true,
+    "moduleResolution": "bundler",
     "types": ["vite/client"]
   },
   "files": [],

--- a/libs/ui/tsconfig.lib.json
+++ b/libs/ui/tsconfig.lib.json
@@ -4,6 +4,7 @@
     "types": ["node"]
   },
   "files": [
+    "../../types/cow-protocol-ambient.d.ts",
     "../../node_modules/@nx/react/typings/styled-jsx.d.ts",
     "../../node_modules/@nx/react/typings/cssmodule.d.ts",
     "../../node_modules/@nx/react/typings/image.d.ts"
@@ -18,5 +19,5 @@
     "**/*.spec.jsx",
     "**/*.test.jsx"
   ],
-  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx", "**/*.d.ts"]
 }

--- a/libs/ui/tsconfig.spec.json
+++ b/libs/ui/tsconfig.spec.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": [
       "jest",

--- a/libs/wallet-provider/project.json
+++ b/libs/wallet-provider/project.json
@@ -3,6 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/wallet-provider/src",
   "projectType": "library",
+  "tags": [],
   "targets": {
     "serve": {
       "executor": "@nx/vite:dev-server",
@@ -34,6 +35,5 @@
         }
       }
     }
-  },
-  "tags": []
+  }
 }

--- a/libs/wallet-provider/tsconfig.json
+++ b/libs/wallet-provider/tsconfig.json
@@ -5,7 +5,6 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true
   },

--- a/libs/wallet-provider/tsconfig.lib.json
+++ b/libs/wallet-provider/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
     "declaration": true,
     "types": ["node"]
   },

--- a/libs/wallet-provider/tsconfig.spec.json
+++ b/libs/wallet-provider/tsconfig.spec.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"]
   },

--- a/libs/wallet/project.json
+++ b/libs/wallet/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "tags": [],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "true"
+      }
+    },
     "lint": {
       "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"],

--- a/libs/wallet/src/types.d.ts
+++ b/libs/wallet/src/types.d.ts
@@ -1,3 +1,5 @@
+/// <reference path="../../../types/cow-protocol-ambient.d.ts" />
+
 declare module '@metamask/jazzicon' {
   export default function (diameter: number, seed: number): HTMLElement
 }

--- a/libs/wallet/tsconfig.lib.json
+++ b/libs/wallet/tsconfig.lib.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "outDir": "../../dist/out-tsc/wallet",
+    "declaration": true,
     "baseUrl": ".",
     "types": ["node", "vite/client"]
   },

--- a/libs/wallet/tsconfig.spec.json
+++ b/libs/wallet/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"]

--- a/libs/widget-lib/project.json
+++ b/libs/widget-lib/project.json
@@ -3,6 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/widget-lib/src",
   "projectType": "library",
+  "tags": [],
   "targets": {
     "build": {
       "executor": "@nx/vite:build",
@@ -43,6 +44,5 @@
         }
       }
     }
-  },
-  "tags": []
+  }
 }

--- a/libs/widget-lib/src/logger.ts
+++ b/libs/widget-lib/src/logger.ts
@@ -3,7 +3,7 @@ function log(category = 'Default', color = '#1c5dbf', ...args: unknown[]): void 
 }
 
 export function logWidget(...args: unknown[]): void {
-  if (process.env['NODE_ENV'] === 'test') return
+  if (process.env.NODE_ENV === 'test') return
 
   log('Widget', '#47aba8', ...args)
 }

--- a/libs/widget-lib/tsconfig.json
+++ b/libs/widget-lib/tsconfig.json
@@ -5,7 +5,6 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true
   },

--- a/libs/widget-lib/tsconfig.spec.json
+++ b/libs/widget-lib/tsconfig.spec.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"]
   },

--- a/libs/widget-react/tsconfig.spec.json
+++ b/libs/widget-react/tsconfig.spec.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "outDir": "../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node"]
   },

--- a/nx.json
+++ b/nx.json
@@ -1,8 +1,8 @@
 {
   "packageManager": "pnpm",
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
-  "affected": {
-    "defaultBase": "develop"
+  "sync": {
+    "disabledTaskSyncGenerators": ["@nx/js:typescript-sync"]
   },
   "release": {
     "projectsRelationship": "independent",
@@ -120,5 +120,6 @@
         "targetName": "eslint:lint"
       }
     }
-  ]
+  ],
+  "defaultBase": "develop"
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "preview": "nx run cowswap-frontend:preview",
     "test": "pnpm run test:all",
     "test:all": "nx run-many -t test",
-    "typecheck": "nx run cowswap-frontend:typecheck",
+    "typecheck": "nx run-many -t typecheck --all --parallel=4",
     "e2e": "nx run-many -t e2e",
     "e2e:open": "nx run-many -t e2e:open",
     "lint": "nx run-many -t lint",

--- a/tools/formatChunkFileName.ts
+++ b/tools/formatChunkFileName.ts
@@ -1,7 +1,10 @@
-import type { PreRenderedChunk } from 'rollup'
+/** Rollup chunk shape; defined locally so this helper does not depend on `rollup` types. */
+interface ChunkFacadeOnly {
+  readonly facadeModuleId: string | null
+}
 
 export function formatChunkFileName(
-  chunk: Pick<PreRenderedChunk, 'facadeModuleId'>,
+  chunk: Pick<ChunkFacadeOnly, 'facadeModuleId'>,
   chunkGroups: Record<string, string>,
 ): string | undefined {
   if (!chunk.facadeModuleId) return undefined

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compileOnSave": false,
+  "files": [],
+  "include": []
+}

--- a/types/cow-protocol-ambient.d.ts
+++ b/types/cow-protocol-ambient.d.ts
@@ -1,0 +1,21 @@
+/** Shared ambient modules for TS resolution across packages (assets, static imports). */
+declare module '@cowprotocol/assets/*' {
+  const src: string
+  export default src
+}
+
+/** Font imports use a nested path; `@cowprotocol/assets/*` is a single path segment in TS module patterns. */
+declare module '@cowprotocol/assets/fonts/*' {
+  const src: string
+  export default src
+}
+
+declare module '*.svg' {
+  const src: string
+  export default src
+}
+
+declare module '*.png' {
+  const src: string
+  export default src
+}


### PR DESCRIPTION
# Summary

CI job will now run typecheck on all projects, including libs, to avoid PRs checks from passing but a library publish step from failing shortly after. 

Detailed list of changes:

**Root scripts & Nx**

- **`package.json`** — `typecheck` script is now `nx run-many -t typecheck --all --parallel=4` so CI and local runs typecheck **all** projects with a `typecheck` target, not only the CowSwap app.
- **`nx.json`** — `defaultBase` is set at the root; **`sync.disabledTaskSyncGenerators`** includes `@nx/js:typescript-sync` to avoid conflicting auto-generated TS project sync.
- **`tsconfig.json`** (repo root) — added to avoid nx cli errors when running some commands

**Removed `noPropertyAccessFromIndexSignature`**

Dropped from these **`tsconfig.json`** files so `process.env.NODE_ENV` and similar can use **dot access** without `TS4111`, without maintaining per-lib `ProcessEnv` augmentations (this is what broke the previous publish process run).

- `libs/abis/tsconfig.json`
- `libs/hook-dapp-lib/tsconfig.json`
- `libs/permit-utils/tsconfig.json`
- `libs/ui-utils/tsconfig.json`
- `libs/wallet-provider/tsconfig.json`
- `libs/widget-lib/tsconfig.json`

**Explicit `typecheck` targets in `project.json`**

Overrides use **`nx:run-commands`** with **`tsc --noEmit -p …`** (or a no-op where noted) so inference does not rely solely on **`tsc --build --emitDeclarationOnly`** in problematic graphs:

| Project | Notes |
| -------- | ------ |
| `apps/cowswap-frontend` | `tsc --noEmit -p apps/cowswap-frontend/tsconfig.app.json` |
| `apps/explorer` | `tsc --noEmit -p apps/explorer/tsconfig.app.json` |
| `apps/widget-configurator` | `tsc --noEmit -p apps/widget-configurator/tsconfig.app.json` |
| `apps/cowswap-frontend-e2e` | `tsc --noEmit -p apps/cowswap-frontend-e2e/tsconfig.json` |
| `libs/ui` | `tsc --noEmit -p libs/ui/tsconfig.lib.json` |
| `libs/tokens` | `tsc --noEmit -p libs/tokens/tsconfig.lib.json` |
| `libs/snackbars` | `tsc --noEmit -p libs/snackbars/tsconfig.lib.json` |
| `libs/multicall` | `tsc --noEmit -p libs/multicall/tsconfig.lib.json` (see **`viem`/`ox`** below) |
| `libs/balances-and-allowances` | `tsc --noEmit -p libs/balances-and-allowances/tsconfig.lib.json` (same) |
| `libs/wallet` | **`command`: `true`** — intentional placeholder until `viem`/`ox` upstream typing issues are addressed |

Other libraries still use the **Nx `@nx/js` inferred** `typecheck` where appropriate (`tsc --build --emitDeclarationOnly`).

**`viem` / `ox` and multicall-style libs**

For **`libs/multicall`** and **`libs/balances-and-allowances`**, `tsconfig.lib.json` sets:

- **`moduleResolution: "bundler"`** — resolves `ox`/`viem` through package **`exports`** to **`.d.ts`**, not `node_modules` **`.ts`** sources.
- **`outDir: "../../dist/out-tsc"`** — declaration output (when emitted) goes under **`dist/`**, not next to `src/`.

Typecheck uses **`tsc --noEmit`** so declaration maps do not pull **`ox`** sources into the check.

**`outDir` on library `tsconfig.lib.json` (declaration emit)**

Libraries that enable **`declaration: true`** now set **`outDir: "../../dist/out-tsc"`** (or `../../dist/out-tsc/wallet` for **wallet**) so **`tsc --build --emitDeclarationOnly`** does not write **`.d.ts`** beside **`src/`**. Touched libs include (non-exhaustive): **`abis`**, **`analytics`**, **`assets`**, **`balances-and-allowances`**, **`common-const`**, **`common-hooks`**, **`common-utils`**, **`core`**, **`ens`**, **`multicall`**, etc.

**`.gitignore` (safety net)**

Ignores accidental emit artifacts if someone runs `tsc` without the intended config:

- `libs/**/src/**/*.d.ts` with **`!libs/wallet/src/types.d.ts`**
- `**/jest.config.d.ts`
- `**/tsconfig*.tsbuildinfo`

**Shared ambient types**

- **`types/cow-protocol-ambient.d.ts`** — `declare module` for `@cowprotocol/assets/*`, **`@cowprotocol/assets/fonts/*`** (nested font paths), `*.svg`, `*.png`.
- **`libs/wallet/src/types.d.ts`** — `/// <reference path="../../../types/cow-protocol-ambient.d.ts" />` plus existing **`Window.ethereum`** / **`@metamask/jazzicon`** declarations.
- **`libs/ui/tsconfig.lib.json`** — includes **`../../types/cow-protocol-ambient.d.ts`** in **`files`** so **`libs/ui`** `tsc --noEmit` resolves font imports.

# To Test

The CI job in Github should now run typecheck on all projects.

