### PR TITLE
feat: parse appData quoteBody in Explorer

### DIFF
--- a/apps/explorer/src/components/AppData/AppDataContent.styles.tsx
+++ b/apps/explorer/src/components/AppData/AppDataContent.styles.tsx
@@ -1,0 +1,98 @@
+import { Color, Media } from '@cowprotocol/ui'
+
+import styled from 'styled-components/macro'
+
+export const JsonPanel = styled.div`
+  border: 1px solid ${Color.explorer_tableRowBorder};
+  background: ${Color.explorer_tableRowBorder};
+  border-radius: 0.5rem;
+  overflow: hidden;
+  margin-top: 16px;
+
+  ${Media.upToSmall()} {
+    margin-left: -14px;
+    margin-right: -14px;
+    border-radius: 0;
+    border-right: 0;
+    border-left: 0;
+  }
+`
+
+export const TopRow = styled.div`
+  --control-size: 3.2rem;
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+  border-bottom: 1px solid ${Color.explorer_tableRowBorder};
+  min-height: var(--control-size);
+`
+
+export const Tabs = styled.div`
+  display: flex;
+  align-items: stretch;
+`
+
+export const TabButton = styled.button<{ $active: boolean }>`
+  appearance: none;
+  border: none;
+  border-bottom: 0.1rem solid
+    ${({ $active }): string => ($active ? 'rgba(255, 255, 255, 0.5)' : 'rgba(255, 255, 255, 0.28)')};
+  background: ${({ $active }): string => ($active ? 'rgba(255, 255, 255, 0.2)' : 'rgba(255, 255, 255, 0.08)')};
+  color: ${({ $active }): string => ($active ? Color.explorer_textActive : 'inherit')};
+  padding: 0.5rem 1rem;
+  font-size: 1.3rem;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+  min-width: 8rem;
+  height: 100%;
+
+  :hover {
+    border-color: rgba(255, 255, 255, 0.6);
+    background: rgba(255, 255, 255, 0.16);
+  }
+
+  :focus-visible {
+    outline: 0.2rem solid rgba(255, 255, 255, 0.35);
+    outline-offset: 0.1rem;
+  }
+`
+
+export const CopyButtonSlot = styled.div`
+  width: var(--control-size);
+  min-width: var(--control-size);
+  aspect-ratio: 1 / 1;
+  height: var(--control-size);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-left: 1px solid ${Color.explorer_tableRowBorder};
+  background: rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+
+  > span {
+    width: 100%;
+    height: 100%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    & > svg {
+      margin: 0;
+    }
+  }
+
+  :hover {
+    background: rgba(255, 255, 255, 0.16);
+  }
+`
+
+export const JsonContent = styled.pre`
+  word-break: break-all;
+  line-height: 1.5;
+  overflow: auto;
+  margin: 0;
+  padding: 0.75rem;
+  white-space: pre-wrap;
+`

