### PR TITLE
fix: add Brave Wallet to WATCH_ASSET_SUPPORED_WALLETS (Fixes #6727)

### DIFF
--- a/libs/wallet/src/constants.ts
+++ b/libs/wallet/src/constants.ts
@@ -19,4 +19,4 @@ export const RABBY_RDNS = 'io.rabby'
 
 export const BRAVE_WALLET_RDNS = 'com.brave.wallet'
 
-export const WATCH_ASSET_SUPPORED_WALLETS = [METAMASK_RDNS]
+export const WATCH_ASSET_SUPPORED_WALLETS = [METAMASK_RDNS, BRAVE_WALLET_RDNS]


### PR DESCRIPTION
## Problem
`WATCH_ASSET_SUPPORED_WALLETS` only contained `METAMASK_RDNS`, so `useIsAssetWatchingSupported()` returned false for Brave Wallet users even though Brave supports `wallet_watchAsset` per EIP-747.

## Fix
Add `BRAVE_WALLET_RDNS` to the array.

Fixes #6727. Requested by @kernelwhisperer in [PR #6619 review](https://github.com/cowprotocol/cowswap/pull/6619#discussion_r2631548163).