### PR TITLE
fix: reduce load on RPC nodes

### DIFF
--- a/apps/cowswap-frontend/src/modules/onchainTransactions/updaters/FinalizeTxUpdater/hooks/usePendingTransactionsContext.ts
+++ b/apps/cowswap-frontend/src/modules/onchainTransactions/updaters/FinalizeTxUpdater/hooks/usePendingTransactionsContext.ts
@@ -16,7 +16,7 @@ import useNativeCurrency from 'lib/hooks/useNativeCurrency'
 
 import { CheckEthereumTransactions } from '../types'
 
-export function usePendingTransactionsContext(): CheckEthereumTransactions | null {
+export function usePendingTransactionsContext(hasPendingTxs: boolean): CheckEthereumTransactions | null {
   const config = useConfig()
   const { chainId, account } = useWalletInfo()
   const safeInfo = useGnosisSafeInfo()
@@ -32,7 +32,7 @@ export function usePendingTransactionsContext(): CheckEthereumTransactions | nul
 
   return useAsyncMemo(
     async () => {
-      if (!lastBlockNumber || !account) return null
+      if (!lastBlockNumber || !account || !hasPendingTxs) return null
 
       const transactionsCount = await getTransactionCount(config, { address: account })
 
@@ -66,6 +66,7 @@ export function usePendingTransactionsContext(): CheckEthereumTransactions | nul
       cancelOrdersBatch,
       getTwapOrderById,
       safeInfo,
+      hasPendingTxs,
     ],
     null,
   )

--- a/apps/cowswap-frontend/src/modules/onchainTransactions/updaters/FinalizeTxUpdater/index.tsx
+++ b/apps/cowswap-frontend/src/modules/onchainTransactions/updaters/FinalizeTxUpdater/index.tsx
@@ -18,7 +18,7 @@ export function FinalizeTxUpdater() {
 
   const transactions = useAllTransactionsDetails(shouldCheckFilter)
 
-  const params = usePendingTransactionsContext()
+  const params = usePendingTransactionsContext(transactions.length > 0)
 
   useEffect(() => {
     if (!params) return

--- a/libs/wallet/src/wagmi/config.ts
+++ b/libs/wallet/src/wagmi/config.ts
@@ -166,17 +166,35 @@ let wagmiAdapter: WagmiAdapter | null = null
 let reownAppKit: ReturnType<typeof createAppKit> | null = null
 let config: Config
 
+// `batch.multicall` collapses concurrent single `useReadContract` calls into one
+// multicall3 aggregate3 — the dominant savings for our `eth_call` budget (otherwise
+// each singular contract read is its own RPC call).
+// `pollingInterval` overrides viem's 4s default so block-driven hooks (BlockNumberProvider,
+// useReadContracts refetches) poll once per ~mainnet block time. Cowswap's UX tolerates
+// the L2 staleness this introduces because trades settle on the protocol's batch cadence.
+const VIEM_CLIENT_TUNING = {
+  batch: {
+    multicall: {
+      wait: 130, //  coalescing window in ms
+      batchSize: 30_000, // calldata size ceiling (30kb)
+    },
+  },
+  // Frequency (in ms) for polling enabled actions & events.
+  pollingInterval: 12_000,
+} as const
+
 if (isSafeIframe) {
   // Safe App iframe: no AppKit — use a plain wagmi config with only the Safe connector.
   config = createConfig({
+    ...VIEM_CLIENT_TUNING,
     connectors,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    chains: SUPPORTED_REOWN_NETWORKS as any,
+    chains: SUPPORTED_REOWN_NETWORKS,
     storage,
     transports: wagmiTransports,
   })
 } else {
   wagmiAdapter = new WagmiAdapter({
+    ...VIEM_CLIENT_TUNING,
     connectors: connectors as ConstructorParameters<typeof WagmiAdapter>[0]['connectors'],
     customRpcUrls,
     networks: SUPPORTED_REOWN_NETWORKS,


### PR DESCRIPTION
# Summary

**Fix A — `apps/cowswap-frontend/.../usePendingTransactionsContext.ts + FinalizeTxUpdater/index.tsx`:**
Hook now takes `hasPendingTxs: boolean`; when no pending txs exist, it returns null without calling `getTransactionCount`. `FinalizeTxUpdater` passes `transactions.length > 0`. Behavior unchanged for users with pending txs; eliminates the nonce call for every connected user every block.

**Fix B + C — `libs/wallet/src/wagmi/config.ts`:**
Added a single `VIEM_CLIENT_TUNING` constant spread into both the Safe-iframe createConfig and the `WagmiAdapter` constructor:
  - `batch.multicall: { wait: 130, batchSize: 30_000 }` — auto-aggregates singular `useReadContract` calls into `multicall3`
  - pollingInterval: 12_000 — overrides viem's 4 s default

I've checked [the version before Viem migration](https://bafybeig3pvq6jzebtemj5lkpiitekvnq4u46knv26jl5mvvyhfzli3thkm.ipfs.inbrowser.link/), and we were making `eth_call` with ~24kb payload. Alchemy recommends keeping the payload less then 100kb, so 30kb looks a good trade-off here.

**Expected impact**
  - eth_blockNumber: ~3× reduction (4 s → 12 s polling)
  - eth_getTransactionCount: ~10–20× reduction (gated on pending txs; most users have none)
  - eth_call: ~5–10× reduction (singular useReadContract calls now batched). Won't reach the full 20× without also addressing D (overlapping balance/allowance pollers).
 
# To Test

1. Balances loading
2. On-chain tx finalizing: mined/failed/replaced (approve, wrap/uwrap, eth-flow)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized pending transaction detection logic for improved efficiency.
  * Enhanced wallet configuration with improved multicall batching and polling intervals for better network communication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cowprotocol/cowswap/pull/7523?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->