### PR TITLE
fix: trade with price impact unknown 

### DIFF
--- a/apps/cowswap-frontend/src/legacy/hooks/usePriceImpact/logger.ts
+++ b/apps/cowswap-frontend/src/legacy/hooks/usePriceImpact/logger.ts
@@ -1,0 +1,3 @@
+import { createCowLogger } from 'common/utils/logger'
+
+export const logPriceImpact = createCowLogger('PriceImpact')

--- a/apps/cowswap-frontend/src/legacy/hooks/usePriceImpact/useFiatValuePriceImpact.test.ts
+++ b/apps/cowswap-frontend/src/legacy/hooks/usePriceImpact/useFiatValuePriceImpact.test.ts
@@ -21,6 +21,15 @@ jest.mock('modules/usdAmount', () => ({
   useTradeUsdAmounts: jest.fn(),
 }))
 
+jest.mock('./logger', () => ({
+  logPriceImpact: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}))
+
 const mockedUseDerivedTradeState = useDerivedTradeState as jest.MockedFunction<typeof useDerivedTradeState>
 const mockedUseTradeUsdAmounts = useTradeUsdAmounts as jest.MockedFunction<typeof useTradeUsdAmounts>
 
@@ -61,6 +70,57 @@ describe('useFiatValuePriceImpact', () => {
     act(() => {
       jest.advanceTimersByTime(120_000)
     })
+
+    expect(result.current).toEqual({ priceImpact: undefined, isLoading: false })
+  })
+
+  it('does not restart the loading timeout when price loading flickers', () => {
+    mockedUseTradeUsdAmounts.mockReturnValue({
+      inputAmount: { value: null, isLoading: true },
+      outputAmount: { value: null, isLoading: true },
+    })
+
+    const { result, rerender } = renderHook(() => useFiatValuePriceImpact())
+
+    expect(result.current).toEqual({ priceImpact: undefined, isLoading: true })
+
+    act(() => {
+      jest.advanceTimersByTime(60_000)
+    })
+
+    mockedUseTradeUsdAmounts.mockReturnValue({
+      inputAmount: { value: null, isLoading: false },
+      outputAmount: { value: null, isLoading: false },
+    })
+    rerender()
+
+    expect(result.current).toEqual({ priceImpact: undefined, isLoading: false })
+
+    mockedUseTradeUsdAmounts.mockReturnValue({
+      inputAmount: { value: null, isLoading: true },
+      outputAmount: { value: null, isLoading: true },
+    })
+    rerender()
+
+    act(() => {
+      jest.advanceTimersByTime(60_000)
+    })
+
+    expect(result.current).toEqual({ priceImpact: undefined, isLoading: false })
+
+    mockedUseTradeUsdAmounts.mockReturnValue({
+      inputAmount: { value: null, isLoading: false },
+      outputAmount: { value: null, isLoading: false },
+    })
+    rerender()
+
+    expect(result.current).toEqual({ priceImpact: undefined, isLoading: false })
+
+    mockedUseTradeUsdAmounts.mockReturnValue({
+      inputAmount: { value: null, isLoading: true },
+      outputAmount: { value: null, isLoading: true },
+    })
+    rerender()
 
     expect(result.current).toEqual({ priceImpact: undefined, isLoading: false })
   })

--- a/apps/cowswap-frontend/src/legacy/hooks/usePriceImpact/useFiatValuePriceImpact.ts
+++ b/apps/cowswap-frontend/src/legacy/hooks/usePriceImpact/useFiatValuePriceImpact.ts
@@ -12,6 +12,8 @@ import { useTradeUsdAmounts } from 'modules/usdAmount'
 
 import { useSafeMemo } from 'common/hooks/useSafeMemo'
 
+import { logPriceImpact } from './logger'
+
 const TRADE_SET_UP_DEBOUNCE_TIME = ms`100ms`
 const PRICE_IMPACT_LOADING_TIMEOUT = ms`15s`
 
