### PR TITLE
chore: add cf scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "preview": "NODE_OPTIONS=--max-old-space-size=8192 nx run cowswap-frontend:preview",
     "test": "pnpm run test:all && pnpm run test:tools",
     "test:all": "nx run-many -t test",
-    "test:tools": "node --test tools/scripts/*.test.mjs",
+    "test:tools": "node --test tools/scripts/*.test.mjs tools/scripts/cf-pages/*.test.mjs",
     "typecheck": "nx run cowswap-frontend:typecheck",
     "e2e": "nx run-many -t e2e",
     "e2e:open": "nx run-many -t e2e:open",

--- a/tools/scripts/cf-pages/cf-api.mjs
+++ b/tools/scripts/cf-pages/cf-api.mjs
@@ -10,7 +10,7 @@
  *   Scope: Account Resources > Include > <your account>
  */
 
-const CF_API_BASE = 'https://api.cloudflare.com/client/v4'
+const DEFAULT_CF_API_BASE = 'https://api.cloudflare.com/client/v4'
 
 /**
  * Reads CF_ACCOUNT_ID and CF_API_TOKEN from env.
@@ -37,7 +37,8 @@ export function getCfCredentials() {
  * @returns {Promise<any>} Parsed JSON response body
  */
 export async function cfFetch(accountId, apiToken, path, options = {}) {
-  const url = `${CF_API_BASE}/accounts/${accountId}/pages/${path}`
+  const apiBase = process.env.CF_API_BASE ?? DEFAULT_CF_API_BASE
+  const url = `${apiBase}/accounts/${accountId}/pages/${path}`
   let res
   try {
     res = await fetch(url, {

--- a/tools/scripts/cf-pages/cf-api.mjs
+++ b/tools/scripts/cf-pages/cf-api.mjs
@@ -1,0 +1,76 @@
+/**
+ * Shared Cloudflare Pages API utility.
+ *
+ * ENV VARS:
+ *   CF_ACCOUNT_ID  (required)  Cloudflare account ID
+ *   CF_API_TOKEN   (required)  Cloudflare API token
+ *
+ * API TOKEN PERMISSIONS (https://dash.cloudflare.com/profile/api-tokens):
+ *   Account > Cloudflare Pages > Edit
+ *   Scope: Account Resources > Include > <your account>
+ */
+
+const CF_API_BASE = 'https://api.cloudflare.com/client/v4'
+
+/**
+ * Reads CF_ACCOUNT_ID and CF_API_TOKEN from env.
+ * Calls cfError (exits 1) if either is missing.
+ *
+ * @returns {{ accountId: string, apiToken: string }}
+ */
+export function getCfCredentials() {
+  const accountId = process.env.CF_ACCOUNT_ID
+  const apiToken = process.env.CF_API_TOKEN
+  if (!accountId) cfError('CF_ACCOUNT_ID env var is required.')
+  if (!apiToken) cfError('CF_API_TOKEN env var is required.')
+  return { accountId, apiToken }
+}
+
+/**
+ * Fetches a Cloudflare Pages API endpoint.
+ * Throws an Error when the API returns success: false or on network failure.
+ *
+ * @param {string} accountId
+ * @param {string} apiToken
+ * @param {string} path  Relative to /accounts/{accountId}/pages/ — e.g. 'projects' or 'projects/my-app/deployments'
+ * @param {RequestInit} [options]
+ * @returns {Promise<any>} Parsed JSON response body
+ */
+export async function cfFetch(accountId, apiToken, path, options = {}) {
+  const url = `${CF_API_BASE}/accounts/${accountId}/pages/${path}`
+  let res
+  try {
+    res = await fetch(url, {
+      ...options,
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        'Content-Type': 'application/json',
+        ...options.headers,
+      },
+    })
+  } catch (err) {
+    throw new Error(`Network error: ${err.message}`)
+  }
+  const text = await res.text()
+  let data
+  try {
+    data = JSON.parse(text)
+  } catch {
+    throw new Error(`Cloudflare API returned non-JSON (HTTP ${res.status}): ${text.slice(0, 200)}`)
+  }
+  if (!data.success) {
+    throw new Error(`Cloudflare API error:\n${JSON.stringify(data.errors ?? [], null, 2)}`)
+  }
+  return data
+}
+
+/**
+ * Prints an error message to stderr (prefixed with "ERROR: ") and exits with code 1.
+ *
+ * @param {string} message
+ * @returns {never}
+ */
+export function cfError(message) {
+  process.stderr.write(`ERROR: ${message}\n`)
+  process.exit(1)
+}

--- a/tools/scripts/cf-pages/cf-api.test.mjs
+++ b/tools/scripts/cf-pages/cf-api.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { cfFetch } from './cf-api.mjs'
+import { startMockCloudflare } from './test-utils.mjs'
+
+describe('cf-api', () => {
+  it('sends Cloudflare auth headers and parses successful JSON responses', async (t) => {
+    const cloudflare = await startMockCloudflare([
+      {
+        method: 'GET',
+        url: '/client/v4/accounts/account-id/pages/projects',
+        response: { body: { success: true, result: { ok: true } } },
+      },
+    ])
+    t.after(() => cloudflare.close())
+
+    process.env.CF_API_BASE = cloudflare.apiBase
+    t.after(() => {
+      delete process.env.CF_API_BASE
+    })
+
+    const data = await cfFetch('account-id', 'api-token', 'projects')
+
+    assert.deepEqual(data.result, { ok: true })
+    assert.equal(cloudflare.requests[0].headers.authorization, 'Bearer api-token')
+    assert.equal(cloudflare.requests[0].headers['content-type'], 'application/json')
+  })
+
+  it('throws Cloudflare API errors from unsuccessful responses', async (t) => {
+    const cloudflare = await startMockCloudflare([
+      {
+        method: 'GET',
+        url: '/client/v4/accounts/account-id/pages/projects',
+        response: { body: { success: false, errors: [{ message: 'denied' }] } },
+      },
+    ])
+    t.after(() => cloudflare.close())
+
+    process.env.CF_API_BASE = cloudflare.apiBase
+    t.after(() => {
+      delete process.env.CF_API_BASE
+    })
+
+    await assert.rejects(() => cfFetch('account-id', 'api-token', 'projects'), /Cloudflare API error/)
+  })
+})

--- a/tools/scripts/cf-pages/create-pages-project.mjs
+++ b/tools/scripts/cf-pages/create-pages-project.mjs
@@ -58,7 +58,7 @@ let buildCaching = 'true'
 let previewDeploymentSetting = 'none'
 let productionDeploymentsEnabled = 'true'
 let isDryRun = false
-const PATH_INCLUDES = ['apps/cowswap-frontend/*']
+const PATH_INCLUDES = []
 const PATH_EXCLUDES = []
 
 const args = process.argv.slice(2)

--- a/tools/scripts/cf-pages/create-pages-project.mjs
+++ b/tools/scripts/cf-pages/create-pages-project.mjs
@@ -12,9 +12,6 @@
  *   CF_ACCOUNT_ID  (required unless --dry-run)  Cloudflare account ID
  *   CF_API_TOKEN   (required unless --dry-run)   Cloudflare API token
  *
- * Only CF_ACCOUNT_ID and CF_API_TOKEN are read from the environment.
- * Pass every other setting as a positional argument or CLI option.
- *
  * OPTIONS:
  *   --dry-run                                        Print the API payload, do not create anything
  *   --project-name <name>                            CF Pages project name
@@ -35,8 +32,7 @@
  *   --help                                           Show this help message
  *
  * PATH_INCLUDES DEFAULT:
- *   apps/cowswap-frontend/* is always watched. --path-include values are appended.
- *   To watch additional paths by default, edit PATH_INCLUDES near the top of this file:
+ *   To watch additional paths by default, edit PATH_INCLUDES:
  *     const PATH_INCLUDES = ['apps/cowswap-frontend/*', 'libs/*']
  *   --path-include values will be appended to that default.
  *
@@ -47,26 +43,6 @@
 
 import { readFileSync } from 'node:fs'
 import { cfError, cfFetch } from './cf-api.mjs'
-
-const UNSUPPORTED_ENV_VARS = [
-  'DRY_RUN',
-  'CF_PROJECT_NAME',
-  'CF_PAGES_BRANCH',
-  'CF_PRODUCTION_BRANCH',
-  'CF_SOURCE_TYPE',
-  'CF_REPO_OWNER',
-  'CF_REPO_NAME',
-  'CF_REPO_ID',
-  'CF_REPO_OWNER_ID',
-  'CF_BUILD_COMMAND',
-  'CF_DESTINATION_DIR',
-  'CF_ROOT_DIR',
-  'CF_BUILD_CACHING',
-  'CF_PREVIEW_DEPLOYMENT_SETTING',
-  'CF_PRODUCTION_DEPLOYMENTS_ENABLED',
-  'CF_PATH_INCLUDES',
-  'CF_PATH_EXCLUDES',
-]
 
 let projectName = ''
 let productionBranch = ''
@@ -171,12 +147,6 @@ for (let i = 0; i < args.length; i++) {
 
 let errors = 0
 
-for (const v of UNSUPPORTED_ENV_VARS) {
-  if (v in process.env) {
-    process.stderr.write(`ERROR: ${v} env var is not supported. Pass non-credential settings as CLI args/options.\n`)
-    errors++
-  }
-}
 if (!projectName) {
   process.stderr.write('ERROR: project name is required as an argument or --project-name.\n')
   errors++

--- a/tools/scripts/cf-pages/create-pages-project.mjs
+++ b/tools/scripts/cf-pages/create-pages-project.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+/**
+ * Create a Cloudflare Pages project connected to a Git branch.
+ *
+ * Useful when the Cloudflare Pages UI branch dropdown does not show the branch
+ * that should be used as the project's production branch.
+ *
+ * USAGE:
+ *   node create-pages-project.mjs <project-name> <production-branch> [options]
+ *
+ * ENV VARS:
+ *   CF_ACCOUNT_ID  (required unless --dry-run)  Cloudflare account ID
+ *   CF_API_TOKEN   (required unless --dry-run)   Cloudflare API token
+ *
+ * Only CF_ACCOUNT_ID and CF_API_TOKEN are read from the environment.
+ * Pass every other setting as a positional argument or CLI option.
+ *
+ * OPTIONS:
+ *   --dry-run                                        Print the API payload, do not create anything
+ *   --project-name <name>                            CF Pages project name
+ *   --branch <branch>                                Production branch
+ *   --source-type <github|gitlab>                    Source provider. Default: github
+ *   --repo-owner <owner>                             Repository owner. Default: cowprotocol
+ *   --repo-name <name>                               Repository name. Default: cowswap
+ *   --repo-id <id>                                   Optional provider repository ID
+ *   --repo-owner-id <id>                             Optional provider owner ID
+ *   --build-command <cmd>                            Build command. Default: pnpm run install:ci && pnpm run build:cowswap
+ *   --destination-dir <dir>                          Build output directory. Default: build/cowswap
+ *   --root-dir <dir>                                 Pages root directory. Optional
+ *   --build-caching <true|false>                     Build cache setting. Default: true
+ *   --path-include <path>                            Build watch include path. Repeatable.
+ *   --path-exclude <path>                            Build watch exclude path. Repeatable.
+ *   --preview-deployment-setting <all|none|custom>   Preview deployment behavior. Default: none
+ *   --production-deployments-enabled <true|false>    Whether pushes to production branch trigger a deploy. Default: true
+ *   --help                                           Show this help message
+ *
+ * PATH_INCLUDES DEFAULT:
+ *   apps/cowswap-frontend/* is always watched. --path-include values are appended.
+ *   To watch additional paths by default, edit PATH_INCLUDES near the top of this file:
+ *     const PATH_INCLUDES = ['apps/cowswap-frontend/*', 'libs/*']
+ *   --path-include values will be appended to that default.
+ *
+ * API TOKEN PERMISSIONS (https://dash.cloudflare.com/profile/api-tokens):
+ *   Account > Cloudflare Pages > Edit
+ *   Scope: Account Resources > Include > <your account>
+ */
+
+import { readFileSync } from 'node:fs'
+import { cfError, cfFetch } from './cf-api.mjs'
+
+const UNSUPPORTED_ENV_VARS = [
+  'DRY_RUN',
+  'CF_PROJECT_NAME',
+  'CF_PAGES_BRANCH',
+  'CF_PRODUCTION_BRANCH',
+  'CF_SOURCE_TYPE',
+  'CF_REPO_OWNER',
+  'CF_REPO_NAME',
+  'CF_REPO_ID',
+  'CF_REPO_OWNER_ID',
+  'CF_BUILD_COMMAND',
+  'CF_DESTINATION_DIR',
+  'CF_ROOT_DIR',
+  'CF_BUILD_CACHING',
+  'CF_PREVIEW_DEPLOYMENT_SETTING',
+  'CF_PRODUCTION_DEPLOYMENTS_ENABLED',
+  'CF_PATH_INCLUDES',
+  'CF_PATH_EXCLUDES',
+]
+
+let projectName = ''
+let productionBranch = ''
+let sourceType = 'github'
+let repoOwner = 'cowprotocol'
+let repoName = 'cowswap'
+let repoId = ''
+let repoOwnerId = ''
+let buildCommand = 'pnpm run install:ci && pnpm run build:cowswap'
+let destinationDir = 'build/cowswap'
+let rootDir = ''
+let buildCaching = 'true'
+let previewDeploymentSetting = 'none'
+let productionDeploymentsEnabled = 'true'
+let isDryRun = false
+const PATH_INCLUDES = ['apps/cowswap-frontend/*']
+const PATH_EXCLUDES = []
+
+const args = process.argv.slice(2)
+
+if (args.includes('--help')) {
+  const source = readFileSync(new URL(import.meta.url), 'utf8')
+  const block = source.match(/\/\*\*([\s\S]*?)\*\//)?.[1] ?? ''
+  process.stderr.write(block.replace(/^ \* ?/gm, '').trim() + '\n')
+  process.exit(0)
+}
+
+function requireValue(flag, args, i) {
+  if (i + 1 >= args.length) {
+    process.stderr.write(`ERROR: ${flag} requires a value.\n`)
+    process.exit(1)
+  }
+  return args[i + 1]
+}
+
+for (let i = 0; i < args.length; i++) {
+  const arg = args[i]
+  switch (arg) {
+    case '--dry-run':
+      isDryRun = true
+      break
+    case '--project-name':
+      projectName = requireValue(arg, args, i++)
+      break
+    case '--branch':
+      productionBranch = requireValue(arg, args, i++)
+      break
+    case '--source-type':
+      sourceType = requireValue(arg, args, i++)
+      break
+    case '--repo-owner':
+      repoOwner = requireValue(arg, args, i++)
+      break
+    case '--repo-name':
+      repoName = requireValue(arg, args, i++)
+      break
+    case '--repo-id':
+      repoId = requireValue(arg, args, i++)
+      break
+    case '--repo-owner-id':
+      repoOwnerId = requireValue(arg, args, i++)
+      break
+    case '--build-command':
+      buildCommand = requireValue(arg, args, i++)
+      break
+    case '--destination-dir':
+      destinationDir = requireValue(arg, args, i++)
+      break
+    case '--root-dir':
+      rootDir = requireValue(arg, args, i++)
+      break
+    case '--build-caching':
+      buildCaching = requireValue(arg, args, i++)
+      break
+    case '--path-include':
+    case '--watch-path-include':
+      PATH_INCLUDES.push(requireValue(arg, args, i++))
+      break
+    case '--path-exclude':
+    case '--watch-path-exclude':
+      PATH_EXCLUDES.push(requireValue(arg, args, i++))
+      break
+    case '--preview-deployment-setting':
+      previewDeploymentSetting = requireValue(arg, args, i++)
+      break
+    case '--production-deployments-enabled':
+      productionDeploymentsEnabled = requireValue(arg, args, i++)
+      break
+    default:
+      if (arg.startsWith('--')) {
+        process.stderr.write(`ERROR: Unknown option: ${arg}\n`)
+        process.exit(1)
+      }
+      if (!projectName) projectName = arg
+      else if (!productionBranch) productionBranch = arg
+      else {
+        process.stderr.write(`ERROR: Unexpected argument: ${arg}\n`)
+        process.exit(1)
+      }
+  }
+}
+
+let errors = 0
+
+for (const v of UNSUPPORTED_ENV_VARS) {
+  if (v in process.env) {
+    process.stderr.write(`ERROR: ${v} env var is not supported. Pass non-credential settings as CLI args/options.\n`)
+    errors++
+  }
+}
+if (!projectName) {
+  process.stderr.write('ERROR: project name is required as an argument or --project-name.\n')
+  errors++
+}
+if (!productionBranch) {
+  process.stderr.write('ERROR: production branch is required as an argument or --branch.\n')
+  errors++
+}
+if (!isDryRun) {
+  if (!process.env.CF_ACCOUNT_ID) {
+    process.stderr.write('ERROR: CF_ACCOUNT_ID env var is required.\n')
+    errors++
+  }
+  if (!process.env.CF_API_TOKEN) {
+    process.stderr.write('ERROR: CF_API_TOKEN env var is required.\n')
+    errors++
+  }
+}
+if (!repoOwner) {
+  process.stderr.write('ERROR: repository owner is required. Pass --repo-owner.\n')
+  errors++
+}
+if (!repoName) {
+  process.stderr.write('ERROR: repository name is required. Pass --repo-name.\n')
+  errors++
+}
+if (!['github', 'gitlab'].includes(sourceType)) {
+  process.stderr.write(`ERROR: source type must be 'github' or 'gitlab', got '${sourceType}'.\n`)
+  errors++
+}
+if (!['all', 'none', 'custom'].includes(previewDeploymentSetting)) {
+  process.stderr.write(
+    `ERROR: preview deployment setting must be 'all', 'none', or 'custom', got '${previewDeploymentSetting}'.\n`,
+  )
+  errors++
+}
+if (!['true', 'false'].includes(productionDeploymentsEnabled)) {
+  process.stderr.write(
+    `ERROR: production deployments enabled must be 'true' or 'false', got '${productionDeploymentsEnabled}'.\n`,
+  )
+  errors++
+}
+if (buildCaching && !['true', 'false'].includes(buildCaching)) {
+  process.stderr.write(`ERROR: build caching must be 'true' or 'false', got '${buildCaching}'.\n`)
+  errors++
+}
+if (errors > 0) process.exit(1)
+
+const payload = {
+  name: projectName,
+  production_branch: productionBranch,
+  source: {
+    type: sourceType,
+    config: {
+      owner: repoOwner,
+      repo_name: repoName,
+      production_branch: productionBranch,
+      production_deployments_enabled: productionDeploymentsEnabled === 'true',
+      preview_deployment_setting: previewDeploymentSetting,
+    },
+  },
+}
+
+if (repoId) payload.source.config.repo_id = repoId
+if (repoOwnerId) payload.source.config.owner_id = repoOwnerId
+
+const buildConfig = {}
+if (buildCommand) buildConfig.build_command = buildCommand
+if (destinationDir) buildConfig.destination_dir = destinationDir
+if (rootDir) buildConfig.root_dir = rootDir
+if (buildCaching) buildConfig.build_caching = buildCaching === 'true'
+if (Object.keys(buildConfig).length > 0) payload.build_config = buildConfig
+
+if (PATH_INCLUDES.length > 0) payload.source.config.path_includes = PATH_INCLUDES
+if (PATH_EXCLUDES.length > 0) payload.source.config.path_excludes = PATH_EXCLUDES
+
+if (isDryRun) {
+  console.log(JSON.stringify(payload, null, 2))
+  process.exit(0)
+}
+
+console.log(
+  `Creating Cloudflare Pages project '${projectName}' from '${repoOwner}/${repoName}' branch '${productionBranch}'...`,
+)
+
+const data = await cfFetch(process.env.CF_ACCOUNT_ID, process.env.CF_API_TOKEN, 'projects', {
+  method: 'POST',
+  body: JSON.stringify(payload),
+}).catch((err) => cfError(err.message))
+
+const subdomain = data.result?.subdomain
+console.log(subdomain ? `Done. Project created: https://${subdomain}` : 'Done. Project created.')

--- a/tools/scripts/cf-pages/create-pages-project.mjs
+++ b/tools/scripts/cf-pages/create-pages-project.mjs
@@ -71,7 +71,7 @@ if (args.includes('--help')) {
 }
 
 function requireValue(flag, args, i) {
-  if (i + 1 >= args.length) {
+  if (i + 1 >= args.length || args[i + 1].startsWith('-')) {
     process.stderr.write(`ERROR: ${flag} requires a value.\n`)
     process.exit(1)
   }

--- a/tools/scripts/cf-pages/create-pages-project.test.mjs
+++ b/tools/scripts/cf-pages/create-pages-project.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { runNode, runScriptAsync, startMockCloudflare } from './test-utils.mjs'
+
+describe('create-pages-project.mjs', () => {
+  it('prints the dry-run Cloudflare Pages project payload', () => {
+    const result = runNode([
+      'tools/scripts/cf-pages/create-pages-project.mjs',
+      'demo-project',
+      'main',
+      '--dry-run',
+      '--path-include',
+      'apps/cowswap-frontend/*',
+    ])
+
+    assert.equal(result.status, 0)
+
+    const payload = JSON.parse(result.stdout)
+    assert.equal(payload.name, 'demo-project')
+    assert.equal(payload.production_branch, 'main')
+    assert.deepEqual(payload.source.config.path_includes, ['apps/cowswap-frontend/*'])
+  })
+
+  it('rejects option-like tokens when an option value is required', () => {
+    const result = runNode([
+      'tools/scripts/cf-pages/create-pages-project.mjs',
+      '--dry-run',
+      '--project-name',
+      '--branch',
+      'main',
+    ])
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /ERROR: --project-name requires a value/)
+  })
+
+  it('posts project creation payload to Cloudflare when not in dry-run mode', async (t) => {
+    const cloudflare = await startMockCloudflare([
+      {
+        method: 'POST',
+        url: '/client/v4/accounts/account-id/pages/projects',
+        response: { body: { success: true, result: { subdomain: 'demo.pages.dev' } } },
+      },
+    ])
+    t.after(() => cloudflare.close())
+
+    const result = await runScriptAsync(
+      'tools/scripts/cf-pages/create-pages-project.mjs',
+      [
+        '--project-name',
+        'demo-project',
+        '--branch',
+        'main',
+        '--repo-owner',
+        'cowprotocol',
+        '--repo-name',
+        'cowswap',
+        '--build-caching',
+        'false',
+      ],
+      { CF_ACCOUNT_ID: 'account-id', CF_API_TOKEN: 'api-token', CF_API_BASE: cloudflare.apiBase },
+    )
+
+    assert.equal(result.status, 0)
+    assert.equal(cloudflare.requests.length, 1)
+    assert.equal(cloudflare.requests[0].headers.authorization, 'Bearer api-token')
+    assert.equal(cloudflare.requests[0].json.name, 'demo-project')
+    assert.equal(cloudflare.requests[0].json.production_branch, 'main')
+    assert.equal(cloudflare.requests[0].json.build_config.build_caching, false)
+    assert.match(result.stdout, /Done\. Project created: https:\/\/demo\.pages\.dev/)
+  })
+})

--- a/tools/scripts/cf-pages/delete-project-deployments.mjs
+++ b/tools/scripts/cf-pages/delete-project-deployments.mjs
@@ -29,15 +29,24 @@ if (!projectName) {
   process.exit(1)
 }
 
+const MAX_ATTEMPTS = 3
+
 async function main() {
+  const attempts = new Map()
+
   while (true) {
     console.log('Fetching a batch of deployments...')
 
     const data = await cfFetch(accountId, apiToken, `projects/${projectName}/deployments`)
-    const ids = (data.result ?? []).map((d) => d.id)
+    const allIds = (data.result ?? []).map((d) => d.id)
+    const ids = allIds.filter((id) => (attempts.get(id) ?? 0) < MAX_ATTEMPTS)
 
     if (ids.length === 0) {
-      console.log('No more deployments found. It is now safe to delete the project.')
+      if (allIds.length > 0) {
+        console.error(`WARNING: ${allIds.length} deployment(s) could not be deleted after ${MAX_ATTEMPTS} attempts.`)
+      } else {
+        console.log('No more deployments found. It is now safe to delete the project.')
+      }
       break
     }
 
@@ -49,7 +58,13 @@ async function main() {
           await cfFetch(accountId, apiToken, `projects/${projectName}/deployments/${id}`, { method: 'DELETE' })
           console.log(`Deleted deployment: ${id}`)
         } catch (err) {
-          console.error(`WARNING: Could not delete deployment ${id}: ${err.message}`)
+          const count = (attempts.get(id) ?? 0) + 1
+          attempts.set(id, count)
+          if (count >= MAX_ATTEMPTS) {
+            console.error(`WARNING: Giving up on deployment ${id} after ${count} failed attempts: ${err.message}`)
+          } else {
+            console.error(`WARNING: Could not delete deployment ${id} (attempt ${count}/${MAX_ATTEMPTS}): ${err.message}`)
+          }
         }
       }),
     )

--- a/tools/scripts/cf-pages/delete-project-deployments.mjs
+++ b/tools/scripts/cf-pages/delete-project-deployments.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * Delete all deployments for a Cloudflare Pages project.
+ *
+ * Run this before deleting the project itself — Cloudflare requires all
+ * deployments to be removed first. Fetches up to 25 deployments per batch,
+ * deletes them in parallel, and loops until none remain.
+ *
+ * USAGE:
+ *   node delete-project-deployments.mjs
+ *
+ * ENV VARS:
+ *   CF_ACCOUNT_ID    (required)  Cloudflare account ID
+ *   CF_API_TOKEN     (required)  Cloudflare API token
+ *   CF_PROJECT_NAME  (optional)  CF Pages project name. Default: swap-dev
+ *
+ * API TOKEN PERMISSIONS (https://dash.cloudflare.com/profile/api-tokens):
+ *   Account > Cloudflare Pages > Edit
+ *   Scope: Account Resources > Include > <your account>
+ */
+
+import { getCfCredentials, cfFetch } from './cf-api.mjs'
+
+const { accountId, apiToken } = getCfCredentials()
+const projectName = process.env.CF_PROJECT_NAME ?? 'swap-dev'
+
+async function main() {
+  while (true) {
+    console.log('Fetching a batch of deployments...')
+
+    const data = await cfFetch(accountId, apiToken, `projects/${projectName}/deployments`)
+    const ids = (data.result ?? []).map((d) => d.id)
+
+    if (ids.length === 0) {
+      console.log('No more deployments found. It is now safe to delete the project.')
+      break
+    }
+
+    console.log(`Deleting ${ids.length} deployment(s)...`)
+
+    await Promise.all(
+      ids.map(async (id) => {
+        try {
+          await cfFetch(accountId, apiToken, `projects/${projectName}/deployments/${id}`, { method: 'DELETE' })
+          console.log(`Deleted deployment: ${id}`)
+        } catch (err) {
+          console.error(`WARNING: Could not delete deployment ${id}: ${err.message}`)
+        }
+      }),
+    )
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`ERROR: ${err.message}\n`)
+  process.exit(1)
+})

--- a/tools/scripts/cf-pages/delete-project-deployments.mjs
+++ b/tools/scripts/cf-pages/delete-project-deployments.mjs
@@ -12,17 +12,22 @@
  * ENV VARS:
  *   CF_ACCOUNT_ID    (required)  Cloudflare account ID
  *   CF_API_TOKEN     (required)  Cloudflare API token
- *   CF_PROJECT_NAME  (optional)  CF Pages project name. Default: swap-dev
+ *   CF_PROJECT_NAME  (required)  CF Pages project name
  *
  * API TOKEN PERMISSIONS (https://dash.cloudflare.com/profile/api-tokens):
  *   Account > Cloudflare Pages > Edit
  *   Scope: Account Resources > Include > <your account>
  */
 
-import { getCfCredentials, cfFetch } from './cf-api.mjs'
+import { cfFetch, getCfCredentials } from './cf-api.mjs'
 
 const { accountId, apiToken } = getCfCredentials()
-const projectName = process.env.CF_PROJECT_NAME ?? 'swap-dev'
+const projectName = process.env.CF_PROJECT_NAME
+
+if (!projectName) {
+  process.stdout.write('No project name provided. CF_PROJECT_NAME is required')
+  process.exit(1)
+}
 
 async function main() {
   while (true) {

--- a/tools/scripts/cf-pages/delete-project-deployments.mjs
+++ b/tools/scripts/cf-pages/delete-project-deployments.mjs
@@ -25,7 +25,7 @@ const { accountId, apiToken } = getCfCredentials()
 const projectName = process.env.CF_PROJECT_NAME
 
 if (!projectName) {
-  process.stdout.write('No project name provided. CF_PROJECT_NAME is required')
+  process.stderr.write('No project name provided. CF_PROJECT_NAME is required')
   process.exit(1)
 }
 

--- a/tools/scripts/cf-pages/delete-project-deployments.test.mjs
+++ b/tools/scripts/cf-pages/delete-project-deployments.test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { runNode, runScriptAsync, startMockCloudflare } from './test-utils.mjs'
+
+describe('delete-project-deployments.mjs', () => {
+  it('prints missing project-name errors to stderr', () => {
+    const result = runNode(['tools/scripts/cf-pages/delete-project-deployments.mjs'], {
+      env: { CF_ACCOUNT_ID: 'account-id', CF_API_TOKEN: 'api-token', CF_PROJECT_NAME: '' },
+    })
+
+    assert.equal(result.status, 1)
+    assert.equal(result.stdout, '')
+    assert.equal(result.stderr, 'No project name provided. CF_PROJECT_NAME is required')
+  })
+
+  it('deletes returned deployments and stops when the next batch is empty', async (t) => {
+    const deploymentsUrl = '/client/v4/accounts/account-id/pages/projects/demo-project/deployments'
+    const cloudflare = await startMockCloudflare([
+      {
+        method: 'GET',
+        url: deploymentsUrl,
+        response: (_request, requests) => {
+          const fetchCount = requests.filter((request) => request.method === 'GET' && request.url === deploymentsUrl).length
+
+          return {
+            body: {
+              success: true,
+              result: fetchCount === 1 ? [{ id: 'deployment-1' }] : [],
+            },
+          }
+        },
+      },
+      {
+        method: 'DELETE',
+        url: `${deploymentsUrl}/deployment-1`,
+        response: { body: { success: true, result: {} } },
+      },
+    ])
+    t.after(() => cloudflare.close())
+
+    const result = await runScriptAsync(
+      'tools/scripts/cf-pages/delete-project-deployments.mjs',
+      [],
+      {
+        CF_ACCOUNT_ID: 'account-id',
+        CF_API_TOKEN: 'api-token',
+        CF_API_BASE: cloudflare.apiBase,
+        CF_PROJECT_NAME: 'demo-project',
+      },
+    )
+
+    assert.equal(result.status, 0)
+    assert.ok(cloudflare.requests.some((request) => request.method === 'DELETE' && request.url === `${deploymentsUrl}/deployment-1`))
+    assert.match(result.stdout, /No more deployments found/)
+  })
+})

--- a/tools/scripts/cf-pages/deployment-management-lib.mjs
+++ b/tools/scripts/cf-pages/deployment-management-lib.mjs
@@ -1,0 +1,130 @@
+const DEFAULT_LIMIT = 10
+
+function requireValue(flag, args, i) {
+  if (i + 1 >= args.length || args[i + 1].startsWith('-')) {
+    throw new Error(`${flag} requires a value`)
+  }
+  return args[i + 1]
+}
+
+function parsePositiveInteger(value, name) {
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer`)
+  }
+  return parsed
+}
+
+export function parseListArgs(args) {
+  let projectName = ''
+  let limit = DEFAULT_LIMIT
+  let hasPositionalLimit = false
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+
+    if (arg === '--limit') {
+      limit = parsePositiveInteger(requireValue(arg, args, i), '--limit')
+      i++
+    } else if (arg.startsWith('--limit=')) {
+      limit = parsePositiveInteger(arg.slice('--limit='.length), '--limit')
+    } else if (arg.startsWith('--')) {
+      throw new Error(`Unknown option: ${arg}`)
+    } else if (!projectName) {
+      projectName = arg
+    } else if (!hasPositionalLimit) {
+      limit = parsePositiveInteger(arg, 'limit')
+      hasPositionalLimit = true
+    } else {
+      throw new Error(`Unexpected argument: ${arg}`)
+    }
+  }
+
+  if (!projectName) throw new Error('project name is required')
+
+  return { projectName, limit }
+}
+
+export function parseRollbackArgs(args) {
+  let projectName = ''
+  let deploymentId = ''
+
+  for (const arg of args) {
+    if (arg.startsWith('-')) {
+      if (!projectName) throw new Error('project name is required')
+      if (!deploymentId) throw new Error('deployment id is required')
+      throw new Error(`Unexpected argument: ${arg}`)
+    }
+    if (!projectName) {
+      projectName = arg
+      continue
+    }
+    if (deploymentId) throw new Error(`Unexpected argument: ${arg}`)
+    deploymentId = arg
+  }
+
+  if (!projectName) throw new Error('project name is required')
+  if (!deploymentId) throw new Error('deployment id is required')
+
+  return { projectName, deploymentId }
+}
+
+function shortCommit(commitHash) {
+  return commitHash ? commitHash.slice(0, 12) : ''
+}
+
+function formatDateTime(dateTime) {
+  if (!dateTime) return ''
+
+  const value = String(dateTime)
+  const match = value.match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?$/)
+
+  return match ? `${match[1]} ${match[2]}` : value
+}
+
+function deploymentRow(deployment, currentDeploymentId) {
+  const metadata = deployment.deployment_trigger?.metadata ?? {}
+  const latestStage = deployment.latest_stage ?? {}
+
+  return {
+    Current: deployment.id === currentDeploymentId ? '➡️' : undefined,
+    Id: deployment.short_id ?? '',
+    Created: formatDateTime(deployment.created_on),
+    Stage: latestStage.name ?? '',
+    Status: latestStage.status ?? '',
+    Commit: shortCommit(metadata.commit_hash),
+    URL: deployment.url ?? '',
+  }
+}
+
+export function summarizeProductionDeployments(deployments, currentDeployment) {
+  const currentDeploymentId = currentDeployment?.id ?? ''
+  const currentDeploymentInList =
+    currentDeploymentId.length > 0 && deployments.some((deployment) => deployment.id === currentDeploymentId)
+
+  return {
+    rows: deployments.map((deployment) => deploymentRow(deployment, currentDeploymentId)),
+    currentDeploymentInList,
+    currentDeploymentOutsideList:
+      currentDeployment && !currentDeploymentInList ? deploymentRow(currentDeployment, currentDeploymentId) : null,
+  }
+}
+
+export function formatDeploymentTable(rows) {
+  if (rows.length === 0) return ''
+
+  const columns = Object.keys(rows[0])
+  const widths = columns.map((column) =>
+    Math.max(column.length, ...rows.map((row) => String(row[column] ?? '').length)),
+  )
+
+  function formatLine(values) {
+    return values.map((value, i) => String(value ?? '').padEnd(widths[i])).join('  ')
+  }
+
+  return [
+    formatLine(columns),
+    widths.map((width) => '-'.repeat(width)).join('  '),
+    ...rows.map((row) => formatLine(columns.map((column) => row[column]))),
+  ].join('\n')
+}

--- a/tools/scripts/cf-pages/deployment-management-lib.test.mjs
+++ b/tools/scripts/cf-pages/deployment-management-lib.test.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import {
+  formatDeploymentTable,
+  parseListArgs,
+  parseRollbackArgs,
+  summarizeProductionDeployments,
+} from './deployment-management-lib.mjs'
+
+function deployment(id, createdOn = '2026-05-25T10:00:00.123Z') {
+  return {
+    id,
+    short_id: id.slice(0, 8),
+    created_on: createdOn,
+    url: `https://${id}.example.pages.dev`,
+    latest_stage: { name: 'deploy', status: 'success' },
+    deployment_trigger: {
+      metadata: {
+        branch: 'main',
+        commit_hash: `${id}abcdef1234567890`,
+      },
+    },
+  }
+}
+
+describe('parseListArgs', () => {
+  it('requires a project name and defaults to the last 10 production deployments', () => {
+    assert.deepEqual(parseListArgs(['cow-fi']), { projectName: 'cow-fi', limit: 10 })
+    assert.throws(() => parseListArgs([]), /project name is required/)
+  })
+
+  it('accepts an explicit limit by flag or positional parameter', () => {
+    assert.deepEqual(parseListArgs(['cow-fi', '--limit', '3']), { projectName: 'cow-fi', limit: 3 })
+    assert.deepEqual(parseListArgs(['cow-fi', '--limit=4']), { projectName: 'cow-fi', limit: 4 })
+    assert.deepEqual(parseListArgs(['cow-fi', '5']), { projectName: 'cow-fi', limit: 5 })
+  })
+
+  it('rejects missing or invalid limits', () => {
+    assert.throws(() => parseListArgs(['--limit']), /--limit requires a value/)
+    assert.throws(() => parseListArgs(['--limit', '--other']), /--limit requires a value/)
+    assert.throws(() => parseListArgs(['--limit', '0']), /--limit must be a positive integer/)
+  })
+})
+
+describe('summarizeProductionDeployments', () => {
+  it('marks the canonical deployment when it is in the listed deployments', () => {
+    const current = deployment('current123')
+    const summary = summarizeProductionDeployments([deployment('older123'), current], current)
+
+    assert.equal(summary.currentDeploymentInList, true)
+    assert.equal(summary.currentDeploymentOutsideList, null)
+    assert.equal(summary.rows[0].Current, '-')
+    assert.notEqual(summary.rows[1].Current, summary.rows[0].Current)
+  })
+
+  it('returns the canonical deployment separately when it is outside the listed deployments', () => {
+    const current = deployment('current123')
+    const summary = summarizeProductionDeployments([deployment('older123')], current)
+
+    assert.equal(summary.currentDeploymentInList, false)
+    assert.equal(summary.currentDeploymentOutsideList.Id, 'current1')
+  })
+
+  it('formats created dates without milliseconds or timezone information', () => {
+    const summary = summarizeProductionDeployments([deployment('older123', '2026-05-25T10:15:30.987+00:00')], null)
+
+    assert.equal(summary.rows[0].Created, '2026-05-25 10:15:30')
+  })
+})
+
+describe('formatDeploymentTable', () => {
+  it('prints string values without single quote wrappers', () => {
+    const summary = summarizeProductionDeployments([deployment('older123')], null)
+    const table = formatDeploymentTable(summary.rows)
+
+    assert.match(table, /older123/)
+    assert.doesNotMatch(table, /'older123'/)
+    assert.doesNotMatch(table, /'success'/)
+  })
+})
+
+describe('parseRollbackArgs', () => {
+  it('requires project name and deployment id', () => {
+    assert.deepEqual(parseRollbackArgs(['cow-fi', 'deployment123']), {
+      projectName: 'cow-fi',
+      deploymentId: 'deployment123',
+    })
+    assert.throws(() => parseRollbackArgs([]), /project name is required/)
+    assert.throws(() => parseRollbackArgs(['cow-fi']), /deployment id is required/)
+    assert.throws(() => parseRollbackArgs(['--project']), /project name is required/)
+    assert.throws(() => parseRollbackArgs(['cow-fi', 'one', 'two']), /Unexpected argument: two/)
+  })
+})

--- a/tools/scripts/cf-pages/deployment-management-lib.test.mjs
+++ b/tools/scripts/cf-pages/deployment-management-lib.test.mjs
@@ -50,7 +50,7 @@ describe('summarizeProductionDeployments', () => {
 
     assert.equal(summary.currentDeploymentInList, true)
     assert.equal(summary.currentDeploymentOutsideList, null)
-    assert.equal(summary.rows[0].Current, '-')
+    assert.equal(summary.rows[0].Current, undefined)
     assert.notEqual(summary.rows[1].Current, summary.rows[0].Current)
   })
 

--- a/tools/scripts/cf-pages/list-production-deployments.mjs
+++ b/tools/scripts/cf-pages/list-production-deployments.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * List recent production Cloudflare Pages deployments and mark the current one.
+ *
+ * Fetches the project's canonical deployment to identify the build currently in
+ * production. If that deployment is outside the requested list, prints it
+ * separately after the recent production deployments table.
+ *
+ * USAGE:
+ *   node list-production-deployments.mjs <project-name> [--limit <count>]
+ *   node list-production-deployments.mjs <project-name> [count]
+ *
+ * ENV VARS:
+ *   CF_ACCOUNT_ID  (required)  Cloudflare account ID
+ *   CF_API_TOKEN   (required)  Cloudflare API token
+ *
+ * OPTIONS:
+ *   --limit <count>  Number of recent production deployments to list. Default: 10
+ *   --help           Show this help message
+ *
+ * API TOKEN PERMISSIONS (https://dash.cloudflare.com/profile/api-tokens):
+ *   Account > Cloudflare Pages > Read
+ *   Scope: Account Resources > Include > <your account>
+ */
+
+import { readFileSync } from 'node:fs'
+import { cfError, cfFetch, getCfCredentials } from './cf-api.mjs'
+import { formatDeploymentTable, parseListArgs, summarizeProductionDeployments } from './deployment-management-lib.mjs'
+
+const args = process.argv.slice(2)
+
+if (args.includes('--help')) {
+  const source = readFileSync(new URL(import.meta.url), 'utf8')
+  const block = source.match(/\/\*\*([\s\S]*?)\*\//)?.[1] ?? ''
+  process.stderr.write(block.replace(/^ \* ?/gm, '').trim() + '\n')
+  process.exit(0)
+}
+
+let projectName
+let limit
+try {
+  const parsedArgs = parseListArgs(args)
+  projectName = parsedArgs.projectName
+  limit = parsedArgs.limit
+} catch (err) {
+  cfError(err.message)
+}
+
+const { accountId, apiToken } = getCfCredentials()
+
+async function main() {
+  console.log(`Fetching project ${projectName}...`)
+  const projectData = await cfFetch(accountId, apiToken, `projects/${projectName}`)
+  const currentDeployment = projectData.result?.canonical_deployment ?? null
+
+  console.log(`Fetching last ${limit} production deployment(s)...`)
+  const deploymentsData = await cfFetch(
+    accountId,
+    apiToken,
+    `projects/${projectName}/deployments?env=production&per_page=${limit}&page=1`,
+  )
+  const deployments = deploymentsData.result ?? []
+  const { rows, currentDeploymentInList, currentDeploymentOutsideList } = summarizeProductionDeployments(
+    deployments,
+    currentDeployment,
+  )
+
+  if (rows.length === 0) {
+    console.log(`No production deployments found for ${projectName}.`)
+  } else {
+    console.log(`Last ${rows.length} production deployment(s) for ${projectName}:`)
+    console.log(formatDeploymentTable(rows))
+  }
+
+  if (!currentDeployment) {
+    console.log('\nCloudflare did not return a current production deployment.')
+  } else if (currentDeploymentInList) {
+    console.log(`\nCurrent production deployment: ${currentDeployment.id}`)
+  } else {
+    console.log('\nCurrent production deployment is outside the listed range:')
+    console.log(formatDeploymentTable([currentDeploymentOutsideList]))
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`ERROR: ${err.message}\n`)
+  process.exit(1)
+})

--- a/tools/scripts/cf-pages/list-production-deployments.test.mjs
+++ b/tools/scripts/cf-pages/list-production-deployments.test.mjs
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { runScriptAsync, startMockCloudflare } from './test-utils.mjs'
+
+describe('list-production-deployments.mjs', () => {
+  it('lists production deployments and marks the current deployment', async (t) => {
+    const cloudflare = await startMockCloudflare([
+      {
+        method: 'GET',
+        url: '/client/v4/accounts/account-id/pages/projects/demo-project',
+        response: {
+          body: {
+            success: true,
+            result: {
+              canonical_deployment: deployment('deploy-current', 'current'),
+            },
+          },
+        },
+      },
+      {
+        method: 'GET',
+        url: '/client/v4/accounts/account-id/pages/projects/demo-project/deployments?env=production&per_page=1&page=1',
+        response: { body: { success: true, result: [deployment('deploy-current', 'current')] } },
+      },
+    ])
+    t.after(() => cloudflare.close())
+
+    const result = await runScriptAsync(
+      'tools/scripts/cf-pages/list-production-deployments.mjs',
+      ['demo-project', '--limit', '1'],
+      { CF_ACCOUNT_ID: 'account-id', CF_API_TOKEN: 'api-token', CF_API_BASE: cloudflare.apiBase },
+    )
+
+    assert.equal(result.status, 0)
+    assert.equal(cloudflare.requests.length, 2)
+    assert.match(result.stdout, /Fetching project demo-project/)
+    assert.match(result.stdout, /2026-05-25 10:15:30/)
+    assert.match(result.stdout, /Current production deployment: deploy-current/)
+    assert.doesNotMatch(result.stdout, /'current'/)
+  })
+
+  it('prints the current production deployment separately when outside the requested list', async (t) => {
+    const cloudflare = await startMockCloudflare([
+      {
+        method: 'GET',
+        url: '/client/v4/accounts/account-id/pages/projects/demo-project',
+        response: {
+          body: {
+            success: true,
+            result: {
+              canonical_deployment: deployment('deploy-current', 'current'),
+            },
+          },
+        },
+      },
+      {
+        method: 'GET',
+        url: '/client/v4/accounts/account-id/pages/projects/demo-project/deployments?env=production&per_page=1&page=1',
+        response: { body: { success: true, result: [deployment('deploy-old', 'old')] } },
+      },
+    ])
+    t.after(() => cloudflare.close())
+
+    const result = await runScriptAsync(
+      'tools/scripts/cf-pages/list-production-deployments.mjs',
+      ['demo-project', '1'],
+      { CF_ACCOUNT_ID: 'account-id', CF_API_TOKEN: 'api-token', CF_API_BASE: cloudflare.apiBase },
+    )
+
+    assert.equal(result.status, 0)
+    assert.match(result.stdout, /Current production deployment is outside the listed range/)
+    assert.match(result.stdout, /current/)
+  })
+})
+
+function deployment(id, shortId) {
+  return {
+    id,
+    short_id: shortId,
+    created_on: '2026-05-25T10:15:30.123Z',
+    deployment_trigger: { metadata: { commit_hash: 'abcdef1234567890' } },
+    latest_stage: { name: 'deploy', status: 'success' },
+    url: `https://${shortId}.pages.dev`,
+  }
+}

--- a/tools/scripts/cf-pages/report-build-usage.mjs
+++ b/tools/scripts/cf-pages/report-build-usage.mjs
@@ -41,25 +41,30 @@ async function getAllProjects() {
   return projects
 }
 
-function countBillable(deployments) {
-  return deployments.filter((d) => new Date(d.created_on) >= startOfMonth && !d.is_skipped).length
+function countDeployments(deployments) {
+  const thisMonth = deployments.filter((d) => new Date(d.created_on) >= startOfMonth)
+  return { billable: thisMonth.filter((d) => !d.is_skipped).length, total: thisMonth.length }
 }
 
-async function getMonthlyBuildCount(projectName) {
+async function getMonthlyBuildCounts(projectName) {
   const deploymentsPath = (page) => `projects/${projectName}/deployments?page=${page}`
 
   const first = await cfFetch(accountId, apiToken, deploymentsPath(1))
   const totalPages = first.result_info?.total_pages ?? 1
-  let count = countBillable(first.result ?? [])
+  let { billable, total } = countDeployments(first.result ?? [])
 
   if (totalPages > 1) {
     const rest = await Promise.all(
       Array.from({ length: totalPages - 1 }, (_, i) => cfFetch(accountId, apiToken, deploymentsPath(i + 2))),
     )
-    for (const data of rest) count += countBillable(data.result ?? [])
+    for (const data of rest) {
+      const counts = countDeployments(data.result ?? [])
+      billable += counts.billable
+      total += counts.total
+    }
   }
 
-  return count
+  return { billable, total }
 }
 
 async function mapConcurrent(items, concurrency, fn) {
@@ -87,8 +92,8 @@ async function main() {
   console.log(`Found ${projects.length} project(s). Counting billable builds for this month...\n`)
 
   const rows = await mapConcurrent(projects, concurrency, async (project) => {
-    const count = await getMonthlyBuildCount(project)
-    return { Project: project, 'Billable Builds': count }
+    const { billable, total } = await getMonthlyBuildCounts(project)
+    return { Project: project, 'Total Builds': total, 'Billable Builds': billable }
   })
   const grandTotal = rows.reduce((sum, r) => sum + r['Billable Builds'], 0)
 

--- a/tools/scripts/cf-pages/report-build-usage.mjs
+++ b/tools/scripts/cf-pages/report-build-usage.mjs
@@ -41,20 +41,24 @@ async function getAllProjects() {
   return projects
 }
 
+function countBillable(deployments) {
+  return deployments.filter((d) => new Date(d.created_on) >= startOfMonth && !d.is_skipped).length
+}
+
 async function getMonthlyBuildCount(projectName) {
-  let count = 0
-  let page = 1
+  const deploymentsPath = (page) => `projects/${projectName}/deployments?page=${page}`
 
-  while (true) {
-    const data = await cfFetch(accountId, apiToken, `projects/${projectName}/deployments?page=${page}`)
-    const deployments = data.result ?? []
-    if (deployments.length === 0) break
+  const first = await cfFetch(accountId, apiToken, deploymentsPath(1))
+  const totalPages = first.result_info?.total_pages ?? 1
+  let count = countBillable(first.result ?? [])
 
-    for (const deploy of deployments) {
-      if (new Date(deploy.created_on) >= startOfMonth && !deploy.is_skipped) count++
-    }
-    page++
+  if (totalPages > 1) {
+    const rest = await Promise.all(
+      Array.from({ length: totalPages - 1 }, (_, i) => cfFetch(accountId, apiToken, deploymentsPath(i + 2))),
+    )
+    for (const data of rest) count += countBillable(data.result ?? [])
   }
+
   return count
 }
 

--- a/tools/scripts/cf-pages/report-build-usage.mjs
+++ b/tools/scripts/cf-pages/report-build-usage.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * Report monthly Cloudflare Pages billable build usage for the account.
+ *
+ * Lists all Pages projects and counts non-skipped deployments since the start
+ * of the current UTC month. Prints a table and grand total against the 500-build
+ * monthly limit.
+ *
+ * USAGE:
+ *   node report-build-usage.mjs
+ *
+ * ENV VARS:
+ *   CF_ACCOUNT_ID  (required)  Cloudflare account ID
+ *   CF_API_TOKEN   (required)  Cloudflare API token
+ *
+ * API TOKEN PERMISSIONS (https://dash.cloudflare.com/profile/api-tokens):
+ *   Account > Cloudflare Pages > Read
+ *   Scope: Account Resources > Include > <your account>
+ */
+
+import { getCfCredentials, cfFetch } from './cf-api.mjs'
+
+const { accountId, apiToken } = getCfCredentials()
+
+const now = new Date()
+const startOfMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
+
+async function getAllProjects() {
+  const projects = []
+  let page = 1
+  while (true) {
+    const data = await cfFetch(accountId, apiToken, `projects?page=${page}`)
+    const result = data.result ?? []
+    if (result.length === 0) break
+    projects.push(...result.map((p) => p.name))
+    page++
+  }
+  return projects
+}
+
+async function getMonthlyBuildCount(projectName) {
+  let count = 0
+  let page = 1
+  let hasMore = true
+
+  while (hasMore) {
+    const data = await cfFetch(accountId, apiToken, `projects/${projectName}/deployments?page=${page}`)
+    const deployments = data.result ?? []
+    if (deployments.length === 0) break
+
+    for (const deploy of deployments) {
+      if (new Date(deploy.created_on) >= startOfMonth) {
+        if (!deploy.is_skipped) count++
+      } else {
+        hasMore = false
+        break
+      }
+    }
+    page++
+  }
+  return count
+}
+
+async function main() {
+  console.log('Scanning Cloudflare account for Pages projects...')
+  const projects = await getAllProjects()
+
+  if (projects.length === 0) {
+    console.log('No Pages projects found.')
+    return
+  }
+
+  console.log(`Found ${projects.length} project(s). Counting billable builds for this month...\n`)
+
+  let grandTotal = 0
+  const rows = []
+
+  for (const project of projects) {
+    const count = await getMonthlyBuildCount(project)
+    grandTotal += count
+    rows.push({ Project: project, 'Billable Builds': count })
+  }
+
+  console.table(rows)
+  console.log(`\n========================================`)
+  console.log(`ACCOUNT BUILD USAGE: ${grandTotal} / 500`)
+  console.log(`========================================`)
+}
+
+main().catch((err) => {
+  process.stderr.write(`ERROR: ${err.message}\n`)
+  process.exit(1)
+})

--- a/tools/scripts/cf-pages/report-build-usage.mjs
+++ b/tools/scripts/cf-pages/report-build-usage.mjs
@@ -22,6 +22,9 @@ import { getCfCredentials, cfFetch } from './cf-api.mjs'
 
 const { accountId, apiToken } = getCfCredentials()
 
+const concurrencyArg = process.argv.find((a) => a.startsWith('--concurrency='))
+const concurrency = concurrencyArg ? parseInt(concurrencyArg.split('=')[1], 10) : 2
+
 const now = new Date()
 const startOfMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
 
@@ -41,24 +44,31 @@ async function getAllProjects() {
 async function getMonthlyBuildCount(projectName) {
   let count = 0
   let page = 1
-  let hasMore = true
 
-  while (hasMore) {
+  while (true) {
     const data = await cfFetch(accountId, apiToken, `projects/${projectName}/deployments?page=${page}`)
     const deployments = data.result ?? []
     if (deployments.length === 0) break
 
     for (const deploy of deployments) {
-      if (new Date(deploy.created_on) >= startOfMonth) {
-        if (!deploy.is_skipped) count++
-      } else {
-        hasMore = false
-        break
-      }
+      if (new Date(deploy.created_on) >= startOfMonth && !deploy.is_skipped) count++
     }
     page++
   }
   return count
+}
+
+async function mapConcurrent(items, concurrency, fn) {
+  const results = new Array(items.length)
+  let idx = 0
+  async function worker() {
+    while (idx < items.length) {
+      const i = idx++
+      results[i] = await fn(items[i])
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, worker))
+  return results
 }
 
 async function main() {
@@ -72,14 +82,11 @@ async function main() {
 
   console.log(`Found ${projects.length} project(s). Counting billable builds for this month...\n`)
 
-  let grandTotal = 0
-  const rows = []
-
-  for (const project of projects) {
+  const rows = await mapConcurrent(projects, concurrency, async (project) => {
     const count = await getMonthlyBuildCount(project)
-    grandTotal += count
-    rows.push({ Project: project, 'Billable Builds': count })
-  }
+    return { Project: project, 'Billable Builds': count }
+  })
+  const grandTotal = rows.reduce((sum, r) => sum + r['Billable Builds'], 0)
 
   console.table(rows)
   console.log(`\n========================================`)

--- a/tools/scripts/cf-pages/report-build-usage.mjs
+++ b/tools/scripts/cf-pages/report-build-usage.mjs
@@ -22,8 +22,22 @@ import { getCfCredentials, cfFetch } from './cf-api.mjs'
 
 const { accountId, apiToken } = getCfCredentials()
 
-const concurrencyArg = process.argv.find((a) => a.startsWith('--concurrency='))
-const concurrency = concurrencyArg ? parseInt(concurrencyArg.split('=')[1], 10) : 2
+const DEFAULT_CONCURRENCY = 2
+
+function normalizeConcurrency(value) {
+  return Number.isInteger(value) && value > 0 ? value : DEFAULT_CONCURRENCY
+}
+
+function parseConcurrency(args) {
+  const concurrencyArg = args.find((a) => a.startsWith('--concurrency='))
+  if (!concurrencyArg) return DEFAULT_CONCURRENCY
+
+  const parsed = parseInt(concurrencyArg.split('=')[1], 10)
+
+  return normalizeConcurrency(parsed)
+}
+
+const concurrency = parseConcurrency(process.argv.slice(2))
 
 const now = new Date()
 const startOfMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
@@ -69,6 +83,7 @@ async function getMonthlyBuildCounts(projectName) {
 
 async function mapConcurrent(items, concurrency, fn) {
   const results = new Array(items.length)
+  const workerCount = Math.min(normalizeConcurrency(concurrency), items.length)
   let idx = 0
   async function worker() {
     while (idx < items.length) {
@@ -76,7 +91,7 @@ async function mapConcurrent(items, concurrency, fn) {
       results[i] = await fn(items[i])
     }
   }
-  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, worker))
+  await Promise.all(Array.from({ length: workerCount }, worker))
   return results
 }
 

--- a/tools/scripts/cf-pages/report-build-usage.test.mjs
+++ b/tools/scripts/cf-pages/report-build-usage.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { runScriptAsync, startMockCloudflare } from './test-utils.mjs'
+
+describe('report-build-usage.mjs', () => {
+  it('falls back to a working concurrency when --concurrency is invalid', async (t) => {
+    const cloudflare = await startMockCloudflare([
+      {
+        method: 'GET',
+        url: '/client/v4/accounts/account-id/pages/projects?page=1',
+        response: { body: { success: true, result: [{ name: 'demo-project' }] } },
+      },
+      {
+        method: 'GET',
+        url: '/client/v4/accounts/account-id/pages/projects?page=2',
+        response: { body: { success: true, result: [] } },
+      },
+      {
+        method: 'GET',
+        url: '/client/v4/accounts/account-id/pages/projects/demo-project/deployments?page=1',
+        response: {
+          body: {
+            success: true,
+            result_info: { total_pages: 1 },
+            result: [
+              { created_on: new Date().toISOString(), is_skipped: false },
+              { created_on: new Date().toISOString(), is_skipped: true },
+            ],
+          },
+        },
+      },
+    ])
+    t.after(() => cloudflare.close())
+
+    const result = await runScriptAsync(
+      'tools/scripts/cf-pages/report-build-usage.mjs',
+      ['--concurrency=0'],
+      { CF_ACCOUNT_ID: 'account-id', CF_API_TOKEN: 'api-token', CF_API_BASE: cloudflare.apiBase },
+    )
+
+    assert.equal(result.status, 0)
+    assert.deepEqual(
+      cloudflare.requests.map((request) => request.url),
+      [
+        '/client/v4/accounts/account-id/pages/projects?page=1',
+        '/client/v4/accounts/account-id/pages/projects?page=2',
+        '/client/v4/accounts/account-id/pages/projects/demo-project/deployments?page=1',
+      ],
+    )
+    assert.match(result.stdout, /ACCOUNT BUILD USAGE: 1 \/ 500/)
+  })
+})

--- a/tools/scripts/cf-pages/rollback-production-deployment.mjs
+++ b/tools/scripts/cf-pages/rollback-production-deployment.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * Roll back a Cloudflare Pages project to a production deployment.
+ *
+ * USAGE:
+ *   node rollback-production-deployment.mjs <project-name> <deployment-id>
+ *
+ * ENV VARS:
+ *   CF_ACCOUNT_ID  (required)  Cloudflare account ID
+ *   CF_API_TOKEN   (required)  Cloudflare API token
+ *
+ * API TOKEN PERMISSIONS (https://dash.cloudflare.com/profile/api-tokens):
+ *   Account > Cloudflare Pages > Edit
+ *   Scope: Account Resources > Include > <your account>
+ */
+
+import { readFileSync } from 'node:fs'
+import { cfError, cfFetch, getCfCredentials } from './cf-api.mjs'
+import { parseRollbackArgs } from './deployment-management-lib.mjs'
+
+const args = process.argv.slice(2)
+
+if (args.includes('--help')) {
+  const source = readFileSync(new URL(import.meta.url), 'utf8')
+  const block = source.match(/\/\*\*([\s\S]*?)\*\//)?.[1] ?? ''
+  process.stderr.write(block.replace(/^ \* ?/gm, '').trim() + '\n')
+  process.exit(0)
+}
+
+let projectName
+let deploymentId
+try {
+  const parsedArgs = parseRollbackArgs(args)
+  projectName = parsedArgs.projectName
+  deploymentId = parsedArgs.deploymentId
+} catch (err) {
+  cfError(err.message)
+}
+
+const { accountId, apiToken } = getCfCredentials()
+
+async function main() {
+  console.log(`Rolling back project '${projectName}' to deployment '${deploymentId}'...`)
+
+  const data = await cfFetch(accountId, apiToken, `projects/${projectName}/deployments/${deploymentId}/rollback`, {
+    method: 'POST',
+  })
+  const deployment = data.result
+
+  console.log(`Done. Production rolled back to deployment: ${deployment?.id ?? deploymentId}`)
+  if (deployment?.url) console.log(`URL: ${deployment.url}`)
+}
+
+main().catch((err) => {
+  process.stderr.write(`ERROR: ${err.message}\n`)
+  process.exit(1)
+})

--- a/tools/scripts/cf-pages/rollback-production-deployment.test.mjs
+++ b/tools/scripts/cf-pages/rollback-production-deployment.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { runScriptAsync, startMockCloudflare } from './test-utils.mjs'
+
+describe('rollback-production-deployment.mjs', () => {
+  it('posts to the Cloudflare deployment rollback endpoint', async (t) => {
+    const cloudflare = await startMockCloudflare([
+      {
+        method: 'POST',
+        url: '/client/v4/accounts/account-id/pages/projects/demo-project/deployments/deployment-id/rollback',
+        response: { body: { success: true, result: { id: 'deployment-id', url: 'https://rollback.pages.dev' } } },
+      },
+    ])
+    t.after(() => cloudflare.close())
+
+    const result = await runScriptAsync(
+      'tools/scripts/cf-pages/rollback-production-deployment.mjs',
+      ['demo-project', 'deployment-id'],
+      { CF_ACCOUNT_ID: 'account-id', CF_API_TOKEN: 'api-token', CF_API_BASE: cloudflare.apiBase },
+    )
+
+    assert.equal(result.status, 0)
+    assert.equal(cloudflare.requests[0].method, 'POST')
+    assert.equal(
+      cloudflare.requests[0].url,
+      '/client/v4/accounts/account-id/pages/projects/demo-project/deployments/deployment-id/rollback',
+    )
+    assert.match(result.stdout, /Done\. Production rolled back to deployment: deployment-id/)
+  })
+})

--- a/tools/scripts/cf-pages/test-utils.mjs
+++ b/tools/scripts/cf-pages/test-utils.mjs
@@ -1,0 +1,128 @@
+import { createServer } from 'node:http'
+import { spawn, spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+export const repoRoot = fileURLToPath(new URL('../../..', import.meta.url))
+
+/**
+ * Run a Node.js command synchronously from the repository root.
+ * Useful for CLI paths that do not need the test process to service async work.
+ *
+ * @param {string[]} args Arguments passed to the Node.js executable.
+ * @param {{ env?: NodeJS.ProcessEnv, input?: string }} [options]
+ * @returns {import('node:child_process').SpawnSyncReturns<string>}
+ */
+export function runNode(args, options = {}) {
+  return spawnSync(process.execPath, args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: { ...process.env, ...options.env },
+    input: options.input,
+  })
+}
+
+/**
+ * Run a cf-pages script asynchronously from the repository root.
+ * Use this when the parent test process must keep running, for example to serve
+ * mock Cloudflare HTTP requests while the child script executes.
+ *
+ * @param {string} scriptPath Path to the script, relative to the repository root.
+ * @param {string[]} [args] CLI arguments passed after the script path.
+ * @param {NodeJS.ProcessEnv} [env] Environment overrides for the child process.
+ * @returns {Promise<{ status: number | null, stderr: string, stdout: string }>}
+ */
+export async function runScriptAsync(scriptPath, args = [], env = {}) {
+  const child = spawn(process.execPath, [scriptPath, ...args], {
+    cwd: repoRoot,
+    env: { ...process.env, ...env },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  let stdout = ''
+  let stderr = ''
+
+  child.stdout.setEncoding('utf8')
+  child.stderr.setEncoding('utf8')
+  child.stdout.on('data', (chunk) => {
+    stdout += chunk
+  })
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk
+  })
+
+  const status = await new Promise((resolve, reject) => {
+    child.on('error', reject)
+    child.on('close', resolve)
+  })
+
+  return { status, stderr, stdout }
+}
+
+/**
+ * Start a local HTTP server that mimics the Cloudflare Pages API.
+ * Routes are matched exactly by method and URL path, including query string.
+ * The returned requests array captures every request body, parsed JSON body,
+ * headers, method, and URL so tests can assert API behavior.
+ *
+ * @param {Array<{
+ *   method: string,
+ *   url: string,
+ *   response:
+ *     | { status?: number, body?: unknown }
+ *     | ((request: { body: string, headers: import('node:http').IncomingHttpHeaders, json: unknown, method: string, url: string }, requests: Array<{ body: string, headers: import('node:http').IncomingHttpHeaders, json: unknown, method: string, url: string }>) => { status?: number, body?: unknown }),
+ * }>} routes Mock API routes.
+ * @returns {Promise<{
+ *   apiBase: string,
+ *   requests: Array<{ body: string, headers: import('node:http').IncomingHttpHeaders, json: unknown, method: string, url: string }>,
+ *   close: () => Promise<void>,
+ * }>}
+ */
+export async function startMockCloudflare(routes) {
+  const requests = []
+
+  const server = createServer((req, res) => {
+    let body = ''
+
+    req.setEncoding('utf8')
+    req.on('data', (chunk) => {
+      body += chunk
+    })
+    req.on('end', () => {
+      const request = {
+        body,
+        headers: req.headers,
+        json: body ? JSON.parse(body) : undefined,
+        method: req.method,
+        url: req.url,
+      }
+      requests.push(request)
+
+      const route = routes.find((item) => item.method === request.method && item.url === request.url)
+      const response = typeof route?.response === 'function' ? route.response(request, requests) : route?.response
+      const responseBody = response?.body ?? {
+        errors: [{ message: `Unexpected ${request.method} ${request.url}` }],
+        result: null,
+        success: false,
+      }
+
+      res.writeHead(response?.status ?? 200, { connection: 'close', 'content-type': 'application/json' })
+      res.end(JSON.stringify(responseBody))
+    })
+  })
+
+  await new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', resolve)
+  })
+
+  const { port } = server.address()
+
+  return {
+    apiBase: `http://127.0.0.1:${port}/client/v4`,
+    requests,
+    async close() {
+      server.closeAllConnections()
+      await new Promise((resolve) => {
+        server.close(resolve)
+      })
+    },
+  }
+}

--- a/tools/scripts/cf-pages/upload-env-vars.mjs
+++ b/tools/scripts/cf-pages/upload-env-vars.mjs
@@ -3,12 +3,11 @@
  * Upload environment variables to a Cloudflare Pages project from a CSV file.
  *
  * USAGE:
- *   node upload-env-vars.mjs <path/to/vars.csv> [--overwrite]
+ *   node upload-env-vars.mjs <path/to/vars.csv> --project <name> [--env <production|preview|both>] [--overwrite]
  *
  * ENV VARS:
- *   CF_ACCOUNT_ID    (required)  Cloudflare account ID
- *   CF_API_TOKEN     (required)  Cloudflare API token
- *   CF_PROJECT_NAME  (optional)  CF Pages project name. Default: swap-dev
+ *   CF_ACCOUNT_ID  (required)  Cloudflare account ID
+ *   CF_API_TOKEN   (required)  Cloudflare API token
  *
  * CSV FORMAT (header row optional):
  *   name,value,type
@@ -28,6 +27,8 @@
  *     MY_VAR,"value,with,commas",text
  *
  * OPTIONS:
+ *   --project      CF Pages project name (required).
+ *   --env          Target environment: production, preview, or both. Default: production.
  *   --overwrite    Overwrite variables that already exist in the target environment.
  *                  Without this flag, existing variables are skipped.
  *
@@ -41,25 +42,41 @@ import { readFileSync } from 'node:fs'
 import { cfError, cfFetch, getCfCredentials } from './cf-api.mjs'
 
 const { accountId, apiToken } = getCfCredentials()
-const projectName = process.env.CF_PROJECT_NAME ?? 'swap-dev'
 
-const TARGET_ENV = 'production'
+const VALID_ENVS = ['production', 'preview', 'both']
 
 const [, , csvFile, ...restArgs] = process.argv
 
 if (!csvFile) {
-  process.stderr.write('Usage: node upload-env-vars.mjs <path/to/vars.csv> [--overwrite]\n')
+  process.stderr.write(
+    'Usage: node upload-env-vars.mjs <path/to/vars.csv> --project <name> [--env <production|preview|both>] [--overwrite]\n',
+  )
   process.exit(1)
 }
 
 let overwrite = false
-for (const arg of restArgs) {
+let targetEnv = 'production'
+let projectName = ''
+for (let i = 0; i < restArgs.length; i++) {
+  const arg = restArgs[i]
   if (arg === '--overwrite') {
     overwrite = true
+  } else if (arg === '--project') {
+    const val = restArgs[++i]
+    if (!val) cfError('--project requires a value')
+    projectName = val
+  } else if (arg === '--env') {
+    const val = restArgs[++i]
+    if (!val || !VALID_ENVS.includes(val)) {
+      cfError(`--env must be one of: ${VALID_ENVS.join(', ')}`)
+    }
+    targetEnv = val
   } else if (arg.startsWith('--')) {
     cfError(`Unknown option: ${arg}`)
   }
 }
+
+if (!projectName) cfError('--project <name> is required')
 
 let content
 try {
@@ -115,12 +132,19 @@ async function fetchExistingVarNames(env) {
   return Object.keys(data.result?.deployment_configs?.[env]?.env_vars ?? {})
 }
 
-let existingVars = []
+let existingProduction = []
+let existingPreview = []
 
 if (!overwrite) {
   console.log(`Fetching existing variables from '${projectName}'...`)
-  existingVars = await fetchExistingVarNames(TARGET_ENV)
-  console.log(`  ${TARGET_ENV}: ${existingVars.length} existing variable(s)`)
+  if (targetEnv === 'production' || targetEnv === 'both') {
+    existingProduction = await fetchExistingVarNames('production')
+    console.log(`  production: ${existingProduction.length} existing variable(s)`)
+  }
+  if (targetEnv === 'preview' || targetEnv === 'both') {
+    existingPreview = await fetchExistingVarNames('preview')
+    console.log(`  preview: ${existingPreview.length} existing variable(s)`)
+  }
 }
 
 console.log(`Reading variables from '${csvFile}'...`)
@@ -154,9 +178,14 @@ for (let row = 0; row < lines.length; row++) {
     cfError(`Row ${row + 1} (${name}): type must be 'text' or 'secret', got '${rawType}'`)
   }
 
-  if (!overwrite && existingVars.includes(name)) {
-    console.log(`  ~ ${name} (skipped — already exists in ${TARGET_ENV})`)
-    continue
+  if (!overwrite) {
+    const skipInProduction = targetEnv === 'production' && existingProduction.includes(name)
+    const skipInPreview = targetEnv === 'preview' && existingPreview.includes(name)
+    const skipInBoth = targetEnv === 'both' && existingProduction.includes(name) && existingPreview.includes(name)
+    if (skipInProduction || skipInPreview || skipInBoth) {
+      console.log(`  ~ ${name} (skipped — already exists in ${targetEnv})`)
+      continue
+    }
   }
 
   envVars[name] = { value, type: cfType }
@@ -168,13 +197,14 @@ if (Object.keys(envVars).length === 0) {
   process.exit(0)
 }
 
-const payload = {
-  deployment_configs: {
-    [TARGET_ENV]: { env_vars: envVars },
-  },
-}
+const envConfigs =
+  targetEnv === 'both'
+    ? { production: { env_vars: envVars }, preview: { env_vars: envVars } }
+    : { [targetEnv]: { env_vars: envVars } }
 
-console.log(`\nUploading to project '${projectName}' [${TARGET_ENV}]...`)
+const payload = { deployment_configs: envConfigs }
+
+console.log(`\nUploading to project '${projectName}' [${targetEnv}]...`)
 
 await cfFetch(accountId, apiToken, `projects/${projectName}`, {
   method: 'PATCH',

--- a/tools/scripts/cf-pages/upload-env-vars.mjs
+++ b/tools/scripts/cf-pages/upload-env-vars.mjs
@@ -3,7 +3,7 @@
  * Upload environment variables to a Cloudflare Pages project from a CSV file.
  *
  * USAGE:
- *   node upload-env-vars.mjs <path/to/vars.csv> [--no-overwrite]
+ *   node upload-env-vars.mjs <path/to/vars.csv> [--overwrite]
  *
  * ENV VARS:
  *   CF_ACCOUNT_ID    (required)  Cloudflare account ID
@@ -28,8 +28,8 @@
  *     MY_VAR,"value,with,commas",text
  *
  * OPTIONS:
- *   --no-overwrite    Skip variables that already exist in the target environment.
- *                     Without this flag, existing variables are overwritten.
+ *   --overwrite    Overwrite variables that already exist in the target environment.
+ *                  Without this flag, existing variables are skipped.
  *
  * API TOKEN PERMISSIONS (https://dash.cloudflare.com/profile/api-tokens):
  *   Account > Cloudflare Pages > Edit
@@ -48,14 +48,14 @@ const TARGET_ENV = 'production'
 const [, , csvFile, ...restArgs] = process.argv
 
 if (!csvFile) {
-  process.stderr.write('Usage: node upload-env-vars.mjs <path/to/vars.csv> [--no-overwrite]\n')
+  process.stderr.write('Usage: node upload-env-vars.mjs <path/to/vars.csv> [--overwrite]\n')
   process.exit(1)
 }
 
-let noOverwrite = false
+let overwrite = false
 for (const arg of restArgs) {
-  if (arg === '--no-overwrite') {
-    noOverwrite = true
+  if (arg === '--overwrite') {
+    overwrite = true
   } else if (arg.startsWith('--')) {
     cfError(`Unknown option: ${arg}`)
   }
@@ -117,7 +117,7 @@ async function fetchExistingVarNames(env) {
 
 let existingVars = []
 
-if (noOverwrite) {
+if (!overwrite) {
   console.log(`Fetching existing variables from '${projectName}'...`)
   existingVars = await fetchExistingVarNames(TARGET_ENV)
   console.log(`  ${TARGET_ENV}: ${existingVars.length} existing variable(s)`)
@@ -151,7 +151,7 @@ for (let row = 0; row < lines.length; row++) {
     cfError(`Row ${row + 1} (${name}): type must be 'text' or 'secret', got '${rawType}'`)
   }
 
-  if (noOverwrite && existingVars.includes(name)) {
+  if (!overwrite && existingVars.includes(name)) {
     console.log(`  ~ ${name} (skipped — already exists in ${TARGET_ENV})`)
     continue
   }

--- a/tools/scripts/cf-pages/upload-env-vars.mjs
+++ b/tools/scripts/cf-pages/upload-env-vars.mjs
@@ -10,7 +10,7 @@
  *   CF_API_TOKEN     (required)  Cloudflare API token
  *   CF_PROJECT_NAME  (optional)  CF Pages project name. Default: swap-dev
  *
- * CSV FORMAT (header row required):
+ * CSV FORMAT (header row optional):
  *   name,value,type
  *
  *   name   Variable name (e.g. REACT_APP_API_URL)
@@ -38,7 +38,7 @@
  */
 
 import { readFileSync } from 'node:fs'
-import { getCfCredentials, cfFetch, cfError } from './cf-api.mjs'
+import { cfError, cfFetch, getCfCredentials } from './cf-api.mjs'
 
 const { accountId, apiToken } = getCfCredentials()
 const projectName = process.env.CF_PROJECT_NAME ?? 'swap-dev'
@@ -129,8 +129,6 @@ const lines = content.split('\n')
 const envVars = {}
 
 for (let row = 0; row < lines.length; row++) {
-  if (row === 0) continue // skip header
-
   const trimmed = lines[row].trim()
   if (!trimmed || trimmed.startsWith('#')) continue
 
@@ -141,6 +139,11 @@ for (let row = 0; row < lines.length; row++) {
 
   if (!name) {
     console.log(`WARNING: Row ${row + 1} has an empty name — skipping.`)
+    continue
+  }
+
+  if (name.toLowerCase() === 'name') {
+    // Header row, skip it
     continue
   }
 

--- a/tools/scripts/cf-pages/upload-env-vars.mjs
+++ b/tools/scripts/cf-pages/upload-env-vars.mjs
@@ -127,6 +127,39 @@ function parseCSVLine(line) {
   return fields
 }
 
+function normalizeCSVFields(fields) {
+  return fields.map((field) => field.replace(/\r+$/, ''))
+}
+
+function buildEnvVarConfigs({
+  name,
+  envVar,
+  targetEnv,
+  overwrite,
+  existingProduction,
+  existingPreview,
+  productionEnvVars,
+  previewEnvVars,
+}) {
+  const addedEnvs = []
+
+  if (targetEnv === 'production' || targetEnv === 'both') {
+    if (overwrite || !existingProduction.includes(name)) {
+      productionEnvVars[name] = envVar
+      addedEnvs.push('production')
+    }
+  }
+
+  if (targetEnv === 'preview' || targetEnv === 'both') {
+    if (overwrite || !existingPreview.includes(name)) {
+      previewEnvVars[name] = envVar
+      addedEnvs.push('preview')
+    }
+  }
+
+  return { addedEnvs }
+}
+
 async function fetchExistingVarNames(env) {
   const data = await cfFetch(accountId, apiToken, `projects/${projectName}`).catch((err) => cfError(err.message))
   return Object.keys(data.result?.deployment_configs?.[env]?.env_vars ?? {})
@@ -150,13 +183,14 @@ if (!overwrite) {
 console.log(`Reading variables from '${csvFile}'...`)
 
 const lines = content.split('\n')
-const envVars = {}
+const productionEnvVars = {}
+const previewEnvVars = {}
 
 for (let row = 0; row < lines.length; row++) {
   const trimmed = lines[row].trim()
   if (!trimmed || trimmed.startsWith('#')) continue
 
-  const fields = parseCSVLine(lines[row])
+  const fields = normalizeCSVFields(parseCSVLine(lines[row]))
   const name = fields[0]?.trim()
   const value = fields[1] ?? ''
   const rawType = (fields[2] ?? '').trim().toLowerCase()
@@ -178,29 +212,39 @@ for (let row = 0; row < lines.length; row++) {
     cfError(`Row ${row + 1} (${name}): type must be 'text' or 'secret', got '${rawType}'`)
   }
 
-  if (!overwrite) {
-    const skipInProduction = targetEnv === 'production' && existingProduction.includes(name)
-    const skipInPreview = targetEnv === 'preview' && existingPreview.includes(name)
-    const skipInBoth = targetEnv === 'both' && existingProduction.includes(name) && existingPreview.includes(name)
-    if (skipInProduction || skipInPreview || skipInBoth) {
-      console.log(`  ~ ${name} (skipped — already exists in ${targetEnv})`)
-      continue
-    }
+  const { addedEnvs } = buildEnvVarConfigs({
+    name,
+    envVar: { value, type: cfType },
+    targetEnv,
+    overwrite,
+    existingProduction,
+    existingPreview,
+    productionEnvVars,
+    previewEnvVars,
+  })
+
+  if (addedEnvs.length === 0) {
+    console.log(`  ~ ${name} (skipped — already exists in ${targetEnv})`)
+    continue
   }
 
-  envVars[name] = { value, type: cfType }
   console.log(`  + ${name} (${rawType})`)
 }
 
-if (Object.keys(envVars).length === 0) {
+const hasProductionVars = Object.keys(productionEnvVars).length > 0
+const hasPreviewVars = Object.keys(previewEnvVars).length > 0
+
+if (!hasProductionVars && !hasPreviewVars) {
   console.log('No variables found in CSV. Nothing to upload.')
   process.exit(0)
 }
 
 const envConfigs =
   targetEnv === 'both'
-    ? { production: { env_vars: envVars }, preview: { env_vars: envVars } }
-    : { [targetEnv]: { env_vars: envVars } }
+    ? { production: { env_vars: productionEnvVars }, preview: { env_vars: previewEnvVars } }
+    : targetEnv === 'production'
+      ? { production: { env_vars: productionEnvVars } }
+      : { preview: { env_vars: previewEnvVars } }
 
 const payload = { deployment_configs: envConfigs }
 

--- a/tools/scripts/cf-pages/upload-env-vars.mjs
+++ b/tools/scripts/cf-pages/upload-env-vars.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * Upload environment variables to a Cloudflare Pages project from a CSV file.
+ *
+ * USAGE:
+ *   node upload-env-vars.mjs <path/to/vars.csv> [--no-overwrite]
+ *
+ * ENV VARS:
+ *   CF_ACCOUNT_ID    (required)  Cloudflare account ID
+ *   CF_API_TOKEN     (required)  Cloudflare API token
+ *   CF_PROJECT_NAME  (optional)  CF Pages project name. Default: swap-dev
+ *
+ * CSV FORMAT (header row required):
+ *   name,value,type
+ *
+ *   name   Variable name (e.g. REACT_APP_API_URL)
+ *   value  Variable value. Values containing commas must be quoted per RFC 4180.
+ *   type   "text" for plain-text variables, "secret" for encrypted secrets
+ *
+ *   Lines starting with # are treated as comments and ignored.
+ *   Blank lines are ignored.
+ *
+ *   Example:
+ *     name,value,type
+ *     # RPC endpoints
+ *     REACT_APP_API_URL,https://api.example.com,text
+ *     REACT_APP_SECRET_KEY,supersecret123,secret
+ *     MY_VAR,"value,with,commas",text
+ *
+ * OPTIONS:
+ *   --no-overwrite    Skip variables that already exist in the target environment.
+ *                     Without this flag, existing variables are overwritten.
+ *
+ * API TOKEN PERMISSIONS (https://dash.cloudflare.com/profile/api-tokens):
+ *   Account > Cloudflare Pages > Edit
+ *   Scope: Account Resources > Include > <your account>
+ *   That single permission is sufficient — no Zone or Worker permissions needed.
+ */
+
+import { readFileSync } from 'node:fs'
+import { getCfCredentials, cfFetch, cfError } from './cf-api.mjs'
+
+const { accountId, apiToken } = getCfCredentials()
+const projectName = process.env.CF_PROJECT_NAME ?? 'swap-dev'
+
+const TARGET_ENV = 'production'
+
+const [, , csvFile, ...restArgs] = process.argv
+
+if (!csvFile) {
+  process.stderr.write('Usage: node upload-env-vars.mjs <path/to/vars.csv> [--no-overwrite]\n')
+  process.exit(1)
+}
+
+let noOverwrite = false
+for (const arg of restArgs) {
+  if (arg === '--no-overwrite') {
+    noOverwrite = true
+  } else if (arg.startsWith('--')) {
+    cfError(`Unknown option: ${arg}`)
+  }
+}
+
+let content
+try {
+  content = readFileSync(csvFile, 'utf8')
+} catch {
+  cfError(`File not found: ${csvFile}`)
+}
+
+/**
+ * Parse a single RFC 4180 CSV line into an array of field strings.
+ * Handles quoted fields (which may contain commas) and escaped double-quotes ("").
+ *
+ * @param {string} line
+ * @returns {string[]}
+ */
+function parseCSVLine(line) {
+  const fields = []
+  let i = 0
+  while (i < line.length) {
+    if (line[i] === '"') {
+      let field = ''
+      i++ // skip opening quote
+      while (i < line.length) {
+        if (line[i] === '"') {
+          if (line[i + 1] === '"') {
+            field += '"'
+            i += 2
+          } else {
+            i++ // skip closing quote
+            break
+          }
+        } else {
+          field += line[i++]
+        }
+      }
+      fields.push(field)
+      if (i < line.length && line[i] === ',') i++
+    } else {
+      const end = line.indexOf(',', i)
+      if (end === -1) {
+        fields.push(line.slice(i))
+        break
+      }
+      fields.push(line.slice(i, end))
+      i = end + 1
+    }
+  }
+  return fields
+}
+
+async function fetchExistingVarNames(env) {
+  const data = await cfFetch(accountId, apiToken, `projects/${projectName}`).catch((err) => cfError(err.message))
+  return Object.keys(data.result?.deployment_configs?.[env]?.env_vars ?? {})
+}
+
+let existingVars = []
+
+if (noOverwrite) {
+  console.log(`Fetching existing variables from '${projectName}'...`)
+  existingVars = await fetchExistingVarNames(TARGET_ENV)
+  console.log(`  ${TARGET_ENV}: ${existingVars.length} existing variable(s)`)
+}
+
+console.log(`Reading variables from '${csvFile}'...`)
+
+const lines = content.split('\n')
+const envVars = {}
+
+for (let row = 0; row < lines.length; row++) {
+  if (row === 0) continue // skip header
+
+  const trimmed = lines[row].trim()
+  if (!trimmed || trimmed.startsWith('#')) continue
+
+  const fields = parseCSVLine(lines[row])
+  const name = fields[0]?.trim()
+  const value = fields[1] ?? ''
+  const rawType = (fields[2] ?? '').trim().toLowerCase()
+
+  if (!name) {
+    console.log(`WARNING: Row ${row + 1} has an empty name — skipping.`)
+    continue
+  }
+
+  let cfType
+  if (rawType === 'text') cfType = 'plain_text'
+  else if (rawType === 'secret') cfType = 'secret_text'
+  else {
+    cfError(`Row ${row + 1} (${name}): type must be 'text' or 'secret', got '${rawType}'`)
+  }
+
+  if (noOverwrite && existingVars.includes(name)) {
+    console.log(`  ~ ${name} (skipped — already exists in ${TARGET_ENV})`)
+    continue
+  }
+
+  envVars[name] = { value, type: cfType }
+  console.log(`  + ${name} (${rawType})`)
+}
+
+if (Object.keys(envVars).length === 0) {
+  console.log('No variables found in CSV. Nothing to upload.')
+  process.exit(0)
+}
+
+const payload = {
+  deployment_configs: {
+    [TARGET_ENV]: { env_vars: envVars },
+  },
+}
+
+console.log(`\nUploading to project '${projectName}' [${TARGET_ENV}]...`)
+
+await cfFetch(accountId, apiToken, `projects/${projectName}`, {
+  method: 'PATCH',
+  body: JSON.stringify(payload),
+}).catch((err) => cfError(err.message))
+
+console.log('Done. Environment variables updated successfully.')

--- a/tools/scripts/cf-pages/upload-env-vars.test.mjs
+++ b/tools/scripts/cf-pages/upload-env-vars.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, it } from 'node:test'
+
+import { runScriptAsync, startMockCloudflare } from './test-utils.mjs'
+
+describe('upload-env-vars.mjs', () => {
+  it('normalizes CRLF CSV values and builds separate production and preview payloads', async (t) => {
+    const dir = mkdtempSync(join(tmpdir(), 'cf-pages-test-'))
+    const csvFile = join(dir, 'vars.csv')
+    writeFileSync(csvFile, 'REACT_APP_URL,https://example.com\r,text\r\n')
+
+    const cloudflare = await startMockCloudflare([
+      {
+        method: 'GET',
+        url: '/client/v4/accounts/account-id/pages/projects/demo-project',
+        response: {
+          body: {
+            success: true,
+            result: {
+              deployment_configs: {
+                production: { env_vars: { REACT_APP_URL: {} } },
+                preview: { env_vars: {} },
+              },
+            },
+          },
+        },
+      },
+      {
+        method: 'PATCH',
+        url: '/client/v4/accounts/account-id/pages/projects/demo-project',
+        response: { body: { success: true, result: {} } },
+      },
+    ])
+    t.after(() => cloudflare.close())
+
+    const result = await runScriptAsync(
+      'tools/scripts/cf-pages/upload-env-vars.mjs',
+      [csvFile, '--project', 'demo-project', '--env', 'both'],
+      { CF_ACCOUNT_ID: 'account-id', CF_API_TOKEN: 'api-token', CF_API_BASE: cloudflare.apiBase },
+    )
+
+    assert.equal(result.status, 0)
+
+    const patchRequest = cloudflare.requests.find((request) => request.method === 'PATCH')
+    assert.ok(patchRequest)
+
+    const payload = patchRequest.json
+    assert.deepEqual(payload.deployment_configs.production.env_vars, {})
+    assert.equal(payload.deployment_configs.preview.env_vars.REACT_APP_URL.value, 'https://example.com')
+    assert.equal(payload.deployment_configs.preview.env_vars.REACT_APP_URL.type, 'plain_text')
+  })
+})


### PR DESCRIPTION
# Summary

Adding a collection of scripts for managing CF pages which I needed during the setup so far.

## create-pages-project: 

Helper for creating a cloudflare pages project. 
Needed as the UI doesn't allow to pick the branch name I wanted.
Added some defaults to make copies easier.

## delete-project-deployments: 

Helper for deleting all builds of a cloudflare pages project.
Needed as I first created a test project and connected cowswap repo to it in my personal account.
Later I wanted to move the project to company account, but it's not possible to link the same repo to different accounts.
So I had to delete the project from the first account.
But to do that all the builds from a project have to be deleted.
There were hundreds of builds (the skipped and failed count).
That's why this script exists!

## report-build-usage

Helper for finding out how many builds have been done in a month.
Cloudflare pages have a limit of 500 builds / month in the free plan.
There's no way to see in the UI how many builds have been used.
This script counts them.

## upload-env-vars

Helper for setting env vars.
There are about 15 env vars that need to be set for the a project currently.
Each need to be manually inserted via the UI for each project, once for the preview and once for the production env.
Since we have 3 projects per app plus preview, it's a pain in the ass to do it manually.

## list-production-deployments

Helper for filtering only production deployments.
In Cloudflare pages UI, all preview and production deployments, including the ones that are skipped, are shown in a single page, with 15 items per page.
<img width="838" height="935" alt="image" src="https://github.com/user-attachments/assets/ba9ec3ea-a676-4c81-ab63-3d7babe4e478" />
There is no way to increase the amount of items per page, nor there's a way to filter only by production deployments.
This script lists the last 10.

<img width="1017" height="317" alt="image" src="https://github.com/user-attachments/assets/43446768-b928-4ac9-a050-60c58997d615" />


## rollback-production-deployment

Helper for rolling back production deployments.
Given the difficulties listed above, this script allows to easily rollback to a given deployment by id.

# To Test

Run the scripts locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloudflare Pages CLI utilities:
    - Create projects with configurable options and dry-run preview; prints created project URL.
    - Delete project deployments in batched retries with progress and safe-delete reporting.
    - List and roll back production deployments with formatted tables and canonical-deployment reporting.
    - Report monthly build usage per project with aggregated totals.
    - Upload environment variables from CSV with robust parsing and optional overwrite.
* **Tests**
  * Unit tests for deployment listing/rollback helpers and table formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cowprotocol/cowswap/pull/7564?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->