### PR TITLE
feat(widget): control tokens switching

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeWidget/TradeWidgetForm.tsx
@@ -51,6 +51,8 @@ import { TradeWarnings } from '../TradeWarnings'
 import { TradeWidgetLinks } from '../TradeWidgetLinks'
 import { WrapFlowActionButton } from '../WrapFlowActionButton'
 
+const noop: () => void = () => void 0
+
 // TODO: Add proper return type annotation
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const scrollToMyOrders = () => {
@@ -66,7 +68,7 @@ const scrollToMyOrders = () => {
 // eslint-disable-next-line max-lines-per-function, complexity
 export function TradeWidgetForm(props: TradeWidgetProps): ReactNode {
   const isInjectedWidgetMode = isInjectedWidget()
-  const { standaloneMode, hideOrdersTable, cardStyle } = useInjectedWidgetParams()
+  const { standaloneMode, hideOrdersTable, cardStyle, disableSwitchingTokens } = useInjectedWidgetParams()
   const isMobile = useMediaQuery(Media.upToSmall(false))
 
   const tradeTypeInfo = useTradeTypeInfoFromUrl()
@@ -223,6 +225,13 @@ export function TradeWidgetForm(props: TradeWidgetProps): ReactNode {
 
   const { t } = useLingui()
 
+  const disableTokensSwitching =
+    shouldLockForAlternativeOrder ||
+    isOutputTokenUnsupported ||
+    isProviderNetworkUnsupported ||
+    isProviderNetworkDeprecated ||
+    disableSwitchingTokens === true
+
   return (
     <>
       <styledEl.ContainerBox id="card" style={isInjectedWidgetMode ? (cardStyle as CSSProperties) : undefined}>
@@ -276,18 +285,9 @@ export function TradeWidgetForm(props: TradeWidgetProps): ReactNode {
                   <CurrencyArrowSeparator
                     isCollapsed={compactView}
                     hasSeparatorLine={!compactView}
-                    onSwitchTokens={
-                      isProviderNetworkUnsupported || isProviderNetworkDeprecated
-                        ? () => void 0
-                        : throttledOnSwitchTokens
-                    }
+                    onSwitchTokens={disableTokensSwitching ? noop : throttledOnSwitchTokens}
                     isLoading={Boolean(sellToken && outputCurrencyInfo.currency && isTradePriceUpdating)}
-                    disabled={
-                      shouldLockForAlternativeOrder ||
-                      isOutputTokenUnsupported ||
-                      isProviderNetworkUnsupported ||
-                      isProviderNetworkDeprecated
-                    }
+                    disabled={disableTokensSwitching}
                     isDarkMode={darkMode}
                   />
                 </styledEl.CurrencySeparatorBox>

--- a/apps/widget-configurator/src/components/forms/behavior/BehaviorSectionForm.tsx
+++ b/apps/widget-configurator/src/components/forms/behavior/BehaviorSectionForm.tsx
@@ -30,6 +30,11 @@ export function BehaviorSectionForm({ values, onChange, toastManager }: Behavior
         onChange={(enabled) => onChange('disablePostTradeTips', !enabled)}
       />
       <SwitchInput
+        checked={!values.disableSwitchingTokens}
+        label="Allow switching tokens places by clicking to the arrow between them"
+        onChange={(enabled) => onChange('disableSwitchingTokens', !enabled)}
+      />
+      <SwitchInput
         checked={!values.disableTokenImport}
         label="Allow custom token imports"
         onChange={(enabled) => onChange('disableTokenImport', !enabled)}

--- a/apps/widget-configurator/src/configurator.constants.ts
+++ b/apps/widget-configurator/src/configurator.constants.ts
@@ -190,6 +190,7 @@ export const DEFAULT_CONFIGURATOR_FORM_VALUES: ConfiguratorFormValues = {
   disableProgressBar: false,
   disablePostTradeTips: false,
   disableTokenImport: false,
+  disableSwitchingTokens: false,
   hideRecentTokens: false,
   hideFavoriteTokens: false,
   hideBridgeInfo: false,

--- a/apps/widget-configurator/src/configurator.types.ts
+++ b/apps/widget-configurator/src/configurator.types.ts
@@ -71,6 +71,7 @@ export interface ConfiguratorFormValues {
   disableProgressBar: boolean
   disablePostTradeTips: boolean
   disableTokenImport: boolean
+  disableSwitchingTokens: boolean
   hideRecentTokens: boolean
   hideFavoriteTokens: boolean
   hideBridgeInfo: boolean | undefined

--- a/apps/widget-configurator/src/hooks/useWidgetParamsAndSettings.ts
+++ b/apps/widget-configurator/src/hooks/useWidgetParamsAndSettings.ts
@@ -185,6 +185,7 @@ function buildWidgetParams(configuratorState: ConfiguratorState | null): CowSwap
     disableProgressBar,
     disablePostTradeTips,
     disableTokenImport,
+    disableSwitchingTokens,
     hideRecentTokens,
     hideFavoriteTokens,
     hideBridgeInfo,
@@ -260,6 +261,7 @@ function buildWidgetParams(configuratorState: ConfiguratorState | null): CowSwap
 
     disableToastMessages,
     disableProgressBar,
+    disableSwitchingTokens,
     disablePostTradeTips,
     disableTokenImport,
     hideRecentTokens,

--- a/libs/widget-lib/src/types.ts
+++ b/libs/widget-lib/src/types.ts
@@ -452,6 +452,11 @@ export interface CowSwapWidgetParams {
   disableProgressBar?: boolean
 
   /**
+   * Disabled switching tokens places by clicking to the arrow between them
+   */
+  disableSwitchingTokens?: boolean
+
+  /**
    * Hides scrollbars inside the widget iframe (`overflow: hidden` on the document).
    * Only use when the host iframe height is driven by `var(--dynamicHeight)` and not constrained (e.g. no max-height).
    *


### PR DESCRIPTION
# Summary

The new `disableSwitchingTokens` should disable switching tokens' places on the arrow click.

<img width="471" height="256" alt="image" src="https://github.com/user-attachments/assets/b72e3dea-fc09-42e9-aca8-8545e6fea68b" />

# To Test

1. Toggle off "Allow switching tokens places by clicking to the arrow between them" in Behavior section
2. Try clicking on the arrow between assets
- [ ] the arrow should not be clickable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to disable token switching in the trade widget. The token exchange button (arrow between sell and buy tokens) can now be controlled through the widget configurator, allowing greater customization of widget behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->