### PR TITLE
fix: fix widget base wallet CSP issue

### DIFF
--- a/apps/widget-configurator/vercel.ts
+++ b/apps/widget-configurator/vercel.ts
@@ -29,7 +29,7 @@ const csp = buildCsp([
   ['connect-src', ["'self'", 'https:', 'wss:']],
   ['media-src', ["'self'", 'data:', 'blob:']],
   // Configurator preview iframe can target external baseUrl values (prod/dev vercel) and localhost.
-  ['frame-src', ["'self'", 'https:', 'http://localhost:3000']],
+  ['frame-src', ["'self'", 'https:', 'http://localhost:3000', 'https://go.cb-w.com']],
   ['frame-ancestors', ['*']],
   ['worker-src', ["'self'"]],
   ['manifest-src', ["'self'"]],


### PR DESCRIPTION
# Summary

Fixes https://github.com/cowprotocol/cowswap/issues/7663, which was a CSP issue in the end.

# To Test

1. Open the preview widget configurator.
2. Set its `baseUrl` to the preview cowswap.
3. In standalone mode and without the Base wallet installed, select that option in the wallet connection modal.
4. Verify it opens Base's login popup instead of crashing the iframe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated widget embedding permissions to allow framing from an additional trusted domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->