### PR TITLE
fix: fix USDT approval after Viem

### DIFF
--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -2704,6 +2704,10 @@ msgstr "Pre"
 msgid "(v)COW token holders are eligible for a fee discount"
 msgstr "(v)COW token holders are eligible for a fee discount"
 
+#: apps/cowswap-frontend/src/modules/onchainTransactions/updaters/OnchainTransactionEventsUpdater.tsx
+msgid "Transaction cancelled: it was not submitted to the blockchain."
+msgstr "Transaction cancelled: it was not submitted to the blockchain."
+
 #: apps/cowswap-frontend/src/modules/wallet/pure/PendingView/index.tsx
 msgid "Error connecting"
 msgstr "Error connecting"
@@ -7252,6 +7256,7 @@ msgstr "Recover!"
 msgid "Estimated fill price"
 msgstr "Estimated fill price"
 
+#: apps/cowswap-frontend/src/legacy/hooks/useWrapCallback.ts
 #: apps/cowswap-frontend/src/modules/ethFlow/containers/EthFlowStepper/index.tsx
 msgid "Transaction failed"
 msgstr "Transaction failed"

--- a/apps/cowswap-frontend/src/modules/zeroApproval/hooks/useShouldZeroApprove/shouldZeroApprove.ts
+++ b/apps/cowswap-frontend/src/modules/zeroApproval/hooks/useShouldZeroApprove/shouldZeroApprove.ts
@@ -1,16 +1,37 @@
 import { Currency, CurrencyAmount } from '@cowprotocol/currency'
 
 import { Nullish } from 'types'
-import { erc20Abi } from 'viem'
+import { Address } from 'viem'
 import { simulateContract } from 'wagmi/actions'
 
 import { ApprovalState } from 'modules/erc20Approve'
 
 import type { Config } from 'wagmi'
 
+const erc20Abi = [
+  {
+    type: 'function',
+    name: 'approve',
+    stateMutability: 'nonpayable',
+    inputs: [
+      {
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    // It's important to keep it empty
+    // Viem validates the output and USDT output is not a standard ERC-20 type (bool expected)
+    outputs: [],
+  },
+]
+
 export interface ShouldZeroApproveParams {
-  tokenAddress: Nullish<string>
-  spender: Nullish<string>
+  tokenAddress: Nullish<Address>
+  spender: Nullish<Address>
   amountToApprove: Nullish<CurrencyAmount<Currency>>
   forceApprove?: boolean
   approvalState?: ApprovalState
@@ -34,22 +55,25 @@ export async function shouldZeroApprove({
 
   try {
     await simulateContract(config, {
-      address: tokenAddress as `0x${string}`,
+      address: tokenAddress,
       abi: erc20Abi,
       functionName: 'approve',
-      args: [spender as `0x${string}`, BigInt(amountToApprove.quotient.toString())],
+      args: [spender, BigInt(amountToApprove.quotient.toString())],
     })
+
     return false
-  } catch {
+  } catch (e) {
+    console.error('shouldZeroApprove #1 error', e)
     try {
       await simulateContract(config, {
-        address: tokenAddress as `0x${string}`,
+        address: tokenAddress,
         abi: erc20Abi,
         functionName: 'approve',
-        args: [spender as `0x${string}`, 0n],
+        args: [spender, 0n],
       })
       return true
-    } catch {
+    } catch (e) {
+      console.error('shouldZeroApprove #2 error', e)
       return false
     }
   }


### PR DESCRIPTION
# Summary

Fixes #7539

The `simulateContract` was throwing:
```
simulateZeroApprove() fails for USDT token with the error:                                                                                                                                               
  ContractFunctionExecutionError: The contract function "approve" returned no data ("0x").
```

It turned out that:
1.  USDT's approve is non-spec-compliant — it returns nothing instead of `bool`. The `erc20Abi` we pass to simulateContract declares approve returns bool.
2. If ABI expects bool but data is 0x (empty) → throw ContractFunctionZeroDataError

To fix that, I redeclared `erc20Abi` with empty outputs, so Viem do not validate it.

# To Test

See #7539

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and diagnostic logging for token approval flows, including a more robust retry with a zero-allowance fallback.
  * Strengthened type safety around approval parameters to reduce runtime issues.

* **Localization**
  * Added English translation for on-chain transaction cancellation and an additional translation entry for related UI text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cowprotocol/cowswap/pull/7541?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->