### PR TITLE
fix: reload the window after emergency wipe

### DIFF
--- a/apps/cowswap-frontend/public/emergency.js
+++ b/apps/cowswap-frontend/public/emergency.js
@@ -28,8 +28,20 @@ if (window.location.pathname !== '/') {
 
 ;(async function () {
   const WIPE_KEY = 'emergencyWipe:v1'
+  const RETURNING_USER_KEY = 'tokens:lastUpdateTimeAtom:v6'
+  const hasVisitedBefore = localStorage.getItem(RETURNING_USER_KEY) !== null
 
-  if (localStorage.getItem(WIPE_KEY)) return
+  if (localStorage.getItem(WIPE_KEY)) {
+    console.log('[COW] Storage already clean')
+    return
+  }
+
+  if (!hasVisitedBefore) {
+    console.log('[COW] New user, skipping storage wipe')
+    localStorage.setItem(WIPE_KEY, '1')
+    return
+  }
+  console.log('[COW] Performing emergency wipe')
 
   // 1. localStorage (re-set wipe flag after)
   localStorage.clear()
@@ -123,6 +135,8 @@ if (window.location.pathname !== '/') {
       )
     }
   } catch {}
+
+  window.location.reload()
 })()
 
 /**


### PR DESCRIPTION
# Summary

Fixes https://www.notion.so/cownation/Tokens-page-crash-3438da5f04ca80b2af6fd70496b0a5de?v=2ce8da5f04ca811b931c000c389a143e

# To Test

You can use `'emergencyWipe:v1'` and `'tokens:lastUpdateTimeAtom:v6'` to toggle each branch:

1. Wipe done, no action
2. Wipe not done, but the user is new, no action
3. Wipe being done for an existing user (tokens:lastUpdateTimeAtom:v6 exists)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data clearing mechanism with improved user detection and automatic page reload upon completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->