### PR TITLE
feat(widget): constrain specific token pairs

### DIFF
--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -277,8 +277,8 @@ msgid "My Custom Hooks ({customHooksCount})"
 msgstr "My Custom Hooks ({customHooksCount})"
 
 #: apps/cowswap-frontend/src/modules/trade/pure/PartnerFeeRow/index.tsx
-msgid "{label} ({feeAsPercent}%)"
-msgstr "{label} ({feeAsPercent}%)"
+#~ msgid "{label} ({feeAsPercent}%)"
+#~ msgstr "{label} ({feeAsPercent}%)"
 
 #: apps/cowswap-frontend/src/modules/twap/containers/TwapFormWidget/tooltips.tsx
 msgid "Your TWAP order won't execute and is protected if the market price dips more than your set price protection."
@@ -3172,8 +3172,8 @@ msgstr "Will be updated {approxNextUpdateTimeAgo}"
 #~ msgstr "Rewards activity"
 
 #: apps/cowswap-frontend/src/modules/trade/pure/ProtocolFeeRow/index.tsx
-msgid "Protocol fee ({protocolFeeAsPercent}%)"
-msgstr "Protocol fee ({protocolFeeAsPercent}%)"
+#~ msgid "Protocol fee ({protocolFeeAsPercent}%)"
+#~ msgstr "Protocol fee ({protocolFeeAsPercent}%)"
 
 #: apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/RefundedBridgingContent/index.tsx
 msgid "Refunded to"
@@ -3444,6 +3444,7 @@ msgid "This token list is not available in your region."
 msgstr "This token list is not available in your region."
 
 #: apps/cowswap-frontend/src/common/pure/ReceiveAmountInfo/index.tsx
+#: apps/cowswap-frontend/src/modules/trade/pure/ProtocolFeeRow/index.tsx
 msgid "Protocol fee"
 msgstr "Protocol fee"
 
@@ -5103,6 +5104,10 @@ msgstr "Order Creation Failed"
 #: apps/cowswap-frontend/src/modules/trade/pure/CompatibilityIssuesWarning/index.tsx
 msgid "This wallet is not yet supported"
 msgstr "This wallet is not yet supported"
+
+#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+msgid "The token pair is constrained"
+msgstr "The token pair is constrained"
 
 #: apps/cowswap-frontend/src/modules/affiliate/containers/AffiliatePartnerCodeInfo.tsx
 #: apps/cowswap-frontend/src/modules/ordersTable/pure/ReceiptModal/ReceiptModal.modal.tsx
@@ -7306,6 +7311,10 @@ msgstr "Cancelled"
 #: apps/cowswap-frontend/src/modules/hooksStore/dapps/PermitHookApp/index.tsx
 msgid "Invalid parameters"
 msgstr "Invalid parameters"
+
+#: apps/cowswap-frontend/src/modules/trade/pure/PartnerFeeRow/index.tsx
+msgid "{label}"
+msgstr "{label}"
 
 #: apps/cowswap-frontend/src/modules/limitOrders/pure/SmallVolumeWarningBanner/index.tsx
 msgid "Small orders are unlikely to be executed"

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
@@ -403,4 +403,7 @@ export const tradeButtonsMap: Record<TradeFormValidation, ButtonErrorConfig | Bu
       </TradeFormBlankButton>
     )
   },
