### PR TITLE
fix(widget): cache widget events source

### DIFF
--- a/apps/cowswap-frontend/src/modules/injectedWidget/utils/widgetMessagesCache.utils.ts
+++ b/apps/cowswap-frontend/src/modules/injectedWidget/utils/widgetMessagesCache.utils.ts
@@ -3,6 +3,7 @@ import { widgetIframeTransport } from '@cowprotocol/widget-lib'
 interface CachedMessageEnvelope {
   data: unknown
   origin: string
+  source: MessageEventSource | null
 }
 
 const messagesCache: Record<string, CachedMessageEnvelope> = {}
@@ -17,6 +18,7 @@ export function cacheWidgetMessage(event: MessageEvent): void {
   messagesCache[method] = {
     data: event.data,
     origin: event.origin,
+    source: event.source,
   }
 }
 
@@ -31,6 +33,7 @@ export function replayCachedWidgetMessage(method: string): void {
     new MessageEvent('message', {
       origin: cachedMessage.origin,
       data: cachedMessage.data,
+      source: cachedMessage.source,
     }),
   )
 }


### PR DESCRIPTION
# Summary

We recently added source check, so we have to add it to the cached messages as well

# To Test

See #7358