### PR TITLE
Viem Migration - fix: fixing the pop up when chain is not supported by a wallet

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useOnSelectNetwork.tsx
+++ b/apps/cowswap-frontend/src/common/hooks/useOnSelectNetwork.tsx
@@ -35,7 +35,8 @@ export function useOnSelectNetwork(): (chainId: SupportedChainId, skipClose?: bo
       } catch (error: any) {
         console.error('Failed to switch networks', error)
 
-        if (isRejectRequestProviderError(error)) {
+        const causeIsRejection = !error.cause || isRejectRequestProviderError(error.cause)
+        if (isRejectRequestProviderError(error) && causeIsRejection) {
           return
         }
 

--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -277,8 +277,8 @@ msgid "My Custom Hooks ({customHooksCount})"
 msgstr "My Custom Hooks ({customHooksCount})"
 
 #: apps/cowswap-frontend/src/modules/trade/pure/PartnerFeeRow/index.tsx
-msgid "{label} ({feeAsPercent}%)"
-msgstr "{label} ({feeAsPercent}%)"
+#~ msgid "{label} ({feeAsPercent}%)"
+#~ msgstr "{label} ({feeAsPercent}%)"
 
 #: apps/cowswap-frontend/src/modules/twap/containers/TwapFormWidget/tooltips.tsx
 msgid "Your TWAP order won't execute and is protected if the market price dips more than your set price protection."
@@ -3172,8 +3172,8 @@ msgstr "Will be updated {approxNextUpdateTimeAgo}"
 #~ msgstr "Rewards activity"
 
 #: apps/cowswap-frontend/src/modules/trade/pure/ProtocolFeeRow/index.tsx
-msgid "Protocol fee ({protocolFeeAsPercent}%)"
-msgstr "Protocol fee ({protocolFeeAsPercent}%)"
+#~ msgid "Protocol fee ({protocolFeeAsPercent}%)"
+#~ msgstr "Protocol fee ({protocolFeeAsPercent}%)"
 
 #: apps/cowswap-frontend/src/modules/bridge/pure/contents/BridgingProgressContent/RefundedBridgingContent/index.tsx
 msgid "Refunded to"
@@ -3444,6 +3444,7 @@ msgid "This token list is not available in your region."
 msgstr "This token list is not available in your region."
 
 #: apps/cowswap-frontend/src/common/pure/ReceiveAmountInfo/index.tsx
+#: apps/cowswap-frontend/src/modules/trade/pure/ProtocolFeeRow/index.tsx
 msgid "Protocol fee"
 msgstr "Protocol fee"
 
@@ -7306,6 +7307,10 @@ msgstr "Cancelled"
 #: apps/cowswap-frontend/src/modules/hooksStore/dapps/PermitHookApp/index.tsx
 msgid "Invalid parameters"
 msgstr "Invalid parameters"
+
+#: apps/cowswap-frontend/src/modules/trade/pure/PartnerFeeRow/index.tsx
+msgid "{label}"
+msgstr "{label}"
 
 #: apps/cowswap-frontend/src/modules/limitOrders/pure/SmallVolumeWarningBanner/index.tsx
 msgid "Small orders are unlikely to be executed"


### PR DESCRIPTION
# Summary

https://github.com/user-attachments/assets/f4b7424a-a0df-4276-ae67-5ece99a0db1c

Notion Issue: https://www.notion.so/cownation/2fc8da5f04ca80568067c0bc4dc9d36a?v=2fc8da5f04ca81ada4ca000c320d51ef&p=3488da5f04ca809f8741fdd325c56a8c&pm=s

When switching to a chain not supported by a WalletConnect wallet (e.g. 1inch on Plasma or Ink), the expected snackbar ("Failed to switch networks... you must change the network in your wallet.") was silently swallowed and never shown to the user.

**Root cause**: wagmi's WalletConnect connector wraps `wallet_addEthereumChain` failures as `UserRejectedRequestError` (code 4001) even when the wallet simply doesn't support the chain — not an actual user rejection. `isRejectRequestProviderError` treats any code-4001 error as a user rejection, causing `useOnSelectNetwork` to return early without showing the snackbar.

**Fix**: also inspect `error.cause` — if the cause itself is not a user rejection, it's a "chain not supported" failure and the snackbar should be shown.

# To Test

1. Connect with a WalletConnect wallet that does not natively support all CoW Swap networks (e.g. 1inch)

- [ ] Open the network selector and select Plasma or Ink
- [ ] A snackbar appears: "Failed to switch networks from the CoW Swap Interface. In order to use CoW Swap on [network], you must change the network in your wallet."
- [ ] The snackbar does NOT appear when the user explicitly rejects a switch prompt for a supported network

2. Switch between supported networks with a wallet that supports them all (e.g. MetaMask)

- [ ] Network switching works as expected with no error snackbar

# Background

When a WalletConnect wallet doesn't know a chain, wagmi's `switchChain` first tries `wallet_switchEthereumChain`. On failure, it falls back to `wallet_addEthereumChain`. If that also fails, wagmi always wraps the error as `UserRejectedRequestError` — regardless of whether the user saw and rejected a prompt or the wallet simply doesn't support the chain. Inspecting `error.cause` allows distinguishing between the two cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined error handling and detection logic when switching blockchain networks to provide more accurate and helpful feedback to users during connection failures.

* **Localization**
  * Updated and consolidated fee-related translations and message references throughout the interface to ensure consistent and clear messaging across different language options and regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->