### PR TITLE
fix: fix approve+swap flow in Safe wallet

### DIFF
--- a/libs/wallet/src/api/hooks.ts
+++ b/libs/wallet/src/api/hooks.ts
@@ -1,4 +1,5 @@
 import { useAtomValue } from 'jotai'
+import { useMemo } from 'react'
 
 import { AccountType } from '@cowprotocol/types'
 
@@ -16,7 +17,7 @@ import { ConnectionType, GnosisSafeInfo, WalletDetails, WalletInfo } from './typ
 
 import { BRAVE_WALLET_RDNS, METAMASK_RDNS, RABBY_RDNS, WATCH_ASSET_SUPPORED_WALLETS } from '../constants'
 import { useAccountType, useIsSmartContractWallet } from '../wagmi/hooks/useIsSmartContractWallet'
-import { useIsSafeApp, useIsSafeViaWc, useIsSafeWallet } from '../wagmi/hooks/useWalletMetadata'
+import { useIsSafeApp, useIsSafeWallet } from '../wagmi/hooks/useWalletMetadata'
 
 export function useWalletInfo(): WalletInfo {
   return useAtomValue(walletInfoAtom)
@@ -39,26 +40,23 @@ export function useIsEagerConnectInProgress(): boolean {
 }
 
 export function useIsTxBundlingSupported(): boolean | null {
-  // TODO this will be fixed in M-3 COW-569
   const { data: capabilities, isLoading: isCapabilitiesLoading } = useWalletCapabilities()
   const isSafeApp = useIsSafeApp()
-  const isSafeViaWc = useIsSafeViaWc()
   const accountType = useAccountType()
   const isSmartContractWallet = useIsSmartContractWallet()
   const isSafeWallet = useIsSafeWallet()
 
-  const result = (() => {
-    if (isSafeApp || isSafeViaWc) return true
+  // eslint-disable-next-line complexity
+  return useMemo(() => {
+    if (isSafeApp) return true
     // Smart accounts (ERC-4337, Coinbase Smart Wallet, EIP-7702, etc.) that are not a Safe lack the
     // fallback handler mechanism TWAP requires — treat them as unsupported.
     // Note: useIsSmartContractWallet() only detects AccountType.SMART_CONTRACT, not EIP-7702 accounts
     // (which keep the same EOA address but have delegation bytecode). We check both explicitly.
     if ((isSmartContractWallet || accountType === AccountType.EIP7702EOA) && !isSafeWallet) return false
     if (isCapabilitiesLoading) return null
-    return capabilities?.atomic?.status === 'supported'
-  })()
-
-  return result
+    return Boolean(capabilities?.atomic?.status === 'supported' || capabilities?.atomicBatch?.supported)
+  }, [isSafeApp, isSmartContractWallet, accountType, isCapabilitiesLoading, capabilities, isSafeWallet])
 }
 
 export function useIsAssetWatchingSupported(): boolean {

--- a/libs/wallet/src/api/hooks/useSendBatchTransactions.ts
+++ b/libs/wallet/src/api/hooks/useSendBatchTransactions.ts
@@ -19,7 +19,7 @@ export function useSendBatchTransactions(): SendBatchTxCallback {
   const safeAppsSdk = useSafeAppsSdk()
   const { chainId, account } = useWalletInfo()
   const { data: capabilities } = useWalletCapabilities()
-  const isAtomicBatchSupported = capabilities?.atomic?.status === 'supported'
+  const isAtomicBatchSupported = capabilities?.atomic?.status === 'supported' || capabilities?.atomicBatch?.supported
 
   return useCallback(
     async (txs: MetaTransactionData[]) => {

--- a/libs/wallet/src/api/hooks/useWalletCapabilities.ts
+++ b/libs/wallet/src/api/hooks/useWalletCapabilities.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { isInjectedWidget, isMobile } from '@cowprotocol/common-utils'
 
@@ -10,8 +10,11 @@ import { useIsWalletConnect } from '../../wagmi/hooks/useIsWalletConnect'
 import { useIsSafeViaWc } from '../../wagmi/hooks/useWalletMetadata'
 import { useWalletInfo } from '../hooks'
 
+import type { GetCapabilitiesData } from '@wagmi/core/query'
+
 export type WalletCapabilities = {
   atomic?: { status: 'supported' | 'ready' | 'unsupported' }
+  atomicBatch?: { supported: boolean }
 }
 
 function shouldCheckCapabilities(
@@ -40,6 +43,21 @@ export function useWalletCapabilities(): { data: WalletCapabilities | undefined;
     [isWalletConnect, widgetProviderMetaInfo, account, chainId],
   )
 
+  const select = useCallback(
+    (capabilities: GetCapabilitiesData) => {
+      if (!capabilities || !chainId) return undefined as WalletCapabilities | undefined
+
+      // Only apply the Safe wallet fallback (first-entry) when connected via Safe WalletConnect,
+      // since Safe's wallet_getCapabilities response may omit the chain ID key.
+      // For other wallets (e.g. MetaMask), a missing chain entry means the chain is not supported —
+      // using a different chain's capabilities would incorrectly enable features like atomic bundling.
+      return (capabilities[chainId] || (isSafeViaWc ? Object.values(capabilities)[0] : undefined)) as
+        | WalletCapabilities
+        | undefined
+    },
+    [chainId, isSafeViaWc],
+  )
+
   // Fetch capabilities for all chains (no chainId filter) so we can apply
   // the Safe wallet fallback: if the exact chain is missing, use the first entry.
   // See https://github.com/safe-global/safe-wallet-monorepo/issues/6906
@@ -52,17 +70,7 @@ export function useWalletCapabilities(): { data: WalletCapabilities | undefined;
       refetchOnMount: false,
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
-      select(capabilities) {
-        if (!capabilities || !chainId) return undefined as WalletCapabilities | undefined
-
-        // Only apply the Safe wallet fallback (first-entry) when connected via Safe WalletConnect,
-        // since Safe's wallet_getCapabilities response may omit the chain ID key.
-        // For other wallets (e.g. MetaMask), a missing chain entry means the chain is not supported —
-        // using a different chain's capabilities would incorrectly enable features like atomic bundling.
-        return (capabilities[chainId] || (isSafeViaWc ? Object.values(capabilities)[0] : undefined)) as
-          | WalletCapabilities
-          | undefined
-      },
+      select,
     },
   })
 }

--- a/libs/wallet/src/wagmi/hooks/useSafeAppsSdk.ts
+++ b/libs/wallet/src/wagmi/hooks/useSafeAppsSdk.ts
@@ -2,14 +2,14 @@ import { useMemo } from 'react'
 
 import SafeAppsSDK from '@safe-global/safe-apps-sdk'
 
-import { useConnectionType } from './useConnectionType'
-
-import { ConnectionType } from '../../api/types'
+import { useIsSafeApp } from './useWalletMetadata'
 
 const sdk = new SafeAppsSDK()
 
 export function useSafeAppsSdk(): SafeAppsSDK | null {
-  const connectionType = useConnectionType()
+  const isSafeApp = useIsSafeApp()
 
-  return useMemo(() => (connectionType === ConnectionType.GNOSIS_SAFE ? sdk : null), [connectionType])
+  return useMemo(() => {
+    return isSafeApp ? sdk : null
+  }, [isSafeApp])
 }

--- a/libs/wallet/src/wagmi/hooks/useWalletMetadata.ts
+++ b/libs/wallet/src/wagmi/hooks/useWalletMetadata.ts
@@ -67,30 +67,32 @@ export function useWalletMetaData(): WalletMetaData {
   const { connector } = useConnection()
   const wcPeerMetadata = useWcPeerMetadata(connector)
 
-  if (!connector) {
-    return METADATA_DISCONNECTED
-  }
-
-  if (connector.id === COW_WIDGET_CONNECTOR_ID) {
-    return {
-      walletName: 'CoW Swap widget',
-      icon: 'Identicon',
+  return useMemo(() => {
+    if (!connector) {
+      return METADATA_DISCONNECTED
     }
-  }
 
-  if (connector.type === ConnectionType.WALLET_CONNECT_V2) {
-    return wcPeerMetadata
-  }
+    if (connector.id === COW_WIDGET_CONNECTOR_ID) {
+      return {
+        walletName: 'CoW Swap widget',
+        icon: 'Identicon',
+      }
+    }
 
-  if (connector.type === ConnectionType.GNOSIS_SAFE) {
-    // TODO: potentially here is where we'll need to work to show the multiple flavours of Safe wallets
-    return METADATA_SAFE
-  }
+    if (connector.type === ConnectionType.WALLET_CONNECT_V2) {
+      return wcPeerMetadata
+    }
 
-  return {
-    icon: connector.icon,
-    walletName: connector.name,
-  }
+    if (connector.type === ConnectionType.GNOSIS_SAFE) {
+      // TODO: potentially here is where we'll need to work to show the multiple flavours of Safe wallets
+      return METADATA_SAFE
+    }
+
+    return {
+      icon: connector.icon,
+      walletName: connector.name,
+    }
+  }, [connector, wcPeerMetadata])
 }
 
 /**
@@ -125,11 +127,14 @@ export function useIsSafeViaWc(): boolean {
   const isSafeApp = useIsSafeApp()
   const { connector } = useConnection()
   const wcPeerMetadata = useWcPeerMetadata(connector)
+  const isWalletConnect = connector?.type !== ConnectionType.WALLET_CONNECT_V2
 
-  if (isSafeApp) return false
-  if (connector?.type !== ConnectionType.WALLET_CONNECT_V2) return false
+  return useMemo(() => {
+    if (isSafeApp) return false
+    if (isWalletConnect) return false
 
-  const peerName = wcPeerMetadata.walletName?.toLowerCase() || ''
+    const peerName = wcPeerMetadata.walletName?.toLowerCase() || ''
 
-  return peerName.includes('safe')
+    return peerName.includes('safe')
+  }, [isSafeApp, isWalletConnect, wcPeerMetadata.walletName])
 }


### PR DESCRIPTION
# Summary

Fixes https://app.notion.com/p/cownation/Approve-limit-order-doesn-t-work-with-Safe-via-WC-36f8da5f04ca80d4bb29f9444e732f79?v=bec8da5f04ca8313aa9b883e472ad52c&source=copy_link

The key problem is in `useIsTxBundlingSupported`, because it was returning true if `isSafeViaWc`, but in fact Safe via WalletConnect doesn't support it:

```
'{"jsonrpc":"2.0","id":1780316125082507,"error":{"code":-32601,"message":"The method wallet_getCapabilities does not exist/is not available"}}'
```

# To Test

See https://app.notion.com/p/cownation/Approve-limit-order-doesn-t-work-with-Safe-via-WC-36f8da5f04ca80d4bb29f9444e732f79?v=bec8da5f04ca8313aa9b883e472ad52c&source=copy_link

If you don't have the old Safe app installed, then test it using Safe Web Desktop.
