### PR TITLE
[vibereview] PR #7529 — layered review (do not merge)

### DIFF
--- a/.vibereview/pr-7529.json
+++ b/.vibereview/pr-7529.json
@@ -1,0 +1,154 @@
+[
+  {
+    "hunk_id": "h_60e34d7c5c31",
+    "file": "apps/cowswap-frontend/src/modules/twap/hooks/useFetchTwapOrdersFromSafe.ts",
+    "line": 6,
+    "layer": "C",
+    "original_layer": "C",
+    "confidence": 0.84,
+    "intents": [
+      "business_logic"
+    ],
+    "rationale": "Switches to a new cached fetch service and changes polling interval (45s to 1m), altering runtime data-fetch behavior.",
+    "escalations": []
+  },
+  {
+    "hunk_id": "h_df35ee2fdce0",
+    "file": "apps/cowswap-frontend/src/modules/twap/hooks/useFetchTwapOrdersFromSafe.ts",
+    "line": 29,
+    "layer": "C",
+    "original_layer": "C",
+    "confidence": 0.84,
+    "intents": [
+      "business_logic"
+    ],
+    "rationale": "Updates to call the new cached fetch function and changes the interval constant, impacting update cadence and behavior.",
+    "escalations": []
+  },
+  {
+    "hunk_id": "h_91fc5a28fc38",
+    "file": "apps/cowswap-frontend/src/modules/twap/services/fetchCachedTwapOrdersFromSafe.ts",
+    "line": 1,
+    "layer": "C",
+    "original_layer": "C",
+    "confidence": 0.92,
+    "intents": [
+      "schema_persistence",
+      "business_logic"
+    ],
+    "rationale": "Introduces localStorage-backed caching, versioning, overlap logic, and merging—adds persistence/cache behavior and affects fetching logic.",
+    "escalations": [
+      "multi_intent"
+    ]
+  },
+  {
+    "hunk_id": "h_c3533acca279",
+    "file": "apps/cowswap-frontend/src/modules/twap/services/fetchTwapOrdersFromSafe.ts",
+    "line": 31,
+    "layer": "C",
+    "original_layer": "C",
+    "confidence": 0.86,
+    "intents": [
+      "type_export_change",
+      "business_logic"
+    ],
+    "rationale": "Exports a type and changes the exported function’s signature and return shape, affecting callers and behavior.",
+    "escalations": [
+      "multi_intent"
+    ]
+  },
+  {
+    "hunk_id": "h_8563d262c35a",
+    "file": "apps/cowswap-frontend/src/modules/twap/services/fetchTwapOrdersFromSafe.ts",
+    "line": 68,
+    "layer": "C",
+    "original_layer": "C",
+    "confidence": 0.83,
+    "intents": [
+      "business_logic"
+    ],
+    "rationale": "Refactors executed-transactions fetching to accept a since parameter, paginates, and returns metadata; modifies merge/return behavior.",
+    "escalations": []
+  },
+  {
+    "hunk_id": "h_2cb2a7c5c781",
+    "file": "apps/cowswap-frontend/src/modules/twap/services/fetchTwapOrdersFromSafe.ts",
+    "line": 140,
+    "layer": "C",
+    "original_layer": "B",
+    "confidence": 0.86,
+    "intents": [
+      "rename_cross_boundary",
+      "type_export_change"
+    ],
+    "rationale": "Renames and exports a utility (mergeByHash -> mergeTwapOrdersByHash) for cross-file use; no logic change but exported symbol/usage change.",
+    "escalations": [
+      "multi_intent"
+    ]
+  },
+  {
+    "hunk_id": "h_dae44996aea4",
+    "file": "apps/cowswap-frontend/src/modules/twap/services/fetchTwapOrdersFromSafe.ts",
+    "line": 159,
+    "layer": "C",
+    "original_layer": "C",
+    "confidence": 0.8,
+    "intents": [
+      "business_logic"
+    ],
+    "rationale": "Alters fetch return type to include a fetchError flag and adds logging; changes error handling/flow for upstream logic.",
+    "escalations": []
+  },
+  {
+    "hunk_id": "h_5f9e9ba91a91",
+    "file": "apps/cowswap-frontend/src/modules/twap/services/fetchTwapOrdersFromSafe.ts",
+    "line": 173,
+    "layer": "C",
+    "original_layer": "C",
+    "confidence": 0.82,
+    "intents": [
+      "business_logic"
+    ],
+    "rationale": "Changes request URL builder semantics (executed flag, since filter, ordering, queued), adds logging; network query behavior change.",
+    "escalations": []
+  },
+  {
+    "hunk_id": "h_6dde44eb3705",
+    "file": "apps/cowswap-frontend/src/modules/zeroApproval/hooks/useZeroApprove.ts",
+    "line": 73,
+    "layer": "B",
+    "original_layer": "B",
+    "confidence": 0.95,
+    "intents": [
+      "business_logic"
+    ],
+    "rationale": "Adds a console log during polling; minor observable behavior change only.",
+    "escalations": []
+  },
+  {
+    "hunk_id": "h_e74bae80516e",
+    "file": "libs/core/src/gnosisSafe/index.ts",
+    "line": 63,
+    "layer": "B",
+    "original_layer": "B",
+    "confidence": 0.94,
+    "intents": [
+      "business_logic"
+    ],
+    "rationale": "Replaces/moves console logging for fetching Safe info; minor logging-only change.",
+    "escalations": []
+  },
+  {
+    "hunk_id": "h_2aa8fc07b66c",
+    "file": "libs/core/src/gnosisSafe/index.ts",
+    "line": 77,
+    "layer": "B",
+    "original_layer": "B",
+    "confidence": 0.94,
+    "intents": [
+      "business_logic"
+    ],
+    "rationale": "Changes console logging for getSafeTransaction; minor, logging-only behavior change.",
+    "escalations": []
+  }
+]

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useFetchTwapOrdersFromSafe.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useFetchTwapOrdersFromSafe.ts
@@ -6,10 +6,10 @@ import ms from 'ms.macro'
 
 import { ComposableCowContractData } from 'modules/advancedOrders/hooks/useComposableCowContract'
 
