### PR TITLE
fix: detect atomic batch support

### DIFF
--- a/libs/wallet/src/api/hooks.ts
+++ b/libs/wallet/src/api/hooks.ts
@@ -47,6 +47,7 @@ export function useIsTxBundlingSupported(): boolean | null {
   const isSmartContractWallet = useIsSmartContractWallet()
   const isSafeWallet = useIsSafeWallet()
 
+  // eslint-disable-next-line complexity
   const result = (() => {
     if (isSafeApp || isSafeViaWc) return true
     // Smart accounts (ERC-4337, Coinbase Smart Wallet, EIP-7702, etc.) that are not a Safe lack the
@@ -55,7 +56,7 @@ export function useIsTxBundlingSupported(): boolean | null {
     // (which keep the same EOA address but have delegation bytecode). We check both explicitly.
     if ((isSmartContractWallet || accountType === AccountType.EIP7702EOA) && !isSafeWallet) return false
     if (isCapabilitiesLoading) return null
-    return capabilities?.atomic?.status === 'supported'
+    return Boolean(capabilities?.atomic?.status === 'supported' || capabilities?.atomicBatch?.supported)
   })()
 
   return result

--- a/libs/wallet/src/api/hooks/useSendBatchTransactions.ts
+++ b/libs/wallet/src/api/hooks/useSendBatchTransactions.ts
@@ -19,7 +19,7 @@ export function useSendBatchTransactions(): SendBatchTxCallback {
   const safeAppsSdk = useSafeAppsSdk()
   const { chainId, account } = useWalletInfo()
   const { data: capabilities } = useWalletCapabilities()
-  const isAtomicBatchSupported = capabilities?.atomic?.status === 'supported'
+  const isAtomicBatchSupported = capabilities?.atomic?.status === 'supported' || capabilities?.atomicBatch?.supported
 
   return useCallback(
     async (txs: MetaTransactionData[]) => {

--- a/libs/wallet/src/api/hooks/useWalletCapabilities.ts
+++ b/libs/wallet/src/api/hooks/useWalletCapabilities.ts
@@ -12,6 +12,7 @@ import { useWalletInfo } from '../hooks'
 
 export type WalletCapabilities = {
   atomic?: { status: 'supported' | 'ready' | 'unsupported' }
+  atomicBatch?: { supported: boolean }
 }
 
 function shouldCheckCapabilities(


### PR DESCRIPTION
# Summary

It looks like the format has been changed.
https://eips.ethereum.org/EIPS/eip-5792#wallet_getcapabilities

<img width="2918" height="596" alt="image" src="https://github.com/user-attachments/assets/42db7fbb-2173-480d-b5d2-1e9fcad34f22" />

# To Test

1. Do approve + swap in Safe
2. Create a approve + TWAP in Safe
3. Cancel TWAP order

https://github.com/user-attachments/assets/e86e6e21-9260-4d51-a620-9b7539110224



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Expanded detection of atomic batch support across wallets, improving routing for multi-call transactions.
  * More accurate capability recognition reduces fallback usage and increases success rates for bundled sends.
  * Transaction-sending now prefers native batch routes when supported, yielding more reliable batch execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cowprotocol/cowswap/pull/7584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->