### PR TITLE
fix: add safe connector to widget-cfg explicitly

### DIFF
--- a/apps/widget-configurator/src/wagmiConfig.ts
+++ b/apps/widget-configurator/src/wagmiConfig.ts
@@ -4,7 +4,7 @@ import { ALL_SUPPORTED_CHAIN_IDS, EvmChains, isEvmChain, SupportedChainId } from
 import { createAppKit } from '@reown/appkit/react'
 import { WagmiAdapter } from '@reown/appkit-adapter-wagmi'
 import { ConnectorController } from '@reown/appkit-controllers'
-import { coinbaseWallet } from '@wagmi/connectors'
+import { coinbaseWallet, safe } from '@wagmi/connectors'
 import { http } from 'viem'
 
 import type { AppKitNetwork } from '@reown/appkit/networks'
@@ -84,7 +84,7 @@ const customRpcUrls = EVM_SUPPORTED_CHAIN_IDS.reduce<Record<string, Array<{ url:
 const COINBASE_LEGACY_WALLET_ID = 'd0ca99ff52b99abc48743dad0f7fc891e041be73574f7fac4afe5d4bb83845c8'
 
 export const wagmiAdapter = new WagmiAdapter({
-  connectors: [coinbaseWallet({ preference: { options: 'all' } })],
+  connectors: [safe({ unstable_getInfoTimeout: 1000 }), coinbaseWallet({ preference: { options: 'all' } })],
   customRpcUrls,
   networks,
   projectId,

--- a/libs/wallet/src/wagmi/getConnectors.ts
+++ b/libs/wallet/src/wagmi/getConnectors.ts
@@ -1,8 +1,8 @@
 import { isInjectedWidget } from '@cowprotocol/common-utils'
 import { WidgetEthereumProvider } from '@cowprotocol/iframe-transport'
 
+import { injected, safe } from '@wagmi/connectors'
 import { EIP1193Provider } from 'viem'
-import { injected, safe } from 'wagmi/connectors'
 
 import { COW_WIDGET_CONNECTOR_ID } from '../reown/consts'
 import { getIsSafeAppIframe } from '../utils/getIsSafeAppIframe'


### PR DESCRIPTION
# Summary

Fixes #7652 (only the 1st case)

I figured out that it throws `RpcError: undefined: "eth_requestAccounts"` not implemented.
The error comes from `SafeAppProvider` on the Widget configurator side.
I just set the connector explicitly from `@wagmi/connectors` and now it works well.

# To Test

See the 1st case of #7652


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Safe wallet connector support, enabling users to connect their Safe wallets to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->