@@ -40,6 +42,7 @@ export function useFiatValuePriceImpact(): { priceImpact: Percent | undefined; i
 
     const timeoutId = setTimeout(() => {
       setHasLoadingTimedOut(true)
+      logPriceImpact.warn(`Price impact loading timed out after ${PRICE_IMPACT_LOADING_TIMEOUT / 1000}s`)
     }, PRICE_IMPACT_LOADING_TIMEOUT)
 
     return () => clearTimeout(timeoutId)

--- a/apps/cowswap-frontend/src/legacy/hooks/usePriceImpact/useFiatValuePriceImpact.ts
+++ b/apps/cowswap-frontend/src/legacy/hooks/usePriceImpact/useFiatValuePriceImpact.ts
@@ -13,7 +13,7 @@ import { useTradeUsdAmounts } from 'modules/usdAmount'
 import { useSafeMemo } from 'common/hooks/useSafeMemo'
 
 const TRADE_SET_UP_DEBOUNCE_TIME = ms`100ms`
-const PRICE_IMPACT_LOADING_TIMEOUT = ms`2m`
+const PRICE_IMPACT_LOADING_TIMEOUT = ms`15s`
 
 export function useFiatValuePriceImpact(): { priceImpact: Percent | undefined; isLoading: boolean } | null {
   const state = useDerivedTradeState()
@@ -33,7 +33,7 @@ export function useFiatValuePriceImpact(): { priceImpact: Percent | undefined; i
   const [hasLoadingTimedOut, setHasLoadingTimedOut] = useState(false)
 
   useEffect(() => {
-    if (!isTradeSetUp || !isLoading) {
+    if (!isTradeSetUp) {
       setHasLoadingTimedOut(false)
       return
     }
@@ -43,7 +43,7 @@ export function useFiatValuePriceImpact(): { priceImpact: Percent | undefined; i
     }, PRICE_IMPACT_LOADING_TIMEOUT)
 
     return () => clearTimeout(timeoutId)
-  }, [isTradeSetUp, isLoading])
+  }, [isTradeSetUp])
 
   return useSafeMemo(() => {
     // Don't calculate price impact if trade is not set up (both trade assets are not set)

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/RateInput/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/RateInput/index.tsx
@@ -259,18 +259,14 @@ export function RateInput() {
           )}
         </styledEl.Header>
         <styledEl.Body>
-          {isLoading && areBothCurrencies ? (
-            <styledEl.RateLoader />
-          ) : (
-            <styledEl.NumericalInput
-              $loading={false}
-              id="rate-limit-amount-input"
-              prependSymbol={isUsdRateMode ? '$' : ''}
-              value={displayedRate + typedTrailingZeros}
-              onUserInput={handleUserInput}
-              disabled={isRateInputDisabled}
-            />
-          )}
+          <styledEl.NumericalInput
+            $loading={isLoading && areBothCurrencies}
+            id="rate-limit-amount-input"
+            prependSymbol={isUsdRateMode ? '$' : ''}
+            value={displayedRate + typedTrailingZeros}
+            onUserInput={handleUserInput}
+            disabled={isRateInputDisabled}
+          />
 
           {secondaryCurrency && (
             <styledEl.CurrencyToggleGroup>

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.test.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.test.ts
@@ -250,6 +250,18 @@ describe('validateTradeForm - price impact loading', () => {
     expect(result || []).not.toContain(TradeFormValidation.ImpactLoading)
   })
 
+  test('disables widget trade when price impact is unknown and widget requires known price impact', () => {
+    const context = {
+      ...baseContext,
+      injectedWidgetParams: { disableTrade: { whenPriceImpactIsUnknown: true } },
+      tradePriceImpact: { loading: false, priceImpact: undefined },
+    } as unknown as TradeFormValidationContext
+
+    const result = validateTradeForm(context)
+    expect(result).toContain(TradeFormValidation.DisableTradeWithUnknownPriceImpact)
+    expect(result || []).not.toContain(TradeFormValidation.ImpactLoading)
+  })
+
   test('does not add ImpactLoading for wrap/unwrap flow even if tradePriceImpact is loading', () => {
     const context = {
       ...baseContext,

--- a/apps/cowswap-frontend/src/modules/usdAmount/logger.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/logger.ts
@@ -1,0 +1,3 @@
+import { createCowLogger } from 'common/utils/logger'
+
+export const logUsdPrices = createCowLogger('UsdPrices')

--- a/apps/cowswap-frontend/src/modules/usdAmount/updaters/UsdPricesUpdater.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/updaters/UsdPricesUpdater.ts
@@ -10,6 +10,7 @@ import useSWR, { SWRConfiguration } from 'swr'
 import { useIsProviderNetworkDeprecated } from 'common/hooks/useIsProviderNetworkDeprecated'
 import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetworkUnsupported'
 
+import { logUsdPrices } from '../logger'
 import { fetchCurrencyUsdPrice } from '../services/fetchCurrencyUsdPrice'
 import {
   currenciesUsdPriceQueueAtom,
@@ -44,6 +45,10 @@ export function UsdPricesUpdater() {
   const swrResponse = useSWR<UsdRawPrices | null>(
     ['UsdPricesUpdater', queue],
     () => {
+      if (queue.length) {
+        logUsdPrices.debug(`Fetching USD prices for ${queue.map(({ symbol }) => symbol).join(', ')}`)
+      }
+
       setUsdPricesLoading(queue)
 
       return processQueue(queue)
@@ -60,7 +65,7 @@ export function UsdPricesUpdater() {
     }
 
     if (error) {
-      console.error('Error loading USD prices', error)
+      logUsdPrices.error('Error loading USD prices', error)
       return
     }
 
@@ -93,7 +98,7 @@ async function processQueue(queue: Token[]): Promise<UsdRawPrices> {
           state.updatedAt = Date.now()
         }
       } catch {
-        console.debug(`[UsdPricesUpdater]: Failed to fetch price for`, currency.symbol)
+        logUsdPrices.warn(`Failed to fetch USD price for ${currency.symbol}`)
       }
 
       return { [getUsdPriceStateKey(currency)]: state }


### PR DESCRIPTION
# Summary

Fixes https://app.notion.com/p/cownation/Can-t-place-trade-with-unknown-price-impact-36f8da5f04ca8007a3d0dba22efa424b

Builds on https://github.com/cowprotocol/cowswap/commit/4563aff1b312935578a2518ba726ed7eb1f8532c and https://github.com/cowprotocol/cowswap/pull/7434 to properly fix https://github.com/cowprotocol/cowswap/issues/7272

This PR allows you to place a **Swap** or **Limit Order**, even if price impact cannot be fetched/calculated.

> [!NOTE]
> Review commit by commit!! The first 2 commits are of utmost importance (Layer A)

# To Test

- [ ] 1. Block API, BFF and DefiLlama requests
- [ ] 2. Wait 15s for "Fetching price impact..." to timeout
- [ ] 3. Verify you can place a Swap
- [ ] 4. Verify you can place a Limit
- [ ] 5. Ensure widget setting "Disable trade when price impact is unknown" is respected

<img width="2865" height="1166" alt="Screenshot From 2026-05-29 13-12-10" src="https://github.com/user-attachments/assets/779bfcb6-7d5e-4119-ac78-2c3511e387fe" />
