### PR TITLE
Viem MIgration - restoring connection regression

### DIFF
--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -6998,6 +6998,10 @@ msgstr "Default approve"
 msgid "Order cannot be filled due to insufficient balance on the current account."
 msgstr "Order cannot be filled due to insufficient balance on the current account."
 
+#: apps/cowswap-frontend/src/modules/wallet/pure/Web3StatusInner/index.tsx
+msgid "Restoring wallet..."
+msgstr "Restoring wallet..."
+
 #: apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
 #: apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
 msgid "required"

--- a/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliatePartnerOnboard.tsx
+++ b/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliatePartnerOnboard.tsx
@@ -67,7 +67,7 @@ export function AffiliatePartnerOnboard(): ReactNode {
         </HeroSubtitle>
         <HeroActions>
           {!account && (
-            <ButtonPrimary buttonSize={ButtonSize.BIG} onClick={toggleWalletModal} data-testid="affiliate-connect">
+            <ButtonPrimary buttonSize={ButtonSize.BIG} data-testid="affiliate-connect" onClick={toggleWalletModal}>
               <Trans>Connect wallet</Trans>
             </ButtonPrimary>
           )}

--- a/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateTraderOnboard.tsx
+++ b/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateTraderOnboard.tsx
@@ -2,7 +2,7 @@ import { useSetAtom } from 'jotai'
 import { ReactNode } from 'react'
 
 import EARN_AS_TRADER_ILLUSTRATION from '@cowprotocol/assets/images/earn-as-trader.svg'
-import { ButtonPrimary } from '@cowprotocol/ui'
+import { ButtonPrimary, ButtonSize } from '@cowprotocol/ui'
 import { useWalletInfo } from '@cowprotocol/wallet'
 
 import { Trans } from '@lingui/react/macro'
@@ -21,8 +21,8 @@ import { toggleTraderModalAtom } from '../state/affiliateTraderModalAtom'
 
 export function AffiliateTraderOnboard(): ReactNode {
   const { account } = useWalletInfo()
-  const toggleWalletModal = useToggleWalletModal()
   const toggleAffiliateModal = useSetAtom(toggleTraderModalAtom)
+  const toggleWalletModal = useToggleWalletModal()
   const traderRewardAmount = formatUsdcCompact(getDefaultTraderRewardAmount())
   const triggerVolumeLabel = formatUsdCompact(getDefaultTriggerVolume())
   const affiliateTimeCapDays = PROGRAM_DEFAULTS.AFFILIATE_TIME_CAP_DAYS
@@ -49,7 +49,7 @@ export function AffiliateTraderOnboard(): ReactNode {
               <Trans>Add code</Trans>
             </ButtonPrimary>
           ) : (
-            <ButtonPrimary onClick={toggleWalletModal}>
+            <ButtonPrimary buttonSize={ButtonSize.BIG} onClick={toggleWalletModal}>
               <Trans>Connect wallet</Trans>
             </ButtonPrimary>
           )}

--- a/apps/cowswap-frontend/src/modules/wallet/containers/Web3Status/index.tsx
+++ b/apps/cowswap-frontend/src/modules/wallet/containers/Web3Status/index.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-import { useConnectionType, useWalletDetails, useWalletInfo } from '@cowprotocol/wallet'
+import { useConnectionType, useIsRestoringConnection, useWalletDetails, useWalletInfo } from '@cowprotocol/wallet'
 
 import { useToggleWalletModal } from 'legacy/state/application/hooks'
 
@@ -21,6 +21,7 @@ export interface Web3StatusProps {
 export function Web3Status({ className, onClick, joinedLeft = false }: Web3StatusProps): ReactNode {
   const connectionType = useConnectionType()
   const { account } = useWalletInfo()
+  const isConnectionRestoring = useIsRestoringConnection()
   const { ensName } = useWalletDetails()
 
   const toggleWalletModal = useToggleWalletModal()
@@ -37,6 +38,7 @@ export function Web3Status({ className, onClick, joinedLeft = false }: Web3Statu
         ensName={ensName}
         connectWallet={toggleWalletModal}
         connectionType={connectionType}
+        isConnectionRestoring={isConnectionRestoring}
       />
     </Wrapper>
   )

--- a/apps/cowswap-frontend/src/modules/wallet/pure/Web3StatusInner/index.tsx
+++ b/apps/cowswap-frontend/src/modules/wallet/pure/Web3StatusInner/index.tsx
@@ -4,7 +4,7 @@ import { useMediaQuery } from '@cowprotocol/common-hooks'
 import { shortenAddress } from '@cowprotocol/common-utils'
 import { Command } from '@cowprotocol/types'
 import { Loader, RowBetween, Media } from '@cowprotocol/ui'
-import { ConnectionType } from '@cowprotocol/wallet'
+import { type ConnectionType } from '@cowprotocol/wallet'
 
 import { t } from '@lingui/core/macro'
 import { Trans } from '@lingui/react/macro'
@@ -20,6 +20,7 @@ import { StatusIcon } from '../StatusIcon'
 
 export interface Web3StatusInnerProps {
   account?: string
+  isConnectionRestoring?: boolean
   pendingCount: number
   connectWallet: Command
   connectionType: ConnectionType
@@ -28,7 +29,15 @@ export interface Web3StatusInnerProps {
 }
 
 export function Web3StatusInner(props: Web3StatusInnerProps): ReactNode {
-  const { account, pendingCount, ensName, connectionType, connectWallet, showUnfillableOrdersAlert } = props
+  const {
+    account,
+    isConnectionRestoring,
+    pendingCount,
+    ensName,
+    connectionType,
+    connectWallet,
+    showUnfillableOrdersAlert,
+  } = props
 
   const hasPendingTransactions = !!pendingCount
   const isUpToExtraSmall = useMediaQuery(Media.upToExtraSmall(false))
@@ -65,6 +74,16 @@ export function Web3StatusInner(props: Web3StatusInnerProps): ReactNode {
         )}
         {!hasPendingTransactions && <StatusIcon connectionType={connectionType} />}
       </Web3StatusConnected>
+    )
+  }
+
+  if (isConnectionRestoring) {
+    return (
+      <Web3StatusConnect id="wallet-restoring" disabled faded>
+        <Text>
+          <Trans>Restoring wallet...</Trans>
+        </Text>
+      </Web3StatusConnect>
     )
   }
 

--- a/apps/cowswap-frontend/src/pages/Account/AffiliatePartner.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/AffiliatePartner.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react'
 
 import { PAGE_TITLES } from '@cowprotocol/common-const'
-import { useWalletInfo } from '@cowprotocol/wallet'
+import { useIsRestoringConnection, useWalletInfo } from '@cowprotocol/wallet'
 import { useWalletChainId } from '@cowprotocol/wallet-provider'
 
 import { useLingui } from '@lingui/react/macro'
@@ -13,14 +13,17 @@ import {
   AffiliatePartnerOnboard,
   AffiliatePartnerStats,
   AffiliateTermsFaqLinks,
+  AffiliateTraderLoading,
   ColumnOneCard,
   ThreeColumnGrid,
   PageWrapper,
+  TraderWalletStatus,
   getAffiliatePartnerPageState,
   isSupportedPayoutsNetwork,
   isSupportedTradingNetwork,
   useAffiliatePartnerInfo,
   useAffiliateStateViewAnalytics,
+  useAffiliateTraderWallet,
 } from 'modules/affiliate'
 import { PageTitle } from 'modules/application'
 
@@ -29,10 +32,13 @@ export default function AffiliatePartner(): ReactNode {
   const { account } = useWalletInfo()
   const chainId = useWalletChainId()
   const { data: partnerInfo, isLoading: infoLoading } = useAffiliatePartnerInfo(account)
+  const walletStatus = useAffiliateTraderWallet()
+  const isConnectionRestoring = useIsRestoringConnection()
   const hasAccount = Boolean(account)
   const isSupportedPayoutNetwork = isSupportedPayoutsNetwork(chainId)
   const isSupportedTradingNetworkValue = isSupportedTradingNetwork(chainId)
   const hasExistingCode = Boolean(partnerInfo?.code)
+  const showLoadingSkeleton = isConnectionRestoring || infoLoading || walletStatus === TraderWalletStatus.PENDING
   const pageState = getAffiliatePartnerPageState({
     hasAccount,
     hasExistingCode,
@@ -60,7 +66,9 @@ export default function AffiliatePartner(): ReactNode {
     <PageWrapper>
       <PageTitle title={i18n._(PAGE_TITLES.AFFILIATE)} />
 
-      {!account || (!isSupportedPayoutNetwork && !partnerInfo && !infoLoading) || !isSupportedTradingNetworkValue ? (
+      {showLoadingSkeleton ? (
+        <AffiliateTraderLoading />
+      ) : !account || (!isSupportedPayoutNetwork && !partnerInfo) || !isSupportedTradingNetworkValue ? (
         <AffiliatePartnerOnboard />
       ) : (
         <>

--- a/apps/cowswap-frontend/src/pages/Account/AffiliateTrader.tsx
+++ b/apps/cowswap-frontend/src/pages/Account/AffiliateTrader.tsx
@@ -2,6 +2,7 @@ import { useAtomValue } from 'jotai'
 import { ReactNode } from 'react'
 
 import { PAGE_TITLES } from '@cowprotocol/common-const'
+import { useIsRestoringConnection } from '@cowprotocol/wallet'
 
 import { useLingui } from '@lingui/react/macro'
 
@@ -35,6 +36,8 @@ export default function AffiliateTrader(): ReactNode {
   const hasSavedCode = !!savedCode
   const pageState = getAffiliateTraderPageState(walletStatus, hasSavedCode)
   const isProviderNetworkUnsupported = useIsProviderNetworkUnsupported()
+  const isConnectionRestoring = useIsRestoringConnection()
+  const showLoadingSkeleton = isConnectionRestoring || walletStatus === TraderWalletStatus.PENDING
 
   useAffiliateStateViewAnalytics({
     action: 'affiliate_trader_page_state_viewed',
@@ -61,7 +64,7 @@ export default function AffiliateTrader(): ReactNode {
           <AffiliateTraderIneligible />
         ) : walletStatus === TraderWalletStatus.UNSUPPORTED ? (
           <AffiliateTraderUnsupportedNetwork />
-        ) : walletStatus === TraderWalletStatus.PENDING ? (
+        ) : showLoadingSkeleton ? (
           <AffiliateTraderLoading />
         ) : !savedCode || walletStatus === TraderWalletStatus.DISCONNECTED ? (
           <AffiliateTraderOnboard />

--- a/libs/ui/src/pure/Button/index.tsx
+++ b/libs/ui/src/pure/Button/index.tsx
@@ -23,6 +23,16 @@ type ButtonSecondaryStyleProps = {
   $fontSize?: string
   $minHeight?: string
 }
+export type ButtonPrimaryProps = HTMLAttributes<HTMLButtonElement> &
+  ButtonProps & {
+    altDisabledStyle?: boolean
+    buttonSize?: ButtonSize
+    padding?: string
+    status?: StatusColorVariant
+    width?: string
+    $borderRadius?: string
+    $gap?: string
+  }
 
 function getButtonStatusStyles(status?: StatusColorVariant): ReturnType<typeof css> | undefined {
   if (!status || status === StatusColorVariant.Default) {

--- a/libs/wallet/src/api/types.ts
+++ b/libs/wallet/src/api/types.ts
@@ -16,6 +16,7 @@ export interface WalletInfo {
   chainId: SupportedChainId
   account?: Address
   active?: boolean
+  isConnectionRestoring?: boolean
 }
 
 export interface WalletDetails {

--- a/libs/wallet/src/index.ts
+++ b/libs/wallet/src/index.ts
@@ -19,6 +19,7 @@ export * from './wagmi/hooks/useIsSmartContractWallet'
 export * from './wagmi/hooks/useDisconnectWallet'
 export * from './wagmi/hooks/useSwitchNetwork'
 export * from './wagmi/hooks/useConnectionType'
+export * from './wagmi/hooks/useIsRestoringConnection'
 
 // Updater
 export { WalletUpdater } from './wagmi/updater'

--- a/libs/wallet/src/wagmi/hooks/useIsRestoringConnection.ts
+++ b/libs/wallet/src/wagmi/hooks/useIsRestoringConnection.ts
@@ -1,12 +1,27 @@
+import { useSyncExternalStore } from 'react'
+
 import { useConnection } from 'wagmi'
 
 import { useWalletInfo } from '../../api/hooks'
+import { config } from '../config'
+
+function getCurrentConnectorUid(): string | null {
+  return config.state.current ?? null
+}
+
+function subscribeToCurrentConnectorUid(callback: () => void): () => void {
+  return config.subscribe((state) => state.current, callback)
+}
 
 export function useIsRestoringConnection(): boolean {
   const { status } = useConnection()
   const { account } = useWalletInfo()
 
-  // WalletInfo is backed by an atom updated from wagmi, so account can lag behind
-  // the connected status for one render. Keep showing reconnecting during that gap.
-  return status === 'reconnecting' || (status === 'connected' && !account)
+  const currentConnectorUid = useSyncExternalStore(subscribeToCurrentConnectorUid, getCurrentConnectorUid, () => null)
+
+  if (status === 'reconnecting') return true
+  if (status === 'connected' && !account) return true
+  if (!!currentConnectorUid && !account) return true
+
+  return false
 }

--- a/libs/wallet/src/wagmi/hooks/useIsRestoringConnection.ts
+++ b/libs/wallet/src/wagmi/hooks/useIsRestoringConnection.ts
@@ -1,0 +1,12 @@
+import { useConnection } from 'wagmi'
+
+import { useWalletInfo } from '../../api/hooks'
+
+export function useIsRestoringConnection(): boolean {
+  const { status } = useConnection()
+  const { account } = useWalletInfo()
+
+  // WalletInfo is backed by an atom updated from wagmi, so account can lag behind
+  // the connected status for one render. Keep showing reconnecting during that gap.
+  return status === 'reconnecting' || (status === 'connected' && !account)
+}

--- a/libs/wallet/src/wagmi/updater.ts
+++ b/libs/wallet/src/wagmi/updater.ts
@@ -41,7 +41,8 @@ function useBrowserUrlKey(): string {
 
 function useWalletInfo(): WalletInfo {
   const urlKey = useBrowserUrlKey()
-  const { address, chainId, isConnected } = useConnection()
+  const { address, chainId, isConnected, status } = useConnection()
+  const isConnectionRestoring = status === 'reconnecting'
   const isChainIdUnsupported = !!chainId && !(chainId in SupportedChainId)
   const [lastStableChainId, setLastStableChainId] = useState<SupportedChainId | undefined>(undefined)
   const [lastResolvedChainId, setLastResolvedChainId] = useState<SupportedChainId>(() => getCurrentChainIdFromUrl())
@@ -76,8 +77,18 @@ function useWalletInfo(): WalletInfo {
       chainId: resolvedChainId,
       active: isConnected,
       account: address,
+      isConnectionRestoring,
     }
-  }, [address, chainId, isConnected, isChainIdUnsupported, lastStableChainId, lastResolvedChainId, urlKey])
+  }, [
+    address,
+    chainId,
+    isConnected,
+    isChainIdUnsupported,
+    isConnectionRestoring,
+    lastStableChainId,
+    lastResolvedChainId,
+    urlKey,
+  ])
 
   useEffect(() => {
     setLastResolvedChainId(walletInfo.chainId)


### PR DESCRIPTION
# Summary                                                                                                                                                                                                                
                                                                                                                                                                                                                           
  Fixes the wallet "restoring" regression that surfaced in [#7468](https://github.com/cowprotocol/cowswap/pull/7468) after rebasing onto current `develop` (which contains the wagmi upgrade from [#7467 / `e93bf10af`](https://github.com/cowprotocol/cowswap/commit/e93bf10af)).                                                        
                                                                                                                                                                                                                           
  `useIsRestoringConnection()` was missing the initial render on page load when a wallet was previously connected. Root cause: `Web3Provider` mounts `<WagmiProvider>` with `reconnectOnMount={false}` and triggers        
  `reconnect()` manually from a `useEffect`. With that flag, wagmi's hydrate leaves the store at `status: 'disconnected'` on first render — even when a connector UID is persisted in storage — and only flips to          
  `'reconnecting'` *after* the manual reconnect effect fires (one render later). The hook's `status === 'reconnecting'` check therefore missed the gap, and the affiliate pages + `Web3Status` pill briefly flashed the    
  disconnected "Connect wallet" CTA.                                                                                                                                                                                     

  The fix subscribes to `config.state.current` via `useSyncExternalStore`. If wagmi already has a `current` connector UID but the wallet info atom hasn't published an account yet, the hook now reports `true`. `current` 
  is cleared atomically with `status: 'disconnected'` on explicit `disconnect()` (verified in `@wagmi/core/disconnect.js`), so this doesn't false-positive after a user-initiated disconnect.
                                                                                                                                                                                                                           
  # To Test                                                                                                                                                                                                              

  1. **Affiliate partner page with a previously connected wallet**                                                                                                                                                         
  
  - [ ] Open `/account/affiliate`                                                                                                                                                                                          
  - [ ] Refresh the page                                                                                                                                                                                                 
  - [ ] Verify the loading skeleton appears immediately — no flash of the disconnected "Connect wallet" CTA before the loader
  - [ ] After restoration completes, verify the correct partner state is shown                                                                                                                                             
                                                                                                                                                                                                                                                                                                                    
  2. **`Web3Status` pill (header)**                                                                                                                                                                                        
                                                                                                                                                                                                                           
  - [ ] Refresh with a previously connected wallet                                                                                                                                                                       
  - [ ] Verify the pill shows `Restoring wallet...` (disabled, faded) and does not flash `Connect wallet` first
                                                                                                                                                                                                                           
  3. **Fresh user (no persisted wallet)**                                                                                                                                                                                  
                                                                                                                                                                                                                           
  - [ ] Clear `sessionStorage` keys prefixed with `cowswap-wallet`                                                                                                                                                         
  - [ ] Reload the affiliate pages                                                                                                                                                                                       
  - [ ] Verify the disconnected CTA renders immediately — the restoring skeleton must **not** appear                                                                                                                       
  - [ ] Verify the `Web3Status` pill shows `Connect wallet` immediately                                                                                                                                                                                                                            
                                                                                                                                                                                                                           
  # Background
                                                                                                                                                                                                                           
  `reconnectOnMount={false}` is intentional in `Web3Provider` — the comments around `reconnectWidgetConnector` and the AppKit `unSyncExistingConnection` race describe why we drive reconnection manually. That means we   
  can't simply flip the flag back to `true` to restore the previous behavior.
                                                                                                                                                                                                                           
  Wagmi's `current` is the only piece of restored state that's available synchronously at first render: zustand's `persist` middleware rehydrates it from `sessionStorage` before React mounts, and `hydrate()` (in        
  `@wagmi/core`) preserves it through the `reconnectOnMount={false}` path while resetting `connections` and `status`. Reading it via `config.state.current` + `useSyncExternalStore` keeps the hook reactive without
  introducing a new global lifecycle atom and without depending on the manual reconnect path's timing.                                                                                                                     
                                                                                                                                                                                                                         
  The unused `WalletInfo.isConnectionRestoring` field (added in this PR but not read anywhere) was intentionally left in place; happy to drop it in a follow-up if preferred.                                              

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Restoring wallet..." status indicator displayed during wallet connection restoration
  * Improved loading state handling on affiliate partner and trader pages during wallet reconnection
  * Enhanced button customization with new sizing options for affiliate onboarding interface

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cowprotocol/cowswap/pull/7519?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->