### PR TITLE
chore: cf pages fork preview

### DIFF
--- a/.github/workflows/cf-pages-preview-mirror.yml
+++ b/.github/workflows/cf-pages-preview-mirror.yml
@@ -2,7 +2,7 @@ name: Cloudflare Pages preview mirror
 
 on:
   pull_request_target:
-    types: [ labeled, closed ]
+    types: [ labeled, synchronize, closed ]
   issue_comment:
     types: [ edited ]
 

--- a/.github/workflows/cf-pages-preview-mirror.yml
+++ b/.github/workflows/cf-pages-preview-mirror.yml
@@ -1,0 +1,43 @@
+name: Cloudflare Pages preview mirror
+
+on:
+  pull_request_target:
+    types: [labeled, closed]
+  issue_comment:
+    types: [edited]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: cf-pages-preview-mirror-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: lts/jod
+  PREVIEW_BRANCH_PREFIX: cf-preview/pr-
+  PREVIEW_TRIGGER_LABEL: trigger-preview
+
+jobs:
+  mirror:
+    name: Mirror fork PR for Cloudflare Pages preview
+    if: github.event_name == 'pull_request_target' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout workflow repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Mirror preview branch
+        run: node tools/scripts/cf-pages/gh-actions/preview-mirror.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cf-pages-preview-mirror.yml
+++ b/.github/workflows/cf-pages-preview-mirror.yml
@@ -2,14 +2,9 @@ name: Cloudflare Pages preview mirror
 
 on:
   pull_request_target:
-    types: [labeled, closed]
+    types: [ labeled, closed ]
   issue_comment:
-    types: [edited]
-
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+    types: [ edited ]
 
 concurrency:
   group: cf-pages-preview-mirror-${{ github.event.pull_request.number || github.event.issue.number }}
@@ -25,6 +20,10 @@ jobs:
     name: Mirror fork PR for Cloudflare Pages preview
     if: github.event_name == 'pull_request_target' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
 
     steps:
       - name: Checkout workflow repository

--- a/.github/workflows/cf-pages-preview-mirror.yml
+++ b/.github/workflows/cf-pages-preview-mirror.yml
@@ -12,8 +12,6 @@ concurrency:
 
 env:
   NODE_VERSION: lts/jod
-  PREVIEW_BRANCH_PREFIX: cf-preview/pr-
-  PREVIEW_TRIGGER_LABEL: trigger-preview
 
 jobs:
   mirror:

--- a/.github/workflows/cf-pages-preview-mirror.yml
+++ b/.github/workflows/cf-pages-preview-mirror.yml
@@ -26,7 +26,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Checkout workflow repository
+      - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ env:
 jobs:
   setup:
     name: Setup
+    if: !startsWith(github.head_ref, 'cf-preview/pr-')
     runs-on: ubuntu-latest
 
     steps:
@@ -190,6 +191,7 @@ jobs:
 
   integration-tests:
     name: Cypress
+    if: !startsWith(github.head_ref, 'cf-preview/pr-')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - develop
   # build on PR creation/updates
   pull_request:
-    types: [opened, synchronize]
+    types: [ opened, synchronize ]
 
 env:
   NODE_VERSION: lts/jod
@@ -27,7 +27,7 @@ env:
 jobs:
   setup:
     name: Setup
-    if: !startsWith(github.head_ref, 'cf-preview/pr-')
+    if: ${{ !startsWith(github.head_ref, 'cf-preview/pr-') }}
     runs-on: ubuntu-latest
 
     steps:
@@ -191,7 +191,7 @@ jobs:
 
   integration-tests:
     name: Cypress
