### PR TITLE
feat: improve safe wallet detection

### DIFF
--- a/libs/wallet/src/wagmi/hooks/useWalletMetadata.ts
+++ b/libs/wallet/src/wagmi/hooks/useWalletMetadata.ts
@@ -105,7 +105,9 @@ export function useIsSafeApp(): boolean {
 
 /**
  * Detects whether the currently connected wallet is a Safe wallet
- * regardless of the connection method (WalletConnect or inside Safe as an App)
+ * regardless of the connection method (WalletConnect or inside Safe as an App).
+ * Warning: this can be false when Safe API is down or rate-limited and does not mean the wallet is not a Safe.
+ * TODO: Rename to useHasGnosisSafeInfo.
  */
 export function useIsSafeWallet(): boolean {
   return !!useGnosisSafeInfo()

--- a/libs/wallet/src/wagmi/updater.ts
+++ b/libs/wallet/src/wagmi/updater.ts
@@ -4,14 +4,15 @@ import { useEffect, useMemo, useState, useSyncExternalStore } from 'react'
 import { getCurrentChainIdFromUrl, getRawCurrentChainIdFromUrl } from '@cowprotocol/common-utils'
 import { getSafeInfo } from '@cowprotocol/core'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { AccountType } from '@cowprotocol/types'
 
 import ms from 'ms.macro'
 import { Address } from 'viem'
 import { useConnection, useEnsName } from 'wagmi'
 
-import { useIsSmartContractWallet } from './hooks/useIsSmartContractWallet'
+import { useAccountType, useIsSmartContractWallet } from './hooks/useIsSmartContractWallet'
 import { useSafeAppsSdk } from './hooks/useSafeAppsSdk'
-import { useIsSafeApp, useWalletMetaData } from './hooks/useWalletMetadata'
+import { useIsSafeApp, useIsSafeViaWc, useWalletMetaData } from './hooks/useWalletMetadata'
 
 import { useIsMetamaskBrowserExtensionWallet } from '../api/hooks'
 import { gnosisSafeInfoAtom, walletDetailsAtom, walletInfoAtom } from '../api/state'
@@ -159,9 +160,21 @@ export function WalletUpdater(): null {
   return null
 }
 
+function useShouldFetchSafeInfo(): boolean {
+  const accountType = useAccountType()
+  const isSafeViaWc = useIsSafeViaWc()
+
+  if (!isSafeViaWc) return false
+  if (accountType === AccountType.EOA) return false
+  if (accountType === AccountType.EIP7702EOA) return false
+
+  return true
+}
+
 function useSafeInfo(): GnosisSafeInfo | undefined {
   const safeAppsSdk = useSafeAppsSdk()
   const { account, chainId } = useWalletInfo()
+  const shouldFetchSafeInfo = useShouldFetchSafeInfo()
 
   const [safeInfo, setSafeInfo] = useState<GnosisSafeInfo | undefined>()
 
@@ -187,7 +200,7 @@ function useSafeInfo(): GnosisSafeInfo | undefined {
           setSafeInfo(undefined)
         }
       } else {
-        if (chainId && account) {
+        if (chainId && account && shouldFetchSafeInfo) {
           try {
             const _safeInfo = await getSafeInfo(chainId, account)
             const { address, threshold, owners, nonce } = _safeInfo
@@ -233,7 +246,7 @@ function useSafeInfo(): GnosisSafeInfo | undefined {
       clearInterval(longSafeInfoInterval !== null ? longSafeInfoInterval : undefined)
       longSafeInfoInterval = null
     }
-  }, [chainId, account, safeAppsSdk])
+  }, [chainId, account, safeAppsSdk, shouldFetchSafeInfo])
 
   return safeInfo
 }


### PR DESCRIPTION
# Summary

Reduce unnecessary Safe Transaction Service calls for non-Safe wallets.

Outside the Safe iframe, `WalletUpdater` used to call `getSafeInfo()` for any connected account on an interval. For EOAs this creates repeated Safe API requests and noisy `403` & `429` console errors.

This PR gates Safe API info fetching so it only runs when the wallet looks like Safe via WalletConnect and is not known to be an EOA/EIP-7702 EOA.

Also clarifies `useIsSafeWallet()` docs: a `false` result can also mean Safe API is down/rate-limited, not necessarily that the wallet is not a Safe.

# To Test

1. Connect with a regular EOA wallet.

- [ ] Verify Safe API `getSafeInfo` requests are not repeatedly logged/polled.
- [ ] Verify the app still loads wallet info normally.

2. Connect with Safe via WalletConnect.

- [ ] Verify Safe wallet is still detected.
- [ ] Verify Safe signing / pending order flows still have Safe info.

3. Open CoW Swap inside Safe app iframe.

- [ ] Verify Safe info is still loaded through the Safe Apps SDK.
- [ ] Verify no regression in Safe app wallet display/signing.

# Background

Safe iframe mode already uses `safeAppsSdk.safe.getInfo()` and does not need Safe Transaction Service for wallet info.

The Safe API `getSafeInfo()` path is still needed for Safe via WalletConnect because downstream flows use Safe address, threshold, owners, nonce, and read-only status.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Safe wallet detection behavior and added warning about potential false negatives when API is unavailable.

* **Refactor**
  * Improved efficiency of Safe wallet information fetching by adding conditional logic based on wallet connection type and account type, reducing unnecessary API calls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cowprotocol/cowswap/pull/7544?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->