### PR TITLE
ci: advertise IPFS cid using GH deployments

### DIFF
--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags: [cowswap-v*]
 
+permissions:
+  contents: read
+  deployments: write
+
 env:
   REACT_APP_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
   REACT_APP_PINATA_API_KEY: ${{ secrets.REACT_APP_PINATA_API_KEY }}
@@ -22,6 +26,9 @@ jobs:
   ipfs:
     name: IPFS
     runs-on: ubuntu-latest
+    environment:
+      name: cowswap-ipfs
+      url: ${{ steps.deploy-ipfs.outputs.url }}
 
     steps:
       - name: Checkout code
@@ -42,4 +49,24 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build Web Apps
-        run: pnpm run ipfs
+        id: deploy-ipfs
+        run: |
+          set -euo pipefail
+
+          output="$(pnpm run ipfs)"
+          printf '%s\n' "$output"
+
+          cid="$(printf '%s\n' "$output" | node tools/scripts/extract-ipfs-deployment.mjs)"
+          url="https://dweb.link/ipfs/${cid}/"
+          fallback_url="https://inbrowser.link/ipfs/${cid}/"
+
+          echo "cid=${cid}" >> "$GITHUB_OUTPUT"
+          echo "url=${url}" >> "$GITHUB_OUTPUT"
+          echo "fallback_url=${fallback_url}" >> "$GITHUB_OUTPUT"
+          {
+            echo "### IPFS deployment"
+            echo
+            echo "- CID: \`${cid}\`"
+            echo "- Primary URL: ${url}"
+            echo "- Fallback URL: ${fallback_url}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/tools/scripts/extract-ipfs-deployment.mjs
+++ b/tools/scripts/extract-ipfs-deployment.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+
+const CID_REGEX = /\b(Qm[1-9A-HJ-NP-Za-km-z]{44}|bafy[a-z2-7]{20,})\b/g
+
+export function extractIpfsCid(output) {
+  return Array.from(output.matchAll(CID_REGEX)).at(-1)?.[0] ?? null
+}
+
+function main() {
+  const output = readFileSync(0, 'utf8')
+  const cid = extractIpfsCid(output)
+
+  if (!cid) {
+    console.error('Could not find IPFS CID in deployment output')
+    process.exit(1)
+  }
+
+  console.log(cid)
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main()
+}

--- a/tools/scripts/extract-ipfs-deployment.test.mjs
+++ b/tools/scripts/extract-ipfs-deployment.test.mjs
@@ -1,0 +1,27 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { extractIpfsCid } from './extract-ipfs-deployment.mjs'
+
+const cidV0 = 'QmYwAPJzv5CZsnAzt8auVZRn9DfVXjGkA4z7K34q4R9qyg'
+const cidV1 = 'bafybeigdyrzt3sfp7udm7hu76jge2pe2bghlxve5jiijb2qlbtndk2nlky'
+
+test('extracts CIDv0 from deployment output', () => {
+  assert.equal(extractIpfsCid(`uploaded\n${cidV0}\n`), cidV0)
+})
+
+test('extracts CIDv1 from deployment output', () => {
+  assert.equal(extractIpfsCid(`Gateway URL: https://ipfs.io/ipfs/${cidV1}/`), cidV1)
+})
+
+test('uses the last CID from noisy output', () => {
+  assert.equal(extractIpfsCid(`previous ${cidV0}\ncurrent ${cidV1}`), cidV1)
+})
+
+test('returns null when output has no CID', () => {
+  assert.equal(extractIpfsCid('deployment finished without a hash'), null)
+})
+
+test('does not match short bafy-like words', () => {
+  assert.equal(extractIpfsCid('not a CID: bafytest'), null)
+})


### PR DESCRIPTION
## Summary

Advertises each IPFS release as a [GitHub Deployment](https://github.com/cowprotocol/cowswap/deployments), making old IPFS releases discoverable without digging through Action logs.

This is useful when testing regression bugs.

## To Test

1. Run unit test: `node --test tools/scripts/extract-ipfs-deployment.test.mjs`
2. Manually after the next IPFS deployment.


## Future Improvements

### 1. Migrate from legacy `ipfs-deploy`

- Migrate to `ipshipyard/ipfs-deploy-action` once we can use a supported upload backend.
- The current `ipfs-deploy` script has not been updated in 4 years, which makes it risky for release infrastructure.
- The new action is properly maintained and exposes `steps.<id>.outputs.cid`, removing the CID extraction script entirely.
- Current blocker: Pinata public pinning is not enough for that action; it requires Kubo, IPFS Cluster, Filebase, or another supported CAR upload provider.

<img width="986" height="328" alt="image" src="https://github.com/user-attachments/assets/296cd4fd-08a3-49d4-bd09-f30fa50256e0" />

### 2. Versioned ENS deployments using subdomains

- Use ENS for named IPFS deployments so historical releases can be opened by version instead of CID.
- This would make IPFS releases easier for users and widget integrators to consume, because they could pin to a known older version instead of always the latest version.

Example ENS names for the last 5 versions:

| Version          | ENS name             | Gateway URL                        |
| ---------------- | -------------------- | ---------------------------------- |
| `cowswap-latest` | `cowswap.eth`        | `https://cowswap.eth.limo/`        |
| `cowswap-v3.9.1` | `v3-9-1.cowswap.eth` | `https://v3-9-1.cowswap.eth.limo/` |
| `cowswap-v3.9.0` | `v3-9-0.cowswap.eth` | `https://v3-9-0.cowswap.eth.limo/` |

## Background
<details>
<summary>Gateway Choice</summary>

Validated against production CID `QmTkBPqHeNa9ifCxujhFf3gNYMZm9UcnVJQkqoiXcVBAxk`:

| Gateway                   | URL                                                                                   | Result | Notes                                                     |
| ------------------------- | ------------------------------------------------------------------------------------- | -----: | --------------------------------------------------------- |
| dweb.link path            | `https://dweb.link/ipfs/QmTkBPqHeNa9ifCxujhFf3gNYMZm9UcnVJQkqoiXcVBAxk/`              |     OK | Primary URL. Redirects to CIDv1 subdomain.                |
| inbrowser.link            | `https://inbrowser.link/ipfs/QmTkBPqHeNa9ifCxujhFf3gNYMZm9UcnVJQkqoiXcVBAxk/`         |     OK | Fallback URL.                                             |
| dweb.link CIDv0 subdomain | `https://QmTkBPqHeNa9ifCxujhFf3gNYMZm9UcnVJQkqoiXcVBAxk.ipfs.dweb.link/`              |   FAIL | Returns 500. Do not use CIDv0 subdomain form.             |
| ipfs.io                   | `https://ipfs.io/ipfs/QmTkBPqHeNa9ifCxujhFf3gNYMZm9UcnVJQkqoiXcVBAxk/`                |   FAIL | Redirects to `https://about.ipfs.io/` in browser testing. |
| Pinata public             | `https://gateway.pinata.cloud/ipfs/QmTkBPqHeNa9ifCxujhFf3gNYMZm9UcnVJQkqoiXcVBAxk/`   |   FAIL | Returns 403: public gateway cannot serve HTML.            |
| trustless-gateway.link    | `https://trustless-gateway.link/ipfs/QmTkBPqHeNa9ifCxujhFf3gNYMZm9UcnVJQkqoiXcVBAxk/` |   FAIL | Returns 406; not for normal HTML browsing.                |

</details>

<details>
<summary>Recent IPFS Deployments</summary>

Last 5 normal `cowswap-v*` IPFS production tag deployments from `gh run view --log`:

| Tag              |   Date UTC | CID                                              | dweb.link                                                                        |
| ---------------- | ---------: | ------------------------------------------------ | -------------------------------------------------------------------------------- |
| `cowswap-v3.9.1` | 2026-04-22 | `QmTkBPqHeNa9ifCxujhFf3gNYMZm9UcnVJQkqoiXcVBAxk` | https://dweb.link/ipfs/QmTkBPqHeNa9ifCxujhFf3gNYMZm9UcnVJQkqoiXcVBAxk/          |
| `cowswap-v3.9.0` | 2026-04-17 | `QmSBe7bHrWjtrnA9jsTig6MyuiiCzyeYXgC2SbkCyRT2oP` | https://dweb.link/ipfs/QmSBe7bHrWjtrnA9jsTig6MyuiiCzyeYXgC2SbkCyRT2oP/          |
| `cowswap-v3.8.0` | 2026-04-17 | `QmeBLSbyJpRKXAi8Z8Ar5a58ep4wdeNctD3tFX11VzvVxc` | https://dweb.link/ipfs/QmeBLSbyJpRKXAi8Z8Ar5a58ep4wdeNctD3tFX11VzvVxc/          |
| `cowswap-v3.7.1` | 2026-04-16 | `QmQNwRvQvKbfS41xM3v7wNdkeGK3CJoSjWayFSwXWUfyq9` | https://dweb.link/ipfs/QmQNwRvQvKbfS41xM3v7wNdkeGK3CJoSjWayFSwXWUfyq9/          |
| `cowswap-v3.7.0` | 2026-04-16 | `QmdMjZXYLCkLiAUU6zZTzgev4vRbYoLcjBsHmFioh1LxTZ` | https://dweb.link/ipfs/QmdMjZXYLCkLiAUU6zZTzgev4vRbYoLcjBsHmFioh1LxTZ/          |

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved IPFS deployment workflow: explicit permissions, named environment with dynamic deployment URL, and safer command execution that captures and exposes deployment CID, primary and fallback URLs, and writes a deployment summary.
  * More robust extraction and validation of IPFS CIDs to ensure reliable deployment tracking.

* **Tests**
  * Added tests covering CID extraction across multiple output formats and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->