### PR TITLE
fix: resolve protocol loading issue when token changes

### DIFF
--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersWidget/index.tsx
@@ -225,7 +225,7 @@ const LimitOrders = React.memo((props: LimitOrdersProps) => {
           {!hideTradeRateDetails && (
             <styledEl.FooterBox>
               <DeadlineInput />
-              <TradeRateDetails rateInfoParams={rateInfoParams} alwaysExpanded={true} />
+              <TradeRateDetails rateInfoParams={rateInfoParams} alwaysExpanded={true} loading={isRateLoading} />
             </styledEl.FooterBox>
           )}
 

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/TradeRateDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/TradeRateDetails/index.tsx
@@ -5,7 +5,7 @@ import { t } from '@lingui/core/macro'
 import { AffiliateTraderRewardsRow, useIsRewardsRowEnabled } from 'modules/affiliate'
 import { TradeFees, TradeTotalCostsDetails } from 'modules/trade'
 import { Box } from 'modules/trade/containers/TradeTotalCostsDetails/styled'
-import { useTradeQuote, useTradeQuoteProtocolFee } from 'modules/tradeQuote'
+import { useTradeQuoteProtocolFee } from 'modules/tradeQuote'
 import { useUsdAmount } from 'modules/usdAmount'
 import { useVolumeFee, useVolumeFeeTooltip } from 'modules/volumeFee'
 
@@ -17,9 +17,14 @@ import { useLimitOrderProtocolFeeAmount } from '../../hooks/useLimitOrderProtoco
 interface TradeRateDetailsProps {
   rateInfoParams?: RateInfoParams
   alwaysExpanded?: boolean
+  loading?: boolean
 }
 
-export function TradeRateDetails({ rateInfoParams, alwaysExpanded = false }: TradeRateDetailsProps): ReactElement {
+export function TradeRateDetails({
+  rateInfoParams,
+  alwaysExpanded = false,
+  loading = false,
+}: TradeRateDetailsProps): ReactElement {
   const [isFeeDetailsOpen, setFeeDetailsOpen] = useState(alwaysExpanded)
   const { volumeBps: partnerFeeBps } = useVolumeFee() || {}
   const isRewardsRowEnabled = useIsRewardsRowEnabled()
@@ -29,7 +34,6 @@ export function TradeRateDetails({ rateInfoParams, alwaysExpanded = false }: Tra
   const partnerFeeUsd = useUsdAmount(partnerFeeAmount).value
   const protocolFeeUsd = useUsdAmount(protocolFeeAmount).value
 
-  const { isLoading } = useTradeQuote()
   const protocolFeeBps = useTradeQuoteProtocolFee()
 
   const toggleAccordion = useCallback(() => {
@@ -47,7 +51,7 @@ export function TradeRateDetails({ rateInfoParams, alwaysExpanded = false }: Tra
       protocolFeeBps={protocolFeeBps}
       withTimelineDot={false}
       volumeFeeTooltip={volumeFeeTooltip}
-      loading={isLoading}
+      loading={loading}
     />
   )
 

--- a/apps/cowswap-frontend/src/modules/trade/pure/PartnerFeeRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/PartnerFeeRow/index.tsx
@@ -2,7 +2,6 @@ import { ReactNode } from 'react'
 
 import { bpsToPercent, formatPercent, FractionUtils } from '@cowprotocol/common-utils'
 import { Currency, CurrencyAmount } from '@cowprotocol/currency'
-import { CenteredDots } from '@cowprotocol/ui'
 
 import { Trans, useLingui } from '@lingui/react/macro'
 import { Nullish } from 'types'
@@ -61,10 +60,11 @@ export function PartnerFeeRow({
       }
       label={
         <>
-          {t`${label}`} ({loading ? <CenteredDots /> : `${feeAsPercent}%`})
+          {t`${label}`} {!loading && ` (${feeAsPercent}%)`}
         </>
       }
       isLast={isLast}
+      loading={loading}
     />
   )
 }

--- a/apps/cowswap-frontend/src/modules/trade/pure/PartnerFeeRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/PartnerFeeRow/index.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react'
 
 import { bpsToPercent, formatPercent, FractionUtils } from '@cowprotocol/common-utils'
 import { Currency, CurrencyAmount } from '@cowprotocol/currency'
+import { CenteredDots } from '@cowprotocol/ui'
 
 import { Trans, useLingui } from '@lingui/react/macro'
 import { Nullish } from 'types'
@@ -19,6 +20,7 @@ interface PartnerFeeRowProps {
   withTimelineDot: boolean
   volumeFeeTooltip: VolumeFeeTooltip
   isLast?: boolean
+  loading?: boolean
 }
 
 export function PartnerFeeRow({
@@ -28,13 +30,14 @@ export function PartnerFeeRow({
   withTimelineDot,
   volumeFeeTooltip,
   isLast = false,
+  loading = false,
 }: PartnerFeeRowProps): ReactNode {
   const feeAsPercent = partnerFeeBps ? formatPercent(bpsToPercent(partnerFeeBps)) : null
   const minPartnerFeeAmount = FractionUtils.amountToAtLeastOneWei(partnerFeeAmount)
   const { t } = useLingui()
 
   if (!partnerFeeAmount || !partnerFeeBps || partnerFeeAmount.equalTo(0)) {
-    return <FreeFeeRow withTimelineDot={false} />
+    return <FreeFeeRow withTimelineDot={false} loading={loading} />
   }
 
   const label = volumeFeeTooltip.label
@@ -56,7 +59,11 @@ export function PartnerFeeRow({
           </Trans>
         )
       }
-      label={t`${label} (${feeAsPercent}%)`}
+      label={
+        <>
+          {t`${label}`} ({loading ? <CenteredDots /> : `${feeAsPercent}%`})
+        </>
+      }
       isLast={isLast}
     />
   )

--- a/apps/cowswap-frontend/src/modules/trade/pure/ProtocolFeeRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/ProtocolFeeRow/index.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react'
 
 import { bpsToPercent, FractionUtils, trimTrailingZeros } from '@cowprotocol/common-utils'
 import { Currency, CurrencyAmount } from '@cowprotocol/currency'
+import { CenteredDots } from '@cowprotocol/ui'
 
 import { t } from '@lingui/core/macro'
 import { Trans } from '@lingui/react/macro'
@@ -17,6 +18,7 @@ interface ProtocolFeeRowProps {
   protocolFeeBps: number | undefined
   withTimelineDot: boolean
   isLast?: boolean
+  loading?: boolean
 }
 
 export function ProtocolFeeRow({
@@ -25,6 +27,7 @@ export function ProtocolFeeRow({
   protocolFeeBps,
   withTimelineDot,
   isLast = false,
+  loading = false,
 }: ProtocolFeeRowProps): ReactNode {
   const protocolFeeAsPercent = protocolFeeBps
     ? trimTrailingZeros(
@@ -52,7 +55,11 @@ export function ProtocolFeeRow({
           trade is executed.
         </Trans>
       }
-      label={t`Protocol fee (${protocolFeeAsPercent}%)`}
+      label={
+        <>
+          {t`Protocol fee`} ({loading ? <CenteredDots /> : `${protocolFeeAsPercent}%`})
+        </>
+      }
       isLast={isLast}
     />
   )

--- a/apps/cowswap-frontend/src/modules/trade/pure/ProtocolFeeRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/ProtocolFeeRow/index.tsx
@@ -2,7 +2,6 @@ import { ReactNode } from 'react'
 
 import { bpsToPercent, FractionUtils, trimTrailingZeros } from '@cowprotocol/common-utils'
 import { Currency, CurrencyAmount } from '@cowprotocol/currency'
-import { CenteredDots } from '@cowprotocol/ui'
 
 import { t } from '@lingui/core/macro'
 import { Trans } from '@lingui/react/macro'
@@ -57,10 +56,11 @@ export function ProtocolFeeRow({
       }
       label={
         <>
-          {t`Protocol fee`} ({loading ? <CenteredDots /> : `${protocolFeeAsPercent}%`})
+          {t`Protocol fee`} {!loading && ` (${protocolFeeAsPercent}%)`}
         </>
       }
       isLast={isLast}
+      loading={loading}
     />
   )
 }

--- a/apps/cowswap-frontend/src/modules/trade/pure/ReviewOrderModalAmountRow/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/ReviewOrderModalAmountRow/index.tsx
@@ -1,7 +1,7 @@
 import { ReactElement, ReactNode } from 'react'
 
 import { Currency, CurrencyAmount } from '@cowprotocol/currency'
-import { FiatAmount, InfoTooltip, TokenAmount } from '@cowprotocol/ui'
+import { CenteredDots, FiatAmount, InfoTooltip, TokenAmount } from '@cowprotocol/ui'
 
 import { Nullish } from 'types'
 
@@ -21,6 +21,7 @@ export type ReviewOrderAmountRowProps = {
   withTimelineDot?: boolean
   highlighted?: boolean
   isLast?: boolean
+  loading?: boolean
 }
 
 export function ReviewOrderModalAmountRow({
@@ -34,8 +35,11 @@ export function ReviewOrderModalAmountRow({
   withTimelineDot = false,
   highlighted = false,
   isLast = false,
+  loading = false,
 }: ReviewOrderAmountRowProps): ReactElement {
-  const Amount = (
+  const Amount = loading ? (
+    <CenteredDots />
+  ) : (
     <Content highlighted={highlighted}>
       {children}
       {!isAmountAccurate && '≈ '}

--- a/apps/cowswap-frontend/src/modules/trade/pure/TradeFees/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/pure/TradeFees/index.tsx
@@ -52,6 +52,7 @@ export function TradeFees({
       partnerFeeBps={partnerFeeBps}
       volumeFeeTooltip={volumeFeeTooltip}
       isLast={isLast}
+      loading={loading}
     />
   )
 
@@ -62,6 +63,7 @@ export function TradeFees({
       protocolFeeAmount={protocolFeeAmount}
       protocolFeeBps={protocolFeeBps}
       isLast={isLast && !hasPartnerFee}
+      loading={loading}
     />
   )
 
@@ -76,6 +78,7 @@ export function TradeFees({
           protocolFeeUsd={protocolFeeUsd}
           protocolFeeAmount={protocolFeeAmount}
           protocolFeeBps={protocolFeeBps}
+          loading={loading}
         />
         {partnerFeeRow}
       </>

--- a/apps/cowswap-frontend/src/modules/trade/state/shouldHideQuoteAmounts.atom.ts
+++ b/apps/cowswap-frontend/src/modules/trade/state/shouldHideQuoteAmounts.atom.ts
@@ -3,10 +3,10 @@ import { atom } from 'jotai'
 import { currentTradeQuoteAtom } from 'modules/tradeQuote'
 
 export const shouldHideQuoteAmountsAtom = atom((get) => {
-  const { isLoading: isRateLoading, error: quoteError } = get(currentTradeQuoteAtom)
+  const { error: quoteError } = get(currentTradeQuoteAtom)
 
   /**
    * When a quote is loading, or there is an error in the quote result, we should not display values
    */
-  return Boolean(isRateLoading || quoteError)
+  return Boolean(quoteError)
 })


### PR DESCRIPTION
# Summary

Fixed #6960

On the limit orders page, the protocol fee should be in a loading state when a quote is being loaded.  
<img width="355" height="417" alt="protocol_fee" src="https://github.com/user-attachments/assets/b0930635-ffd3-4ae2-b5af-02731a4e5e13" />

---

# To Test

1. <Step one> Open the Limit Orders page  
2. <Step two> Specify a trade selling some amount of WETH for USDC  
3. <Step three> Change WETH to DAI  
4. <Step four> Check the fee field  

---

# Background

Originally, when a trade quote is being loaded, the trade rate details are in a hidden state.  
So, the `isLoading` state cannot be obtained from Jotai, which is why this issue existed before.  

I passed the loading state as a prop from `LimitOrdersWidget` so it could be rendered correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fee rows (partner, protocol, free) and the trade-fee display now show proper loading indicators while rate quotes are being fetched.
  * Review modal amount rows display a loading placeholder instead of calculated amounts/percentages during loading.
  * Quote amounts are now hidden only on error, not while quotes are loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->