### PR TITLE
fix: appzi page crash in case of missing chunk

### DIFF
--- a/apps/cowswap-frontend/src/appzi.ts
+++ b/apps/cowswap-frontend/src/appzi.ts
@@ -73,13 +73,13 @@ type AppziSettings = {
 }
 
 function initialize(): void {
-  if (isAppziEnabled) {
-    ReactAppzi.initialize(APPZI_TOKEN)
+  if (!isAppziEnabled || typeof window === 'undefined') return
 
-    if (typeof window !== 'undefined') {
-      window.appziSettings = window.appziSettings || {}
-    }
-  }
+  window.appziSettings = window.appziSettings || {}
+
+  try {
+    ReactAppzi.initialize(APPZI_TOKEN)
+  } catch {}
 }
 
 function updateAppziSettings({ data = {}, userId = '' }: AppziSettings): void {


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Tokens-page-crash-3438da5f04ca80b2af6fd70496b0a5de

Although, I'm not 100% sure, just deducing from the stack trace.

The issue is that the stack trace is minified which makes it hard to pinpoint.

I have another PR to removing guessing from the equation, in future cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined initialization logic with improved error handling to enhance application stability and resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->