### PR TITLE
fix: use cowswap cf-pages preview in widget builds

### DIFF
--- a/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.test.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.test.ts
@@ -5,6 +5,12 @@ describe('branchNameToCfPagesSubdomain', () => {
     expect(branchNameToCfPagesSubdomain('cf-preview/pr-7657')).toBe('cf-preview-pr-7657')
     expect(branchNameToCfPagesSubdomain('Feature/API_fix')).toBe('feature-api-fix')
     expect(branchNameToCfPagesSubdomain('fix/deepsec-high-frontend-hardening')).toBe('fix-deepsec-high-frontend-ha')
+    expect(branchNameToCfPagesSubdomain('test-----a-badna9878979/-long-andweird7896branchname')).toBe(
+      'test-----a-badna9878979--lon',
+    )
+    expect(branchNameToCfPagesSubdomain('test--branch--wierd/--')).toBe('test--branch--wierd')
+    expect(branchNameToCfPagesSubdomain('/feature/')).toBe('feature')
+    expect(branchNameToCfPagesSubdomain('---')).toBe('preview')
   })
 })
 

--- a/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.test.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.test.ts
@@ -1,0 +1,19 @@
+import { branchNameToCfPagesSubdomain, vercelPreviewSlugToCfPagesSubdomain } from './useWidgetParamsAndSettings'
+
+describe('branchNameToCfPagesSubdomain', () => {
+  it('matches Cloudflare Pages preview subdomains', () => {
+    expect(branchNameToCfPagesSubdomain('cf-preview/pr-7657')).toBe('cf-preview-pr-7657')
+    expect(branchNameToCfPagesSubdomain('Feature/API_fix')).toBe('feature-api-fix')
+    expect(branchNameToCfPagesSubdomain('fix/deepsec-high-frontend-hardening')).toBe('fix-deepsec-high-frontend-ha')
+  })
+})
+
+describe('vercelPreviewSlugToCfPagesSubdomain', () => {
+  it('maps visible Vercel preview slugs to Cloudflare Pages aliases', () => {
+    expect(vercelPreviewSlugToCfPagesSubdomain('fix-permit-flow')).toBe('fix-permit-flow')
+    expect(vercelPreviewSlugToCfPagesSubdomain('fix-deepsec-high-fro-87dcc4')).toBe('fix-deepsec-high-fro')
+    expect(
+      vercelPreviewSlugToCfPagesSubdomain('fix-deepsec-high-fro-87dcc4', 'fix/deepsec-high-frontend-hardening'),
+    ).toBe('fix-deepsec-high-frontend-ha')
+  })
+})

--- a/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
@@ -8,13 +8,17 @@ import { ConfiguratorState } from '../types'
 const vercelWidgetConfiguratorPrefix = 'widget-configurator-git-'
 const cfPagesPreviewSuffix = `.swap-dev-5u6.pages.dev`
 const cfPagesPreviewSubdomainMaxLength = 28
+const cfPagesPreviewSubdomainFallback = 'preview'
 const vercelPreviewHashSuffix = /-[a-f0-9]{6}$/
 
 export const branchNameToCfPagesSubdomain = (branchName: string): string => {
-  return branchName
+  const subdomain = branchName
     .toLowerCase()
     .replace(/[^a-z0-9]/g, '-')
     .slice(0, cfPagesPreviewSubdomainMaxLength)
+    .replace(/^-+|-+$/g, '')
+
+  return subdomain || cfPagesPreviewSubdomainFallback
 }
 
 export const vercelPreviewSlugToCfPagesSubdomain = (

--- a/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
+++ b/apps/widget-configurator/src/app/configurator/hooks/useWidgetParamsAndSettings.ts
@@ -5,7 +5,26 @@ import { CowSwapWidgetParams, TradeType, WidgetHookEvents } from '@cowprotocol/w
 import { isDev, isLocalHost, isVercel } from '../../../env'
 import { ConfiguratorState } from '../types'
 
-const vercelSuffix = '-cowswap-dev.vercel.app'
+const vercelWidgetConfiguratorPrefix = 'widget-configurator-git-'
+const cfPagesPreviewSuffix = `.swap-dev-5u6.pages.dev`
+const cfPagesPreviewSubdomainMaxLength = 28
+const vercelPreviewHashSuffix = /-[a-f0-9]{6}$/
+
+export const branchNameToCfPagesSubdomain = (branchName: string): string => {
+  return branchName
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '-')
+    .slice(0, cfPagesPreviewSubdomainMaxLength)
+}
+
+export const vercelPreviewSlugToCfPagesSubdomain = (
+  branchSlug: string,
+  branchName = process.env.VERCEL_GIT_COMMIT_REF,
+): string => {
+  const branch = branchName || branchSlug.replace(vercelPreviewHashSuffix, '')
+
+  return branchNameToCfPagesSubdomain(branch)
+}
 
 const getBaseUrl = (): string => {
   if (typeof window === 'undefined' || !window) return ''
@@ -15,9 +34,9 @@ const getBaseUrl = (): string => {
   if (isDev) return 'https://dev.swap.cow.fi'
 
   if (isVercel) {
-    const prKey = window.location.hostname.replace('widget-configurator-git-', '').replace(vercelSuffix, '')
+    const prKey = window.location.hostname.replace(vercelWidgetConfiguratorPrefix, '')
 
-    return `https://swap-dev-git-${prKey}${vercelSuffix}`
+    return `https://${vercelPreviewSlugToCfPagesSubdomain(prKey)}${cfPagesPreviewSuffix}`
   }
 
   return 'https://swap.cow.fi'

--- a/apps/widget-configurator/vite.config.mts
+++ b/apps/widget-configurator/vite.config.mts
@@ -31,6 +31,7 @@ export default defineConfig(({ mode }) => {
     root: path.resolve(__dirname, './'),
     define: {
       ...getReactProcessEnv(mode),
+      // Maps Vercel env var into the build so the branch name can be reused inside the app
       'process.env.VERCEL_GIT_COMMIT_REF': JSON.stringify(process.env.VERCEL_GIT_COMMIT_REF || ''),
     },
 

--- a/apps/widget-configurator/vite.config.mts
+++ b/apps/widget-configurator/vite.config.mts
@@ -31,6 +31,7 @@ export default defineConfig(({ mode }) => {
     root: path.resolve(__dirname, './'),
     define: {
       ...getReactProcessEnv(mode),
+      'process.env.VERCEL_GIT_COMMIT_REF': JSON.stringify(process.env.VERCEL_GIT_COMMIT_REF || ''),
     },
 
     cacheDir: '../../node_modules/.vite/widget-configurator',


### PR DESCRIPTION
# Summary

Use the new cf-pages preview from CoW Swap in widget preview builds.
Long and weird branch names are also supported.


# To Test

1. Open the widget preview
* Should load CoW Swap preview from cf-pages and point to this PR's build https://fix-cf-widget-url.swap-dev-5u6.pages.dev/

Additionally, created PRs from branches with edge case names to assert it worked. See https://github.com/cowprotocol/cowswap/pull/7677 and https://github.com/cowprotocol/cowswap/pull/7676

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Jest coverage for branch-name normalization and Cloudflare Pages subdomain conversion, including edge cases and fallback behavior.
* **Refactor**
  * Updated the preview environment URL generation to use Cloudflare Pages preview subdomains instead of constructing a Vercel hostname from a prior suffix.
  * Improved branch key derivation by normalizing branch names and translating Vercel preview slugs.
* **Chores**
  * Injected the branch reference environment value into the client build for more reliable preview labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->