--- a/apps/explorer/src/components/AppData/AppDataContent.styles.tsx
+++ b/apps/explorer/src/components/AppData/AppDataContent.styles.tsx
@@ -70,6 +70,7 @@ export const CopyButtonSlot = styled.div`
   border-left: 1px solid ${Color.explorer_tableRowBorder};
   background: rgba(255, 255, 255, 0.08);
   cursor: pointer;
+  margin-left: auto;
 
   > span {
     width: 100%;

--- a/apps/explorer/src/components/AppData/AppDataContent.tsx
+++ b/apps/explorer/src/components/AppData/AppDataContent.tsx
@@ -29,8 +29,12 @@ export function AppDataContent({ appData, fullAppData, showDecodedAppData }: App
 
   const [tab, setTab] = useState<AppDataTab>(() => getStoredView())
 
-  const jsonData = useMemo(() => {
-    return stringifyJson(tab === 'raw' ? decodedAppData : parseQuoteBody(decodedAppData))
+  const { hasQuoteBody, jsonData } = useMemo(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const hasQuoteBody = !!(decodedAppData?.metadata as any).bridging?.quoteBody
+    const jsonData = stringifyJson(tab === 'raw' || !hasQuoteBody ? decodedAppData : parseQuoteBody(decodedAppData))
+
+    return { hasQuoteBody, jsonData }
   }, [tab, decodedAppData])
 
   useEffect(() => {
@@ -49,14 +53,16 @@ export function AppDataContent({ appData, fullAppData, showDecodedAppData }: App
   return (
     <styledEl.JsonPanel>
       <styledEl.TopRow>
-        <styledEl.Tabs>
-          <styledEl.TabButton type="button" $active={tab === 'raw'} onClick={() => setTab('raw')}>
-            Raw
-          </styledEl.TabButton>
-          <styledEl.TabButton type="button" $active={tab === 'parsed'} onClick={() => setTab('parsed')}>
-            Parsed
-          </styledEl.TabButton>
-        </styledEl.Tabs>
+        {hasQuoteBody && (
+          <styledEl.Tabs>
+            <styledEl.TabButton type="button" $active={tab === 'raw'} onClick={() => setTab('raw')}>
+              Raw
+            </styledEl.TabButton>
+            <styledEl.TabButton type="button" $active={tab === 'parsed'} onClick={() => setTab('parsed')}>
+              Parsed
+            </styledEl.TabButton>
+          </styledEl.Tabs>
+        )}
         <styledEl.CopyButtonSlot>
           <CopyButton text={jsonData} />
         </styledEl.CopyButtonSlot>

--- a/apps/explorer/src/components/AppData/AppDataContent.tsx
+++ b/apps/explorer/src/components/AppData/AppDataContent.tsx
@@ -31,7 +31,7 @@ export function AppDataContent({ appData, fullAppData, showDecodedAppData }: App
 
   const { hasQuoteBody, jsonData } = useMemo(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const hasQuoteBody = !!(decodedAppData?.metadata as any).bridging?.quoteBody
+    const hasQuoteBody = !!(decodedAppData?.metadata as any)?.bridging?.quoteBody
     const jsonData = stringifyJson(tab === 'raw' || !hasQuoteBody ? decodedAppData : parseQuoteBody(decodedAppData))
 
     return { hasQuoteBody, jsonData }

--- a/apps/explorer/src/components/AppData/AppDataContent.tsx
+++ b/apps/explorer/src/components/AppData/AppDataContent.tsx
@@ -1,7 +1,16 @@
-import { ReactNode } from 'react'
+import { ReactNode, useEffect, useMemo, useState } from 'react'
+
+import * as styledEl from './AppDataContent.styles'
+import {
+  AppDataTab,
+  getStoredView,
+  stringifyJson,
+  parseQuoteBody,
+  APPDATA_VIEW_STORAGE_KEY,
+} from './AppDataContent.utils'
 
 import { useAppData } from '../../hooks/useAppData'
-import { RowWithCopyButton } from '../common/RowWithCopyButton'
+import { CopyButton } from '../common/CopyButton'
 import Spinner from '../common/Spinner'
 import { Notification } from '../Notification'
 
@@ -18,22 +27,41 @@ export function AppDataContent({ appData, fullAppData, showDecodedAppData }: App
     hasError: appDataError,
   } = useAppData(appData, fullAppData)
 
-  const appDataString = JSON.stringify(decodedAppData, null, 2)
+  const [tab, setTab] = useState<AppDataTab>(() => getStoredView())
+
+  const jsonData = useMemo(() => {
+    return stringifyJson(tab === 'raw' ? decodedAppData : parseQuoteBody(decodedAppData))
+  }, [tab, decodedAppData])
+
+  useEffect(() => {
+    window.localStorage.setItem(APPDATA_VIEW_STORAGE_KEY, tab)
+  }, [tab])
 
   if (appDataLoading) return <Spinner />
 
-  if (showDecodedAppData) {
-    if (appDataError)
-      return (
-        <Notification type="error" message="Error when getting metadata info." closable={false} appendMessage={false} />
-      )
-    return (
-      <RowWithCopyButton
-        textToCopy={appDataString}
-        contentsToDisplay={<pre className="json-formatter">{appDataString}</pre>}
-      />
-    )
-  }
+  if (!showDecodedAppData) return null
 
-  return null
+  if (appDataError)
+    return (
+      <Notification type="error" message="Error when getting metadata info." closable={false} appendMessage={false} />
+    )
+
+  return (
+    <styledEl.JsonPanel>
+      <styledEl.TopRow>
+        <styledEl.Tabs>
+          <styledEl.TabButton type="button" $active={tab === 'raw'} onClick={() => setTab('raw')}>
+            Raw
+          </styledEl.TabButton>
+          <styledEl.TabButton type="button" $active={tab === 'parsed'} onClick={() => setTab('parsed')}>
+            Parsed
+          </styledEl.TabButton>
+        </styledEl.Tabs>
+        <styledEl.CopyButtonSlot>
+          <CopyButton text={jsonData} />
+        </styledEl.CopyButtonSlot>
+      </styledEl.TopRow>
+      <styledEl.JsonContent>{jsonData}</styledEl.JsonContent>
+    </styledEl.JsonPanel>
+  )
 }

--- a/apps/explorer/src/components/AppData/AppDataContent.utils.ts
+++ b/apps/explorer/src/components/AppData/AppDataContent.utils.ts
@@ -1,0 +1,38 @@
+import { AnyAppDataDocVersion } from '@cowprotocol/cow-sdk'
+
+export type AppDataTab = 'raw' | 'parsed'
+
+export const APPDATA_VIEW_STORAGE_KEY = 'explorer.appDataContent.view'
+
+export function getStoredView(): AppDataTab {
+  if (typeof window === 'undefined') return 'raw'
+
+  const storedView = window.localStorage.getItem(APPDATA_VIEW_STORAGE_KEY)
+  return storedView === 'parsed' ? 'parsed' : 'raw'
+}
+
+export function stringifyJson(value: unknown): string {
+  if (value === undefined) return ''
+  return JSON.stringify(value, null, 2)
+}
+
+export function parseQuoteBody(decodedAppData?: AnyAppDataDocVersion): unknown {
+  if (!decodedAppData) return undefined
+
+  try {
+    return {
+      ...decodedAppData,
+      metadata: {
+        ...decodedAppData.metadata,
+        bridging: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ...(decodedAppData.metadata as any).bridging,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          quoteBody: JSON.parse((decodedAppData.metadata as any).bridging.quoteBody),
+        },
+      },
+    }
+  } catch {
+    return decodedAppData
+  }
+}

--- a/apps/explorer/src/components/AppDataRowContent/AppDataRowContent.styles.tsx
+++ b/apps/explorer/src/components/AppDataRowContent/AppDataRowContent.styles.tsx
@@ -1,0 +1,18 @@
+import { Color } from '@cowprotocol/ui'
+
+import styled from 'styled-components/macro'
+
+export const ShowMoreButton = styled.button`
+  font-size: 1.4rem;
+  margin-top: 0.5rem;
+  border: none;
+  background: none;
+  color: ${Color.explorer_textActive};
+  align-self: flex-start;
+  padding: 0;
+
+  :hover {
+    text-decoration: underline;
+    cursor: pointer;
+  }
+`

--- a/apps/explorer/src/components/AppDataRowContent/AppDataRowContent.tsx
+++ b/apps/explorer/src/components/AppDataRowContent/AppDataRowContent.tsx
@@ -1,37 +1,20 @@
 import { ReactNode, useState } from 'react'
 
-import { Color } from '@cowprotocol/ui'
-
-import AppDataWrapper from 'components/common/AppDataWrapper'
+import { AppDataWrapper } from 'components/common/AppDataWrapper'
 import { RowWithCopyButton } from 'components/common/RowWithCopyButton'
 import { useAppData } from 'hooks/useAppData'
-import styled from 'styled-components/macro'
 
-import { AppDataContent } from './AppDataContent'
+import * as styledEl from './AppDataRowContent.styles'
 
-type DecodeAppDataProps = {
+import { AppDataContent } from '../AppData/AppDataContent'
+
+interface AppDataRowContentProps {
   appData: string
   fullAppData?: string
   showExpanded?: boolean
 }
 
-const ShowMoreButton = styled.button`
-  font-size: 1.4rem;
-  margin-top: 0.5rem;
-  border: none;
-  background: none;
-  color: ${Color.explorer_textActive};
-  align-self: flex-start;
-  padding: 0;
-
-  :hover {
-    text-decoration: underline;
-    cursor: pointer;
-  }
-`
-
-export const DecodeAppData = (props: DecodeAppDataProps): ReactNode => {
-  const { appData, showExpanded = false, fullAppData } = props
+export function AppDataRowContent({ appData, showExpanded = false, fullAppData }: AppDataRowContentProps): ReactNode {
   const { ipfsUri, hasError: appDataError } = useAppData(appData, fullAppData)
 
   const isLegacyAppDataHex = fullAppData === undefined
@@ -57,9 +40,9 @@ export const DecodeAppData = (props: DecodeAppDataProps): ReactNode => {
           appData
         )}
         &nbsp;
-        <ShowMoreButton onClick={() => setShowDecodedAppData((state) => !state)}>
+        <styledEl.ShowMoreButton onClick={() => setShowDecodedAppData((state) => !state)}>
           {showDecodedAppData ? '[-] Show less' : '[+] Show more'}
-        </ShowMoreButton>
+        </styledEl.ShowMoreButton>
       </>
       <div className={`hidden-content ${appDataError && 'error'}`}>
         <AppDataContent appData={appData} fullAppData={fullAppData} showDecodedAppData={showDecodedAppData} />

--- a/apps/explorer/src/components/AppDataRowContent/AppDataRowContent.tsx
+++ b/apps/explorer/src/components/AppDataRowContent/AppDataRowContent.tsx
@@ -14,10 +14,13 @@ interface AppDataRowContentProps {
   showExpanded?: boolean
 }
 
+const EMPTY_APP_DATA = '0x0000000000000000000000000000000000000000000000000000000000000000'
+
 export function AppDataRowContent({ appData, showExpanded = false, fullAppData }: AppDataRowContentProps): ReactNode {
   const { ipfsUri, hasError: appDataError } = useAppData(appData, fullAppData)
 
   const isLegacyAppDataHex = fullAppData === undefined
+  const hasAppData = appData.trim() !== EMPTY_APP_DATA
   const [showDecodedAppData, setShowDecodedAppData] = useState<boolean>(showExpanded)
 
   return (
@@ -40,9 +43,11 @@ export function AppDataRowContent({ appData, showExpanded = false, fullAppData }
           appData
         )}
         &nbsp;
-        <styledEl.ShowMoreButton onClick={() => setShowDecodedAppData((state) => !state)}>
-          {showDecodedAppData ? '[-] Show less' : '[+] Show more'}
-        </styledEl.ShowMoreButton>
+        {hasAppData && (
+          <styledEl.ShowMoreButton onClick={() => setShowDecodedAppData((state) => !state)}>
+            {showDecodedAppData ? '[-] Show less' : '[+] Show more'}
+          </styledEl.ShowMoreButton>
+        )}
       </>
       <div className={`hidden-content ${appDataError && 'error'}`}>
         <AppDataContent appData={appData} fullAppData={fullAppData} showDecodedAppData={showDecodedAppData} />

--- a/apps/explorer/src/components/common/AppDataWrapper/index.tsx
+++ b/apps/explorer/src/components/common/AppDataWrapper/index.tsx
@@ -2,7 +2,9 @@ import { Color } from '@cowprotocol/ui'
 
 import styled from 'styled-components/macro'
 
-const AppDataWrapper = styled.div`
+export const AppDataWrapper = styled.div`
+  width: 100%;
+
   .json-formatter {
     word-break: break-all;
     line-height: 1.5;
@@ -17,14 +19,14 @@ const AppDataWrapper = styled.div`
       width: 8px !important;
       height: 8px !important;
     }
