### PR TITLE
fix(approval): use isSafeWallet to check if the transaction is from safe

### DIFF
--- a/apps/cowswap-frontend/src/modules/erc20Approve/containers/TradeApproveModal/useTradeApproveCallback.test.ts
+++ b/apps/cowswap-frontend/src/modules/erc20Approve/containers/TradeApproveModal/useTradeApproveCallback.test.ts
@@ -31,6 +31,8 @@ jest.mock('@cowprotocol/balances-and-allowances', () => ({
 
 jest.mock('@cowprotocol/wallet', () => ({
   useWalletInfo: jest.fn(),
+  useIsSafeWallet: jest.fn().mockReturnValue(false),
+  useIsSafeViaWc: jest.fn().mockReturnValue(false),
 }))
 
 jest.mock('entities/optimisticAllowance/useSetOptimisticAllowance', () => ({

--- a/apps/cowswap-frontend/src/modules/erc20Approve/containers/TradeApproveModal/useTradeApproveCallback.ts
+++ b/apps/cowswap-frontend/src/modules/erc20Approve/containers/TradeApproveModal/useTradeApproveCallback.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 
 import { useTradeSpenderAddress } from '@cowprotocol/balances-and-allowances'
 import { Currency, CurrencyAmount } from '@cowprotocol/currency'
-import { useWalletInfo } from '@cowprotocol/wallet'
+import { useIsSafeWallet, useWalletInfo } from '@cowprotocol/wallet'
 
 import { useSetOptimisticAllowance } from 'entities/optimisticAllowance/useSetOptimisticAllowance'
 import { usePublicClient } from 'wagmi'
@@ -20,8 +20,6 @@ interface TradeApproveCallbackParams {
   useModals: boolean
   waitForTxConfirmation?: boolean
 }
-
-const EVM_TX_HASH_LENGTH = 64 + 2
 
 const DEFAULT_APPROVE_PARAMS: TradeApproveCallbackParams = {
   useModals: true,
@@ -76,6 +74,7 @@ export function useTradeApproveCallback(currency: Currency | undefined): TradeAp
   const publicClient = usePublicClient()
   const setOptimisticAllowance = useSetOptimisticAllowance()
 
+  const isSafeWallet = useIsSafeWallet()
   const approveCallback = useApproveCallback(currency, spender)
   const approvalAnalytics = useApprovalAnalytics()
   const handleApprovalError = useHandleApprovalError(symbol)
@@ -101,9 +100,9 @@ export function useTradeApproveCallback(currency: Currency | undefined): TradeAp
 
         approvalAnalytics('Sign', symbol)
 
-        // Check the length to skip waiting for Safe tx
-        // We have to return undefined in order to avoid jumping into confirm screen after approval tx sending
-        if (response.hash.length !== EVM_TX_HASH_LENGTH) {
+        // Safe wallets return a safeTxHash (not an on-chain tx hash), so we can't wait for a receipt.
+        // We return undefined to avoid the confirm screen hanging indefinitely.
+        if (isSafeWallet) {
           return undefined
         }
 
@@ -139,6 +138,7 @@ export function useTradeApproveCallback(currency: Currency | undefined): TradeAp
       updateApproveProgressModalState,
       approveCallback,
       resetApproveProgressModalState,
+      isSafeWallet,
       account,
       spender,
       chainId,

--- a/apps/cowswap-frontend/src/modules/erc20Approve/containers/TradeApproveModal/useTradeApproveCallback.ts
+++ b/apps/cowswap-frontend/src/modules/erc20Approve/containers/TradeApproveModal/useTradeApproveCallback.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 
 import { useTradeSpenderAddress } from '@cowprotocol/balances-and-allowances'
 import { Currency, CurrencyAmount } from '@cowprotocol/currency'
-import { useIsSafeWallet, useWalletInfo } from '@cowprotocol/wallet'
+import { useIsSafeViaWc, useIsSafeWallet, useWalletInfo } from '@cowprotocol/wallet'
 
 import { useSetOptimisticAllowance } from 'entities/optimisticAllowance/useSetOptimisticAllowance'
 import { usePublicClient } from 'wagmi'
@@ -74,7 +74,9 @@ export function useTradeApproveCallback(currency: Currency | undefined): TradeAp
   const publicClient = usePublicClient()
   const setOptimisticAllowance = useSetOptimisticAllowance()
 
-  const isSafeWallet = useIsSafeWallet()
+  const isSafeApp = useIsSafeWallet()
+  const isSafeViaWc = useIsSafeViaWc()
+  const isSafeWallet = isSafeApp || isSafeViaWc
   const approveCallback = useApproveCallback(currency, spender)
   const approvalAnalytics = useApprovalAnalytics()
   const handleApprovalError = useHandleApprovalError(symbol)


### PR DESCRIPTION
# Summary                                                                                                                                       
                                                                                                                                                
 Fix: Safe wallet approval modal stuck on "Waiting for confirmation"          
https://www.notion.so/cownation/Safe-approving-is-stuck-with-no-response-3488da5f04ca80fb9afafd7b5915ebbd                                                                 
                                                                                                                                                
  When approving tokens from the "unfillable" warning on the orders table using a Safe wallet, the approval modal gets stuck spinning on        
  "Waiting for confirmation" indefinitely — even after the transaction is confirmed on-chain.                                                   
                                                                                                                                                
# Root Cause                                                                                                                                  

  The code used a hash length check (response.hash.length !== 66) to detect Safe transactions and skip calling waitForTransactionReceipt.       
  However, Safe transaction hashes (safeTxHash) are also keccak256 hashes — exactly 66 characters (0x + 64 hex). So the check never matched, and
   the code called waitForTransactionReceipt with a Safe tx hash that doesn't exist on-chain, causing it to hang forever.                       
                                                                                                                                              
# Fix                                                                                                                                           
   
  Replaced the fragile hash length check with useIsSafeWallet() from @cowprotocol/wallet, which properly detects Safe wallets regardless of     
  connection method (Safe App or WalletConnect). When a Safe wallet is detected, the code returns early, and the finally block resets the modal
  state — closing it correctly.                                                                                                                 
                                                                                                                                              
# To Test

  1. Open CoW Swap inside a 1/1 Safe wallet (via Safe Apps) or connect a Safe via WalletConnect                                                 
  2. Place a limit/TWAP order with a token that has 0 or insufficient allowance
  3. Go to "My orders" and find the order with the "unfillable" / "insufficient allowance" warning                                              
  4. Click the approve button on the warning                                                                                                    
                                                                                                                                                
  - The approval modal should appear showing "Approving [token] for trading"                                                                    
  - After signing the approval in Safe, the modal should close (not spin forever on "Waiting for confirmation")                                 
  - Verify the same flow still works correctly with a regular EOA wallet (MetaMask, etc.) — modal should close after tx confirmation            
                                                                                                                                                
# Background                                                                                                                                    
                                                                                                                                                
  The previous check compared response.hash.length against EVM_TX_HASH_LENGTH (66 chars) to distinguish Safe tx hashes from regular EVM tx      
  hashes. This worked historically when Safe connectors returned hashes of different lengths, but Safe transaction hashes are standard bytes32
  keccak256 hashes — the same 66-character format as EVM tx hashes. Using useIsSafeWallet() is a reliable detection method that doesn't depend  
  on hash format assumptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Safe wallet detection during token approval so Safe wallets no longer wait for on-chain receipts. This prevents the approval confirmation from hanging and results in a smoother, more reliable approval flow for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->