### PR TITLE
feat: improve affiliate onboarding copy

### DIFF
--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -370,6 +370,11 @@ msgstr "Unwrapping {amountStr} {wrapped} to {native}"
 msgid "{symbolName} orders require a minimum transaction expiration time threshold of {minutes} minutes to ensure the best swapping experience."
 msgstr "{symbolName} orders require a minimum transaction expiration time threshold of {minutes} minutes to ensure the best swapping experience."
 
+#: apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateTraderModalUnsupported.tsx
+#: apps/cowswap-frontend/src/modules/affiliate/pure/AffiliateTraderModal/AffiliateTradeCodeForm.tsx
+msgid "You've been referred - here's your reward"
+msgstr "You've been referred - here's your reward"
+
 #: apps/cowswap-frontend/src/modules/tokensList/containers/SelectTokenWidget/hooks/useWidgetMetadata.ts
 msgid "From network"
 msgstr "From network"
@@ -1000,8 +1005,8 @@ msgstr "Enable Hooks"
 #~ msgstr "Claim LlamaPay Vesting Hook"
 
 #: apps/cowswap-frontend/src/modules/affiliate/pure/AffiliateTraderModal/CodeLinkingSubtitle.tsx
-msgid "Swap once to activate. Earn <0>{rewardAmount}</0> per <1>{triggerVolume}</1> of eligible volume over {timeCapDays} days. Rewards are paid out weekly to your Ethereum wallet."
-msgstr "Swap once to activate. Earn <0>{rewardAmount}</0> per <1>{triggerVolume}</1> of eligible volume over {timeCapDays} days. Rewards are paid out weekly to your Ethereum wallet."
+#~ msgid "Swap once to activate. Earn <0>{rewardAmount}</0> per <1>{triggerVolume}</1> of eligible volume over {timeCapDays} days. Rewards are paid out weekly to your Ethereum wallet."
+#~ msgstr "Swap once to activate. Earn <0>{rewardAmount}</0> per <1>{triggerVolume}</1> of eligible volume over {timeCapDays} days. Rewards are paid out weekly to your Ethereum wallet."
 
 #: apps/cowswap-frontend/src/modules/yield/containers/YieldWidget/index.tsx
 msgid "Seamlessly swap your tokens into CoW AMM pools"
@@ -1019,6 +1024,10 @@ msgstr "Overview"
 #: apps/cowswap-frontend/src/modules/ethFlow/pure/EthFlowModalContent/configs.ts
 msgid "Loading operation"
 msgstr "Loading operation"
+
+#: apps/cowswap-frontend/src/modules/affiliate/pure/AffiliateTraderModal/CodeLinkingSubtitle.tsx
+msgid "Connect your wallet to activate it and start earning rewards when you trade."
+msgstr "Connect your wallet to activate it and start earning rewards when you trade."
 
 #: apps/cowswap-frontend/src/modules/affiliate/containers/AffiliatePartnerOnboard.tsx
 #~ msgid "Share your referral code and earn <0>{partnerRewardAmount}</0> for every <1>{triggerVolumeLabel}</1> in eligible volume within {affiliateTimeCapDays} days.<2/><3/>"
@@ -1195,6 +1204,10 @@ msgstr "Failed"
 #: apps/cowswap-frontend/src/modules/ordersTable/pure/ReceiptModal/ReceiptModal.modal.tsx
 msgid "The amount of extra tokens you get on top of your limit price."
 msgstr "The amount of extra tokens you get on top of your limit price."
+
+#: apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateTraderModalCodeLinking.tsx
+msgid "Connect wallet to activate"
+msgstr "Connect wallet to activate"
 
 #: apps/cowswap-frontend/src/pages/games/MevSlicer/index.tsx
 msgid "sandwich-icon"
@@ -1629,6 +1642,10 @@ msgstr "s"
 #: apps/cowswap-frontend/src/modules/ethFlow/pure/EthFlowStepper/steps/Step2.tsx
 msgid "Order Cancelled"
 msgstr "Order Cancelled"
+
+#: apps/cowswap-frontend/src/modules/affiliate/pure/AffiliateTraderModal/CodeLinkingSubtitle.tsx
+#~ msgid "Swap once to activate."
+#~ msgstr "Swap once to activate."
 
 #: apps/cowswap-frontend/src/modules/accountProxy/containers/InvalidCoWShedSetup/index.tsx
 msgid "Please contact CoW Swap support!"
@@ -2082,8 +2099,8 @@ msgid "Unknown"
 msgstr "Unknown"
 
 #: apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateTraderModalCodeLinking.tsx
-msgid "Connect to verify code"
-msgstr "Connect to verify code"
+#~ msgid "Connect to verify code"
+#~ msgstr "Connect to verify code"
 
 #: apps/cowswap-frontend/src/common/pure/AddressInputPanel/hooks/useReceiverPlaceholder.ts
 msgid "Wallet Address or ENS name"
