### PR TITLE
fix: fix brave wallet specific crash

### DIFF
--- a/docs/BRAVE_WALLET_CRASH_INVESTIGATION.md
+++ b/docs/BRAVE_WALLET_CRASH_INVESTIGATION.md
@@ -1,0 +1,115 @@
+# Brave Wallet Renderer Crash Investigation
+
+## Summary
+
+Brave tabs crashed on CoW Swap when Brave Wallet was enabled. The crash reproduced on
+`swap.cow.fi`, local development builds, and local production builds. It did not reproduce
+in Chrome or Firefox, and it stopped when Brave Wallet was disabled.
+
+The final working mitigation is to keep Brave Wallet's EIP-6963 announcement hidden during
+startup without reading, wrapping, logging, or redispatching its `detail.provider` object.
+The provider is materialized only when the user explicitly opens the wallet modal.
+
+## Confirmed Conditions
+
+- Crashes happened in Brave with Brave Wallet enabled.
+- Crashes also happened when the MetaMask extension was enabled alongside Brave Wallet.
+- With Brave Wallet disabled and only MetaMask enabled, the app did not crash in the same
+  test window.
+- With both Brave Wallet and MetaMask disabled, the app did not crash.
+- The crash required no user action after page load.
+- Browser console logs did not show a final app exception close to the crash.
+
+## CDP Evidence
+
+A local Chrome DevTools Protocol recorder captured process, heap, DOM, and target-crash
+state during the repro.
+
+Important observations from the successful crash capture:
+
+- CDP emitted `Inspector.targetCrashed`.
+- CDP emitted `Target.targetCrashed` with `status: "crashed"` and `errorCode: 10`.
+- The last healthy sample was about 0.4 seconds before the target crash.
+- At the last healthy sample:
+  - JS heap was stable, about `105.9 MB`.
+  - The page renderer was about `722.6 MB`, CPU about `7%`.
+  - GPU CPU was about `99%`.
+  - Brave Wallet was still deferred from downstream dispatch.
+- After the crash, page-level CDP calls timed out, but OS process sampling continued.
+
+This means the tab target crashed inside Brave/Chromium; it was not a normal JavaScript
+exception or React error boundary case.
+
+## Root Cause
+
+The root cause is Brave Wallet's EIP-6963 provider object being unsafe to materialize during
+CoW Swap startup.
+
+Before the fix, `interceptEIP6963Providers()` intercepted every `eip6963:announceProvider`
+event and immediately read `detail.provider`, wrapped it with `createIsolatedProvider()`,
+and logged the provider object. That happened even when the announcement was later deferred
+from downstream wagmi/AppKit dispatch.
+
+For Brave Wallet, that provider is a Brave-owned proxy object. The investigation showed that
+deferring downstream dispatch was not enough: the page could still crash because our startup
+interceptor had already touched the provider object.
+
+The crash stopped only after Brave Wallet announcements were changed to store metadata and
+the original event lazily, without reading `detail.provider` at all during startup.
+
+## Retained Fix
+
+The retained code path is intentionally small:
+
+- Brave Wallet EIP-6963 announcements are stopped in capture phase and stored lazily.
+- The lazy record contains only wallet metadata and the original event reference.
+- `detail.provider` is not read until the explicit wallet modal path calls
+  `flushDeferredProviders()`.
+- Non-Brave EIP-6963 wallets keep the existing immediate wrapping behavior.
+- Provider-object logging was removed from `createIsolatedProvider()` to avoid forcing
+  browser/devtools inspection of wallet provider proxies.
+
+Trade-off: Brave Wallet is no longer auto-materialized during startup. If the user wants to
+connect Brave Wallet, the wallet modal path materializes and dispatches the deferred provider
+intentionally.
+
+## Rejected Or Removed Hypotheses
+
+These changes were tested or explored but are not part of the final minimal fix:
+
+- Moving `HydrateAtom` writes out of render phase. This removed a React warning but did not
+  stop the Brave crash.
+- Moving URL trade-state writes from `useMemo` to `useLayoutEffect`. This reduced render-phase
+  risk but was not the crash root cause.
+- Removing additional token-list subscriptions/fetching. This reduced startup work but was not
+  necessary for the final fix.
+- Suppressing all EIP-6963 request/announce flows until reconnect settled. The crash persisted
+  because Brave's provider object was still being read/wrapped.
+- Setting `activeProviderRef` to `PROVIDER_DISCONNECTED` after empty reconnect. This was not
+  enough to prevent the crash.
+- A `proxyByRdns` registry and config-side avoidance of `connector.getProvider()`. Not needed
+  once Brave Wallet's provider is never materialized during startup.
+- A Brave injected auto-reconnect storage guard. Plausible defensive path, but not supported by
+  the final crash evidence.
+- Request deduplication and circuit breaker logic inside provider isolation. Useful as a
+  possible future hardening idea, but not needed for this bugfix.
+- The CDP recorder script. It was diagnostic tooling only; the useful results are summarized
+  here instead of keeping the script in the application diff.
+
+## Verification Performed
+
+- The regression test first failed against the old behavior because reading
+  `detail.provider` happened immediately.
+- After the fix, the regression test passes and proves Brave Wallet's provider getter is not
+  read until `flushDeferredProviders()` runs.
+- Manual Brave verification after the fix:
+  - several minutes idle with Brave Wallet enabled: no crash
+  - interactive app usage: no crash
+  - Brave Wallet plus MetaMask extension enabled: no crash in the same test window
+
+## Follow-Up Risk
+
+This is an app-side mitigation for a Brave/Brave Wallet renderer crash. It avoids the known
+trigger, but it cannot guarantee Brave will not crash if Brave Wallet itself has another
+provider-proxy failure path. If crashes return, the next useful data is another CDP capture
+showing whether `Target.targetCrashed` still occurs before any Brave provider materialization.

