### PR TITLE
fix: prevent 2 concurrent builds for the same tag

### DIFF
--- a/.github/workflows/deployment-v2.yml
+++ b/.github/workflows/deployment-v2.yml
@@ -6,8 +6,8 @@ on:
     tags: [ cowswap-*, explorer-* ]
 
 concurrency:
-  group: release-branch-sync
-  cancel-in-progress: false
+  group: ${{ startsWith(github.ref, 'refs/tags/') && format('release-tag-{0}', github.sha) || 'release-branch-sync' }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/tags/') }}
 
 permissions:
   contents: write


### PR DESCRIPTION
# Summary

Fix issue that, when both explorer and cowswap are released at the same time, triggers 2 builds of the new deployment flow.

See the thread https://nomevlabs.slack.com/archives/C0369B33Z8W/p1779360873536969

# To Test

Can only be tested in the next release and when both cowswap and explorer are being updated at the same time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized deployment workflow configuration to improve release handling and concurrency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->