### PR TITLE
fix(hooks): treat simulated gasUsed as floor, not literal gasLimit

### DIFF
--- a/apps/cowswap-frontend/src/entities/orderHooks/useHooksStateWithSimulatedGas.ts
+++ b/apps/cowswap-frontend/src/entities/orderHooks/useHooksStateWithSimulatedGas.ts
@@ -28,7 +28,7 @@ export function useHooksStateWithSimulatedGas(): HooksStoreState {
       // the simulation can't see (e.g. first-time COWShed proxy deploy) still
       // get through.
       const paddedSimulatedBudget = (BigInt(hookTenderlyData.gasUsed) * GAS_LIMIT_SAFETY_FACTOR_PCT) / 100n
-      const dappBudget = BigInt(hook.hook.gasLimit)
+      const dappBudget = hook.hook.gasLimit ? BigInt(hook.hook.gasLimit) : 0n
       const gasLimit = (paddedSimulatedBudget > dappBudget ? paddedSimulatedBudget : dappBudget).toString()
 
       return { ...hook, hook: { ...hook.hook, gasLimit } }

--- a/apps/cowswap-frontend/src/entities/orderHooks/useHooksStateWithSimulatedGas.ts
+++ b/apps/cowswap-frontend/src/entities/orderHooks/useHooksStateWithSimulatedGas.ts
@@ -7,6 +7,14 @@ import { useTenderlyBundleSimulation } from 'modules/tenderly/hooks/useTenderlyB
 import { HooksStoreState } from './hookDetailsAtom'
 import { useHooks } from './useHooks'
 
+// Tenderly's `gasUsed` is the gas CONSUMED on the happy path. As an on-chain
+// `gasLimit` (= the budget the trampoline forwards), it under-allocates for
+// nested-call hooks because EIP-150's 63/64 rule and the per-frame reentrancy
+// sentry both reserve gas that `gasUsed` does not surface. The CoW-Shed flow
+// has ~14 nested CALLs and needs ~1.5x the consumed gas as budget. Expressed
+// as percent (bigint can't multiply by a fractional factor directly).
+const GAS_LIMIT_SAFETY_FACTOR_PCT = 150n
+
 export function useHooksStateWithSimulatedGas(): HooksStoreState {
   const hooksRaw = useHooks()
   const { data: tenderlyData } = useTenderlyBundleSimulation()
@@ -16,15 +24,10 @@ export function useHooksStateWithSimulatedGas(): HooksStoreState {
       const hookTenderlyData = tenderlyData?.[hook.uuid]
       if (!hookTenderlyData?.gasUsed || hookTenderlyData.gasUsed === '0' || !hookTenderlyData.status) return hook
 
-      // Tenderly's `gasUsed` is the gas CONSUMED on the happy path. As an
-      // on-chain `gasLimit` (= the budget the trampoline forwards), it
-      // under-allocates for nested-call hooks because EIP-150's 63/64 rule and
-      // the per-frame reentrancy sentry both reserve gas that `gasUsed` does
-      // not surface. The CoW-Shed flow has ~14 nested CALLs and needs ~1.5x
-      // the consumed gas as budget. We also take max() with whatever the dapp
-      // itself declared, so dapps with state the simulation can't see (e.g.
-      // first-time COWShed proxy deploy) still get through.
-      const paddedSimulatedBudget = (BigInt(hookTenderlyData.gasUsed) * 150n) / 100n
+      // Take max() with whatever the dapp itself declared, so dapps with state
+      // the simulation can't see (e.g. first-time COWShed proxy deploy) still
+      // get through.
+      const paddedSimulatedBudget = (BigInt(hookTenderlyData.gasUsed) * GAS_LIMIT_SAFETY_FACTOR_PCT) / 100n
       const dappBudget = BigInt(hook.hook.gasLimit)
       const gasLimit = (paddedSimulatedBudget > dappBudget ? paddedSimulatedBudget : dappBudget).toString()
 

--- a/apps/cowswap-frontend/src/entities/orderHooks/useHooksStateWithSimulatedGas.ts
+++ b/apps/cowswap-frontend/src/entities/orderHooks/useHooksStateWithSimulatedGas.ts
@@ -7,6 +7,24 @@ import { useTenderlyBundleSimulation } from 'modules/tenderly/hooks/useTenderlyB
 import { HooksStoreState } from './hookDetailsAtom'
 import { useHooks } from './useHooks'
 
+// Tenderly's simulation returns `gasUsed`, which is the gas the call would
+// CONSUME on the happy path. Using that as the on-chain `gasLimit` (= the
+// budget passed to the call) under-allocates for nested-call hooks like
+// the CoW-Shed flow, because EIP-150's 63/64 rule and the per-frame
+// reentrancy sentry both reserve gas that the consumed measurement does
+// not surface. For ~14 nested levels the actual budget required is
+// ~1.5–2x the consumed gas.
+//
+// We pad the simulated gasUsed by this factor before treating it as a
+// budget, and take the max with whatever budget the hook dapp itself
+// declared (the dapp may have its own informed estimate).
+const GAS_LIMIT_SAFETY_NUMERATOR = 150n
+const GAS_LIMIT_SAFETY_DENOMINATOR = 100n
+
+function maxBigInt(a: bigint, b: bigint): bigint {
+  return a > b ? a : b
+}
+
 export function useHooksStateWithSimulatedGas(): HooksStoreState {
   const hooksRaw = useHooks()
   const { data: tenderlyData } = useTenderlyBundleSimulation()
@@ -15,7 +33,19 @@ export function useHooksStateWithSimulatedGas(): HooksStoreState {
     (hook: CowHookDetails): CowHookDetails => {
       const hookTenderlyData = tenderlyData?.[hook.uuid]
       if (!hookTenderlyData?.gasUsed || hookTenderlyData.gasUsed === '0' || !hookTenderlyData.status) return hook
-      const hookData = { ...hook.hook, gasLimit: hookTenderlyData.gasUsed }
+
+      const simulatedBudget =
+        (BigInt(hookTenderlyData.gasUsed) * GAS_LIMIT_SAFETY_NUMERATOR) / GAS_LIMIT_SAFETY_DENOMINATOR
+      const dappDeclaredBudget = (() => {
+        try {
+          return BigInt(hook.hook.gasLimit)
+        } catch {
+          return 0n
+        }
+      })()
+      const gasLimit = maxBigInt(simulatedBudget, dappDeclaredBudget).toString()
+
+      const hookData = { ...hook.hook, gasLimit }
       return { ...hook, hook: hookData }
     },
     [tenderlyData],

--- a/apps/cowswap-frontend/src/entities/orderHooks/useHooksStateWithSimulatedGas.ts
+++ b/apps/cowswap-frontend/src/entities/orderHooks/useHooksStateWithSimulatedGas.ts
@@ -7,24 +7,6 @@ import { useTenderlyBundleSimulation } from 'modules/tenderly/hooks/useTenderlyB
 import { HooksStoreState } from './hookDetailsAtom'
 import { useHooks } from './useHooks'
 
-// Tenderly's simulation returns `gasUsed`, which is the gas the call would
-// CONSUME on the happy path. Using that as the on-chain `gasLimit` (= the
-// budget passed to the call) under-allocates for nested-call hooks like
-// the CoW-Shed flow, because EIP-150's 63/64 rule and the per-frame
-// reentrancy sentry both reserve gas that the consumed measurement does
-// not surface. For ~14 nested levels the actual budget required is
-// ~1.5–2x the consumed gas.
-//
-// We pad the simulated gasUsed by this factor before treating it as a
-// budget, and take the max with whatever budget the hook dapp itself
-// declared (the dapp may have its own informed estimate).
-const GAS_LIMIT_SAFETY_NUMERATOR = 150n
-const GAS_LIMIT_SAFETY_DENOMINATOR = 100n
-
-function maxBigInt(a: bigint, b: bigint): bigint {
-  return a > b ? a : b
-}
-
 export function useHooksStateWithSimulatedGas(): HooksStoreState {
   const hooksRaw = useHooks()
   const { data: tenderlyData } = useTenderlyBundleSimulation()
@@ -34,19 +16,19 @@ export function useHooksStateWithSimulatedGas(): HooksStoreState {
       const hookTenderlyData = tenderlyData?.[hook.uuid]
       if (!hookTenderlyData?.gasUsed || hookTenderlyData.gasUsed === '0' || !hookTenderlyData.status) return hook
 
-      const simulatedBudget =
-        (BigInt(hookTenderlyData.gasUsed) * GAS_LIMIT_SAFETY_NUMERATOR) / GAS_LIMIT_SAFETY_DENOMINATOR
-      const dappDeclaredBudget = (() => {
-        try {
-          return BigInt(hook.hook.gasLimit)
-        } catch {
-          return 0n
-        }
-      })()
-      const gasLimit = maxBigInt(simulatedBudget, dappDeclaredBudget).toString()
+      // Tenderly's `gasUsed` is the gas CONSUMED on the happy path. As an
+      // on-chain `gasLimit` (= the budget the trampoline forwards), it
+      // under-allocates for nested-call hooks because EIP-150's 63/64 rule and
+      // the per-frame reentrancy sentry both reserve gas that `gasUsed` does
+      // not surface. The CoW-Shed flow has ~14 nested CALLs and needs ~1.5x
+      // the consumed gas as budget. We also take max() with whatever the dapp
+      // itself declared, so dapps with state the simulation can't see (e.g.
+      // first-time COWShed proxy deploy) still get through.
+      const paddedSimulatedBudget = (BigInt(hookTenderlyData.gasUsed) * 150n) / 100n
+      const dappBudget = BigInt(hook.hook.gasLimit)
+      const gasLimit = (paddedSimulatedBudget > dappBudget ? paddedSimulatedBudget : dappBudget).toString()
 
-      const hookData = { ...hook.hook, gasLimit }
-      return { ...hook, hook: hookData }
+      return { ...hook, hook: { ...hook.hook, gasLimit } }
     },
     [tenderlyData],
   )


### PR DESCRIPTION
## Summary

`useHooksStateWithSimulatedGas` was overriding the hook's `gasLimit` with Tenderly's simulated `gasUsed`. That under-allocates for nested-call hooks (the CoW-Shed flow has ~14 nested `CALL` frames), because two structural costs aren't surfaced in `gasUsed`:

1. **EIP-150 63/64 rule** — every nested `CALL` only forwards 63/64 of remaining gas. Cumulative overhead across 14 levels is `(64/63)^14 ≈ 1.25×` of actual burn.
2. **Reentrancy sentry + returndata buffer** — ~2,300 gas reserved per frame, ~30k total across 14 frames.

Combined, the minimum `gasLimit` a hook needs to **complete** is materially higher than the gas it **consumes**.

## Evidence

Three Arbitrum orders, all `fulfilled` at the order level but with `HookTrampoline.executeHooks` reverting OOG inside the swap settlement (silently swallowed):

| Order | gasLimit | Inner `gas_used` | Path |
|---|---:|---:|---|
| [`0x274ce0d4…`](https://arbiscan.io/tx/0x274ce0d4fa1ca717d7b253ebd00d770c1ab7b4e98434f49f7edbfff229f3bc66) | 258,142 | 250,683 | OOG at `DeployableVM.buildInputs` |
| [`0xf5fc5bbe…`](https://arbiscan.io/tx/0xf5fc5bbea2af45bb0fdca39d20f8decb4720ed0356dace6c93137452ade8ceee) | 278,172 | 269,188 | OOG at `BCoWPool.fallback` |
| [`0xed5e6116…`](https://arbiscan.io/tx/0xed5e611659a7461a9c5aeb4c072de45e4b11427d3581d251a208a6c9b1c28534) | 505,649 | 497,898 | OOG at `FiatTokenProxy._delegate`, first-time COWShed deploy |

Tenderly threshold search at the actual settle blocks shows the **minimum passing budget** is:

| Scenario | Tenderly `gasUsed` | Minimum passing `gasLimit` | Ratio |
|---|---:|---:|---:|
| Repeat user (COWShed deployed) | ~260k | ~335k | ~1.29× |
| First-time user (COWShed deploy) | ~497k | ~600k | ~1.21× |

`gasUsed` is consistently **~25% below** the minimum required budget. Using it verbatim as `gasLimit` produces OOG on chain.

## Fix

Treat `gasUsed` as a floor, not a verbatim assignment:

```ts
const simulatedBudget = (BigInt(gasUsed) * 150n) / 100n
const dappDeclaredBudget = BigInt(hook.gasLimit ?? 0)
const gasLimit = max(simulatedBudget, dappDeclaredBudget)
```

- **1.5× multiplier** absorbs the structural overhead with margin
- **`max(...)` with the dapp's declared `gasLimit`** preserves the dapp's own informed estimate (e.g. CoW-Shed hook dapps that know to add a buffer for first-time proxy deployment via [`bleu/cow-hooks-dapps#126`](https://github.com/bleu/cow-hooks-dapps/pull/126))

## Companion PR

The CoW Shed hook dapps need their own buffer for first-time deploys (a ~250k cost the estimator misses entirely). Tracked in [`bleu/cow-hooks-dapps#126`](https://github.com/bleu/cow-hooks-dapps/pull/126) — that PR computes the dapp's own `gasLimit` aware of deploy state, which this PR then preserves via `max(...)`.

Together, the two PRs cover every regime: repeat users get a small overshoot via the 1.5× pad, first-time users get the dapp-side buffer through.

## Test plan

- [x] Local typecheck on the changed file — clean
- [x] Tenderly simulation of the three failing orders confirms the new `gasLimit` (after 1.5× pad or dapp-declared, whichever higher) passes
- [ ] CI on this PR
- [ ] Manual: run cowswap-frontend locally with this branch + `bleu/cow-hooks-dapps` PR branch, place a `COW_AMM_WITHDRAW` order from a fresh wallet on Arbitrum, confirm the hook executes (no `execution reverted` inside `settle()`)
- [ ] Regression spot-check on `PERMIT_TOKEN` hook (lighter call tree — should remain unchanged in behaviour because dapp-declared gasLimit already exceeds 1.5× of gasUsed there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved gas budget handling for hook-related operations by deriving each hook’s gas limit from simulation results.
  * Applies a 150% safety multiplier to simulated gas usage and uses the higher value between the adjusted simulation budget and the hook’s provided gas limit to reduce the risk of underestimating gas.
  * Ensures the selected gas limit is consistently computed and applied across hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->