### PR TITLE
Viem Migration - Allow smart accounts to use gasless off-chain signing

### DIFF
--- a/libs/wallet/src/api/hooks.ts
+++ b/libs/wallet/src/api/hooks.ts
@@ -1,6 +1,8 @@
 import { useAtomValue, useSetAtom } from 'jotai'
 import { useCallback } from 'react'
 
+import { AccountType } from '@cowprotocol/types'
+
 import { useConnection } from 'wagmi'
 
 import { useWalletCapabilities } from './hooks/useWalletCapabilities'
@@ -21,7 +23,8 @@ import { ConnectionType, GnosisSafeInfo, WalletDetails, WalletInfo } from './typ
 
 import { BRAVE_WALLET_RDNS, METAMASK_RDNS, RABBY_RDNS, WATCH_ASSET_SUPPORED_WALLETS } from '../constants'
 import { useConnectionType } from '../wagmi/hooks/useConnectionType'
-import { useIsSafeApp, useIsSafeViaWc } from '../wagmi/hooks/useWalletMetadata'
+import { useAccountType, useIsSmartContractWallet } from '../wagmi/hooks/useIsSmartContractWallet'
+import { useIsSafeApp, useIsSafeViaWc, useIsSafeWallet } from '../wagmi/hooks/useWalletMetadata'
 
 export function useWalletInfo(): WalletInfo {
   return useAtomValue(walletInfoAtom)
@@ -58,9 +61,17 @@ export function useIsTxBundlingSupported(): boolean | null {
   const { data: capabilities, isLoading: isCapabilitiesLoading } = useWalletCapabilities()
   const isSafeApp = useIsSafeApp()
   const isSafeViaWc = useIsSafeViaWc()
+  const accountType = useAccountType()
+  const isSmartContractWallet = useIsSmartContractWallet()
+  const isSafeWallet = useIsSafeWallet()
 
   const result = (() => {
     if (isSafeApp || isSafeViaWc) return true
+    // Smart accounts (ERC-4337, Coinbase Smart Wallet, EIP-7702, etc.) that are not a Safe lack the
+    // fallback handler mechanism TWAP requires — treat them as unsupported.
+    // Note: useIsSmartContractWallet() only detects AccountType.SMART_CONTRACT, not EIP-7702 accounts
+    // (which keep the same EOA address but have delegation bytecode). We check both explicitly.
+    if ((isSmartContractWallet || accountType === AccountType.EIP7702EOA) && !isSafeWallet) return false
     if (isCapabilitiesLoading) return null
     return capabilities?.atomic?.status === 'supported'
   })()

--- a/libs/wallet/src/wagmi/updater.ts
+++ b/libs/wallet/src/wagmi/updater.ts
@@ -13,7 +13,7 @@ import { useIsSmartContractWallet } from './hooks/useIsSmartContractWallet'
 import { useSafeAppsSdk } from './hooks/useSafeAppsSdk'
 import { useIsSafeApp, useWalletMetaData } from './hooks/useWalletMetadata'
 
-import { useSetEip6963Provider } from '../api/hooks'
+import { useIsMetamaskBrowserExtensionWallet, useSetEip6963Provider } from '../api/hooks'
 import { gnosisSafeInfoAtom, walletDetailsAtom, walletInfoAtom } from '../api/state'
 import { multiInjectedProvidersAtom } from '../api/state/multiInjectedProvidersAtom'
 import { ConnectionType, GnosisSafeInfo, WalletDetails, WalletInfo } from '../api/types'
@@ -98,6 +98,7 @@ function useWalletDetails(account?: Address, standaloneMode?: boolean): WalletDe
   const isSmartContractWallet = useIsSmartContractWallet()
   const { walletName, icon } = useWalletMetaData(standaloneMode)
   const isSafeApp = useIsSafeApp()
+  const isMetaMask = useIsMetamaskBrowserExtensionWallet()
 
   return useMemo(() => {
     return {
@@ -107,12 +108,13 @@ function useWalletDetails(account?: Address, standaloneMode?: boolean): WalletDe
       ensName: ensName || undefined,
       isSupportedWallet: checkIsSupportedWallet(walletName),
 
-      // Smart accounts (ERC-4337, Coinbase Smart Wallet, etc.) support EIP-1271 off-chain signing.
-      // Only Safe App connections need on-chain pre-signing (multi-sig flow via the Safe SDK).
-      allowsOffchainSigning: !isSafeApp,
+      // EOAs can always sign off-chain. MetaMask smart accounts also support EIP-1271 off-chain
+      // signing. All other smart contract wallets (Coinbase Smart Wallet, ERC-4337, Safe, etc.)
+      // must use on-chain pre-signing.
+      allowsOffchainSigning: !isSmartContractWallet || isMetaMask,
       isSafeApp,
     }
-  }, [isSmartContractWallet, isSafeApp, walletName, icon, ensName])
+  }, [isSmartContractWallet, isSafeApp, isMetaMask, walletName, icon, ensName])
 }
 
 // used for on-chain calls

