### PR TITLE
refactor: simplify QuoteApiError

### DIFF
--- a/apps/cowswap-frontend/src/api/cowProtocol/errors/OperatorError.ts
+++ b/apps/cowswap-frontend/src/api/cowProtocol/errors/OperatorError.ts
@@ -92,7 +92,7 @@ export enum ApiErrorCodeDetails {
   UNHANDLED_DELETE_ERROR = 'The order cancellation was not accepted by the network.',
 }
 
-export default class OperatorError extends Error {
+export class OperatorError extends Error {
   name = 'OperatorError'
   type: ApiErrorCodes
   description: ApiErrorObject['description']

--- a/apps/cowswap-frontend/src/api/cowProtocol/errors/OperatorError.ts
+++ b/apps/cowswap-frontend/src/api/cowProtocol/errors/OperatorError.ts
@@ -1,7 +1,3 @@
-import { t } from '@lingui/core/macro'
-
-type ApiActionType = 'get' | 'create' | 'delete'
-
 export interface ApiErrorObject {
   errorType: ApiErrorCodes
   description: string
@@ -96,85 +92,11 @@ export enum ApiErrorCodeDetails {
   UNHANDLED_DELETE_ERROR = 'The order cancellation was not accepted by the network.',
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function _mapActionToErrorDetail(action?: ApiActionType) {
-  switch (action) {
-    case 'get':
-      return ApiErrorCodeDetails.UNHANDLED_GET_ERROR
-    case 'create':
-      return ApiErrorCodeDetails.UNHANDLED_CREATE_ERROR
-    case 'delete':
-      return ApiErrorCodeDetails.UNHANDLED_DELETE_ERROR
-    default:
-      console.error(
-        '[OperatorError::_mapActionToErrorDetails] Uncaught error mapping error action type to server error. Please try again later.',
-      )
-      return `Something failed. Please try again later.`
-  }
-}
-
 export default class OperatorError extends Error {
   name = 'OperatorError'
   type: ApiErrorCodes
   description: ApiErrorObject['description']
 
-  // Status 400 errors
-  // https://github.com/cowprotocol/services/blob/9014ae55412a356e46343e051aefeb683cc69c41/orderbook/openapi.yml#L563
-  static apiErrorDetails = ApiErrorCodeDetails
-
-  public static getErrorMessage(orderPostError: ApiErrorObject, action: ApiActionType): string {
-    try {
-      if (orderPostError.errorType) {
-        const errorMessage = OperatorError.apiErrorDetails[orderPostError.errorType]
-        // shouldn't fall through as this error constructor expects the error code to exist but just in case
-        return errorMessage || orderPostError.errorType
-      } else {
-        console.error('Unknown reason for bad order submission', orderPostError)
-        return orderPostError.description
-      }
-    } catch {
-      console.error('Error handling a 400 error. Likely a problem deserialising the JSON response')
-      return _mapActionToErrorDetail(action)
-    }
-  }
-  // TODO: Reduce function complexity by extracting logic
-  // eslint-disable-next-line complexity
-  static getErrorFromStatusCode(statusCode: number, errorObject: ApiErrorObject, action: 'create' | 'delete'): string {
-    switch (statusCode) {
-      case 400:
-      case 404:
-        return this.getErrorMessage(errorObject, action)
-
-      case 403: {
-        const acceptedText = t`accepted`
-        const cancelledText = t`cancelled`
-        const statusText = action === 'create' ? acceptedText : cancelledText
-        return t`The order cannot be ${statusText}. Your account is deny-listed.`
-      }
-
-      case 429: {
-        const placementsText = t`accepted. Too many order placements`
-        const cancellationsText = t`cancelled. Too many order cancellations`
-        const msg = action === 'create' ? placementsText : cancellationsText
-        return t`The order cannot be ${msg}. Please, retry in a minute`
-      }
-
-      case 500:
-      default: {
-        console.error(
-          `[OperatorError::getErrorFromStatusCode] Error ${
-            action === 'create' ? 'creating' : 'cancelling'
-          } the order, status code:`,
-          statusCode || 'unknown',
-        )
-        const creatingText = t`creating`
-        const cancellingText = t`cancelling`
-        const verb = action === 'create' ? creatingText : cancellingText
-        return t`Error ${verb} the order`
-      }
-    }
-  }
   constructor(apiError: ApiErrorObject) {
     super(apiError.description)
 
@@ -184,8 +106,4 @@ export default class OperatorError extends Error {
     // In case we don't have a custom message, use the one provided by the backend in the description
     this.message = message === this.type.toString() ? this.description : message
   }
-}
-
-export function isValidOperatorError(error: unknown): error is OperatorError {
-  return error instanceof OperatorError
 }

--- a/apps/cowswap-frontend/src/api/cowProtocol/errors/QuoteError.ts
+++ b/apps/cowswap-frontend/src/api/cowProtocol/errors/QuoteError.ts
@@ -1,11 +1,9 @@
 import { ApiErrorCodes, ApiErrorObject } from './OperatorError'
 
-export interface QuoteApiErrorObject {
+interface QuoteApiErrorObject {
   errorType: QuoteApiErrorCodes
   description: string
-  // TODO: Replace any with proper type definitions
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data?: any
+  data?: unknown
 }
 
 // Conforms to backend API
@@ -71,64 +69,19 @@ export function mapOperatorErrorToQuoteError(error?: ApiErrorObject): QuoteApiEr
   }
 }
 
-export class QuoteApiError extends Error {
+export class QuoteApiError<Data = unknown> extends Error {
   name = 'QuoteErrorObject'
   type: QuoteApiErrorCodes
   description: string
-  // any data attached
-  // TODO: Replace any with proper type definitions
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data?: any
-
-  // Status 400 errors
-  // https://github.com/cowprotocol/services/blob/9014ae55412a356e46343e051aefeb683cc69c41/orderbook/openapi.yml#L563
-  static quoteErrorDetails = QuoteApiErrorDetails
-
-  // TODO: Add proper return type annotation
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  public static async getErrorMessage(response: Response) {
-    try {
-      const orderPostError: QuoteApiErrorObject = await response.json()
-
-      if (orderPostError.errorType) {
-        const errorMessage = QuoteApiError.quoteErrorDetails[orderPostError.errorType]
-        // shouldn't fall through as this error constructor expects the error code to exist but just in case
-        return errorMessage || orderPostError.errorType
-      } else {
-        console.error('Unknown reason for bad quote fetch', orderPostError)
-        return orderPostError.description
-      }
-    } catch {
-      console.error('Error handling 400/404 error. Likely a problem deserialising the JSON response')
-      return QuoteApiError.quoteErrorDetails.UNHANDLED_ERROR
-    }
-  }
-
-  // TODO: Add proper return type annotation
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  static async getErrorFromStatusCode(response: Response) {
-    switch (response.status) {
-      case 400:
-      case 404:
-        return this.getErrorMessage(response)
-
-      case 500:
-      default:
-        console.error(
-          '[QuoteError::getErrorFromStatusCode] Error fetching quote, status code:',
-          response.status || 'unknown',
-        )
-        return 'Error fetching quote'
-    }
-  }
+  data?: Data
 
   constructor(quoteError: QuoteApiErrorObject) {
     super(quoteError.description)
 
     this.type = quoteError.errorType
     this.description = quoteError.description
-    this.message = QuoteApiError.quoteErrorDetails[quoteError.errorType]
-    this.data = quoteError?.data
+    this.message = QuoteApiErrorDetails[quoteError.errorType]
+    this.data = quoteError?.data as Data
   }
 }
 

--- a/apps/cowswap-frontend/src/common/utils/getSwapErrorMessage.ts
+++ b/apps/cowswap-frontend/src/common/utils/getSwapErrorMessage.ts
@@ -1,6 +1,6 @@
 import { capitalizeFirstLetter, getProviderErrorMessage, isRejectRequestProviderError } from '@cowprotocol/common-utils'
 
-import OperatorError from 'api/cowProtocol/errors/OperatorError'
+import { OperatorError } from 'api/cowProtocol/errors/OperatorError'
 
 export const USER_SWAP_REJECTED_ERROR = 'User rejected signing the order'
 

--- a/apps/cowswap-frontend/src/common/utils/getSwapErrorMessage.ts
+++ b/apps/cowswap-frontend/src/common/utils/getSwapErrorMessage.ts
@@ -1,6 +1,6 @@
 import { capitalizeFirstLetter, getProviderErrorMessage, isRejectRequestProviderError } from '@cowprotocol/common-utils'
 
-import { isValidOperatorError } from 'api/cowProtocol/errors/OperatorError'
+import OperatorError from 'api/cowProtocol/errors/OperatorError'
 
 export const USER_SWAP_REJECTED_ERROR = 'User rejected signing the order'
 
@@ -16,4 +16,8 @@ export function getSwapErrorMessage(error: Error): string {
 
     return defaultErrorMessage
   }
+}
+
+function isValidOperatorError(error: unknown): error is OperatorError {
+  return error instanceof OperatorError
 }

--- a/apps/cowswap-frontend/src/legacy/utils/trade.ts
+++ b/apps/cowswap-frontend/src/legacy/utils/trade.ts
@@ -28,7 +28,7 @@ import { ChangeOrderStatusParams, Order, OrderStatus } from 'legacy/state/orders
 import { AppDataInfo } from 'modules/appData'
 
 import { getIsOrderBookTypedError } from 'api/cowProtocol'
-import OperatorError, { ApiErrorObject } from 'api/cowProtocol/errors/OperatorError'
+import { ApiErrorObject, OperatorError } from 'api/cowProtocol/errors/OperatorError'
 
 import type { WalletClient } from 'viem'
 

--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -2548,9 +2548,7 @@ msgstr "(via WalletConnect)"
 msgid "<0>Select an {accountProxyLabelString}</0> and then select a token you want to recover from CoW Shed."
 msgstr "<0>Select an {accountProxyLabelString}</0> and then select a token you want to recover from CoW Shed."
 
-#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteApiErrorButton.pure.tsx
 #: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/quoteErrors.utils.ts
-#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/QuoteErrorsButton.pure.tsx
 msgid "Error loading price. Try again later."
 msgstr "Error loading price. Try again later."
 

--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -81,8 +81,8 @@ msgstr "Because you are using a smart contract wallet, you will pay a separate g
 #~ msgstr "It isn’t a valid referral code."
 
 #: apps/cowswap-frontend/src/api/cowProtocol/errors/OperatorError.ts
-msgid "cancelled. Too many order cancellations"
-msgstr "cancelled. Too many order cancellations"
+#~ msgid "cancelled. Too many order cancellations"
+#~ msgstr "cancelled. Too many order cancellations"
 
 #: apps/cowswap-frontend/src/modules/twap/containers/SetupFallbackHandlerWarning/index.tsx
 msgid "Your Safe fallback handler was changed after TWAP orders were placed. All open TWAP orders are not getting created because of that. Please, update the fallback handler in order to make the orders work again."
@@ -305,8 +305,8 @@ msgid "Your-code"
 msgstr "Your-code"
 
 #: apps/cowswap-frontend/src/api/cowProtocol/errors/OperatorError.ts
-msgid "The order cannot be {statusText}. Your account is deny-listed."
-msgstr "The order cannot be {statusText}. Your account is deny-listed."
+#~ msgid "The order cannot be {statusText}. Your account is deny-listed."
+#~ msgstr "The order cannot be {statusText}. Your account is deny-listed."
 
 #: apps/cowswap-frontend/src/modules/bridge/pure/ProxyAccountBanner/index.tsx
 msgid "The bridge provider modified the recipient address to <0/>. This ensure smooooth bridging."
@@ -1248,8 +1248,8 @@ msgstr "Confirm"
 msgid "Total vCOW balance"
 msgstr "Total vCOW balance"
 
-#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
-#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/quoteErrors.utils.ts
+#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/UnsupportedTokenButton.pure.tsx
 msgid "Unsupported token"
 msgstr "Unsupported token"
 
@@ -1405,7 +1405,7 @@ msgstr "Order Open"
 msgid "View contract"
 msgstr "View contract"
 
-#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/quoteErrors.utils.ts
 msgid "Only \"sell\" orders are supported"
 msgstr "Only \"sell\" orders are supported"
 
@@ -1458,8 +1458,8 @@ msgstr "Switch to {wrappedNativeSymbol}"
 #~ msgstr "Select an {ACCOUNT_PROXY_LABEL} to check for available refunds {chain}"
 
 #: apps/cowswap-frontend/src/api/cowProtocol/errors/OperatorError.ts
-msgid "creating"
-msgstr "creating"
+#~ msgid "creating"
+#~ msgstr "creating"
 
 #: libs/hook-dapp-lib/src/hookDappsRegistry.ts
 #~ msgid "Permit a token"
@@ -1601,8 +1601,8 @@ msgid "No results found"
 msgstr "No results found"
 
 #: apps/cowswap-frontend/src/api/cowProtocol/errors/OperatorError.ts
-msgid "accepted. Too many order placements"
-msgstr "accepted. Too many order placements"
+#~ msgid "accepted. Too many order placements"
+#~ msgstr "accepted. Too many order placements"
 
 #: apps/cowswap-frontend/src/modules/orderProgressBar/helpers.ts
 #: apps/cowswap-frontend/src/modules/orderProgressBar/pure/TransactionSubmittedContent/SurplusModal.tsx
@@ -1717,8 +1717,8 @@ msgstr "of"
 #~ msgstr "Access to {displaySymbol} through this interface is subject to regulatory and location-based restrictions."
 
 #: apps/cowswap-frontend/src/api/cowProtocol/errors/OperatorError.ts
-msgid "Error {verb} the order"
-msgstr "Error {verb} the order"
+#~ msgid "Error {verb} the order"
+#~ msgstr "Error {verb} the order"
 
 #: apps/cowswap-frontend/src/modules/tokensList/pure/TokenSearchContent/index.tsx
 msgid "No available tokens found to bridge"
@@ -2150,8 +2150,8 @@ msgid "Clear selection"
 msgstr "Clear selection"
 
 #: apps/cowswap-frontend/src/api/cowProtocol/errors/OperatorError.ts
-msgid "accepted"
-msgstr "accepted"
+#~ msgid "accepted"
+#~ msgstr "accepted"
 
 #: apps/cowswap-frontend/src/modules/tokensList/containers/LpTokenPage/index.tsx
 msgid "TVL"
@@ -2548,8 +2548,9 @@ msgstr "(via WalletConnect)"
 msgid "<0>Select an {accountProxyLabelString}</0> and then select a token you want to recover from CoW Shed."
 msgstr "<0>Select an {accountProxyLabelString}</0> and then select a token you want to recover from CoW Shed."
 
-#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
-#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteApiErrorButton.pure.tsx
+#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/quoteErrors.utils.ts
+#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/QuoteErrorsButton.pure.tsx
 msgid "Error loading price. Try again later."
 msgstr "Error loading price. Try again later."
 
@@ -3181,7 +3182,7 @@ msgstr "No order history"
 msgid "Rewards will be sent on Ethereum to"
 msgstr "Rewards will be sent on Ethereum to"
 
-#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteApiErrorButton.pure.tsx
 msgid "Bridging without swapping is not yet supported. Let us know if you want this feature!"
 msgstr "Bridging without swapping is not yet supported. Let us know if you want this feature!"
 
@@ -3872,7 +3873,7 @@ msgstr "The time each part of your TWAP order will remain active."
 msgid "Buy per part"
 msgstr "Buy per part"
 
-#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/QuoteErrorsButton.pure.tsx
 msgid "No intermediate tokens found for the route"
 msgstr "No intermediate tokens found for the route"
 
@@ -3982,8 +3983,8 @@ msgstr "Read more about unsupported tokens"
 #~ msgstr "Switch to base & claim"
 
 #: apps/cowswap-frontend/src/api/cowProtocol/errors/OperatorError.ts
-msgid "cancelling"
-msgstr "cancelling"
+#~ msgid "cancelling"
+#~ msgstr "cancelling"
 
 #: apps/cowswap-frontend/src/modules/affiliate/pure/TraderReferralCodeModal/TraderReferralCodeModalContent.tsx
 #~ msgid "This wallet isn't eligible."
@@ -4321,8 +4322,8 @@ msgid "This contract is deployed per account, with that account becoming the sin
 msgstr "This contract is deployed per account, with that account becoming the single owner. CoW Shed acts as an intermediary account that handles trading on your behalf."
 
 #: apps/cowswap-frontend/src/api/cowProtocol/errors/OperatorError.ts
-msgid "The order cannot be {msg}. Please, retry in a minute"
-msgstr "The order cannot be {msg}. Please, retry in a minute"
+#~ msgid "The order cannot be {msg}. Please, retry in a minute"
+#~ msgstr "The order cannot be {msg}. Please, retry in a minute"
 
 #: apps/cowswap-frontend/src/common/containers/MultipleOrdersCancellationModal/index.tsx
 msgid "Request cancellations"
@@ -4359,7 +4360,6 @@ msgstr "Yield"
 msgid "Error importing token list"
 msgstr "Error importing token list"
 
-#: apps/cowswap-frontend/src/api/cowProtocol/errors/OperatorError.ts
 #: apps/cowswap-frontend/src/modules/ethFlow/pure/EthFlowStepper/steps/Step1.tsx
 msgid "cancelled"
 msgstr "cancelled"
@@ -4381,7 +4381,7 @@ msgid "Issues have been reported with Metamask sending transactions to the wrong
 msgstr "Issues have been reported with Metamask sending transactions to the wrong chain on versions prior to <0>v{VERSION_WHERE_BUG_WAS_FIXED}</0>. Before you sign, please check in your wallet that the transaction is being sent to the network:"
 
 #: apps/cowswap-frontend/src/modules/limitOrders/containers/TradeButtons/limitOrdersTradeButtonsMap.tsx
-#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/quoteErrors.utils.ts
 msgid "Sell amount is too small"
 msgstr "Sell amount is too small"
 
@@ -4769,8 +4769,8 @@ msgstr "Place orders for higher than available balance!"
 msgid "first."
 msgstr "first."
 
-#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
-#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/quoteErrors.utils.ts
+#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/quoteErrors.utils.ts
 msgid "No routes found"
 msgstr "No routes found"
 
@@ -5529,7 +5529,7 @@ msgstr "Unlock the Power of TWAP Orders"
 msgid "Unwrapping"
 msgstr "Unwrapping"
 
-#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/QuoteErrorsButton.pure.tsx
 msgid "Unknown quote error"
 msgstr "Unknown quote error"
 
@@ -5623,7 +5623,7 @@ msgstr "N/A"
 msgid "This transaction can be simulated before execution to ensure that it will be succeed, generating a detailed report of the transaction execution."
 msgstr "This transaction can be simulated before execution to ensure that it will be succeed, generating a detailed report of the transaction execution."
 
-#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/quoteErrors.utils.ts
 msgid "Sell amount too small to bridge"
 msgstr "Sell amount too small to bridge"
 
@@ -6033,7 +6033,7 @@ msgid "on {chainLabel}"
 msgstr "on {chainLabel}"
 
 #: apps/cowswap-frontend/src/modules/limitOrders/containers/TradeButtons/limitOrdersTradeButtonsMap.tsx
-#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/quoteErrors.utils.ts
 msgid "Invalid price. Try increasing input/output amount."
 msgstr "Invalid price. Try increasing input/output amount."
 
@@ -6086,7 +6086,7 @@ msgstr "Boost Your Yield with One-Click Conversion"
 msgid "Vested"
 msgstr "Vested"
 
-#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/quoteErrors.utils.ts
 msgid "Bridging deposit address is not verified! Please contact CoW Swap support!"
 msgstr "Bridging deposit address is not verified! Please contact CoW Swap support!"
 
@@ -7127,7 +7127,7 @@ msgstr "In order to protect your funds, you will need to remove the approval on 
 msgid "Advanced"
 msgstr "Advanced"
 
-#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteApiErrorButton.pure.tsx
 msgid "Not yet supported"
 msgstr "Not yet supported"
 
@@ -7144,11 +7144,11 @@ msgstr "Order cannot be filled due to insufficient allowance"
 msgid "turn on expert mode"
 msgstr "turn on expert mode"
 
-#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/quoteErrors.utils.ts
 msgid "Insufficient liquidity for this trade."
 msgstr "Insufficient liquidity for this trade."
 
-#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/quoteErrors.utils.ts
 msgid "Buying native currency with smart contract wallets is not currently supported"
 msgstr "Buying native currency with smart contract wallets is not currently supported"
 
@@ -7338,7 +7338,7 @@ msgstr "Best price found!"
 msgid "Bridging succeeded"
 msgstr "Bridging succeeded"
 
-#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+#: apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/quoteErrors.utils.ts
 msgid "Tokens must be different"
 msgstr "Tokens must be different"
 

--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.ts
@@ -27,7 +27,7 @@ import { useTradeFlowAnalytics } from 'modules/trade'
 import { TradeConfirmActions } from 'modules/trade/hooks/useTradeConfirmActions'
 import { useAlternativeOrder, useHideAlternativeOrderModal } from 'modules/trade/state/alternativeOrder'
 
-import OperatorError from 'api/cowProtocol/errors/OperatorError'
+import { OperatorError } from 'api/cowProtocol/errors/OperatorError'
 import { CowSwapAnalyticsCategory } from 'common/analytics/types'
 import { useConfirmPriceImpactWithoutFee } from 'common/hooks/useConfirmPriceImpactWithoutFee'
 import { useIsSafeApprovalBundle } from 'common/hooks/useIsSafeApprovalBundle'

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteApiErrorButton.pure.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteApiErrorButton.pure.tsx
@@ -1,0 +1,78 @@
+import { ReactNode } from 'react'
+
+import { BridgeQuoteErrors } from '@cowprotocol/sdk-bridging'
+import { HelpTooltip } from '@cowprotocol/ui'
+
+import { t } from '@lingui/core/macro'
+
+import { QuoteApiError, QuoteApiErrorCodes } from 'api/cowProtocol/errors/QuoteError'
+
+import { getBridgeQuoteErrorTexts, getQuoteErrorTexts } from './QuoteErrorsButton/quoteErrors.utils'
+import { TradeFormBlankButton } from './TradeFormBlankButton'
+import { UnsupportedTokenButton } from './UnsupportedTokenButton.pure'
+
+import { TradeFormButtonContext } from '../types'
+
+export function QuoteApiErrorButton(props: TradeFormButtonContext): ReactNode {
+  const { quote } = props
+
+  if (!quote || !(quote.error instanceof QuoteApiError)) return null
+
+  const DEFAULT_QUOTE_ERROR = t`Error loading price. Try again later.`
+
+  const quoteErrorTexts = getQuoteErrorTexts()
+
+  {
+    /*TODO: sell=buy feature. Remove all SameBuyAndSellToken usages once feature is ready */
+  }
+  const quoteErrorTextsForBridges: Partial<Record<QuoteApiErrorCodes, string>> = {
+    [QuoteApiErrorCodes.SameBuyAndSellToken]: t`Not yet supported`,
+  }
+
+  const errorTooltipContentForBridges: Partial<Record<QuoteApiErrorCodes, string>> = {
+    [QuoteApiErrorCodes.SameBuyAndSellToken]: t`Bridging without swapping is not yet supported. Let us know if you want this feature!`,
+  }
+
+  const bridgeQuoteErrorTexts = getBridgeQuoteErrorTexts()
+
+  const errorType = quote.error.type
+
+  if (errorType === QuoteApiErrorCodes.UnsupportedToken) {
+    return <UnsupportedTokenButton {...props} />
+  }
+
+  const isBridge = quote.isBridgeQuote
+  const errorText = (() => {
+    const quoteErrorText = quoteErrorTexts[errorType]
+    const bridgeQuoteErrorText = quoteErrorTextsForBridges[errorType]
+
+    if (isBridge && bridgeQuoteErrorText) {
+      // Do not display "Not yet supported" when sell and intermediate tokens are the same
+      // Because user doesn't see intermediate token
+      if (errorType === QuoteApiErrorCodes.SameBuyAndSellToken) {
+        const areSwapAssetsDifferent =
+          props.derivedState.inputCurrency?.symbol?.toLowerCase() !==
+          props.derivedState.outputCurrency?.symbol?.toLowerCase()
+
+        if (areSwapAssetsDifferent) {
+          return bridgeQuoteErrorTexts[BridgeQuoteErrors.NO_ROUTES]
+        }
+      }
+
+      return bridgeQuoteErrorText
+    }
+
+    return quoteErrorText || DEFAULT_QUOTE_ERROR
+  })()
+
+  const errorTooltipText = isBridge && errorTooltipContentForBridges[errorType]
+
+  return (
+    <TradeFormBlankButton disabled={true}>
+      <>
+        {errorText}
+        {errorTooltipText && <HelpTooltip text={errorTooltipText} />}
+      </>
+    </TradeFormBlankButton>
+  )
+}

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteApiErrorButton.pure.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteApiErrorButton.pure.tsx
@@ -7,7 +7,11 @@ import { t } from '@lingui/core/macro'
 
 import { QuoteApiError, QuoteApiErrorCodes } from 'api/cowProtocol/errors/QuoteError'
 
-import { getBridgeQuoteErrorTexts, getQuoteErrorTexts } from './QuoteErrorsButton/quoteErrors.utils'
+import {
+  getBridgeQuoteErrorTexts,
+  getDefaultQuoteError,
+  getQuoteErrorTexts,
+} from './QuoteErrorsButton/quoteErrors.utils'
 import { TradeFormBlankButton } from './TradeFormBlankButton'
 import { UnsupportedTokenButton } from './UnsupportedTokenButton.pure'
 
@@ -18,7 +22,7 @@ export function QuoteApiErrorButton(props: TradeFormButtonContext): ReactNode {
 
   if (!quote || !(quote.error instanceof QuoteApiError)) return null
 
-  const DEFAULT_QUOTE_ERROR = t`Error loading price. Try again later.`
+  const DEFAULT_QUOTE_ERROR = getDefaultQuoteError()
 
   const quoteErrorTexts = getQuoteErrorTexts()
 

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/QuoteErrorsButton.pure.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/QuoteErrorsButton.pure.tsx
@@ -1,80 +1,28 @@
 import { ReactNode } from 'react'
 
 import { BridgeProviderQuoteError, BridgeQuoteErrors } from '@cowprotocol/sdk-bridging'
-import { HelpTooltip, InfoTooltip } from '@cowprotocol/ui'
+import { InfoTooltip } from '@cowprotocol/ui'
 
 import { t } from '@lingui/core/macro'
 import { Trans } from '@lingui/react/macro'
 
-import { QuoteApiError, QuoteApiErrorCodes } from 'api/cowProtocol/errors/QuoteError'
+import { QuoteApiError } from 'api/cowProtocol/errors/QuoteError'
 
-import { getBridgeQuoteErrorTexts, getQuoteErrorTexts } from './quoteErrors.utils'
+import { getBridgeQuoteErrorTexts } from './quoteErrors.utils'
 
 import { TradeFormButtonContext } from '../../types'
+import { QuoteApiErrorButton } from '../QuoteApiErrorButton.pure'
 import { TradeFormBlankButton } from '../TradeFormBlankButton'
-import { UnsupportedTokenButton } from '../UnsupportedTokenButton.pure'
 
 export function QuoteErrorsButton(props: TradeFormButtonContext): ReactNode {
   const DEFAULT_QUOTE_ERROR = t`Error loading price. Try again later.`
 
-  const quoteErrorTexts = getQuoteErrorTexts()
-
-  {
-    /*TODO: sell=buy feature. Remove all SameBuyAndSellToken usages once feature is ready */
-  }
-  const quoteErrorTextsForBridges: Partial<Record<QuoteApiErrorCodes, string>> = {
-    [QuoteApiErrorCodes.SameBuyAndSellToken]: t`Not yet supported`,
-  }
-
   const bridgeQuoteErrorTexts = getBridgeQuoteErrorTexts()
-
-  const errorTooltipContentForBridges: Partial<Record<QuoteApiErrorCodes, string>> = {
-    [QuoteApiErrorCodes.SameBuyAndSellToken]: t`Bridging without swapping is not yet supported. Let us know if you want this feature!`,
-  }
 
   const { quote } = props
 
   if (quote.error instanceof QuoteApiError) {
-    const errorType = quote.error.type
-
-    if (errorType === QuoteApiErrorCodes.UnsupportedToken) {
-      return <UnsupportedTokenButton {...props} />
-    }
-
-    const isBridge = quote.isBridgeQuote
-    const errorText = (() => {
-      const quoteErrorText = quoteErrorTexts[errorType]
-      const bridgeQuoteErrorText = quoteErrorTextsForBridges[errorType]
-
-      if (isBridge && bridgeQuoteErrorText) {
-        // Do not display "Not yet supported" when sell and intermediate tokens are the same
-        // Because user doesn't see intermediate token
-        if (errorType === QuoteApiErrorCodes.SameBuyAndSellToken) {
-          const areSwapAssetsDifferent =
-            props.derivedState.inputCurrency?.symbol?.toLowerCase() !==
-            props.derivedState.outputCurrency?.symbol?.toLowerCase()
-
-          if (areSwapAssetsDifferent) {
-            return bridgeQuoteErrorTexts[BridgeQuoteErrors.NO_ROUTES]
-          }
-        }
-
-        return bridgeQuoteErrorText
-      }
-
-      return quoteErrorText || DEFAULT_QUOTE_ERROR
-    })()
-
-    const errorTooltipText = isBridge && errorTooltipContentForBridges[errorType]
-
-    return (
-      <TradeFormBlankButton disabled={true}>
-        <>
-          {errorText}
-          {errorTooltipText && <HelpTooltip text={errorTooltipText} />}
-        </>
-      </TradeFormBlankButton>
-    )
+    return <QuoteApiErrorButton {...props} />
   }
 
   if (quote.error instanceof BridgeProviderQuoteError) {

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/QuoteErrorsButton.pure.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/QuoteErrorsButton.pure.tsx
@@ -1,0 +1,101 @@
+import { ReactNode } from 'react'
+
+import { BridgeProviderQuoteError, BridgeQuoteErrors } from '@cowprotocol/sdk-bridging'
+import { HelpTooltip, InfoTooltip } from '@cowprotocol/ui'
+
+import { t } from '@lingui/core/macro'
+import { Trans } from '@lingui/react/macro'
+
+import { QuoteApiError, QuoteApiErrorCodes } from 'api/cowProtocol/errors/QuoteError'
+
+import { getBridgeQuoteErrorTexts, getQuoteErrorTexts } from './quoteErrors.utils'
+
+import { TradeFormButtonContext } from '../../types'
+import { TradeFormBlankButton } from '../TradeFormBlankButton'
+import { UnsupportedTokenButton } from '../UnsupportedTokenButton.pure'
+
+export function QuoteErrorsButton(props: TradeFormButtonContext): ReactNode {
+  const DEFAULT_QUOTE_ERROR = t`Error loading price. Try again later.`
+
+  const quoteErrorTexts = getQuoteErrorTexts()
+
+  {
+    /*TODO: sell=buy feature. Remove all SameBuyAndSellToken usages once feature is ready */
+  }
+  const quoteErrorTextsForBridges: Partial<Record<QuoteApiErrorCodes, string>> = {
+    [QuoteApiErrorCodes.SameBuyAndSellToken]: t`Not yet supported`,
+  }
+
+  const bridgeQuoteErrorTexts = getBridgeQuoteErrorTexts()
+
+  const errorTooltipContentForBridges: Partial<Record<QuoteApiErrorCodes, string>> = {
+    [QuoteApiErrorCodes.SameBuyAndSellToken]: t`Bridging without swapping is not yet supported. Let us know if you want this feature!`,
+  }
+
+  const { quote } = props
+
+  if (quote.error instanceof QuoteApiError) {
+    const errorType = quote.error.type
+
+    if (errorType === QuoteApiErrorCodes.UnsupportedToken) {
+      return <UnsupportedTokenButton {...props} />
+    }
+
+    const isBridge = quote.isBridgeQuote
+    const errorText = (() => {
+      const quoteErrorText = quoteErrorTexts[errorType]
+      const bridgeQuoteErrorText = quoteErrorTextsForBridges[errorType]
+
+      if (isBridge && bridgeQuoteErrorText) {
+        // Do not display "Not yet supported" when sell and intermediate tokens are the same
+        // Because user doesn't see intermediate token
+        if (errorType === QuoteApiErrorCodes.SameBuyAndSellToken) {
+          const areSwapAssetsDifferent =
+            props.derivedState.inputCurrency?.symbol?.toLowerCase() !==
+            props.derivedState.outputCurrency?.symbol?.toLowerCase()
+
+          if (areSwapAssetsDifferent) {
+            return bridgeQuoteErrorTexts[BridgeQuoteErrors.NO_ROUTES]
+          }
+        }
+
+        return bridgeQuoteErrorText
+      }
+
+      return quoteErrorText || DEFAULT_QUOTE_ERROR
+    })()
+
+    const errorTooltipText = isBridge && errorTooltipContentForBridges[errorType]
+
+    return (
+      <TradeFormBlankButton disabled={true}>
+        <>
+          {errorText}
+          {errorTooltipText && <HelpTooltip text={errorTooltipText} />}
+        </>
+      </TradeFormBlankButton>
+    )
+  }
+
+  if (quote.error instanceof BridgeProviderQuoteError) {
+    const errorMessage = quote.error.message as BridgeQuoteErrors
+    const errorText = bridgeQuoteErrorTexts[errorMessage] || DEFAULT_QUOTE_ERROR
+
+    return (
+      <TradeFormBlankButton disabled={true}>
+        <>
+          {errorText}
+          {errorMessage === BridgeQuoteErrors.NO_INTERMEDIATE_TOKENS && (
+            <InfoTooltip content={t`No intermediate tokens found for the route`} />
+          )}
+        </>
+      </TradeFormBlankButton>
+    )
+  }
+
+  return (
+    <TradeFormBlankButton disabled={true}>
+      <Trans>Unknown quote error</Trans>
+    </TradeFormBlankButton>
+  )
+}

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/QuoteErrorsButton.pure.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/QuoteErrorsButton.pure.tsx
@@ -8,14 +8,14 @@ import { Trans } from '@lingui/react/macro'
 
 import { QuoteApiError } from 'api/cowProtocol/errors/QuoteError'
 
-import { getBridgeQuoteErrorTexts } from './quoteErrors.utils'
+import { getBridgeQuoteErrorTexts, getDefaultQuoteError } from './quoteErrors.utils'
 
 import { TradeFormButtonContext } from '../../types'
 import { QuoteApiErrorButton } from '../QuoteApiErrorButton.pure'
 import { TradeFormBlankButton } from '../TradeFormBlankButton'
 
 export function QuoteErrorsButton(props: TradeFormButtonContext): ReactNode {
-  const DEFAULT_QUOTE_ERROR = t`Error loading price. Try again later.`
+  const DEFAULT_QUOTE_ERROR = getDefaultQuoteError()
 
   const bridgeQuoteErrorTexts = getBridgeQuoteErrorTexts()
 

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/quoteErrors.utils.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/QuoteErrorsButton/quoteErrors.utils.ts
@@ -1,0 +1,38 @@
+import { BridgeQuoteErrors } from '@cowprotocol/sdk-bridging'
+
+import { t } from '@lingui/core/macro'
+
+import { QuoteApiErrorCodes } from 'api/cowProtocol/errors/QuoteError'
+
+export function getBridgeQuoteErrorTexts(): Record<BridgeQuoteErrors, string> {
+  const DEFAULT_QUOTE_ERROR = getDefaultQuoteError()
+
+  return {
+    [BridgeQuoteErrors.API_ERROR]: DEFAULT_QUOTE_ERROR,
+    [BridgeQuoteErrors.INVALID_BRIDGE]: DEFAULT_QUOTE_ERROR,
+    [BridgeQuoteErrors.TX_BUILD_ERROR]: DEFAULT_QUOTE_ERROR,
+    [BridgeQuoteErrors.QUOTE_ERROR]: DEFAULT_QUOTE_ERROR,
+    [BridgeQuoteErrors.INVALID_API_JSON_RESPONSE]: DEFAULT_QUOTE_ERROR,
+    [BridgeQuoteErrors.NO_INTERMEDIATE_TOKENS]: t`No routes found`,
+    [BridgeQuoteErrors.NO_ROUTES]: t`No routes found`,
+    [BridgeQuoteErrors.ONLY_SELL_ORDER_SUPPORTED]: t`Only "sell" orders are supported`,
+    [BridgeQuoteErrors.QUOTE_DOES_NOT_MATCH_DEPOSIT_ADDRESS]: t`Bridging deposit address is not verified! Please contact CoW Swap support!`,
+    [BridgeQuoteErrors.SELL_AMOUNT_TOO_SMALL]: t`Sell amount too small to bridge`,
+  }
+}
+
+export function getDefaultQuoteError(): string {
+  return t`Error loading price. Try again later.`
+}
+
+export function getQuoteErrorTexts(): Record<QuoteApiErrorCodes, string> {
+  return {
+    [QuoteApiErrorCodes.UNHANDLED_ERROR]: getDefaultQuoteError(),
+    [QuoteApiErrorCodes.TransferEthToContract]: t`Buying native currency with smart contract wallets is not currently supported`,
+    [QuoteApiErrorCodes.UnsupportedToken]: t`Unsupported token`,
+    [QuoteApiErrorCodes.InsufficientLiquidity]: t`Insufficient liquidity for this trade.`,
+    [QuoteApiErrorCodes.FeeExceedsFrom]: t`Sell amount is too small`,
+    [QuoteApiErrorCodes.ZeroPrice]: t`Invalid price. Try increasing input/output amount.`,
+    [QuoteApiErrorCodes.SameBuyAndSellToken]: t`Tokens must be different`,
+  }
+}

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/TradeFormButtons/tradeButtonsMap.tsx
@@ -3,24 +3,22 @@ import { ReactNode } from 'react'
 import { getChainInfo } from '@cowprotocol/common-const'
 import { getIsNativeToken, getWrappedToken } from '@cowprotocol/common-utils'
 import { isEvmChain } from '@cowprotocol/cow-sdk'
-import { BridgeProviderQuoteError, BridgeQuoteErrors } from '@cowprotocol/sdk-bridging'
-import { CenteredDots, HelpTooltip, InfoTooltip, TokenSymbol } from '@cowprotocol/ui'
+import { CenteredDots, HelpTooltip, TokenSymbol } from '@cowprotocol/ui'
 
 import { t } from '@lingui/core/macro'
 import { Trans } from '@lingui/react/macro'
-import styled from 'styled-components/macro'
 
 import { TradeApproveButton } from 'modules/erc20Approve'
-import { CompatibilityIssuesWarning } from 'modules/trade'
 
-import { QuoteApiError, QuoteApiErrorCodes } from 'api/cowProtocol/errors/QuoteError'
 import { TradeLoadingButton } from 'common/pure/TradeLoadingButton'
 
 import { ProxyAccountLoading, ProxyAccountUnknown } from './common'
 
 import { XSTOCK_MIN_TRADE_SIZE_USD } from '../../consts'
 import { TradeFormButtonContext, TradeFormValidation } from '../../types'
+import { QuoteErrorsButton } from '../QuoteErrorsButton/QuoteErrorsButton.pure'
 import { TradeFormBlankButton } from '../TradeFormBlankButton'
+import { UnsupportedTokenButton } from '../UnsupportedTokenButton.pure'
 
 type ButtonComponent = React.ComponentType<ButtonComponentProps>
 
@@ -29,62 +27,6 @@ type ButtonComponentProps = TradeFormButtonContext & { isDisabled?: boolean }
 interface ButtonErrorConfig {
   text: ReactNode
   id?: string
-}
-
-function getBridgeQuoteErrorTexts(): Record<BridgeQuoteErrors, string> {
-  const DEFAULT_QUOTE_ERROR = getDefaultQuoteError()
-
-  return {
-    [BridgeQuoteErrors.API_ERROR]: DEFAULT_QUOTE_ERROR,
-    [BridgeQuoteErrors.INVALID_BRIDGE]: DEFAULT_QUOTE_ERROR,
-    [BridgeQuoteErrors.TX_BUILD_ERROR]: DEFAULT_QUOTE_ERROR,
-    [BridgeQuoteErrors.QUOTE_ERROR]: DEFAULT_QUOTE_ERROR,
-    [BridgeQuoteErrors.INVALID_API_JSON_RESPONSE]: DEFAULT_QUOTE_ERROR,
-    [BridgeQuoteErrors.NO_INTERMEDIATE_TOKENS]: t`No routes found`,
-    [BridgeQuoteErrors.NO_ROUTES]: t`No routes found`,
-    [BridgeQuoteErrors.ONLY_SELL_ORDER_SUPPORTED]: t`Only "sell" orders are supported`,
-    [BridgeQuoteErrors.QUOTE_DOES_NOT_MATCH_DEPOSIT_ADDRESS]: t`Bridging deposit address is not verified! Please contact CoW Swap support!`,
-    [BridgeQuoteErrors.SELL_AMOUNT_TOO_SMALL]: t`Sell amount too small to bridge`,
-  }
-}
-
-function getDefaultQuoteError(): string {
-  return t`Error loading price. Try again later.`
-}
-
-function getQuoteErrorTexts(): Record<QuoteApiErrorCodes, string> {
-  return {
-    [QuoteApiErrorCodes.UNHANDLED_ERROR]: getDefaultQuoteError(),
-    [QuoteApiErrorCodes.TransferEthToContract]: t`Buying native currency with smart contract wallets is not currently supported`,
-    [QuoteApiErrorCodes.UnsupportedToken]: t`Unsupported token`,
-    [QuoteApiErrorCodes.InsufficientLiquidity]: t`Insufficient liquidity for this trade.`,
-    [QuoteApiErrorCodes.FeeExceedsFrom]: t`Sell amount is too small`,
-    [QuoteApiErrorCodes.ZeroPrice]: t`Invalid price. Try increasing input/output amount.`,
-    [QuoteApiErrorCodes.SameBuyAndSellToken]: t`Tokens must be different`,
-  }
-}
-
-const CompatibilityIssuesWarningWrapper = styled.div`
-  margin-top: -10px;
-`
-
-const UnsupportedTokenButton = ({ derivedState, isSupportedWallet }: ButtonComponentProps): ReactNode => {
-  const { inputCurrency, outputCurrency } = derivedState
-
-  return inputCurrency && outputCurrency ? (
-    <>
-      <TradeFormBlankButton disabled={true}>
-        <Trans>Unsupported token</Trans>
-      </TradeFormBlankButton>
-      <CompatibilityIssuesWarningWrapper>
-        <CompatibilityIssuesWarning
-          currencyIn={inputCurrency}
-          currencyOut={outputCurrency}
-          isSupportedWallet={isSupportedWallet}
-        />
-      </CompatibilityIssuesWarningWrapper>
-    </>
-  ) : null
 }
 
 export const tradeButtonsMap: Record<TradeFormValidation, ButtonErrorConfig | ButtonComponent> = {
@@ -153,89 +95,7 @@ export const tradeButtonsMap: Record<TradeFormValidation, ButtonErrorConfig | Bu
     return <UnsupportedTokenButton {...props} />
   },
   [TradeFormValidation.QuoteErrors]: (props: ButtonComponentProps) => {
-    const DEFAULT_QUOTE_ERROR = t`Error loading price. Try again later.`
-
-    const quoteErrorTexts = getQuoteErrorTexts()
-
-    {
-      /*TODO: sell=buy feature. Remove all SameBuyAndSellToken usages once feature is ready */
-    }
-    const quoteErrorTextsForBridges: Partial<Record<QuoteApiErrorCodes, string>> = {
-      [QuoteApiErrorCodes.SameBuyAndSellToken]: t`Not yet supported`,
-    }
-
-    const bridgeQuoteErrorTexts = getBridgeQuoteErrorTexts()
-
-    const errorTooltipContentForBridges: Partial<Record<QuoteApiErrorCodes, string>> = {
-      [QuoteApiErrorCodes.SameBuyAndSellToken]: t`Bridging without swapping is not yet supported. Let us know if you want this feature!`,
-    }
-
-    const { quote } = props
-
-    if (quote.error instanceof QuoteApiError) {
-      const errorType = quote.error.type
-
-      if (errorType === QuoteApiErrorCodes.UnsupportedToken) {
-        return <UnsupportedTokenButton {...props} />
-      }
-
-      const isBridge = quote.isBridgeQuote
-      const errorText = (() => {
-        const quoteErrorText = quoteErrorTexts[errorType]
-        const bridgeQuoteErrorText = quoteErrorTextsForBridges[errorType]
-
-        if (isBridge && bridgeQuoteErrorText) {
-          // Do not display "Not yet supported" when sell and intermediate tokens are the same
-          // Because user doesn't see intermediate token
-          if (errorType === QuoteApiErrorCodes.SameBuyAndSellToken) {
-            const areSwapAssetsDifferent =
-              props.derivedState.inputCurrency?.symbol?.toLowerCase() !==
-              props.derivedState.outputCurrency?.symbol?.toLowerCase()
-
-            if (areSwapAssetsDifferent) {
-              return bridgeQuoteErrorTexts[BridgeQuoteErrors.NO_ROUTES]
-            }
-          }
-
-          return bridgeQuoteErrorText
-        }
-
-        return quoteErrorText || DEFAULT_QUOTE_ERROR
-      })()
-
-      const errorTooltipText = isBridge && errorTooltipContentForBridges[errorType]
-
-      return (
-        <TradeFormBlankButton disabled={true}>
-          <>
-            {errorText}
-            {errorTooltipText && <HelpTooltip text={errorTooltipText} />}
-          </>
-        </TradeFormBlankButton>
-      )
-    }
-
-    if (quote.error instanceof BridgeProviderQuoteError) {
-      const errorMessage = quote.error.message as BridgeQuoteErrors
-      const errorText = bridgeQuoteErrorTexts[errorMessage] || DEFAULT_QUOTE_ERROR
-
-      return (
-        <TradeFormBlankButton disabled={true}>
-          <>
-            {errorText}
-            {errorMessage === BridgeQuoteErrors.NO_INTERMEDIATE_TOKENS && (
-              <InfoTooltip content={t`No intermediate tokens found for the route`} />
-            )}
-          </>
-        </TradeFormBlankButton>
-      )
-    }
-
-    return (
-      <TradeFormBlankButton disabled={true}>
-        <Trans>Unknown quote error</Trans>
-      </TradeFormBlankButton>
-    )
+    return <QuoteErrorsButton {...props} />
   },
   [TradeFormValidation.QuoteExpired]: {
     text: <Trans>Quote expired. Refreshing...</Trans>,

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/UnsupportedTokenButton.pure.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/pure/UnsupportedTokenButton.pure.tsx
@@ -1,0 +1,33 @@
+import { ReactNode } from 'react'
+
+import { Trans } from '@lingui/react/macro'
+import styled from 'styled-components/macro'
+
+import { CompatibilityIssuesWarning } from 'modules/trade'
+
+import { TradeFormBlankButton } from './TradeFormBlankButton'
+
+import { TradeFormButtonContext } from '../types'
+
+const CompatibilityIssuesWarningWrapper = styled.div`
+  margin-top: -10px;
+`
+
+export function UnsupportedTokenButton({ derivedState, isSupportedWallet }: TradeFormButtonContext): ReactNode {
+  const { inputCurrency, outputCurrency } = derivedState
+
+  return inputCurrency && outputCurrency ? (
+    <>
+      <TradeFormBlankButton disabled={true}>
+        <Trans>Unsupported token</Trans>
+      </TradeFormBlankButton>
+      <CompatibilityIssuesWarningWrapper>
+        <CompatibilityIssuesWarning
+          currencyIn={inputCurrency}
+          currencyOut={outputCurrency}
+          isSupportedWallet={isSupportedWallet}
+        />
+      </CompatibilityIssuesWarningWrapper>
+    </>
+  ) : null
+}

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/TradeRateDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/TradeRateDetails/index.tsx
@@ -134,7 +134,8 @@ function useNetworkFeeAmount(): CurrencyAmount<Currency> | null {
 
   const inputCurrency = derivedTradeState?.inputCurrency
 
-  const costsExceedFeeRaw = tradeQuote.error instanceof QuoteApiError ? tradeQuote?.error?.data?.fee_amount : undefined
+  const errorData = tradeQuote?.error as QuoteApiError<{ fee_amount: string }> | undefined
+  const costsExceedFeeRaw = errorData instanceof QuoteApiError ? errorData.data?.fee_amount : undefined
 
   return useMemo(() => {
     if (!costsExceedFeeRaw || !inputCurrency) return null


### PR DESCRIPTION
# Summary

The PR contains only code refactoring, no logic changes.
This is a preparation for adding new error codes of `/quote` response.

1. Extracted `QuoteErrorsButton` and `UnsupportedTokenButton` pure component. Pure refactoring, no logic changes https://github.com/cowprotocol/cowswap/commit/87162b6abe3f2cd9b4ff99fb8d0ccb4b3642f37d
2. Extract `QuoteApiErrorButton` pure component. Pure refactoring, no logic changes https://github.com/cowprotocol/cowswap/commit/9de8ff698eb20eb48aa8b5ad84f9e87808fa8c04
3. Removed dead code in `OperatorError`, moved `isValidOperatorError` to the only place where it's in use https://github.com/cowprotocol/cowswap/commit/b52b891ed5f1ad6ac315ae0a5894721a3af04ea2
4. Fixed default export of `OperatorError` https://github.com/cowprotocol/cowswap/commit/73814e771d459e428b81581331f23a7037e7e4d4
5. Removed dead code in `QuoteApiError`, fixed `data?: any` type https://github.com/cowprotocol/cowswap/commit/b755ca909ef8591de9e5b4ab857483d6db3f82c3

# To Test

No need to test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated quote error UI components that display clearer, context-aware error text (including bridge and unsupported-token scenarios) with optional tooltips.
* **Refactor**
  * Reorganized quote/placement error handling to improve modular rendering and more consistent error-message selection across the trade flow.
  * Improved type safety for quote error payloads to ensure reliable fee and error-data handling.
* **Localization**
  * Updated translation source attribution and marked certain OperatorError strings as obsolete while keeping message content unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->