### PR TITLE
fix(affiliate): gate feedback button by affiliate network state

### DIFF
--- a/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateFeedbackButton.container.tsx
+++ b/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateFeedbackButton.container.tsx
@@ -1,27 +1,70 @@
+import { useAtomValue } from 'jotai'
 import { type ReactNode, useCallback } from 'react'
 
 import FeedbackIcon from '@cowprotocol/assets/cow-swap/feedback.svg'
 import { useWalletDetails, useWalletInfo } from '@cowprotocol/wallet'
+import { useWalletChainId } from '@cowprotocol/wallet-provider'
 
 import { t } from '@lingui/core/macro'
 import { Trans } from '@lingui/react/macro'
 import { isAppziEnabled, openAffiliateFeedbackAppzi } from 'appzi'
 import SVG from 'react-inlinesvg'
+import { useLocation } from 'react-router'
 
-import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetworkUnsupported'
+import { Routes as RoutesEnum } from 'common/constants/routes'
 
 import * as styledEl from './AffiliateFeedbackButton.styled'
 
+import { TraderWalletStatus, useAffiliateTraderWallet } from '../hooks/useAffiliateTraderWallet'
+import { isSupportedTradingNetwork } from '../lib/affiliateProgramUtils'
+import { affiliateTraderSavedCodeAtom } from '../state/affiliateTraderSavedCodeAtom'
+
+interface AffiliateFeedbackTriggerProps {
+  canShow: boolean
+  chainId?: number
+}
+
 export function AffiliateFeedbackButton(): ReactNode {
-  const { account, chainId } = useWalletInfo()
+  const { pathname } = useLocation()
+
+  if (pathname === RoutesEnum.ACCOUNT_AFFILIATE_PARTNER) {
+    return <AffiliatePartnerFeedbackButton />
+  }
+
+  if (pathname === RoutesEnum.ACCOUNT_AFFILIATE_TRADER) {
+    return <AffiliateTraderFeedbackButton />
+  }
+
+  return null
+}
+
+function AffiliatePartnerFeedbackButton(): ReactNode {
+  const chainId = useWalletChainId()
+
+  return <AffiliateFeedbackTrigger canShow={isSupportedTradingNetwork(chainId)} chainId={chainId} />
+}
+
+function AffiliateTraderFeedbackButton(): ReactNode {
+  const chainId = useWalletChainId()
+  const { savedCode } = useAtomValue(affiliateTraderSavedCodeAtom)
+  const walletStatus = useAffiliateTraderWallet()
+  const canShow =
+    isSupportedTradingNetwork(chainId) && Boolean(savedCode) && walletStatus !== TraderWalletStatus.INELIGIBLE
+
+  return <AffiliateFeedbackTrigger canShow={canShow} chainId={chainId} />
+}
+
+function AffiliateFeedbackTrigger({ canShow, chainId }: AffiliateFeedbackTriggerProps): ReactNode {
+  const { account } = useWalletInfo()
   const { walletName } = useWalletDetails()
-  const isProviderNetworkUnsupported = useIsProviderNetworkUnsupported()
 
   const handleClick = useCallback((): void => {
+    if (!chainId) return
+
     openAffiliateFeedbackAppzi({ account, chainId, walletName })
   }, [account, chainId, walletName])
 
-  if (!isAppziEnabled || !account || isProviderNetworkUnsupported) {
+  if (!isAppziEnabled || !account || !chainId || !canShow) {
     return null
   }
 

--- a/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateFeedbackButton.container.tsx
+++ b/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateFeedbackButton.container.tsx
@@ -8,17 +8,20 @@ import { Trans } from '@lingui/react/macro'
 import { isAppziEnabled, openAffiliateFeedbackAppzi } from 'appzi'
 import SVG from 'react-inlinesvg'
 
+import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetworkUnsupported'
+
 import * as styledEl from './AffiliateFeedbackButton.styled'
 
 export function AffiliateFeedbackButton(): ReactNode {
   const { account, chainId } = useWalletInfo()
   const { walletName } = useWalletDetails()
+  const isProviderNetworkUnsupported = useIsProviderNetworkUnsupported()
 
   const handleClick = useCallback((): void => {
     openAffiliateFeedbackAppzi({ account, chainId, walletName })
   }, [account, chainId, walletName])
 
-  if (!isAppziEnabled) {
+  if (!isAppziEnabled || !account || isProviderNetworkUnsupported) {
     return null
   }
 

--- a/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateFeedbackButton.test.tsx
+++ b/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateFeedbackButton.test.tsx
@@ -1,15 +1,23 @@
+import { useAtomValue } from 'jotai'
+
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { useWalletDetails, useWalletInfo } from '@cowprotocol/wallet'
+import { useWalletChainId } from '@cowprotocol/wallet-provider'
 
 import { i18n } from '@lingui/core'
 import { I18nProvider } from '@lingui/react'
 import { fireEvent, render, screen, type RenderResult } from '@testing-library/react'
 import { openAffiliateFeedbackAppzi } from 'appzi'
+import { MemoryRouter } from 'react-router'
 import { ThemeProvider as StyledComponentsThemeProvider } from 'styled-components/macro'
 import { getCowswapTheme } from 'theme'
 
-import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetworkUnsupported'
+import { Routes as RoutesEnum } from 'common/constants/routes'
 
 import { AffiliateFeedbackButton } from './AffiliateFeedbackButton.container'
+
+import { TraderWalletStatus, useAffiliateTraderWallet } from '../hooks/useAffiliateTraderWallet'
+import { isSupportedTradingNetwork } from '../lib/affiliateProgramUtils'
 
 jest.mock('@cowprotocol/wallet', () => {
   return {
@@ -18,13 +26,35 @@ jest.mock('@cowprotocol/wallet', () => {
   }
 })
 
+jest.mock('@cowprotocol/wallet-provider', () => ({
+  useWalletChainId: jest.fn(),
+}))
+
 jest.mock('appzi', () => ({
   isAppziEnabled: true,
   openAffiliateFeedbackAppzi: jest.fn(),
 }))
 
-jest.mock('common/hooks/useIsProviderNetworkUnsupported', () => ({
-  useIsProviderNetworkUnsupported: jest.fn(),
+jest.mock('jotai', () => {
+  const actualModule = jest.requireActual('jotai')
+
+  return {
+    ...actualModule,
+    useAtomValue: jest.fn(),
+  }
+})
+
+jest.mock('../hooks/useAffiliateTraderWallet', () => ({
+  TraderWalletStatus: {
+    ELIGIBLE: 'eligible',
+    INELIGIBLE: 'ineligible',
+    LINKED: 'linked',
+  },
+  useAffiliateTraderWallet: jest.fn(),
+}))
+
+jest.mock('../lib/affiliateProgramUtils', () => ({
+  isSupportedTradingNetwork: jest.fn((chainId?: number) => chainId !== undefined && chainId !== 11155111),
 }))
 
 jest.mock('react-inlinesvg', () => ({
@@ -34,9 +64,10 @@ jest.mock('react-inlinesvg', () => ({
 
 const useWalletDetailsMock = useWalletDetails as jest.MockedFunction<typeof useWalletDetails>
 const useWalletInfoMock = useWalletInfo as jest.MockedFunction<typeof useWalletInfo>
-const useIsProviderNetworkUnsupportedMock = useIsProviderNetworkUnsupported as jest.MockedFunction<
-  typeof useIsProviderNetworkUnsupported
->
+const useWalletChainIdMock = useWalletChainId as jest.MockedFunction<typeof useWalletChainId>
+const useAtomValueMock = useAtomValue as jest.MockedFunction<typeof useAtomValue>
+const useAffiliateTraderWalletMock = useAffiliateTraderWallet as jest.MockedFunction<typeof useAffiliateTraderWallet>
+const isSupportedTradingNetworkMock = isSupportedTradingNetwork as jest.MockedFunction<typeof isSupportedTradingNetwork>
 const openAffiliateFeedbackAppziMock = openAffiliateFeedbackAppzi as jest.MockedFunction<
   typeof openAffiliateFeedbackAppzi
 >
@@ -44,13 +75,15 @@ const openAffiliateFeedbackAppziMock = openAffiliateFeedbackAppzi as jest.Mocked
 i18n.load('en-US', {})
 i18n.activate('en-US')
 
-function renderComponent(): RenderResult {
+function renderComponent(pathname: string = RoutesEnum.ACCOUNT_AFFILIATE_PARTNER): RenderResult {
   return render(
-    <I18nProvider i18n={i18n}>
-      <StyledComponentsThemeProvider theme={getCowswapTheme(false)}>
-        <AffiliateFeedbackButton />
-      </StyledComponentsThemeProvider>
-    </I18nProvider>,
+    <MemoryRouter initialEntries={[pathname]}>
+      <I18nProvider i18n={i18n}>
+        <StyledComponentsThemeProvider theme={getCowswapTheme(false)}>
+          <AffiliateFeedbackButton />
+        </StyledComponentsThemeProvider>
+      </I18nProvider>
+    </MemoryRouter>,
   )
 }
 
@@ -63,27 +96,40 @@ describe('AffiliateFeedbackButton', () => {
     } as ReturnType<typeof useWalletDetails>)
     useWalletInfoMock.mockReturnValue({
       account: '0x0000000000000000000000000000000000000001',
-      chainId: 1,
+      chainId: SupportedChainId.MAINNET,
     } as ReturnType<typeof useWalletInfo>)
-    useIsProviderNetworkUnsupportedMock.mockReturnValue(false)
+    useWalletChainIdMock.mockReturnValue(SupportedChainId.MAINNET)
+    useAtomValueMock.mockReturnValue({ savedCode: 'COW-123', isLinked: true })
+    useAffiliateTraderWalletMock.mockReturnValue(TraderWalletStatus.LINKED)
+    isSupportedTradingNetworkMock.mockImplementation(
+      (chainId?: number) => chainId !== undefined && chainId !== 11155111,
+    )
   })
 
-  it('opens the Appzi feedback form with wallet context', () => {
+  it('opens the Appzi feedback form with wallet context on the affiliate page', () => {
     renderComponent()
 
     fireEvent.click(screen.getByRole('button', { name: 'Give feedback' }))
 
     expect(openAffiliateFeedbackAppziMock).toHaveBeenCalledWith({
       account: '0x0000000000000000000000000000000000000001',
-      chainId: 1,
+      chainId: SupportedChainId.MAINNET,
       walletName: 'Safe',
     })
+  })
+
+  it('renders on the affiliate page for supported non-Ethereum affiliate networks', () => {
+    useWalletChainIdMock.mockReturnValue(SupportedChainId.BNB)
+
+    renderComponent()
+
+    expect(screen.getByRole('button', { name: 'Give feedback' })).not.toBeNull()
   })
 
   it('does not render without a connected wallet', () => {
     useWalletInfoMock.mockReturnValue({
       account: undefined,
-      chainId: 1,
+      chainId: SupportedChainId.MAINNET,
     } as ReturnType<typeof useWalletInfo>)
 
     renderComponent()
@@ -91,10 +137,49 @@ describe('AffiliateFeedbackButton', () => {
     expect(screen.queryByRole('button', { name: 'Give feedback' })).toBeNull()
   })
 
-  it('does not render when the provider network is unsupported', () => {
-    useIsProviderNetworkUnsupportedMock.mockReturnValue(true)
+  it('does not render on the affiliate page when the network is not affiliate-supported', () => {
+    useWalletChainIdMock.mockReturnValue(11155111)
 
     renderComponent()
+
+    expect(screen.queryByRole('button', { name: 'Give feedback' })).toBeNull()
+  })
+
+  it('renders on the My Rewards page when a saved code exists and the trader is eligible', () => {
+    useAffiliateTraderWalletMock.mockReturnValue(TraderWalletStatus.ELIGIBLE)
+
+    renderComponent(RoutesEnum.ACCOUNT_AFFILIATE_TRADER)
+
+    expect(screen.getByRole('button', { name: 'Give feedback' })).not.toBeNull()
+  })
+
+  it('does not render on the My Rewards page when no code is saved', () => {
+    useAtomValueMock.mockReturnValue({})
+    useAffiliateTraderWalletMock.mockReturnValue(TraderWalletStatus.ELIGIBLE)
+
+    renderComponent(RoutesEnum.ACCOUNT_AFFILIATE_TRADER)
+
+    expect(screen.queryByRole('button', { name: 'Give feedback' })).toBeNull()
+  })
+
+  it('does not render on the My Rewards page when the trader is ineligible', () => {
+    useAffiliateTraderWalletMock.mockReturnValue(TraderWalletStatus.INELIGIBLE)
+
+    renderComponent(RoutesEnum.ACCOUNT_AFFILIATE_TRADER)
+
+    expect(screen.queryByRole('button', { name: 'Give feedback' })).toBeNull()
+  })
+
+  it('does not render on the My Rewards page when the network is not affiliate-supported', () => {
+    useWalletChainIdMock.mockReturnValue(11155111)
+
+    renderComponent(RoutesEnum.ACCOUNT_AFFILIATE_TRADER)
+
+    expect(screen.queryByRole('button', { name: 'Give feedback' })).toBeNull()
+  })
+
+  it('does not render outside affiliate account pages', () => {
+    renderComponent(RoutesEnum.ACCOUNT_TOKENS)
 
     expect(screen.queryByRole('button', { name: 'Give feedback' })).toBeNull()
   })

--- a/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateFeedbackButton.test.tsx
+++ b/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateFeedbackButton.test.tsx
@@ -7,6 +7,8 @@ import { openAffiliateFeedbackAppzi } from 'appzi'
 import { ThemeProvider as StyledComponentsThemeProvider } from 'styled-components/macro'
 import { getCowswapTheme } from 'theme'
 
+import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetworkUnsupported'
+
 import { AffiliateFeedbackButton } from './AffiliateFeedbackButton.container'
 
 jest.mock('@cowprotocol/wallet', () => {
@@ -21,6 +23,10 @@ jest.mock('appzi', () => ({
   openAffiliateFeedbackAppzi: jest.fn(),
 }))
 
+jest.mock('common/hooks/useIsProviderNetworkUnsupported', () => ({
+  useIsProviderNetworkUnsupported: jest.fn(),
+}))
+
 jest.mock('react-inlinesvg', () => ({
   __esModule: true,
   default: () => null,
@@ -28,6 +34,9 @@ jest.mock('react-inlinesvg', () => ({
 
 const useWalletDetailsMock = useWalletDetails as jest.MockedFunction<typeof useWalletDetails>
 const useWalletInfoMock = useWalletInfo as jest.MockedFunction<typeof useWalletInfo>
+const useIsProviderNetworkUnsupportedMock = useIsProviderNetworkUnsupported as jest.MockedFunction<
+  typeof useIsProviderNetworkUnsupported
+>
 const openAffiliateFeedbackAppziMock = openAffiliateFeedbackAppzi as jest.MockedFunction<
   typeof openAffiliateFeedbackAppzi
 >
@@ -56,6 +65,7 @@ describe('AffiliateFeedbackButton', () => {
       account: '0x0000000000000000000000000000000000000001',
       chainId: 1,
     } as ReturnType<typeof useWalletInfo>)
+    useIsProviderNetworkUnsupportedMock.mockReturnValue(false)
   })
 
   it('opens the Appzi feedback form with wallet context', () => {
@@ -68,5 +78,24 @@ describe('AffiliateFeedbackButton', () => {
       chainId: 1,
       walletName: 'Safe',
     })
+  })
+
+  it('does not render without a connected wallet', () => {
+    useWalletInfoMock.mockReturnValue({
+      account: undefined,
+      chainId: 1,
+    } as ReturnType<typeof useWalletInfo>)
+
+    renderComponent()
+
+    expect(screen.queryByRole('button', { name: 'Give feedback' })).toBeNull()
+  })
+
+  it('does not render when the provider network is unsupported', () => {
+    useIsProviderNetworkUnsupportedMock.mockReturnValue(true)
+
+    renderComponent()
+
+    expect(screen.queryByRole('button', { name: 'Give feedback' })).toBeNull()
   })
 })

--- a/apps/cowswap-frontend/src/pages/Account/index.test.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/index.test.tsx
@@ -13,11 +13,16 @@ import { getCowswapTheme } from 'theme'
 import { TraderWalletStatus, useAffiliateTraderWallet } from 'modules/affiliate'
 
 import { Routes as RoutesEnum } from 'common/constants/routes'
+import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetworkUnsupported'
 
 import Account from './index'
 
 jest.mock('@cowprotocol/wallet', () => ({
   useWalletInfo: jest.fn(),
+}))
+
+jest.mock('common/hooks/useIsProviderNetworkUnsupported', () => ({
+  useIsProviderNetworkUnsupported: jest.fn(),
 }))
 
 jest.mock('jotai', () => {
@@ -51,6 +56,9 @@ jest.mock('./Menu', () => ({
 }))
 
 const useWalletInfoMock = useWalletInfo as jest.MockedFunction<typeof useWalletInfo>
+const useIsProviderNetworkUnsupportedMock = useIsProviderNetworkUnsupported as jest.MockedFunction<
+  typeof useIsProviderNetworkUnsupported
+>
 const useAtomValueMock = useAtomValue as jest.MockedFunction<typeof useAtomValue>
 const useAffiliateTraderWalletMock = useAffiliateTraderWallet as jest.MockedFunction<typeof useAffiliateTraderWallet>
 
@@ -84,12 +92,29 @@ describe('Account', () => {
     jest.clearAllMocks()
     useAtomValueMock.mockReturnValue({ savedCode: 'COW-123', isLinked: true })
     useAffiliateTraderWalletMock.mockReturnValue(TraderWalletStatus.LINKED)
+    useIsProviderNetworkUnsupportedMock.mockReturnValue(false)
   })
 
   it('shows the feedback button on the affiliate page when a wallet is connected', () => {
     renderComponent(RoutesEnum.ACCOUNT_AFFILIATE_PARTNER, '0x0000000000000000000000000000000000000001')
 
     expect(screen.getByRole('button', { name: 'Give feedback' })).not.toBeNull()
+    expect(useAffiliateTraderWalletMock).not.toHaveBeenCalled()
+  })
+
+  it('does not show the feedback button on the affiliate page without a connected wallet', () => {
+    renderComponent(RoutesEnum.ACCOUNT_AFFILIATE_PARTNER)
+
+    expect(screen.queryByRole('button', { name: 'Give feedback' })).toBeNull()
+    expect(useAffiliateTraderWalletMock).not.toHaveBeenCalled()
+  })
+
+  it('does not show the feedback button on the affiliate page when the provider network is unsupported', () => {
+    useIsProviderNetworkUnsupportedMock.mockReturnValue(true)
+
+    renderComponent(RoutesEnum.ACCOUNT_AFFILIATE_PARTNER, '0x0000000000000000000000000000000000000001')
+
+    expect(screen.queryByRole('button', { name: 'Give feedback' })).toBeNull()
     expect(useAffiliateTraderWalletMock).not.toHaveBeenCalled()
   })
 

--- a/apps/cowswap-frontend/src/pages/Account/index.test.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/index.test.tsx
@@ -2,6 +2,7 @@ import { useAtomValue } from 'jotai'
 import { type ReactNode } from 'react'
 
 import { useWalletInfo } from '@cowprotocol/wallet'
+import { useWalletChainId } from '@cowprotocol/wallet-provider'
 
 import { i18n } from '@lingui/core'
 import { I18nProvider } from '@lingui/react'
@@ -10,7 +11,7 @@ import { MemoryRouter, Route, Routes } from 'react-router'
 import { ThemeProvider as StyledComponentsThemeProvider } from 'styled-components/macro'
 import { getCowswapTheme } from 'theme'
 
-import { TraderWalletStatus, useAffiliateTraderWallet } from 'modules/affiliate'
+import { TraderWalletStatus, isSupportedPayoutsNetwork, useAffiliateTraderWallet } from 'modules/affiliate'
 
 import { Routes as RoutesEnum } from 'common/constants/routes'
 import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetworkUnsupported'
@@ -19,6 +20,10 @@ import Account from './index'
 
 jest.mock('@cowprotocol/wallet', () => ({
   useWalletInfo: jest.fn(),
+}))
+
+jest.mock('@cowprotocol/wallet-provider', () => ({
+  useWalletChainId: jest.fn(),
 }))
 
 jest.mock('common/hooks/useIsProviderNetworkUnsupported', () => ({
@@ -42,6 +47,7 @@ jest.mock('modules/affiliate', () => ({
     LINKED: 'linked',
   },
   affiliateTraderSavedCodeAtom: Symbol('affiliateTraderSavedCodeAtom'),
+  isSupportedPayoutsNetwork: jest.fn((chainId?: number) => chainId === 1),
   useAffiliateTraderWallet: jest.fn(),
 }))
 
@@ -56,10 +62,12 @@ jest.mock('./Menu', () => ({
 }))
 
 const useWalletInfoMock = useWalletInfo as jest.MockedFunction<typeof useWalletInfo>
+const useWalletChainIdMock = useWalletChainId as jest.MockedFunction<typeof useWalletChainId>
 const useIsProviderNetworkUnsupportedMock = useIsProviderNetworkUnsupported as jest.MockedFunction<
   typeof useIsProviderNetworkUnsupported
 >
 const useAtomValueMock = useAtomValue as jest.MockedFunction<typeof useAtomValue>
+const isSupportedPayoutsNetworkMock = isSupportedPayoutsNetwork as jest.MockedFunction<typeof isSupportedPayoutsNetwork>
 const useAffiliateTraderWalletMock = useAffiliateTraderWallet as jest.MockedFunction<typeof useAffiliateTraderWallet>
 
 i18n.load('en-US', {})
@@ -90,8 +98,10 @@ function renderComponent(pathname: string, account?: string): RenderResult {
 describe('Account', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    useWalletChainIdMock.mockReturnValue(1)
     useAtomValueMock.mockReturnValue({ savedCode: 'COW-123', isLinked: true })
     useAffiliateTraderWalletMock.mockReturnValue(TraderWalletStatus.LINKED)
+    isSupportedPayoutsNetworkMock.mockImplementation((chainId?: number) => chainId === 1)
     useIsProviderNetworkUnsupportedMock.mockReturnValue(false)
   })
 
@@ -99,6 +109,15 @@ describe('Account', () => {
     renderComponent(RoutesEnum.ACCOUNT_AFFILIATE_PARTNER, '0x0000000000000000000000000000000000000001')
 
     expect(screen.getByRole('button', { name: 'Give feedback' })).not.toBeNull()
+    expect(useAffiliateTraderWalletMock).not.toHaveBeenCalled()
+  })
+
+  it('does not show the feedback button on the affiliate page when the wallet is not on the payout network', () => {
+    useWalletChainIdMock.mockReturnValue(100)
+
+    renderComponent(RoutesEnum.ACCOUNT_AFFILIATE_PARTNER, '0x0000000000000000000000000000000000000001')
+
+    expect(screen.queryByRole('button', { name: 'Give feedback' })).toBeNull()
     expect(useAffiliateTraderWalletMock).not.toHaveBeenCalled()
   })
 

--- a/apps/cowswap-frontend/src/pages/Account/index.test.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/index.test.tsx
@@ -11,7 +11,12 @@ import { MemoryRouter, Route, Routes } from 'react-router'
 import { ThemeProvider as StyledComponentsThemeProvider } from 'styled-components/macro'
 import { getCowswapTheme } from 'theme'
 
-import { TraderWalletStatus, isSupportedPayoutsNetwork, useAffiliateTraderWallet } from 'modules/affiliate'
+import {
+  TraderWalletStatus,
+  isSupportedPayoutsNetwork,
+  isSupportedTradingNetwork,
+  useAffiliateTraderWallet,
+} from 'modules/affiliate'
 
 import { Routes as RoutesEnum } from 'common/constants/routes'
 import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetworkUnsupported'
@@ -48,6 +53,7 @@ jest.mock('modules/affiliate', () => ({
   },
   affiliateTraderSavedCodeAtom: Symbol('affiliateTraderSavedCodeAtom'),
   isSupportedPayoutsNetwork: jest.fn((chainId?: number) => chainId === 1),
+  isSupportedTradingNetwork: jest.fn((chainId?: number) => chainId !== undefined && chainId !== 11155111),
   useAffiliateTraderWallet: jest.fn(),
 }))
 
@@ -68,6 +74,7 @@ const useIsProviderNetworkUnsupportedMock = useIsProviderNetworkUnsupported as j
 >
 const useAtomValueMock = useAtomValue as jest.MockedFunction<typeof useAtomValue>
 const isSupportedPayoutsNetworkMock = isSupportedPayoutsNetwork as jest.MockedFunction<typeof isSupportedPayoutsNetwork>
+const isSupportedTradingNetworkMock = isSupportedTradingNetwork as jest.MockedFunction<typeof isSupportedTradingNetwork>
 const useAffiliateTraderWalletMock = useAffiliateTraderWallet as jest.MockedFunction<typeof useAffiliateTraderWallet>
 
 i18n.load('en-US', {})
@@ -102,6 +109,9 @@ describe('Account', () => {
     useAtomValueMock.mockReturnValue({ savedCode: 'COW-123', isLinked: true })
     useAffiliateTraderWalletMock.mockReturnValue(TraderWalletStatus.LINKED)
     isSupportedPayoutsNetworkMock.mockImplementation((chainId?: number) => chainId === 1)
+    isSupportedTradingNetworkMock.mockImplementation(
+      (chainId?: number) => chainId !== undefined && chainId !== 11155111,
+    )
     useIsProviderNetworkUnsupportedMock.mockReturnValue(false)
   })
 
@@ -143,6 +153,15 @@ describe('Account', () => {
     renderComponent(RoutesEnum.ACCOUNT_AFFILIATE_TRADER, '0x0000000000000000000000000000000000000001')
 
     expect(screen.getByRole('button', { name: 'Give feedback' })).not.toBeNull()
+  })
+
+  it('does not show the feedback button on the My Rewards page when the wallet is not on a supported trading network', () => {
+    useWalletChainIdMock.mockReturnValue(11155111)
+
+    renderComponent(RoutesEnum.ACCOUNT_AFFILIATE_TRADER, '0x0000000000000000000000000000000000000001')
+
+    expect(screen.queryByRole('button', { name: 'Give feedback' })).toBeNull()
+    expect(useAffiliateTraderWalletMock).not.toHaveBeenCalled()
   })
 
   it('does not show the feedback button on the My Rewards page when no code is saved', () => {

--- a/apps/cowswap-frontend/src/pages/Account/index.test.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/index.test.tsx
@@ -1,8 +1,4 @@
-import { useAtomValue } from 'jotai'
 import { type ReactNode } from 'react'
-
-import { useWalletInfo } from '@cowprotocol/wallet'
-import { useWalletChainId } from '@cowprotocol/wallet-provider'
 
 import { i18n } from '@lingui/core'
 import { I18nProvider } from '@lingui/react'
@@ -11,50 +7,12 @@ import { MemoryRouter, Route, Routes } from 'react-router'
 import { ThemeProvider as StyledComponentsThemeProvider } from 'styled-components/macro'
 import { getCowswapTheme } from 'theme'
 
-import {
-  TraderWalletStatus,
-  isSupportedPayoutsNetwork,
-  isSupportedTradingNetwork,
-  useAffiliateTraderWallet,
-} from 'modules/affiliate'
-
 import { Routes as RoutesEnum } from 'common/constants/routes'
-import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetworkUnsupported'
 
 import Account from './index'
 
-jest.mock('@cowprotocol/wallet', () => ({
-  useWalletInfo: jest.fn(),
-}))
-
-jest.mock('@cowprotocol/wallet-provider', () => ({
-  useWalletChainId: jest.fn(),
-}))
-
-jest.mock('common/hooks/useIsProviderNetworkUnsupported', () => ({
-  useIsProviderNetworkUnsupported: jest.fn(),
-}))
-
-jest.mock('jotai', () => {
-  const actualModule = jest.requireActual('jotai')
-
-  return {
-    ...actualModule,
-    useAtomValue: jest.fn(),
-  }
-})
-
 jest.mock('modules/affiliate', () => ({
   AffiliateFeedbackButton: () => <button type="button">Give feedback</button>,
-  TraderWalletStatus: {
-    ELIGIBLE: 'eligible',
-    INELIGIBLE: 'ineligible',
-    LINKED: 'linked',
-  },
-  affiliateTraderSavedCodeAtom: Symbol('affiliateTraderSavedCodeAtom'),
-  isSupportedPayoutsNetwork: jest.fn((chainId?: number) => chainId === 1),
-  isSupportedTradingNetwork: jest.fn((chainId?: number) => chainId !== undefined && chainId !== 11155111),
-  useAffiliateTraderWallet: jest.fn(),
 }))
 
 jest.mock('modules/application', () => ({
@@ -67,24 +25,10 @@ jest.mock('./Menu', () => ({
   AccountMenu: () => <nav aria-label="Account menu" />,
 }))
 
-const useWalletInfoMock = useWalletInfo as jest.MockedFunction<typeof useWalletInfo>
-const useWalletChainIdMock = useWalletChainId as jest.MockedFunction<typeof useWalletChainId>
-const useIsProviderNetworkUnsupportedMock = useIsProviderNetworkUnsupported as jest.MockedFunction<
-  typeof useIsProviderNetworkUnsupported
->
-const useAtomValueMock = useAtomValue as jest.MockedFunction<typeof useAtomValue>
-const isSupportedPayoutsNetworkMock = isSupportedPayoutsNetwork as jest.MockedFunction<typeof isSupportedPayoutsNetwork>
-const isSupportedTradingNetworkMock = isSupportedTradingNetwork as jest.MockedFunction<typeof isSupportedTradingNetwork>
-const useAffiliateTraderWalletMock = useAffiliateTraderWallet as jest.MockedFunction<typeof useAffiliateTraderWallet>
-
 i18n.load('en-US', {})
 i18n.activate('en-US')
 
-function renderComponent(pathname: string, account?: string): RenderResult {
-  useWalletInfoMock.mockReturnValue({
-    account,
-  } as ReturnType<typeof useWalletInfo>)
-
+function renderComponent(pathname: string): RenderResult {
   return render(
     <MemoryRouter initialEntries={[pathname]}>
       <I18nProvider i18n={i18n}>
@@ -105,91 +49,22 @@ function renderComponent(pathname: string, account?: string): RenderResult {
 describe('Account', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    useWalletChainIdMock.mockReturnValue(1)
-    useAtomValueMock.mockReturnValue({ savedCode: 'COW-123', isLinked: true })
-    useAffiliateTraderWalletMock.mockReturnValue(TraderWalletStatus.LINKED)
-    isSupportedPayoutsNetworkMock.mockImplementation((chainId?: number) => chainId === 1)
-    isSupportedTradingNetworkMock.mockImplementation(
-      (chainId?: number) => chainId !== undefined && chainId !== 11155111,
-    )
-    useIsProviderNetworkUnsupportedMock.mockReturnValue(false)
   })
 
-  it('shows the feedback button on the affiliate page when a wallet is connected', () => {
-    renderComponent(RoutesEnum.ACCOUNT_AFFILIATE_PARTNER, '0x0000000000000000000000000000000000000001')
-
-    expect(screen.getByRole('button', { name: 'Give feedback' })).not.toBeNull()
-    expect(useAffiliateTraderWalletMock).not.toHaveBeenCalled()
-  })
-
-  it('does not show the feedback button on the affiliate page when the wallet is not on the payout network', () => {
-    useWalletChainIdMock.mockReturnValue(100)
-
-    renderComponent(RoutesEnum.ACCOUNT_AFFILIATE_PARTNER, '0x0000000000000000000000000000000000000001')
-
-    expect(screen.queryByRole('button', { name: 'Give feedback' })).toBeNull()
-    expect(useAffiliateTraderWalletMock).not.toHaveBeenCalled()
-  })
-
-  it('does not show the feedback button on the affiliate page without a connected wallet', () => {
+  it('includes the feedback button on the affiliate page title', () => {
     renderComponent(RoutesEnum.ACCOUNT_AFFILIATE_PARTNER)
 
-    expect(screen.queryByRole('button', { name: 'Give feedback' })).toBeNull()
-    expect(useAffiliateTraderWalletMock).not.toHaveBeenCalled()
-  })
-
-  it('does not show the feedback button on the affiliate page when the provider network is unsupported', () => {
-    useIsProviderNetworkUnsupportedMock.mockReturnValue(true)
-
-    renderComponent(RoutesEnum.ACCOUNT_AFFILIATE_PARTNER, '0x0000000000000000000000000000000000000001')
-
-    expect(screen.queryByRole('button', { name: 'Give feedback' })).toBeNull()
-    expect(useAffiliateTraderWalletMock).not.toHaveBeenCalled()
-  })
-
-  it('shows the feedback button on the My Rewards page when an eligible wallet is connected', () => {
-    useAffiliateTraderWalletMock.mockReturnValue(TraderWalletStatus.ELIGIBLE)
-
-    renderComponent(RoutesEnum.ACCOUNT_AFFILIATE_TRADER, '0x0000000000000000000000000000000000000001')
-
     expect(screen.getByRole('button', { name: 'Give feedback' })).not.toBeNull()
   })
 
-  it('does not show the feedback button on the My Rewards page when the wallet is not on a supported trading network', () => {
-    useWalletChainIdMock.mockReturnValue(11155111)
-
-    renderComponent(RoutesEnum.ACCOUNT_AFFILIATE_TRADER, '0x0000000000000000000000000000000000000001')
-
-    expect(screen.queryByRole('button', { name: 'Give feedback' })).toBeNull()
-    expect(useAffiliateTraderWalletMock).not.toHaveBeenCalled()
-  })
-
-  it('does not show the feedback button on the My Rewards page when no code is saved', () => {
-    useAtomValueMock.mockReturnValue({})
-    useAffiliateTraderWalletMock.mockReturnValue(TraderWalletStatus.ELIGIBLE)
-
-    renderComponent(RoutesEnum.ACCOUNT_AFFILIATE_TRADER, '0x0000000000000000000000000000000000000001')
-
-    expect(screen.queryByRole('button', { name: 'Give feedback' })).toBeNull()
-  })
-
-  it('does not show the feedback button on the My Rewards page when the wallet is ineligible', () => {
-    useAffiliateTraderWalletMock.mockReturnValue(TraderWalletStatus.INELIGIBLE)
-
-    renderComponent(RoutesEnum.ACCOUNT_AFFILIATE_TRADER, '0x0000000000000000000000000000000000000001')
-
-    expect(screen.queryByRole('button', { name: 'Give feedback' })).toBeNull()
-  })
-
-  it('does not show the feedback button on the My Rewards page without a connected wallet', () => {
+  it('includes the feedback button on the My Rewards page title', () => {
     renderComponent(RoutesEnum.ACCOUNT_AFFILIATE_TRADER)
 
-    expect(screen.queryByRole('button', { name: 'Give feedback' })).toBeNull()
-    expect(useAffiliateTraderWalletMock).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'Give feedback' })).not.toBeNull()
   })
 
   it('does not show the feedback button on other account pages', () => {
-    renderComponent(RoutesEnum.ACCOUNT_TOKENS, '0x0000000000000000000000000000000000000001')
+    renderComponent(RoutesEnum.ACCOUNT_TOKENS)
 
     expect(screen.queryByRole('button', { name: 'Give feedback' })).toBeNull()
   })

--- a/apps/cowswap-frontend/src/pages/Account/index.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/index.tsx
@@ -14,6 +14,7 @@ import {
   TraderWalletStatus,
   affiliateTraderSavedCodeAtom,
   isSupportedPayoutsNetwork,
+  isSupportedTradingNetwork,
   useAffiliateTraderWallet,
 } from 'modules/affiliate'
 import { Content, PageTitle, Title } from 'modules/application'
@@ -33,6 +34,7 @@ const Delegate = lazy(() => import(/* webpackChunkName: "delegate" */ 'pages/Acc
 interface AccountTitleProps {
   canShowAffiliateFeedbackButton: boolean
   canShowAffiliatePartnerFeedbackButton: boolean
+  canShowAffiliateTraderFeedbackButton: boolean
   id?: string
   name?: string
   pathname: string
@@ -66,6 +68,7 @@ function MyRewardsTitleWithFeedback({ id, name }: TitleWithFeedbackProps): React
 function AccountTitle({
   canShowAffiliateFeedbackButton,
   canShowAffiliatePartnerFeedbackButton,
+  canShowAffiliateTraderFeedbackButton,
   id,
   name,
   pathname,
@@ -83,6 +86,10 @@ function AccountTitle({
   }
 
   if (pathname === RoutesEnum.ACCOUNT_AFFILIATE_TRADER) {
+    if (!canShowAffiliateTraderFeedbackButton) {
+      return <Title id={id}>{name}</Title>
+    }
+
     return <MyRewardsTitleWithFeedback id={id} name={name} />
   }
 
@@ -133,6 +140,8 @@ export default function Account(): ReactNode {
   const canShowAffiliateFeedbackButton = Boolean(account) && !isProviderNetworkUnsupported
   const canShowAffiliatePartnerFeedbackButton =
     canShowAffiliateFeedbackButton && isSupportedPayoutsNetwork(walletChainId)
+  const canShowAffiliateTraderFeedbackButton =
+    canShowAffiliateFeedbackButton && isSupportedTradingNetwork(walletChainId)
 
   return (
     <Wrapper>
@@ -141,6 +150,7 @@ export default function Account(): ReactNode {
         <Content>
           <AccountTitle
             canShowAffiliatePartnerFeedbackButton={canShowAffiliatePartnerFeedbackButton}
+            canShowAffiliateTraderFeedbackButton={canShowAffiliateTraderFeedbackButton}
             canShowAffiliateFeedbackButton={canShowAffiliateFeedbackButton}
             id={id}
             name={name}

--- a/apps/cowswap-frontend/src/pages/Account/index.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/index.tsx
@@ -17,6 +17,7 @@ import {
 import { Content, PageTitle, Title } from 'modules/application'
 
 import { Routes as RoutesEnum } from 'common/constants/routes'
+import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetworkUnsupported'
 
 import { AccountMenu } from './Menu'
 import { CardsWrapper, Container, TitleRow } from './styled'
@@ -113,8 +114,9 @@ export const AccountOverview = (): ReactNode => {
 export default function Account(): ReactNode {
   const { pathname } = useLocation()
   const { account } = useWalletInfo()
+  const isProviderNetworkUnsupported = useIsProviderNetworkUnsupported()
   const [id, name] = getPropsFromRoute(pathname)
-  const canShowAffiliateFeedbackButton = Boolean(account)
+  const canShowAffiliateFeedbackButton = Boolean(account) && !isProviderNetworkUnsupported
 
   return (
     <Wrapper>

--- a/apps/cowswap-frontend/src/pages/Account/index.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/index.tsx
@@ -3,6 +3,7 @@ import { lazy, ReactNode } from 'react'
 
 import { PAGE_TITLES } from '@cowprotocol/common-const'
 import { useWalletInfo } from '@cowprotocol/wallet'
+import { useWalletChainId } from '@cowprotocol/wallet-provider'
 
 import { t } from '@lingui/core/macro'
 import { useLingui } from '@lingui/react/macro'
@@ -12,6 +13,7 @@ import {
   AffiliateFeedbackButton,
   TraderWalletStatus,
   affiliateTraderSavedCodeAtom,
+  isSupportedPayoutsNetwork,
   useAffiliateTraderWallet,
 } from 'modules/affiliate'
 import { Content, PageTitle, Title } from 'modules/application'
@@ -30,6 +32,7 @@ const Delegate = lazy(() => import(/* webpackChunkName: "delegate" */ 'pages/Acc
 
 interface AccountTitleProps {
   canShowAffiliateFeedbackButton: boolean
+  canShowAffiliatePartnerFeedbackButton: boolean
   id?: string
   name?: string
   pathname: string
@@ -60,13 +63,23 @@ function MyRewardsTitleWithFeedback({ id, name }: TitleWithFeedbackProps): React
   return <TitleWithFeedback id={id} name={name} />
 }
 
-function AccountTitle({ canShowAffiliateFeedbackButton, id, name, pathname }: AccountTitleProps): ReactNode {
-  if (!canShowAffiliateFeedbackButton) {
+function AccountTitle({
+  canShowAffiliateFeedbackButton,
+  canShowAffiliatePartnerFeedbackButton,
+  id,
+  name,
+  pathname,
+}: AccountTitleProps): ReactNode {
+  if (pathname === RoutesEnum.ACCOUNT_AFFILIATE_PARTNER) {
+    if (canShowAffiliatePartnerFeedbackButton) {
+      return <TitleWithFeedback id={id} name={name} />
+    }
+
     return <Title id={id}>{name}</Title>
   }
 
-  if (pathname === RoutesEnum.ACCOUNT_AFFILIATE_PARTNER) {
-    return <TitleWithFeedback id={id} name={name} />
+  if (!canShowAffiliateFeedbackButton) {
+    return <Title id={id}>{name}</Title>
   }
 
   if (pathname === RoutesEnum.ACCOUNT_AFFILIATE_TRADER) {
@@ -114,9 +127,12 @@ export const AccountOverview = (): ReactNode => {
 export default function Account(): ReactNode {
   const { pathname } = useLocation()
   const { account } = useWalletInfo()
+  const walletChainId = useWalletChainId()
   const isProviderNetworkUnsupported = useIsProviderNetworkUnsupported()
   const [id, name] = getPropsFromRoute(pathname)
   const canShowAffiliateFeedbackButton = Boolean(account) && !isProviderNetworkUnsupported
+  const canShowAffiliatePartnerFeedbackButton =
+    canShowAffiliateFeedbackButton && isSupportedPayoutsNetwork(walletChainId)
 
   return (
     <Wrapper>
@@ -124,6 +140,7 @@ export default function Account(): ReactNode {
       <AccountPageWrapper>
         <Content>
           <AccountTitle
+            canShowAffiliatePartnerFeedbackButton={canShowAffiliatePartnerFeedbackButton}
             canShowAffiliateFeedbackButton={canShowAffiliateFeedbackButton}
             id={id}
             name={name}

--- a/apps/cowswap-frontend/src/pages/Account/index.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/index.tsx
@@ -1,26 +1,15 @@
-import { useAtomValue } from 'jotai'
 import { lazy, ReactNode } from 'react'
 
 import { PAGE_TITLES } from '@cowprotocol/common-const'
-import { useWalletInfo } from '@cowprotocol/wallet'
-import { useWalletChainId } from '@cowprotocol/wallet-provider'
 
 import { t } from '@lingui/core/macro'
 import { useLingui } from '@lingui/react/macro'
 import { Outlet, useLocation } from 'react-router'
 
-import {
-  AffiliateFeedbackButton,
-  TraderWalletStatus,
-  affiliateTraderSavedCodeAtom,
-  isSupportedPayoutsNetwork,
-  isSupportedTradingNetwork,
-  useAffiliateTraderWallet,
-} from 'modules/affiliate'
+import { AffiliateFeedbackButton } from 'modules/affiliate'
 import { Content, PageTitle, Title } from 'modules/application'
 
 import { Routes as RoutesEnum } from 'common/constants/routes'
-import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetworkUnsupported'
 
 import { AccountMenu } from './Menu'
 import { CardsWrapper, Container, TitleRow } from './styled'
@@ -32,9 +21,6 @@ const Governance = lazy(() => import(/* webpackChunkName: "governance" */ 'pages
 const Delegate = lazy(() => import(/* webpackChunkName: "delegate" */ 'pages/Account/Delegate'))
 
 interface AccountTitleProps {
-  canShowAffiliateFeedbackButton: boolean
-  canShowAffiliatePartnerFeedbackButton: boolean
-  canShowAffiliateTraderFeedbackButton: boolean
   id?: string
   name?: string
   pathname: string
@@ -54,43 +40,9 @@ function TitleWithFeedback({ id, name }: TitleWithFeedbackProps): ReactNode {
   )
 }
 
-function MyRewardsTitleWithFeedback({ id, name }: TitleWithFeedbackProps): ReactNode {
-  const { savedCode } = useAtomValue(affiliateTraderSavedCodeAtom)
-  const walletStatus = useAffiliateTraderWallet()
-
-  if (!savedCode || walletStatus === TraderWalletStatus.INELIGIBLE) {
-    return <Title id={id}>{name}</Title>
-  }
-
-  return <TitleWithFeedback id={id} name={name} />
-}
-
-function AccountTitle({
-  canShowAffiliateFeedbackButton,
-  canShowAffiliatePartnerFeedbackButton,
-  canShowAffiliateTraderFeedbackButton,
-  id,
-  name,
-  pathname,
-}: AccountTitleProps): ReactNode {
-  if (pathname === RoutesEnum.ACCOUNT_AFFILIATE_PARTNER) {
-    if (canShowAffiliatePartnerFeedbackButton) {
-      return <TitleWithFeedback id={id} name={name} />
-    }
-
-    return <Title id={id}>{name}</Title>
-  }
-
-  if (!canShowAffiliateFeedbackButton) {
-    return <Title id={id}>{name}</Title>
-  }
-
-  if (pathname === RoutesEnum.ACCOUNT_AFFILIATE_TRADER) {
-    if (!canShowAffiliateTraderFeedbackButton) {
-      return <Title id={id}>{name}</Title>
-    }
-
-    return <MyRewardsTitleWithFeedback id={id} name={name} />
+function AccountTitle({ id, name, pathname }: AccountTitleProps): ReactNode {
+  if (pathname === RoutesEnum.ACCOUNT_AFFILIATE_PARTNER || pathname === RoutesEnum.ACCOUNT_AFFILIATE_TRADER) {
+    return <TitleWithFeedback id={id} name={name} />
   }
 
   return <Title id={id}>{name}</Title>
@@ -133,29 +85,14 @@ export const AccountOverview = (): ReactNode => {
 
 export default function Account(): ReactNode {
   const { pathname } = useLocation()
-  const { account } = useWalletInfo()
-  const walletChainId = useWalletChainId()
-  const isProviderNetworkUnsupported = useIsProviderNetworkUnsupported()
   const [id, name] = getPropsFromRoute(pathname)
-  const canShowAffiliateFeedbackButton = Boolean(account) && !isProviderNetworkUnsupported
-  const canShowAffiliatePartnerFeedbackButton =
-    canShowAffiliateFeedbackButton && isSupportedPayoutsNetwork(walletChainId)
-  const canShowAffiliateTraderFeedbackButton =
-    canShowAffiliateFeedbackButton && isSupportedTradingNetwork(walletChainId)
 
   return (
     <Wrapper>
       <AccountMenu />
       <AccountPageWrapper>
         <Content>
-          <AccountTitle
-            canShowAffiliatePartnerFeedbackButton={canShowAffiliatePartnerFeedbackButton}
-            canShowAffiliateTraderFeedbackButton={canShowAffiliateTraderFeedbackButton}
-            canShowAffiliateFeedbackButton={canShowAffiliateFeedbackButton}
-            id={id}
-            name={name}
-            pathname={pathname}
-          />
+          <AccountTitle id={id} name={name} pathname={pathname} />
           <Outlet />
         </Content>
       </AccountPageWrapper>


### PR DESCRIPTION
# Summary

Hide the affiliate Appzi feedback button when the current wallet/network state cannot use the relevant affiliate flow, with the visibility checks owned by `AffiliateFeedbackButton`.

The button now uses the raw provider chain from `useWalletChainId()` instead of the `useWalletInfo()` URL fallback. It returns `null` when there is no connected wallet, the current route is not an affiliate account page, or the connected chain is not affiliate-supported.

On the Affiliate partner/stats page, the button is shown on all affiliate-supported networks, matching the page content. On My Rewards, the button keeps the existing saved-code/ineligible-wallet behavior and is also hidden on affiliate-excluded networks such as Sepolia.

When the Affiliate partner onboarding card is shown on an affiliate-supported network with the feedback button available, the card expands to the full available content width instead of keeping the default narrow onboarding width.

# To Test

1. Open the Affiliate rewards page with no wallet connected.

- [ ] Verify the `Give feedback` button is not displayed.

2. Connect a wallet on Ethereum mainnet and open the Affiliate rewards page.

- [ ] Verify the `Give feedback` button is displayed.
- [ ] Click the button and verify the Appzi affiliate feedback form opens with wallet context.

3. Connect a wallet on an affiliate-supported non-Ethereum network, such as BNB or Gnosis Chain, and open the Affiliate stats page.

- [ ] Verify the same stats content is shown.
- [ ] Verify the `Give feedback` button is displayed.
- [ ] If the onboarding/switch-to-Ethereum card is shown, verify it uses the full content width.

4. Switch the Affiliate rewards page to an affiliate-excluded network, such as Sepolia.

- [ ] Verify the affiliate unsupported-network state is shown.
- [ ] Verify the `Give feedback` button is not displayed.

5. Open My Rewards on an affiliate-supported network with an eligible linked/saved-code wallet state.

- [ ] Verify the `Give feedback` button is displayed according to the existing My Rewards eligibility rules.

6. Open My Rewards with no saved code or an ineligible wallet state.

- [ ] Verify the `Give feedback` button is not displayed.

# Background

`useWalletInfo()` intentionally resolves unsupported wallet chains to a supported URL chain for most app flows. Feedback visibility needs the actual provider chain instead, so the button uses `useWalletChainId()` and the existing affiliate-supported-network helper.
