### PR TITLE
[DRAFT] fix: quick vibe-coded fix for env var missing (WIP)

### DIFF
--- a/apps/cowswap-frontend/vite.config.mts
+++ b/apps/cowswap-frontend/vite.config.mts
@@ -18,8 +18,9 @@ import * as path from 'path'
 import pkg from './package.json'
 
 import { formatChunkFileName } from '../../tools/formatChunkFileName'
-import { getReactProcessEnv } from '../../tools/getReactProcessEnv'
+import { getReactAppEnvRecord, getReactProcessEnv } from '../../tools/getReactProcessEnv'
 import { NODE_STD_LIBS } from '../../tools/nodeStdLibs'
+import { reactAppEnvPostDefinePlugin } from '../../tools/vite-plugins/reactAppEnvPostDefinePlugin'
 import { robotsPlugin } from '../../tools/vite-plugins/robotsPlugin'
 
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
@@ -41,6 +42,7 @@ const sentryReleaseName = `CowSwap@v${pkg.version}`
 // eslint-disable-next-line max-lines-per-function
 export default defineConfig(({ mode, isPreview }) => {
   const isProduction = mode === 'production'
+  const reactAppEnvRecord = getReactAppEnvRecord(mode)
 
   const plugins: PluginOption[] = [
     nodePolyfills({
@@ -52,6 +54,7 @@ export default defineConfig(({ mode, isPreview }) => {
       },
       protocolImports: true,
     }),
+    reactAppEnvPostDefinePlugin(reactAppEnvRecord),
     react(),
     viteTsConfigPaths({
       root: '../../',

--- a/tools/getReactProcessEnv.ts
+++ b/tools/getReactProcessEnv.ts
@@ -1,7 +1,11 @@
 import { loadEnv } from 'vite'
 
+export function getReactAppEnvRecord(mode: string): Record<string, string> {
+  return loadEnv(mode, process.cwd(), ['REACT_APP_'])
+}
+
 export function getReactProcessEnv(mode: string): { [key: string]: string } {
-  const env = loadEnv(mode, process.cwd(), ['REACT_APP_'])
+  const env = getReactAppEnvRecord(mode)
 
   // expose .env as process.env instead of import.meta since jest does not import meta yet
   return Object.entries(env).reduce((prev, [key, val]) => {

--- a/tools/vite-plugins/reactAppEnvPostDefinePlugin.ts
+++ b/tools/vite-plugins/reactAppEnvPostDefinePlugin.ts
@@ -1,0 +1,39 @@
+import type { Plugin } from 'vite'
+
+/**
+ * Inlines `process.env.REACT_APP_*` after other transforms (e.g. vite-plugin-node-polyfills).
+ * Polyfills rewrite `process` to a shim import, which prevents Vite `define` from replacing
+ * `process.env.REACT_APP_*` member access in app and workspace lib source.
+ */
+export function reactAppEnvPostDefinePlugin(reactAppEnv: Record<string, string>): Plugin {
+  return {
+    name: 'cow-react-app-env-post-define',
+    enforce: 'post',
+    transform(code, id) {
+      if (!/\.[cm]?[jt]sx?$/.test(id)) {
+        return null
+      }
+
+      if (id.includes('node_modules') && !id.includes('/libs/')) {
+        return null
+      }
+
+      let result = code
+      let changed = false
+
+      for (const [key, value] of Object.entries(reactAppEnv)) {
+        const pattern = `process.env.${key}`
+        if (result.includes(pattern)) {
+          result = result.split(pattern).join(JSON.stringify(value))
+          changed = true
+        }
+      }
+
+      if (!changed) {
+        return null
+      }
+
+      return { code: result, map: null }
+    },
+  }
+}


### PR DESCRIPTION
# Summary

It looks like bumping vite-plugin-node-polyfills in https://github.com/cowprotocol/cowswap/pull/7575 is causing some env variables not to load properly, so you get a `Missing REACT_APP_ENVIRONMENT` error.

This is a quick vibe-coded fix. Treat it like debugging code, not an actual solution.

Might be related to https://github.com/davidmyersdev/vite-plugin-node-polyfills/issues/83.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal build configuration and environment variable handling
  * Enhanced Vite plugin system for more efficient build process management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cowprotocol/cowswap/pull/7577?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->