### PR TITLE
fix: redirect .finance to .fi except for widget

### DIFF
--- a/apps/cowswap-frontend/public/emergency.js
+++ b/apps/cowswap-frontend/public/emergency.js
@@ -7,9 +7,9 @@ if (window.location.host === 'barn.cowswap.exchange') {
   window.location.href = 'https://barn.cow.fi'
 }
 
-// swap.cow.finance → swap.cow.fi when embedded (iframe / sandboxed); top-level stays on .finance until migrated
+// swap.cow.finance → swap.cow.fi when top-level (not embedded). iframes stay on .finance
 try {
-  if (window.location.host === 'swap.cow.finance' && window.top !== window.self) {
+  if (window.location.host === 'swap.cow.finance' && window.top === window.self) {
     const next = new URL(window.location.href)
     next.protocol = 'https:'
     next.hostname = 'swap.cow.fi'

--- a/apps/cowswap-frontend/public/emergency.js
+++ b/apps/cowswap-frontend/public/emergency.js
@@ -7,6 +7,20 @@ if (window.location.host === 'barn.cowswap.exchange') {
   window.location.href = 'https://barn.cow.fi'
 }
 
+// swap.cow.finance → swap.cow.fi when embedded (iframe / sandboxed); top-level stays on .finance until migrated
+try {
+  if (window.location.host === 'swap.cow.finance' && window.top !== window.self) {
+    const next = new URL(window.location.href)
+    next.protocol = 'https:'
+    next.hostname = 'swap.cow.fi'
+    window.location.replace(next.href)
+  }
+} catch {
+  if (window.location.host === 'swap.cow.finance') {
+    window.location.replace('https://swap.cow.fi/')
+  }
+}
+
 // We use the HashRouter, thus the pathname should ALWAYS be a '/'
 if (window.location.pathname !== '/') {
   window.location.pathname = '/'


### PR DESCRIPTION
# Summary

Redirect .finance to .fi except for widget

# To Test

Cannot be tested until deployed to prod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic domain redirect for users accessing the legacy domain, seamlessly routing to the primary domain with HTTPS protocol enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->