### PR TITLE
feat: captcha feature flag

### DIFF
--- a/apps/cowswap-frontend/src/modules/captcha/README.md
+++ b/apps/cowswap-frontend/src/modules/captcha/README.md
@@ -6,6 +6,8 @@ On success, `api/captchaApi.ts` exchanges the Turnstile token for a JWT, `entiti
 
 Exchange URL: selected backend API origin plus `/auth/turnstile`.
 
+Feature flag: `isCaptchaEnabled`. Missing or false disables the widget, prevents token exchange, and clears any stored captcha JWT from the orderbook bearer token path.
+
 Deployment requirements:
 
 - Cloudflare Turnstile hostname management must include `localhost`, `vercel.app`, and `cow.fi`.

--- a/apps/cowswap-frontend/src/modules/captcha/containers/CaptchaWidget.container.test.tsx
+++ b/apps/cowswap-frontend/src/modules/captcha/containers/CaptchaWidget.container.test.tsx
@@ -70,12 +70,18 @@ describe('CaptchaWidget', () => {
     useThemeMock.mockReturnValue({ darkMode: false } as ReturnType<typeof useTheme>)
   })
 
-  it('does not render or exchange tokens when the captcha flag is missing', () => {
-    renderWithStore()
+  it('does not clear stored captcha state when the captcha flag is missing', () => {
+    const store = createStore()
+    const jwt = createJwt()
+
+    store.set(captchaJwtAtom, jwt)
+
+    renderWithStore(store)
 
     expect(screen.queryByTestId('turnstile')).toBeNull()
     expect(exchangeTurnstileTokenMock).not.toHaveBeenCalled()
-    expect(setBearerTokenMock).toHaveBeenCalledWith(null)
+    expect(setBearerTokenMock).not.toHaveBeenCalled()
+    expect(store.get(captchaJwtAtom)?.token).toBe(jwt)
   })
 
   it('does not render when the captcha flag is disabled', () => {

--- a/apps/cowswap-frontend/src/modules/captcha/containers/CaptchaWidget.container.test.tsx
+++ b/apps/cowswap-frontend/src/modules/captcha/containers/CaptchaWidget.container.test.tsx
@@ -1,0 +1,119 @@
+import { Provider as JotaiProvider } from 'jotai'
+import { createStore } from 'jotai/vanilla'
+import { act, ReactNode } from 'react'
+
+import { useTheme } from '@cowprotocol/common-hooks'
+
+import { render, screen, waitFor } from '@testing-library/react'
+import { setBearerToken } from 'cowSdk'
+import { captchaJwtAtom } from 'entities/captcha/state/captchaJwtAtom'
+
+import { featureFlagsAtom } from 'common/state/featureFlagsState'
+
+import { CaptchaWidget } from './CaptchaWidget.container'
+
+import { exchangeTurnstileToken } from '../api/captchaApi'
+
+jest.mock('@cowprotocol/common-hooks', () => {
+  const actualModule = jest.requireActual('@cowprotocol/common-hooks')
+
+  return {
+    ...actualModule,
+    useTheme: jest.fn(),
+  }
+})
+
+jest.mock('@marsidev/react-turnstile', () => ({
+  __esModule: true,
+  Turnstile: () => <div data-testid="turnstile" />,
+}))
+
+jest.mock('cowSdk', () => ({
+  setBearerToken: jest.fn(),
+}))
+
+jest.mock('../api/captchaApi', () => ({
+  exchangeTurnstileToken: jest.fn(),
+}))
+
+jest.mock('../config/captcha.const', () => ({
+  TURNSTILE_DEMO_INTERACTIVE_SITE_KEY: 'demo-site-key',
+  TURNSTILE_SITE_KEY: 'site-key',
+}))
+
+const useThemeMock = useTheme as jest.MockedFunction<typeof useTheme>
+const setBearerTokenMock = setBearerToken as jest.MockedFunction<typeof setBearerToken>
+const exchangeTurnstileTokenMock = exchangeTurnstileToken as jest.MockedFunction<typeof exchangeTurnstileToken>
+
+function renderWithStore(store = createStore()): ReturnType<typeof render> {
+  function Wrapper({ children }: { children: ReactNode }): ReactNode {
+    return <JotaiProvider store={store}>{children}</JotaiProvider>
+  }
+
+  return render(<CaptchaWidget />, { wrapper: Wrapper })
+}
+
+function createJwt(): string {
+  const payload = globalThis
+    .btoa(JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 3600 }))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+
+  return `header.${payload}.signature`
+}
+
+describe('CaptchaWidget', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    localStorage.clear()
+    useThemeMock.mockReturnValue({ darkMode: false } as ReturnType<typeof useTheme>)
+  })
+
+  it('does not render or exchange tokens when the captcha flag is missing', () => {
+    renderWithStore()
+
+    expect(screen.queryByTestId('turnstile')).toBeNull()
+    expect(exchangeTurnstileTokenMock).not.toHaveBeenCalled()
+    expect(setBearerTokenMock).toHaveBeenCalledWith(null)
+  })
+
+  it('does not render when the captcha flag is disabled', () => {
+    const store = createStore()
+    store.set(featureFlagsAtom, { isCaptchaEnabled: false })
+
+    renderWithStore(store)
+
+    expect(screen.queryByTestId('turnstile')).toBeNull()
+  })
+
+  it('renders Turnstile when the captcha flag is enabled', () => {
+    const store = createStore()
+    store.set(featureFlagsAtom, { isCaptchaEnabled: true })
+
+    renderWithStore(store)
+
+    expect(screen.getByTestId('turnstile')).not.toBeNull()
+  })
+
+  it('clears a stored captcha JWT and bearer token when the flag is disabled', async () => {
+    const store = createStore()
+    const jwt = createJwt()
+
+    store.set(featureFlagsAtom, { isCaptchaEnabled: true })
+    store.set(captchaJwtAtom, jwt)
+
+    renderWithStore(store)
+
+    await waitFor(() => expect(setBearerTokenMock).toHaveBeenCalledWith(jwt))
+
+    act(() => {
+      store.set(featureFlagsAtom, { isCaptchaEnabled: false })
+    })
+
+    await waitFor(() => {
+      expect(store.get(captchaJwtAtom)).toBeNull()
+      expect(setBearerTokenMock).toHaveBeenLastCalledWith(null)
+    })
+  })
+})

--- a/apps/cowswap-frontend/src/modules/captcha/containers/CaptchaWidget.container.tsx
+++ b/apps/cowswap-frontend/src/modules/captcha/containers/CaptchaWidget.container.tsx
@@ -44,7 +44,7 @@ export function CaptchaWidget(): ReactNode {
   }, [captchaJwt, isCaptchaEnabled, siteKey])
 
   useEffect(() => {
-    if (isCaptchaEnabled) return
+    if (isCaptchaEnabled !== false) return
 
     exchangeRequestIdRef.current += 1
 

--- a/apps/cowswap-frontend/src/modules/captcha/containers/CaptchaWidget.container.tsx
+++ b/apps/cowswap-frontend/src/modules/captcha/containers/CaptchaWidget.container.tsx
@@ -24,19 +24,22 @@ export function CaptchaWidget(): ReactNode {
   const theme = useTheme()
 
   useEffect(() => {
-    if (!isCaptchaEnabled) return
+    if (!isCaptchaEnabled) {
+      logCaptcha.debug('Disabled by feature flag')
+      return
+    }
 
     if (!siteKey) {
-      logCaptcha.warn('Missing env TURNSTILE_SITE_KEY, captcha widget disabled')
+      logCaptcha.warn('Disabled by missing env TURNSTILE_SITE_KEY')
       return
     }
 
     if (captchaJwt?.token) {
       setBearerToken(captchaJwt.token)
-      logCaptcha.info('Captcha JWT applied to orderbook context', { expiresAt: captchaJwt.expiresAt })
+      logCaptcha.info('JWT applied to orderbook context', { expiresAt: captchaJwt.expiresAt })
     } else {
       setBearerToken(null)
-      logCaptcha.info('Captcha JWT cleared from orderbook context')
+      logCaptcha.info('JWT cleared from orderbook context')
     }
   }, [captchaJwt, isCaptchaEnabled, siteKey])
 
@@ -53,7 +56,7 @@ export function CaptchaWidget(): ReactNode {
     if (!isCaptchaEnabled || !captchaJwt) return
 
     const timeout = window.setTimeout(() => {
-      logCaptcha.warn('Captcha JWT expired')
+      logCaptcha.warn('JWT expired')
       setCaptchaJwt(null)
     }, getJwtTtl(captchaJwt.expiresAt))
 
@@ -103,14 +106,14 @@ export function CaptchaWidget(): ReactNode {
             return
           }
 
-          logCaptcha.info('Captcha JWT received', { requestId })
+          logCaptcha.info('JWT received', { requestId })
           setCaptchaJwt(jwt)
         } catch (error) {
           if (exchangeRequestIdRef.current !== requestId) {
             return
           }
 
-          logCaptcha.error('Captcha JWT exchange failed', { requestId, error })
+          logCaptcha.error('JWT exchange failed', { requestId, error })
           setCaptchaJwt(null)
         }
       }}

--- a/apps/cowswap-frontend/src/modules/captcha/containers/CaptchaWidget.container.tsx
+++ b/apps/cowswap-frontend/src/modules/captcha/containers/CaptchaWidget.container.tsx
@@ -1,4 +1,4 @@
-import { useAtom } from 'jotai'
+import { useAtom, useAtomValue } from 'jotai'
 import { ReactNode, useEffect, useRef, useState } from 'react'
 
 import { useTheme } from '@cowprotocol/common-hooks'
@@ -8,6 +8,8 @@ import { Turnstile, type TurnstileInstance } from '@marsidev/react-turnstile'
 import { setBearerToken } from 'cowSdk'
 import { captchaJwtAtom } from 'entities/captcha/state/captchaJwtAtom'
 
+import { featureFlagsAtom } from 'common/state/featureFlagsState'
+
 import { exchangeTurnstileToken } from '../api/captchaApi'
 import { TURNSTILE_SITE_KEY } from '../config/captcha.const'
 import { useCaptchaDebugControls } from '../hooks/useCaptchaDebugControls'
@@ -15,12 +17,15 @@ import { logCaptcha } from '../logger'
 
 export function CaptchaWidget(): ReactNode {
   const [captchaJwt, setCaptchaJwt] = useAtom(captchaJwtAtom)
+  const { isCaptchaEnabled } = useAtomValue(featureFlagsAtom)
   const captchaRef = useRef<TurnstileInstance | undefined>(undefined)
   const exchangeRequestIdRef = useRef(0)
   const [siteKey, setSiteKey] = useState(TURNSTILE_SITE_KEY)
   const theme = useTheme()
 
   useEffect(() => {
+    if (!isCaptchaEnabled) return
+
     if (!siteKey) {
       logCaptcha.warn('Missing env TURNSTILE_SITE_KEY, captcha widget disabled')
       return
@@ -33,10 +38,21 @@ export function CaptchaWidget(): ReactNode {
       setBearerToken(null)
       logCaptcha.info('Captcha JWT cleared from orderbook context')
     }
-  }, [captchaJwt, siteKey])
+  }, [captchaJwt, isCaptchaEnabled, siteKey])
 
   useEffect(() => {
-    if (!captchaJwt) return
+    if (isCaptchaEnabled) return
+
+    exchangeRequestIdRef.current += 1
+
+    setBearerToken(null)
+    if (captchaJwt) setCaptchaJwt(null)
+
+    logCaptcha.info(`Disabled by feature flag, cleared bearer token${captchaJwt ? ', cleared stored JWT' : ''}`)
+  }, [captchaJwt, isCaptchaEnabled, setCaptchaJwt])
+
+  useEffect(() => {
+    if (!isCaptchaEnabled || !captchaJwt) return
 
     const timeout = window.setTimeout(() => {
       logCaptcha.warn('Captcha JWT expired')
@@ -44,11 +60,11 @@ export function CaptchaWidget(): ReactNode {
     }, getJwtTtl(captchaJwt.expiresAt))
 
     return () => window.clearTimeout(timeout)
-  }, [captchaJwt, setCaptchaJwt])
+  }, [captchaJwt, isCaptchaEnabled, setCaptchaJwt])
 
   useCaptchaDebugControls({ exchangeRequestIdRef, setCaptchaJwt, setSiteKey })
 
-  if (!siteKey || captchaJwt) return null
+  if (!isCaptchaEnabled || !siteKey || captchaJwt) return null
 
   return (
     <Turnstile

--- a/apps/cowswap-frontend/src/modules/captcha/containers/CaptchaWidget.container.tsx
+++ b/apps/cowswap-frontend/src/modules/captcha/containers/CaptchaWidget.container.tsx
@@ -47,8 +47,6 @@ export function CaptchaWidget(): ReactNode {
 
     setBearerToken(null)
     if (captchaJwt) setCaptchaJwt(null)
-
-    logCaptcha.info(`Disabled by feature flag, cleared bearer token${captchaJwt ? ', cleared stored JWT' : ''}`)
   }, [captchaJwt, isCaptchaEnabled, setCaptchaJwt])
 
   useEffect(() => {


### PR DESCRIPTION
# Summary

Adds a frontend feature flag gate for captcha while the backend `/auth/turnstile` endpoint is not ready.

When `isCaptchaEnabled` is missing or false:
- Turnstile does not render
- captcha token exchange is not triggered
- existing orderbook bearer token is cleared
- stored captcha JWT is cleared

Also adds focused tests for disabled, enabled, and cleanup behavior.

# To Test

1. Verify flag-off behavior

- [x] With `isCaptchaEnabled` missing or false, captcha is not rendered in the trade widget
- [x] No request is made to `/auth/turnstile`
- [x] Existing captcha JWT/bearer token state is cleared

2. Verify flag-on behavior

- [x] Turn the flag on temporarily on https://app.launchdarkly.com/projects/default/flags/isCaptchaEnabled
- [x] With `isCaptchaEnabled=true` and `REACT_APP_TURNSTILE_SITE_KEY` configured, Turnstile renders

# Background

The captcha backend endpoint is not deployed yet, so captcha must default off and only activate after LaunchDarkly enables `isCaptchaEnabled`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a captcha feature flag to control captcha widget visibility and functionality.

* **Documentation**
  * Updated captcha documentation to explain feature flag behavior.

* **Tests**
  * Added comprehensive test coverage for captcha feature flag functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->