### PR TITLE
Document Safe API client token handling

### DIFF
--- a/apps/cowswap-frontend/AGENTS.md
+++ b/apps/cowswap-frontend/AGENTS.md
@@ -24,6 +24,9 @@ Root rules: [`../../AGENTS.md`](../../AGENTS.md) (global safety, workflow, and v
 - Abstractions should not depend on details; concrete details should depend on abstractions.
 - If code is shared by two or more apps, move it to `libs/`; if it is used by one app only, keep it in that app.
 
+## Security notes
+- Safe API client token handling is documented in [`docs/safe-api-token.md`](./docs/safe-api-token.md). Treat `REACT_APP_SAFE_API_AUTH_TOKEN` as an intentional public client token unless that document changes.
+
 ## Module structure and boundaries
 - Organize domain code by module under `src/modules/<domain>/`.
 - Typical module entities:

--- a/apps/cowswap-frontend/docs/safe-api-token.md
+++ b/apps/cowswap-frontend/docs/safe-api-token.md
@@ -1,0 +1,19 @@
+---
+author: agents
+status: normative
+last_reviewed: 2026-06-19
+source_of_truth_scope: cowswap-frontend Safe API client token handling
+---
+
+# Safe API Client Token
+
+`REACT_APP_SAFE_API_AUTH_TOKEN` is intentionally consumed by browser code for Safe API reliability and rate-limit behavior.
+
+Treat this value as a public client token, not as a private server-side secret. Do not remove it or flag it solely because it is browser-exposed.
+
+Replacing this token requires an approved product or architecture change, such as routing Safe API traffic through a backend proxy. Any replacement must preserve Safe wallet and TWAP behavior, including unauthenticated fallback behavior where it exists.
+
+Known client-side consumers:
+
+- `@cowprotocol/core` Safe API helpers create Safe API Kit clients with this token when available.
+- `cowswap-frontend` TWAP Safe transaction history requests send this token as a bearer token when available, and fall back to unauthenticated requests when it is absent.


### PR DESCRIPTION
## What changed
- Added a compact `apps/cowswap-frontend/AGENTS.md` pointer for Safe API client token handling.
- Added `apps/cowswap-frontend/docs/safe-api-token.md` documenting that `REACT_APP_SAFE_API_AUTH_TOKEN` is an intentional public client token and defining the remediation boundary.

## Why
Future security-review and agent runs need a durable repo-local source of truth for this accepted browser exposure, without expanding root or frontend AGENTS into a business-logic dump.

## Validation
- `pnpm agents:check`