@@ -3503,6 +3520,10 @@ msgstr "Your order expired. This could be due to gas spikes, volatile prices, or
 #: apps/cowswap-frontend/src/legacy/components/Header/NotificationAlertPopover/NotificationAlertPopover.pure.tsx
 msgid "Not now"
 msgstr "Not now"
+
+#: apps/cowswap-frontend/src/modules/affiliate/pure/AffiliateTraderModal/CodeLinkingSubtitle.tsx
+msgid "Start earning rewards when you trade."
+msgstr "Start earning rewards when you trade."
 
 #: apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTable/Content/UnsupportedNetwork/OrdersTableUnsupportedNetworkContent.tsx
 #: apps/cowswap-frontend/src/pages/Account/Tokens/TokensOverview.tsx
@@ -5421,9 +5442,7 @@ msgstr "Transaction {errorType}"
 msgid "Price impact <0>unknown</0> - trade carefully"
 msgstr "Price impact <0>unknown</0> - trade carefully"
 
-#: apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateTraderModalUnsupported.tsx
 #: apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateTraderOnboard.tsx
-#: apps/cowswap-frontend/src/modules/affiliate/pure/AffiliateTraderModal/AffiliateTradeCodeForm.tsx
 msgid "Earn while you trade"
 msgstr "Earn while you trade"
 
@@ -5801,6 +5820,10 @@ msgstr "Orders on CoW Swap can either be market orders (which fill at the market
 #: apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
 msgid "at least"
 msgstr "at least"
+
+#: apps/cowswap-frontend/src/modules/affiliate/pure/AffiliateTraderModal/CodeLinkingSubtitle.tsx
+msgid "Earn <0>{rewardAmount}</0> per <1>{triggerVolume}</1> of eligible volume over {timeCapDays} days. Rewards are paid out weekly to your Ethereum wallet."
+msgstr "Earn <0>{rewardAmount}</0> per <1>{triggerVolume}</1> of eligible volume over {timeCapDays} days. Rewards are paid out weekly to your Ethereum wallet."
 
 #: apps/cowswap-frontend/src/modules/twap/utils/deadlinePartsDisplay.ts
 msgid "m"
@@ -6460,6 +6483,10 @@ msgstr "Swap costs are at least {formattedFeePercentage}% of the swap amount"
 msgid "Limit orders on CoW Swap capture surplus - so if the price moves in your favor, you're likely to get more than you asked for."
 msgstr "Limit orders on CoW Swap capture surplus - so if the price moves in your favor, you're likely to get more than you asked for."
 
+#: apps/cowswap-frontend/src/modules/affiliate/pure/AffiliateTraderModal/CodeLinkingSubtitle.tsx
+msgid "Your friend shared a referral code with you."
+msgstr "Your friend shared a referral code with you."
+
 #: apps/cowswap-frontend/src/modules/ordersTable/pure/ReceiptModal/ReceiptModal.modal.tsx
 msgid "Avg. execution price"
 msgstr "Avg. execution price"
@@ -6856,6 +6883,10 @@ msgstr "Connect signer"
 #: apps/cowswap-frontend/src/modules/accountProxy/pure/WalletNotConnected/index.tsx
 msgid "Connect wallet banner"
 msgstr "Connect wallet banner"
+
+#: apps/cowswap-frontend/src/modules/affiliate/pure/AffiliateTraderModal/CodeLinkingSubtitle.tsx
+#~ msgid "Your friend shared a referral code with you. Connect your wallet to activate it and start earning rewards when you trade."
+#~ msgstr "Your friend shared a referral code with you. Connect your wallet to activate it and start earning rewards when you trade."
 
 #: apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/SettingsDropdown/SettingsDropdown.container.tsx
 msgid "Enable Partial Approvals"

