### PR TITLE
fix(swap): hide MetaMask version warning on mobile browsers

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/MetamaskTransactionWarning/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/MetamaskTransactionWarning/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { CHAIN_INFO } from '@cowprotocol/common-const'
-import { getIsNativeToken } from '@cowprotocol/common-utils'
+import { getIsNativeToken, isMobile } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { Currency } from '@cowprotocol/currency'
 import { InlineBanner, StatusColorVariant } from '@cowprotocol/ui'
@@ -123,7 +123,9 @@ function useShouldDisplayMetamaskWarning(): { shouldDisplayMetamaskWarning: bool
   const { data: walletClient } = useWalletClient()
 
   useEffect(() => {
-    if (!isMetamask || !walletClient) {
+    // The bug only affects the browser extension. On mobile devices (including
+    // MetaMask's in-app browser) the warning should never appear.
+    if (!isMetamask || !walletClient || isMobile) {
       setIsAffected(false)
       return
     }


### PR DESCRIPTION
The warning was incorrectly shown when using the MetaMask mobile app browser. The underlying bug only affects the desktop browser extension, not mobile. When `web3_clientVersion` returns null (as it can in the mobile context), `isAffected` falls back to the `isMetamask` flag which is true, causing the banner to show.                                                                               
  Skip the check entirely on mobile devices so the banner is only displayed for desktop browser extension users.                             
                                                                                                                       
  Fixes #7462

  # Summary                                                                                                                                  
   
  Fixes #7462                                                                                                                                
                                                                                                                       
  Added `isMobile` guard to `useShouldDisplayMetamaskWarning` so the MetaMask version check is skipped entirely on mobile devices.           
   
  # To Test                                                                                                                                  
                                                                                                                       
  1. Open CoW Swap on a mobile device or in MetaMask's in-app browser                                                                        
   
  - [ ] Warning banner should **not** appear when connected via MetaMask mobile                                                              
  - [ ] Warning banner should **not** appear when using MetaMask's built-in browser                                    
                                                                                                                                             
  2. Open CoW Swap on desktop with MetaMask browser extension (version < 12.10.4)                                                            
                                                                                                                                             
  - [ ] Warning banner **should** still appear for affected desktop extension versions                                                       
                                                                                                                       
  3. Open CoW Swap on desktop with MetaMask extension (version ≥ 12.10.4)                                                                    
                                                                                                                       
  - [ ] Warning banner should **not** appear                                                                                                 
                                                                                                                       
  # Background

  The `useShouldDisplayMetamaskWarning` hook calls `web3_clientVersion` to detect the MetaMask extension version. On mobile, this RPC method  can return `null`, which causes `isAffected` to be set to `undefined`. The fallback logic (`isAffected === undefined ? isMetamask : isAffected`) then evaluates to `isMetamask = true`, incorrectly showing the banner.                                                        
                                                                                                                       
  The fix adds `isMobile` (from `@cowprotocol/common-utils`, evaluated via UAParser at module load) as an early-exit condition — matching the xisting comment that "MM via SDK on mobile returns a Geth-style version string, not a MetaMask extension version."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed MetaMask transaction warnings on mobile devices to provide a smoother mobile trading experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->