+
     ::-webkit-scrollbar-thumb {
       background: ${Color.explorer_bgOpaque};
       border-radius: 4px;
     }
+
     ::-webkit-scrollbar-track {
       background-color: ${Color.explorer_bgOpaque};
     }
   }
 `
-
-export default AppDataWrapper

--- a/apps/explorer/src/components/orders/DetailsTable/items/AppDataItem.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/items/AppDataItem.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-import { DecodeAppData } from '../../../AppDataRowContent/AppDataRowContent'
+import { AppDataRowContent } from '../../../AppDataRowContent/AppDataRowContent'
 import { DetailRow } from '../../../common/DetailRow'
 import { DetailsTableTooltips } from '../detailsTableTooltips'
 
@@ -12,7 +12,7 @@ interface AppDataItemProps {
 export function AppDataItem({ appData, fullAppData }: AppDataItemProps): ReactNode {
   return (
     <DetailRow label="AppData" tooltipText={DetailsTableTooltips.appData}>
-      <DecodeAppData appData={appData} fullAppData={fullAppData ?? undefined} />
+      <AppDataRowContent appData={appData} fullAppData={fullAppData ?? undefined} />
     </DetailRow>
   )
 }

--- a/apps/explorer/src/components/orders/DetailsTable/items/AppDataItem.tsx
+++ b/apps/explorer/src/components/orders/DetailsTable/items/AppDataItem.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-import { DecodeAppData } from '../../../AppData/DecodeAppData'
+import { DecodeAppData } from '../../../AppDataRowContent/AppDataRowContent'
 import { DetailRow } from '../../../common/DetailRow'
 import { DetailsTableTooltips } from '../detailsTableTooltips'
 

--- a/apps/explorer/src/explorer/pages/AppData/DecodePage.tsx
+++ b/apps/explorer/src/explorer/pages/AppData/DecodePage.tsx
@@ -4,7 +4,7 @@ import Form, { FormValidation } from '@rjsf/core'
 
 import { decodeAppDataSchema, FormProps, handleErrors, transformErrors } from './config'
 
-import { DecodeAppData } from '../../../components/AppDataRowContent/AppDataRowContent'
+import { AppDataRowContent } from '../../../components/AppDataRowContent/AppDataRowContent'
 
 import { TabData } from './index'
 
@@ -91,7 +91,7 @@ const DecodePage: React.FC<DecodeProps> = ({ tabData, setTabData }) => {
         </div>
         {isSubmitted && (
           <div className="decode-section">
-            <DecodeAppData showExpanded appData={formData?.appData} />
+            <AppDataRowContent showExpanded appData={formData?.appData} />
           </div>
         )}
       </div>

--- a/apps/explorer/src/explorer/pages/AppData/DecodePage.tsx
+++ b/apps/explorer/src/explorer/pages/AppData/DecodePage.tsx
@@ -4,7 +4,7 @@ import Form, { FormValidation } from '@rjsf/core'
 
 import { decodeAppDataSchema, FormProps, handleErrors, transformErrors } from './config'
 
-import { DecodeAppData } from '../../../components/AppData/DecodeAppData'
+import { DecodeAppData } from '../../../components/AppDataRowContent/AppDataRowContent'
 
 import { TabData } from './index'
 

--- a/apps/explorer/src/explorer/pages/AppData/EncodePage.tsx
+++ b/apps/explorer/src/explorer/pages/AppData/EncodePage.tsx
@@ -16,7 +16,7 @@ import {
   uiSchema,
 } from './config'
 
-import AppDataWrapper from '../../../components/common/AppDataWrapper'
+import { AppDataWrapper } from '../../../components/common/AppDataWrapper'
 import { RowWithCopyButton } from '../../../components/common/RowWithCopyButton'
 import { metadataApiSDK } from '../../../cowSdk'
 

--- a/apps/explorer/src/explorer/pages/AppData/styled.ts
+++ b/apps/explorer/src/explorer/pages/AppData/styled.ts
@@ -3,7 +3,7 @@ import { Color, Media, UI } from '@cowprotocol/ui'
 import { transparentize } from 'polished'
 import styled from 'styled-components/macro'
 
-import AppDataWrapper from '../../../components/common/AppDataWrapper'
+import { AppDataWrapper } from '../../../components/common/AppDataWrapper'
 import ExplorerTabs from '../../components/common/ExplorerTabs/ExplorerTabs'
 import { ContentCard as Content, Wrapper as WrapperTemplate } from '../styled'
 
@@ -171,6 +171,8 @@ export const Wrapper = styled(WrapperTemplate)`
     }
 
     .hidden-content {
+      width: 100%;
+
       h2 {
         margin: 2rem 0 2rem 0;
         font-size: 2rem;
@@ -179,13 +181,11 @@ export const Wrapper = styled(WrapperTemplate)`
       ${Media.LargeAndUp()} {
         position: sticky;
         top: 2.8rem;
-        width: 30vw;
       }
 
       ${Media.MediumAndUp()} {
         position: sticky;
         top: 3rem;
-        width: 35vw;
       }
 
       ${Media.upToSmall()} {
@@ -198,7 +198,6 @@ export const Wrapper = styled(WrapperTemplate)`
       ${Media.LargeAndUp()} {
         position: sticky;
         top: 4rem;
-        width: 60rem;
       }
     }
   }

