### PR TITLE
fix: unify 'scan' spelling for chain explorer labels

### DIFF
--- a/apps/cowswap-frontend/src/modules/orderProgressBar/pure/OrderProgressBar/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/pure/OrderProgressBar/index.cosmos.tsx
@@ -728,14 +728,14 @@ const Fixtures = {
 
   // Different chains combination
   // Tests: Polygon → Base
-  // Validates: Each chain uses its specific explorer (PolygonScan → BaseScan)
+  // Validates: Each chain uses its specific explorer (Polygonscan → Basescan)
   // Ensures: Chain-specific explorer names are correctly resolved
   'bridging-explorer-links-polygon-to-base': () => (
     <Wrapper>
       <div style={{ marginBottom: '16px', padding: '8px', background: 'rgba(0,150,0,0.1)', borderRadius: '8px' }}>
         <strong>✅ Different Chains:</strong> Polygon → Base
         <br />
-        <strong>Expected:</strong> "View on PolygonScan" → "View on BaseScan"
+        <strong>Expected:</strong> "View on Polygonscan" → "View on Basescan"
       </div>
       <OrderProgressBar
         {...defaultProps}
@@ -1040,14 +1040,14 @@ const Fixtures = {
   ),
 
   // AVALANCHE VALIDATION: Specific explorer branding
-  // Tests: ETH → Avalanche (uses SnowTrace, not "Avalanche Explorer")
+  // Tests: ETH → Avalanche (uses Snowscan, not "Avalanche Explorer")
   // Validates: Chain-specific explorer names are correctly resolved
   'bridging-explorer-links-avalanche': () => (
     <Wrapper>
       <div style={{ marginBottom: '16px', padding: '8px', background: 'rgba(255,100,100,0.1)', borderRadius: '8px' }}>
         <strong>🔺 Avalanche Test:</strong> ETH → Avalanche
         <br />
-        <strong>Expected:</strong> "View on Etherscan" → "View on SnowTrace"
+        <strong>Expected:</strong> "View on Etherscan" → "View on Snowscan"
       </div>
       <OrderProgressBar
         {...defaultProps}

--- a/apps/explorer/src/components/orders/DetailsTable/detailsTableTooltips.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/detailsTableTooltips.tsx
@@ -14,7 +14,7 @@ export const DetailsTableTooltips = {
   ),
   toBridgeReceiver:
     'This bridge provider uses special receiver address to bridge funds. This address is deterministic for a quote and has been verified by CoW Swap.',
-  hash: 'The onchain settlement transaction for this order. Can be viewed on Etherscan.',
+  hash: 'The onchain settlement transaction for this order. Can be viewed on a block explorer.',
   appData:
     'The AppData hash for this order. It can denote encoded metadata with info on the app, environment and more, although not all interfaces follow the same pattern. Show more will try to decode that information.',
   status: 'The order status is either Signing, Open, Filled, Partially filled, Expired or Cancelled.',

--- a/apps/explorer/src/hooks/useGetOrders.tsx
+++ b/apps/explorer/src/hooks/useGetOrders.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
+import { CHAIN_INFO } from '@cowprotocol/common-const'
 import { ALL_SUPPORTED_CHAIN_IDS, getAddressKey } from '@cowprotocol/cow-sdk'
 
 import { Props as ExplorerLinkProps } from 'components/common/BlockExplorerLink'
@@ -184,7 +185,7 @@ export function useTxOrderExplorerLink(
             networkId: network,
             identifier: txHash,
             showLogo: true,
-            label: network === Network.GNOSIS_CHAIN ? 'Gnosisscan' : 'Etherscan',
+            label: CHAIN_INFO[network]?.explorerTitle || 'Etherscan',
           })
         }
       })


### PR DESCRIPTION
## Summary
- Replace hardcoded explorer names in `useGetOrders.tsx` with centralized `CHAIN_INFO[network].explorerTitle`, so every chain displays its correct explorer name instead of a Gnosis/Ethereum ternary
- Update hardcoded "Etherscan" in `detailsTableTooltips.tsx` to chain-agnostic "block explorer"
- Fix outdated explorer name references in cosmos test fixtures (`PolygonScan` → `Polygonscan`, `BaseScan` → `Basescan`, `SnowTrace` → `Snowscan`) to match the unified lowercase 'scan' spelling from cow-sdk

Fixes #6827