### PR TITLE
fix: hide sc custom recipient warning for non-evm

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/containers/Warnings/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/Warnings/index.tsx
@@ -8,6 +8,7 @@ import { TradeType } from '@cowprotocol/widget-lib'
 import { useInjectedWidgetParams } from 'modules/injectedWidget'
 import {
   useIsCurrentTradeBridging,
+  useIsNonEvmBridging,
   useNonEvmReceiverConfirmed,
   useSetNonEvmReceiverConfirmed,
   useTradePriceImpact,
@@ -32,6 +33,7 @@ export function Warnings({ buyingFiatAmount, hideQuoteAmount }: WarningsProps): 
   const formState = useSwapFormState()
   const tradeUrlParams = useTradeRouteContext()
   const isCurrentTradeBridging = useIsCurrentTradeBridging()
+  const isNonEvmBridging = useIsNonEvmBridging()
   const shouldCheckBridgingRecipient = useShouldCheckBridgingRecipient()
   const nonEvmReceiverConfirmed = useNonEvmReceiverConfirmed()
   const setNonEvmReceiverConfirmed = useSetNonEvmReceiverConfirmed()
@@ -55,8 +57,15 @@ export function Warnings({ buyingFiatAmount, hideQuoteAmount }: WarningsProps): 
 
   // Show SC wallet warning only when recipient was NOT explicitly set by the user
   // (i.e. the connected wallet address will be used as the recipient on another chain)
+  // For non-EVM chains the EVM wallet address is not a valid fallback,
+  // so there is nothing to warn about — the "Recipient is required" validation handles that case.
   const showScWalletWarning =
-    shouldCheckBridgingRecipient && !recipient && !!account && !!outputChainId && !isFractionFalsy(outputCurrencyAmount)
+    shouldCheckBridgingRecipient &&
+    !recipient &&
+    !isNonEvmBridging &&
+    !!account &&
+    !!outputChainId &&
+    !isFractionFalsy(outputCurrencyAmount)
 
   return (
     <>


### PR DESCRIPTION
# Summary

Fixes #7424
