### PR TITLE
fix(account): restore COW-from-locked-GNO claim flow

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useContract.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useContract.ts
@@ -2,6 +2,8 @@ import { useMemo } from 'react'
 
 import {
   getEthFlowContractAddresses,
+  MERKLE_DROP_CONTRACT_ADDRESSES,
+  TOKEN_DISTRO_CONTRACT_ADDRESSES,
   V_COW_CONTRACT_ADDRESS,
   WRAPPED_NATIVE_CURRENCIES,
 } from '@cowprotocol/common-const'
@@ -11,7 +13,14 @@ import {
   CowEnv,
   SupportedChainId,
 } from '@cowprotocol/cow-sdk'
-import { CoWSwapEthFlowAbi, GPv2SettlementAbi, vCowAbi, WethAbi } from '@cowprotocol/cowswap-abis'
+import {
+  CoWSwapEthFlowAbi,
+  GPv2SettlementAbi,
+  MerkleDropAbi,
+  TokenDistroAbi,
+  vCowAbi,
+  WethAbi,
+} from '@cowprotocol/cowswap-abis'
 import { useWalletInfo } from '@cowprotocol/wallet'
 
 import { type Address, erc20Abi } from 'viem'
@@ -208,6 +217,88 @@ export function useVCowContract(): {
         }),
     }
   }, [vCowAddress, chainId, publicClient, walletClient])
