### PR TITLE
chore: specify exact version for @next/swc-linux-x64-gnu in pnpm

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,5 +11,5 @@ minimumReleaseAgeExclude:
   - next
   - typescript
   - '@types/*'
-  - '@next/*'
+  - '@next/swc-linux-x64-gnu@15.5.18' # security patch
   - '@cowprotocol/*'


### PR DESCRIPTION
# Summary

Builds on top of https://github.com/cowprotocol/cowswap/pull/7471 but only adds an exception for this specific version