### PR TITLE
Revert "fix: Fixes allowances issue with limit orders"

### DIFF
--- a/apps/cowswap-frontend/src/modules/ordersTable/utils/getOrderParams.test.ts
+++ b/apps/cowswap-frontend/src/modules/ordersTable/utils/getOrderParams.test.ts
@@ -1,36 +1,8 @@
 import { BalancesAndAllowances } from '@cowprotocol/balances-and-allowances'
-import { getAddressKey } from '@cowprotocol/cow-sdk'
-
-import BigNumber from 'bignumber.js'
-import JSBI from 'jsbi'
-
-import { ParsedOrder } from 'utils/orderUtils/parseOrder'
 
 import { getOrderParams } from './getOrderParams'
 
 import { ordersMock } from '../test/ordersTable.mock'
-
-function createPartiallyExecutedOrder(
-  baseOrder: ParsedOrder,
-  params: { sellAmount: string; executedSellAmount: string; executedBuyAmount?: string },
-): ParsedOrder {
-  const { sellAmount, executedSellAmount, executedBuyAmount = '1' } = params
-  const filledAmount = new BigNumber(executedSellAmount)
-
-  return {
-    ...baseOrder,
-    sellAmount,
-    executionData: {
-      ...baseOrder.executionData,
-      executedSellAmount: JSBI.BigInt(executedSellAmount),
-      executedBuyAmount: JSBI.BigInt(executedBuyAmount),
-      filledAmount,
-      filledPercentage: filledAmount.div(new BigNumber(sellAmount)),
-      partiallyFilled: true,
-      fullyFilled: false,
-    },
-  }
-}
 
 // TODO: Break down this large function into smaller functions
 
