### PR TITLE
fix(cowswap-frontend): disable Confirm Swap during quote refresh

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/SwapConfirmModal.utils.test.ts
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/SwapConfirmModal.utils.test.ts
@@ -11,7 +11,7 @@ const defaultParams: GetSwapConfirmDisabledStateParams = {
 }
 
 describe('getSwapConfirmDisabledState', () => {
-  it('disables confirm when bridge quote is refreshing', () => {
+  it('disables confirm when quote is refreshing', () => {
     const result = getSwapConfirmDisabledState({
       ...defaultParams,
       quoteCounter: 0,
@@ -23,7 +23,7 @@ describe('getSwapConfirmDisabledState', () => {
     })
   })
 
-  it('disables confirm when bridge quote is stale', () => {
+  it('disables confirm when quote is stale', () => {
     const result = getSwapConfirmDisabledState({
       ...defaultParams,
       isQuoteStale: true,
@@ -35,7 +35,7 @@ describe('getSwapConfirmDisabledState', () => {
     })
   })
 
-  it('disables confirm when bridge quote is loading', () => {
+  it('disables confirm when quote is loading', () => {
     const result = getSwapConfirmDisabledState({
       ...defaultParams,
       isQuoteLoading: true,
@@ -73,6 +73,45 @@ describe('getSwapConfirmDisabledState', () => {
 
   it('enables confirm when quote is valid and balance is enough', () => {
     const result = getSwapConfirmDisabledState(defaultParams)
+
+    expect(result).toEqual({
+      disableConfirm: false,
+      isInsufficientBalance: false,
+    })
+  })
+
+  it('disables confirm for swap quote refresh without bridge details', () => {
+    const result = getSwapConfirmDisabledState({
+      ...defaultParams,
+      shouldDisplayBridgeDetails: false,
+      quoteCounter: 0,
+    })
+
+    expect(result).toEqual({
+      disableConfirm: true,
+      isInsufficientBalance: false,
+    })
+  })
+
+  it('disables confirm for stale swap quote without bridge details', () => {
+    const result = getSwapConfirmDisabledState({
+      ...defaultParams,
+      shouldDisplayBridgeDetails: false,
+      isQuoteStale: true,
+    })
+
+    expect(result).toEqual({
+      disableConfirm: true,
+      isInsufficientBalance: false,
+    })
+  })
+
+  it('does not require bridge quote amounts for plain swap', () => {
+    const result = getSwapConfirmDisabledState({
+      ...defaultParams,
+      shouldDisplayBridgeDetails: false,
+      hasBridgeQuoteAmounts: false,
+    })
 
     expect(result).toEqual({
       disableConfirm: false,

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/SwapConfirmModal.utils.test.ts
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/SwapConfirmModal.utils.test.ts
@@ -1,6 +1,7 @@
 import { getSwapConfirmDisabledState, GetSwapConfirmDisabledStateParams } from './SwapConfirmModal.utils'
 
 const defaultParams: GetSwapConfirmDisabledStateParams = {
+  isTradeContextReady: true,
   shouldDisplayBridgeDetails: true,
   hasBridgeQuoteAmounts: true,
   hasCurrentCurrency: true,
@@ -98,6 +99,18 @@ describe('getSwapConfirmDisabledState', () => {
       ...defaultParams,
       shouldDisplayBridgeDetails: false,
       isQuoteStale: true,
+    })
+
+    expect(result).toEqual({
+      disableConfirm: true,
+      isInsufficientBalance: false,
+    })
+  })
+
+  it('disables confirm when trade context is not ready', () => {
+    const result = getSwapConfirmDisabledState({
+      ...defaultParams,
+      isTradeContextReady: false,
     })
 
     expect(result).toEqual({

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/SwapConfirmModal.utils.ts
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/SwapConfirmModal.utils.ts
@@ -24,9 +24,9 @@ export function getSwapConfirmDisabledState(params: GetSwapConfirmDisabledStateP
     isQuoteStale,
   } = params
 
-  const isBridgeQuoteRefreshing = shouldDisplayBridgeDetails && (isQuoteLoading || quoteCounter === 0 || isQuoteStale)
+  const isQuoteRefreshing = isQuoteLoading || quoteCounter === 0 || isQuoteStale
 
-  if (isBridgeQuoteRefreshing) {
+  if (isQuoteRefreshing) {
     return {
       disableConfirm: true,
       isInsufficientBalance: false,

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/SwapConfirmModal.utils.ts
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/SwapConfirmModal.utils.ts
@@ -1,4 +1,5 @@
 export interface GetSwapConfirmDisabledStateParams {
+  isTradeContextReady: boolean
   shouldDisplayBridgeDetails: boolean
   hasBridgeQuoteAmounts: boolean
   hasCurrentCurrency: boolean
@@ -15,6 +16,7 @@ export interface SwapConfirmDisabledState {
 
 export function getSwapConfirmDisabledState(params: GetSwapConfirmDisabledStateParams): SwapConfirmDisabledState {
   const {
+    isTradeContextReady,
     shouldDisplayBridgeDetails,
     hasBridgeQuoteAmounts,
     hasCurrentCurrency,
@@ -27,6 +29,13 @@ export function getSwapConfirmDisabledState(params: GetSwapConfirmDisabledStateP
   const isQuoteRefreshing = isQuoteLoading || quoteCounter === 0 || isQuoteStale
 
   if (isQuoteRefreshing) {
+    return {
+      disableConfirm: true,
+      isInsufficientBalance: false,
+    }
+  }
+
+  if (!isTradeContextReady) {
     return {
       disableConfirm: true,
       isInsufficientBalance: false,

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/index.tsx
@@ -46,6 +46,7 @@ import { useSwapDeadlineState } from '../../hooks/useSwapSettings'
 
 export interface SwapConfirmModalProps {
   doTrade(): Promise<false | void>
+  isTradeContextReady: boolean
 
   inputCurrencyInfo: CurrencyPreviewInfo
   outputCurrencyInfo: CurrencyPreviewInfo
@@ -59,7 +60,15 @@ export interface SwapConfirmModalProps {
 export function SwapConfirmModal(props: SwapConfirmModalProps): ReactNode {
   const { t } = useLingui()
   const CONFIRM_TITLE = t`Swap`
-  const { inputCurrencyInfo, outputCurrencyInfo, priceImpact, recipient, recipientAddress, doTrade } = props
+  const {
+    inputCurrencyInfo,
+    outputCurrencyInfo,
+    priceImpact,
+    recipient,
+    recipientAddress,
+    doTrade,
+    isTradeContextReady,
+  } = props
 
   const { account } = useWalletInfo()
   const appData = useAppData()
@@ -109,6 +118,7 @@ export function SwapConfirmModal(props: SwapConfirmModalProps): ReactNode {
     }
 
     return getSwapConfirmDisabledState({
+      isTradeContextReady,
       shouldDisplayBridgeDetails,
       hasBridgeQuoteAmounts: Boolean(bridgeQuoteAmounts),
       hasCurrentCurrency,
@@ -123,6 +133,7 @@ export function SwapConfirmModal(props: SwapConfirmModalProps): ReactNode {
     inputCurrencyInfo,
     isQuoteLoading,
     isQuoteStale,
+    isTradeContextReady,
     quoteCounter,
     shouldDisplayBridgeDetails,
   ])

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapWidget/index.tsx
@@ -279,6 +279,7 @@ export function SwapWidget({ topContent, bottomContent, allowSwapSameToken }: Sw
           confirmModal={
             <SwapConfirmModal
               doTrade={doTrade.callback}
+              isTradeContextReady={doTrade.contextIsReady}
               recipient={recipient}
               recipientAddress={recipientAddress}
               priceImpact={priceImpact}


### PR DESCRIPTION
# Summary

Fixes #7422

Disable the confirm action while swap quote data is in a transient/invalid state to prevent the “enabled but unresponsive” click case on the confirm screen.

- Disable confirm when quote is loading, refreshing (`quoteCounter === 0`), or stale.
- Keep bridge-only logic for missing bridge quote amounts unchanged.
- Extend `SwapConfirmModal` utils tests with plain swap refresh/stale cases and bridge-safety checks.

# To Test

1. Open Swap and create a regular same-chain swap, then open the confirm screen.

- [ ] Wait until quote validity reaches `1 sec`, then `Refreshing quote...`.
- [ ] Confirm button is disabled during refresh/loading.
- [ ] Clicking while disabled does not trigger wallet signature flow.
- [ ] After refresh completes and countdown restarts, button becomes enabled again.

2. Open Swap and Bridge flow, then open the confirm screen.

- [ ] Confirm Swap and Bridge is disabled while quote is refreshing/loading/stale.
- [ ] Missing bridge quote amounts still disables confirm in bridge mode.
- [ ] Insufficient-balance label appears only for real insufficient balance.
- [ ] After quote refresh completes, button re-enables and normal flow works.

3. Keep confirm modal open, move tab to background for 2-3 minutes, then return.

- [ ] If quote is stale/refreshing on return, confirm stays disabled.
- [ ] Once a fresh quote is received, confirm re-enables.
- [ ] No case remains where the button looks enabled but does nothing.

# Background

A prior fix addressed this behavior for Swap + Bridge (`#7253`), but plain Swap could still hit the same UX bug.  
This change applies the same refresh/stale/loading disable guard to plain Swap without altering bridge-specific disable semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap confirmation logic: quote refresh/loading/stale states now consistently disable confirmation regardless of bridge-detail display; plain swaps no longer require bridge quote amounts to enable confirm when balance is sufficient.
  * Confirmation now respects trade-context readiness before enabling actions.
* **Tests**
  * Expanded tests to cover the updated confirmation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->