+
+  return useMemo(
+    () => ({
+      contract,
+      chainId: chainId ?? undefined,
+    }),
+    [contract, chainId],
+  )
+}
+
+export function useMerkleDropContract(): {
+  contract: {
+    claim: (index: number, amount: string, proof: string[]) => Promise<{ hash: `0x${string}` }>
+  } | null
+  chainId: SupportedChainId | undefined
+} {
+  const { chainId } = useWalletInfo()
+  const { data: walletClient } = useWalletClient()
+  const address = chainId ? MERKLE_DROP_CONTRACT_ADDRESSES[chainId] : ''
+
+  const contract = useMemo(() => {
+    if (!address || !chainId || !walletClient) return null
+    const contractAddress = address as Address
+    return {
+      claim: async (index: number, amount: string, proof: string[]) => {
+        const hash = await walletClient.writeContract({
+          address: contractAddress,
+          abi: MerkleDropAbi,
+          functionName: 'claim',
+          args: [BigInt(index), BigInt(amount), proof as readonly `0x${string}`[]],
+          account: walletClient.account,
+        })
+        return { hash }
+      },
+    }
+  }, [address, chainId, walletClient])
+
+  return useMemo(
+    () => ({
+      contract,
+      chainId: chainId ?? undefined,
+    }),
+    [contract, chainId],
+  )
+}
+
+export function useTokenDistroContract(): {
+  contract: {
+    balances: (account: string) => Promise<{ claimed: bigint }>
+    claim: () => Promise<{ hash: `0x${string}` }>
+  } | null
+  chainId: SupportedChainId | undefined
+} {
+  const { chainId } = useWalletInfo()
+  const publicClient = usePublicClient()
+  const { data: walletClient } = useWalletClient()
+  const address = chainId ? TOKEN_DISTRO_CONTRACT_ADDRESSES[chainId] : ''
+
+  const contract = useMemo(() => {
+    if (!address || !chainId || !publicClient || !walletClient) return null
+    const contractAddress = address as Address
+    return {
+      balances: async (account: string) => {
+        const [, claimed] = await publicClient.readContract({
+          address: contractAddress,
+          abi: TokenDistroAbi,
+          functionName: 'balances',
+          args: [account as Address],
+        })
+        return { claimed }
+      },
+      claim: async () => {
+        const hash = await walletClient.writeContract({
+          address: contractAddress,
+          abi: TokenDistroAbi,
+          functionName: 'claim',
+          account: walletClient.account,
+        })
+        return { hash }
+      },
+    }
+  }, [address, chainId, publicClient, walletClient])
 
   return useMemo(
     () => ({

--- a/apps/cowswap-frontend/src/pages/Account/LockedGnoVesting/hooks.ts
+++ b/apps/cowswap-frontend/src/pages/Account/LockedGnoVesting/hooks.ts
@@ -4,11 +4,8 @@ import {
   COW_TOKEN_TO_CHAIN,
   LOCKED_GNO_VESTING_DURATION,
   LOCKED_GNO_VESTING_START_TIME,
-  MERKLE_DROP_CONTRACT_ADDRESSES,
-  TOKEN_DISTRO_CONTRACT_ADDRESSES,
 } from '@cowprotocol/common-const'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { MerkleDropAbi, TokenDistroAbi } from '@cowprotocol/cowswap-abis'
 import { Currency, CurrencyAmount } from '@cowprotocol/currency'
 import { Command } from '@cowprotocol/types'
 import { useWalletInfo } from '@cowprotocol/wallet'
@@ -18,41 +15,14 @@ import useSWR from 'swr'
 
 import { useTransactionAdder } from 'legacy/state/enhancedTransactions/hooks'
 
-import { useContract } from 'common/hooks/useContract'
+import { useMerkleDropContract, useTokenDistroContract } from 'common/hooks/useContract'
 
 import { fetchClaim } from './claimData'
 
 // We just generally use the mainnet version. We don't read from the contract anyways so the address doesn't matter
 const _COW = COW_TOKEN_TO_CHAIN[SupportedChainId.MAINNET]
 
-interface MerkleDropContract {
-  claim(index: number, amount: string, proof: string[]): Promise<{ hash: `0x${string}` }>
-}
-
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- return type is complex (UseContractResult<Abi>)
-function useMerkleDropContract() {
-  const { chainId } = useWalletInfo()
-  return useContract<MerkleDropContract | null>(
-    chainId != null ? MERKLE_DROP_CONTRACT_ADDRESSES[chainId] : undefined,
-    MerkleDropAbi,
-    true,
-  )
-}
-
-interface TokenDistroContract {
-  balances(account: string): Promise<{ claimed: bigint }>
-  claim(): Promise<{ hash: `0x${string}` }>
-}
-
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- return type is complex (UseContractResult<Abi>)
-function useTokenDistroContract() {
-  const { chainId } = useWalletInfo()
-  return useContract<TokenDistroContract | null>(
-    chainId != null ? TOKEN_DISTRO_CONTRACT_ADDRESSES[chainId] : undefined,
-    TokenDistroAbi,
-    true,
-  )
-}
+type TokenDistroContract = NonNullable<ReturnType<typeof useTokenDistroContract>['contract']>
 
 export const useAllocation = (): CurrencyAmount<Currency> => {
   const { t } = useLingui()
@@ -154,7 +124,7 @@ export function useClaimCowFromLockedGnoCallback({
       throw new Error(t`Not connected`)
     }
 
-    if (!merkleDrop || !tokenDistro) {
+    if (!merkleDrop || !tokenDistro || !tokenDistroChainId) {
       throw new Error(t`Contract not present or not connected to any supported chain`)
     }
 


### PR DESCRIPTION
# Summary
                                                                                                                                                                                                          
  Fixes [#7526](https://github.com/cowprotocol/cowswap/issues/7526)
                                                                                                                                                                                                          
  `apps/cowswap-frontend/src/common/hooks/useContract.ts` exports a `useContract()` stub left over from the Viem migration. Its own JSDoc says *"Minimal stub for legacy useContract(address, abi,        
  withContract). Returns contract data only; contract methods require viem/wagmi."* It unconditionally returns `contract: null`. The locked-GNO claim flow in `pages/Account/LockedGnoVesting/hooks.ts`
  was still calling that stub to build `MerkleDrop` and `TokenDistro` handles, so:                                                                                                                        
                                                                                                                                                                                                        
  - `merkleDrop` and `tokenDistro` were always `null`.                                                                                                                                                    
  - The guard at `hooks.ts:157` (`if (!merkleDrop || !tokenDistro) throw …`) fired on every click.
  - The Claim button on the *COW vesting from locked GNO* card always surfaced the modal *"Contract not present or not connected to any supported chain"*, on both Ethereum and Gnosis Chain.             
                                                                                                                                                                                                          
  This PR adds proper viem-backed wrappers next to the existing `useVCowContract`/`useTokenContract` in `common/hooks/useContract.ts`:                                                                    
                                                                                                                                                                                                          
  - **`useMerkleDropContract()`** — exposes `claim(index, amount, proof)` via `walletClient.writeContract` against `MERKLE_DROP_CONTRACT_ADDRESSES[chainId]`.                                             
  - **`useTokenDistroContract()`** — exposes `balances(account)` via `publicClient.readContract` (returning the second tuple element as `{ claimed }` to match the previous call shape) and `claim()` via
  `walletClient.writeContract` against `TOKEN_DISTRO_CONTRACT_ADDRESSES[chainId]`.                                                                                                                        
                                                                                                                                                                                                        
  `LockedGnoVesting/hooks.ts` now consumes those wrappers directly, the dead local `useMerkleDropContract`/`useTokenDistroContract` helpers are removed, and the SWR `TokenDistroContract` interface is   
  derived from the new wrapper's return type so call sites and types stay in sync. Both wrappers return `{ contract: null }` when there's no wallet/public client/supported chainId — the same fail-closed
   shape the claim guard and the SWR fetcher already handle.                                                                                                                                              
                                                                                                                                                                                                        
  # To Test                                                                                                                                                                                               
   
  1. **Restored claim flow on Ethereum**                                                                                                                                                                  
                                                                                                                                                                                                        
  - [ ] Connect a wallet that holds a vested COW-from-locked-GNO allocation on Ethereum (e.g. `0xe91f64ca1da165ca8437686b69a022156550837b` via impersonator.xyz, or via an anvil mainnet fork for full    
  E2E).
  - [ ] Open *Account → Overview*.                                                                                                                                                                        
  - [ ] Click **Claim** on the *COW vesting from locked GNO* card.                                                                                                                                      
  - [ ] Verify the modal **no longer** shows *"Contract not present or not connected to any supported chain"*.                                                                                            
  - [ ] Verify the wallet receives a `claim()` transaction request against `0x68FFAaC7A431f276fe73604C127Bd78E49070c92` (mainnet TokenDistro) — or against `0x64646f112FfD6F1B7533359CFaAF7998F23C8c40`
  (mainnet MerkleDrop) if this is the first claim for that account.                                                                                                                                       
  - [ ] With a real signer (anvil fork or a wallet you control), confirm the transaction and verify it lands on-chain.                                                                                     
   
  # Background                                                                                                                                                                                            
                                                                                                                                                                                                        
  This is a Viem-migration regression introduced together with PR #7061 *"feat!: migrate to Viem, Wagmi, and Reown"* (commit `48daef9bfb`, 2026-04-14). That migration replaced the old ethers-v5         
  `useContract(...)` (which returned a real `Contract` instance) with the documented stub that returns `{ contract: null }`. Most contract call sites were updated to viem-native wrappers in the same PR
  — but the locked-GNO path (`pages/Account/LockedGnoVesting/hooks.ts`) was missed. The fix is mechanical: wrap the two contracts in the same style as `useVCowContract`, keep the consumer-side interface
   (`MerkleDropContract` / `TokenDistroContract`) identical so the claim callback, the SWR key, and the existing TS narrowing don't need to change.                                                     

  The wrappers' return shape (`{ contract, chainId }` with `chainId: SupportedChainId | undefined`) is slightly stricter than the stub (`chainId: SupportedChainId` always defined). The claim callback   
  now has a single extra null check on `tokenDistroChainId` to satisfy that narrowing — semantically equivalent, since the contract is non-null only when chainId is set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Merkle Drop token claiming functionality with cryptographic proof verification for eligible accounts
  * Integrated Token Distribution contract support, allowing users to check claimed balances and submit claim transactions
  * Refactored contract interaction patterns for streamlined token distribution workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cowprotocol/cowswap/pull/7536?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->