### PR TITLE
fix(wallet): preserve EIP-6963 provider detail invariant

### DIFF
--- a/libs/wallet/src/wagmi/providerIsolation.test.ts
+++ b/libs/wallet/src/wagmi/providerIsolation.test.ts
@@ -1,0 +1,54 @@
+import { interceptEIP6963Providers } from './providerIsolation'
+
+import type { EIP1193EventMap, EIP1193Provider } from 'viem'
+
+type CowIsolationWindow = Window & {
+  __cowEip6963InterceptRegistered?: boolean
+  __cowEip6963ReDispatched?: WeakSet<Event>
+}
+
+function buildProvider(): EIP1193Provider {
+  const listeners = new Map<keyof EIP1193EventMap, EIP1193EventMap[keyof EIP1193EventMap]>()
+
+  return {
+    request: jest.fn(async () => ['0x0000000000000000000000000000000000000000']) as EIP1193Provider['request'],
+    on: jest.fn(<event extends keyof EIP1193EventMap>(event: event, listener: EIP1193EventMap[event]) => {
+      listeners.set(event, listener)
+    }) as EIP1193Provider['on'],
+    removeListener: jest.fn(<event extends keyof EIP1193EventMap>(event: event) => {
+      listeners.delete(event)
+    }) as EIP1193Provider['removeListener'],
+  }
+}
+
+describe('interceptEIP6963Providers', () => {
+  it('re-dispatches announced providers with frozen EIP-6963 detail', () => {
+    const win = window as CowIsolationWindow
+    delete win.__cowEip6963InterceptRegistered
+    delete win.__cowEip6963ReDispatched
+
+    const originalProvider = buildProvider()
+    const receivedDetails: Array<{ info: { name: string; rdns: string }; provider: EIP1193Provider }> = []
+
+    interceptEIP6963Providers()
+
+    window.addEventListener('eip6963:announceProvider', (event) => {
+      receivedDetails.push(
+        (event as CustomEvent<{ info: { name: string; rdns: string }; provider: EIP1193Provider }>).detail,
+      )
+    })
+
+    window.dispatchEvent(
+      new CustomEvent('eip6963:announceProvider', {
+        detail: Object.freeze({
+          info: { name: 'MetaMask', rdns: 'io.metamask' },
+          provider: originalProvider,
+        }),
+      }),
+    )
+
+    expect(receivedDetails).toHaveLength(1)
+    expect(Object.isFrozen(receivedDetails[0])).toBe(true)
+    expect(receivedDetails[0].provider).not.toBe(originalProvider)
+  })
+})

--- a/libs/wallet/src/wagmi/providerIsolation.ts
+++ b/libs/wallet/src/wagmi/providerIsolation.ts
@@ -108,6 +108,11 @@ type IsolationWindow = Window & {
   __cowEip6963ReDispatched?: WeakSet<Event>
 }
 
+type Eip6963ProviderDetail = {
+  info: { name?: string; rdns?: string }
+  provider: EIP1193Provider
+}
+
 function getReDispatched(): WeakSet<Event> {
   const win = window as IsolationWindow
   if (!win.__cowEip6963ReDispatched) {
@@ -139,10 +144,7 @@ export function interceptEIP6963Providers(): void {
       if (reDispatched.has(event)) return
       event.stopImmediatePropagation()
 
-      const detail = (event as CustomEvent).detail as {
-        info: { name?: string; rdns?: string }
-        provider: EIP1193Provider
-      }
+      const detail = (event as CustomEvent<Eip6963ProviderDetail>).detail
 
       console.log(
         '[providerIsolation] intercepted eip6963:announceProvider for',
@@ -150,7 +152,7 @@ export function interceptEIP6963Providers(): void {
       )
 
       const newEvent = new CustomEvent('eip6963:announceProvider', {
-        detail: { info: detail.info, provider: createIsolatedProvider(detail.provider) },
+        detail: Object.freeze({ info: detail.info, provider: createIsolatedProvider(detail.provider) }),
       })
       reDispatched.add(newEvent)
       window.dispatchEvent(newEvent)


### PR DESCRIPTION
## Summary
- Preserve the EIP-6963 frozen detail invariant when re-dispatching provider announcements through wallet provider isolation.
- Add a focused unit test covering the re-dispatched provider detail and wrapped provider identity.

## Investigation notes
- Reports point at Brave/MetaMask/ObjectMultiplex content-script warnings and a browser-level `STATUS_ACCESS_VIOLATION` tab crash.
- The release PR #7582 (`release/2026-05-27`) has a build that does not reproduce the issue per the latest report; this draft PR is intentionally based on `main` for hotfix evaluation.
- The most relevant release changes appear to be #7575 (`@reown/appkit` and `@reown/appkit-adapter-wagmi` `1.8.16` -> `1.8.19`, dependency pinning) and #7552 (EVM chain guards/default wallet network handling).
- This provider-isolation hardening is not confirmed as the release fix. Keeping the PR draft while we decide whether to replace it with a minimal cherry-pick from the release PR.

## Verification
- `node_modules/.bin/jest --config libs/wallet/jest.config.ts --runTestsByPath libs/wallet/src/wagmi/providerIsolation.test.ts --runInBand`
- `node_modules/.bin/tsc --noEmit -p libs/wallet/tsconfig.spec.json`
- `node_modules/.bin/prettier --check libs/wallet/src/wagmi/providerIsolation.ts libs/wallet/src/wagmi/providerIsolation.test.ts`