--- a/libs/wallet/src/wagmi/updater.ts
+++ b/libs/wallet/src/wagmi/updater.ts
@@ -107,9 +107,9 @@ function useWalletDetails(account?: Address, standaloneMode?: boolean): WalletDe
       ensName: ensName || undefined,
       isSupportedWallet: checkIsSupportedWallet(walletName),
 
-      // TODO: For now, all SC wallets use pre-sign instead of offchain signing
-      // In the future, once the API adds EIP-1271 support, we can allow some SC wallets to use offchain signing
-      allowsOffchainSigning: !isSmartContractWallet,
+      // Smart accounts (ERC-4337, Coinbase Smart Wallet, etc.) support EIP-1271 off-chain signing.
+      // Only Safe App connections need on-chain pre-signing (multi-sig flow via the Safe SDK).
+      allowsOffchainSigning: !isSafeApp,
       isSafeApp,
     }
   }, [isSmartContractWallet, isSafeApp, walletName, icon, ensName])


### PR DESCRIPTION
# Summary

Fixes [Smart accounts: allow gasless signing](https://www.notion.so/cownation/2fc8da5f04ca80568067c0bc4dc9d36a?v=2fc8da5f04ca81ada4ca000c320d51ef&p=3568da5f04ca8034a635d59fd3a4d2fb&pm=s)

MetaMask smart accounts (EIP-7702) were incorrectly treated the same as Gnosis Safe multi-sig wallets, forcing users to pay gas for order placement and using the wrong order cancellation method.

Root cause: `allowsOffchainSigning` was `!isSmartContractWallet`, blocking all smart contract wallets from off-chain signing — including MetaMask EIP-7702 accounts, which still produce standard ECDSA signatures and don't require EIP-1271 validation.

Fix: Changed to `!isSmartContractWallet || isMetaMask`. MetaMask connections get an exception because their smart accounts delegate via EIP-7702 but retain the original EOA key, so signatures are standard ECDSA and the CoW API can validate them as normal. All other smart contract wallets (Coinbase Smart Wallet, ERC-4337, Safe, etc.) continue using on-chain pre-signing, since the CoW API does not yet support EIP-1271 validation for them.

Also adds EIP-7702 account detection to the TWAP bundling check, correctly treating EIP-7702 accounts as unsupported for TWAP (same as other non-Safe smart accounts).

# To Test

1. Connect a MetaMask smart account (EIP-7702)
2. Place an order

- [ ] Order should be placed gaslessly (off-chain signing, no gas prompt)
- [ ] Order cancellation should default to off-chain (not on-chain)
- [ ] Coinbase Smart Wallet and other ERC-4337 wallets should still use on-chain pre-signing
- [ ] Safe App connections (via the Safe SDK) should still use on-chain pre-signing as before

# Background

MetaMask EIP-7702 accounts keep the same EOA address and private key — the contract bytecode at that address is just a delegation. This means their EIP-712 signatures are indistinguishable from regular EOA signatures and require no special API support. True ERC-4337 smart contract wallets require EIP-1271 `isValidSignature()` verification, which the CoW API does not currently support, so they must continue using pre-signing.
