### PR TITLE
refactor(affiliate): remove feature flag checks for affiliate program

### DIFF
--- a/apps/cow-fi/app/(main)/affiliate-program/page.tsx
+++ b/apps/cow-fi/app/(main)/affiliate-program/page.tsx
@@ -5,7 +5,6 @@ import { useCowAnalytics } from '@cowprotocol/analytics'
 import IMG_ICON_COW_LENS from '@cowprotocol/assets/images/icon-cow-lens.svg'
 import IMG_ICON_FAQ from '@cowprotocol/assets/images/icon-faq.svg'
 import IMG_COWSWAP_HERO from '@cowprotocol/assets/images/image-affiliate-hero.svg'
-import { useFeatureFlags } from '@cowprotocol/common-hooks'
 import { Media, ProductLogo, ProductVariant, UI } from '@cowprotocol/ui'
 
 import { CowFiCategory } from 'src/common/analytics/types'
@@ -14,7 +13,6 @@ import styled from 'styled-components/macro'
 import FAQ from '@/components/FAQ'
 import LazySVG from '@/components/LazySVG'
 import { Link, LinkType } from '@/components/Link'
-import { NotFoundPageComponent } from '@/components/NotFoundPageComponent'
 import {
   AFFILIATE_PROGRAM_CTA,
   AFFILIATE_PROGRAM_DOCS_CTA,
@@ -255,10 +253,6 @@ function FooterCtaSection({ sendEvent }: { sendEvent: SendEvent }): ReactNode {
 }
 export default function Page(): ReactNode {
   const analytics = useCowAnalytics()
-  const { isAffiliateProgramEnabled } = useFeatureFlags()
-
-  if (isAffiliateProgramEnabled === undefined) return null
-  if (isAffiliateProgramEnabled === false) return <NotFoundPageComponent />
 
   const sendEvent = (action: string): void => {
     analytics.sendEvent({ category: CowFiCategory.COWSWAP, action })

--- a/apps/cow-fi/components/Layout/const.ts
+++ b/apps/cow-fi/components/Layout/const.ts
@@ -27,8 +27,8 @@ const LEARN_NAV_ITEM: MenuItem = {
   ],
 }
 
-export function getNavItems(isSolversEnabled: boolean, isAffiliateProgramEnabled: boolean): MenuItem[] {
-  return [getAboutNavItem(isAffiliateProgramEnabled), getProductsNavItem(isSolversEnabled), LEARN_NAV_ITEM]
+export function getNavItems(isSolversEnabled: boolean): MenuItem[] {
+  return [getAboutNavItem(), getProductsNavItem(isSolversEnabled), LEARN_NAV_ITEM]
 }
 
 function getProductsNavItem(isSolversEnabled: boolean): MenuItem {
@@ -80,7 +80,7 @@ function getProductsNavItem(isSolversEnabled: boolean): MenuItem {
   }
 }
 
-function getAboutNavItem(isAffiliateProgramEnabled: boolean): MenuItem {
+function getAboutNavItem(): MenuItem {
   return {
     label: 'About',
     children: [
@@ -105,7 +105,7 @@ function getAboutNavItem(isAffiliateProgramEnabled: boolean): MenuItem {
         external: true,
       },
       { label: 'Careers', href: '/careers' },
-      ...(isAffiliateProgramEnabled ? [{ label: 'Affiliate Program', href: '/affiliate-program' }] : []),
+      { label: 'Affiliate Program', href: '/affiliate-program' },
     ],
   }
 }

--- a/apps/cow-fi/components/Layout/index.tsx
+++ b/apps/cow-fi/components/Layout/index.tsx
@@ -44,7 +44,7 @@ interface LayoutProps {
 
 export function Layout({ children, bgColor, host, showCowSaucer, contentMinHeight }: Readonly<LayoutProps>): ReactNode {
   useSetupPage()
-  const { isSolversEnabled, isAffiliateProgramEnabled } = useFeatureFlags()
+  const { isSolversEnabled } = useFeatureFlags()
 
   const GlobalStyles = GlobalCoWDAOStyles()
   const LocalStyles = createGlobalStyle(
@@ -62,7 +62,7 @@ export function Layout({ children, bgColor, host, showCowSaucer, contentMinHeigh
       {/* Override global light theme to force dark mode for MenuBar only */}
       <ThemeProvider theme={darkTheme}>
         <MenuBar
-          navItems={getNavItems(!!isSolversEnabled, !!isAffiliateProgramEnabled)}
+          navItems={getNavItems(!!isSolversEnabled)}
           productVariant={PRODUCT_VARIANT}
           additionalNavButtons={NAV_ADDITIONAL_BUTTONS}
           padding="10px 60px"
@@ -77,7 +77,7 @@ export function Layout({ children, bgColor, host, showCowSaucer, contentMinHeigh
         <Footer
           maxWidth={PAGE_MAX_WIDTH}
           productVariant={PRODUCT_VARIANT}
-          navItems={getGlobalFooterNavItems(!!isAffiliateProgramEnabled)}
+          navItems={getGlobalFooterNavItems()}
           host={host ?? process.env.NEXT_PUBLIC_SITE_URL!}
           expanded
           hasTouchFooter

--- a/apps/cowswap-frontend/src/modules/affiliate/README.md
+++ b/apps/cowswap-frontend/src/modules/affiliate/README.md
@@ -12,11 +12,10 @@ The affiliate program will amplify word-of-mouth marketing for CoW Swap by incen
 - Accountants (Finance Squad)
 - Maintainers (Web Squad, DevOps Squad)
 
-## 3) Feature flag
+## 3) Frontend availability
 
-- Gated by a LaunchDarkly feature flag called `isAffiliateProgramEnabled`
-- When enabled:
-  1.  two new pages show up in `Account`, i.e. `My Rewards` and `Affiliate`
+- Always enabled in the frontend:
+  1.  two pages show up in `Account`, i.e. `My Rewards` and `Affiliate`
   2.  the referral code input row shows up in the trade form alongside a Modal to input the code
 - In injected widget mode, the rewards row is hidden.
 

--- a/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateTraderHeaderButton.test.tsx
+++ b/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateTraderHeaderButton.test.tsx
@@ -1,5 +1,4 @@
 import { useCowAnalytics } from '@cowprotocol/analytics'
-import { useFeatureFlags } from '@cowprotocol/common-hooks'
 import { isInjectedWidget } from '@cowprotocol/common-utils'
 
 import { i18n } from '@lingui/core'
@@ -23,15 +22,6 @@ jest.mock('@cowprotocol/analytics', () => {
   }
 })
 
-jest.mock('@cowprotocol/common-hooks', () => {
-  const actualModule = jest.requireActual('@cowprotocol/common-hooks')
-
-  return {
-    ...actualModule,
-    useFeatureFlags: jest.fn(),
-  }
-})
-
 jest.mock('@cowprotocol/common-utils', () => {
   const actualModule = jest.requireActual('@cowprotocol/common-utils')
 
@@ -48,7 +38,6 @@ jest.mock('common/hooks/useNavigate', () => {
 })
 
 const useCowAnalyticsMock = useCowAnalytics as jest.MockedFunction<typeof useCowAnalytics>
-const useFeatureFlagsMock = useFeatureFlags as jest.MockedFunction<typeof useFeatureFlags>
 const isInjectedWidgetMock = isInjectedWidget as jest.MockedFunction<typeof isInjectedWidget>
 const useNavigateMock = useNavigate as jest.MockedFunction<typeof useNavigate>
 
@@ -75,27 +64,14 @@ describe('AffiliateTraderHeaderButton', () => {
     useCowAnalyticsMock.mockReturnValue({
       sendEvent,
     } as unknown as ReturnType<typeof useCowAnalytics>)
-    useFeatureFlagsMock.mockReturnValue({
-      isAffiliateProgramEnabled: true,
-    } as ReturnType<typeof useFeatureFlags>)
     isInjectedWidgetMock.mockReturnValue(false)
     useNavigateMock.mockReturnValue(navigate)
   })
 
-  it('renders the header refer button when the affiliate program is enabled', () => {
+  it('renders the header refer button', () => {
     renderComponent()
 
     expect(screen.getByRole('button', { name: 'Refer' })).not.toBeNull()
-  })
-
-  it('does not render when the affiliate program is disabled', () => {
-    useFeatureFlagsMock.mockReturnValue({
-      isAffiliateProgramEnabled: false,
-    } as ReturnType<typeof useFeatureFlags>)
-
-    renderComponent()
-
-    expect(screen.queryByRole('button', { name: 'Refer' })).toBeNull()
   })
 
   it('does not render in widget mode', () => {

--- a/apps/cowswap-frontend/src/modules/affiliate/hooks/useAffiliateTraderRefUrlSideEffect.ts
+++ b/apps/cowswap-frontend/src/modules/affiliate/hooks/useAffiliateTraderRefUrlSideEffect.ts
@@ -2,7 +2,6 @@ import { useSetAtom } from 'jotai'
 import { useEffect } from 'react'
 
 import { useCowAnalytics } from '@cowprotocol/analytics'
-import { useFeatureFlags } from '@cowprotocol/common-hooks'
 
 import { useLocation } from 'react-router'
 
@@ -11,7 +10,6 @@ import { affiliateTraderModalAtom } from '../state/affiliateTraderModalAtom'
 import { logAffiliate } from '../utils/logger'
 
 export function useAffiliateTraderRefUrlSideEffect(): void {
-  const { isAffiliateProgramEnabled } = useFeatureFlags()
   const setAffiliateModalOpen = useSetAtom(affiliateTraderModalAtom)
   const location = useLocation()
   const analytics = useCowAnalytics()
@@ -26,7 +24,7 @@ export function useAffiliateTraderRefUrlSideEffect(): void {
       logAffiliate('Invalid ref code in URL', { refCodeParam })
     }
 
-    if (!refCode || !refCodeParam || !isAffiliateProgramEnabled) return
+    if (!refCode || !refCodeParam) return
 
     logAffiliate('Ref code found in URL, opening affiliate modal', { refCode })
     setAffiliateModalOpen(true)
@@ -36,5 +34,5 @@ export function useAffiliateTraderRefUrlSideEffect(): void {
       action: 'referral_url_opened',
       label: refCode,
     })
-  }, [analytics, isAffiliateProgramEnabled, location.search, setAffiliateModalOpen])
+  }, [analytics, location.search, setAffiliateModalOpen])
 }

--- a/apps/cowswap-frontend/src/modules/affiliate/hooks/useIsRewardsRowEnabled.ts
+++ b/apps/cowswap-frontend/src/modules/affiliate/hooks/useIsRewardsRowEnabled.ts
@@ -1,4 +1,3 @@
-import { useFeatureFlags } from '@cowprotocol/common-hooks'
 import { isInjectedWidget } from '@cowprotocol/common-utils'
 
 import { TraderWalletStatus, useAffiliateTraderWallet } from './useAffiliateTraderWallet'
@@ -7,7 +6,6 @@ import { useIsRefCodeExpired } from './useIsRefCodeExpired'
 import { AFFILIATE_HIDE_REWARDS_ROW_IF_INELIGIBLE } from '../config/affiliateProgram.const'
 
 export function useIsRewardsRowEnabled(): boolean {
-  const { isAffiliateProgramEnabled } = useFeatureFlags()
   const walletStatus = useAffiliateTraderWallet()
   const isRefCodeExpired = useIsRefCodeExpired()
 
@@ -21,5 +19,5 @@ export function useIsRewardsRowEnabled(): boolean {
     return false
   }
 
-  return isAffiliateProgramEnabled && !isInjectedWidget()
+  return !isInjectedWidget()
 }

--- a/apps/cowswap-frontend/src/modules/affiliate/hooks/useShouldShowAffiliateTraderHeaderButton.ts
+++ b/apps/cowswap-frontend/src/modules/affiliate/hooks/useShouldShowAffiliateTraderHeaderButton.ts
@@ -1,8 +1,5 @@
-import { useFeatureFlags } from '@cowprotocol/common-hooks'
 import { isInjectedWidget } from '@cowprotocol/common-utils'
 
 export function useShouldShowAffiliateTraderHeaderButton(): boolean {
-  const { isAffiliateProgramEnabled } = useFeatureFlags()
-
-  return isAffiliateProgramEnabled && !isInjectedWidget()
+  return !isInjectedWidget()
 }

--- a/apps/cowswap-frontend/src/modules/application/containers/App/RoutesApp.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/App/RoutesApp.tsx
@@ -9,7 +9,6 @@ import {
   DUNE_DASHBOARD_LINK,
   TWITTER_LINK,
 } from '@cowprotocol/common-const'
-import { useFeatureFlags } from '@cowprotocol/common-hooks'
 
 import { Navigate, Route, Routes } from 'react-router'
 
@@ -82,20 +81,14 @@ const lazyRoutes: LazyRouteProps[] = [
 ]
 
 export function RoutesApp(): ReactNode {
-  const { isAffiliateProgramEnabled } = useFeatureFlags()
-
   return (
     <Routes>
       {/*Account*/}
       <Route path={RoutesEnum.ACCOUNT} element={<Account />}>
         <Route path={RoutesEnum.ACCOUNT} element={<AccountOverview />} />
         <Route path={RoutesEnum.ACCOUNT_TOKENS} element={<AccountTokensOverview />} />
-        {isAffiliateProgramEnabled && (
-          <Route path={RoutesEnum.ACCOUNT_AFFILIATE_PARTNER} element={<AccountAffiliatePartner />} />
-        )}
-        {isAffiliateProgramEnabled && (
-          <Route path={RoutesEnum.ACCOUNT_AFFILIATE_TRADER} element={<AccountAffiliateTrader />} />
-        )}
+        <Route path={RoutesEnum.ACCOUNT_AFFILIATE_PARTNER} element={<AccountAffiliatePartner />} />
+        <Route path={RoutesEnum.ACCOUNT_AFFILIATE_TRADER} element={<AccountAffiliateTrader />} />
         <Route path="*" element={<AccountNotFound />} />
       </Route>
 

--- a/apps/cowswap-frontend/src/modules/application/containers/App/menuConsts.test.ts
+++ b/apps/cowswap-frontend/src/modules/application/containers/App/menuConsts.test.ts
@@ -48,7 +48,7 @@ jest.mock('common/constants/routes', () => ({
 }))
 
 function getMoreItemHrefs(isSolversEnabled: boolean): string[] {
-  const navItems = NAV_ITEMS(SupportedChainId.MAINNET, false, isSolversEnabled)
+  const navItems = NAV_ITEMS(SupportedChainId.MAINNET, isSolversEnabled)
   const moreItem = navItems[navItems.length - 1]
 
   if (!moreItem?.children) {

--- a/apps/cowswap-frontend/src/modules/application/containers/App/menuConsts.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/App/menuConsts.tsx
@@ -27,29 +27,25 @@ type UntranslatedMenuItem = {
   }>
 }
 
-const ACCOUNT_ITEM = (chainId: SupportedChainId, isAffiliateProgramEnabled: boolean): UntranslatedMenuItem => ({
+const ACCOUNT_ITEM = (chainId: SupportedChainId): UntranslatedMenuItem => ({
   label: msg`Account`,
   children: [
     {
       href: '/account',
       label: msg`Overview`,
     },
-    ...(isAffiliateProgramEnabled
-      ? [
-          {
-            href: Routes.ACCOUNT_AFFILIATE_PARTNER,
-            label: msg`Affiliate`,
-            badge: msg`New`,
-            badgeType: BadgeTypes.ALERT,
-          },
-          {
-            href: Routes.ACCOUNT_AFFILIATE_TRADER,
-            label: msg`My Rewards`,
-            badge: msg`New`,
-            badgeType: BadgeTypes.ALERT,
-          },
-        ]
-      : []),
+    {
+      href: Routes.ACCOUNT_AFFILIATE_PARTNER,
+      label: msg`Affiliate`,
+      badge: msg`New`,
+      badgeType: BadgeTypes.ALERT,
+    },
+    {
+      href: Routes.ACCOUNT_AFFILIATE_TRADER,
+      label: msg`My Rewards`,
+      badge: msg`New`,
+      badgeType: BadgeTypes.ALERT,
+    },
     {
       href: '/account/tokens',
       label: msg`Tokens`,
@@ -143,12 +139,8 @@ const MORE_ITEM = (isSolversEnabled: boolean): UntranslatedMenuItem => ({
   ],
 })
 
-export const NAV_ITEMS = (
-  chainId: SupportedChainId,
-  isAffiliateProgramEnabled: boolean,
-  isSolversEnabled: boolean,
-): MenuItem[] => {
-  const _ACCOUNT_ITEM = ACCOUNT_ITEM(chainId, isAffiliateProgramEnabled)
+export const NAV_ITEMS = (chainId: SupportedChainId, isSolversEnabled: boolean): MenuItem[] => {
+  const _ACCOUNT_ITEM = ACCOUNT_ITEM(chainId)
   const accountItem: MenuItem = {
     label: i18n._(_ACCOUNT_ITEM.label),
     children: _ACCOUNT_ITEM.children.map(({ href, label, badge, badgeType }) => ({

--- a/apps/cowswap-frontend/src/modules/application/containers/AppContainer/AppContainer.container.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/AppContainer/AppContainer.container.tsx
@@ -58,7 +58,7 @@ interface FooterSectionProps {
 export function AppContainer({ children }: AppContainerProps): ReactNode {
   const { chainId, account } = useWalletInfo()
   const { walletName } = useWalletDetails()
-  const { isYieldEnabled, isAffiliateProgramEnabled } = useFeatureFlags()
+  const { isYieldEnabled } = useFeatureFlags()
 
   useAnalyticsReporter({
     account,
@@ -133,7 +133,7 @@ export function AppContainer({ children }: AppContainerProps): ReactNode {
 
         {/* Render MobileHeaderControls outside of MenuBar on mobile */}
         {isMobile && !isInjectedWidgetMode && networkAndAccountControls}
-        {isAffiliateProgramEnabled && <AffiliateTraderModal />}
+        <AffiliateTraderModal />
       </styledEl.AppWrapper>
     </PageBackgroundContext.Provider>
   )

--- a/apps/cowswap-frontend/src/modules/application/containers/AppMenu/index.tsx
+++ b/apps/cowswap-frontend/src/modules/application/containers/AppMenu/index.tsx
@@ -42,7 +42,7 @@ export function AppMenu({ children, customTheme: overriddenCustomTheme }: AppMen
   const { chainId } = useWalletInfo()
   const isInjectedWidgetMode = isInjectedWidget()
   const menuItems = useMenuItems()
-  const { isAffiliateProgramEnabled, isSolversEnabled } = useFeatureFlags()
+  const { isSolversEnabled } = useFeatureFlags()
   const [darkMode, toggleDarkMode] = useDarkModeManager()
   const { setLocale } = useUserLocaleManager()
   const isMobile = useMediaQuery(isMobileQuery(false))
@@ -90,9 +90,9 @@ export function AppMenu({ children, customTheme: overriddenCustomTheme }: AppMen
           }
         }),
       },
-      ...NAV_ITEMS(chainId, !!isAffiliateProgramEnabled, !!isSolversEnabled),
+      ...NAV_ITEMS(chainId, !!isSolversEnabled),
     ]
-  }, [t, menuItems, chainId, getTradeUrlParams, isAffiliateProgramEnabled, isSolversEnabled])
+  }, [t, menuItems, chainId, getTradeUrlParams, isSolversEnabled])
 
   if (isInjectedWidgetMode) return null
 

--- a/apps/cowswap-frontend/src/pages/Account/Menu.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/Menu.tsx
@@ -1,7 +1,6 @@
 import { ReactNode } from 'react'
 
 import { ACCOUNT_PROXY_LABEL } from '@cowprotocol/common-const'
-import { useFeatureFlags } from '@cowprotocol/common-hooks'
 import { useExtractText } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { useWalletInfo } from '@cowprotocol/wallet'
@@ -19,15 +18,11 @@ interface MenuItem {
   url: string
 }
 
-const ACCOUNT_MENU_LINKS = (chainId: SupportedChainId, isAffiliateProgramEnabled: boolean): MenuItem[] => {
+const ACCOUNT_MENU_LINKS = (chainId: SupportedChainId): MenuItem[] => {
   return [
     { title: msg`Overview`, url: '/account' },
-    ...(isAffiliateProgramEnabled
-      ? [
-          { title: msg`Affiliate`, url: '/account/affiliate' },
-          { title: msg`My Rewards`, url: '/account/my-rewards' },
-        ]
-      : []),
+    { title: msg`Affiliate`, url: '/account/affiliate' },
+    { title: msg`My Rewards`, url: '/account/my-rewards' },
     { title: msg`Tokens`, url: '/account/tokens' },
     { title: ACCOUNT_PROXY_LABEL, url: getProxyAccountUrl(chainId) },
   ]
@@ -35,13 +30,12 @@ const ACCOUNT_MENU_LINKS = (chainId: SupportedChainId, isAffiliateProgramEnabled
 
 export function AccountMenu(): ReactNode {
   const { chainId } = useWalletInfo()
-  const { isAffiliateProgramEnabled } = useFeatureFlags()
   const { extractTextFromStringOrI18nDescriptor } = useExtractText()
 
   return (
     <SideMenu longList>
       <ul>
-        {ACCOUNT_MENU_LINKS(chainId, isAffiliateProgramEnabled).map(({ title, url }) => (
+        {ACCOUNT_MENU_LINKS(chainId).map(({ title, url }) => (
           <li key={url}>
             <NavLink end to={url} className={({ isActive }) => (isActive ? 'active' : undefined)}>
               {extractTextFromStringOrI18nDescriptor(title)}

--- a/apps/cowswap-frontend/src/pages/Account/index.test.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/index.test.tsx
@@ -1,7 +1,6 @@
 import { useAtomValue } from 'jotai'
 import { type ReactNode } from 'react'
 
-import { useFeatureFlags } from '@cowprotocol/common-hooks'
 import { useWalletInfo } from '@cowprotocol/wallet'
 
 import { i18n } from '@lingui/core'
@@ -16,15 +15,6 @@ import { TraderWalletStatus, useAffiliateTraderWallet } from 'modules/affiliate'
 import { Routes as RoutesEnum } from 'common/constants/routes'
 
 import Account from './index'
-
-jest.mock('@cowprotocol/common-hooks', () => {
-  const actualModule = jest.requireActual('@cowprotocol/common-hooks')
-
-  return {
-    ...actualModule,
-    useFeatureFlags: jest.fn(),
-  }
-})
 
 jest.mock('@cowprotocol/wallet', () => ({
   useWalletInfo: jest.fn(),
@@ -60,7 +50,6 @@ jest.mock('./Menu', () => ({
   AccountMenu: () => <nav aria-label="Account menu" />,
 }))
 
-const useFeatureFlagsMock = useFeatureFlags as jest.MockedFunction<typeof useFeatureFlags>
 const useWalletInfoMock = useWalletInfo as jest.MockedFunction<typeof useWalletInfo>
 const useAtomValueMock = useAtomValue as jest.MockedFunction<typeof useAtomValue>
 const useAffiliateTraderWalletMock = useAffiliateTraderWallet as jest.MockedFunction<typeof useAffiliateTraderWallet>
@@ -72,9 +61,6 @@ function renderComponent(pathname: string, account?: string): RenderResult {
   useWalletInfoMock.mockReturnValue({
     account,
   } as ReturnType<typeof useWalletInfo>)
-  useFeatureFlagsMock.mockReturnValue({
-    isAffiliateProgramEnabled: true,
-  } as ReturnType<typeof useFeatureFlags>)
 
   return render(
     <MemoryRouter initialEntries={[pathname]}>

--- a/apps/cowswap-frontend/src/pages/Account/index.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/index.tsx
@@ -2,7 +2,6 @@ import { useAtomValue } from 'jotai'
 import { lazy, ReactNode } from 'react'
 
 import { PAGE_TITLES } from '@cowprotocol/common-const'
-import { useFeatureFlags } from '@cowprotocol/common-hooks'
 import { useWalletInfo } from '@cowprotocol/wallet'
 
 import { t } from '@lingui/core/macro'
@@ -76,7 +75,7 @@ function AccountTitle({ canShowAffiliateFeedbackButton, id, name, pathname }: Ac
   return <Title id={id}>{name}</Title>
 }
 
-function getPropsFromRoute(route: string, isAffiliateProgramEnabled: boolean): string[] {
+function getPropsFromRoute(route: string): string[] {
   switch (route) {
     case RoutesEnum.ACCOUNT:
       return ['account-overview', t`Account overview`]
@@ -85,9 +84,9 @@ function getPropsFromRoute(route: string, isAffiliateProgramEnabled: boolean): s
     case RoutesEnum.ACCOUNT_TOKENS:
       return ['account-tokens', t`Tokens overview`]
     case RoutesEnum.ACCOUNT_AFFILIATE_PARTNER:
-      return isAffiliateProgramEnabled ? ['account-affiliate', t`Rewards hub - Affiliate`] : []
+      return ['account-affiliate', t`Rewards hub - Affiliate`]
     case RoutesEnum.ACCOUNT_AFFILIATE_TRADER:
-      return isAffiliateProgramEnabled ? ['account-my-rewards', t`Rewards hub - My Rewards`] : []
+      return ['account-my-rewards', t`Rewards hub - My Rewards`]
     default:
       return []
   }
@@ -114,9 +113,8 @@ export const AccountOverview = (): ReactNode => {
 export default function Account(): ReactNode {
   const { pathname } = useLocation()
   const { account } = useWalletInfo()
-  const { isAffiliateProgramEnabled } = useFeatureFlags()
-  const [id, name] = getPropsFromRoute(pathname, isAffiliateProgramEnabled)
-  const canShowAffiliateFeedbackButton = Boolean(account) && isAffiliateProgramEnabled
+  const [id, name] = getPropsFromRoute(pathname)
+  const canShowAffiliateFeedbackButton = Boolean(account)
 
   return (
     <Wrapper>

--- a/libs/ui/src/containers/Footer/footer.constants.ts
+++ b/libs/ui/src/containers/Footer/footer.constants.ts
@@ -182,7 +182,7 @@ export function getAboutFooterNavChildren(): NavItemChildrenProps[] {
     },
     {
       label: 'Affiliate Program',
-      href: '/affiliate-program',
+      href: 'https://cow.fi/affiliate-program',
       utmContent: 'footer-about-affiliate-program',
     },
   ]

--- a/libs/ui/src/containers/Footer/footer.constants.ts
+++ b/libs/ui/src/containers/Footer/footer.constants.ts
@@ -183,6 +183,7 @@ export function getAboutFooterNavChildren(): NavItemChildrenProps[] {
     {
       label: 'Affiliate Program',
       href: 'https://cow.fi/affiliate-program',
+      external: true,
       utmContent: 'footer-about-affiliate-program',
     },
   ]

--- a/libs/ui/src/containers/Footer/footer.constants.ts
+++ b/libs/ui/src/containers/Footer/footer.constants.ts
@@ -151,7 +151,7 @@ const FOOTER_NAV_GROUP_MISC = {
   ],
 } as const satisfies NavItemProps
 
-export function getAboutFooterNavChildren(isAffiliateProgramEnabled: boolean): NavItemChildrenProps[] {
+export function getAboutFooterNavChildren(): NavItemChildrenProps[] {
   return [
     {
       href: 'https://docs.cow.fi/governance',
@@ -180,21 +180,17 @@ export function getAboutFooterNavChildren(isAffiliateProgramEnabled: boolean): N
       external: true,
       utmContent: 'footer-misc-bug-bounty',
     },
-    ...(isAffiliateProgramEnabled
-      ? [
-          {
-            label: 'Affiliate Program',
-            href: '/affiliate-program',
-            utmContent: 'footer-about-affiliate-program',
-          },
-        ]
-      : []),
+    {
+      label: 'Affiliate Program',
+      href: '/affiliate-program',
+      utmContent: 'footer-about-affiliate-program',
+    },
   ]
 }
 
-export function getGlobalFooterNavItems(isAffiliateProgramEnabled: boolean): NavItemProps[] {
+export function getGlobalFooterNavItems(): NavItemProps[] {
   return [
-    { label: 'About', children: getAboutFooterNavChildren(isAffiliateProgramEnabled) },
+    { label: 'About', children: getAboutFooterNavChildren() },
     FOOTER_NAV_GROUP_PRODUCTS,
     FOOTER_NAV_GROUP_HELP,
     FOOTER_NAV_GROUP_MISC,

--- a/libs/ui/src/containers/Footer/index.tsx
+++ b/libs/ui/src/containers/Footer/index.tsx
@@ -93,7 +93,7 @@ const FooterLink = ({ href, external, label, utmSource: _utmSource, utmContent, 
   )
 }
 
-export const GLOBAL_FOOTER_NAV_ITEMS = getGlobalFooterNavItems(false)
+export const GLOBAL_FOOTER_NAV_ITEMS = getGlobalFooterNavItems()
 
 export const Footer = ({
   description = GLOBAL_FOOTER_DESCRIPTION,

--- a/libs/ui/src/containers/Footer/index.tsx
+++ b/libs/ui/src/containers/Footer/index.tsx
@@ -37,6 +37,8 @@ import { UI } from '../../enum'
 import { MenuItem } from '../../pure/MenuBar'
 import { ProductLogo, ProductVariant } from '../../pure/ProductLogo'
 
+export { getGlobalFooterNavItems } from './footer.constants'
+
 export interface NavItemProps extends Omit<MenuItem, 'label' | 'badge'> {
   label?: string
   badge?: string


### PR DESCRIPTION
# Summary

 - Removes the affiliate program feature flag so the affiliate program is always available.
 - Also fixes a prod footer bug I found: the Affiliate Program footer link never renders

  # To Test

  1. Open `/affiliate-program` in the cowfi deployment

  - [x] Verify the affiliate program page loads

  2. Check the global footer

  - [x] Verify the footer includes `Affiliate Program`
  - [x] Verify clicking it opens `https://cow.fi/affiliate-program`
  - [x] Verify the link points to `https://cow.fi/affiliate-program` from other hosts like `swap.cow.fi`
  
  
<img width="223" alt="image" src="https://github.com/user-attachments/assets/1e7af0ec-b0ad-4316-b8c0-cffe7b605c2f" /> 
<img width="223"  alt="image" src="https://github.com/user-attachments/assets/49409b8f-b27e-4e1e-aebf-7a75c80d8fa3" />

  3. Open affiliate account pages

  - [x] Verify the Affiliate page loads
  - [x] Verify the My Rewards page loads


  4. Test affiliate referral flow

  - [ ] Open the app with a new account
  - [ ] Complete a small trade with a new ref code
  - [ ] Verify the whole affiliate flow still works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Affiliate program is now universally enabled in the application and always available to users.

* **Improvements**
  * Affiliate program navigation links and menu options are always visible in the interface.
  * Affiliate account features, including rewards and referral functionality, are now always accessible (except in widget mode).
  * Affiliate routing is now always available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->