@@ -38,10 +10,10 @@ describe('getOrderParams', () => {
   const BASE_ORDER = ordersMock[0]
   const BASE_BALANCES_AND_ALLOWANCES: BalancesAndAllowances = {
     balances: {
-      [getAddressKey(BASE_ORDER.inputToken.address)]: BigInt(BASE_ORDER.sellAmount),
+      [BASE_ORDER.inputToken.address.toLowerCase()]: BigInt(BASE_ORDER.sellAmount),
     },
     allowances: {
-      [getAddressKey(BASE_ORDER.inputToken.address)]: BigInt(BASE_ORDER.sellAmount),
+      [BASE_ORDER.inputToken.address.toLowerCase()]: BigInt(BASE_ORDER.sellAmount),
     },
     isLoading: false,
   }
@@ -51,7 +23,6 @@ describe('getOrderParams', () => {
       ...BASE_ORDER,
       partiallyFillable: false,
     }
-
     it('should have hasEnoughBalance true when order is fill or kill and balance is sufficient', () => {
       const order = { ...FILL_OR_KILL_ORDER }
       const balancesAndAllowances: BalancesAndAllowances = { ...BASE_BALANCES_AND_ALLOWANCES }
@@ -75,7 +46,6 @@ describe('getOrderParams', () => {
       const result = getOrderParams(1, balancesAndAllowances, order)
       expect(result.hasEnoughAllowance).toEqual(true)
     })
-
     it('should have hasEnoughAllowance false when order is fill or kill and allowance is insufficient', () => {
       const order = {
         ...FILL_OR_KILL_ORDER,
@@ -92,151 +62,50 @@ describe('getOrderParams', () => {
       ...BASE_ORDER,
       partiallyFillable: true,
     }
-
     it('should have hasEnoughBalance true when order is partially fillable and balance is > 0.05%', () => {
       const order = { ...PARTIALLY_FILLABLE_ORDER }
       const balancesAndAllowances: BalancesAndAllowances = {
         ...BASE_BALANCES_AND_ALLOWANCES,
         balances: {
-          [getAddressKey(order.inputToken.address)]: BigInt(String(+order.sellAmount * 0.00051)),
+          [order.inputToken.address.toLowerCase()]: BigInt(String(+order.sellAmount * 0.00051)),
         },
       }
       const result = getOrderParams(1, balancesAndAllowances, order)
       expect(result.hasEnoughBalance).toEqual(true)
     })
-
     it('should have hasEnoughBalance false when order is partially fillable and balance is < 0.05%', () => {
       const order = { ...PARTIALLY_FILLABLE_ORDER }
       const balancesAndAllowances: BalancesAndAllowances = {
         ...BASE_BALANCES_AND_ALLOWANCES,
         balances: {
-          [getAddressKey(order.inputToken.address)]: BigInt(String(+order.sellAmount * 0.00049)),
+          [order.inputToken.address.toLowerCase()]: BigInt(String(+order.sellAmount * 0.00049)),
         },
       }
       const result = getOrderParams(1, balancesAndAllowances, order)
       expect(result.hasEnoughBalance).toEqual(false)
     })
 
-    it('should have hasEnoughAllowance true when order is partially fillable and allowance covers full sell amount', () => {
+    it('should have hasEnoughAllowance true when order is partially fillable and allowance is > 0.05%', () => {
       const order = { ...PARTIALLY_FILLABLE_ORDER }
       const balancesAndAllowances: BalancesAndAllowances = {
         ...BASE_BALANCES_AND_ALLOWANCES,
         allowances: {
-          [getAddressKey(order.inputToken.address)]: BigInt(order.sellAmount),
+          [order.inputToken.address.toLowerCase()]: BigInt(String(+order.sellAmount * 0.00051)),
         },
       }
       const result = getOrderParams(1, balancesAndAllowances, order)
       expect(result.hasEnoughAllowance).toEqual(true)
     })
-
-    it('should have hasEnoughAllowance false when order is partially fillable and allowance is below full sell amount', () => {
+    it('should have hasEnoughAllowance false when order is partially fillable and allowance is < 0.05%', () => {
       const order = { ...PARTIALLY_FILLABLE_ORDER }
       const balancesAndAllowances: BalancesAndAllowances = {
         ...BASE_BALANCES_AND_ALLOWANCES,
         allowances: {
-          [getAddressKey(order.inputToken.address)]: BigInt(String(+order.sellAmount * 0.5)),
+          [order.inputToken.address.toLowerCase()]: BigInt(String(+order.sellAmount * 0.00049)),
         },
       }
       const result = getOrderParams(1, balancesAndAllowances, order)
       expect(result.hasEnoughAllowance).toEqual(false)
-    })
-
-    it('should have hasEnoughAllowance false when order is partially fillable and allowance is dust only', () => {
-      const order = { ...PARTIALLY_FILLABLE_ORDER }
-      const balancesAndAllowances: BalancesAndAllowances = {
-        ...BASE_BALANCES_AND_ALLOWANCES,
-        allowances: {
-          [getAddressKey(order.inputToken.address)]: BigInt(String(+order.sellAmount * 0.00049)),
-        },
-      }
-      const result = getOrderParams(1, balancesAndAllowances, order)
-      expect(result.hasEnoughAllowance).toEqual(false)
-    })
-
-    it('should have hasEnoughAllowance true when partially filled and allowance is greater than the remainder', () => {
-      const order = createPartiallyExecutedOrder(PARTIALLY_FILLABLE_ORDER, {
-        sellAmount: '1000',
-        executedSellAmount: '600',
-      })
-      const balancesAndAllowances: BalancesAndAllowances = {
-        ...BASE_BALANCES_AND_ALLOWANCES,
-        allowances: {
-          [getAddressKey(order.inputToken.address)]: 500n,
-        },
-      }
-      const result = getOrderParams(1, balancesAndAllowances, order)
-      expect(result.hasEnoughAllowance).toEqual(true)
-    })
-
-    it('should have hasEnoughAllowance false when partially filled and allowance is below the remainder', () => {
-      const order = createPartiallyExecutedOrder(PARTIALLY_FILLABLE_ORDER, {
-        sellAmount: '1000',
-        executedSellAmount: '600',
-      })
-      const balancesAndAllowances: BalancesAndAllowances = {
-        ...BASE_BALANCES_AND_ALLOWANCES,
-        allowances: {
-          [getAddressKey(order.inputToken.address)]: 300n,
-        },
-      }
-      const result = getOrderParams(1, balancesAndAllowances, order)
-      expect(result.hasEnoughAllowance).toEqual(false)
-    })
-
-    it('should have hasEnoughAllowance true when partially filled and allowance equals the remainder exactly', () => {
-      const order = createPartiallyExecutedOrder(PARTIALLY_FILLABLE_ORDER, {
-        sellAmount: '1000',
-        executedSellAmount: '600',
-      })
-      const balancesAndAllowances: BalancesAndAllowances = {
-        ...BASE_BALANCES_AND_ALLOWANCES,
-        allowances: {
-          [getAddressKey(order.inputToken.address)]: 400n,
-        },
-      }
-      const result = getOrderParams(1, balancesAndAllowances, order)
-      expect(result.hasEnoughAllowance).toEqual(true)
-    })
-  })
-
-  describe('missing balances/allowances (not loaded yet)', () => {
-    it('should have hasEnoughBalance undefined when the balance is not available', () => {
-      const order = { ...BASE_ORDER }
-      const balancesAndAllowances: BalancesAndAllowances = {
-        balances: {},
-        allowances: {
-          [getAddressKey(order.inputToken.address)]: BigInt(order.sellAmount),
-        },
-        isLoading: true,
-      }
-      const result = getOrderParams(1, balancesAndAllowances, order)
-      expect(result.hasEnoughBalance).toBeUndefined()
-    })
-
-    it('should have hasEnoughAllowance undefined when the allowance map is missing the token', () => {
-      const order = { ...BASE_ORDER }
-      const balancesAndAllowances: BalancesAndAllowances = {
-        balances: {
-          [getAddressKey(order.inputToken.address)]: BigInt(order.sellAmount),
-        },
-        allowances: {},
-        isLoading: true,
-      }
-      const result = getOrderParams(1, balancesAndAllowances, order)
-      expect(result.hasEnoughAllowance).toBeUndefined()
-    })
-
-    it('should have hasEnoughAllowance undefined when allowances are not loaded', () => {
-      const order = { ...BASE_ORDER }
-      const balancesAndAllowances: BalancesAndAllowances = {
-        balances: {
-          [getAddressKey(order.inputToken.address)]: BigInt(order.sellAmount),
-        },
-        allowances: undefined,
-        isLoading: true,
-      }
-      const result = getOrderParams(1, balancesAndAllowances, order)
-      expect(result.hasEnoughAllowance).toBeUndefined()
     })
   })
 })

--- a/apps/cowswap-frontend/src/modules/ordersTable/utils/getOrderParams.ts
+++ b/apps/cowswap-frontend/src/modules/ordersTable/utils/getOrderParams.ts
@@ -1,9 +1,7 @@
 import { BalancesAndAllowances } from '@cowprotocol/balances-and-allowances'
 import { isEnoughAmount } from '@cowprotocol/common-utils'
-import { getAddressKey, type SupportedChainId } from '@cowprotocol/cow-sdk'
+import { getAddressKey, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { Currency, CurrencyAmount, Percent, Token } from '@cowprotocol/currency'
-
-import { getRemainderAmountsWithoutSurplus } from 'legacy/state/orders/utils'
 
 import { RateInfoParams } from 'common/pure/RateInfo'
 import { getOrderPermitAmount } from 'utils/orderUtils/getOrderPermitAmount'
@@ -31,7 +29,6 @@ export function getOrderParams(
   const isOrderAtLeastOnceFilled = order.executionData.filledAmount.gt(0)
   const sellAmount = CurrencyAmount.fromRawAmount(order.inputToken, order.sellAmount)
   const buyAmount = CurrencyAmount.fromRawAmount(order.outputToken, order.buyAmount)
-
   const isPermitInvalid = pendingOrdersPermitValidityState
     ? pendingOrdersPermitValidityState[order.id] === false
     : false
@@ -49,20 +46,12 @@ export function getOrderParams(
   const balance = balances[getAddressKey(order.inputToken.address)]
   const allowance = allowances?.[getAddressKey(order.inputToken.address)]
 
-  // After the first fill, the permit is spent, so we only use the on-chain allowance from then on.
-  // Before the first fill, we use the bigger of the on-chain approve allowance, or permit amount (once validated on-chain).
-  const effectiveAllowance = isOrderAtLeastOnceFilled ? allowance : getBiggerAmount(allowance, permitAmount)
-
-  const sellAmountRemaining = isOrderAtLeastOnceFilled
-    ? CurrencyAmount.fromRawAmount(order.inputToken, getRemainderAmountsWithoutSurplus(order).sellAmount)
-    : sellAmount
-
   const { hasEnoughBalance, hasEnoughAllowance } = _hasEnoughBalanceAndAllowance({
-    balance,
-    allowance: effectiveAllowance,
     partiallyFillable: order.partiallyFillable,
     sellAmount,
-    sellAmountRemaining,
+    balance,
+    // If the order has been filled at least once, we should not consider the permit amount
+    allowance: !isOrderAtLeastOnceFilled ? getBiggerAmount(allowance, permitAmount) : allowance,
   })
 
   return {
@@ -75,34 +64,20 @@ export function getOrderParams(
   }
 }
 
-interface HasEnoughBalanceAndAllowanceParams {
+function _hasEnoughBalanceAndAllowance(params: {
   balance: bigint | undefined
   allowance: bigint | undefined
   partiallyFillable: boolean
   sellAmount: CurrencyAmount<Token>
-  sellAmountRemaining: CurrencyAmount<Token>
-}
-
-function _hasEnoughBalanceAndAllowance({
-  balance,
-  allowance,
-  partiallyFillable,
-  sellAmount,
-  sellAmountRemaining,
-}: HasEnoughBalanceAndAllowanceParams): {
+}): {
   hasEnoughBalance: boolean | undefined
   hasEnoughAllowance: boolean | undefined
 } {
-  // For partially fillable orders, we want to check there's at least `PERCENTAGE_FOR_PARTIAL_FILLS` of balance instead
-  // of the full amount:
-  const balanceAmount = partiallyFillable ? sellAmount.multiply(PERCENTAGE_FOR_PARTIAL_FILLS) : sellAmount
-  const hasEnoughBalance = isEnoughAmount(balanceAmount, balance)
-
-  // However, for allowance, we probably want to check if the allowance covers the full sell amount remaining:
-  const hasEnoughAllowance = isEnoughAmount(sellAmountRemaining, allowance)
-
-  // Otherwise, a fillable order with full balance available but just some dust allowance would be considered fillable,
-  // and the user would falsely expect it to be fully fillable, which would not be the case.
+  const { allowance, balance, partiallyFillable, sellAmount } = params
+  // Check there's at least PERCENTAGE_FOR_PARTIAL_FILLS of balance/allowance to consider it as enough
+  const amount = partiallyFillable ? sellAmount.multiply(PERCENTAGE_FOR_PARTIAL_FILLS) : sellAmount
+  const hasEnoughBalance = isEnoughAmount(amount, balance)
+  const hasEnoughAllowance = isEnoughAmount(amount, allowance)
 
   return { hasEnoughBalance, hasEnoughAllowance }
 }


### PR DESCRIPTION
This reverts commit be0d4c767c8a462b538f7bf4f061a521bc79ab1f.

# Summary

Switch back to the old behaviour where only 0.05% of the original sell amount is needed in order to not trigger the inssuficient allowance warning.

# To Test

1. Create a limit order.
2. Revoke its allowance.
3. Verify the allowance warning appears.
4. Approve 0.05% of the sell token.
5. Verify the allowance warning disappears.

# Background

Slack conversation: https://nomevlabs.slack.com/archives/C0361CDG8GP/p1781601276928229


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal order validation logic for balance and allowance calculations by removing legacy remainder-based computations.

* **Tests**
  * Streamlined test coverage for order parameter validation to focus on critical threshold scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->