### PR TITLE
feat: add recovery banner component and related functionality

### DIFF
--- a/apps/cowswap-frontend/src/common/constants/banners.ts
+++ b/apps/cowswap-frontend/src/common/constants/banners.ts
@@ -1,6 +1,7 @@
 // Banner IDs for various dismissable banners across the app
 export const BANNER_IDS = {
   DELEGATE: 'delegate-banner-v1',
+  RECOVERY: 'recoveryBanner:v0',
   LIMIT_ORDERS_INFO: 'limitOrders_showInfoBanner',
   LIMIT_ORDERS_PROTOCOL_FEE: 'limitOrders_cip74ProtocolFeeBanner',
   COW_AMM: 'cow_amm_banner_2024_va',

--- a/apps/cowswap-frontend/src/modules/application/containers/AppContainer/AppContainer.container.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/AppContainer/AppContainer.container.tsx
@@ -23,6 +23,7 @@ import { useGetMarketDimension } from 'common/hooks/useGetMarketDimension'
 
 import { CowSpeechBubbleHiringBanner } from './CowSpeechBubble/CowSpeechBubbleHiringBanner'
 import { CowSpeechBubbleNotificationBanner } from './CowSpeechBubble/CowSpeechBubbleNotificationBanner'
+import { RecoveryBanner } from './RecoveryBanner'
 import { SnowfallOverlay } from './SnowfallOverlay.pure'
 
 import { PageBackgroundContext, PageBackgroundVariant } from '../../contexts/PageBackgroundContext'
@@ -111,6 +112,7 @@ export function AppContainer({ children }: AppContainerProps): ReactNode {
     <PageBackgroundContext.Provider value={pageBackgroundValue}>
       <styledEl.AppWrapper>
         <URLWarning />
+        <RecoveryBanner />
         <InvalidLocalTimeWarning />
 
         <OrdersPanel />

--- a/apps/cowswap-frontend/src/modules/application/containers/AppContainer/RecoveryBanner/RecoveryBanner.constants.ts
+++ b/apps/cowswap-frontend/src/modules/application/containers/AppContainer/RecoveryBanner/RecoveryBanner.constants.ts
@@ -1,0 +1,2 @@
+export const RECOVERY_BANNER_FLAG = 'isRecoveryBannerEnabled'
+export const RECOVERY_BANNER_REVOKE_URL = 'https://revoke.cash/exploits/cowswap'

--- a/apps/cowswap-frontend/src/modules/application/containers/AppContainer/RecoveryBanner/RecoveryBanner.container.test.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/AppContainer/RecoveryBanner/RecoveryBanner.container.test.tsx
@@ -1,0 +1,132 @@
+import { useCowAnalytics } from '@cowprotocol/analytics'
+import { useFeatureFlags } from '@cowprotocol/common-hooks'
+import { isInjectedWidget } from '@cowprotocol/common-utils'
+
+import { i18n } from '@lingui/core'
+import { I18nProvider } from '@lingui/react'
+import { fireEvent, render, screen, type RenderResult } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { ThemeProvider as StyledComponentsThemeProvider } from 'styled-components/macro'
+import { getCowswapTheme } from 'theme'
+
+import { BANNER_IDS } from 'common/constants/banners'
+
+import { RECOVERY_BANNER_REVOKE_URL } from './RecoveryBanner.constants'
+import { RecoveryBanner } from './RecoveryBanner.container'
+
+jest.mock('@cowprotocol/analytics', () => {
+  const actualModule = jest.requireActual('@cowprotocol/analytics')
+
+  return {
+    ...actualModule,
+    __resetGtmInstance: jest.fn(),
+    useCowAnalytics: jest.fn(),
+  }
+})
+
+jest.mock('@cowprotocol/common-hooks', () => {
+  const actualModule = jest.requireActual('@cowprotocol/common-hooks')
+
+  return {
+    ...actualModule,
+    useFeatureFlags: jest.fn(),
+  }
+})
+
+jest.mock('@cowprotocol/common-utils', () => {
+  const actualModule = jest.requireActual('@cowprotocol/common-utils')
+
+  return {
+    ...actualModule,
+    isInjectedWidget: jest.fn(),
+  }
+})
+
+jest.mock('react-inlinesvg', () => {
+  return function MockSvg() {
+    return <svg />
+  }
+})
+
+const useCowAnalyticsMock = useCowAnalytics as jest.MockedFunction<typeof useCowAnalytics>
+const useFeatureFlagsMock = useFeatureFlags as jest.MockedFunction<typeof useFeatureFlags>
+const isInjectedWidgetMock = isInjectedWidget as jest.MockedFunction<typeof isInjectedWidget>
+
+i18n.load('en-US', {})
+i18n.activate('en-US')
+
+function renderComponent(): RenderResult {
+  return render(
+    <MemoryRouter initialEntries={['/1/swap']}>
+      <I18nProvider i18n={i18n}>
+        <StyledComponentsThemeProvider theme={getCowswapTheme(false)}>
+          <RecoveryBanner />
+        </StyledComponentsThemeProvider>
+      </I18nProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('RecoveryBanner', () => {
+  const sendEvent = jest.fn()
+
+  beforeEach(() => {
+    localStorage.clear()
+    jest.clearAllMocks()
+
+    useCowAnalyticsMock.mockReturnValue({
+      sendEvent,
+    } as unknown as ReturnType<typeof useCowAnalytics>)
+    useFeatureFlagsMock.mockReturnValue({
+      isRecoveryBannerEnabled: true,
+    } as ReturnType<typeof useFeatureFlags>)
+    isInjectedWidgetMock.mockReturnValue(false)
+  })
+
+  it('renders when the flag is enabled and tracks the impression', () => {
+    renderComponent()
+
+    expect(screen.getByTestId('recovery-banner')).not.toBeNull()
+    expect(screen.getByRole('link', { name: 'Revoke.cash' }).getAttribute('href')).toBe(RECOVERY_BANNER_REVOKE_URL)
+    expect(sendEvent).toHaveBeenCalledWith('recovery_banner_shown', undefined)
+  })
+
+  it('does not render when the flag is disabled', () => {
+    useFeatureFlagsMock.mockReturnValue({
+      isRecoveryBannerEnabled: false,
+    } as ReturnType<typeof useFeatureFlags>)
+
+    renderComponent()
+
+    expect(screen.queryByTestId('recovery-banner')).toBeNull()
+    expect(sendEvent).not.toHaveBeenCalled()
+  })
+
+  it('does not render inside injected widget mode', () => {
+    isInjectedWidgetMock.mockReturnValue(true)
+
+    renderComponent()
+
+    expect(screen.queryByTestId('recovery-banner')).toBeNull()
+    expect(sendEvent).not.toHaveBeenCalled()
+  })
+
+  it('persists dismissal locally and tracks dismiss and revoke clicks', () => {
+    const { unmount } = renderComponent()
+
+    fireEvent.click(screen.getByRole('link', { name: 'Revoke.cash' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss incident notice' }))
+
+    expect(sendEvent).toHaveBeenCalledWith('recovery_banner_link_clicked', {
+      linkTarget: 'revokeCash',
+    })
+    expect(sendEvent).toHaveBeenCalledWith('recovery_banner_dismissed', undefined)
+    expect(localStorage.getItem(BANNER_IDS.RECOVERY)).toBe('false')
+    expect(screen.queryByTestId('recovery-banner')).toBeNull()
+
+    unmount()
+    renderComponent()
+
+    expect(screen.queryByTestId('recovery-banner')).toBeNull()
+  })
+})

--- a/apps/cowswap-frontend/src/modules/application/containers/AppContainer/RecoveryBanner/RecoveryBanner.container.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/AppContainer/RecoveryBanner/RecoveryBanner.container.tsx
@@ -1,0 +1,94 @@
+import { type ReactNode, useCallback, useEffect, useRef } from 'react'
+
+import { useCowAnalytics } from '@cowprotocol/analytics'
+import { useFeatureFlags } from '@cowprotocol/common-hooks'
+import { isInjectedWidget } from '@cowprotocol/common-utils'
+
+import { t } from '@lingui/core/macro'
+import { Trans } from '@lingui/react/macro'
+import { useLocation } from 'react-router'
+
+import { RECOVERY_BANNER_FLAG, RECOVERY_BANNER_REVOKE_URL } from './RecoveryBanner.constants'
+import * as styledEl from './RecoveryBanner.styled'
+import { useRecoveryBanner } from './useRecoveryBanner'
+
+const RECOVERY_BANNER_ANALYTICS_EVENT = {
+  dismissed: 'recovery_banner_dismissed',
+  linkClicked: 'recovery_banner_link_clicked',
+  shown: 'recovery_banner_shown',
+} as const
+
+export function RecoveryBanner(): ReactNode {
+  const { pathname } = useLocation()
+  const { isVisible, dismiss } = useRecoveryBanner()
+  const { [RECOVERY_BANNER_FLAG]: isRecoveryBannerEnabled } = useFeatureFlags()
+  const cowAnalytics = useCowAnalytics()
+  const lastTrackedPathRef = useRef<string | null>(null)
+
+  const shouldRender = Boolean(isRecoveryBannerEnabled) && isVisible && !isInjectedWidget()
+
+  const sendAnalyticsEvent = useCallback(
+    (eventName: string, additionalParams?: Record<string, string>): void => {
+      cowAnalytics.sendEvent(eventName, additionalParams)
+    },
+    [cowAnalytics],
+  )
+
+  useEffect(() => {
+    if (!shouldRender) {
+      lastTrackedPathRef.current = null
+      return
+    }
+
+    if (lastTrackedPathRef.current === pathname) {
+      return
+    }
+
+    lastTrackedPathRef.current = pathname
+    sendAnalyticsEvent(RECOVERY_BANNER_ANALYTICS_EVENT.shown)
+  }, [pathname, sendAnalyticsEvent, shouldRender])
+
+  const handleDismiss = useCallback(() => {
+    sendAnalyticsEvent(RECOVERY_BANNER_ANALYTICS_EVENT.dismissed)
+    dismiss()
+  }, [dismiss, sendAnalyticsEvent])
+
+  const handleRevokeClick = useCallback(() => {
+    sendAnalyticsEvent(RECOVERY_BANNER_ANALYTICS_EVENT.linkClicked, { linkTarget: 'revokeCash' })
+  }, [sendAnalyticsEvent])
+
+  if (!shouldRender) {
+    return null
+  }
+
+  return (
+    <styledEl.Banner data-testid="recovery-banner">
+      <styledEl.IconWrap aria-hidden="true">
+        <styledEl.Icon />
+      </styledEl.IconWrap>
+
+      <styledEl.Content>
+        <styledEl.Title>
+          <Trans>
+            CoW Swap <styledEl.TitleAccent>is back online</styledEl.TitleAccent>
+          </Trans>
+        </styledEl.Title>
+
+        <styledEl.Description>
+          <Trans>
+            A recent DNS incident has been resolved. CoW Swap contracts remain safe. If you interacted with the site on
+            April 14, review your token approvals on{' '}
+            <styledEl.Link href={RECOVERY_BANNER_REVOKE_URL} onClickOptional={handleRevokeClick}>
+              Revoke.cash
+            </styledEl.Link>
+            .
+          </Trans>
+        </styledEl.Description>
+      </styledEl.Content>
+
+      <styledEl.CloseButton type="button" aria-label={t`Dismiss incident notice`} onClick={handleDismiss}>
+        <styledEl.CloseIcon aria-hidden="true" />
+      </styledEl.CloseButton>
+    </styledEl.Banner>
+  )
+}

--- a/apps/cowswap-frontend/src/modules/application/containers/AppContainer/RecoveryBanner/RecoveryBanner.styled.ts
+++ b/apps/cowswap-frontend/src/modules/application/containers/AppContainer/RecoveryBanner/RecoveryBanner.styled.ts
@@ -1,5 +1,6 @@
 import { Color, ExternalLink, Media, UI } from '@cowprotocol/ui'
 
+import { darken } from 'color2k'
 import { CheckCircle } from 'react-feather'
 import styled from 'styled-components/macro'
 import { CloseIcon as SharedCloseIcon } from 'theme'
@@ -11,7 +12,7 @@ export const Banner = styled.div`
   gap: 5px;
   padding: 12px 10px;
   background: ${Color.successDark};
-  color: var(${UI.COLOR_BLACK});
+  color: ${darken(Color.successDark, 0.62)};
 
   ${Media.upToMedium()} {
     align-items: flex-start;

--- a/apps/cowswap-frontend/src/modules/application/containers/AppContainer/RecoveryBanner/RecoveryBanner.styled.ts
+++ b/apps/cowswap-frontend/src/modules/application/containers/AppContainer/RecoveryBanner/RecoveryBanner.styled.ts
@@ -64,7 +64,7 @@ export const Content = styled.div`
 export const Title = styled.h2`
   margin: 0;
   font-size: 22px;
-  font-weight: ${UI.FONT_WEIGHT_BOLD};
+  font-weight: var(${UI.FONT_WEIGHT_BOLD});
   line-height: 1;
   color: inherit;
   white-space: nowrap;

--- a/apps/cowswap-frontend/src/modules/application/containers/AppContainer/RecoveryBanner/RecoveryBanner.styled.ts
+++ b/apps/cowswap-frontend/src/modules/application/containers/AppContainer/RecoveryBanner/RecoveryBanner.styled.ts
@@ -1,0 +1,138 @@
+import { Color, ExternalLink, Media, UI } from '@cowprotocol/ui'
+
+import { CheckCircle } from 'react-feather'
+import styled from 'styled-components/macro'
+import { CloseIcon as SharedCloseIcon } from 'theme'
+
+export const Banner = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 12px 10px;
+  background: ${Color.successDark};
+  color: var(${UI.COLOR_BLACK});
+
+  ${Media.upToMedium()} {
+    align-items: flex-start;
+    padding: 12px 16px;
+  }
+`
+
+export const IconWrap = styled.div`
+  --size: 28px;
+  width: var(--size);
+  height: var(--size);
+  flex: 0 0 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--size);
+  color: inherit;
+
+  ${Media.upToSmall()} {
+    width: 28px;
+    height: 28px;
+    flex-basis: 28px;
+  }
+`
+
+export const Icon = styled(CheckCircle).attrs(() => ({
+  size: 24,
+  strokeWidth: 2.5,
+}))`
+  flex-shrink: 0;
+  color: inherit;
+`
+
+export const Content = styled.div`
+  min-width: 0;
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  flex-wrap: wrap;
+
+  ${Media.upToMedium()} {
+    align-items: flex-start;
+    gap: 6px;
+    flex-direction: column;
+  }
+`
+
+export const Title = styled.h2`
+  margin: 0;
+  font-size: 22px;
+  font-weight: ${UI.FONT_WEIGHT_BOLD};
+  line-height: 1;
+  color: inherit;
+  white-space: nowrap;
+
+  ${Media.upToMedium()} {
+    white-space: normal;
+  }
+`
+
+export const TitleAccent = styled.span`
+  color: inherit;
+  font-weight: 200;
+`
+
+export const Description = styled.p`
+  margin: 0;
+  min-width: 0;
+  font-size: 13px;
+  line-height: 1;
+  color: inherit;
+
+  ${Media.upToMedium()} {
+    line-height: 1.4;
+  }
+`
+
+export const Link = styled(ExternalLink)`
+  color: inherit;
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+
+  &:hover {
+    color: inherit;
+  }
+
+  &:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+`
+
+export const CloseIcon = styled(SharedCloseIcon).attrs(() => ({
+  size: 24,
+}))`
+  cursor: inherit;
+`
+
+export const CloseButton = styled.button`
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+
+  &:hover ${CloseIcon} {
+    opacity: 1;
+  }
+
+  &:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+    border-radius: 6px;
+  }
+`

--- a/apps/cowswap-frontend/src/modules/application/containers/AppContainer/RecoveryBanner/RecoveryBanner.styled.ts
+++ b/apps/cowswap-frontend/src/modules/application/containers/AppContainer/RecoveryBanner/RecoveryBanner.styled.ts
@@ -11,8 +11,8 @@ export const Banner = styled.div`
   align-items: center;
   gap: 5px;
   padding: 12px 10px;
+  color: ${darken(Color.successDark, 0.28)};
   background: ${Color.successDark};
-  color: ${darken(Color.successDark, 0.62)};
 
   ${Media.upToMedium()} {
     align-items: flex-start;

--- a/apps/cowswap-frontend/src/modules/application/containers/AppContainer/RecoveryBanner/RecoveryBanner.styled.ts
+++ b/apps/cowswap-frontend/src/modules/application/containers/AppContainer/RecoveryBanner/RecoveryBanner.styled.ts
@@ -51,7 +51,7 @@ export const Content = styled.div`
   flex: 1 1 auto;
   display: flex;
   align-items: center;
-  gap: 24px;
+  gap: 10px;
   flex-wrap: wrap;
 
   ${Media.upToMedium()} {
@@ -83,12 +83,8 @@ export const Description = styled.p`
   margin: 0;
   min-width: 0;
   font-size: 13px;
-  line-height: 1;
+  line-height: 1.4;
   color: inherit;
-
-  ${Media.upToMedium()} {
-    line-height: 1.4;
-  }
 `
 
 export const Link = styled(ExternalLink)`

--- a/apps/cowswap-frontend/src/modules/application/containers/AppContainer/RecoveryBanner/index.ts
+++ b/apps/cowswap-frontend/src/modules/application/containers/AppContainer/RecoveryBanner/index.ts
@@ -1,0 +1,1 @@
+export { RecoveryBanner } from './RecoveryBanner.container'

--- a/apps/cowswap-frontend/src/modules/application/containers/AppContainer/RecoveryBanner/useRecoveryBanner.ts
+++ b/apps/cowswap-frontend/src/modules/application/containers/AppContainer/RecoveryBanner/useRecoveryBanner.ts
@@ -1,0 +1,30 @@
+import { useAtom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
+import { useCallback, useMemo } from 'react'
+
+import { BANNER_IDS } from 'common/constants/banners'
+
+const recoveryBannerAtom = atomWithStorage<boolean>(BANNER_IDS.RECOVERY, true, undefined, {
+  getOnInit: true,
+})
+
+export interface UseRecoveryBannerReturn {
+  dismiss: () => void
+  isVisible: boolean
+}
+
+export function useRecoveryBanner(): UseRecoveryBannerReturn {
+  const [isVisible, setIsVisible] = useAtom(recoveryBannerAtom)
+
+  const dismiss = useCallback(() => {
+    setIsVisible(false)
+  }, [setIsVisible])
+
+  return useMemo(
+    () => ({
+      dismiss,
+      isVisible,
+    }),
+    [dismiss, isVisible],
+  )
+}

--- a/apps/cowswap-frontend/src/theme/components.tsx
+++ b/apps/cowswap-frontend/src/theme/components.tsx
@@ -1,10 +1,9 @@
-import { Command } from '@cowprotocol/types'
 import { UI } from '@cowprotocol/ui'
 
 import { X } from 'react-feather'
 import styled from 'styled-components/macro'
 
-export const CloseIcon = styled(X)<{ onClick: Command }>`
+export const CloseIcon = styled(X)`
   cursor: pointer;
   opacity: 0.6;
   transition: opacity var(${UI.ANIMATION_DURATION}) ease-in-out;


### PR DESCRIPTION
# Summary

  Adds a temporary, dismissible RecoveryBanner to CoW Swap with fixed incident copy, Revoke.cash linking, local dismissal persistence, feature-flag gating, and analytics tracking.

  The banner is rendered in the app shell below existing CMS/URL warnings so critical announcements keep priority, and it is excluded from injected widget mode. The implementation also adds focused tests for visibility, dismissal persistence, widget exclusion, and analytics events.
  
<img width="1444" height="258" alt="Screenshot 2026-04-17 at 12 41 41" src="https://github.com/user-attachments/assets/a226a7f4-de0d-472b-b4a1-afee87e541fb" />

  # To Test

  1. Open swap.cow.fi in the regular app with the recovery banner feature flag enabled and the dismissal key cleared

  - [ ] Verify the recovery banner is shown at the top of the app
  - [ ] Verify the copy matches the approved incident messaging
  - [ ] Verify the Revoke.cash link points to https://revoke.cash/exploits/cowswap
  - [ ] Verify the close icon matches the existing announcement banner sizing
  - [ ] If a CMS/URL warning is active, verify it stays above the recovery banner

  2. Dismiss the banner

  - [ ] Click the Dismiss incident notice close button
  - [ ] Verify the banner disappears immediately
  - [ ] Refresh the page
  - [ ] Verify the banner stays dismissed after reload

  3. Verify gated visibility rules

  - [ ] Disable the isRecoveryBannerEnabled feature flag and verify the banner does not render
  - [ ] Open an injected widget / embedded app context and verify the banner does not render there

  4. Verify analytics behavior

  - [ ] Verify recovery_banner_shown is emitted when the banner becomes visible
  - [ ] Verify recovery_banner_dismissed is emitted when the banner is closed
  - [ ] Verify recovery_banner_link_clicked is emitted when Revoke.cash is clicked with linkTarget: revokeCash

  # Background

  This adds a dedicated hardcoded recovery banner instead of relying on the CMS announcement flow for this incident-specific messaging.

  The banner uses a versioned persisted dismissal key (recoveryBanner:v0), is controlled by the `isRecoveryBannerEnabled` feature flag, and keeps the existing CMS warning system as the top-priority slot for critical announcements.