### PR TITLE
fix(twap): fallback TWAP history requests to public API

### DIFF
--- a/apps/cowswap-frontend/src/modules/twap/services/fetchTwapOrdersFromSafe.ts
+++ b/apps/cowswap-frontend/src/modules/twap/services/fetchTwapOrdersFromSafe.ts
@@ -81,7 +81,7 @@ async function fetchRecentlyExecutedTransactions(
 
     const headers = getSafeApiHeaders()
 
-    const response: AllTransactionsListResponse = await fetch(url, { headers }).then((res) => res.json())
+    const response = await fetchWithFallback<AllTransactionsListResponse>(url, headers)
     const results = response?.results || []
 
     return parseSafeTransactionsResult(composableCowContract, results)
@@ -120,7 +120,7 @@ async function fetchSafeTransactionsChunk(
 
   if (nextUrl) {
     try {
-      const response: AllTransactionsListResponse = await fetch(nextUrl, { headers }).then((res) => res.json())
+      const response = await fetchWithFallback<AllTransactionsListResponse>(nextUrl, headers)
 
       await delay(SAFE_TX_REQUEST_DELAY)
 
@@ -134,7 +134,18 @@ async function fetchSafeTransactionsChunk(
 
   const url = getSafeHistoryRequestUrl(chainId, safeAddress, 0)
 
-  return fetch(url, { headers }).then((res) => res.json())
+  return fetchWithFallback(url, headers)
+}
+
+function fetchWithFallback<T>(url: string, headers: HeadersInit): Promise<T> {
+  return fetch(url, { headers })
+    .then((res) => {
+      if (res.status === 429 || res.status === 403) {
+        return fetch(url)
+      }
+      return res
+    })
+    .then((res) => res.json())
 }
 
 function getSafeHistoryRequestUrl(chainId: SupportedChainId, safeAddress: string, offset: number): string {


### PR DESCRIPTION
# Summary

Added a fallback to `/multisig-transactions` Safe API requests.
By default, we try to fetch it with `Authorization` header. If it throws 403 or 429 we try it again without the authorization.
This mechanism should help a bit with the API requests limitations.

# To Test

1. Open TWAP in Safe
2. Open devtools, network tab, filter the requests with `multisig-transactions`
3. See the requests
4. If there is a requests with 429 or 403 response, then it should be followed by the similar one, but without `Authorization` header

<img width="907" height="430" alt="image" src="https://github.com/user-attachments/assets/3967aff3-81c8-4353-b63a-9b7accf4e2fd" />

<img width="1606" height="547" alt="image" src="https://github.com/user-attachments/assets/a7007a84-812f-418f-a97f-fac64af6bab0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when fetching Safe multisig transaction data by adding a fallback retry: requests that hit rate limits or auth failures are retried without auth and paginated history requests now use the same resilient fetch flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cowprotocol/cowswap/pull/7540?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->