-import { fetchTwapOrdersFromSafe } from '../services/fetchTwapOrdersFromSafe'
+import { fetchCachedTwapOrdersFromSafe } from '../services/fetchCachedTwapOrdersFromSafe'
 import { TwapOrdersSafeData } from '../types'
 
-const PENDING_TWAP_UPDATE_INTERVAL = ms`45s`
+const TWAP_SAFE_ORDERS_UPDATE_INTERVAL = ms`1m`
 
 export function useFetchTwapOrdersFromSafe({
   chainId,
@@ -29,12 +29,12 @@ export function useFetchTwapOrdersFromSafe({
 
       updateInProgressRef.current = true
 
-      fetchTwapOrdersFromSafe(chainId, safeAddress, composableCowContract, setOrdersSafeData).finally(() => {
+      fetchCachedTwapOrdersFromSafe(chainId, safeAddress, composableCowContract, setOrdersSafeData).finally(() => {
         updateInProgressRef.current = false
       })
     }
 
-    const interval = setInterval(persistOrders, PENDING_TWAP_UPDATE_INTERVAL)
+    const interval = setInterval(persistOrders, TWAP_SAFE_ORDERS_UPDATE_INTERVAL)
 
     persistOrders()
 

--- a/apps/cowswap-frontend/src/modules/twap/services/fetchCachedTwapOrdersFromSafe.ts
+++ b/apps/cowswap-frontend/src/modules/twap/services/fetchCachedTwapOrdersFromSafe.ts
@@ -1,0 +1,112 @@
+import { isTruthy } from '@cowprotocol/common-utils'
+import { getAddressKey, SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import ms from 'ms.macro'
+
+import { ComposableCowContractData } from 'modules/advancedOrders/hooks/useComposableCowContract'
+
+import { fetchTwapOrdersFromSafe, mergeTwapOrdersByHash } from './fetchTwapOrdersFromSafe'
+
+import type { TwapDataArray } from './fetchTwapOrdersFromSafe'
+
+const SAFE_TX_SCAN_CACHE_VERSION = 10
+const SAFE_TX_SCAN_OVERLAP = ms`1m`
+
+type SafeTwapScanCache = {
+  version: typeof SAFE_TX_SCAN_CACHE_VERSION
+  newestSubmissionDate: string
+  orders: TwapDataArray
+}
+
+// eslint-disable-next-line complexity
+export async function fetchCachedTwapOrdersFromSafe(
+  chainId: SupportedChainId,
+  safeAddress: string,
+  composableCowContract: ComposableCowContractData,
+  setData: (state: TwapDataArray) => void,
+): Promise<TwapDataArray> {
+  const cached = readSafeTwapScanCache(chainId, safeAddress)
+  const executedSince = cached ? getOverlappedSubmissionDate(cached.newestSubmissionDate) : undefined
+
+  if (cached) setData(cached.orders)
+
+  const fresh = await fetchTwapOrdersFromSafe(chainId, safeAddress, composableCowContract, executedSince).catch(
+    (error) => {
+      if (!cached) throw error
+
+      console.error('Error fetching TWAP orders from Safe', { safeAddress }, error)
+      return null
+    },
+  )
+
+  if (!fresh) return cached?.orders || []
+  if (!fresh.complete && cached) return cached.orders
+
+  const merged = mergeTwapOrdersByHash(cached ? [...cached.orders, ...fresh.orders] : fresh.orders)
+  const executedOrders = merged.filter((order) => order.safeTxParams.isExecuted)
+  const newestSubmissionDate = getNewestSubmissionDate([
+    cached?.newestSubmissionDate,
+    fresh.newestSubmissionDate,
+    ...executedOrders.map((order) => order.safeTxParams.submissionDate),
+  ])
+
+  if (fresh.complete) {
+    writeSafeTwapScanCache(chainId, safeAddress, executedOrders, newestSubmissionDate)
+  }
+
+  setData(merged)
+  return merged
+}
+
+function getSafeTwapScanCacheKey(chainId: SupportedChainId, safeAddress: string): string {
+  return `cow:twap:safe-scan:v${SAFE_TX_SCAN_CACHE_VERSION}:${chainId}:${getAddressKey(safeAddress)}`
+}
+
+function readSafeTwapScanCache(chainId: SupportedChainId, safeAddress: string): SafeTwapScanCache | null {
+  try {
+    const serialized = window.localStorage.getItem(getSafeTwapScanCacheKey(chainId, safeAddress))
+    if (!serialized) return null
+
+    const parsed = JSON.parse(serialized) as Partial<SafeTwapScanCache>
+
+    if (parsed.version !== SAFE_TX_SCAN_CACHE_VERSION || !parsed.newestSubmissionDate || !parsed.orders) return null
+
+    return {
+      version: SAFE_TX_SCAN_CACHE_VERSION,
+      newestSubmissionDate: parsed.newestSubmissionDate,
+      orders: parsed.orders.filter((order) => order.safeTxParams.isExecuted),
+    }
+  } catch {
+    return null
+  }
+}
+
+function writeSafeTwapScanCache(
+  chainId: SupportedChainId,
+  safeAddress: string,
+  orders: TwapDataArray,
+  newestSubmissionDate: string,
+): void {
+  if (!newestSubmissionDate) return
+
+  try {
+    const cache: SafeTwapScanCache = {
+      version: SAFE_TX_SCAN_CACHE_VERSION,
+      newestSubmissionDate,
+      orders,
+    }
+
+    console.log(`[COW][SafeAPI] Saving to cache TWAP executed orders newestSubmissionDate=${newestSubmissionDate}`)
+    window.localStorage.setItem(getSafeTwapScanCacheKey(chainId, safeAddress), JSON.stringify(cache))
+  } catch {
+    // Ignore storage failures. The next load will run without cache.
+  }
+}
+
+function getOverlappedSubmissionDate(submissionDate: string): string {
+  return new Date(new Date(submissionDate).getTime() - SAFE_TX_SCAN_OVERLAP).toISOString()
+}
+
+function getNewestSubmissionDate(dates: (string | undefined)[]): string {
+  return dates.filter(isTruthy).reduce((latest, date) => (date > latest ? date : latest), '')
+}

--- a/apps/cowswap-frontend/src/modules/twap/services/fetchTwapOrdersFromSafe.ts
+++ b/apps/cowswap-frontend/src/modules/twap/services/fetchTwapOrdersFromSafe.ts
@@ -31,16 +31,24 @@ function getSafeApiHeaders(): HeadersInit {
   return { Authorization: `Bearer ${SAFE_API_AUTH_TOKEN}` }
 }
 
-type TwapDataArray = TwapOrdersSafeData[]
+export type TwapDataArray = TwapOrdersSafeData[]
+
+export type FetchTwapOrdersFromSafeResult = {
+  orders: TwapDataArray
+  newestSubmissionDate?: string
+  complete: boolean
+}
+
+type SafeTransactionsChunk = AllTransactionsListResponse & { fetchError?: boolean }
 
 export async function fetchTwapOrdersFromSafe(
   chainId: SupportedChainId,
   safeAddress: string,
   composableCowContract: ComposableCowContractData,
-  setData: (state: TwapDataArray) => void,
+  executedSince?: string,
   nextUrl?: string,
   accumulator: TwapDataArray[] = [],
-): Promise<TwapDataArray> {
+): Promise<FetchTwapOrdersFromSafeResult> {
   const response = await fetchSafeTransactionsChunk(chainId, safeAddress, nextUrl)
 
   const results = response?.results || []
@@ -60,34 +68,70 @@ export async function fetchTwapOrdersFromSafe(
      * isExecuted=true — which lets the status logic correctly transition the order
      * away from WaitSigning.
      */
-    const executedResults = await fetchRecentlyExecutedTransactions(chainId, safeAddress, composableCowContract)
+    const executedResult = await fetchRecentlyExecutedTransactions(
+      chainId,
+      safeAddress,
+      composableCowContract,
+      executedSince,
+    )
 
-    const merged = mergeByHash([...flattenState, ...executedResults])
-
-    setData(merged)
-    return merged
+    return {
+      orders: mergeTwapOrdersByHash([...flattenState, ...executedResult.orders]),
+      newestSubmissionDate: executedResult.newestSubmissionDate,
+      complete: !response.fetchError && executedResult.complete,
+    }
   }
 
-  return fetchTwapOrdersFromSafe(chainId, safeAddress, composableCowContract, setData, response.next, accumulator)
+  return fetchTwapOrdersFromSafe(chainId, safeAddress, composableCowContract, executedSince, response.next, accumulator)
 }
 
+// eslint-disable-next-line complexity
 async function fetchRecentlyExecutedTransactions(
   chainId: SupportedChainId,
   safeAddress: string,
   composableCowContract: ComposableCowContractData,
-): Promise<TwapDataArray> {
+  since?: string,
+  nextUrl?: string,
+  accumulator: TwapDataArray[] = [],
+  newestSubmissionDate?: string,
+): Promise<FetchTwapOrdersFromSafeResult> {
   try {
-    const url = `${getSafeApiUrl(chainId)}/v2/safes/${safeAddress}/multisig-transactions/?executed=true&limit=${HISTORY_TX_COUNT_LIMIT}&ordering=-submissionDate`
-
+    const url = nextUrl || getSafeHistoryRequestUrl(chainId, safeAddress, true, since)
     const headers = getSafeApiHeaders()
 
+    console.log(
+      `[COW][SafeAPI] Fetch TWAP executed orders (${nextUrl ? 'next' : 'first'} page${since && !nextUrl ? ` since ${since}` : ''})`,
+    )
     const response: AllTransactionsListResponse = await fetch(url, { headers }).then((res) => res.json())
     const results = response?.results || []
+    const parsedResults = parseSafeTransactionsResult(composableCowContract, results)
+    const nextNewestSubmissionDate = getNewestSubmissionDate([
+      newestSubmissionDate,
+      ...results.map(getTransactionSubmissionDate),
+    ])
 
-    return parseSafeTransactionsResult(composableCowContract, results)
+    accumulator.push(parsedResults)
+
+    if (response.next && accumulator.length < SAFE_TX_HISTORY_DEPTH) {
+      return fetchRecentlyExecutedTransactions(
+        chainId,
+        safeAddress,
+        composableCowContract,
+        since,
+        response.next,
+        accumulator,
+        nextNewestSubmissionDate,
+      )
+    }
+
+    return {
+      orders: accumulator.flat(),
+      newestSubmissionDate: nextNewestSubmissionDate,
+      complete: !response.next,
+    }
   } catch (error) {
     console.error('Error fetching executed Safe transactions', { safeAddress }, error)
-    return []
+    return { orders: [], complete: false }
   }
 }
 
@@ -96,7 +140,7 @@ async function fetchRecentlyExecutedTransactions(
  * This ensures that if the same transaction appears in both the pending and executed
  * fetches (e.g. a tx that just executed), we keep the executed version.
  */
-function mergeByHash(items: TwapDataArray): TwapDataArray {
+export function mergeTwapOrdersByHash(items: TwapDataArray): TwapDataArray {
   const map = new Map<string, TwapOrdersSafeData>()
 
   for (const item of items) {
@@ -115,11 +159,12 @@ async function fetchSafeTransactionsChunk(
   chainId: SupportedChainId,
   safeAddress: string,
   nextUrl?: string,
-): Promise<AllTransactionsListResponse> {
+): Promise<SafeTransactionsChunk> {
   const headers = getSafeApiHeaders()
 
   if (nextUrl) {
     try {
+      console.log('[COW][SafeAPI] Fetch TWAP pending orders (next page)')
       const response: AllTransactionsListResponse = await fetch(nextUrl, { headers }).then((res) => res.json())
 
       await delay(SAFE_TX_REQUEST_DELAY)
@@ -128,17 +173,44 @@ async function fetchSafeTransactionsChunk(
     } catch (error) {
       console.error('Error fetching Safe transactions', { safeAddress, nextUrl }, error)
 
-      return { results: [], count: 0 }
+      return { results: [], count: 0, fetchError: true }
     }
   }
 
-  const url = getSafeHistoryRequestUrl(chainId, safeAddress, 0)
+  const url = getSafeHistoryRequestUrl(chainId, safeAddress, false)
 
+  console.log('[COW][SafeAPI] Fetch TWAP pending orders (first page)')
   return fetch(url, { headers }).then((res) => res.json())
 }
 
-function getSafeHistoryRequestUrl(chainId: SupportedChainId, safeAddress: string, offset: number): string {
-  return `${getSafeApiUrl(chainId)}/v2/safes/${safeAddress}/multisig-transactions/?executed=false&limit=${HISTORY_TX_COUNT_LIMIT}&offset=${offset}&queued=true&trusted=true`
+function getSafeHistoryRequestUrl(
+  chainId: SupportedChainId,
+  safeAddress: string,
+  executed: boolean,
+  since?: string,
+): string {
+  const params = new URLSearchParams({
+    executed: String(executed),
+    limit: String(HISTORY_TX_COUNT_LIMIT),
+    ordering: '-submissionDate',
+    trusted: 'true',
+  })
+
+  if (since) params.set('submission_date__gte', since)
+
+  if (!executed) {
+    params.set('queued', 'true')
+  }
+
+  return `${getSafeApiUrl(chainId)}/v2/safes/${safeAddress}/multisig-transactions/?${params.toString()}`
+}
+
+function getNewestSubmissionDate(dates: (string | undefined)[]): string {
+  return dates.filter(isTruthy).reduce((latest, date) => (date > latest ? date : latest), '')
+}
+
+function getTransactionSubmissionDate(transaction: unknown): string | undefined {
+  return isSafeMultisigTransactionListResponse(transaction) ? transaction.submissionDate : undefined
 }
 
 function parseSafeTransactionsResult(

--- a/apps/cowswap-frontend/src/modules/zeroApproval/hooks/useZeroApprove.ts
+++ b/apps/cowswap-frontend/src/modules/zeroApproval/hooks/useZeroApprove.ts
@@ -73,6 +73,7 @@ async function waitForSafeTransactionExecution({
   return await pollUntil(
     async () => {
       try {
+        console.log('[COW][SafeAPI] Wait for Safe transaction execution')
         return await safeApiKit.getTransaction(txHash)
       } catch {
         return null

--- a/libs/core/src/gnosisSafe/index.ts
+++ b/libs/core/src/gnosisSafe/index.ts
@@ -63,10 +63,10 @@ export function getSafeAccountUrl(chainId: SupportedChainId, safeAddress: string
 }
 
 export async function getSafeInfo(chainId: number, safeAddress: string): Promise<SafeInfoResponse> {
-  console.log('[api/gnosisSafe] getSafeInfo', chainId, safeAddress)
   try {
     const client = await _getClientOrThrow(chainId)
 
+    console.log('[COW][SafeAPI] Fetch Safe info')
     return client.getSafeInfo(safeAddress)
   } catch (error) {
     return Promise.reject(error)
@@ -77,9 +77,9 @@ export async function getSafeTransaction(
   chainId: number,
   safeTxHash: string,
 ): Promise<SafeMultisigTransactionResponse> {
-  console.log('[api/gnosisSafe] getSafeTransaction', chainId, safeTxHash)
   const client = await _getClientOrThrow(chainId)
 
+  console.log('[COW][SafeAPI] Fetch Safe transaction')
   return client.getTransaction(safeTxHash)
 }
 


### PR DESCRIPTION
> **This is a layered-review companion for #7529.** It is not meant to be merged.
> The underlying diff is byte-identical to #7529 — review here for clarity, merge there.

## Layers

| Layer | Commit | Hunks | Files | Review depth |
|-------|--------|-------|-------|--------------|
| **B** — Light human review | [`3aa4f12`](https://github.com/cowprotocol/cowswap/commit/3aa4f129b230122643c3e6d3bab19ec64255718c) | 3 | 2 | Skim intent + tests |
| **C** — Human review required | [`95a0c47`](https://github.com/cowprotocol/cowswap/commit/95a0c4784299a40cd25716666d555484535a3350) | 8 | 3 | Full review |

To review only the human-required changes: `git diff 3aa4f12..95a0c47`

## Manifest

<details>
<summary>3 hunks in Layer B</summary>

- `apps/cowswap-frontend/src/modules/zeroApproval/hooks/useZeroApprove.ts:73` — business_logic — _"Adds a console log during polling; minor observable behavior change only."_
- `libs/core/src/gnosisSafe/index.ts:63` — business_logic — _"Replaces/moves console logging for fetching Safe info; minor logging-only change."_
- `libs/core/src/gnosisSafe/index.ts:77` — business_logic — _"Changes console logging for getSafeTransaction; minor, logging-only behavior change."_
</details>

<details open>
<summary>8 hunks in Layer C — focus your review here</summary>

- `apps/cowswap-frontend/src/modules/twap/hooks/useFetchTwapOrdersFromSafe.ts:6` — business_logic — _"Switches to a new cached fetch service and changes polling interval (45s to 1m), altering runtime data-fetch behavior."_
- `apps/cowswap-frontend/src/modules/twap/hooks/useFetchTwapOrdersFromSafe.ts:29` — business_logic — _"Updates to call the new cached fetch function and changes the interval constant, impacting update cadence and behavior."_
- `apps/cowswap-frontend/src/modules/twap/services/fetchCachedTwapOrdersFromSafe.ts:1` — schema_persistence — _"Introduces localStorage-backed caching, versioning, overlap logic, and merging—adds persistence/cache behavior and affects fetching logic."_
- `apps/cowswap-frontend/src/modules/twap/services/fetchTwapOrdersFromSafe.ts:31` — type_export_change — _"Exports a type and changes the exported function’s signature and return shape, affecting callers and behavior."_
- `apps/cowswap-frontend/src/modules/twap/services/fetchTwapOrdersFromSafe.ts:68` — business_logic — _"Refactors executed-transactions fetching to accept a since parameter, paginates, and returns metadata; modifies merge/return behavior."_
- `apps/cowswap-frontend/src/modules/twap/services/fetchTwapOrdersFromSafe.ts:140` — rename_cross_boundary — _"Renames and exports a utility (mergeByHash -> mergeTwapOrdersByHash) for cross-file use; no logic change but exported symbol/usage change."_
- `apps/cowswap-frontend/src/modules/twap/services/fetchTwapOrdersFromSafe.ts:159` — business_logic — _"Alters fetch return type to include a fetchError flag and adds logging; changes error handling/flow for upstream logic."_
- `apps/cowswap-frontend/src/modules/twap/services/fetchTwapOrdersFromSafe.ts:173` — business_logic — _"Changes request URL builder semantics (executed flag, since filter, ordering, queued), adds logging; network query behavior change."_
</details>

## Escalations

1 hunks were escalated beyond their classifier verdict:

- `apps/cowswap-frontend/src/modules/twap/services/fetchTwapOrdersFromSafe.ts:140` — B → C — _Multiple intents detected in a single hunk._

## Provenance

- Source: `cowprotocol/cowswap#7529` @ `d876aed`
- Generated: 2026-05-19 12:45 UTC
- Tool: `vibereview@0.1.0`
- Provider: `openai` (`gpt-5`)
- Manifest: [`.vibereview/pr-7529.json`](https://github.com/cowprotocol/cowswap/blob/HEAD/.vibereview/pr-7529.json)
