### PR TITLE
Fix mobile injected wallet startup blank

### DIFF
--- a/libs/common-utils/src/userAgent.test.ts
+++ b/libs/common-utils/src/userAgent.test.ts
@@ -1,0 +1,25 @@
+describe('userAgent', () => {
+  afterEach(() => {
+    jest.resetModules()
+    delete (window as Window & { ethereum?: unknown }).ethereum
+  })
+
+  it('does not throw when an injected wallet bridge throws on access', () => {
+    Object.defineProperty(window, 'ethereum', {
+      configurable: true,
+      get() {
+        throw new Error('provider unavailable')
+      },
+    })
+
+    let userAgentModule: typeof import('./userAgent') | undefined
+
+    expect(() => {
+      jest.isolateModules(() => {
+        userAgentModule = require('./userAgent') as typeof import('./userAgent')
+      })
+    }).not.toThrow()
+
+    expect(userAgentModule?.isCoinbaseWalletBrowser).toBe(false)
+  })
+})

--- a/libs/common-utils/src/userAgent.ts
+++ b/libs/common-utils/src/userAgent.ts
@@ -12,6 +12,14 @@ let isCoinbaseWalletBrowser: boolean = false
 let majorBrowserVersion: number | undefined
 let isChrome: boolean = false
 
+function getInjectedWalletInfo(): { isCoinbaseWallet?: boolean } | undefined {
+  try {
+    return (window as Window & { ethereum?: { isCoinbaseWallet?: boolean } }).ethereum
+  } catch {
+    return undefined
+  }
+}
+
 if (typeof window !== 'undefined') {
   userAgentRaw = window.navigator.userAgent
   parser = new UAParser(userAgentRaw)
@@ -20,9 +28,7 @@ if (typeof window !== 'undefined') {
   userAgent = parser.getResult()
   isMobile = type === 'mobile' || type === 'tablet'
   isImTokenBrowser = /imToken/.test(userAgentRaw)
-  // TODO: Replace any with proper type definitions
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  isCoinbaseWalletBrowser = !!(window as any).ethereum?.isCoinbaseWallet
+  isCoinbaseWalletBrowser = !!getInjectedWalletInfo()?.isCoinbaseWallet
 
   // TODO: Add proper return type annotation
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type

--- a/libs/wallet/src/api/utils/connection.test.ts
+++ b/libs/wallet/src/api/utils/connection.test.ts
@@ -1,0 +1,19 @@
+import { getInjectedProvider, getIsInjected } from './connection'
+
+describe('connection utils', () => {
+  afterEach(() => {
+    delete (window as Window & { ethereum?: unknown }).ethereum
+  })
+
+  it('returns false when an injected wallet bridge throws on access', () => {
+    Object.defineProperty(window, 'ethereum', {
+      configurable: true,
+      get() {
+        throw new Error('provider unavailable')
+      },
+    })
+
+    expect(getIsInjected()).toBe(false)
+    expect(getInjectedProvider()).toBeUndefined()
+  })
+})

--- a/libs/wallet/src/api/utils/connection.ts
+++ b/libs/wallet/src/api/utils/connection.ts
@@ -1,7 +1,23 @@
 import { isMobile } from '@cowprotocol/common-utils'
 
+import type { EIP1193Provider } from 'viem'
+
+type WindowWithInjectedProvider = {
+  ethereum?: unknown
+}
+
+export function getInjectedProvider(targetWindow?: WindowWithInjectedProvider): EIP1193Provider | undefined {
+  try {
+    const ethereumWindow = targetWindow ?? (typeof window === 'undefined' ? undefined : window)
+
+    return ethereumWindow?.ethereum as EIP1193Provider | undefined
+  } catch {
+    return undefined
+  }
+}
+
 export function getIsInjected(): boolean {
-  return Boolean(window.ethereum)
+  return Boolean(getInjectedProvider())
 }
 
 export function getIsInjectedMobileBrowser(): boolean {

--- a/libs/wallet/src/wagmi/config.ts
+++ b/libs/wallet/src/wagmi/config.ts
@@ -81,6 +81,8 @@ const wagmiAdapter = new WagmiAdapter({
 const urlChainId = getCurrentChainIdFromUrl()
 const defaultEvmChainId: EvmChains = isEvmChain(urlChainId) ? urlChainId : EvmChains.MAINNET
 
+// AppKit 1.8.19 does not copy createAppKit({ enableInjected }) into OptionsController.state.
+// WagmiAdapter.addWagmiConnectors() reads this controller state before adding its default injected connector.
 OptionsController.setOptions({ ...OptionsController.state, enableInjected: false })
 
 const reownAppKit = createAppKit({

--- a/libs/wallet/src/wagmi/config.ts
+++ b/libs/wallet/src/wagmi/config.ts
@@ -4,6 +4,7 @@ import { EvmChains, isEvmChain } from '@cowprotocol/cow-sdk'
 
 import { createAppKit } from '@reown/appkit/react'
 import { WagmiAdapter } from '@reown/appkit-adapter-wagmi'
+import { OptionsController } from '@reown/appkit-controllers'
 import { http } from 'viem'
 import { type Transport } from 'wagmi'
 
@@ -80,12 +81,15 @@ const wagmiAdapter = new WagmiAdapter({
 const urlChainId = getCurrentChainIdFromUrl()
 const defaultEvmChainId: EvmChains = isEvmChain(urlChainId) ? urlChainId : EvmChains.MAINNET
 
+OptionsController.setOptions({ ...OptionsController.state, enableInjected: false })
+
 const reownAppKit = createAppKit({
   adapters: [wagmiAdapter],
   allowUnsupportedChain: true,
   customRpcUrls,
   defaultNetwork: VIEM_CHAINS[defaultEvmChainId],
   enableEIP6963: true,
+  enableInjected: false,
   enableReconnect: true,
   enableWalletGuide: false,
   featuredWalletIds: [

--- a/libs/wallet/src/wagmi/getConnectors.test.ts
+++ b/libs/wallet/src/wagmi/getConnectors.test.ts
@@ -1,0 +1,76 @@
+import { isInjectedWidget } from '@cowprotocol/common-utils'
+
+import { injected, safe } from '@wagmi/connectors'
+
+import { getConnectors } from './getConnectors'
+
+import { COW_WIDGET_CONNECTOR_ID } from '../reown/consts'
+import { getIsSafeAppIframe } from '../utils/getIsSafeAppIframe'
+
+import type { CreateConnectorFn } from 'wagmi'
+
+const mockBrowserInjectedConnector = (() => undefined) as unknown as CreateConnectorFn
+const mockWidgetConnector = (() => undefined) as unknown as CreateConnectorFn
+const mockSafeConnector = (() => undefined) as unknown as CreateConnectorFn
+
+jest.mock('@cowprotocol/common-utils', () => ({
+  isInjectedWidget: jest.fn(),
+}))
+
+jest.mock('@cowprotocol/iframe-transport', () => ({
+  WidgetEthereumProvider: jest.fn(),
+}))
+
+jest.mock('@wagmi/connectors', () => ({
+  injected: jest.fn((params: { target?: { id?: string } }) =>
+    params.target?.id === 'cow-widget' ? mockWidgetConnector : mockBrowserInjectedConnector,
+  ),
+  safe: jest.fn(() => mockSafeConnector),
+}))
+
+jest.mock('../utils/getIsSafeAppIframe', () => ({
+  getIsSafeAppIframe: jest.fn(),
+}))
+
+const isInjectedWidgetMock = isInjectedWidget as jest.MockedFunction<typeof isInjectedWidget>
+const getIsSafeAppIframeMock = getIsSafeAppIframe as jest.MockedFunction<typeof getIsSafeAppIframe>
+const injectedMock = injected as jest.MockedFunction<typeof injected>
+const safeMock = safe as jest.MockedFunction<typeof safe>
+
+describe('getConnectors', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    isInjectedWidgetMock.mockReturnValue(false)
+    getIsSafeAppIframeMock.mockReturnValue(false)
+  })
+
+  it('adds the guarded browser injected connector in regular app mode', () => {
+    expect(getConnectors()).toEqual([mockBrowserInjectedConnector])
+    expect(injectedMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({ id: 'injected' }),
+        shimDisconnect: true,
+      }),
+    )
+  })
+
+  it('does not add the browser injected connector in Safe App mode', () => {
+    getIsSafeAppIframeMock.mockReturnValue(true)
+
+    expect(getConnectors()).toEqual([mockSafeConnector])
+    expect(safeMock).toHaveBeenCalledWith({ unstable_getInfoTimeout: 1000 })
+    expect(injectedMock).not.toHaveBeenCalled()
+  })
+
+  it('does not add the browser injected connector in injected widget mode', () => {
+    isInjectedWidgetMock.mockReturnValue(true)
+
+    expect(getConnectors()).toEqual([mockWidgetConnector])
+    expect(injectedMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({ id: COW_WIDGET_CONNECTOR_ID }),
+        shimDisconnect: false,
+      }),
+    )
+  })
+})

--- a/libs/wallet/src/wagmi/getConnectors.ts
+++ b/libs/wallet/src/wagmi/getConnectors.ts
@@ -4,13 +4,25 @@ import { WidgetEthereumProvider } from '@cowprotocol/iframe-transport'
 import { injected, safe } from '@wagmi/connectors'
 import { EIP1193Provider } from 'viem'
 
+import { getInjectedProvider } from '../api/utils/connection'
 import { COW_WIDGET_CONNECTOR_ID } from '../reown/consts'
 import { getIsSafeAppIframe } from '../utils/getIsSafeAppIframe'
 
 import type { CreateConnectorFn } from 'wagmi'
 
+function getBrowserInjectedConnector(): CreateConnectorFn {
+  return injected({
+    target: {
+      id: 'injected',
+      name: 'Injected',
+      provider: getInjectedProvider,
+    },
+    shimDisconnect: true,
+  })
+}
+
 export function getConnectors(): CreateConnectorFn[] | undefined {
-  const connectors: CreateConnectorFn[] = []
+  const connectors: CreateConnectorFn[] = [getBrowserInjectedConnector()]
 
   if (getIsSafeAppIframe()) {
     connectors.push(safe({ unstable_getInfoTimeout: 1000 }))
@@ -29,5 +41,5 @@ export function getConnectors(): CreateConnectorFn[] | undefined {
     )
   }
 
-  return connectors.length === 0 ? undefined : connectors
+  return connectors
 }

--- a/libs/wallet/src/wagmi/getConnectors.ts
+++ b/libs/wallet/src/wagmi/getConnectors.ts
@@ -22,13 +22,19 @@ function getBrowserInjectedConnector(): CreateConnectorFn {
 }
 
 export function getConnectors(): CreateConnectorFn[] | undefined {
-  const connectors: CreateConnectorFn[] = [getBrowserInjectedConnector()]
+  const isSafeApp = getIsSafeAppIframe()
+  const isWidget = isInjectedWidget()
+  const connectors: CreateConnectorFn[] = []
 
-  if (getIsSafeAppIframe()) {
+  if (!isSafeApp && !isWidget) {
+    connectors.push(getBrowserInjectedConnector())
+  }
+
+  if (isSafeApp) {
     connectors.push(safe({ unstable_getInfoTimeout: 1000 }))
   }
 
-  if (isInjectedWidget()) {
+  if (isWidget) {
     connectors.push(
       injected({
         target: {
@@ -41,5 +47,5 @@ export function getConnectors(): CreateConnectorFn[] | undefined {
     )
   }
 
-  return connectors
+  return connectors.length === 0 ? undefined : connectors
 }


### PR DESCRIPTION
## What changed
- Guard injected wallet-provider reads so a throwing mobile wallet bridge cannot abort app startup.
- Register an app-owned Wagmi injected connector that uses the guarded provider lookup.
- Disable Reown/AppKit default injected connector creation so it does not read `window.ethereum` directly.
- Add regression coverage for throwing `window.ethereum` access in wallet connection and user-agent helpers.

## Why
- Mobile integrated wallet browsers can expose `window.ethereum` through a bridge that throws while the app or wallet libraries inspect it during startup.
- On the release branch, that could leave the app on a blank page or fail before the user can connect a wallet.
- The AppKit default injected connector bypassed our guarded provider lookup, so the fix needs both the guarded helper and explicit connector wiring.

## QA Testing

Preview URL QA:
- Open the branch preview in MetaMask Mobile and 1inch Wallet browser: https://fix-7689-mobile-injected-wal.swap-dev-5u6.pages.dev
- Open the reported route state in the same mobile wallet browsers: https://fix-7689-mobile-injected-wal.swap-dev-5u6.pages.dev/#/59144/swap/aLinUSDT/ETH
- Confirm the swap page renders instead of a blank screen, and `Connect wallet` starts the wallet connection flow.

Developer verification:
- `libs/wallet/src/api/utils/connection.test.ts` covers injected-provider lookup when `window.ethereum` throws.
- `libs/common-utils/src/userAgent.test.ts` covers user-agent startup detection when `window.ethereum` throws.
- Local Playwright smoke with an iPhone 13 viewport and throwing `window.ethereum` getter rendered the app in Chromium and WebKit.
- Local Playwright smoke with a healthy mocked injected provider rendered the app connected as `0x000...001` with no app-bundle page errors.
- `GITHUB_PACKAGES_TOKEN=dummy NX_DAEMON=false pnpm build:cowswap`

## Preview URLs

| Surface | URL |
| --- | --- |
| swap-dev - branch preview URL | https://fix-7689-mobile-injected-wal.swap-dev-5u6.pages.dev |
| explorer-dev - branch preview URL | https://fix-7689-mobile-injected-wal.explorer-dev-dxz.pages.dev |

Refs #7689