+  [TradeFormValidation.WidgetConstrainedTokenPair]: {
+    text: <Trans>The token pair is constrained</Trans>,
+  },
 }

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.test.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.test.ts
@@ -32,6 +32,7 @@ describe('validateTradeForm - xStock logic', () => {
       recipient: '0x123',
       isQuoteBasedOrder: true,
       tradeType: TradeType.SWAP,
+      slippage: null,
     },
     tradeQuote: { isLoading: false } as unknown as TradeQuoteState,
     isOnline: true,
@@ -48,12 +49,13 @@ describe('validateTradeForm - xStock logic', () => {
     intermediateTokenToBeImported: false,
     isAccountProxyLoading: false,
     isProxySetupValid: true,
-    customTokenError: null,
+    customTokenError: undefined,
     isRestrictedForCountry: false,
     isBalancesLoading: false,
     isBundlingSupported: true,
     isInputCurrencyXstock: false,
     isOutputCurrencyXstock: false,
+    injectedWidgetParams: {},
   }
 
   test('shows xStock minimum trade size for sell orders when xStock sell amount is below $10', () => {

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
@@ -90,6 +90,21 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
     return [TradeFormValidation.XstockMinimumTradeSize]
   }
 
+  if (injectedWidgetParams.tokenPairConstraints && inputCurrency && outputCurrency) {
+    const isTradeConstrained = injectedWidgetParams.tokenPairConstraints.some((rule) => {
+      return (
+        rule.sell.chainId === inputCurrency.chainId &&
+        areAddressesEqual(rule.sell.address, getCurrencyAddress(inputCurrency)) &&
+        rule.buy.chainId === outputCurrency.chainId &&
+        areAddressesEqual(rule.buy.address, getCurrencyAddress(outputCurrency))
+      )
+    })
+
+    if (isTradeConstrained) {
+      validations.push(TradeFormValidation.WidgetConstrainedTokenPair)
+    }
+  }
+
   if (!isWrapUnwrap && tradeQuote.error) {
     if (inputAmountIsNotSet) {
       validations.push(TradeFormValidation.InputAmountNotSet)
@@ -220,21 +235,6 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
 
     if (isPriceImpactAboveThreshold) {
       validations.push(TradeFormValidation.DisableTradeWithHighPriceImpact)
-    }
-  }
-
-  if (injectedWidgetParams.tokenPairConstraints && inputCurrency && outputCurrency) {
-    const isTradeConstrained = injectedWidgetParams.tokenPairConstraints.some((rule) => {
-      return (
-        rule.sell.chainId === inputCurrency.chainId &&
-        areAddressesEqual(rule.sell.address, getCurrencyAddress(inputCurrency)) &&
-        rule.buy.chainId === outputCurrency.chainId &&
-        areAddressesEqual(rule.buy.address, getCurrencyAddress(outputCurrency))
-      )
-    })
-
-    if (isTradeConstrained) {
-      validations.push(TradeFormValidation.WidgetConstrainedTokenPair)
     }
   }
 

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
@@ -1,5 +1,5 @@
-import { getIsNativeToken, isFractionFalsy, isSellOrder } from '@cowprotocol/common-utils'
-import { isEvmChain } from '@cowprotocol/cow-sdk'
+import { getCurrencyAddress, getIsNativeToken, isFractionFalsy, isSellOrder } from '@cowprotocol/common-utils'
+import { areAddressesEqual, isEvmChain } from '@cowprotocol/cow-sdk'
 
 import { TradeType } from 'modules/trade'
 import { getIsFastQuote, isQuoteExpired } from 'modules/tradeQuote'
@@ -220,6 +220,21 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
 
     if (isPriceImpactAboveThreshold) {
       validations.push(TradeFormValidation.DisableTradeWithHighPriceImpact)
+    }
+  }
+
+  if (injectedWidgetParams.tokenPairConstraints && inputCurrency && outputCurrency) {
+    const isTradeConstrained = injectedWidgetParams.tokenPairConstraints.some((rule) => {
+      return (
+        rule.sell.chainId === inputCurrency.chainId &&
+        areAddressesEqual(rule.sell.address, getCurrencyAddress(inputCurrency)) &&
+        rule.buy.chainId === outputCurrency.chainId &&
+        areAddressesEqual(rule.buy.address, getCurrencyAddress(outputCurrency))
+      )
+    })
+
+    if (isTradeConstrained) {
+      validations.push(TradeFormValidation.WidgetConstrainedTokenPair)
     }
   }
 

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/types.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/types.ts
@@ -116,4 +116,5 @@ export enum TradeFormValidation {
   // Widget controlled
   DisableTradeWithUnknownPriceImpact,
   DisableTradeWithHighPriceImpact,
+  WidgetConstrainedTokenPair,
 }

--- a/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
@@ -5,7 +5,7 @@ import { CowSwapWidgetParams, TradeType, WidgetHookEvents } from '@cowprotocol/w
 import { isDev, isLocalHost, isVercel } from '../../../env'
 import { ConfiguratorState } from '../types'
 
-// const vercelSuffix = '-cowswap-dev.vercel.app'
+const vercelSuffix = '-cowswap-dev.vercel.app'
 
 const getBaseUrl = (): string => {
   if (typeof window === 'undefined' || !window) return ''
@@ -15,11 +15,9 @@ const getBaseUrl = (): string => {
   if (isDev) return 'https://dev.swap.cow.fi'
 
   if (isVercel) {
-    // const prKey = window.location.hostname.replace('widget-configurator-git-', '').replace(vercelSuffix, '')
+    const prKey = window.location.hostname.replace('widget-configurator-git-', '').replace(vercelSuffix, '')
 
-    // TODO: revert
-    return 'https://swap-dev-git-feat-widget-tokenpairconstraints-cowswap-dev.vercel.app'
-    // return `https://swap-dev-git-${prKey}${vercelSuffix}`
+    return `https://swap-dev-git-${prKey}${vercelSuffix}`
   }
 
   return 'https://swap.cow.fi'

--- a/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
@@ -5,7 +5,7 @@ import { CowSwapWidgetParams, TradeType, WidgetHookEvents } from '@cowprotocol/w
 import { isDev, isLocalHost, isVercel } from '../../../env'
 import { ConfiguratorState } from '../types'
 
-const vercelSuffix = '-cowswap-dev.vercel.app'
+// const vercelSuffix = '-cowswap-dev.vercel.app'
 
 const getBaseUrl = (): string => {
   if (typeof window === 'undefined' || !window) return ''
@@ -15,9 +15,11 @@ const getBaseUrl = (): string => {
   if (isDev) return 'https://dev.swap.cow.fi'
 
   if (isVercel) {
-    const prKey = window.location.hostname.replace('widget-configurator-git-', '').replace(vercelSuffix, '')
+    // const prKey = window.location.hostname.replace('widget-configurator-git-', '').replace(vercelSuffix, '')
 
-    return `https://swap-dev-git-${prKey}${vercelSuffix}`
+    // TODO: revert
+    return 'https://swap-dev-git-feat-widget-tokenpairconstraints-cowswap-dev.vercel.app'
+    // return `https://swap-dev-git-${prKey}${vercelSuffix}`
   }
 
   return 'https://swap.cow.fi'

--- a/libs/widget-lib/src/types.ts
+++ b/libs/widget-lib/src/types.ts
@@ -450,6 +450,14 @@ export interface CowSwapWidgetParams {
     whenPriceImpactIsHigherThan?: number
   }
 
+  /**
+   * Disables trading of specific token pair
+   */
+  tokenPairConstraints?: {
+    sell: { address: string; chainId: SupportedChainId }
+    buy: { address: string; chainId: SupportedChainId }
+  }[]
+
   hooks?: Partial<{
     onBeforeApproval(payload: OnApprovalPayload): WidgetHookResult
     onBeforeWrapOrUnwrap(payload: OnTradeParamsPayload): WidgetHookResult


### PR DESCRIPTION
# Summary

There was a request from one of integration partners to disable trading of specific token pairs.

# To Test

1. Open the widget and paste the object into "Raw JSON params"
2. Choose UNI -> DAI on Mainnet
3. It should display "The token pair is constrained" state and disable possibility to trade


```
{
	"tokenPairConstraints": [
		{
		"sell": {"address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984", "chainId": 1},
		"buy": {"address": "0x6B175474E89094C44Da98b954EedeAC495271d0F", "chainId": 1}
		}
	]
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token pair constraint validation for widgets. When constraints are configured, users cannot trade restricted token pairs and will receive the error message "The token pair is constrained."
  * Widget configuration now supports defining allowed token pair combinations per blockchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->