### PR TITLE
Fix stale insufficient liquidity error after buy-token switch

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeQuote/services/doQuotePolling.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/services/doQuotePolling.ts
@@ -38,6 +38,7 @@ export function doQuotePolling({
     // Also avoid quote refresh when only appData.quote (contains slippage) is changed
     // Important! We should skip quote updating only if there is no quote response
     if (
+      !hasParamsChanged &&
       isQuoteCached(currentQuote) &&
       quoteUsingSameParameters(currentQuote, quoteParams, currentQuoteAppDataDoc, appData, hasSmartSlippage)
     ) {
@@ -54,7 +55,7 @@ export function doQuotePolling({
   const fetchStartTimestamp = Date.now()
 
   // Don't fetch fast quote in confirm screen and in bridging mode
-  if (fastQuote && !isConfirmOpen && !isBridging) {
+  if (shouldFetchFastQuote(fastQuote, isConfirmOpen, isBridging)) {
     fetchQuote({ hasParamsChanged, priceQuality: PriceQuality.FAST, fetchStartTimestamp })
   }
   fetchQuote({ hasParamsChanged, priceQuality: PriceQuality.OPTIMAL, fetchStartTimestamp })
@@ -67,4 +68,8 @@ function isQuoteCached(quote: TradeQuoteState): boolean {
   const hasCachedError = quote.error
 
   return Boolean(hasCachedResponse || hasCachedError)
+}
+
+function shouldFetchFastQuote(fastQuote: boolean | undefined, isConfirmOpen: boolean, isBridging: boolean): boolean {
+  return Boolean(fastQuote && !isConfirmOpen && !isBridging)
 }


### PR DESCRIPTION
### Summary

Fixes #7438

- Fixes a stale `Insufficient liquidity` error that remained visible after switching buy token back to a valid token (e.g. `USDC`).
- Root cause: quote polling could reuse cached state even after token changes, so refetch could be delayed until next polling tick.
- Update: cache-reuse skip now applies only when quote params have **not** changed, forcing immediate quote reload on token change.

### To Test

1. Connect a wallet on Ethereum.
2. Set sell token to `WETH` and amount to `1`.
3. Set buy token to `USDC` and confirm quote loads.
   - [ ] Quote is shown normally.
4. Change buy token to `0x583019fF0f430721aDa9cfb4fac8F06cA104d0B4`.
   - [ ] `Insufficient liquidity for this trade.` error is shown.
5. Change buy token back to `USDC`.
   - [ ] Stale insufficient liquidity error disappears immediately.
   - [ ] Quote is reloaded right away (no need to wait for next polling refresh).

### Background

Previously, quote polling could skip refetch when cached quote state looked reusable. In this flow, that caused the old insufficient liquidity error to persist briefly even after selecting a valid token again. The fix ensures param changes trigger immediate refetch.

[Screencast from 2026-05-03 22-54-39.webm](https://github.com/user-attachments/assets/54e5bbad-5016-415b-bd51-96e29be538bb)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for quote polling logic to enhance maintainability.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->