### PR TITLE
fix(bridge): fix recipient param in quote

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/__snapshots__/useTradeQuotePolling.test.tsx.snap
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/__snapshots__/useTradeQuotePolling.test.tsx.snap
@@ -38,6 +38,7 @@ exports[`useTradeQuotePolling() When wallet is connected Then should put account
     "account": "0x333333f332a06ecb5d20d35da44ba07986d6e203",
     "amount": 10000000n,
     "appCode": "CoW Swap",
+    "bridgeRecipient": "0x333333f332a06ecb5d20d35da44ba07986d6e203",
     "buyTokenAddress": "0x0625aFB445C3B6B7B929342a04A22599fd5dBB59",
     "buyTokenChainId": 11155111,
     "buyTokenDecimals": 18,

--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useQuoteParamsRecipient.test.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useQuoteParamsRecipient.test.ts
@@ -115,7 +115,10 @@ describe('useQuoteParamsRecipient', () => {
 
       const { result } = renderHook(() => useQuoteParamsRecipient())
 
-      expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: undefined })
+      expect(result.current).toEqual({
+        receiver: ACCOUNT_ADDRESS,
+        bridgeRecipient: ACCOUNT_ADDRESS,
+      })
     })
 
     it('should use recipientAddress when recipient is ENS name with resolved address', () => {
@@ -123,7 +126,7 @@ describe('useQuoteParamsRecipient', () => {
 
       const { result } = renderHook(() => useQuoteParamsRecipient())
 
-      expect(result.current).toEqual({ receiver: ANOTHER_VALID_ADDRESS, bridgeRecipient: undefined })
+      expect(result.current).toEqual({ receiver: ANOTHER_VALID_ADDRESS, bridgeRecipient: ANOTHER_VALID_ADDRESS })
     })
 
     it('should fall back to account when recipient is invalid', () => {
@@ -131,7 +134,7 @@ describe('useQuoteParamsRecipient', () => {
 
       const { result } = renderHook(() => useQuoteParamsRecipient())
 
-      expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: undefined })
+      expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: ACCOUNT_ADDRESS })
     })
 
     it('should fall back to account when recipient is not set', () => {
@@ -139,7 +142,7 @@ describe('useQuoteParamsRecipient', () => {
 
       const { result } = renderHook(() => useQuoteParamsRecipient())
 
-      expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: undefined })
+      expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: ACCOUNT_ADDRESS })
     })
   })
 
@@ -153,7 +156,7 @@ describe('useQuoteParamsRecipient', () => {
 
       const { result } = renderHook(() => useQuoteParamsRecipient())
 
-      expect(result.current).toEqual({ receiver: VALID_ADDRESS, bridgeRecipient: undefined })
+      expect(result.current).toEqual({ receiver: VALID_ADDRESS, bridgeRecipient: VALID_ADDRESS })
     })
 
     it('should return account when recipientAddress is undefined', () => {
@@ -161,7 +164,7 @@ describe('useQuoteParamsRecipient', () => {
 
       const { result } = renderHook(() => useQuoteParamsRecipient())
 
-      expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: undefined })
+      expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: ACCOUNT_ADDRESS })
     })
 
     it('should return account when recipientAddress is invalid', () => {
@@ -169,7 +172,7 @@ describe('useQuoteParamsRecipient', () => {
 
       const { result } = renderHook(() => useQuoteParamsRecipient())
 
-      expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: undefined })
+      expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: ACCOUNT_ADDRESS })
     })
 
     it('should ignore recipient and use recipientAddress when both are valid EVM', () => {
@@ -177,7 +180,7 @@ describe('useQuoteParamsRecipient', () => {
 
       const { result } = renderHook(() => useQuoteParamsRecipient())
 
-      expect(result.current).toEqual({ receiver: ANOTHER_VALID_ADDRESS, bridgeRecipient: undefined })
+      expect(result.current).toEqual({ receiver: ANOTHER_VALID_ADDRESS, bridgeRecipient: ANOTHER_VALID_ADDRESS })
     })
 
     it('should use recipient when recipientAddress is not set', () => {
@@ -185,7 +188,7 @@ describe('useQuoteParamsRecipient', () => {
 
       const { result } = renderHook(() => useQuoteParamsRecipient())
 
-      expect(result.current).toEqual({ receiver: VALID_ADDRESS, bridgeRecipient: undefined })
+      expect(result.current).toEqual({ receiver: VALID_ADDRESS, bridgeRecipient: VALID_ADDRESS })
     })
   })
 
@@ -199,7 +202,7 @@ describe('useQuoteParamsRecipient', () => {
 
       const { result } = renderHook(() => useQuoteParamsRecipient())
 
-      expect(result.current).toEqual({ receiver: VALID_ADDRESS, bridgeRecipient: undefined })
+      expect(result.current).toEqual({ receiver: VALID_ADDRESS, bridgeRecipient: VALID_ADDRESS })
     })
 
     it('should return account when nothing is set', () => {
@@ -207,7 +210,7 @@ describe('useQuoteParamsRecipient', () => {
 
       const { result } = renderHook(() => useQuoteParamsRecipient())
 
-      expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: undefined })
+      expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: ACCOUNT_ADDRESS })
     })
 
     it('should return recipient when it is a valid EVM address', () => {
@@ -215,7 +218,7 @@ describe('useQuoteParamsRecipient', () => {
 
       const { result } = renderHook(() => useQuoteParamsRecipient())
 
-      expect(result.current).toEqual({ receiver: VALID_ADDRESS, bridgeRecipient: undefined })
+      expect(result.current).toEqual({ receiver: VALID_ADDRESS, bridgeRecipient: VALID_ADDRESS })
     })
 
     it('should return account when recipient is invalid non-EVM/non-Solana/non-BTC string', () => {
@@ -223,7 +226,7 @@ describe('useQuoteParamsRecipient', () => {
 
       const { result } = renderHook(() => useQuoteParamsRecipient())
 
-      expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: undefined })
+      expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: ACCOUNT_ADDRESS })
     })
   })
 
@@ -269,7 +272,7 @@ describe('useQuoteParamsRecipient', () => {
 
       const { result } = renderHook(() => useQuoteParamsRecipient())
 
-      expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: undefined })
+      expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: ACCOUNT_ADDRESS })
     })
 
     it('should reject BTC address when output chain is EVM (chainId=1)', () => {
@@ -277,7 +280,7 @@ describe('useQuoteParamsRecipient', () => {
 
       const { result } = renderHook(() => useQuoteParamsRecipient())
 
-      expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: undefined })
+      expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: ACCOUNT_ADDRESS })
     })
 
     it('should accept SOL address when outputCurrency is null (backward compat)', () => {
@@ -323,7 +326,7 @@ describe('useQuoteParamsRecipient', () => {
 
       const { result } = renderHook(() => useQuoteParamsRecipient())
 
-      expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: undefined })
+      expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: ACCOUNT_ADDRESS })
     })
 
     it('should return undefined bridgeRecipient when outputCurrency is null and no recipient is set', () => {
@@ -331,7 +334,7 @@ describe('useQuoteParamsRecipient', () => {
 
       const { result } = renderHook(() => useQuoteParamsRecipient())
 
-      expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: undefined })
+      expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: ACCOUNT_ADDRESS })
     })
   })
 

--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useQuoteParamsRecipient.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useQuoteParamsRecipient.ts
@@ -24,17 +24,17 @@ export function useQuoteParamsRecipient(): { receiver: Nullish<string>; bridgeRe
     // Non-EVM recipient (Solana/BTC): pass as bridgeRecipient for the bridge provider,
     // and use account as the EVM receiver for the CoW API.
     // Non-EVM always takes priority over the bridge provider type — do not reorder.
-    const bridgeRecipient = resolveNonEvmBridgeRecipient(recipient, outputCurrency)
-    if (bridgeRecipient) {
-      return { receiver: account, bridgeRecipient }
+    const nonEvmBridgeRecipient = resolveNonEvmBridgeRecipient(recipient, outputCurrency)
+    if (nonEvmBridgeRecipient) {
+      return { receiver: account, bridgeRecipient: nonEvmBridgeRecipient }
     }
 
     // For non-EVM output chains, always fall back to the default placeholder when no valid
     // recipient was resolved (empty, invalid, or wrong-chain input).
     // Prevents the quote API from receiving an invalid address and returning errors instead of prices.
-    const defaultBridgeRecipient = getDefaultNonEvmBridgeRecipient(outputCurrency)
-    if (defaultBridgeRecipient) {
-      return { receiver: account, bridgeRecipient: defaultBridgeRecipient }
+    const defaultNonEvmBridgeRecipient = getDefaultNonEvmBridgeRecipient(outputCurrency)
+    if (defaultNonEvmBridgeRecipient) {
+      return { receiver: account, bridgeRecipient: defaultNonEvmBridgeRecipient }
     }
 
     // EVM ReceiverAccountBridgeProvider: use the custom recipient for both
@@ -42,8 +42,10 @@ export function useQuoteParamsRecipient(): { receiver: Nullish<string>; bridgeRe
       return { receiver: recipient, bridgeRecipient: recipient }
     }
 
+    const resolvedReceiver = resolveEvmReceiver(recipientAddress, recipient, account)
+
     // Default: EVM-only receiver, no separate bridge recipient
-    return { receiver: resolveEvmReceiver(recipientAddress, recipient, account), bridgeRecipient: undefined }
+    return { receiver: resolvedReceiver, bridgeRecipient: resolvedReceiver }
   }, [isReceiverAccountBridgeProvider, account, recipient, recipientAddress, outputCurrency])
 }
 

--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useQuoteParamsRecipient.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useQuoteParamsRecipient.ts
@@ -44,7 +44,7 @@ export function useQuoteParamsRecipient(): { receiver: Nullish<string>; bridgeRe
 
     const resolvedReceiver = resolveEvmReceiver(recipientAddress, recipient, account)
 
-    // Default: EVM-only receiver, no separate bridge recipient
+    // Default: EVM receiver, used for both receiver and bridge recipient
     return { receiver: resolvedReceiver, bridgeRecipient: resolvedReceiver }
   }, [isReceiverAccountBridgeProvider, account, recipient, recipientAddress, outputCurrency])
 }


### PR DESCRIPTION
# Summary

Fixes https://app.notion.com/p/cownation/CC-03-Infinite-loop-on-bridge-quoting-36e8da5f04ca80c98d58cb1a3ff07a86?v=bec8da5f04ca8313aa9b883e472ad52c&source=copy_link

I guess this was a type, because there is a comment `Default: EVM-only receiver, **no separate bridge recipient**`, but in fact they are separate.

# To Test

1. Setup `/#/8453/swap/USDT/0xaf88d065e77c8cC2239327C5EDb3A432268e5831?targetChainId=42161`
2. Get a quote
3. Specify a custom recipient
4. Wait till the next quote is loaded
- [ ] AR: it reloads the quotes spontaniously
- [ ] ER: it doesn't reload the quote without reason (timer, parameters changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed cross-chain bridge recipient resolution to consistently apply the correct address across different transaction scenarios, improving reliability for bridge operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->