### PR TITLE
fix: remove redundant entries from PR comment

### DIFF
--- a/tools/scripts/cf-pages/gh-actions/preview-mirror-comment.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror-comment.mjs
@@ -29,10 +29,8 @@ export function buildPreviewCommentBody({
   return `<!-- ${MANAGED_COMMENT_MARKER} ${markerAttributes.join(' ')} -->
 Cloudflare Pages preview mirror
 
-Preview branch: \`${branchName}\`
 Preview branch URL: https://github.com/${repoFullName}/tree/${branchName}
 Mirror PR: #${mirrorPullRequestNumber}
-Mirror PR URL: ${mirrorPullRequestUrl}
 Cloudflare Pages preview links will be posted on the mirror PR by the Cloudflare Pages GitHub integration once builds complete.
 
 Source fork branch: \`${sourceRepoFullName}:${sourceBranch}\`

--- a/tools/scripts/cf-pages/gh-actions/preview-mirror-comment.test.mjs
+++ b/tools/scripts/cf-pages/gh-actions/preview-mirror-comment.test.mjs
@@ -25,7 +25,7 @@ describe('preview-mirror-comment', () => {
       body,
       /<!-- cf-pages-preview-mirror original-pr=123 target-sha=abc1234567890abcdef1234567890abcdef12345 mirrored-sha=abc1234567890abcdef1234567890abcdef12345 -->/,
     )
-    assert.match(body, /`cf-preview\/pr-123`/)
+    assert.match(body, /cf-preview\/pr-123/)
     assert.match(body, /Mirror PR: #456/)
     assert.match(body, /Cloudflare Pages preview links will be posted on the mirror PR/)
     assert.doesNotMatch(body, /pages\.dev/)


### PR DESCRIPTION
# Summary

Small change to remove some redundant info from the forked PR comment: https://github.com/cowprotocol/cowswap/pull/7657#issuecomment-4721161540

<img width="900" height="439" alt="Screenshot 2026-06-18 at 14 28 14" src="https://github.com/user-attachments/assets/4751819e-8e7e-4e27-aec7-70eec41604f3" />

# To Test

Needs to be merged, a fork PR created, `trigger-preview` label added to it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed redundant preview link information from automated GitHub preview comments, simplifying the comment display while retaining essential preview branch URL and PR details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->