### PR TITLE
ci(release): make GH release and tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,8 @@ jobs:
       contents: write
       pull-requests: write
     outputs:
-      published: ${{ steps.changesets.outputs.published }}
-      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
+      hasReleases: ${{ steps.detect.outputs.hasReleases }}
+      pendingReleases: ${{ steps.detect.outputs.pendingReleases }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -47,12 +47,27 @@ jobs:
           BASELINE_REF: ${{ inputs.baseline_ref }}
         run: node tools/scripts/commits-to-changesets.mjs
 
+      # Runs BEFORE the changesets action so it reads main's working tree
+      # (the action may switch the working dir to its PR branch).
+      - name: Detect pending releases
+        id: detect
+        run: |
+          PENDING=$(node tools/scripts/detect-pending-releases.mjs)
+          echo "pendingReleases=$PENDING" >> "$GITHUB_OUTPUT"
+          if [ "$PENDING" = "[]" ]; then
+            echo "hasReleases=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "hasReleases=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Pending releases: $PENDING"
+
+      # Version-only mode: opens/updates the changeset-release/main version PR
+      # when .changeset/*.md files exist. No publish step — job 2 handles
+      # npm publishing and GitHub releases with the right tag format.
       - name: Changesets action
-        id: changesets
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           version: pnpm changeset version
-          publish: echo "publish handled in next job"
           commit: "chore(main): release"
           title: "chore(main): release"
           createGithubReleases: false
@@ -62,7 +77,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: release
-    if: needs.release.outputs.published == 'true'
+    if: needs.release.outputs.hasReleases == 'true'
     permissions:
       contents: write
       id-token: write
@@ -111,13 +126,54 @@ jobs:
             fi
           done
 
+      # nx release publish is idempotent — it skips packages already on npm.
       - name: Publish released packages
         run: pnpm exec nx release publish --tag latest --access public --provenance
 
-      - name: Tag release baseline
+      # Per-package `<short>-v<version>` tag + GitHub release for every pending
+      # entry — apps included. Runs AFTER npm publish so a failed publish
+      # doesn't leave orphan tags. The `cowswap-v*` and `explorer-v*` tags
+      # this pushes are what triggers deployment.yml.
+      - name: Create tags and GitHub releases
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_AUTH }}
+          PENDING_RELEASES: ${{ needs.release.outputs.pendingReleases }}
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          node -e '
+            const pkgs = JSON.parse(process.env.PENDING_RELEASES || "[]");
+            for (const p of pkgs) {
+              process.stdout.write(`${p.tag}\t${p.path}\n`);
+            }
+          ' > /tmp/pending.tsv
+
+          while IFS=$'\t' read -r tag path; do
+            [ -z "$tag" ] && continue
+            echo "Creating tag and release for ${tag}"
+
+            if [ -f "${path}/CHANGELOG.md" ]; then
+              NOTES=$(awk '/^## /{p++; if(p==2)exit; if(p==1)next} p==1' "${path}/CHANGELOG.md")
+            else
+              NOTES=""
+            fi
+            [ -z "$NOTES" ] && NOTES="Release ${tag}"
+
+            git tag -a "${tag}" -m "Release ${tag}"
+            git push origin "${tag}"
+
+            printf '%s\n' "$NOTES" > /tmp/notes.md
+            gh release create "${tag}" \
+              --title "${tag}" \
+              --notes-file /tmp/notes.md
+          done < /tmp/pending.tsv
+
+      # Converter baseline tag. The converter's `git describe --match release-*`
+      # depends on this to know where to start scanning commits next run.
+      - name: Tag release baseline
+        run: |
           TAG="release-$(date -u +%Y%m%dT%H%M%SZ)"
           git tag -a "$TAG" -m "Release published at $TAG"
           git push origin "$TAG"

--- a/tools/scripts/detect-pending-releases.mjs
+++ b/tools/scripts/detect-pending-releases.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+// Walks every tracked package and emits a JSON array of those whose
+// `<short>-v<version>` git tag does not yet exist. Used by the Release
+// workflow as both the publish-job gate and the iteration source for tag +
+// GitHub release creation.
+//
+// Short name = the part of pkg.name after the scope (e.g. `@cowprotocol/cowswap`
+// → `cowswap`). Matches the historical release-please tag convention and the
+// `cowswap-v*` / `explorer-v*` patterns deployment.yml listens for.
+
+import { readFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), '../..')
+
+const registry = JSON.parse(
+  readFileSync(join(rootDir, 'tools/release/tracked-packages.json'), 'utf-8'),
+)
+
+const pending = []
+for (const path of registry.packages) {
+  const pkg = JSON.parse(readFileSync(join(rootDir, path, 'package.json'), 'utf-8'))
+  if (!pkg.name) continue
+  const shortName = pkg.name.includes('/') ? pkg.name.split('/').pop() : pkg.name
+  const tag = `${shortName}-v${pkg.version}`
+
+  const existing = execFileSync('git', ['tag', '--list', tag], {
+    cwd: rootDir,
+    encoding: 'utf-8',
+  }).trim()
+  if (existing === tag) continue
+
+  pending.push({
+    name: pkg.name,
+    shortName,
+    version: pkg.version,
+    path,
+    tag,
+    private: !!pkg.private,
+  })
+}
+
+process.stdout.write(JSON.stringify(pending))


### PR DESCRIPTION
# Summary

It turned out that the new release flow (using changesets) doesn't create GH releases at all.
There is an existing `createGithubReleases` parameter in https://github.com/changesets/action, but it doesn't work as we used to have it with release-please. Because of that, we have the option disabled, and we make GH release and tags in the second job (`publish`).

### release.yml — job 1 (release):
  - Converter runs.
  - New `Detect pending releases` step runs before the changesets action (so it sees main's tree, not the action's PR branch). Outputs hasReleases (boolean) and pendingReleases (JSON array).
  - Changesets action in version-only mode — opens/updates the version PR when changesets are present, no-ops otherwise. createGithubReleases: false (we do them ourselves with the right tag format).

### release.yml — job 2 (publish):
  - Gate changed from published == 'true' to hasReleases == 'true'.
  - Existing npm publish kept as-is (nx release publish is idempotent, skips already-published versions).
  - New `Create tags and GitHub releases` step iterates pendingReleases and, for each entry: extracts the topmost CHANGELOG.md section (sans the version header), creates <short>-v<version> annotated tag, pushes it, and creates a GH release via gh release create.
  - release-<ISO> baseline tag kept (converter still needs it).

### deployment.yml compatibility:
  - cowswap-v* and explorer-v* tags are produced exactly as before (release-please convention preserved). When job 2 pushes them, the existing Deployment workflow trigger fires unchanged — vercel-pre-prod deploys to staging.


# To Test

Try it live :) 