--- a/libs/wallet/src/wagmi/Web3Provider.tsx
+++ b/libs/wallet/src/wagmi/Web3Provider.tsx
@@ -9,6 +9,7 @@ import { WagmiProvider } from 'wagmi'
 
 import { config, reownAppKit } from './config'
 import { markInitialReconnectSettled } from './initialReconnectLifecycle'
+import { flushDeferredProviders } from './providerIsolation'
 import { SafeConnectionHandler } from './SafeConnectionHandler'
 
 import { getIsInjectedMobileBrowser } from '../api/utils/connection'
@@ -151,6 +152,7 @@ function OpenWalletModalOnCustomEvent(): null {
     if (!reownAppKit) return
     const appKit = reownAppKit
     const handler = (): void => {
+      flushDeferredProviders()
       void appKit.open()
     }
     document.addEventListener(OPEN_WALLET_MODAL_EVENT, handler)

--- a/libs/wallet/src/wagmi/providerIsolation.test.ts
+++ b/libs/wallet/src/wagmi/providerIsolation.test.ts
@@ -1,0 +1,99 @@
+import type { EIP1193Provider } from 'viem'
+
+type ProviderIsolationModule = typeof import('./providerIsolation')
+
+type IsolationTestWindow = Window &
+  typeof globalThis & {
+    __cowEip6963InterceptRegistered?: boolean
+    __cowEip6963ReDispatched?: WeakSet<Event>
+    __cowEip6963DeferredBraveWallet?: unknown[]
+    __cowEip6963AnnounceProviderListener?: EventListener
+  }
+
+const provider: EIP1193Provider = {
+  request: jest.fn(),
+  on: jest.fn(),
+  removeListener: jest.fn(),
+}
+
+function resetWindowState(): void {
+  const win = window as IsolationTestWindow
+  if (win.__cowEip6963AnnounceProviderListener) {
+    window.removeEventListener('eip6963:announceProvider', win.__cowEip6963AnnounceProviderListener, {
+      capture: true,
+    })
+  }
+  delete win.__cowEip6963InterceptRegistered
+  delete win.__cowEip6963ReDispatched
+  delete win.__cowEip6963DeferredBraveWallet
+  delete win.__cowEip6963AnnounceProviderListener
+}
+
+async function loadProviderIsolation(): Promise<ProviderIsolationModule> {
+  jest.resetModules()
+  return import('./providerIsolation')
+}
+
+describe('interceptEIP6963Providers', () => {
+  beforeEach(() => {
+    resetWindowState()
+  })
+
+  it('does not read Brave Wallet provider until deferred announcements are flushed', async () => {
+    const { flushDeferredProviders, interceptEIP6963Providers } = await loadProviderIsolation()
+    const downstreamListener = jest.fn()
+    let providerReadCount = 0
+    const detail: { info: { name: string; rdns: string }; provider: EIP1193Provider } = {
+      info: { name: 'Brave Wallet', rdns: 'com.brave.wallet' },
+      get provider() {
+        providerReadCount += 1
+        return provider
+      },
+    }
+
+    interceptEIP6963Providers()
+    window.addEventListener('eip6963:announceProvider', downstreamListener, { capture: true })
+
+    window.dispatchEvent(
+      new CustomEvent('eip6963:announceProvider', {
+        bubbles: true,
+        detail,
+      }),
+    )
+
+    expect(providerReadCount).toBe(0)
+    expect(downstreamListener).not.toHaveBeenCalled()
+
+    flushDeferredProviders()
+
+    expect(providerReadCount).toBe(1)
+    expect(downstreamListener).toHaveBeenCalledTimes(1)
+  })
+
+  it('continues to wrap non-Brave providers immediately', async () => {
+    const { interceptEIP6963Providers } = await loadProviderIsolation()
+    const downstreamListener = jest.fn()
+    let providerReadCount = 0
+    const detail: { info: { name: string; rdns: string }; provider: EIP1193Provider } = {
+      info: { name: 'MetaMask', rdns: 'io.metamask' },
+      get provider() {
+        providerReadCount += 1
+        return provider
+      },
+    }
+
+    interceptEIP6963Providers()
+    window.addEventListener('eip6963:announceProvider', downstreamListener, { capture: true })
+
+    window.dispatchEvent(
+      new CustomEvent('eip6963:announceProvider', {
+        bubbles: true,
+        detail,
+      }),
+    )
+
+    expect(providerReadCount).toBe(1)
+    expect(downstreamListener).toHaveBeenCalledTimes(1)
+    expect((downstreamListener.mock.calls[0]?.[0] as CustomEvent).detail.provider).not.toBe(provider)
+  })
+})

--- a/libs/wallet/src/wagmi/providerIsolation.ts
+++ b/libs/wallet/src/wagmi/providerIsolation.ts
@@ -21,6 +21,16 @@ export const PROVIDER_DISCONNECTED: unique symbol = Symbol('PROVIDER_DISCONNECTE
  */
 export const activeProviderRef: { current: EIP1193Provider | typeof PROVIDER_DISCONNECTED | null } = { current: null }
 
+type Eip6963ProviderInfo = { name?: string; rdns?: string }
+type Eip6963ProviderDetail = {
+  info: Eip6963ProviderInfo
+  provider: EIP1193Provider
+}
+type DeferredBraveWalletAnnouncement = {
+  info: Eip6963ProviderInfo
+  event: CustomEvent<Eip6963ProviderDetail>
+}
+
 // Cache isolated providers by their original so identity is stable across calls.
 const cache = new WeakMap<object, EIP1193Provider>()
 
@@ -36,12 +46,7 @@ const cache = new WeakMap<object, EIP1193Provider>()
  */
 export function createIsolatedProvider(original: EIP1193Provider): EIP1193Provider {
   const cached = cache.get(original as object)
-  if (cached) {
-    console.log('[providerIsolation] reusing cached proxy for provider', original)
-    return cached
-  }
-
-  console.log('[providerIsolation] creating isolated proxy for provider', original)
+  if (cached) return cached
 
   // Maps original listener → wrapped listener so removeListener works correctly.
   type AccountsChangedListener = EIP1193EventMap['accountsChanged']
@@ -106,6 +111,8 @@ export function createIsolatedProvider(original: EIP1193Provider): EIP1193Provid
 type IsolationWindow = Window & {
   __cowEip6963InterceptRegistered?: boolean
   __cowEip6963ReDispatched?: WeakSet<Event>
+  __cowEip6963DeferredBraveWallet?: DeferredBraveWalletAnnouncement[]
+  __cowEip6963AnnounceProviderListener?: EventListener
 }
 
 function getReDispatched(): WeakSet<Event> {
@@ -114,6 +121,64 @@ function getReDispatched(): WeakSet<Event> {
     win.__cowEip6963ReDispatched = new WeakSet<Event>()
   }
   return win.__cowEip6963ReDispatched
+}
+
+function getDeferredBraveWalletAnnouncements(): DeferredBraveWalletAnnouncement[] {
+  const win = window as IsolationWindow
+  if (!win.__cowEip6963DeferredBraveWallet) {
+    win.__cowEip6963DeferredBraveWallet = []
+  }
+  return win.__cowEip6963DeferredBraveWallet
+}
+
+function getProviderIdentifier(info: Eip6963ProviderInfo): string {
+  return info.rdns ?? info.name ?? 'unknown'
+}
+
+function isBraveWalletInfo(info: Eip6963ProviderInfo): boolean {
+  return info.rdns === 'com.brave.wallet' || info.name === 'Brave Wallet'
+}
+
+function createIsolatedProviderAnnouncement(detail: Eip6963ProviderDetail): CustomEvent<Eip6963ProviderDetail> {
+  const newEvent = new CustomEvent<Eip6963ProviderDetail>('eip6963:announceProvider', {
+    detail: { info: detail.info, provider: createIsolatedProvider(detail.provider) },
+  })
+  getReDispatched().add(newEvent)
+
+  return newEvent
+}
+
+function deferBraveWalletAnnouncement(info: Eip6963ProviderInfo, event: CustomEvent<Eip6963ProviderDetail>): void {
+  const deferred = getDeferredBraveWalletAnnouncements()
+  const identifier = getProviderIdentifier(info)
+  const replacementIndex = deferred.findIndex((announcement) => getProviderIdentifier(announcement.info) === identifier)
+  const announcement = { info, event }
+
+  if (replacementIndex >= 0) {
+    deferred[replacementIndex] = announcement
+  } else {
+    deferred.push(announcement)
+  }
+}
+
+/**
+ * Dispatches Brave Wallet EIP-6963 announcements that were hidden during page load.
+ * Call this only from an explicit wallet-selection path; materializing the Brave
+ * provider at startup can crash Brave's renderer process.
+ */
+export function flushDeferredProviders(): void {
+  if (typeof window === 'undefined') return
+
+  const deferred = getDeferredBraveWalletAnnouncements()
+  if (deferred.length === 0) return
+
+  for (const announcement of deferred.splice(0)) {
+    const event = createIsolatedProviderAnnouncement({
+      info: announcement.info,
+      provider: announcement.event.detail.provider,
+    })
+    window.dispatchEvent(event)
+  }
 }
 
 /**
@@ -129,32 +194,22 @@ export function interceptEIP6963Providers(): void {
   const win = window as IsolationWindow
   if (win.__cowEip6963InterceptRegistered) return
   win.__cowEip6963InterceptRegistered = true
+  const announceProviderListener = ((event: Event): void => {
+    const reDispatched = getReDispatched()
+    if (reDispatched.has(event)) return
+    event.stopImmediatePropagation()
 
-  console.log('[providerIsolation] interceptEIP6963Providers: capture listener registered')
+    const customEvent = event as CustomEvent<Eip6963ProviderDetail>
+    const detail = customEvent.detail
 
-  window.addEventListener(
-    'eip6963:announceProvider',
-    (event) => {
-      const reDispatched = getReDispatched()
-      if (reDispatched.has(event)) return
-      event.stopImmediatePropagation()
+    if (isBraveWalletInfo(detail.info)) {
+      deferBraveWalletAnnouncement(detail.info, customEvent)
+      return
+    }
 
-      const detail = (event as CustomEvent).detail as {
-        info: { name?: string; rdns?: string }
-        provider: EIP1193Provider
-      }
-
-      console.log(
-        '[providerIsolation] intercepted eip6963:announceProvider for',
-        detail.info?.name ?? detail.info?.rdns,
-      )
-
-      const newEvent = new CustomEvent('eip6963:announceProvider', {
-        detail: { info: detail.info, provider: createIsolatedProvider(detail.provider) },
-      })
-      reDispatched.add(newEvent)
-      window.dispatchEvent(newEvent)
-    },
-    { capture: true },
-  )
+    const newEvent = createIsolatedProviderAnnouncement(detail)
+    window.dispatchEvent(newEvent)
+  }) satisfies EventListener
+  win.__cowEip6963AnnounceProviderListener = announceProviderListener
+  window.addEventListener('eip6963:announceProvider', announceProviderListener, { capture: true })
 }


### PR DESCRIPTION
# Summary

Fixing a nasty Brave wallet only bug, likely introduced in a recent Brave browser release.

The bug causes the browser tab to crash after a few seconds, even without user interaction.
The crash doesn't happen when the Brave wallet is disabled.
No other browsers are affected AFAICT.

## ⚠️ NOTE! ⚠️ 

While Brave browser no longer crashes and can be used with other wallets such as Metamask, the native Brave wallet is not yet working!

# To Test

1. Open app inside a browser (Firefox, Chrome, Brave)
2. On Brave browser specifically, make sure the built-in Brave wallet is enabled
3. Connect a wallet and perform operations as usual (swap, approve, ethflow)
* SHOULD NOT CRASH!!!
4. Repeat for all 3 mentioned browsers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed crashes when using Brave Wallet during swap startup by optimizing wallet provider initialization timing

* **Documentation**
  * Added investigation documentation analyzing Brave Wallet crash incidents and mitigation strategy

* **Tests**
  * Added test coverage for wallet provider interception and isolation mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->