--- a/apps/explorer/src/test/components/verboseDetails.test.tsx
+++ b/apps/explorer/src/test/components/verboseDetails.test.tsx
@@ -42,10 +42,6 @@ jest.mock('../../components/orders/OrderHooksDetails', () => ({
   ),
 }))
 
-jest.mock('../../components/AppData/DecodeAppData', () => ({
-  DecodeAppData: (): React.ReactNode => <span>DecodeAppData</span>,
-}))
-
 jest.mock('../../components/common/Spinner', () => ({
   __esModule: true,
   default: (): React.ReactNode => <span>Spinner</span>,


### PR DESCRIPTION
# Summary

Explorer's `appData`'s `quoteBody` is currently shown as a stringified JSON, which makes it inconvenient to look for specific fields/values. This PR adds 2 tabs in `appData`'s row: raw and parsed. Also:

- The copy button respect that setting as well, and will copy the raw or parsed version accordingly.
- The selected tab is persisted in `localStorage`.
- On narrow viewports, the JSON container will expand horizontally slightly to better display the content.

**Raw tab:**
<img width="1920" height="1963" alt="localhost_4200_base_orders_0xc0bff84914b666c24213d4ec08ef0e078a06065f246fc6890e4c1871caa241ff9fa3c00a92ec5f96b1ad2527ab41b3932efeda5869dfcbb4_tab=overview" src="https://github.com/user-attachments/assets/6c75567b-62c8-4f33-9a78-678946cf1674" />

**Parsed tab:**
<img width="1920" height="1963" alt="localhost_4200_base_orders_0xc0bff84914b666c24213d4ec08ef0e078a06065f246fc6890e4c1871caa241ff9fa3c00a92ec5f96b1ad2527ab41b3932efeda5869dfcbb4_tab=overview (1)" src="https://github.com/user-attachments/assets/bd6caaba-0b90-4680-bdc8-cd2e6d2dc6b6" />

**Narrow viewport:**
<img width="420" alt="localhost_4200_base_orders_0xc0bff84914b666c24213d4ec08ef0e078a06065f246fc6890e4c1871caa241ff9fa3c00a92ec5f96b1ad2527ab41b3932efeda5869dfcbb4_tab=overview (2)" src="https://github.com/user-attachments/assets/4f05a619-380e-4a8e-af20-092273ba50b0" />


# To Test

Check an order in Explorer and verify what's described above works as expected:
- raw = old behaviour.
- parsed = new behaviour with parsed `quoteBody`.