### PR TITLE
fix: fee calculation logic for high fee warning on sell orders

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/HighFeeWarning/hooks/useHighFeeWarning.ts
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/HighFeeWarning/hooks/useHighFeeWarning.ts
@@ -41,19 +41,15 @@ export function useHighFeeWarning(): UseHighFeeWarningReturn {
       isSell,
       beforeAllFees,
       afterNetworkCosts,
-      costs: { networkFee, partnerFee, bridgeFee },
-      quotePrice,
+      costs: { bridgeFee, networkFee, partnerFee },
     } = receiveAmountInfo
 
     const outputAmountWithoutFee = isSell ? beforeAllFees.buyAmount : afterNetworkCosts.buyAmount
 
     const inputAmountAfterFees = isSell ? beforeAllFees.sellAmount : afterNetworkCosts.sellAmount
 
-    const feeAsCurrency = isSell ? quotePrice.quote(networkFee.amountInSellCurrency) : networkFee.amountInSellCurrency
-
-    const volumeFeeAmount = partnerFee.amount
-
-    const totalFeeAmount = volumeFeeAmount ? feeAsCurrency.add(volumeFeeAmount) : feeAsCurrency
+    const networkFeeAmount = isSell ? networkFee.amountInBuyCurrency : networkFee.amountInSellCurrency
+    const totalFeeAmount = networkFeeAmount.add(partnerFee.amount)
     const targetAmount = isSell ? outputAmountWithoutFee : inputAmountAfterFees
 
     if (targetAmount.equalTo(0)) return DEFAULT_FEE_STATE


### PR DESCRIPTION
# Summary

Fixes incorrect high-fee warning percentages for sell orders. Reported in Slack https://nomevlabs.slack.com/archives/C0361CDG8GP/p1777307383068449

This is not a regression. The same issue can be reproduced on [cowswap-v3.7.0](https://dweb.link/ipfs/QmdMjZXYLCkLiAUU6zZTzgev4vRbYoLcjBsHmFioh1LxTZ/)

As you can see in the screenshot when trading 1.5 USD for 0.74 USD with a 0.7 network fee the fee is higher than 50%, it works for buy but not for sell:

<img width="2377" height="730" alt="Screenshot From 2026-04-28 12-53-15" src="https://github.com/user-attachments/assets/2985ef7d-dee3-4fa3-b6ab-0c40ce5728e0" />

# To Test

1. Open the Swap page and enter a small sell order where network costs are a significant part of the output amount.
2. Verify the high-fee warning percentage matches the displayed network costs divided by the output amount.
3. Verify sell orders no longer underestimate the fee percentage.
4. Verify buy orders still show the expected high-fee warning percentage.

# Background

The previous calculation converted sell-side network fees through `quotePrice.quote(...)`, but `quotePrice` is derived from quote amounts and already includes network cost effects.