--- a/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateTraderModalCodeLinking.tsx
+++ b/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateTraderModalCodeLinking.tsx
@@ -47,7 +47,7 @@ export function AffiliateTraderModalCodeLinking(): ReactNode {
   const submitButtonLabel = useMemo(() => {
     if (isVerifying) return t`Checking code...`
     if (savedCode) return t`Start trading`
-    if (!account) return t`Connect to verify code`
+    if (!account) return t`Connect wallet to activate`
     return t`Verify code`
   }, [account, isVerifying, savedCode])
 

--- a/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateTraderModalUnsupported.tsx
+++ b/apps/cowswap-frontend/src/modules/affiliate/containers/AffiliateTraderModalUnsupported.tsx
@@ -14,7 +14,7 @@ export function AffiliateTraderModalUnsupported(): ReactNode {
       <Body>
         <img src={svgEarnAsTraderSrc} alt="" role="presentation" />
         <Title>
-          <Trans>Earn while you trade</Trans>
+          <Trans>You&apos;ve been referred - here&apos;s your reward</Trans>
         </Title>
         <CodeLinkingSubtitle />
       </Body>

--- a/apps/cowswap-frontend/src/modules/affiliate/hooks/useAffiliateTraderCodeInput.ts
+++ b/apps/cowswap-frontend/src/modules/affiliate/hooks/useAffiliateTraderCodeInput.ts
@@ -40,7 +40,7 @@ export function useAffiliateTraderCodeInput(): UseAffiliateTraderCodeInputResult
   useAffiliateTraderCodeFromUrl(onRecoveredFromUrl)
 
   useEffect(() => {
-    if (shouldAutoVerify.current && !!account) {
+    if (shouldAutoVerify.current && !!account && !!codeInput) {
       shouldAutoVerify.current = false
       verifyCode(codeInput, account)
     }

--- a/apps/cowswap-frontend/src/modules/affiliate/pure/AffiliateTraderModal/AffiliateTradeCodeForm.tsx
+++ b/apps/cowswap-frontend/src/modules/affiliate/pure/AffiliateTraderModal/AffiliateTradeCodeForm.tsx
@@ -80,9 +80,9 @@ export function AffiliateTradeCodeForm({
       <Body>
         <img src={svgEarnAsTraderSrc} alt="" role="presentation" />
         <Title>
-          <Trans>Earn while you trade</Trans>
+          <Trans>You&apos;ve been referred - here&apos;s your reward</Trans>
         </Title>
-        <CodeLinkingSubtitle codeInfo={codeInfo} />
+        <CodeLinkingSubtitle codeInfo={codeInfo} isWalletConnected={!!account} />
         <LabelRow>
           <Label htmlFor={referralCodeInputId}>
             <LabelContent>

--- a/apps/cowswap-frontend/src/modules/affiliate/pure/AffiliateTraderModal/CodeLinkingSubtitle.tsx
+++ b/apps/cowswap-frontend/src/modules/affiliate/pure/AffiliateTraderModal/CodeLinkingSubtitle.tsx
@@ -16,19 +16,26 @@ import { HowItWorks } from '../HowItWorks'
 
 export interface CodeLinkingSubtitleProps {
   codeInfo?: TraderInfoResponse | null
+  isWalletConnected?: boolean
 }
 
 export function CodeLinkingSubtitle(props: CodeLinkingSubtitleProps): ReactNode {
-  const { codeInfo } = props
+  const { codeInfo, isWalletConnected } = props
   const rewardAmount = formatUsdcCompact(codeInfo?.traderRewardAmount ?? getDefaultTraderRewardAmount())
   const triggerVolume = formatUsdCompact(codeInfo?.triggerVolume ?? getDefaultTriggerVolume())
   const timeCapDays = codeInfo?.timeCapDays ?? PROGRAM_DEFAULTS.AFFILIATE_TIME_CAP_DAYS
 
   return (
     <Subtitle>
+      <Trans>Your friend shared a referral code with you.</Trans>{' '}
+      {isWalletConnected ? (
+        <Trans>Start earning rewards when you trade.</Trans>
+      ) : (
+        <Trans>Connect your wallet to activate it and start earning rewards when you trade.</Trans>
+      )}{' '}
       <Trans>
-        Swap once to activate. Earn <strong>{rewardAmount}</strong> per <strong>{triggerVolume}</strong> of eligible
-        volume over {timeCapDays} days. Rewards are paid out weekly to your Ethereum wallet.
+        Earn <strong>{rewardAmount}</strong> per <strong>{triggerVolume}</strong> of eligible volume over {timeCapDays}{' '}
+        days. Rewards are paid out weekly to your Ethereum wallet.
       </Trans>{' '}
       <HowItWorks />
     </Subtitle>


### PR DESCRIPTION
# Summary

Fixes https://nomevlabs.slack.com/archives/C07BMTK4F19/p1780912787999709

Improves affiliate referral modal copy so referred traders understand they are activating a shared reward code, not creating their own affiliate link.

Also includes fix commit 4b62838d8781b5c15339da204f93a5bc1a1d6a70, which prevents a race in auto-verifying a URL referral code before the input state is populated.

# To Test

1. Open Swap with `/?ref=COWBOY`

- [ ] Modal says `You've been referred - here's your reward`
- [ ] Disconnected CTA says `Connect wallet to activate`
- [ ] After connecting, the URL code remains populated and verifies without an empty-code format error

# Background

Old copy made the referred-trader flow look like affiliate-code creation.


Before & after:
<img width="373" alt="Screenshot From 2026-06-10 14-56-55" src="https://github.com/user-attachments/assets/53a9bb09-3f37-4b4d-a280-6062d28033e1" /> <img width="356" alt="Screenshot From 2026-06-10 15-40-49" src="https://github.com/user-attachments/assets/66068e7e-f57b-4874-8841-ea3dd00056f2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updated referral modal messaging to reflect “You’ve been referred—here’s your reward”, including clearer reward timing and earning call-to-actions.
  * Improved referral code linking subtitles to show the right instruction depending on whether a wallet is connected.

* **Bug Fixes**
  * Prevented automatic referral code verification from running unless a wallet is connected and a referral code has been entered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->