### PR TITLE
[codex] Track blocked TWAP wallet demand

### DIFF
--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/index.tsx
@@ -9,6 +9,7 @@ import { TradeFormValidation } from 'modules/tradeFormValidation/types'
 import { useTradeQuoteFeeFiatAmount } from 'modules/tradeQuote'
 import { SellNativeWarningBanner } from 'modules/tradeWidgetAddons'
 
+import { useUnsupportedWalletAnalytics } from './useUnsupportedWalletAnalytics'
 import {
   FallbackHandlerWarning,
   SmallPartTimeWarning,
@@ -47,6 +48,7 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
   const { canTrade, walletIsNotConnected } = useTwapWarningsContext()
   const tradeUrlParams = useTradeRouteContext()
   const isSafeViaWc = useIsSafeViaWc()
+  const unsupportedWalletAnalyticsData = useUnsupportedWalletAnalytics({ isSafeViaWc, localFormValidation })
 
   const toggleFallbackHandlerSetupFlag = useCallback(
     (isFallbackHandlerSetupAccepted: boolean) => {
@@ -73,7 +75,14 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
     <>
       {(() => {
         if (localFormValidation === TwapFormState.TX_BUNDLING_NOT_SUPPORTED) {
-          return <UnsupportedWalletWarning isSafeViaWc={isSafeViaWc} chainId={chainId} account={account} />
+          return (
+            <UnsupportedWalletWarning
+              analyticsData={unsupportedWalletAnalyticsData}
+              isSafeViaWc={isSafeViaWc}
+              chainId={chainId}
+              account={account}
+            />
+          )
         }
 
         if (primaryFormValidation === TradeFormValidation.SellNativeToken) {

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/unsupportedWalletAnalytics.utils.test.ts
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/unsupportedWalletAnalytics.utils.test.ts
@@ -1,0 +1,69 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import {
+  createUnsupportedWalletAnalyticsEvent,
+  getUnsupportedWalletAnalyticsSignature,
+  UnsupportedWalletAnalyticsData,
+} from './unsupportedWalletAnalytics.utils'
+
+import { ExtensibleFallbackVerification } from '../../services/verifyExtensibleFallback'
+
+const analyticsData: UnsupportedWalletAnalyticsData = {
+  chainId: SupportedChainId.MAINNET,
+  walletName: 'MetaMask',
+  isSafeViaWc: false,
+  isSmartContractWallet: false,
+  verificationState: ExtensibleFallbackVerification.HAS_NOTHING,
+  sellTokenSymbol: 'COW',
+  buyTokenSymbol: 'ETH',
+  sellAmount: '10',
+  buyAmount: '0.1',
+  sellAmountUsd: '12.34',
+  buyAmountUsd: '12.28',
+}
+
+describe('unsupportedWalletAnalytics.utils', () => {
+  it('creates a TWAP blocked-wallet analytics event with trade context', () => {
+    expect(createUnsupportedWalletAnalyticsEvent('twap_unsupported_wallet_viewed', analyticsData)).toEqual({
+      category: 'TWAP',
+      action: 'twap_unsupported_wallet_viewed',
+      label: 'unsupported_wallet',
+      chainId: SupportedChainId.MAINNET,
+      blocked_reason: 'tx_bundling_not_supported',
+      warning_variant: 'unsupported_wallet',
+      wallet_name: 'MetaMask',
+      is_safe_via_wc: false,
+      is_smart_contract_wallet: false,
+      verification_state: ExtensibleFallbackVerification.HAS_NOTHING,
+      sell_token_symbol: 'COW',
+      buy_token_symbol: 'ETH',
+      sell_amount: '10',
+      buy_amount: '0.1',
+      sell_amount_usd: '12.34',
+      buy_amount_usd: '12.28',
+    })
+  })
+
+  it('does not change the signature when only amounts change', () => {
+    const previousSignature = getUnsupportedWalletAnalyticsSignature(analyticsData)
+    const nextSignature = getUnsupportedWalletAnalyticsSignature({
+      ...analyticsData,
+      sellAmount: '11',
+      buyAmount: '0.11',
+      sellAmountUsd: '13.57',
+      buyAmountUsd: '13.49',
+    })
+
+    expect(nextSignature).toEqual(previousSignature)
+  })
+
+  it('changes the signature when the blocked wallet state changes', () => {
+    const previousSignature = getUnsupportedWalletAnalyticsSignature(analyticsData)
+    const nextSignature = getUnsupportedWalletAnalyticsSignature({
+      ...analyticsData,
+      isSafeViaWc: true,
+    })
+
+    expect(nextSignature).not.toEqual(previousSignature)
+  })
+})

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/unsupportedWalletAnalytics.utils.ts
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/unsupportedWalletAnalytics.utils.ts
@@ -1,0 +1,57 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import { CowSwapAnalyticsCategory, CowSwapGtmEvent } from 'common/analytics/types'
+
+import { ExtensibleFallbackVerification } from '../../services/verifyExtensibleFallback'
+
+export interface UnsupportedWalletAnalyticsData {
+  chainId: SupportedChainId
+  walletName?: string
+  isSafeViaWc: boolean
+  isSmartContractWallet: boolean | undefined
+  verificationState?: ExtensibleFallbackVerification
+  sellTokenSymbol?: string
+  buyTokenSymbol?: string
+  sellAmount?: string
+  buyAmount?: string
+  sellAmountUsd?: string
+  buyAmountUsd?: string
+}
+
+export function createUnsupportedWalletAnalyticsEvent(
+  action: string,
+  analyticsData: UnsupportedWalletAnalyticsData,
+): CowSwapGtmEvent {
+  const warningVariant = analyticsData.isSafeViaWc ? 'safe_via_wallet_connect' : 'unsupported_wallet'
+
+  return {
+    category: CowSwapAnalyticsCategory.TWAP,
+    action,
+    label: warningVariant,
+    chainId: analyticsData.chainId,
+    blocked_reason: 'tx_bundling_not_supported',
+    warning_variant: warningVariant,
+    wallet_name: analyticsData.walletName,
+    is_safe_via_wc: analyticsData.isSafeViaWc,
+    is_smart_contract_wallet: analyticsData.isSmartContractWallet,
+    verification_state: analyticsData.verificationState,
+    sell_token_symbol: analyticsData.sellTokenSymbol,
+    buy_token_symbol: analyticsData.buyTokenSymbol,
+    sell_amount: analyticsData.sellAmount,
+    buy_amount: analyticsData.buyAmount,
+    sell_amount_usd: analyticsData.sellAmountUsd,
+    buy_amount_usd: analyticsData.buyAmountUsd,
+  }
+}
+
+export function getUnsupportedWalletAnalyticsSignature(analyticsData: UnsupportedWalletAnalyticsData): string {
+  return JSON.stringify([
+    analyticsData.chainId,
+    analyticsData.walletName,
+    analyticsData.isSafeViaWc,
+    analyticsData.isSmartContractWallet,
+    analyticsData.verificationState,
+    analyticsData.sellTokenSymbol,
+    analyticsData.buyTokenSymbol,
+  ])
+}

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/useUnsupportedWalletAnalytics.ts
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/useUnsupportedWalletAnalytics.ts
@@ -1,0 +1,90 @@
+import { useEffect, useMemo, useRef } from 'react'
+
+import { useCowAnalytics } from '@cowprotocol/analytics'
+import { useWalletDetails, useWalletInfo } from '@cowprotocol/wallet'
+
+import { useAdvancedOrdersDerivedState } from 'modules/advancedOrders'
+
+import { CowSwapAnalyticsCategory } from 'common/analytics/types'
+
+import {
+  createUnsupportedWalletAnalyticsEvent,
+  getUnsupportedWalletAnalyticsSignature,
+  UnsupportedWalletAnalyticsData,
+} from './unsupportedWalletAnalytics.utils'
+
+import { useFallbackHandlerVerification } from '../../hooks/useFallbackHandlerVerification'
+import { TwapFormState } from '../../pure/PrimaryActionButton/getTwapFormState'
+
+interface UseUnsupportedWalletAnalyticsParams {
+  isSafeViaWc: boolean
+  localFormValidation: TwapFormState | null
+}
+
+export function useUnsupportedWalletAnalytics({
+  isSafeViaWc,
+  localFormValidation,
+}: UseUnsupportedWalletAnalyticsParams): UnsupportedWalletAnalyticsData {
+  const { account, chainId } = useWalletInfo()
+  const { isSmartContractWallet, walletName } = useWalletDetails()
+  const { inputCurrencyAmount, inputCurrencyFiatAmount, outputCurrencyAmount, outputCurrencyFiatAmount } =
+    useAdvancedOrdersDerivedState()
+  const verification = useFallbackHandlerVerification()
+  const cowAnalytics = useCowAnalytics()
+  const lastUnsupportedWalletEventSignatureRef = useRef<string | null>(null)
+
+  const unsupportedWalletAnalyticsData = useMemo(() => {
+    return {
+      chainId,
+      walletName,
+      isSafeViaWc,
+      isSmartContractWallet,
+      verificationState: verification ?? undefined,
+      sellTokenSymbol: inputCurrencyAmount?.currency.symbol,
+      buyTokenSymbol: outputCurrencyAmount?.currency.symbol,
+      sellAmount: inputCurrencyAmount?.toExact(),
+      buyAmount: outputCurrencyAmount?.toExact(),
+      sellAmountUsd: inputCurrencyFiatAmount?.toExact(),
+      buyAmountUsd: outputCurrencyFiatAmount?.toExact(),
+    }
+  }, [
+    chainId,
+    inputCurrencyAmount,
+    inputCurrencyFiatAmount,
+    isSafeViaWc,
+    isSmartContractWallet,
+    outputCurrencyAmount,
+    outputCurrencyFiatAmount,
+    verification,
+    walletName,
+  ])
+
+  useEffect(() => {
+    if (
+      !account ||
+      !unsupportedWalletAnalyticsData.verificationState ||
+      localFormValidation !== TwapFormState.TX_BUNDLING_NOT_SUPPORTED
+    ) {
+      return
+    }
+
+    const nextSignature = getUnsupportedWalletAnalyticsSignature(unsupportedWalletAnalyticsData)
+
+    if (lastUnsupportedWalletEventSignatureRef.current === nextSignature) {
+      return
+    }
+
+    lastUnsupportedWalletEventSignatureRef.current = nextSignature
+    // Preserve the legacy event name for downstream dashboards while routing it through the
+    // same deduped blocked-wallet impression logic as the new detailed event.
+    cowAnalytics.sendEvent({
+      category: CowSwapAnalyticsCategory.TWAP,
+      action: 'non-compatible',
+    })
+    cowAnalytics.sendEvent(
+      createUnsupportedWalletAnalyticsEvent('twap_unsupported_wallet_viewed', unsupportedWalletAnalyticsData),
+    )
+  }, [account, cowAnalytics, localFormValidation, unsupportedWalletAnalyticsData])
+
+  return unsupportedWalletAnalyticsData
+}

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/warnings/UnsupportedWalletWarning.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/warnings/UnsupportedWalletWarning.tsx
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react'
+
 import { getSafeAccountUrl } from '@cowprotocol/core'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { ExternalLink, InlineBanner, StatusColorVariant } from '@cowprotocol/ui'
@@ -6,15 +8,26 @@ import { Trans } from '@lingui/react/macro'
 
 import { UNSUPPORTED_WALLET_LINK } from 'modules/twap/const'
 
+import { toCowSwapGtmEvent } from 'common/analytics/types'
+
+import {
+  createUnsupportedWalletAnalyticsEvent,
+  UnsupportedWalletAnalyticsData,
+} from '../unsupportedWalletAnalytics.utils'
+
 export interface UnsupportedWalletWarningProps {
+  analyticsData: UnsupportedWalletAnalyticsData
   chainId: SupportedChainId
   account?: string
   isSafeViaWc: boolean
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function UnsupportedWalletWarning({ isSafeViaWc, chainId, account }: UnsupportedWalletWarningProps) {
+export function UnsupportedWalletWarning({
+  analyticsData,
+  isSafeViaWc,
+  chainId,
+  account,
+}: UnsupportedWalletWarningProps): ReactNode {
   if (isSafeViaWc && account) {
     return (
       <InlineBanner bannerType={StatusColorVariant.Info}>
@@ -23,8 +36,16 @@ export function UnsupportedWalletWarning({ isSafeViaWc, chainId, account }: Unsu
         </strong>
         <p>
           <Trans>
-            Use the <ExternalLink href={getSafeAccountUrl(chainId, account)}>Safe app</ExternalLink> for advanced
-            trading.
+            Use the{' '}
+            <ExternalLink
+              href={getSafeAccountUrl(chainId, account)}
+              data-click-event={toCowSwapGtmEvent(
+                createUnsupportedWalletAnalyticsEvent('twap_unsupported_wallet_safe_app_clicked', analyticsData),
+              )}
+            >
+              Safe app
+            </ExternalLink>{' '}
+            for advanced trading.
           </Trans>
         </p>
       </InlineBanner>
@@ -39,8 +60,15 @@ export function UnsupportedWalletWarning({ isSafeViaWc, chainId, account }: Unsu
       <p>
         <Trans>
           TWAP orders currently require a Safe with a special fallback handler. Have one? Switch to it! Need setup?{' '}
-          <ExternalLink href={UNSUPPORTED_WALLET_LINK}>Click here</ExternalLink>. Future updates may extend wallet
-          support!
+          <ExternalLink
+            href={UNSUPPORTED_WALLET_LINK}
+            data-click-event={toCowSwapGtmEvent(
+              createUnsupportedWalletAnalyticsEvent('twap_unsupported_wallet_docs_clicked', analyticsData),
+            )}
+          >
+            Click here
+          </ExternalLink>
+          . Future updates may extend wallet support!
         </Trans>
       </p>
       <p>

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWidget/index.tsx
@@ -129,17 +129,12 @@ export function TwapFormWidget({ tradeWarnings }: TwapFormWidget): ReactNode {
 
   useEffect(() => {
     if (account && verification) {
-      if (localFormValidation === TwapFormState.TX_BUNDLING_NOT_SUPPORTED) {
-        cowAnalytics.sendEvent({
-          category: CowSwapAnalyticsCategory.TWAP,
-          action: 'non-compatible',
-        })
-      } else if (isFallbackHandlerRequired) {
+      if (localFormValidation !== TwapFormState.TX_BUNDLING_NOT_SUPPORTED && isFallbackHandlerRequired) {
         cowAnalytics.sendEvent({
           category: CowSwapAnalyticsCategory.TWAP,
           action: 'safe-that-could-be-converted',
         })
-      } else if (isFallbackHandlerCompatible) {
+      } else if (localFormValidation !== TwapFormState.TX_BUNDLING_NOT_SUPPORTED && isFallbackHandlerCompatible) {
         cowAnalytics.sendEvent({
           category: CowSwapAnalyticsCategory.TWAP,
           action: 'compatible',


### PR DESCRIPTION
## Summary

This PR adds frontend analytics for users who appear interested in TWAP but are blocked by wallet compatibility requirements.

## What changed

- add a dedicated blocked-wallet TWAP impression event with wallet and trade context
- dedupe blocked impressions by wallet and compatibility state instead of quote amount churn
- track clicks on the unsupported-wallet docs CTA and Safe app CTA
- keep the legacy `non-compatible` event alive, but emit it through the same deduped blocked-wallet path to preserve downstream reporting while introducing a canonical viewed event
- add focused test coverage for the blocked-wallet analytics payload and dedupe semantics

## Why

We want a more trustworthy signal for estimating demand from users who would likely have used TWAP but were blocked because they were not using a Safe-compatible setup. The previous coarse analytics were noisy for this purpose, especially when blocked users changed quote amounts. This change consolidates the signal into a stable blocked-impression path while preserving backward compatibility for existing dashboards.

## Validation

- `pnpm exec eslint apps/cowswap-frontend/src/modules/twap/containers/TwapFormWidget/index.tsx apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/index.tsx apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/useUnsupportedWalletAnalytics.ts apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/warnings/UnsupportedWalletWarning.tsx apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/unsupportedWalletAnalytics.utils.ts apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/unsupportedWalletAnalytics.utils.test.ts`
- `pnpm exec jest --config ./apps/cowswap-frontend/jest.config.mjs --runTestsByPath ./apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/unsupportedWalletAnalytics.utils.test.ts --runInBand`
- `pnpx nx run cowswap-frontend:typecheck`

## Follow-up

- GTM changes are not required for the primary blocked-wallet impression events because they go through the existing analytics pipeline.
- If we later want richer payloads for the unsupported-wallet CTA click events in GA4, the GTM click-event mapping can be extended separately.
