### PR TITLE
fix: spammy affiliate logging

### DIFF
--- a/apps/cowswap-frontend/src/modules/affiliate/hooks/useHasLocalTrades.ts
+++ b/apps/cowswap-frontend/src/modules/affiliate/hooks/useHasLocalTrades.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 
 import { Address } from '@cowprotocol/cow-sdk'
 
@@ -21,19 +21,13 @@ export function useHasLocalTrades(account: Address | undefined): boolean {
     if (!account || !ordersState) return false
 
     const orders = getLocalTrades(account, ordersState).filter(isExecutedNonIntegratorOrder)
-
-    if (orders.length > 0) {
-      logAffiliate(
-        safeShortenAddress(account),
-        `Found ${orders.length} trades in local state. Latest order IDs: ${orders
-          .slice(0, 3)
-          .map((order) => order.id)
-          .join(', ')}`,
-      )
-    }
-
     return orders.length > 0
   }, [account, ordersState])
 
+  useEffect(() => {
+    if (account && hasPastTrades) {
+      logAffiliate(safeShortenAddress(account), `Found trades in local state`)
+    }
+  }, [hasPastTrades, account])
   return hasPastTrades
 }


### PR DESCRIPTION
# Summary

Fixes 
<img width="546" height="818" alt="image (2)" src="https://github.com/user-attachments/assets/0acdf348-1d00-4ba3-925c-7e438461648f" />

## To Test

Open dev tools and check that this log is not spammed all the time.

## Background

This log should happen only if `hasPastTrades` changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized internal trade history detection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->