### PR TITLE
fix: unregister service workers

### DIFF
--- a/apps/cowswap-frontend/public/emergency.js
+++ b/apps/cowswap-frontend/public/emergency.js
@@ -97,6 +97,18 @@ if (window.location.pathname !== '/') {
       )
     }
   } catch {}
+
+  // 6. Service Workers (async — best-effort)
+  try {
+    if ('serviceWorker' in navigator) {
+      const registrations = await navigator.serviceWorker.getRegistrations()
+      await Promise.all(
+        registrations.map(function (r) {
+          return r.unregister()
+        }),
+      )
+    }
+  } catch {}
 })()
 
 /**


### PR DESCRIPTION
# Summary

unregister workers because they also can have their internal storage 

# Background

Optional: Give background information for changes you've made, that might be difficult to explain via comments
