### PR TITLE
fix(explorer): make explorer max-width's wider

### DIFF
--- a/apps/explorer/src/components/orders/OrderNotFound/index.tsx
+++ b/apps/explorer/src/components/orders/OrderNotFound/index.tsx
@@ -10,7 +10,6 @@ import styled from 'styled-components/macro'
 import { Search } from '../../../explorer/components/common/Search'
 
 const Wrapper = styled.div`
-  max-width: 140rem;
   display: flex;
   flex-flow: column wrap;
   align-items: center;

--- a/apps/explorer/src/explorer/pages/AppData/styled.ts
+++ b/apps/explorer/src/explorer/pages/AppData/styled.ts
@@ -12,8 +12,6 @@ export const StyledExplorerTabs = styled(ExplorerTabs)`
 `
 
 export const Wrapper = styled(WrapperTemplate)`
-  max-width: 118rem;
-
   .disclaimer {
     font-size: 1.2rem;
     line-height: 1.3;

--- a/apps/explorer/src/explorer/pages/Order.tsx
+++ b/apps/explorer/src/explorer/pages/Order.tsx
@@ -10,8 +10,6 @@ import { OrderWidget } from '../components/OrderWidget'
 import { APP_TITLE } from '../const'
 
 const Wrapper = styled(WrapperMod)`
-  max-width: 140rem;
-
   > h1 {
     padding: 2.4rem 0 0.75rem;
   }

--- a/apps/explorer/src/explorer/pages/Solvers.styles.tsx
+++ b/apps/explorer/src/explorer/pages/Solvers.styles.tsx
@@ -5,8 +5,6 @@ import styled from 'styled-components/macro'
 import { StyledSearch, Wrapper as WrapperMod } from './styled'
 
 export const Wrapper = styled(WrapperMod)`
-  max-width: 140rem;
-
   ${Media.upToMedium()} {
     padding: 0 1.2rem 4.2rem;
   }

--- a/apps/explorer/src/explorer/styled.ts
+++ b/apps/explorer/src/explorer/styled.ts
@@ -66,7 +66,7 @@ export const GlobalStyle = createGlobalStyle`
 `
 
 export const MainWrapper = styled.div`
-  --pageMaxWidth: 140rem;
+  --pageMaxWidth: 1600px;
   max-width: var(--pageMaxWidth);
   width: 100%;
   min-height: 100vh;


### PR DESCRIPTION
# Summary

Makes Explorer's max-width wider so that orders table fits without horizontal scrollabars.

Fixes https://github.com/cowprotocol/cowswap/issues/7425

# To Test

Open Explorer orders table and verify there's no horizontal scrollbars (if the screen is wide enough)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed maximum width constraints from multiple pages in the explorer application and adjusted page width sizing for improved layout flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->