### PR TITLE
feat(wallet): add ConnectWalletButton and isConnectionRestoring state

### DIFF
--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -7027,6 +7027,10 @@ msgstr "Default approve"
 msgid "Order cannot be filled due to insufficient balance on the current account."
 msgstr "Order cannot be filled due to insufficient balance on the current account."
 
+#: apps/cowswap-frontend/src/modules/wallet/pure/Web3StatusInner/index.tsx
+msgid "Restoring wallet..."
+msgstr "Restoring wallet..."
+
 #: apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
 #: apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
 msgid "required"

--- a/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliatePartnerOnboard.tsx
+++ b/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliatePartnerOnboard.tsx
@@ -67,7 +67,7 @@ export function AffiliatePartnerOnboard(): ReactNode {
         </HeroSubtitle>
         <HeroActions>
           {!account && (
-            <ButtonPrimary buttonSize={ButtonSize.BIG} onClick={toggleWalletModal} data-testid="affiliate-connect">
+            <ButtonPrimary buttonSize={ButtonSize.BIG} data-testid="affiliate-connect" onClick={toggleWalletModal}>
               <Trans>Connect wallet</Trans>
             </ButtonPrimary>
           )}

--- a/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateTraderOnboard.tsx
+++ b/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateTraderOnboard.tsx
@@ -2,7 +2,7 @@ import { useSetAtom } from 'jotai'
 import { ReactNode } from 'react'
 
 import EARN_AS_TRADER_ILLUSTRATION from '@cowprotocol/assets/images/earn-as-trader.svg'
-import { ButtonPrimary } from '@cowprotocol/ui'
+import { ButtonPrimary, ButtonSize } from '@cowprotocol/ui'
 import { useWalletInfo } from '@cowprotocol/wallet'
 
 import { Trans } from '@lingui/react/macro'
@@ -21,8 +21,8 @@ import { toggleTraderModalAtom } from '../state/affiliateTraderModalAtom'
 
 export function AffiliateTraderOnboard(): ReactNode {
   const { account } = useWalletInfo()
-  const toggleWalletModal = useToggleWalletModal()
   const toggleAffiliateModal = useSetAtom(toggleTraderModalAtom)
+  const toggleWalletModal = useToggleWalletModal()
   const traderRewardAmount = formatUsdcCompact(getDefaultTraderRewardAmount())
   const triggerVolumeLabel = formatUsdCompact(getDefaultTriggerVolume())
   const affiliateTimeCapDays = PROGRAM_DEFAULTS.AFFILIATE_TIME_CAP_DAYS
@@ -49,7 +49,7 @@ export function AffiliateTraderOnboard(): ReactNode {
               <Trans>Add code</Trans>
             </ButtonPrimary>
           ) : (
-            <ButtonPrimary onClick={toggleWalletModal}>
+            <ButtonPrimary buttonSize={ButtonSize.BIG} onClick={toggleWalletModal}>
               <Trans>Connect wallet</Trans>
             </ButtonPrimary>
           )}

--- a/apps/cowswap-frontend/src/modules/wallet/containers/Web3Status/index.tsx
+++ b/apps/cowswap-frontend/src/modules/wallet/containers/Web3Status/index.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-import { useConnectionType, useWalletDetails, useWalletInfo } from '@cowprotocol/wallet'
+import { useConnectionType, useIsRestoringConnection, useWalletDetails, useWalletInfo } from '@cowprotocol/wallet'
 
 import { useToggleWalletModal } from 'legacy/state/application/hooks'
 
@@ -21,6 +21,7 @@ export interface Web3StatusProps {
 export function Web3Status({ className, onClick, joinedLeft = false }: Web3StatusProps): ReactNode {
   const connectionType = useConnectionType()
   const { account } = useWalletInfo()
+  const isConnectionRestoring = useIsRestoringConnection()
   const { ensName } = useWalletDetails()
 
   const toggleWalletModal = useToggleWalletModal()
@@ -37,6 +38,7 @@ export function Web3Status({ className, onClick, joinedLeft = false }: Web3Statu
         ensName={ensName}
         connectWallet={toggleWalletModal}
         connectionType={connectionType}
+        isConnectionRestoring={isConnectionRestoring}
       />
     </Wrapper>
   )

--- a/apps/cowswap-frontend/src/modules/wallet/pure/Web3StatusInner/index.tsx
+++ b/apps/cowswap-frontend/src/modules/wallet/pure/Web3StatusInner/index.tsx
@@ -4,7 +4,7 @@ import { useMediaQuery } from '@cowprotocol/common-hooks'
 import { shortenAddress } from '@cowprotocol/common-utils'
 import { Command } from '@cowprotocol/types'
 import { Loader, RowBetween, Media } from '@cowprotocol/ui'
-import { ConnectionType } from '@cowprotocol/wallet'
+import { type ConnectionType } from '@cowprotocol/wallet'
 
 import { t } from '@lingui/core/macro'
 import { Trans } from '@lingui/react/macro'
@@ -20,6 +20,7 @@ import { StatusIcon } from '../StatusIcon'
 
 export interface Web3StatusInnerProps {
   account?: string
+  isConnectionRestoring?: boolean
   pendingCount: number
   connectWallet: Command
   connectionType: ConnectionType
@@ -28,7 +29,15 @@ export interface Web3StatusInnerProps {
 }
 
 export function Web3StatusInner(props: Web3StatusInnerProps): ReactNode {
-  const { account, pendingCount, ensName, connectionType, connectWallet, showUnfillableOrdersAlert } = props
+  const {
+    account,
+    isConnectionRestoring,
+    pendingCount,
+    ensName,
+    connectionType,
+    connectWallet,
+    showUnfillableOrdersAlert,
+  } = props
 
   const hasPendingTransactions = !!pendingCount
   const isUpToExtraSmall = useMediaQuery(Media.upToExtraSmall(false))
@@ -65,6 +74,16 @@ export function Web3StatusInner(props: Web3StatusInnerProps): ReactNode {
         )}
         {!hasPendingTransactions && <StatusIcon connectionType={connectionType} />}
       </Web3StatusConnected>
+    )
+  }
+
+  if (isConnectionRestoring) {
+    return (
+      <Web3StatusConnect id="wallet-restoring" disabled faded>
+        <Text>
+          <Trans>Restoring wallet...</Trans>
+        </Text>
+      </Web3StatusConnect>
     )
   }
 

--- a/apps/cowswap-frontend/src/pages/Account/AffiliatePartner.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/AffiliatePartner.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react'
 
 import { PAGE_TITLES } from '@cowprotocol/common-const'
-import { useWalletInfo } from '@cowprotocol/wallet'
+import { useIsRestoringConnection, useWalletInfo } from '@cowprotocol/wallet'
 import { useWalletChainId } from '@cowprotocol/wallet-provider'
 
 import { useLingui } from '@lingui/react/macro'
@@ -13,14 +13,17 @@ import {
   AffiliatePartnerOnboard,
   AffiliatePartnerStats,
   AffiliateTermsFaqLinks,
+  AffiliateTraderLoading,
   ColumnOneCard,
   ThreeColumnGrid,
   PageWrapper,
+  TraderWalletStatus,
   getAffiliatePartnerPageState,
   isSupportedPayoutsNetwork,
   isSupportedTradingNetwork,
   useAffiliatePartnerInfo,
   useAffiliateStateViewAnalytics,
+  useAffiliateTraderWallet,
 } from 'modules/affiliate'
 import { PageTitle } from 'modules/application'
 
@@ -29,10 +32,13 @@ export default function AffiliatePartner(): ReactNode {
   const { account } = useWalletInfo()
   const chainId = useWalletChainId()
   const { data: partnerInfo, isLoading: infoLoading } = useAffiliatePartnerInfo(account)
+  const walletStatus = useAffiliateTraderWallet()
+  const isConnectionRestoring = useIsRestoringConnection()
   const hasAccount = Boolean(account)
   const isSupportedPayoutNetwork = isSupportedPayoutsNetwork(chainId)
   const isSupportedTradingNetworkValue = isSupportedTradingNetwork(chainId)
   const hasExistingCode = Boolean(partnerInfo?.code)
+  const showLoadingSkeleton = isConnectionRestoring || infoLoading || walletStatus === TraderWalletStatus.PENDING
   const pageState = getAffiliatePartnerPageState({
     hasAccount,
     hasExistingCode,
@@ -60,7 +66,9 @@ export default function AffiliatePartner(): ReactNode {
     <PageWrapper>
       <PageTitle title={i18n._(PAGE_TITLES.AFFILIATE)} />
 
-      {!account || (!isSupportedPayoutNetwork && !partnerInfo && !infoLoading) || !isSupportedTradingNetworkValue ? (
+      {showLoadingSkeleton ? (
+        <AffiliateTraderLoading />
+      ) : !account || (!isSupportedPayoutNetwork && !partnerInfo) || !isSupportedTradingNetworkValue ? (
         <AffiliatePartnerOnboard />
       ) : (
         <>

--- a/apps/cowswap-frontend/src/pages/Account/AffiliateTrader.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/AffiliateTrader.tsx
@@ -2,6 +2,7 @@ import { useAtomValue } from 'jotai'
 import { ReactNode } from 'react'
 
 import { PAGE_TITLES } from '@cowprotocol/common-const'
+import { useIsRestoringConnection } from '@cowprotocol/wallet'
 
 import { useLingui } from '@lingui/react/macro'
 
@@ -35,6 +36,8 @@ export default function AffiliateTrader(): ReactNode {
   const hasSavedCode = !!savedCode
   const pageState = getAffiliateTraderPageState(walletStatus, hasSavedCode)
   const isProviderNetworkUnsupported = useIsProviderNetworkUnsupported()
+  const isConnectionRestoring = useIsRestoringConnection()
+  const showLoadingSkeleton = isConnectionRestoring || walletStatus === TraderWalletStatus.PENDING
 
   useAffiliateStateViewAnalytics({
     action: 'affiliate_trader_page_state_viewed',
@@ -61,7 +64,7 @@ export default function AffiliateTrader(): ReactNode {
           <AffiliateTraderIneligible />
         ) : walletStatus === TraderWalletStatus.UNSUPPORTED ? (
           <AffiliateTraderUnsupportedNetwork />
-        ) : walletStatus === TraderWalletStatus.PENDING ? (
+        ) : showLoadingSkeleton ? (
           <AffiliateTraderLoading />
         ) : !savedCode || walletStatus === TraderWalletStatus.DISCONNECTED ? (
           <AffiliateTraderOnboard />

--- a/libs/ui/src/pure/Button/index.tsx
+++ b/libs/ui/src/pure/Button/index.tsx
@@ -23,6 +23,16 @@ type ButtonSecondaryStyleProps = {
   $fontSize?: string
   $minHeight?: string
 }
+export type ButtonPrimaryProps = HTMLAttributes<HTMLButtonElement> &
+  ButtonProps & {
+    altDisabledStyle?: boolean
+    buttonSize?: ButtonSize
+    padding?: string
+    status?: StatusColorVariant
+    width?: string
+    $borderRadius?: string
+    $gap?: string
+  }
 
 function getButtonStatusStyles(status?: StatusColorVariant): ReturnType<typeof css> | undefined {
   if (!status || status === StatusColorVariant.Default) {

--- a/libs/wallet/src/api/types.ts
+++ b/libs/wallet/src/api/types.ts
@@ -16,6 +16,7 @@ export interface WalletInfo {
   chainId: SupportedChainId
   account?: Address
   active?: boolean
+  isConnectionRestoring?: boolean
 }
 
 export interface WalletDetails {

--- a/libs/wallet/src/index.ts
+++ b/libs/wallet/src/index.ts
@@ -19,6 +19,7 @@ export * from './wagmi/hooks/useIsSmartContractWallet'
 export * from './wagmi/hooks/useDisconnectWallet'
 export * from './wagmi/hooks/useSwitchNetwork'
 export * from './wagmi/hooks/useConnectionType'
+export * from './wagmi/hooks/useIsRestoringConnection'
 
 // Updater
 export { WalletUpdater } from './wagmi/updater'

--- a/libs/wallet/src/wagmi/Web3Provider.tsx
+++ b/libs/wallet/src/wagmi/Web3Provider.tsx
@@ -8,6 +8,7 @@ import { reconnect } from '@wagmi/core'
 import { WagmiProvider } from 'wagmi'
 
 import { config, reownAppKit } from './config'
+import { markInitialReconnectSettled } from './initialReconnectLifecycle'
 import { SafeConnectionHandler } from './SafeConnectionHandler'
 
 import { getIsInjectedMobileBrowser } from '../api/utils/connection'
@@ -39,9 +40,13 @@ function reconnectWidgetConnector(): (() => void) | undefined {
     // Clear the shimDisconnect flag so reconnect() passes isAuthorized() even if the
     // connector was previously "disconnected" (which can happen on widget recreations).
     void config.storage?.removeItem(`${COW_WIDGET_CONNECTOR_ID}.disconnected`)
-    reconnect(config, { connectors: [widgetConnector] }).catch((error) => {
-      console.debug('[ReconnectOnMount] widget connector reconnect failed', error)
-    })
+    reconnect(config, { connectors: [widgetConnector] })
+      .catch((error) => {
+        console.debug('[ReconnectOnMount] widget connector reconnect failed', error)
+      })
+      .finally(() => {
+        markInitialReconnectSettled()
+      })
   }
 
   doReconnect()
@@ -79,7 +84,12 @@ function ReconnectOnMount(): null {
   useEffect((): (() => void) | void => {
     // When running as a pure Safe App (not a widget), skip reconnect and let SafeConnectionHandler
     // handle the wallet — reconnecting a previously saved non-Safe connector first causes a race condition.
-    if (isEmbeddedInIframe() && !isInjectedWidget()) return
+    if (isEmbeddedInIframe() && !isInjectedWidget()) {
+      // SafeConnectionHandler drives the connection here; we won't observe a wagmi reconnect lifecycle,
+      // so settle immediately to avoid the restoring spinner getting stuck in this context.
+      markInitialReconnectSettled()
+      return
+    }
 
     if (isInjectedWidget()) {
       // In widget context, use reconnect() (not connect()) to avoid triggering wallet popups.
@@ -114,6 +124,8 @@ function ReconnectOnMount(): null {
             console.debug('[ReconnectOnMount] mobile reconnect result', res)
           } catch (error) {
             console.debug('[ReconnectOnMount] mobile reconnect failed', error)
+          } finally {
+            markInitialReconnectSettled()
           }
         })()
         return
@@ -126,6 +138,9 @@ function ReconnectOnMount(): null {
       })
       .catch((error: unknown) => {
         console.error('[ReconnectOnMount] error', error)
+      })
+      .finally(() => {
+        markInitialReconnectSettled()
       })
   }, [])
   return null

--- a/libs/wallet/src/wagmi/config.ts
+++ b/libs/wallet/src/wagmi/config.ts
@@ -139,6 +139,28 @@ const WAGMI_STORAGE_KEY = isInjectedWidget()
     ? 'cowswap-wallet-safe'
     : 'cowswap-wallet'
 
+function persistedStateHasSession(state: unknown): boolean {
+  if (!state || typeof state !== 'object') return false
+  const s = state as { current?: unknown; connections?: { __type?: string; value?: unknown } }
+  if (typeof s.current === 'string' && s.current) return true
+  const c = s.connections
+  return c?.__type === 'Map' && Array.isArray(c.value) && c.value.length > 0
+}
+
+// Sniff persisted wagmi state synchronously at module init, BEFORE WagmiProvider's
+// `<Hydrate>` mounts and runs `setState({ connections: new Map() })` (which the guard
+// below may rewrite to `current: null`, erasing the signal at runtime). Used by the
+// initialReconnectLifecycle module to know whether a wallet session needs restoring.
+export const HAS_PERSISTED_WAGMI_SESSION = ((): boolean => {
+  if (typeof window === 'undefined') return false
+  try {
+    const raw = window.sessionStorage.getItem(`${WAGMI_STORAGE_KEY}.store`)
+    return raw ? persistedStateHasSession(JSON.parse(raw)?.state) : false
+  } catch {
+    return false
+  }
+})()
+
 const storage =
   typeof window === 'undefined'
     ? createStorage({

--- a/libs/wallet/src/wagmi/hooks/useIsRestoringConnection.ts
+++ b/libs/wallet/src/wagmi/hooks/useIsRestoringConnection.ts
@@ -1,12 +1,27 @@
+import { useSyncExternalStore } from 'react'
+
 import { useConnection } from 'wagmi'
 
 import { useWalletInfo } from '../../api/hooks'
+import { config } from '../config'
+
+function getCurrentConnectorUid(): string | null {
+  return config.state.current ?? null
+}
+
+function subscribeToCurrentConnectorUid(callback: () => void): () => void {
+  return config.subscribe((state) => state.current, callback)
+}
 
 export function useIsRestoringConnection(): boolean {
   const { status } = useConnection()
   const { account } = useWalletInfo()
 
-  // WalletInfo is backed by an atom updated from wagmi, so account can lag behind
-  // the connected status for one render. Keep showing reconnecting during that gap.
-  return status === 'reconnecting' || (status === 'connected' && !account)
+  const currentConnectorUid = useSyncExternalStore(subscribeToCurrentConnectorUid, getCurrentConnectorUid, () => null)
+
+  if (status === 'reconnecting') return true
+  if (status === 'connected' && !account) return true
+  if (!!currentConnectorUid && !account) return true
+
+  return false
 }

--- a/libs/wallet/src/wagmi/hooks/useIsRestoringConnection.ts
+++ b/libs/wallet/src/wagmi/hooks/useIsRestoringConnection.ts
@@ -1,0 +1,12 @@
+import { useConnection } from 'wagmi'
+
+import { useWalletInfo } from '../../api/hooks'
+
+export function useIsRestoringConnection(): boolean {
+  const { status } = useConnection()
+  const { account } = useWalletInfo()
+
+  // WalletInfo is backed by an atom updated from wagmi, so account can lag behind
+  // the connected status for one render. Keep showing reconnecting during that gap.
+  return status === 'reconnecting' || (status === 'connected' && !account)
+}

--- a/libs/wallet/src/wagmi/hooks/useIsRestoringConnection.ts
+++ b/libs/wallet/src/wagmi/hooks/useIsRestoringConnection.ts
@@ -3,25 +3,29 @@ import { useSyncExternalStore } from 'react'
 import { useConnection } from 'wagmi'
 
 import { useWalletInfo } from '../../api/hooks'
-import { config } from '../config'
+import { getInitialReconnectLifecycle, subscribeInitialReconnect } from '../initialReconnectLifecycle'
 
-function getCurrentConnectorUid(): string | null {
-  return config.state.current ?? null
-}
-
-function subscribeToCurrentConnectorUid(callback: () => void): () => void {
-  return config.subscribe((state) => state.current, callback)
+function getServerSnapshot(): 'pending' | 'settled' {
+  return 'settled'
 }
 
 export function useIsRestoringConnection(): boolean {
   const { status } = useConnection()
   const { account } = useWalletInfo()
 
-  const currentConnectorUid = useSyncExternalStore(subscribeToCurrentConnectorUid, getCurrentConnectorUid, () => null)
+  // Web3Provider mounts WagmiProvider with reconnectOnMount={false} and triggers
+  // reconnect() from a useEffect, so wagmi's own `status` only flips to 'reconnecting'
+  // one render after mount. The `config.setState` guard in config.ts then erases
+  // `current` on any subsequent Hydrate.onMount, so we can't rely on the live wagmi
+  // state for the initial-load window either.
+  //
+  // Track the lifecycle explicitly: 'pending' from module init (if sessionStorage held a
+  // session) until ReconnectOnMount calls markInitialReconnectSettled() in every code path.
+  const lifecycle = useSyncExternalStore(subscribeInitialReconnect, getInitialReconnectLifecycle, getServerSnapshot)
 
+  if (lifecycle === 'pending' && !account) return true
   if (status === 'reconnecting') return true
   if (status === 'connected' && !account) return true
-  if (!!currentConnectorUid && !account) return true
 
   return false
 }

--- a/libs/wallet/src/wagmi/initialReconnectLifecycle.ts
+++ b/libs/wallet/src/wagmi/initialReconnectLifecycle.ts
@@ -1,0 +1,23 @@
+import { HAS_PERSISTED_WAGMI_SESSION } from './config'
+
+type Lifecycle = 'pending' | 'settled'
+
+let lifecycle: Lifecycle = HAS_PERSISTED_WAGMI_SESSION ? 'pending' : 'settled'
+const listeners = new Set<() => void>()
+
+export function markInitialReconnectSettled(): void {
+  if (lifecycle === 'settled') return
+  lifecycle = 'settled'
+  for (const listener of listeners) listener()
+}
+
+export function subscribeInitialReconnect(callback: () => void): () => void {
+  listeners.add(callback)
+  return () => {
+    listeners.delete(callback)
+  }
+}
+
+export function getInitialReconnectLifecycle(): Lifecycle {
+  return lifecycle
+}

--- a/libs/wallet/src/wagmi/updater.ts
+++ b/libs/wallet/src/wagmi/updater.ts
@@ -41,7 +41,8 @@ function useBrowserUrlKey(): string {
 
 function useWalletInfo(): WalletInfo {
   const urlKey = useBrowserUrlKey()
-  const { address, chainId, isConnected } = useConnection()
+  const { address, chainId, isConnected, status } = useConnection()
+  const isConnectionRestoring = status === 'reconnecting'
   const isChainIdUnsupported = !!chainId && !(chainId in SupportedChainId)
   const [lastStableChainId, setLastStableChainId] = useState<SupportedChainId | undefined>(undefined)
   const [lastResolvedChainId, setLastResolvedChainId] = useState<SupportedChainId>(() => getCurrentChainIdFromUrl())
@@ -76,8 +77,18 @@ function useWalletInfo(): WalletInfo {
       chainId: resolvedChainId,
       active: isConnected,
       account: address,
+      isConnectionRestoring,
     }
-  }, [address, chainId, isConnected, isChainIdUnsupported, lastStableChainId, lastResolvedChainId, urlKey])
+  }, [
+    address,
+    chainId,
+    isConnected,
+    isChainIdUnsupported,
+    isConnectionRestoring,
+    lastStableChainId,
+    lastResolvedChainId,
+    urlKey,
+  ])
 
   useEffect(() => {
     setLastResolvedChainId(walletInfo.chainId)


### PR DESCRIPTION
# Summary

- Fixes https://www.notion.so/cownation/Add-a-loader-when-page-is-being-loaded-3028da5f04ca801ba19ccdb9dfa9773c
- Shows the affiliate loading skeleton while wallet connection is restoring.
- Applies this to both affiliate partner and trader pages.
- Keeps the regular affiliate onboarding CTAs unchanged once restoration finishes.

# To Test

1. Affiliate partner page with a previously connected wallet

- [ ] Open the affiliate partner onboarding page
- [ ] Refresh with a previously connected wallet
- [ ] Verify the page shows the loading skeleton while wallet restoration is pending
- [ ] Verify the page does not briefly show the disconnected onboarding CTA during restoration
- [ ] After restoration completes, verify the correct partner state is shown

2. Affiliate trader page with a previously connected wallet

- [ ] Open the trader affiliate onboarding page
- [ ] Refresh with a previously connected wallet
- [ ] Verify the page shows the loading skeleton while wallet restoration is pending
- [ ] Verify disconnected users still see `Connect wallet` after restoration completes
- [ ] Verify connected users with no saved code see `Add code`

# Background

With Wagmi/Viem we can detect wallet restoration through `useIsRestoringConnection()`. The affiliate pages now treat that state like other pending page data and show the existing loading skeleton instead of briefly rendering disconnected onboarding UI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wallet restoration indicator displaying "Restoring wallet..." during reconnection attempts
  * Enhanced loading state handling in affiliate pages when wallet connection is being restored

* **Improvements**
  * Updated affiliate onboarding button sizing for better UI presentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cowprotocol/cowswap/pull/7468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->