-    if: !startsWith(github.head_ref, 'cf-preview/pr-')
+    if: ${{ !startsWith(github.head_ref, 'cf-preview/pr-') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -245,13 +245,13 @@ jobs:
 
       # Open tmate ssh connection on failure for debugging
       # Uncomment when needed and push upstream
-#      - name: Setup tmate session
-#        uses: mxschmitt/action-tmate@v3
-#        if: ${{ failure() }}
+  #      - name: Setup tmate session
+  #        uses: mxschmitt/action-tmate@v3
+  #        if: ${{ failure() }}
 
   notify-failure:
     name: Notify Slack on Failure
-    needs: [setup, test, lint, typecheck, agent-harness, integration-tests]
+    needs: [ setup, test, lint, typecheck, agent-harness, integration-tests ]
     runs-on: ubuntu-latest
     if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - develop
   # build on PR creation/updates
   pull_request:
-    types: [ opened, synchronize ]
+    types: [opened, synchronize]
 
 env:
   NODE_VERSION: lts/jod
@@ -245,13 +245,13 @@ jobs:
 
       # Open tmate ssh connection on failure for debugging
       # Uncomment when needed and push upstream
-  #      - name: Setup tmate session
-  #        uses: mxschmitt/action-tmate@v3
-  #        if: ${{ failure() }}
+#      - name: Setup tmate session
+#        uses: mxschmitt/action-tmate@v3
+#        if: ${{ failure() }}
 
   notify-failure:
     name: Notify Slack on Failure
-    needs: [ setup, test, lint, typecheck, agent-harness, integration-tests ]
+    needs: [setup, test, lint, typecheck, agent-harness, integration-tests]
     runs-on: ubuntu-latest
     if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
 

--- a/.github/workflows/i18n-extract.yml
+++ b/.github/workflows/i18n-extract.yml
@@ -21,7 +21,7 @@ jobs:
   i18n-extract:
     name: Extract i18n strings
     runs-on: ubuntu-latest
-    # Only run for normal same-repo PRs. cf-preview mirrors contain fork code.
+    # Only run for PRs from the same repo (GITHUB_TOKEN can't push to forks) and NOT cf-preview branches, as that mirrors forked PRs.
     if: github.event.pull_request.head.repo.full_name == github.repository && !startsWith(github.head_ref, 'cf-preview/pr-')
 
     steps:

--- a/.github/workflows/i18n-extract.yml
+++ b/.github/workflows/i18n-extract.yml
@@ -21,8 +21,8 @@ jobs:
   i18n-extract:
     name: Extract i18n strings
     runs-on: ubuntu-latest
-    # Only run for PRs from the same repo (GITHUB_TOKEN can't push to forks)
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Only run for normal same-repo PRs. cf-preview mirrors contain fork code.
+    if: github.event.pull_request.head.repo.full_name == github.repository && !startsWith(github.head_ref, 'cf-preview/pr-')
 
     steps:
       - name: Checkout PR branch

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "preview": "NODE_OPTIONS=--max-old-space-size=8192 nx run cowswap-frontend:preview",
     "test": "pnpm run test:all && pnpm run test:tools",
     "test:all": "nx run-many -t test",
-    "test:tools": "node --test tools/scripts/*.test.mjs tools/scripts/cf-pages/*.test.mjs",
+    "test:tools": "node --test tools/scripts/*.test.mjs tools/scripts/cf-pages/*.test.mjs tools/scripts/cf-pages/gh-actions/*.test.mjs",
     "typecheck": "nx run cowswap-frontend:typecheck",
     "e2e": "nx run-many -t e2e",
     "e2e:open": "nx run-many -t e2e:open",

--- a/tools/scripts/cf-pages/gh-actions/github-client.mjs
+++ b/tools/scripts/cf-pages/gh-actions/github-client.mjs
@@ -84,8 +84,32 @@ export function createGitHubClient({ apiBase = process.env.GITHUB_API_URL ?? GIT
     async getRef(branchName) {
       return request('GET', `/repos/${owner}/${repo}/git/ref/${encodeGitRefPath(`heads/${branchName}`)}`)
     },
-    async listIssueComments(issueNumber) {
-      return request('GET', `/repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=100`)
+    async findIssueComment(issueNumber, predicate) {
+      const perPage = 100
+      let page = 1
+
+      while (true) {
+        const comments = await request(
+          'GET',
+          `/repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=${perPage}&page=${page}`,
+        )
+
+        if (!Array.isArray(comments)) {
+          return null
+        }
+
+        const match = comments.find(predicate)
+
+        if (match) {
+          return match
+        }
+
+        if (comments.length < perPage) {
+          return null
+        }
+
+        page += 1
+      }
     },
     async removeIssueLabel(issueNumber, labelName) {
       try {

--- a/tools/scripts/cf-pages/gh-actions/github-client.mjs
+++ b/tools/scripts/cf-pages/gh-actions/github-client.mjs
@@ -72,17 +72,14 @@ export function createGitHubClient({ apiBase = process.env.GITHUB_API_URL ?? GIT
     async getPullRequestByHead(branchName) {
       const pulls = await request(
         'GET',
-        `/repos/${owner}/${repo}/pulls?state=all&head=${encodeURIComponent(`${owner}:${branchName}`)}&per_page=10`,
+        `/repos/${owner}/${repo}/pulls?state=open&head=${encodeURIComponent(`${owner}:${branchName}`)}&per_page=1`,
       )
 
       if (!Array.isArray(pulls)) {
         return null
       }
 
-      return pulls.find((pullRequest) => pullRequest.state === 'open') ?? pulls[0] ?? null
-    },
-    async getRef(branchName) {
-      return request('GET', `/repos/${owner}/${repo}/git/ref/${encodeGitRefPath(`heads/${branchName}`)}`)
+      return pulls[0] ?? null
     },
     async findIssueComment(issueNumber, predicate) {
       const perPage = 100

--- a/tools/scripts/cf-pages/gh-actions/github-client.mjs
+++ b/tools/scripts/cf-pages/gh-actions/github-client.mjs
@@ -1,0 +1,146 @@
+const GITHUB_API_BASE = 'https://api.github.com'
+
+export class GitHubApiError extends Error {
+  constructor(status, message) {
+    super(message)
+    this.name = 'GitHubApiError'
+    this.status = status
+  }
+}
+
+export function createGitHubClient({ apiBase = process.env.GITHUB_API_URL ?? GITHUB_API_BASE, repoFullName, token }) {
+  const [owner, repo] = repoFullName.split('/')
+
+  if (!owner || !repo) {
+    throw new Error(`Expected GITHUB_REPOSITORY to be in owner/repo format, received: ${repoFullName}`)
+  }
+
+  async function request(method, path, body) {
+    const response = await fetch(`${apiBase}${path}`, {
+      body: body ? JSON.stringify(body) : undefined,
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      method,
+    })
+    const responseBody = await response.text()
+    const data = parseGitHubResponse(responseBody)
+
+    if (!response.ok) {
+      const message = getGitHubErrorMessage(data, response.status)
+      throw new GitHubApiError(response.status, message)
+    }
+
+    return data
+  }
+
+  return {
+    async addIssueLabels(issueNumber, labels) {
+      return request('POST', `/repos/${owner}/${repo}/issues/${issueNumber}/labels`, { labels })
+    },
+    async createIssueComment(issueNumber, body) {
+      return request('POST', `/repos/${owner}/${repo}/issues/${issueNumber}/comments`, { body })
+    },
+    async createPullRequest(payload) {
+      return request('POST', `/repos/${owner}/${repo}/pulls`, payload)
+    },
+    async createRef(branchName, sha) {
+      return request('POST', `/repos/${owner}/${repo}/git/refs`, {
+        ref: `refs/heads/${branchName}`,
+        sha,
+      })
+    },
+    async closePullRequest(prNumber) {
+      return request('PATCH', `/repos/${owner}/${repo}/pulls/${prNumber}`, { state: 'closed' })
+    },
+    async deleteRef(branchName) {
+      return request('DELETE', `/repos/${owner}/${repo}/git/refs/${encodeGitRefPath(`heads/${branchName}`)}`)
+    },
+    async getCollaboratorPermission(username) {
+      const data = await request(
+        'GET',
+        `/repos/${owner}/${repo}/collaborators/${encodeURIComponent(username)}/permission`,
+      )
+      return typeof data.permission === 'string' ? data.permission : 'none'
+    },
+    async getPullRequest(prNumber) {
+      return request('GET', `/repos/${owner}/${repo}/pulls/${prNumber}`)
+    },
+    async getPullRequestByHead(branchName) {
+      const pulls = await request(
+        'GET',
+        `/repos/${owner}/${repo}/pulls?state=all&head=${encodeURIComponent(`${owner}:${branchName}`)}&per_page=10`,
+      )
+
+      if (!Array.isArray(pulls)) {
+        return null
+      }
+
+      return pulls.find((pullRequest) => pullRequest.state === 'open') ?? pulls[0] ?? null
+    },
+    async getRef(branchName) {
+      return request('GET', `/repos/${owner}/${repo}/git/ref/${encodeGitRefPath(`heads/${branchName}`)}`)
+    },
+    async listIssueComments(issueNumber) {
+      return request('GET', `/repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=100`)
+    },
+    async removeIssueLabel(issueNumber, labelName) {
+      try {
+        return await request(
+          'DELETE',
+          `/repos/${owner}/${repo}/issues/${issueNumber}/labels/${encodeURIComponent(labelName)}`,
+        )
+      } catch (error) {
+        if (isNotFoundError(error)) {
+          return null
+        }
+        throw error
+      }
+    },
+    async updateIssueComment(commentId, body) {
+      return request('PATCH', `/repos/${owner}/${repo}/issues/comments/${commentId}`, { body })
+    },
+    async updatePullRequest(prNumber, payload) {
+      return request('PATCH', `/repos/${owner}/${repo}/pulls/${prNumber}`, payload)
+    },
+    async updateRef(branchName, sha) {
+      return request('PATCH', `/repos/${owner}/${repo}/git/refs/${encodeGitRefPath(`heads/${branchName}`)}`, {
+        force: true,
+        sha,
+      })
+    },
+  }
+}
+
+export function isNotFoundError(error) {
+  return error?.status === 404
+}
+
+function encodeGitRefPath(refPath) {
+  return refPath.split('/').map(encodeURIComponent).join('/')
+}
+
+function parseGitHubResponse(responseBody) {
+  if (!responseBody) {
+    return {}
+  }
+
+  try {
+    return JSON.parse(responseBody)
+  } catch {
+    return {
+      message: responseBody,
+    }
+  }
+}
+
+function getGitHubErrorMessage(data, status) {
+  if (typeof data.message === 'string') {
+    return data.message
+  }
+
+  return `GitHub API request failed with status ${status}`
+}

--- a/tools/scripts/cf-pages/gh-actions/github-client.test.mjs
+++ b/tools/scripts/cf-pages/gh-actions/github-client.test.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { GitHubApiError, createGitHubClient, isNotFoundError } from './github-client.mjs'
+
+describe('github-client', () => {
+  it('sends authenticated GitHub REST requests for repository operations', async () => {
+    const originalFetch = globalThis.fetch
+    const requests = []
+    globalThis.fetch = async (url, options) => {
+      requests.push({ options, url })
+
+      return {
+        ok: true,
+        status: 200,
+        async text() {
+          return JSON.stringify({ permission: 'write' })
+        },
+      }
+    }
+
+    try {
+      const client = createGitHubClient({
+        apiBase: 'https://api.github.test',
+        repoFullName: 'cowprotocol/cowswap',
+        token: 'github-token',
+      })
+
+      const permission = await client.getCollaboratorPermission('maintainer')
+
+      assert.equal(permission, 'write')
+      assert.equal(
+        requests[0].url,
+        'https://api.github.test/repos/cowprotocol/cowswap/collaborators/maintainer/permission',
+      )
+      assert.equal(requests[0].options.method, 'GET')
+      assert.equal(requests[0].options.headers.Authorization, 'Bearer github-token')
+      assert.equal(requests[0].options.headers.Accept, 'application/vnd.github+json')
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it('throws GitHubApiError with API response messages', async () => {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = async () => {
+      return {
+        ok: false,
+        status: 403,
+        async text() {
+          return JSON.stringify({ message: 'Resource not accessible by integration' })
+        },
+      }
+    }
+
+    try {
+      const client = createGitHubClient({
+        apiBase: 'https://api.github.test',
+        repoFullName: 'cowprotocol/cowswap',
+        token: 'github-token',
+      })
+
+      await assert.rejects(
+        client.getPullRequest(123),
+        (error) =>
+          error instanceof GitHubApiError &&
+          error.status === 403 &&
+          error.message === 'Resource not accessible by integration',
+      )
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it('identifies GitHub 404 errors', () => {
+    assert.equal(isNotFoundError(new GitHubApiError(404, 'Not Found')), true)
+    assert.equal(isNotFoundError(new GitHubApiError(500, 'Server Error')), false)
+  })
+})

--- a/tools/scripts/cf-pages/gh-actions/github-client.test.mjs
+++ b/tools/scripts/cf-pages/gh-actions/github-client.test.mjs
@@ -72,6 +72,87 @@ describe('github-client', () => {
     }
   })
 
+  it('finds issue comments beyond the first page', async () => {
+    const originalFetch = globalThis.fetch
+    const requestedUrls = []
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({ body: 'other comment', id: index + 1 }))
+    const secondPage = [{ body: 'target comment', id: 101 }]
+
+    globalThis.fetch = async (url) => {
+      requestedUrls.push(url)
+      const body = url.includes('page=2') ? secondPage : firstPage
+
+      return {
+        ok: true,
+        status: 200,
+        async text() {
+          return JSON.stringify(body)
+        },
+      }
+    }
+
+    try {
+      const client = createGitHubClient({
+        apiBase: 'https://api.github.test',
+        repoFullName: 'cowprotocol/cowswap',
+        token: 'github-token',
+      })
+
+      const comment = await client.findIssueComment(123, (issueComment) => issueComment.body === 'target comment')
+
+      assert.deepEqual(comment, secondPage[0])
+      assert.deepEqual(
+        requestedUrls.map((url) => new URL(url).searchParams.get('page')),
+        ['1', '2'],
+      )
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it('stops paging issue comments after finding a match', async () => {
+    const originalFetch = globalThis.fetch
+    const requestedUrls = []
+    const firstPage = [
+      { body: 'target comment', id: 1 },
+      ...Array.from({ length: 99 }, (_, index) => ({ body: 'other comment', id: index + 2 })),
+    ]
+
+    globalThis.fetch = async (url) => {
+      requestedUrls.push(url)
+
+      if (url.includes('page=2')) {
+        throw new Error('Unexpected second page request')
+      }
+
+      return {
+        ok: true,
+        status: 200,
+        async text() {
+          return JSON.stringify(firstPage)
+        },
+      }
+    }
+
+    try {
+      const client = createGitHubClient({
+        apiBase: 'https://api.github.test',
+        repoFullName: 'cowprotocol/cowswap',
+        token: 'github-token',
+      })
+
+      const comment = await client.findIssueComment(123, (issueComment) => issueComment.body === 'target comment')
+
+      assert.deepEqual(comment, firstPage[0])
+      assert.deepEqual(
+        requestedUrls.map((url) => new URL(url).searchParams.get('page')),
+        ['1'],
+      )
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
   it('identifies GitHub 404 errors', () => {
     assert.equal(isNotFoundError(new GitHubApiError(404, 'Not Found')), true)
     assert.equal(isNotFoundError(new GitHubApiError(500, 'Server Error')), false)

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror-comment.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror-comment.mjs
@@ -95,7 +95,7 @@ function parseManagedCommentMetadata(commentBody) {
 }
 
 function parseSyncCheckbox(commentBody) {
-  const checkboxMatch = commentBody.match(new RegExp(`- \\[([xX ])\\] ${escapeRegExp(SYNC_CHECKBOX_TEXT)}`))
+  const checkboxMatch = commentBody.match(/- \[([xX ])\] Sync Cloudflare preview to approval target commit/)
 
   if (!checkboxMatch) {
     return null
@@ -112,8 +112,4 @@ function normalizeGitSha(value) {
   }
 
   return value.toLowerCase()
-}
-
-function escapeRegExp(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror-comment.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror-comment.mjs
@@ -1,0 +1,119 @@
+export const MANAGED_COMMENT_MARKER = 'cf-pages-preview-mirror'
+
+const GIT_SHA_PATTERN = /^[0-9a-f]{40}$/i
+const SYNC_CHECKBOX_TEXT = 'Sync Cloudflare preview to approval target commit'
+
+export function buildPreviewCommentBody({
+  actor,
+  branchName,
+  mirrorPullRequestNumber,
+  mirrorPullRequestUrl,
+  now,
+  originalPrNumber,
+  repoFullName,
+  sourceBranch,
+  sourceRepoFullName,
+  sourceSha,
+  approvalTargetSha = sourceSha,
+  mirroredSha = sourceSha,
+}) {
+  const markerAttributes = [`original-pr=${originalPrNumber}`, `target-sha=${approvalTargetSha}`]
+  if (mirroredSha) {
+    markerAttributes.push(`mirrored-sha=${mirroredSha}`)
+  }
+  const approvalTargetShortSha = formatShortSha(approvalTargetSha)
+  const mirroredShaLine = mirroredSha
+    ? `Last mirrored SHA: \`${formatShortSha(mirroredSha)}\``
+    : 'Last mirrored SHA: not available'
+
+  return `<!-- ${MANAGED_COMMENT_MARKER} ${markerAttributes.join(' ')} -->
+Cloudflare Pages preview mirror
+
+Preview branch: \`${branchName}\`
+Preview branch URL: https://github.com/${repoFullName}/tree/${branchName}
+Mirror PR: #${mirrorPullRequestNumber}
+Mirror PR URL: ${mirrorPullRequestUrl}
+Cloudflare Pages preview links will be posted on the mirror PR by the Cloudflare Pages GitHub integration once builds complete.
+
+Source fork branch: \`${sourceRepoFullName}:${sourceBranch}\`
+Approval target SHA: \`${approvalTargetShortSha}\`
+${mirroredShaLine}
+Last comment update: @${actor} at ${now.toISOString()}
+
+- [ ] ${SYNC_CHECKBOX_TEXT}
+`
+}
+
+export function parseManagedPreviewComment(commentBody) {
+  const metadata = parseManagedCommentMetadata(commentBody)
+
+  if (!metadata) {
+    return null
+  }
+
+  const checkbox = parseSyncCheckbox(commentBody)
+
+  if (!checkbox) {
+    return {
+      ...metadata,
+      shouldSync: false,
+    }
+  }
+
+  return {
+    ...metadata,
+    shouldSync: checkbox.checked,
+  }
+}
+
+export function formatShortSha(sha) {
+  return sha.slice(0, 12)
+}
+
+function parseManagedCommentMetadata(commentBody) {
+  const markerMatch = commentBody.match(new RegExp(`<!--\\s*${MANAGED_COMMENT_MARKER}([^>]*)-->`))
+
+  if (!markerMatch) {
+    return null
+  }
+
+  const attributes = new Map()
+  for (const attributeMatch of markerMatch[1].matchAll(/([a-z-]+)=([^\s>]+)/g)) {
+    attributes.set(attributeMatch[1], attributeMatch[2])
+  }
+
+  const originalPrNumber = Number(attributes.get('original-pr'))
+  if (!Number.isInteger(originalPrNumber) || originalPrNumber <= 0) {
+    return null
+  }
+
+  return {
+    mirroredSha: normalizeGitSha(attributes.get('mirrored-sha')),
+    originalPrNumber,
+    targetSha: normalizeGitSha(attributes.get('target-sha')),
+  }
+}
+
+function parseSyncCheckbox(commentBody) {
+  const checkboxMatch = commentBody.match(new RegExp(`- \\[([xX ])\\] ${escapeRegExp(SYNC_CHECKBOX_TEXT)}`))
+
+  if (!checkboxMatch) {
+    return null
+  }
+
+  return {
+    checked: checkboxMatch[1].toLowerCase() === 'x',
+  }
+}
+
+function normalizeGitSha(value) {
+  if (typeof value !== 'string' || !GIT_SHA_PATTERN.test(value)) {
+    return null
+  }
+
+  return value.toLowerCase()
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror-comment.test.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror-comment.test.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { buildPreviewCommentBody, parseManagedPreviewComment } from './preview-mirror-comment.mjs'
+
+const SOURCE_SHA = 'abc1234567890abcdef1234567890abcdef12345'
+const APPROVED_SOURCE_SHA = '1111111111111111111111111111111111111111'
+
+describe('preview-mirror-comment', () => {
+  it('builds an unchecked sync comment without guessing Cloudflare Pages project URLs', () => {
+    const body = buildPreviewCommentBody({
+      actor: 'maintainer',
+      branchName: 'cf-preview/pr-123',
+      mirrorPullRequestNumber: 456,
+      mirrorPullRequestUrl: 'https://github.com/cowprotocol/cowswap/pull/456',
+      now: new Date('2026-06-05T10:30:00.000Z'),
+      originalPrNumber: 123,
+      repoFullName: 'cowprotocol/cowswap',
+      sourceBranch: 'feature/new-swap',
+      sourceRepoFullName: 'external/cowswap',
+      sourceSha: SOURCE_SHA,
+    })
+
+    assert.match(
+      body,
+      /<!-- cf-pages-preview-mirror original-pr=123 target-sha=abc1234567890abcdef1234567890abcdef12345 mirrored-sha=abc1234567890abcdef1234567890abcdef12345 -->/,
+    )
+    assert.match(body, /`cf-preview\/pr-123`/)
+    assert.match(body, /Mirror PR: #456/)
+    assert.match(body, /Cloudflare Pages preview links will be posted on the mirror PR/)
+    assert.doesNotMatch(body, /pages\.dev/)
+    assert.match(body, /Approval target SHA: `abc123456789`/)
+    assert.match(body, /Last mirrored SHA: `abc123456789`/)
+    assert.match(body, /- \[ \] Sync Cloudflare preview to approval target commit/)
+    assert.doesNotMatch(body, /latest fork commit/)
+  })
+
+  it('parses checked sync requests from managed comments', () => {
+    const parsed = parseManagedPreviewComment(`
+<!-- cf-pages-preview-mirror original-pr=123 target-sha=${APPROVED_SOURCE_SHA} mirrored-sha=${SOURCE_SHA} -->
+- [x] Sync Cloudflare preview to approval target commit
+`)
+
+    assert.deepEqual(parsed, {
+      mirroredSha: SOURCE_SHA,
+      originalPrNumber: 123,
+      shouldSync: true,
+      targetSha: APPROVED_SOURCE_SHA,
+    })
+  })
+
+  it('ignores unchecked managed comments', () => {
+    const parsed = parseManagedPreviewComment(`
+<!-- cf-pages-preview-mirror original-pr=123 target-sha=${SOURCE_SHA} mirrored-sha=${SOURCE_SHA} -->
+- [ ] Sync Cloudflare preview to approval target commit
+`)
+
+    assert.deepEqual(parsed, {
+      mirroredSha: SOURCE_SHA,
+      originalPrNumber: 123,
+      shouldSync: false,
+      targetSha: SOURCE_SHA,
+    })
+  })
+
+  it('ignores legacy sync checkbox text', () => {
+    const parsed = parseManagedPreviewComment(`
+<!-- cf-pages-preview-mirror original-pr=123 target-sha=${APPROVED_SOURCE_SHA} mirrored-sha=${SOURCE_SHA} -->
+- [x] Sync Cloudflare preview to latest fork commit
+`)
+
+    assert.deepEqual(parsed, {
+      mirroredSha: SOURCE_SHA,
+      originalPrNumber: 123,
+      shouldSync: false,
+      targetSha: APPROVED_SOURCE_SHA,
+    })
+  })
+})

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror-comment.test.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror-comment.test.mjs
@@ -62,18 +62,4 @@ describe('preview-mirror-comment', () => {
       targetSha: SOURCE_SHA,
     })
   })
-
-  it('ignores legacy sync checkbox text', () => {
-    const parsed = parseManagedPreviewComment(`
-<!-- cf-pages-preview-mirror original-pr=123 target-sha=${APPROVED_SOURCE_SHA} mirrored-sha=${SOURCE_SHA} -->
-- [x] Sync Cloudflare preview to latest fork commit
-`)
-
-    assert.deepEqual(parsed, {
-      mirroredSha: SOURCE_SHA,
-      originalPrNumber: 123,
-      shouldSync: false,
-      targetSha: APPROVED_SOURCE_SHA,
-    })
-  })
 })

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.mjs
@@ -2,6 +2,7 @@ const DEFAULT_BRANCH_PREFIX = 'cf-preview/pr-'
 const DEFAULT_TRIGGER_LABEL = 'trigger-preview'
 const GITHUB_API_BASE = 'https://api.github.com'
 const MANAGED_COMMENT_MARKER = 'cf-pages-preview-mirror'
+const MIRROR_PULL_REQUEST_LABELS = ['DONT_MERGE']
 const SYNC_CHECKBOX_TEXT = 'Sync Cloudflare preview to latest fork commit'
 const TRUSTED_PERMISSIONS = new Set(['admin', 'maintain', 'write'])
 
@@ -71,7 +72,11 @@ export function parseSyncRequest(commentBody) {
   }
 }
 
-export function createGitHubClient({ apiBase = process.env.GITHUB_API_URL ?? GITHUB_API_BASE, repoFullName, token }) {
+export function createGitHubClient({
+  apiBase = process.env.GITHUB_API_URL ?? GITHUB_API_BASE,
+  repoFullName,
+  token,
+}) {
   const [owner, repo] = repoFullName.split('/')
 
   if (!owner || !repo) {
@@ -101,6 +106,9 @@ export function createGitHubClient({ apiBase = process.env.GITHUB_API_URL ?? GIT
   }
 
   return {
+    async addIssueLabels(issueNumber, labels) {
+      return request('POST', `/repos/${owner}/${repo}/issues/${issueNumber}/labels`, { labels })
+    },
     async createIssueComment(issueNumber, body) {
       return request('POST', `/repos/${owner}/${repo}/issues/${issueNumber}/comments`, { body })
     },
@@ -362,21 +370,25 @@ async function deletePreviewBranch(client, branchName) {
 async function upsertMirrorPullRequest(client, sourcePullRequest, branchName) {
   const body = buildMirrorPullRequestBody(sourcePullRequest)
   const existingPullRequest = await client.getPullRequestByHead(branchName)
+  let mirrorPullRequest
 
   if (existingPullRequest?.state === 'open') {
-    return client.updatePullRequest(existingPullRequest.number, {
+    mirrorPullRequest = await client.updatePullRequest(existingPullRequest.number, {
       body,
       title: buildMirrorPullRequestTitle(sourcePullRequest.number),
     })
+  } else {
+    mirrorPullRequest = await client.createPullRequest({
+      base: sourcePullRequest.base.ref,
+      body,
+      draft: true,
+      head: branchName,
+      title: buildMirrorPullRequestTitle(sourcePullRequest.number),
+    })
+    await client.addIssueLabels(mirrorPullRequest.number, MIRROR_PULL_REQUEST_LABELS)
   }
 
-  return client.createPullRequest({
-    base: sourcePullRequest.base.ref,
-    body,
-    draft: false,
-    head: branchName,
-    title: buildMirrorPullRequestTitle(sourcePullRequest.number),
-  })
+  return mirrorPullRequest
 }
 
 async function closeMirrorPullRequest(client, branchName) {

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.mjs
@@ -269,6 +269,13 @@ async function handleEditedIssueComment({ actor, client, event, now, options }) 
     }
   }
 
+  if (event.issue.number !== syncRequest.originalPrNumber) {
+    return {
+      reason: 'managed comment issue does not match original pull request',
+      status: 'ignored',
+    }
+  }
+
   await assertTrustedActor(client, actor)
 
   const pullRequest = await client.getPullRequest(syncRequest.originalPrNumber)

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.mjs
@@ -3,8 +3,9 @@ const DEFAULT_TRIGGER_LABEL = 'trigger-preview'
 const GITHUB_API_BASE = 'https://api.github.com'
 const MANAGED_COMMENT_MARKER = 'cf-pages-preview-mirror'
 const MIRROR_PULL_REQUEST_LABELS = ['DONT_MERGE']
-const SYNC_CHECKBOX_TEXT = 'Sync Cloudflare preview to latest fork commit'
+const SYNC_CHECKBOX_TEXT = 'Sync Cloudflare preview to approval target commit'
 const TRUSTED_PERMISSIONS = new Set(['admin', 'maintain', 'write'])
+const GIT_SHA_PATTERN = /^[0-9a-f]{40}$/i
 
 export class GitHubApiError extends Error {
   constructor(status, message) {
@@ -29,10 +30,19 @@ export function buildPreviewCommentBody({
   sourceBranch,
   sourceRepoFullName,
   sourceSha,
+  approvalTargetSha = sourceSha,
+  mirroredSha = sourceSha,
 }) {
-  const shortSha = sourceSha.slice(0, 12)
+  const markerAttributes = [`original-pr=${originalPrNumber}`, `target-sha=${approvalTargetSha}`]
+  if (mirroredSha) {
+    markerAttributes.push(`mirrored-sha=${mirroredSha}`)
+  }
+  const approvalTargetShortSha = formatShortSha(approvalTargetSha)
+  const mirroredShaLine = mirroredSha
+    ? `Last mirrored SHA: \`${formatShortSha(mirroredSha)}\``
+    : 'Last mirrored SHA: not available'
 
-  return `<!-- ${MANAGED_COMMENT_MARKER} original-pr=${originalPrNumber} -->
+  return `<!-- ${MANAGED_COMMENT_MARKER} ${markerAttributes.join(' ')} -->
 Cloudflare Pages preview mirror
 
 Preview branch: \`${branchName}\`
@@ -42,41 +52,37 @@ Mirror PR URL: ${mirrorPullRequestUrl}
 Cloudflare Pages preview links will be posted on the mirror PR by the Cloudflare Pages GitHub integration once builds complete.
 
 Source fork branch: \`${sourceRepoFullName}:${sourceBranch}\`
-Mirrored SHA: \`${shortSha}\`
-Last synced by: @${actor} at ${now.toISOString()}
+Approval target SHA: \`${approvalTargetShortSha}\`
+${mirroredShaLine}
+Last comment update: @${actor} at ${now.toISOString()}
 
 - [ ] ${SYNC_CHECKBOX_TEXT}
 `
 }
 
 export function parseSyncRequest(commentBody) {
-  const markerMatch = commentBody.match(new RegExp(`<!--\\s*${MANAGED_COMMENT_MARKER}\\s+original-pr=(\\d+)\\s*-->`))
+  const metadata = parseManagedCommentMetadata(commentBody)
 
-  if (!markerMatch) {
+  if (!metadata) {
     return null
   }
 
-  const checkboxPattern = new RegExp(`- \\[[xX ]\\] ${escapeRegExp(SYNC_CHECKBOX_TEXT)}`)
-  const checkboxMatch = commentBody.match(checkboxPattern)
+  const checkbox = parseSyncCheckbox(commentBody)
 
-  if (!checkboxMatch) {
+  if (!checkbox) {
     return {
-      originalPrNumber: Number(markerMatch[1]),
+      ...metadata,
       shouldSync: false,
     }
   }
 
   return {
-    originalPrNumber: Number(markerMatch[1]),
-    shouldSync: checkboxMatch[0].startsWith('- [x]') || checkboxMatch[0].startsWith('- [X]'),
+    ...metadata,
+    shouldSync: checkbox.checked,
   }
 }
 
-export function createGitHubClient({
-  apiBase = process.env.GITHUB_API_URL ?? GITHUB_API_BASE,
-  repoFullName,
-  token,
-}) {
+export function createGitHubClient({ apiBase = process.env.GITHUB_API_URL ?? GITHUB_API_BASE, repoFullName, token }) {
   const [owner, repo] = repoFullName.split('/')
 
   if (!owner || !repo) {
@@ -204,6 +210,16 @@ export async function handlePreviewMirrorEvent({ actor, client, event, now = new
     })
   }
 
+  if (event.action === 'synchronize' && event.pull_request) {
+    return handleSynchronizedPullRequest({
+      actor,
+      client,
+      event,
+      now,
+      options: normalizedOptions,
+    })
+  }
+
   if (event.action === 'edited' && event.comment && event.issue?.pull_request) {
     return handleEditedIssueComment({
       actor,
@@ -242,6 +258,7 @@ async function handleLabeledPullRequest({ actor, client, event, now, options }) 
   }
 
   const result = await syncPreviewBranch({
+    approvedSha: pullRequest.head.sha,
     actor,
     client,
     commentId: null,
@@ -253,6 +270,59 @@ async function handleLabeledPullRequest({ actor, client, event, now, options }) 
   await client.removeIssueLabel(pullRequest.number, options.triggerLabel)
 
   return result
+}
+
+async function handleSynchronizedPullRequest({ actor, client, event, now, options }) {
+  const pullRequest = event.pull_request
+
+  if (!isForkPullRequest(pullRequest)) {
+    return {
+      reason: 'pull request is not from a fork',
+      status: 'ignored',
+    }
+  }
+
+  const branchName = buildPreviewBranch(pullRequest.number, options.branchPrefix)
+  const existingComment = await findPreviewComment(client, pullRequest.number)
+
+  if (!existingComment) {
+    return {
+      reason: 'managed preview comment not found',
+      status: 'ignored',
+    }
+  }
+
+  const existingSyncRequest = parseSyncRequest(existingComment.body)
+  const mirrorPullRequest = await client.getPullRequestByHead(branchName)
+
+  if (!mirrorPullRequest) {
+    return {
+      reason: 'mirror pull request not found',
+      status: 'ignored',
+    }
+  }
+
+  const body = buildPreviewCommentBody({
+    actor,
+    approvalTargetSha: pullRequest.head.sha,
+    branchName,
+    mirroredSha: existingSyncRequest?.mirroredSha ?? existingSyncRequest?.targetSha ?? null,
+    mirrorPullRequestNumber: mirrorPullRequest.number,
+    mirrorPullRequestUrl: mirrorPullRequest.html_url,
+    now,
+    originalPrNumber: pullRequest.number,
+    repoFullName: options.repoFullName,
+    sourceBranch: pullRequest.head.ref,
+    sourceRepoFullName: pullRequest.head.repo.full_name,
+    sourceSha: pullRequest.head.sha,
+  })
+
+  await client.updateIssueComment(existingComment.id, body)
+
+  return {
+    branchName,
+    status: 'approval-target-updated',
+  }
 }
 
 async function handleClosedPullRequest({ client, event, options }) {
@@ -286,6 +356,13 @@ async function handleEditedIssueComment({ actor, client, event, now, options }) 
 
   await assertTrustedActor(client, actor)
 
+  if (!syncRequest.targetSha) {
+    return {
+      reason: 'managed sync comment is missing approval target sha',
+      status: 'ignored',
+    }
+  }
+
   const pullRequest = await client.getPullRequest(syncRequest.originalPrNumber)
 
   if (pullRequest.state !== 'open') {
@@ -303,6 +380,7 @@ async function handleEditedIssueComment({ actor, client, event, now, options }) 
   }
 
   return syncPreviewBranch({
+    approvedSha: syncRequest.targetSha,
     actor,
     client,
     commentId: event.comment.id,
@@ -312,14 +390,16 @@ async function handleEditedIssueComment({ actor, client, event, now, options }) 
   })
 }
 
-async function syncPreviewBranch({ actor, client, commentId, now, options, pullRequest }) {
+async function syncPreviewBranch({ actor, approvedSha, client, commentId, now, options, pullRequest }) {
   const branchName = buildPreviewBranch(pullRequest.number, options.branchPrefix)
-  await upsertPreviewBranch(client, branchName, pullRequest.head.sha)
-  const mirrorPullRequest = await upsertMirrorPullRequest(client, pullRequest, branchName)
+  await upsertPreviewBranch(client, branchName, approvedSha)
+  const mirrorPullRequest = await upsertMirrorPullRequest(client, pullRequest, branchName, approvedSha)
 
   const body = buildPreviewCommentBody({
     actor,
+    approvalTargetSha: pullRequest.head.sha,
     branchName,
+    mirroredSha: approvedSha,
     mirrorPullRequestNumber: mirrorPullRequest.number,
     mirrorPullRequestUrl: mirrorPullRequest.html_url,
     now,
@@ -327,7 +407,7 @@ async function syncPreviewBranch({ actor, client, commentId, now, options, pullR
     repoFullName: options.repoFullName,
     sourceBranch: pullRequest.head.ref,
     sourceRepoFullName: pullRequest.head.repo.full_name,
-    sourceSha: pullRequest.head.sha,
+    sourceSha: approvedSha,
   })
 
   if (commentId) {
@@ -367,8 +447,8 @@ async function deletePreviewBranch(client, branchName) {
   }
 }
 
-async function upsertMirrorPullRequest(client, sourcePullRequest, branchName) {
-  const body = buildMirrorPullRequestBody(sourcePullRequest)
+async function upsertMirrorPullRequest(client, sourcePullRequest, branchName, sourceSha) {
+  const body = buildMirrorPullRequestBody(sourcePullRequest, sourceSha)
   const existingPullRequest = await client.getPullRequestByHead(branchName)
   let mirrorPullRequest
 
@@ -403,24 +483,21 @@ function buildMirrorPullRequestTitle(originalPrNumber) {
   return `preview: mirror fork PR #${originalPrNumber}`
 }
 
-function buildMirrorPullRequestBody(sourcePullRequest) {
+function buildMirrorPullRequestBody(sourcePullRequest, sourceSha = sourcePullRequest.head.sha) {
   return [
     `<!-- ${MANAGED_COMMENT_MARKER} original-pr=${sourcePullRequest.number} -->`,
     `This PR mirrors fork PR #${sourcePullRequest.number} for Cloudflare Pages preview builds.`,
     '',
     `Source PR: ${sourcePullRequest.html_url}`,
     `Source fork branch: \`${sourcePullRequest.head.repo.full_name}:${sourcePullRequest.head.ref}\``,
-    `Mirrored SHA: \`${sourcePullRequest.head.sha.slice(0, 12)}\``,
+    `Mirrored SHA: \`${formatShortSha(sourceSha)}\``,
     '',
     'Do not merge this PR. Close the source PR to clean up this mirror.',
   ].join('\n')
 }
 
 async function upsertPreviewComment(client, issueNumber, body) {
-  const comments = await client.listIssueComments(issueNumber)
-  const existingComment = comments.find((comment) => {
-    return typeof comment.body === 'string' && parseSyncRequest(comment.body)?.originalPrNumber === issueNumber
-  })
+  const existingComment = await findPreviewComment(client, issueNumber)
 
   if (existingComment) {
     await client.updateIssueComment(existingComment.id, body)
@@ -428,6 +505,13 @@ async function upsertPreviewComment(client, issueNumber, body) {
   }
 
   await client.createIssueComment(issueNumber, body)
+}
+
+async function findPreviewComment(client, issueNumber) {
+  const comments = await client.listIssueComments(issueNumber)
+  return comments.find((comment) => {
+    return typeof comment.body === 'string' && parseSyncRequest(comment.body)?.originalPrNumber === issueNumber
+  })
 }
 
 async function assertTrustedActor(client, actor) {
@@ -455,6 +539,54 @@ function isForkPullRequest(pullRequest) {
 
 function encodeGitRefPath(refPath) {
   return refPath.split('/').map(encodeURIComponent).join('/')
+}
+
+function parseManagedCommentMetadata(commentBody) {
+  const markerMatch = commentBody.match(new RegExp(`<!--\\s*${MANAGED_COMMENT_MARKER}([^>]*)-->`))
+
+  if (!markerMatch) {
+    return null
+  }
+
+  const attributes = new Map()
+  for (const attributeMatch of markerMatch[1].matchAll(/([a-z-]+)=([^\s>]+)/g)) {
+    attributes.set(attributeMatch[1], attributeMatch[2])
+  }
+
+  const originalPrNumber = Number(attributes.get('original-pr'))
+  if (!Number.isInteger(originalPrNumber) || originalPrNumber <= 0) {
+    return null
+  }
+
+  return {
+    mirroredSha: normalizeGitSha(attributes.get('mirrored-sha')),
+    originalPrNumber,
+    targetSha: normalizeGitSha(attributes.get('target-sha')),
+  }
+}
+
+function parseSyncCheckbox(commentBody) {
+  const checkboxMatch = commentBody.match(new RegExp(`- \\[([xX ])\\] ${escapeRegExp(SYNC_CHECKBOX_TEXT)}`))
+
+  if (!checkboxMatch) {
+    return null
+  }
+
+  return {
+    checked: checkboxMatch[1].toLowerCase() === 'x',
+  }
+}
+
+function normalizeGitSha(value) {
+  if (typeof value !== 'string' || !GIT_SHA_PATTERN.test(value)) {
+    return null
+  }
+
+  return value.toLowerCase()
+}
+
+function formatShortSha(sha) {
+  return sha.slice(0, 12)
 }
 
 function parseGitHubResponse(responseBody) {

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.mjs
@@ -8,6 +8,7 @@ import {
 
 const DEFAULT_BRANCH_PREFIX = 'cf-preview/pr-'
 const DEFAULT_TRIGGER_LABEL = 'trigger-preview'
+const GITHUB_ACTIONS_BOT_LOGIN = 'github-actions[bot]'
 const MIRROR_PULL_REQUEST_LABELS = ['DONT_MERGE']
 const TRUSTED_PERMISSIONS = new Set(['admin', 'maintain', 'write'])
 
@@ -335,7 +336,9 @@ async function savePreviewComment(client, { body, commentId, issueNumber }) {
 async function findPreviewComment(client, issueNumber) {
   return client.findIssueComment(issueNumber, (comment) => {
     return (
-      typeof comment.body === 'string' && parseManagedPreviewComment(comment.body)?.originalPrNumber === issueNumber
+      comment.user?.login === GITHUB_ACTIONS_BOT_LOGIN &&
+      typeof comment.body === 'string' &&
+      parseManagedPreviewComment(comment.body)?.originalPrNumber === issueNumber
     )
   })
 }

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.mjs
@@ -1,192 +1,18 @@
+import { isNotFoundError } from './github-client.mjs'
+import {
+  buildPreviewCommentBody,
+  formatShortSha,
+  MANAGED_COMMENT_MARKER,
+  parseManagedPreviewComment,
+} from './preview-mirror-comment.mjs'
+
 const DEFAULT_BRANCH_PREFIX = 'cf-preview/pr-'
 const DEFAULT_TRIGGER_LABEL = 'trigger-preview'
-const GITHUB_API_BASE = 'https://api.github.com'
-const MANAGED_COMMENT_MARKER = 'cf-pages-preview-mirror'
 const MIRROR_PULL_REQUEST_LABELS = ['DONT_MERGE']
-const SYNC_CHECKBOX_TEXT = 'Sync Cloudflare preview to approval target commit'
 const TRUSTED_PERMISSIONS = new Set(['admin', 'maintain', 'write'])
-const GIT_SHA_PATTERN = /^[0-9a-f]{40}$/i
-
-export class GitHubApiError extends Error {
-  constructor(status, message) {
-    super(message)
-    this.name = 'GitHubApiError'
-    this.status = status
-  }
-}
 
 export function buildPreviewBranch(originalPrNumber, branchPrefix = DEFAULT_BRANCH_PREFIX) {
   return `${branchPrefix}${originalPrNumber}`
-}
-
-export function buildPreviewCommentBody({
-  actor,
-  branchName,
-  mirrorPullRequestNumber,
-  mirrorPullRequestUrl,
-  now,
-  originalPrNumber,
-  repoFullName,
-  sourceBranch,
-  sourceRepoFullName,
-  sourceSha,
-  approvalTargetSha = sourceSha,
-  mirroredSha = sourceSha,
-}) {
-  const markerAttributes = [`original-pr=${originalPrNumber}`, `target-sha=${approvalTargetSha}`]
-  if (mirroredSha) {
-    markerAttributes.push(`mirrored-sha=${mirroredSha}`)
-  }
-  const approvalTargetShortSha = formatShortSha(approvalTargetSha)
-  const mirroredShaLine = mirroredSha
-    ? `Last mirrored SHA: \`${formatShortSha(mirroredSha)}\``
-    : 'Last mirrored SHA: not available'
-
-  return `<!-- ${MANAGED_COMMENT_MARKER} ${markerAttributes.join(' ')} -->
-Cloudflare Pages preview mirror
-
-Preview branch: \`${branchName}\`
-Preview branch URL: https://github.com/${repoFullName}/tree/${branchName}
-Mirror PR: #${mirrorPullRequestNumber}
-Mirror PR URL: ${mirrorPullRequestUrl}
-Cloudflare Pages preview links will be posted on the mirror PR by the Cloudflare Pages GitHub integration once builds complete.
-
-Source fork branch: \`${sourceRepoFullName}:${sourceBranch}\`
-Approval target SHA: \`${approvalTargetShortSha}\`
-${mirroredShaLine}
-Last comment update: @${actor} at ${now.toISOString()}
-
-- [ ] ${SYNC_CHECKBOX_TEXT}
-`
-}
-
-export function parseSyncRequest(commentBody) {
-  const metadata = parseManagedCommentMetadata(commentBody)
-
-  if (!metadata) {
-    return null
-  }
-
-  const checkbox = parseSyncCheckbox(commentBody)
-
-  if (!checkbox) {
-    return {
-      ...metadata,
-      shouldSync: false,
-    }
-  }
-
-  return {
-    ...metadata,
-    shouldSync: checkbox.checked,
-  }
-}
-
-export function createGitHubClient({ apiBase = process.env.GITHUB_API_URL ?? GITHUB_API_BASE, repoFullName, token }) {
-  const [owner, repo] = repoFullName.split('/')
-
-  if (!owner || !repo) {
-    throw new Error(`Expected GITHUB_REPOSITORY to be in owner/repo format, received: ${repoFullName}`)
-  }
-
-  async function request(method, path, body) {
-    const response = await fetch(`${apiBase}${path}`, {
-      body: body ? JSON.stringify(body) : undefined,
-      headers: {
-        Accept: 'application/vnd.github+json',
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
-      method,
-    })
-    const responseBody = await response.text()
-    const data = parseGitHubResponse(responseBody)
-
-    if (!response.ok) {
-      const message = getGitHubErrorMessage(data, response.status)
-      throw new GitHubApiError(response.status, message)
-    }
-
-    return data
-  }
-
-  return {
-    async addIssueLabels(issueNumber, labels) {
-      return request('POST', `/repos/${owner}/${repo}/issues/${issueNumber}/labels`, { labels })
-    },
-    async createIssueComment(issueNumber, body) {
-      return request('POST', `/repos/${owner}/${repo}/issues/${issueNumber}/comments`, { body })
-    },
-    async createPullRequest(payload) {
-      return request('POST', `/repos/${owner}/${repo}/pulls`, payload)
-    },
-    async createRef(branchName, sha) {
-      return request('POST', `/repos/${owner}/${repo}/git/refs`, {
-        ref: `refs/heads/${branchName}`,
-        sha,
-      })
-    },
-    async closePullRequest(prNumber) {
-      return request('PATCH', `/repos/${owner}/${repo}/pulls/${prNumber}`, { state: 'closed' })
-    },
-    async deleteRef(branchName) {
-      return request('DELETE', `/repos/${owner}/${repo}/git/refs/${encodeGitRefPath(`heads/${branchName}`)}`)
-    },
-    async getCollaboratorPermission(username) {
-      const data = await request(
-        'GET',
-        `/repos/${owner}/${repo}/collaborators/${encodeURIComponent(username)}/permission`,
-      )
-      return typeof data.permission === 'string' ? data.permission : 'none'
-    },
-    async getPullRequest(prNumber) {
-      return request('GET', `/repos/${owner}/${repo}/pulls/${prNumber}`)
-    },
-    async getPullRequestByHead(branchName) {
-      const pulls = await request(
-        'GET',
-        `/repos/${owner}/${repo}/pulls?state=all&head=${encodeURIComponent(`${owner}:${branchName}`)}&per_page=10`,
-      )
-
-      if (!Array.isArray(pulls)) {
-        return null
-      }
-
-      return pulls.find((pullRequest) => pullRequest.state === 'open') ?? pulls[0] ?? null
-    },
-    async getRef(branchName) {
-      return request('GET', `/repos/${owner}/${repo}/git/ref/${encodeGitRefPath(`heads/${branchName}`)}`)
-    },
-    async listIssueComments(issueNumber) {
-      return request('GET', `/repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=100`)
-    },
-    async removeIssueLabel(issueNumber, labelName) {
-      try {
-        return await request(
-          'DELETE',
-          `/repos/${owner}/${repo}/issues/${issueNumber}/labels/${encodeURIComponent(labelName)}`,
-        )
-      } catch (error) {
-        if (isNotFoundError(error)) {
-          return null
-        }
-        throw error
-      }
-    },
-    async updateIssueComment(commentId, body) {
-      return request('PATCH', `/repos/${owner}/${repo}/issues/comments/${commentId}`, { body })
-    },
-    async updatePullRequest(prNumber, payload) {
-      return request('PATCH', `/repos/${owner}/${repo}/pulls/${prNumber}`, payload)
-    },
-    async updateRef(branchName, sha) {
-      return request('PATCH', `/repos/${owner}/${repo}/git/refs/${encodeGitRefPath(`heads/${branchName}`)}`, {
-        force: true,
-        sha,
-      })
-    },
-  }
 }
 
 export async function handlePreviewMirrorEvent({ actor, client, event, now = new Date(), options }) {
@@ -248,25 +74,24 @@ async function handleLabeledPullRequest({ actor, client, event, now, options }) 
 
   await assertTrustedActor(client, actor)
 
-  if (!isForkPullRequest(pullRequest)) {
-    await client.removeIssueLabel(pullRequest.number, options.triggerLabel)
+  let result
 
-    return {
+  if (isForkPullRequest(pullRequest)) {
+    result = await syncPreviewBranch({
+      approvedSha: pullRequest.head.sha,
+      actor,
+      client,
+      commentId: null,
+      now,
+      options,
+      pullRequest,
+    })
+  } else {
+    result = {
       reason: 'pull request is not from a fork',
       status: 'ignored',
     }
   }
-
-  const result = await syncPreviewBranch({
-    approvedSha: pullRequest.head.sha,
-    actor,
-    client,
-    commentId: null,
-    now,
-    options,
-    pullRequest,
-  })
-
   await client.removeIssueLabel(pullRequest.number, options.triggerLabel)
 
   return result
@@ -292,7 +117,7 @@ async function handleSynchronizedPullRequest({ actor, client, event, now, option
     }
   }
 
-  const existingSyncRequest = parseSyncRequest(existingComment.body)
+  const existingPreviewComment = parseManagedPreviewComment(existingComment.body)
   const mirrorPullRequest = await client.getPullRequestByHead(branchName)
 
   if (!mirrorPullRequest) {
@@ -306,7 +131,7 @@ async function handleSynchronizedPullRequest({ actor, client, event, now, option
     actor,
     approvalTargetSha: pullRequest.head.sha,
     branchName,
-    mirroredSha: existingSyncRequest?.mirroredSha ?? existingSyncRequest?.targetSha ?? null,
+    mirroredSha: existingPreviewComment?.mirroredSha ?? existingPreviewComment?.targetSha ?? null,
     mirrorPullRequestNumber: mirrorPullRequest.number,
     mirrorPullRequestUrl: mirrorPullRequest.html_url,
     now,
@@ -338,7 +163,7 @@ async function handleClosedPullRequest({ client, event, options }) {
 }
 
 async function handleEditedIssueComment({ actor, client, event, now, options }) {
-  const syncRequest = parseSyncRequest(event.comment.body)
+  const syncRequest = parseManagedPreviewComment(event.comment.body)
 
   if (!syncRequest?.shouldSync) {
     return {
@@ -410,11 +235,11 @@ async function syncPreviewBranch({ actor, approvedSha, client, commentId, now, o
     sourceSha: approvedSha,
   })
 
-  if (commentId) {
-    await client.updateIssueComment(commentId, body)
-  } else {
-    await upsertPreviewComment(client, pullRequest.number, body)
-  }
+  await savePreviewComment(client, {
+    body,
+    commentId,
+    issueNumber: pullRequest.number,
+  })
 
   return {
     branchName,
@@ -425,6 +250,7 @@ async function syncPreviewBranch({ actor, approvedSha, client, commentId, now, o
 
 async function upsertPreviewBranch(client, branchName, sha) {
   try {
+    // Checks whether the branch exists, and throws if it doesnt. Ignore result as we only care about the existence, not contents
     await client.getRef(branchName)
     await client.updateRef(branchName, sha)
   } catch (error) {
@@ -461,7 +287,7 @@ async function upsertMirrorPullRequest(client, sourcePullRequest, branchName, so
     mirrorPullRequest = await client.createPullRequest({
       base: sourcePullRequest.base.ref,
       body,
-      draft: true,
+      draft: true, // We don't intend them to be merged, create as draft
       head: branchName,
       title: buildMirrorPullRequestTitle(sourcePullRequest.number),
     })
@@ -496,21 +322,22 @@ function buildMirrorPullRequestBody(sourcePullRequest, sourceSha = sourcePullReq
   ].join('\n')
 }
 
-async function upsertPreviewComment(client, issueNumber, body) {
-  const existingComment = await findPreviewComment(client, issueNumber)
+async function savePreviewComment(client, { body, commentId, issueNumber }) {
+  const _commentId = commentId || (await findPreviewComment(client, issueNumber))?.id
 
-  if (existingComment) {
-    await client.updateIssueComment(existingComment.id, body)
-    return
+  if (_commentId) {
+    await client.updateIssueComment(_commentId, body)
+  } else {
+    await client.createIssueComment(issueNumber, body)
   }
-
-  await client.createIssueComment(issueNumber, body)
 }
 
 async function findPreviewComment(client, issueNumber) {
   const comments = await client.listIssueComments(issueNumber)
   return comments.find((comment) => {
-    return typeof comment.body === 'string' && parseSyncRequest(comment.body)?.originalPrNumber === issueNumber
+    return (
+      typeof comment.body === 'string' && parseManagedPreviewComment(comment.body)?.originalPrNumber === issueNumber
+    )
   })
 }
 
@@ -535,86 +362,4 @@ function isForkPullRequest(pullRequest) {
   const baseRepoName = pullRequest.base?.repo?.full_name
 
   return Boolean(headRepoName && baseRepoName && headRepoName !== baseRepoName)
-}
-
-function encodeGitRefPath(refPath) {
-  return refPath.split('/').map(encodeURIComponent).join('/')
-}
-
-function parseManagedCommentMetadata(commentBody) {
-  const markerMatch = commentBody.match(new RegExp(`<!--\\s*${MANAGED_COMMENT_MARKER}([^>]*)-->`))
-
-  if (!markerMatch) {
-    return null
-  }
-
-  const attributes = new Map()
-  for (const attributeMatch of markerMatch[1].matchAll(/([a-z-]+)=([^\s>]+)/g)) {
-    attributes.set(attributeMatch[1], attributeMatch[2])
-  }
-
-  const originalPrNumber = Number(attributes.get('original-pr'))
-  if (!Number.isInteger(originalPrNumber) || originalPrNumber <= 0) {
-    return null
-  }
-
-  return {
-    mirroredSha: normalizeGitSha(attributes.get('mirrored-sha')),
-    originalPrNumber,
-    targetSha: normalizeGitSha(attributes.get('target-sha')),
-  }
-}
-
-function parseSyncCheckbox(commentBody) {
-  const checkboxMatch = commentBody.match(new RegExp(`- \\[([xX ])\\] ${escapeRegExp(SYNC_CHECKBOX_TEXT)}`))
-
-  if (!checkboxMatch) {
-    return null
-  }
-
-  return {
-    checked: checkboxMatch[1].toLowerCase() === 'x',
-  }
-}
-
-function normalizeGitSha(value) {
-  if (typeof value !== 'string' || !GIT_SHA_PATTERN.test(value)) {
-    return null
-  }
-
-  return value.toLowerCase()
-}
-
-function formatShortSha(sha) {
-  return sha.slice(0, 12)
-}
-
-function parseGitHubResponse(responseBody) {
-  if (!responseBody) {
-    return {}
-  }
-
-  try {
-    return JSON.parse(responseBody)
-  } catch {
-    return {
-      message: responseBody,
-    }
-  }
-}
-
-function getGitHubErrorMessage(data, status) {
-  if (typeof data.message === 'string') {
-    return data.message
-  }
-
-  return `GitHub API request failed with status ${status}`
-}
-
-function isNotFoundError(error) {
-  return error?.status === 404
-}
-
-function escapeRegExp(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.mjs
@@ -12,20 +12,18 @@ const GITHUB_ACTIONS_BOT_LOGIN = 'github-actions[bot]'
 const MIRROR_PULL_REQUEST_LABELS = ['DONT_MERGE']
 const TRUSTED_PERMISSIONS = new Set(['admin', 'maintain', 'write'])
 
-export function buildPreviewBranch(originalPrNumber, branchPrefix = DEFAULT_BRANCH_PREFIX) {
-  return `${branchPrefix}${originalPrNumber}`
+export function buildPreviewBranch(originalPrNumber) {
+  return `${DEFAULT_BRANCH_PREFIX}${originalPrNumber}`
 }
 
 export async function handlePreviewMirrorEvent({ actor, client, event, now = new Date(), options }) {
-  const normalizedOptions = normalizeOptions(options)
-
   if (event.action === 'labeled' && event.pull_request) {
     return handleLabeledPullRequest({
       actor,
       client,
       event,
       now,
-      options: normalizedOptions,
+      options,
     })
   }
 
@@ -33,7 +31,6 @@ export async function handlePreviewMirrorEvent({ actor, client, event, now = new
     return handleClosedPullRequest({
       client,
       event,
-      options: normalizedOptions,
     })
   }
 
@@ -43,7 +40,7 @@ export async function handlePreviewMirrorEvent({ actor, client, event, now = new
       client,
       event,
       now,
-      options: normalizedOptions,
+      options,
     })
   }
 
@@ -53,7 +50,7 @@ export async function handlePreviewMirrorEvent({ actor, client, event, now = new
       client,
       event,
       now,
-      options: normalizedOptions,
+      options,
     })
   }
 
@@ -64,7 +61,7 @@ export async function handlePreviewMirrorEvent({ actor, client, event, now = new
 }
 
 async function handleLabeledPullRequest({ actor, client, event, now, options }) {
-  if (event.label?.name !== options.triggerLabel) {
+  if (event.label?.name !== DEFAULT_TRIGGER_LABEL) {
     return {
       reason: 'label does not match trigger label',
       status: 'ignored',
@@ -93,7 +90,7 @@ async function handleLabeledPullRequest({ actor, client, event, now, options }) 
       status: 'ignored',
     }
   }
-  await client.removeIssueLabel(pullRequest.number, options.triggerLabel)
+  await client.removeIssueLabel(pullRequest.number, DEFAULT_TRIGGER_LABEL)
 
   return result
 }
@@ -108,7 +105,7 @@ async function handleSynchronizedPullRequest({ actor, client, event, now, option
     }
   }
 
-  const branchName = buildPreviewBranch(pullRequest.number, options.branchPrefix)
+  const branchName = buildPreviewBranch(pullRequest.number)
   const existingComment = await findPreviewComment(client, pullRequest.number)
 
   if (!existingComment) {
@@ -151,9 +148,9 @@ async function handleSynchronizedPullRequest({ actor, client, event, now, option
   }
 }
 
-async function handleClosedPullRequest({ client, event, options }) {
+async function handleClosedPullRequest({ client, event }) {
   const pullRequest = event.pull_request
-  const branchName = buildPreviewBranch(pullRequest.number, options.branchPrefix)
+  const branchName = buildPreviewBranch(pullRequest.number)
   await closeMirrorPullRequest(client, branchName)
   await deletePreviewBranch(client, branchName)
 
@@ -217,7 +214,7 @@ async function handleEditedIssueComment({ actor, client, event, now, options }) 
 }
 
 async function syncPreviewBranch({ actor, approvedSha, client, commentId, now, options, pullRequest }) {
-  const branchName = buildPreviewBranch(pullRequest.number, options.branchPrefix)
+  const branchName = buildPreviewBranch(pullRequest.number)
   await upsertPreviewBranch(client, branchName, approvedSha)
   const mirrorPullRequest = await upsertMirrorPullRequest(client, pullRequest, branchName, approvedSha)
 
@@ -251,8 +248,6 @@ async function syncPreviewBranch({ actor, approvedSha, client, commentId, now, o
 
 async function upsertPreviewBranch(client, branchName, sha) {
   try {
-    // Checks whether the branch exists, and throws if it doesnt. Ignore result as we only care about the existence, not contents
-    await client.getRef(branchName)
     await client.updateRef(branchName, sha)
   } catch (error) {
     if (isNotFoundError(error)) {
@@ -279,7 +274,7 @@ async function upsertMirrorPullRequest(client, sourcePullRequest, branchName, so
   const existingPullRequest = await client.getPullRequestByHead(branchName)
   let mirrorPullRequest
 
-  if (existingPullRequest?.state === 'open') {
+  if (existingPullRequest) {
     mirrorPullRequest = await client.updatePullRequest(existingPullRequest.number, {
       body,
       title: buildMirrorPullRequestTitle(sourcePullRequest.number),
@@ -301,7 +296,7 @@ async function upsertMirrorPullRequest(client, sourcePullRequest, branchName, so
 async function closeMirrorPullRequest(client, branchName) {
   const mirrorPullRequest = await client.getPullRequestByHead(branchName)
 
-  if (mirrorPullRequest?.state === 'open') {
+  if (mirrorPullRequest) {
     await client.closePullRequest(mirrorPullRequest.number)
   }
 }
@@ -348,14 +343,6 @@ async function assertTrustedActor(client, actor) {
 
   if (!TRUSTED_PERMISSIONS.has(permission)) {
     throw new Error(`@${actor} must have write, maintain, or admin permission to trigger preview mirroring.`)
-  }
-}
-
-function normalizeOptions(options) {
-  return {
-    branchPrefix: options.branchPrefix ?? DEFAULT_BRANCH_PREFIX,
-    repoFullName: options.repoFullName,
-    triggerLabel: options.triggerLabel ?? DEFAULT_TRIGGER_LABEL,
   }
 }
 

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.mjs
@@ -1,0 +1,469 @@
+const DEFAULT_BRANCH_PREFIX = 'cf-preview/pr-'
+const DEFAULT_TRIGGER_LABEL = 'trigger-preview'
+const GITHUB_API_BASE = 'https://api.github.com'
+const MANAGED_COMMENT_MARKER = 'cf-pages-preview-mirror'
+const SYNC_CHECKBOX_TEXT = 'Sync Cloudflare preview to latest fork commit'
+const TRUSTED_PERMISSIONS = new Set(['admin', 'maintain', 'write'])
+
+export class GitHubApiError extends Error {
+  constructor(status, message) {
+    super(message)
+    this.name = 'GitHubApiError'
+    this.status = status
+  }
+}
+
+export function buildPreviewBranch(originalPrNumber, branchPrefix = DEFAULT_BRANCH_PREFIX) {
+  return `${branchPrefix}${originalPrNumber}`
+}
+
+export function buildPreviewCommentBody({
+  actor,
+  branchName,
+  mirrorPullRequestNumber,
+  mirrorPullRequestUrl,
+  now,
+  originalPrNumber,
+  repoFullName,
+  sourceBranch,
+  sourceRepoFullName,
+  sourceSha,
+}) {
+  const shortSha = sourceSha.slice(0, 12)
+
+  return `<!-- ${MANAGED_COMMENT_MARKER} original-pr=${originalPrNumber} -->
+Cloudflare Pages preview mirror
+
+Preview branch: \`${branchName}\`
+Preview branch URL: https://github.com/${repoFullName}/tree/${branchName}
+Mirror PR: #${mirrorPullRequestNumber}
+Mirror PR URL: ${mirrorPullRequestUrl}
+Cloudflare Pages preview links will be posted on the mirror PR by the Cloudflare Pages GitHub integration once builds complete.
+
+Source fork branch: \`${sourceRepoFullName}:${sourceBranch}\`
+Mirrored SHA: \`${shortSha}\`
+Last synced by: @${actor} at ${now.toISOString()}
+
+- [ ] ${SYNC_CHECKBOX_TEXT}
+`
+}
+
+export function parseSyncRequest(commentBody) {
+  const markerMatch = commentBody.match(new RegExp(`<!--\\s*${MANAGED_COMMENT_MARKER}\\s+original-pr=(\\d+)\\s*-->`))
+
+  if (!markerMatch) {
+    return null
+  }
+
+  const checkboxPattern = new RegExp(`- \\[[xX ]\\] ${escapeRegExp(SYNC_CHECKBOX_TEXT)}`)
+  const checkboxMatch = commentBody.match(checkboxPattern)
+
+  if (!checkboxMatch) {
+    return {
+      originalPrNumber: Number(markerMatch[1]),
+      shouldSync: false,
+    }
+  }
+
+  return {
+    originalPrNumber: Number(markerMatch[1]),
+    shouldSync: checkboxMatch[0].startsWith('- [x]') || checkboxMatch[0].startsWith('- [X]'),
+  }
+}
+
+export function createGitHubClient({ apiBase = process.env.GITHUB_API_URL ?? GITHUB_API_BASE, repoFullName, token }) {
+  const [owner, repo] = repoFullName.split('/')
+
+  if (!owner || !repo) {
+    throw new Error(`Expected GITHUB_REPOSITORY to be in owner/repo format, received: ${repoFullName}`)
+  }
+
+  async function request(method, path, body) {
+    const response = await fetch(`${apiBase}${path}`, {
+      body: body ? JSON.stringify(body) : undefined,
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      method,
+    })
+    const responseBody = await response.text()
+    const data = parseGitHubResponse(responseBody)
+
+    if (!response.ok) {
+      const message = getGitHubErrorMessage(data, response.status)
+      throw new GitHubApiError(response.status, message)
+    }
+
+    return data
+  }
+
+  return {
+    async createIssueComment(issueNumber, body) {
+      return request('POST', `/repos/${owner}/${repo}/issues/${issueNumber}/comments`, { body })
+    },
+    async createPullRequest(payload) {
+      return request('POST', `/repos/${owner}/${repo}/pulls`, payload)
+    },
+    async createRef(branchName, sha) {
+      return request('POST', `/repos/${owner}/${repo}/git/refs`, {
+        ref: `refs/heads/${branchName}`,
+        sha,
+      })
+    },
+    async closePullRequest(prNumber) {
+      return request('PATCH', `/repos/${owner}/${repo}/pulls/${prNumber}`, { state: 'closed' })
+    },
+    async deleteRef(branchName) {
+      return request('DELETE', `/repos/${owner}/${repo}/git/refs/${encodeGitRefPath(`heads/${branchName}`)}`)
+    },
+    async getCollaboratorPermission(username) {
+      const data = await request(
+        'GET',
+        `/repos/${owner}/${repo}/collaborators/${encodeURIComponent(username)}/permission`,
+      )
+      return typeof data.permission === 'string' ? data.permission : 'none'
+    },
+    async getPullRequest(prNumber) {
+      return request('GET', `/repos/${owner}/${repo}/pulls/${prNumber}`)
+    },
+    async getPullRequestByHead(branchName) {
+      const pulls = await request(
+        'GET',
+        `/repos/${owner}/${repo}/pulls?state=all&head=${encodeURIComponent(`${owner}:${branchName}`)}&per_page=10`,
+      )
+
+      if (!Array.isArray(pulls)) {
+        return null
+      }
+
+      return pulls.find((pullRequest) => pullRequest.state === 'open') ?? pulls[0] ?? null
+    },
+    async getRef(branchName) {
+      return request('GET', `/repos/${owner}/${repo}/git/ref/${encodeGitRefPath(`heads/${branchName}`)}`)
+    },
+    async listIssueComments(issueNumber) {
+      return request('GET', `/repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=100`)
+    },
+    async removeIssueLabel(issueNumber, labelName) {
+      try {
+        return await request(
+          'DELETE',
+          `/repos/${owner}/${repo}/issues/${issueNumber}/labels/${encodeURIComponent(labelName)}`,
+        )
+      } catch (error) {
+        if (isNotFoundError(error)) {
+          return null
+        }
+        throw error
+      }
+    },
+    async updateIssueComment(commentId, body) {
+      return request('PATCH', `/repos/${owner}/${repo}/issues/comments/${commentId}`, { body })
+    },
+    async updatePullRequest(prNumber, payload) {
+      return request('PATCH', `/repos/${owner}/${repo}/pulls/${prNumber}`, payload)
+    },
+    async updateRef(branchName, sha) {
+      return request('PATCH', `/repos/${owner}/${repo}/git/refs/${encodeGitRefPath(`heads/${branchName}`)}`, {
+        force: true,
+        sha,
+      })
+    },
+  }
+}
+
+export async function handlePreviewMirrorEvent({ actor, client, event, now = new Date(), options }) {
+  const normalizedOptions = normalizeOptions(options)
+
+  if (event.action === 'labeled' && event.pull_request) {
+    return handleLabeledPullRequest({
+      actor,
+      client,
+      event,
+      now,
+      options: normalizedOptions,
+    })
+  }
+
+  if (event.action === 'closed' && event.pull_request) {
+    return handleClosedPullRequest({
+      client,
+      event,
+      options: normalizedOptions,
+    })
+  }
+
+  if (event.action === 'edited' && event.comment && event.issue?.pull_request) {
+    return handleEditedIssueComment({
+      actor,
+      client,
+      event,
+      now,
+      options: normalizedOptions,
+    })
+  }
+
+  return {
+    reason: 'unsupported event',
+    status: 'ignored',
+  }
+}
+
+async function handleLabeledPullRequest({ actor, client, event, now, options }) {
+  if (event.label?.name !== options.triggerLabel) {
+    return {
+      reason: 'label does not match trigger label',
+      status: 'ignored',
+    }
+  }
+
+  const pullRequest = event.pull_request
+
+  await assertTrustedActor(client, actor)
+
+  if (!isForkPullRequest(pullRequest)) {
+    await client.removeIssueLabel(pullRequest.number, options.triggerLabel)
+
+    return {
+      reason: 'pull request is not from a fork',
+      status: 'ignored',
+    }
+  }
+
+  const result = await syncPreviewBranch({
+    actor,
+    client,
+    commentId: null,
+    now,
+    options,
+    pullRequest,
+  })
+
+  await client.removeIssueLabel(pullRequest.number, options.triggerLabel)
+
+  return result
+}
+
+async function handleClosedPullRequest({ client, event, options }) {
+  const pullRequest = event.pull_request
+  const branchName = buildPreviewBranch(pullRequest.number, options.branchPrefix)
+  await closeMirrorPullRequest(client, branchName)
+  await deletePreviewBranch(client, branchName)
+
+  return {
+    branchName,
+    status: 'deleted',
+  }
+}
+
+async function handleEditedIssueComment({ actor, client, event, now, options }) {
+  const syncRequest = parseSyncRequest(event.comment.body)
+
+  if (!syncRequest?.shouldSync) {
+    return {
+      reason: 'managed sync checkbox is not checked',
+      status: 'ignored',
+    }
+  }
+
+  await assertTrustedActor(client, actor)
+
+  const pullRequest = await client.getPullRequest(syncRequest.originalPrNumber)
+
+  if (pullRequest.state !== 'open') {
+    return {
+      reason: 'source pull request is not open',
+      status: 'ignored',
+    }
+  }
+
+  if (!isForkPullRequest(pullRequest)) {
+    return {
+      reason: 'pull request is not from a fork',
+      status: 'ignored',
+    }
+  }
+
+  return syncPreviewBranch({
+    actor,
+    client,
+    commentId: event.comment.id,
+    now,
+    options,
+    pullRequest,
+  })
+}
+
+async function syncPreviewBranch({ actor, client, commentId, now, options, pullRequest }) {
+  const branchName = buildPreviewBranch(pullRequest.number, options.branchPrefix)
+  await upsertPreviewBranch(client, branchName, pullRequest.head.sha)
+  const mirrorPullRequest = await upsertMirrorPullRequest(client, pullRequest, branchName)
+
+  const body = buildPreviewCommentBody({
+    actor,
+    branchName,
+    mirrorPullRequestNumber: mirrorPullRequest.number,
+    mirrorPullRequestUrl: mirrorPullRequest.html_url,
+    now,
+    originalPrNumber: pullRequest.number,
+    repoFullName: options.repoFullName,
+    sourceBranch: pullRequest.head.ref,
+    sourceRepoFullName: pullRequest.head.repo.full_name,
+    sourceSha: pullRequest.head.sha,
+  })
+
+  if (commentId) {
+    await client.updateIssueComment(commentId, body)
+  } else {
+    await upsertPreviewComment(client, pullRequest.number, body)
+  }
+
+  return {
+    branchName,
+    mirrorPullRequestNumber: mirrorPullRequest.number,
+    status: 'synced',
+  }
+}
+
+async function upsertPreviewBranch(client, branchName, sha) {
+  try {
+    await client.getRef(branchName)
+    await client.updateRef(branchName, sha)
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      await client.createRef(branchName, sha)
+      return
+    }
+
+    throw error
+  }
+}
+
+async function deletePreviewBranch(client, branchName) {
+  try {
+    await client.deleteRef(branchName)
+  } catch (error) {
+    if (!isNotFoundError(error)) {
+      throw error
+    }
+  }
+}
+
+async function upsertMirrorPullRequest(client, sourcePullRequest, branchName) {
+  const body = buildMirrorPullRequestBody(sourcePullRequest)
+  const existingPullRequest = await client.getPullRequestByHead(branchName)
+
+  if (existingPullRequest?.state === 'open') {
+    return client.updatePullRequest(existingPullRequest.number, {
+      body,
+      title: buildMirrorPullRequestTitle(sourcePullRequest.number),
+    })
+  }
+
+  return client.createPullRequest({
+    base: sourcePullRequest.base.ref,
+    body,
+    draft: false,
+    head: branchName,
+    title: buildMirrorPullRequestTitle(sourcePullRequest.number),
+  })
+}
+
+async function closeMirrorPullRequest(client, branchName) {
+  const mirrorPullRequest = await client.getPullRequestByHead(branchName)
+
+  if (mirrorPullRequest?.state === 'open') {
+    await client.closePullRequest(mirrorPullRequest.number)
+  }
+}
+
+function buildMirrorPullRequestTitle(originalPrNumber) {
+  return `preview: mirror fork PR #${originalPrNumber}`
+}
+
+function buildMirrorPullRequestBody(sourcePullRequest) {
+  return [
+    `<!-- ${MANAGED_COMMENT_MARKER} original-pr=${sourcePullRequest.number} -->`,
+    `This PR mirrors fork PR #${sourcePullRequest.number} for Cloudflare Pages preview builds.`,
+    '',
+    `Source PR: ${sourcePullRequest.html_url}`,
+    `Source fork branch: \`${sourcePullRequest.head.repo.full_name}:${sourcePullRequest.head.ref}\``,
+    `Mirrored SHA: \`${sourcePullRequest.head.sha.slice(0, 12)}\``,
+    '',
+    'Do not merge this PR. Close the source PR to clean up this mirror.',
+  ].join('\n')
+}
+
+async function upsertPreviewComment(client, issueNumber, body) {
+  const comments = await client.listIssueComments(issueNumber)
+  const existingComment = comments.find((comment) => {
+    return typeof comment.body === 'string' && parseSyncRequest(comment.body)?.originalPrNumber === issueNumber
+  })
+
+  if (existingComment) {
+    await client.updateIssueComment(existingComment.id, body)
+    return
+  }
+
+  await client.createIssueComment(issueNumber, body)
+}
+
+async function assertTrustedActor(client, actor) {
+  const permission = await client.getCollaboratorPermission(actor)
+
+  if (!TRUSTED_PERMISSIONS.has(permission)) {
+    throw new Error(`@${actor} must have write, maintain, or admin permission to trigger preview mirroring.`)
+  }
+}
+
+function normalizeOptions(options) {
+  return {
+    branchPrefix: options.branchPrefix ?? DEFAULT_BRANCH_PREFIX,
+    repoFullName: options.repoFullName,
+    triggerLabel: options.triggerLabel ?? DEFAULT_TRIGGER_LABEL,
+  }
+}
+
+function isForkPullRequest(pullRequest) {
+  const headRepoName = pullRequest.head?.repo?.full_name
+  const baseRepoName = pullRequest.base?.repo?.full_name
+
+  return Boolean(headRepoName && baseRepoName && headRepoName !== baseRepoName)
+}
+
+function encodeGitRefPath(refPath) {
+  return refPath.split('/').map(encodeURIComponent).join('/')
+}
+
+function parseGitHubResponse(responseBody) {
+  if (!responseBody) {
+    return {}
+  }
+
+  try {
+    return JSON.parse(responseBody)
+  } catch {
+    return {
+      message: responseBody,
+    }
+  }
+}
+
+function getGitHubErrorMessage(data, status) {
+  if (typeof data.message === 'string') {
+    return data.message
+  }
+
+  return `GitHub API request failed with status ${status}`
+}
+
+function isNotFoundError(error) {
+  return error?.status === 404
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.mjs
@@ -333,8 +333,7 @@ async function savePreviewComment(client, { body, commentId, issueNumber }) {
 }
 
 async function findPreviewComment(client, issueNumber) {
-  const comments = await client.listIssueComments(issueNumber)
-  return comments.find((comment) => {
+  return client.findIssueComment(issueNumber, (comment) => {
     return (
       typeof comment.body === 'string' && parseManagedPreviewComment(comment.body)?.originalPrNumber === issueNumber
     )

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.test.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.test.mjs
@@ -79,7 +79,7 @@ function createFakeClient({ comments = [], permission = 'write', pullRequest = f
     },
     async createIssueComment(issueNumber, body) {
       calls.push(['createIssueComment', issueNumber, body])
-      storedComments.push({ body, id: 999, user: { type: 'Bot' } })
+      storedComments.push({ body, id: 999, user: { login: 'github-actions[bot]', type: 'Bot' } })
       return { id: 999 }
     },
     async createPullRequest(payload) {
@@ -344,7 +344,7 @@ describe('preview-mirror-lib', () => {
       sourceSha: SOURCE_SHA,
     })
     const client = createFakeClient({
-      comments: [{ body: existingComment, id: 999, user: { type: 'Bot' } }],
+      comments: [{ body: existingComment, id: 999, user: { login: 'github-actions[bot]', type: 'Bot' } }],
       refExists: true,
     })
     await client.createPullRequest({
@@ -392,6 +392,69 @@ describe('preview-mirror-lib', () => {
     assert.match(updateCall[2], /Approval target SHA: `def4567890ab`/)
     assert.match(updateCall[2], /Last mirrored SHA: `abc123456789`/)
     assert.match(updateCall[2], /- \[ \] Sync Cloudflare preview to approval target commit/)
+  })
+
+  it('ignores spoofed managed comments not authored by GitHub Actions', async () => {
+    const existingComment = buildPreviewCommentBody({
+      actor: 'maintainer',
+      branchName: 'cf-preview/pr-123',
+      mirrorPullRequestNumber: 456,
+      mirrorPullRequestUrl: 'https://github.com/cowprotocol/cowswap/pull/456',
+      now: new Date('2026-06-05T10:30:00.000Z'),
+      originalPrNumber: 123,
+      repoFullName: 'cowprotocol/cowswap',
+      sourceBranch: 'feature/new-swap',
+      sourceRepoFullName: 'external/cowswap',
+      sourceSha: SOURCE_SHA,
+    })
+    const client = createFakeClient({
+      comments: [
+        { body: existingComment, id: 998, user: { login: 'external-contributor', type: 'User' } },
+        { body: existingComment, id: 999, user: { login: 'github-actions[bot]', type: 'Bot' } },
+      ],
+      refExists: true,
+    })
+    await client.createPullRequest({
+      base: 'develop',
+      body: 'old body',
+      draft: true,
+      head: 'cf-preview/pr-123',
+      title: 'preview: mirror fork PR #123',
+    })
+    client.calls.length = 0
+
+    const result = await handlePreviewMirrorEvent({
+      actor: 'external-contributor',
+      client,
+      event: synchronizeEvent(
+        forkPullRequest({
+          head: {
+            ref: 'feature/new-swap',
+            repo: {
+              full_name: 'external/cowswap',
+            },
+            sha: NEXT_SOURCE_SHA,
+          },
+        }),
+      ),
+      now: new Date('2026-06-05T10:45:00.000Z'),
+      options: {
+        repoFullName: 'cowprotocol/cowswap',
+      },
+    })
+
+    assert.deepEqual(result, {
+      branchName: 'cf-preview/pr-123',
+      status: 'approval-target-updated',
+    })
+    assert.deepEqual(
+      client.calls.map((call) => call.slice(0, 2)),
+      [
+        ['findIssueComment', 123],
+        ['getPullRequestByHead', 'cf-preview/pr-123'],
+        ['updateIssueComment', 999],
+      ],
+    )
   })
 
   it('ignores checked managed comments edited on a different pull request issue', async () => {

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.test.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.test.mjs
@@ -1,0 +1,333 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import {
+  buildPreviewBranch,
+  buildPreviewCommentBody,
+  handlePreviewMirrorEvent,
+  parseSyncRequest,
+} from './preview-mirror-lib.mjs'
+
+function forkPullRequest(overrides = {}) {
+  return {
+    base: {
+      ref: 'develop',
+      repo: {
+        full_name: 'cowprotocol/cowswap',
+      },
+    },
+    head: {
+      ref: 'feature/new-swap',
+      repo: {
+        full_name: 'external/cowswap',
+      },
+      sha: 'abc1234567890abcdef1234567890abcdef1234',
+    },
+    html_url: 'https://github.com/cowprotocol/cowswap/pull/123',
+    number: 123,
+    state: 'open',
+    ...overrides,
+  }
+}
+
+function labeledEvent(labelName = 'trigger-preview') {
+  return {
+    action: 'labeled',
+    label: { name: labelName },
+    pull_request: forkPullRequest(),
+  }
+}
+
+function checkboxEvent(body) {
+  return {
+    action: 'edited',
+    comment: {
+      body,
+      id: 777,
+    },
+    issue: {
+      number: 123,
+      pull_request: {},
+    },
+  }
+}
+
+function createFakeClient({ comments = [], permission = 'write', pullRequest = forkPullRequest(), refExists = false } = {}) {
+  const calls = []
+  const storedComments = [...comments]
+  let mirrorPullRequest = null
+  let hasRef = refExists
+
+  return {
+    calls,
+    async closePullRequest(prNumber) {
+      calls.push(['closePullRequest', prNumber])
+      if (mirrorPullRequest?.number === prNumber) {
+        mirrorPullRequest = { ...mirrorPullRequest, state: 'closed' }
+      }
+      return mirrorPullRequest
+    },
+    async createIssueComment(issueNumber, body) {
+      calls.push(['createIssueComment', issueNumber, body])
+      storedComments.push({ body, id: 999, user: { type: 'Bot' } })
+      return { id: 999 }
+    },
+    async createPullRequest(payload) {
+      calls.push(['createPullRequest', payload])
+      mirrorPullRequest = {
+        body: payload.body,
+        head: { ref: payload.head },
+        html_url: 'https://github.com/cowprotocol/cowswap/pull/456',
+        number: 456,
+        state: 'open',
+        title: payload.title,
+      }
+      return mirrorPullRequest
+    },
+    async createRef(branchName, sha) {
+      calls.push(['createRef', branchName, sha])
+      hasRef = true
+    },
+    async deleteRef(branchName) {
+      calls.push(['deleteRef', branchName])
+      hasRef = false
+    },
+    async getCollaboratorPermission(username) {
+      calls.push(['getCollaboratorPermission', username])
+      return permission
+    },
+    async getPullRequest(prNumber) {
+      calls.push(['getPullRequest', prNumber])
+      return pullRequest
+    },
+    async getPullRequestByHead(branchName) {
+      calls.push(['getPullRequestByHead', branchName])
+      return mirrorPullRequest?.head.ref === branchName ? mirrorPullRequest : null
+    },
+    async getRef(branchName) {
+      calls.push(['getRef', branchName])
+      if (!hasRef) {
+        const error = new Error('not found')
+        error.status = 404
+        throw error
+      }
+      return { object: { sha: 'oldsha' } }
+    },
+    async listIssueComments(issueNumber) {
+      calls.push(['listIssueComments', issueNumber])
+      return storedComments
+    },
+    async removeIssueLabel(issueNumber, labelName) {
+      calls.push(['removeIssueLabel', issueNumber, labelName])
+    },
+    async updateIssueComment(commentId, body) {
+      calls.push(['updateIssueComment', commentId, body])
+      return { id: commentId }
+    },
+    async updatePullRequest(prNumber, payload) {
+      calls.push(['updatePullRequest', prNumber, payload])
+      mirrorPullRequest = {
+        ...mirrorPullRequest,
+        ...payload,
+        number: prNumber,
+        state: payload.state ?? mirrorPullRequest?.state ?? 'open',
+      }
+      return mirrorPullRequest
+    },
+    async updateRef(branchName, sha) {
+      calls.push(['updateRef', branchName, sha])
+      hasRef = true
+    },
+  }
+}
+
+describe('preview-mirror-lib', () => {
+  it('builds stable Cloudflare preview branch names from PR numbers', () => {
+    assert.equal(buildPreviewBranch(123), 'cf-preview/pr-123')
+  })
+
+  it('builds an unchecked sync comment without guessing Cloudflare Pages project URLs', () => {
+    const body = buildPreviewCommentBody({
+      actor: 'maintainer',
+      branchName: 'cf-preview/pr-123',
+      mirrorPullRequestNumber: 456,
+      mirrorPullRequestUrl: 'https://github.com/cowprotocol/cowswap/pull/456',
+      now: new Date('2026-06-05T10:30:00.000Z'),
+      originalPrNumber: 123,
+      repoFullName: 'cowprotocol/cowswap',
+      sourceBranch: 'feature/new-swap',
+      sourceRepoFullName: 'external/cowswap',
+      sourceSha: 'abc1234567890abcdef1234567890abcdef1234',
+    })
+
+    assert.match(body, /<!-- cf-pages-preview-mirror original-pr=123 -->/)
+    assert.match(body, /`cf-preview\/pr-123`/)
+    assert.match(body, /Mirror PR: #456/)
+    assert.match(body, /Cloudflare Pages preview links will be posted on the mirror PR/)
+    assert.doesNotMatch(body, /pages\.dev/)
+    assert.match(body, /Mirrored SHA: `abc123456789`/)
+    assert.match(body, /- \[ \] Sync Cloudflare preview to latest fork commit/)
+  })
+
+  it('parses checked sync requests from managed comments', () => {
+    const parsed = parseSyncRequest(`
+<!-- cf-pages-preview-mirror original-pr=123 -->
+- [x] Sync Cloudflare preview to latest fork commit
+`)
+
+    assert.deepEqual(parsed, { originalPrNumber: 123, shouldSync: true })
+  })
+
+  it('ignores unchecked managed comments', () => {
+    const parsed = parseSyncRequest(`
+<!-- cf-pages-preview-mirror original-pr=123 -->
+- [ ] Sync Cloudflare preview to latest fork commit
+`)
+
+    assert.deepEqual(parsed, { originalPrNumber: 123, shouldSync: false })
+  })
+
+  it('creates a preview branch, comments on the original PR, and removes the trigger label', async () => {
+    const client = createFakeClient()
+
+    const result = await handlePreviewMirrorEvent({
+      actor: 'maintainer',
+      client,
+      event: labeledEvent(),
+      now: new Date('2026-06-05T10:30:00.000Z'),
+      options: {
+        repoFullName: 'cowprotocol/cowswap',
+      },
+    })
+
+    assert.deepEqual(result, {
+      branchName: 'cf-preview/pr-123',
+      mirrorPullRequestNumber: 456,
+      status: 'synced',
+    })
+    assert.deepEqual(
+      client.calls.map((call) => call.slice(0, 2)),
+      [
+        ['getCollaboratorPermission', 'maintainer'],
+        ['getRef', 'cf-preview/pr-123'],
+        ['createRef', 'cf-preview/pr-123'],
+        ['getPullRequestByHead', 'cf-preview/pr-123'],
+        ['createPullRequest', {
+          base: 'develop',
+          body: [
+            '<!-- cf-pages-preview-mirror original-pr=123 -->',
+            'This PR mirrors fork PR #123 for Cloudflare Pages preview builds.',
+            '',
+            'Source PR: https://github.com/cowprotocol/cowswap/pull/123',
+            'Source fork branch: `external/cowswap:feature/new-swap`',
+            'Mirrored SHA: `abc123456789`',
+            '',
+            'Do not merge this PR. Close the source PR to clean up this mirror.',
+          ].join('\n'),
+          draft: false,
+          head: 'cf-preview/pr-123',
+          title: 'preview: mirror fork PR #123',
+        }],
+        ['listIssueComments', 123],
+        ['createIssueComment', 123],
+        ['removeIssueLabel', 123],
+      ],
+    )
+  })
+
+  it('force-updates an existing preview branch when a checked managed comment is edited', async () => {
+    const checkedComment = buildPreviewCommentBody({
+      actor: 'maintainer',
+      branchName: 'cf-preview/pr-123',
+      mirrorPullRequestNumber: 456,
+      mirrorPullRequestUrl: 'https://github.com/cowprotocol/cowswap/pull/456',
+      now: new Date('2026-06-05T10:30:00.000Z'),
+      originalPrNumber: 123,
+      repoFullName: 'cowprotocol/cowswap',
+      sourceBranch: 'feature/new-swap',
+      sourceRepoFullName: 'external/cowswap',
+      sourceSha: 'abc1234567890abcdef1234567890abcdef1234',
+    }).replace('- [ ] Sync Cloudflare preview', '- [x] Sync Cloudflare preview')
+    const client = createFakeClient({ refExists: true })
+
+    const result = await handlePreviewMirrorEvent({
+      actor: 'maintainer',
+      client,
+      event: checkboxEvent(checkedComment),
+      now: new Date('2026-06-05T10:45:00.000Z'),
+      options: {
+        repoFullName: 'cowprotocol/cowswap',
+      },
+    })
+
+    assert.deepEqual(result, {
+      branchName: 'cf-preview/pr-123',
+      mirrorPullRequestNumber: 456,
+      status: 'synced',
+    })
+    assert.deepEqual(
+      client.calls.map((call) => call.slice(0, 2)),
+      [
+        ['getCollaboratorPermission', 'maintainer'],
+        ['getPullRequest', 123],
+        ['getRef', 'cf-preview/pr-123'],
+        ['updateRef', 'cf-preview/pr-123'],
+        ['getPullRequestByHead', 'cf-preview/pr-123'],
+        ['createPullRequest', {
+          base: 'develop',
+          body: [
+            '<!-- cf-pages-preview-mirror original-pr=123 -->',
+            'This PR mirrors fork PR #123 for Cloudflare Pages preview builds.',
+            '',
+            'Source PR: https://github.com/cowprotocol/cowswap/pull/123',
+            'Source fork branch: `external/cowswap:feature/new-swap`',
+            'Mirrored SHA: `abc123456789`',
+            '',
+            'Do not merge this PR. Close the source PR to clean up this mirror.',
+          ].join('\n'),
+          draft: false,
+          head: 'cf-preview/pr-123',
+          title: 'preview: mirror fork PR #123',
+        }],
+        ['updateIssueComment', 777],
+      ],
+    )
+    const updateCall = client.calls.find((call) => call[0] === 'updateIssueComment')
+    assert.match(updateCall[2], /- \[ \] Sync Cloudflare preview to latest fork commit/)
+  })
+
+  it('deletes the preview branch when the source fork PR closes', async () => {
+    const client = createFakeClient({ refExists: true })
+    await client.createPullRequest({
+      base: 'develop',
+      body: 'old body',
+      draft: false,
+      head: 'cf-preview/pr-123',
+      title: 'preview: mirror fork PR #123',
+    })
+    client.calls.length = 0
+
+    const result = await handlePreviewMirrorEvent({
+      actor: 'external-contributor',
+      client,
+      event: {
+        action: 'closed',
+        pull_request: forkPullRequest({ state: 'closed' }),
+      },
+      now: new Date('2026-06-05T10:45:00.000Z'),
+      options: {
+        repoFullName: 'cowprotocol/cowswap',
+      },
+    })
+
+    assert.deepEqual(result, {
+      branchName: 'cf-preview/pr-123',
+      status: 'deleted',
+    })
+    assert.deepEqual(client.calls, [
+      ['getPullRequestByHead', 'cf-preview/pr-123'],
+      ['closePullRequest', 456],
+      ['deleteRef', 'cf-preview/pr-123'],
+    ])
+  })
+})

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.test.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.test.mjs
@@ -115,15 +115,6 @@ function createFakeClient({ comments = [], permission = 'write', pullRequest = f
       calls.push(['getPullRequestByHead', branchName])
       return mirrorPullRequest?.head.ref === branchName ? mirrorPullRequest : null
     },
-    async getRef(branchName) {
-      calls.push(['getRef', branchName])
-      if (!hasRef) {
-        const error = new Error('not found')
-        error.status = 404
-        throw error
-      }
-      return { object: { sha: 'oldsha' } }
-    },
     async findIssueComment(issueNumber, predicate) {
       calls.push(['findIssueComment', issueNumber])
       return storedComments.find(predicate) ?? null
@@ -151,9 +142,18 @@ function createFakeClient({ comments = [], permission = 'write', pullRequest = f
     },
     async updateRef(branchName, sha) {
       calls.push(['updateRef', branchName, sha])
+      if (!hasRef) {
+        const error = new Error('not found')
+        error.status = 404
+        throw error
+      }
       hasRef = true
     },
   }
+}
+
+function callSummary(calls) {
+  return calls.map(([name, value]) => (name === 'createPullRequest' ? [name] : [name, value]))
 }
 
 describe('preview-mirror-lib', () => {
@@ -180,34 +180,25 @@ describe('preview-mirror-lib', () => {
       status: 'synced',
     })
     assert.deepEqual(
-      client.calls.map((call) => call.slice(0, 2)),
+      callSummary(client.calls),
       [
         ['getCollaboratorPermission', 'maintainer'],
-        ['getRef', 'cf-preview/pr-123'],
+        ['updateRef', 'cf-preview/pr-123'],
         ['createRef', 'cf-preview/pr-123'],
         ['getPullRequestByHead', 'cf-preview/pr-123'],
-        ['createPullRequest', {
-          base: 'develop',
-          body: [
-            '<!-- cf-pages-preview-mirror original-pr=123 -->',
-            'This PR mirrors fork PR #123 for Cloudflare Pages preview builds.',
-            '',
-            'Source PR: https://github.com/cowprotocol/cowswap/pull/123',
-            'Source fork branch: `external/cowswap:feature/new-swap`',
-            'Mirrored SHA: `abc123456789`',
-            '',
-            'Do not merge this PR. Close the source PR to clean up this mirror.',
-          ].join('\n'),
-          draft: true,
-          head: 'cf-preview/pr-123',
-          title: 'preview: mirror fork PR #123',
-        }],
+        ['createPullRequest'],
         ['addIssueLabels', 456],
         ['findIssueComment', 123],
         ['createIssueComment', 123],
         ['removeIssueLabel', 123],
       ],
     )
+    const createPullRequestCall = client.calls.find((call) => call[0] === 'createPullRequest')
+    assert.equal(createPullRequestCall[1].base, 'develop')
+    assert.equal(createPullRequestCall[1].draft, true)
+    assert.equal(createPullRequestCall[1].head, 'cf-preview/pr-123')
+    assert.equal(createPullRequestCall[1].title, 'preview: mirror fork PR #123')
+    assert.match(createPullRequestCall[1].body, /Mirrored SHA: `abc123456789`/)
     const labelCall = client.calls.find((call) => call[0] === 'addIssueLabels')
     assert.deepEqual(labelCall, ['addIssueLabels', 456, ['DONT_MERGE']])
   })
@@ -254,33 +245,23 @@ describe('preview-mirror-lib', () => {
       status: 'synced',
     })
     assert.deepEqual(
-      client.calls.map((call) => call.slice(0, 2)),
+      callSummary(client.calls),
       [
         ['getCollaboratorPermission', 'maintainer'],
         ['getPullRequest', 123],
-        ['getRef', 'cf-preview/pr-123'],
         ['updateRef', 'cf-preview/pr-123'],
         ['getPullRequestByHead', 'cf-preview/pr-123'],
-        ['createPullRequest', {
-          base: 'develop',
-          body: [
-            '<!-- cf-pages-preview-mirror original-pr=123 -->',
-            'This PR mirrors fork PR #123 for Cloudflare Pages preview builds.',
-            '',
-            'Source PR: https://github.com/cowprotocol/cowswap/pull/123',
-            'Source fork branch: `external/cowswap:feature/new-swap`',
-            'Mirrored SHA: `111111111111`',
-            '',
-            'Do not merge this PR. Close the source PR to clean up this mirror.',
-          ].join('\n'),
-          draft: true,
-          head: 'cf-preview/pr-123',
-          title: 'preview: mirror fork PR #123',
-        }],
+        ['createPullRequest'],
         ['addIssueLabels', 456],
         ['updateIssueComment', 777],
       ],
     )
+    const createPullRequestCall = client.calls.find((call) => call[0] === 'createPullRequest')
+    assert.equal(createPullRequestCall[1].base, 'develop')
+    assert.equal(createPullRequestCall[1].draft, true)
+    assert.equal(createPullRequestCall[1].head, 'cf-preview/pr-123')
+    assert.equal(createPullRequestCall[1].title, 'preview: mirror fork PR #123')
+    assert.match(createPullRequestCall[1].body, /Mirrored SHA: `111111111111`/)
     const updateRefCall = client.calls.find((call) => call[0] === 'updateRef')
     assert.deepEqual(updateRefCall, ['updateRef', 'cf-preview/pr-123', APPROVED_SOURCE_SHA])
     const updateCall = client.calls.find((call) => call[0] === 'updateIssueComment')
@@ -316,10 +297,9 @@ describe('preview-mirror-lib', () => {
       status: 'synced',
     })
     assert.deepEqual(
-      client.calls.map((call) => call.slice(0, 2)),
+      callSummary(client.calls),
       [
         ['getCollaboratorPermission', 'maintainer'],
-        ['getRef', 'cf-preview/pr-123'],
         ['updateRef', 'cf-preview/pr-123'],
         ['getPullRequestByHead', 'cf-preview/pr-123'],
         ['updatePullRequest', 456],
@@ -381,7 +361,7 @@ describe('preview-mirror-lib', () => {
       status: 'approval-target-updated',
     })
     assert.deepEqual(
-      client.calls.map((call) => call.slice(0, 2)),
+      callSummary(client.calls),
       [
         ['findIssueComment', 123],
         ['getPullRequestByHead', 'cf-preview/pr-123'],
@@ -448,7 +428,7 @@ describe('preview-mirror-lib', () => {
       status: 'approval-target-updated',
     })
     assert.deepEqual(
-      client.calls.map((call) => call.slice(0, 2)),
+      callSummary(client.calls),
       [
         ['findIssueComment', 123],
         ['getPullRequestByHead', 'cf-preview/pr-123'],

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.test.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.test.mjs
@@ -1,12 +1,8 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
-import {
-  buildPreviewBranch,
-  buildPreviewCommentBody,
-  handlePreviewMirrorEvent,
-  parseSyncRequest,
-} from './preview-mirror-lib.mjs'
+import { buildPreviewCommentBody } from './preview-mirror-comment.mjs'
+import { buildPreviewBranch, handlePreviewMirrorEvent } from './preview-mirror-lib.mjs'
 
 const SOURCE_SHA = 'abc1234567890abcdef1234567890abcdef12345'
 const NEXT_SOURCE_SHA = 'def4567890abcdef1234567890abcdef12345678'
@@ -163,76 +159,6 @@ function createFakeClient({ comments = [], permission = 'write', pullRequest = f
 describe('preview-mirror-lib', () => {
   it('builds stable Cloudflare preview branch names from PR numbers', () => {
     assert.equal(buildPreviewBranch(123), 'cf-preview/pr-123')
-  })
-
-  it('builds an unchecked sync comment without guessing Cloudflare Pages project URLs', () => {
-    const body = buildPreviewCommentBody({
-      actor: 'maintainer',
-      branchName: 'cf-preview/pr-123',
-      mirrorPullRequestNumber: 456,
-      mirrorPullRequestUrl: 'https://github.com/cowprotocol/cowswap/pull/456',
-      now: new Date('2026-06-05T10:30:00.000Z'),
-      originalPrNumber: 123,
-      repoFullName: 'cowprotocol/cowswap',
-      sourceBranch: 'feature/new-swap',
-      sourceRepoFullName: 'external/cowswap',
-      sourceSha: SOURCE_SHA,
-    })
-
-    assert.match(
-      body,
-      /<!-- cf-pages-preview-mirror original-pr=123 target-sha=abc1234567890abcdef1234567890abcdef12345 mirrored-sha=abc1234567890abcdef1234567890abcdef12345 -->/,
-    )
-    assert.match(body, /`cf-preview\/pr-123`/)
-    assert.match(body, /Mirror PR: #456/)
-    assert.match(body, /Cloudflare Pages preview links will be posted on the mirror PR/)
-    assert.doesNotMatch(body, /pages\.dev/)
-    assert.match(body, /Approval target SHA: `abc123456789`/)
-    assert.match(body, /Last mirrored SHA: `abc123456789`/)
-    assert.match(body, /- \[ \] Sync Cloudflare preview to approval target commit/)
-    assert.doesNotMatch(body, /latest fork commit/)
-  })
-
-  it('parses checked sync requests from managed comments', () => {
-    const parsed = parseSyncRequest(`
-<!-- cf-pages-preview-mirror original-pr=123 target-sha=${APPROVED_SOURCE_SHA} mirrored-sha=${SOURCE_SHA} -->
-- [x] Sync Cloudflare preview to approval target commit
-`)
-
-    assert.deepEqual(parsed, {
-      mirroredSha: SOURCE_SHA,
-      originalPrNumber: 123,
-      shouldSync: true,
-      targetSha: APPROVED_SOURCE_SHA,
-    })
-  })
-
-  it('ignores unchecked managed comments', () => {
-    const parsed = parseSyncRequest(`
-<!-- cf-pages-preview-mirror original-pr=123 target-sha=${SOURCE_SHA} mirrored-sha=${SOURCE_SHA} -->
-- [ ] Sync Cloudflare preview to approval target commit
-`)
-
-    assert.deepEqual(parsed, {
-      mirroredSha: SOURCE_SHA,
-      originalPrNumber: 123,
-      shouldSync: false,
-      targetSha: SOURCE_SHA,
-    })
-  })
-
-  it('ignores legacy sync checkbox text', () => {
-    const parsed = parseSyncRequest(`
-<!-- cf-pages-preview-mirror original-pr=123 target-sha=${APPROVED_SOURCE_SHA} mirrored-sha=${SOURCE_SHA} -->
-- [x] Sync Cloudflare preview to latest fork commit
-`)
-
-    assert.deepEqual(parsed, {
-      mirroredSha: SOURCE_SHA,
-      originalPrNumber: 123,
-      shouldSync: false,
-      targetSha: APPROVED_SOURCE_SHA,
-    })
   })
 
   it('creates a preview branch, comments on the original PR, and removes the trigger label', async () => {

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.test.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.test.mjs
@@ -60,6 +60,9 @@ function createFakeClient({ comments = [], permission = 'write', pullRequest = f
 
   return {
     calls,
+    async addIssueLabels(issueNumber, labels) {
+      calls.push(['addIssueLabels', issueNumber, labels])
+    },
     async closePullRequest(prNumber) {
       calls.push(['closePullRequest', prNumber])
       if (mirrorPullRequest?.number === prNumber) {
@@ -76,6 +79,7 @@ function createFakeClient({ comments = [], permission = 'write', pullRequest = f
       calls.push(['createPullRequest', payload])
       mirrorPullRequest = {
         body: payload.body,
+        draft: payload.draft,
         head: { ref: payload.head },
         html_url: 'https://github.com/cowprotocol/cowswap/pull/456',
         number: 456,
@@ -224,15 +228,18 @@ describe('preview-mirror-lib', () => {
             '',
             'Do not merge this PR. Close the source PR to clean up this mirror.',
           ].join('\n'),
-          draft: false,
+          draft: true,
           head: 'cf-preview/pr-123',
           title: 'preview: mirror fork PR #123',
         }],
+        ['addIssueLabels', 456],
         ['listIssueComments', 123],
         ['createIssueComment', 123],
         ['removeIssueLabel', 123],
       ],
     )
+    const labelCall = client.calls.find((call) => call[0] === 'addIssueLabels')
+    assert.deepEqual(labelCall, ['addIssueLabels', 456, ['DONT_MERGE']])
   })
 
   it('force-updates an existing preview branch when a checked managed comment is edited', async () => {
@@ -285,15 +292,57 @@ describe('preview-mirror-lib', () => {
             '',
             'Do not merge this PR. Close the source PR to clean up this mirror.',
           ].join('\n'),
-          draft: false,
+          draft: true,
           head: 'cf-preview/pr-123',
           title: 'preview: mirror fork PR #123',
         }],
+        ['addIssueLabels', 456],
         ['updateIssueComment', 777],
       ],
     )
     const updateCall = client.calls.find((call) => call[0] === 'updateIssueComment')
     assert.match(updateCall[2], /- \[ \] Sync Cloudflare preview to latest fork commit/)
+  })
+
+  it('updates an existing mirror pull request without adding labels', async () => {
+    const client = createFakeClient({ refExists: true })
+    await client.createPullRequest({
+      base: 'develop',
+      body: 'old body',
+      draft: false,
+      head: 'cf-preview/pr-123',
+      title: 'preview: mirror fork PR #123',
+    })
+    client.calls.length = 0
+
+    const result = await handlePreviewMirrorEvent({
+      actor: 'maintainer',
+      client,
+      event: labeledEvent(),
+      now: new Date('2026-06-05T10:45:00.000Z'),
+      options: {
+        repoFullName: 'cowprotocol/cowswap',
+      },
+    })
+
+    assert.deepEqual(result, {
+      branchName: 'cf-preview/pr-123',
+      mirrorPullRequestNumber: 456,
+      status: 'synced',
+    })
+    assert.deepEqual(
+      client.calls.map((call) => call.slice(0, 2)),
+      [
+        ['getCollaboratorPermission', 'maintainer'],
+        ['getRef', 'cf-preview/pr-123'],
+        ['updateRef', 'cf-preview/pr-123'],
+        ['getPullRequestByHead', 'cf-preview/pr-123'],
+        ['updatePullRequest', 456],
+        ['listIssueComments', 123],
+        ['createIssueComment', 123],
+        ['removeIssueLabel', 123],
+      ],
+    )
   })
 
   it('ignores checked managed comments edited on a different pull request issue', async () => {
@@ -333,7 +382,7 @@ describe('preview-mirror-lib', () => {
     await client.createPullRequest({
       base: 'develop',
       body: 'old body',
-      draft: false,
+      draft: true,
       head: 'cf-preview/pr-123',
       title: 'preview: mirror fork PR #123',
     })

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.test.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.test.mjs
@@ -38,7 +38,7 @@ function labeledEvent(labelName = 'trigger-preview') {
   }
 }
 
-function checkboxEvent(body) {
+function checkboxEvent(body, issueNumber = 123) {
   return {
     action: 'edited',
     comment: {
@@ -46,7 +46,7 @@ function checkboxEvent(body) {
       id: 777,
     },
     issue: {
-      number: 123,
+      number: issueNumber,
       pull_request: {},
     },
   }
@@ -294,6 +294,38 @@ describe('preview-mirror-lib', () => {
     )
     const updateCall = client.calls.find((call) => call[0] === 'updateIssueComment')
     assert.match(updateCall[2], /- \[ \] Sync Cloudflare preview to latest fork commit/)
+  })
+
+  it('ignores checked managed comments edited on a different pull request issue', async () => {
+    const checkedComment = buildPreviewCommentBody({
+      actor: 'maintainer',
+      branchName: 'cf-preview/pr-123',
+      mirrorPullRequestNumber: 456,
+      mirrorPullRequestUrl: 'https://github.com/cowprotocol/cowswap/pull/456',
+      now: new Date('2026-06-05T10:30:00.000Z'),
+      originalPrNumber: 123,
+      repoFullName: 'cowprotocol/cowswap',
+      sourceBranch: 'feature/new-swap',
+      sourceRepoFullName: 'external/cowswap',
+      sourceSha: 'abc1234567890abcdef1234567890abcdef1234',
+    }).replace('- [ ] Sync Cloudflare preview', '- [x] Sync Cloudflare preview')
+    const client = createFakeClient({ refExists: true })
+
+    const result = await handlePreviewMirrorEvent({
+      actor: 'maintainer',
+      client,
+      event: checkboxEvent(checkedComment, 124),
+      now: new Date('2026-06-05T10:45:00.000Z'),
+      options: {
+        repoFullName: 'cowprotocol/cowswap',
+      },
+    })
+
+    assert.deepEqual(result, {
+      reason: 'managed comment issue does not match original pull request',
+      status: 'ignored',
+    })
+    assert.deepEqual(client.calls, [])
   })
 
   it('deletes the preview branch when the source fork PR closes', async () => {

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.test.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.test.mjs
@@ -124,9 +124,9 @@ function createFakeClient({ comments = [], permission = 'write', pullRequest = f
       }
       return { object: { sha: 'oldsha' } }
     },
-    async listIssueComments(issueNumber) {
-      calls.push(['listIssueComments', issueNumber])
-      return storedComments
+    async findIssueComment(issueNumber, predicate) {
+      calls.push(['findIssueComment', issueNumber])
+      return storedComments.find(predicate) ?? null
     },
     async removeIssueLabel(issueNumber, labelName) {
       calls.push(['removeIssueLabel', issueNumber, labelName])
@@ -203,7 +203,7 @@ describe('preview-mirror-lib', () => {
           title: 'preview: mirror fork PR #123',
         }],
         ['addIssueLabels', 456],
-        ['listIssueComments', 123],
+        ['findIssueComment', 123],
         ['createIssueComment', 123],
         ['removeIssueLabel', 123],
       ],
@@ -323,7 +323,7 @@ describe('preview-mirror-lib', () => {
         ['updateRef', 'cf-preview/pr-123'],
         ['getPullRequestByHead', 'cf-preview/pr-123'],
         ['updatePullRequest', 456],
-        ['listIssueComments', 123],
+        ['findIssueComment', 123],
         ['createIssueComment', 123],
         ['removeIssueLabel', 123],
       ],
@@ -383,7 +383,7 @@ describe('preview-mirror-lib', () => {
     assert.deepEqual(
       client.calls.map((call) => call.slice(0, 2)),
       [
-        ['listIssueComments', 123],
+        ['findIssueComment', 123],
         ['getPullRequestByHead', 'cf-preview/pr-123'],
         ['updateIssueComment', 999],
       ],

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.test.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror-lib.test.mjs
@@ -8,6 +8,10 @@ import {
   parseSyncRequest,
 } from './preview-mirror-lib.mjs'
 
+const SOURCE_SHA = 'abc1234567890abcdef1234567890abcdef12345'
+const NEXT_SOURCE_SHA = 'def4567890abcdef1234567890abcdef12345678'
+const APPROVED_SOURCE_SHA = '1111111111111111111111111111111111111111'
+
 function forkPullRequest(overrides = {}) {
   return {
     base: {
@@ -21,7 +25,7 @@ function forkPullRequest(overrides = {}) {
       repo: {
         full_name: 'external/cowswap',
       },
-      sha: 'abc1234567890abcdef1234567890abcdef1234',
+      sha: SOURCE_SHA,
     },
     html_url: 'https://github.com/cowprotocol/cowswap/pull/123',
     number: 123,
@@ -49,6 +53,13 @@ function checkboxEvent(body, issueNumber = 123) {
       number: issueNumber,
       pull_request: {},
     },
+  }
+}
+
+function synchronizeEvent(pullRequest = forkPullRequest()) {
+  return {
+    action: 'synchronize',
+    pull_request: pullRequest,
   }
 }
 
@@ -126,6 +137,10 @@ function createFakeClient({ comments = [], permission = 'write', pullRequest = f
     },
     async updateIssueComment(commentId, body) {
       calls.push(['updateIssueComment', commentId, body])
+      const storedComment = storedComments.find((comment) => comment.id === commentId)
+      if (storedComment) {
+        storedComment.body = body
+      }
       return { id: commentId }
     },
     async updatePullRequest(prNumber, payload) {
@@ -161,34 +176,63 @@ describe('preview-mirror-lib', () => {
       repoFullName: 'cowprotocol/cowswap',
       sourceBranch: 'feature/new-swap',
       sourceRepoFullName: 'external/cowswap',
-      sourceSha: 'abc1234567890abcdef1234567890abcdef1234',
+      sourceSha: SOURCE_SHA,
     })
 
-    assert.match(body, /<!-- cf-pages-preview-mirror original-pr=123 -->/)
+    assert.match(
+      body,
+      /<!-- cf-pages-preview-mirror original-pr=123 target-sha=abc1234567890abcdef1234567890abcdef12345 mirrored-sha=abc1234567890abcdef1234567890abcdef12345 -->/,
+    )
     assert.match(body, /`cf-preview\/pr-123`/)
     assert.match(body, /Mirror PR: #456/)
     assert.match(body, /Cloudflare Pages preview links will be posted on the mirror PR/)
     assert.doesNotMatch(body, /pages\.dev/)
-    assert.match(body, /Mirrored SHA: `abc123456789`/)
-    assert.match(body, /- \[ \] Sync Cloudflare preview to latest fork commit/)
+    assert.match(body, /Approval target SHA: `abc123456789`/)
+    assert.match(body, /Last mirrored SHA: `abc123456789`/)
+    assert.match(body, /- \[ \] Sync Cloudflare preview to approval target commit/)
+    assert.doesNotMatch(body, /latest fork commit/)
   })
 
   it('parses checked sync requests from managed comments', () => {
     const parsed = parseSyncRequest(`
-<!-- cf-pages-preview-mirror original-pr=123 -->
-- [x] Sync Cloudflare preview to latest fork commit
+<!-- cf-pages-preview-mirror original-pr=123 target-sha=${APPROVED_SOURCE_SHA} mirrored-sha=${SOURCE_SHA} -->
+- [x] Sync Cloudflare preview to approval target commit
 `)
 
-    assert.deepEqual(parsed, { originalPrNumber: 123, shouldSync: true })
+    assert.deepEqual(parsed, {
+      mirroredSha: SOURCE_SHA,
+      originalPrNumber: 123,
+      shouldSync: true,
+      targetSha: APPROVED_SOURCE_SHA,
+    })
   })
 
   it('ignores unchecked managed comments', () => {
     const parsed = parseSyncRequest(`
-<!-- cf-pages-preview-mirror original-pr=123 -->
-- [ ] Sync Cloudflare preview to latest fork commit
+<!-- cf-pages-preview-mirror original-pr=123 target-sha=${SOURCE_SHA} mirrored-sha=${SOURCE_SHA} -->
+- [ ] Sync Cloudflare preview to approval target commit
 `)
 
-    assert.deepEqual(parsed, { originalPrNumber: 123, shouldSync: false })
+    assert.deepEqual(parsed, {
+      mirroredSha: SOURCE_SHA,
+      originalPrNumber: 123,
+      shouldSync: false,
+      targetSha: SOURCE_SHA,
+    })
+  })
+
+  it('ignores legacy sync checkbox text', () => {
+    const parsed = parseSyncRequest(`
+<!-- cf-pages-preview-mirror original-pr=123 target-sha=${APPROVED_SOURCE_SHA} mirrored-sha=${SOURCE_SHA} -->
+- [x] Sync Cloudflare preview to latest fork commit
+`)
+
+    assert.deepEqual(parsed, {
+      mirroredSha: SOURCE_SHA,
+      originalPrNumber: 123,
+      shouldSync: false,
+      targetSha: APPROVED_SOURCE_SHA,
+    })
   })
 
   it('creates a preview branch, comments on the original PR, and removes the trigger label', async () => {
@@ -253,9 +297,20 @@ describe('preview-mirror-lib', () => {
       repoFullName: 'cowprotocol/cowswap',
       sourceBranch: 'feature/new-swap',
       sourceRepoFullName: 'external/cowswap',
-      sourceSha: 'abc1234567890abcdef1234567890abcdef1234',
+      sourceSha: APPROVED_SOURCE_SHA,
     }).replace('- [ ] Sync Cloudflare preview', '- [x] Sync Cloudflare preview')
-    const client = createFakeClient({ refExists: true })
+    const client = createFakeClient({
+      pullRequest: forkPullRequest({
+        head: {
+          ref: 'feature/new-swap',
+          repo: {
+            full_name: 'external/cowswap',
+          },
+          sha: NEXT_SOURCE_SHA,
+        },
+      }),
+      refExists: true,
+    })
 
     const result = await handlePreviewMirrorEvent({
       actor: 'maintainer',
@@ -288,7 +343,7 @@ describe('preview-mirror-lib', () => {
             '',
             'Source PR: https://github.com/cowprotocol/cowswap/pull/123',
             'Source fork branch: `external/cowswap:feature/new-swap`',
-            'Mirrored SHA: `abc123456789`',
+            'Mirrored SHA: `111111111111`',
             '',
             'Do not merge this PR. Close the source PR to clean up this mirror.',
           ].join('\n'),
@@ -300,8 +355,12 @@ describe('preview-mirror-lib', () => {
         ['updateIssueComment', 777],
       ],
     )
+    const updateRefCall = client.calls.find((call) => call[0] === 'updateRef')
+    assert.deepEqual(updateRefCall, ['updateRef', 'cf-preview/pr-123', APPROVED_SOURCE_SHA])
     const updateCall = client.calls.find((call) => call[0] === 'updateIssueComment')
-    assert.match(updateCall[2], /- \[ \] Sync Cloudflare preview to latest fork commit/)
+    assert.match(updateCall[2], /Approval target SHA: `def4567890ab`/)
+    assert.match(updateCall[2], /Last mirrored SHA: `111111111111`/)
+    assert.match(updateCall[2], /- \[ \] Sync Cloudflare preview to approval target commit/)
   })
 
   it('updates an existing mirror pull request without adding labels', async () => {
@@ -345,6 +404,70 @@ describe('preview-mirror-lib', () => {
     )
   })
 
+  it('refreshes the approval target comment on fork PR synchronize without mirroring code', async () => {
+    const existingComment = buildPreviewCommentBody({
+      actor: 'maintainer',
+      branchName: 'cf-preview/pr-123',
+      mirrorPullRequestNumber: 456,
+      mirrorPullRequestUrl: 'https://github.com/cowprotocol/cowswap/pull/456',
+      now: new Date('2026-06-05T10:30:00.000Z'),
+      originalPrNumber: 123,
+      repoFullName: 'cowprotocol/cowswap',
+      sourceBranch: 'feature/new-swap',
+      sourceRepoFullName: 'external/cowswap',
+      sourceSha: SOURCE_SHA,
+    })
+    const client = createFakeClient({
+      comments: [{ body: existingComment, id: 999, user: { type: 'Bot' } }],
+      refExists: true,
+    })
+    await client.createPullRequest({
+      base: 'develop',
+      body: 'old body',
+      draft: true,
+      head: 'cf-preview/pr-123',
+      title: 'preview: mirror fork PR #123',
+    })
+    client.calls.length = 0
+
+    const result = await handlePreviewMirrorEvent({
+      actor: 'external-contributor',
+      client,
+      event: synchronizeEvent(
+        forkPullRequest({
+          head: {
+            ref: 'feature/new-swap',
+            repo: {
+              full_name: 'external/cowswap',
+            },
+            sha: NEXT_SOURCE_SHA,
+          },
+        }),
+      ),
+      now: new Date('2026-06-05T10:45:00.000Z'),
+      options: {
+        repoFullName: 'cowprotocol/cowswap',
+      },
+    })
+
+    assert.deepEqual(result, {
+      branchName: 'cf-preview/pr-123',
+      status: 'approval-target-updated',
+    })
+    assert.deepEqual(
+      client.calls.map((call) => call.slice(0, 2)),
+      [
+        ['listIssueComments', 123],
+        ['getPullRequestByHead', 'cf-preview/pr-123'],
+        ['updateIssueComment', 999],
+      ],
+    )
+    const updateCall = client.calls.find((call) => call[0] === 'updateIssueComment')
+    assert.match(updateCall[2], /Approval target SHA: `def4567890ab`/)
+    assert.match(updateCall[2], /Last mirrored SHA: `abc123456789`/)
+    assert.match(updateCall[2], /- \[ \] Sync Cloudflare preview to approval target commit/)
+  })
+
   it('ignores checked managed comments edited on a different pull request issue', async () => {
     const checkedComment = buildPreviewCommentBody({
       actor: 'maintainer',
@@ -356,7 +479,7 @@ describe('preview-mirror-lib', () => {
       repoFullName: 'cowprotocol/cowswap',
       sourceBranch: 'feature/new-swap',
       sourceRepoFullName: 'external/cowswap',
-      sourceSha: 'abc1234567890abcdef1234567890abcdef1234',
+      sourceSha: SOURCE_SHA,
     }).replace('- [ ] Sync Cloudflare preview', '- [x] Sync Cloudflare preview')
     const client = createFakeClient({ refExists: true })
 

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror.mjs
@@ -37,9 +37,7 @@ async function main() {
     client,
     event,
     options: {
-      branchPrefix: process.env.PREVIEW_BRANCH_PREFIX,
       repoFullName,
-      triggerLabel: process.env.PREVIEW_TRIGGER_LABEL,
     },
   })
 

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror.mjs
@@ -18,7 +18,8 @@
 
 import fs from 'node:fs'
 
-import { createGitHubClient, handlePreviewMirrorEvent } from './preview-mirror-lib.mjs'
+import { createGitHubClient } from './github-client.mjs'
+import { handlePreviewMirrorEvent } from './preview-mirror-lib.mjs'
 
 async function main() {
   const eventPath = getRequiredEnv('GITHUB_EVENT_PATH')

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+/**
+ * GitHub Actions entrypoint for Cloudflare Pages fork-preview mirroring.
+ *
+ * This script is intentionally separate from the other scripts in
+ * `tools/scripts/cf-pages`, which are local/operator Cloudflare API utilities.
+ * It is meant to run only inside the `cf-pages-preview-mirror.yml` GitHub
+ * Actions workflow with GitHub's event context available via
+ * `GITHUB_EVENT_PATH`, `GITHUB_REPOSITORY`, `GITHUB_ACTOR`, and `GITHUB_TOKEN`.
+ *
+ * It does not use Cloudflare credentials. Its only job is to create, update,
+ * or delete an upstream GitHub preview branch and mirror PR so the native
+ * Cloudflare Pages Git integration can build and comment on that PR.
+ */
+
+import fs from 'node:fs'
+
+import { createGitHubClient, handlePreviewMirrorEvent } from './preview-mirror-lib.mjs'
+
+async function main() {
+  const eventPath = getRequiredEnv('GITHUB_EVENT_PATH')
+  const event = JSON.parse(fs.readFileSync(eventPath, 'utf8'))
+  const repoFullName = getRequiredEnv('GITHUB_REPOSITORY')
+  const token = getRequiredEnv('GITHUB_TOKEN')
+  const actor = getRequiredEnv('GITHUB_ACTOR')
+  const client = createGitHubClient({
+    repoFullName,
+    token,
+  })
+
+  const result = await handlePreviewMirrorEvent({
+    actor,
+    client,
+    event,
+    options: {
+      branchPrefix: process.env.PREVIEW_BRANCH_PREFIX,
+      repoFullName,
+      triggerLabel: process.env.PREVIEW_TRIGGER_LABEL,
+    },
+  })
+
+  process.stdout.write(`${JSON.stringify(result)}\n`)
+}
+
+function getRequiredEnv(name) {
+  const value = process.env[name]
+
+  if (!value) {
+    throw new Error(`${name} env var is required.`)
+  }
+
+  return value
+}
+
+main().catch((error) => {
+  process.stderr.write(`ERROR: ${error.message}\n`)
+  process.exit(1)
+})

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror.mjs
@@ -11,7 +11,9 @@
  *
  * It does not use Cloudflare credentials. Its only job is to create, update,
  * or delete an upstream GitHub preview branch and mirror PR so the native
- * Cloudflare Pages Git integration can build and comment on that PR.
+ * Cloudflare Pages Git integration can build and comment on that PR. On fork
+ * pushes, it only refreshes the managed approval comment with the new target
+ * SHA; it does not mirror code until a trusted maintainer checks the box.
  */
 
 import fs from 'node:fs'


### PR DESCRIPTION
# Summary

Different from Vercel, cf-pages do not trigger builds on forks.
This PR adds a new gh action to mirror forked PRs, so they can have cf-pages deployments.

To use it, a maintainer must add the label `trigger-preview` to the forked PR.
It'll then add a comment with the mirrored PR, where cf should publish the preview links.
Once there are changes, the maintainer can go to the PR comment and click on the checkbox, triggered a re-sync.

# To Test

Only after merged.

1. Fork the repo
2. Send a pull request
3. With a maintainer account, add the label `trigger-preview`
* Should add a comment pointing to the mirrored PR
4. Add changes to the PR
5. Click on the PR comment's checkbox
* Should refresh the mirrored PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled Cloudflare Pages preview branch mirroring for pull requests, including automatic mirror PR creation, continued sync controlled by a managed PR comment (checkbox), and cleanup when the source PR closes.
* **Chores**
  * Added a dedicated GitHub Actions workflow to mirror preview branches, and tightened CI/i18n triggers to skip preview mirror branches.
* **Tests**
  * Expanded coverage for preview mirror naming, mirror PR/comment behavior, and the GitHub API client (paging and error handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->