### PR TITLE
[codex] Prevent MetaMask mobile quote button hang

### DIFF
--- a/libs/wallet/src/api/hooks/useWalletCapabilities.test.ts
+++ b/libs/wallet/src/api/hooks/useWalletCapabilities.test.ts
@@ -1,0 +1,34 @@
+import { shouldCheckCapabilities } from './useWalletCapabilities.utils'
+
+const desktopEnvironment = {
+  isInjectedMobileBrowser: false,
+  isInjectedWidget: false,
+  isMobile: false,
+}
+
+const mobileEnvironment = {
+  ...desktopEnvironment,
+  isMobile: true,
+}
+
+describe('shouldCheckCapabilities', () => {
+  it('checks capabilities for desktop injected wallets', () => {
+    expect(shouldCheckCapabilities(false, { isLoading: false }, desktopEnvironment)).toBe(true)
+  })
+
+  it('skips capabilities for injected mobile browsers', () => {
+    expect(
+      shouldCheckCapabilities(false, { isLoading: false }, { ...mobileEnvironment, isInjectedMobileBrowser: true }),
+    ).toBe(false)
+  })
+
+  it('skips capabilities for mobile WalletConnect sessions', () => {
+    expect(shouldCheckCapabilities(true, { isLoading: false }, mobileEnvironment)).toBe(false)
+  })
+
+  it('waits for widget provider metadata before deciding on mobile', () => {
+    expect(shouldCheckCapabilities(false, { isLoading: true }, { ...mobileEnvironment, isInjectedWidget: true })).toBe(
+      false,
+    )
+  })
+})

--- a/libs/wallet/src/api/hooks/useWalletCapabilities.ts
+++ b/libs/wallet/src/api/hooks/useWalletCapabilities.ts
@@ -4,12 +4,15 @@ import { isInjectedWidget, isMobile } from '@cowprotocol/common-utils'
 
 import { useCapabilities } from 'wagmi'
 
+import { shouldCheckCapabilities } from './useWalletCapabilities.utils'
 import { useWidgetProviderMetaInfo } from './useWidgetProviderMetaInfo'
 
 import { useIsWalletConnect } from '../../wagmi/hooks/useIsWalletConnect'
 import { useIsSafeViaWc } from '../../wagmi/hooks/useWalletMetadata'
 import { useWalletInfo } from '../hooks'
+import { getIsInjectedMobileBrowser } from '../utils/connection'
 
+import type { WalletCapabilitiesEnvironment } from './useWalletCapabilities.utils'
 import type { GetCapabilitiesData } from '@wagmi/core/query'
 
 export type WalletCapabilities = {
@@ -17,19 +20,12 @@ export type WalletCapabilities = {
   atomicBatch?: { supported: boolean }
 }
 
-function shouldCheckCapabilities(
-  isWalletConnect: boolean,
-  { data, isLoading }: ReturnType<typeof useWidgetProviderMetaInfo>,
-): boolean {
-  // When widget in the mobile device, wait till providerWcMetadata is loaded
-  // In order to detect if is connected to WalletConnect
-  if (isInjectedWidget() && isMobile && isLoading) {
-    return false
+function getWalletCapabilitiesEnvironment(): WalletCapabilitiesEnvironment {
+  return {
+    isInjectedMobileBrowser: getIsInjectedMobileBrowser(),
+    isInjectedWidget: isInjectedWidget(),
+    isMobile,
   }
-
-  const isWalletConnectViaWidget = Boolean(data?.providerWcMetadata)
-
-  return !((isWalletConnect || isWalletConnectViaWidget) && isMobile)
 }
 
 export function useWalletCapabilities(): { data: WalletCapabilities | undefined; isLoading: boolean } {
@@ -39,7 +35,12 @@ export function useWalletCapabilities(): { data: WalletCapabilities | undefined;
   const isSafeViaWc = useIsSafeViaWc()
 
   const shouldFetchCapabilities = useMemo(
-    () => Boolean(shouldCheckCapabilities(isWalletConnect, widgetProviderMetaInfo) && account && chainId),
+    () =>
+      Boolean(
+        shouldCheckCapabilities(isWalletConnect, widgetProviderMetaInfo, getWalletCapabilitiesEnvironment()) &&
+          account &&
+          chainId,
+      ),
     [isWalletConnect, widgetProviderMetaInfo, account, chainId],
   )
 

--- a/libs/wallet/src/api/hooks/useWalletCapabilities.utils.ts
+++ b/libs/wallet/src/api/hooks/useWalletCapabilities.utils.ts
@@ -1,0 +1,36 @@
+export interface WidgetProviderMetaInfoState {
+  data?: { providerWcMetadata?: unknown }
+  isLoading: boolean
+}
+
+export interface WalletCapabilitiesEnvironment {
+  isInjectedMobileBrowser: boolean
+  isInjectedWidget: boolean
+  isMobile: boolean
+}
+
+export function shouldCheckCapabilities(
+  isWalletConnect: boolean,
+  { data, isLoading }: WidgetProviderMetaInfoState,
+  environment: WalletCapabilitiesEnvironment,
+): boolean {
+  // When widget in the mobile device, wait till providerWcMetadata is loaded
+  // In order to detect if is connected to WalletConnect
+  if (environment.isInjectedWidget && environment.isMobile && isLoading) {
+    return false
+  }
+
+  const isWalletConnectViaWidget = Boolean(data?.providerWcMetadata)
+
+  if ((isWalletConnect || isWalletConnectViaWidget) && environment.isMobile) {
+    return false
+  }
+
+  // Some injected mobile browsers expose wallet_getCapabilities but never settle the request.
+  // Treat them as capability-unknown so regular trading is not blocked by WalletCapabilitiesLoading.
+  if (environment.isInjectedMobileBrowser) {
+    return false
+  }
+
+  return true
+}


### PR DESCRIPTION
## What changed
- Skip wallet capability probing for injected mobile browsers before enabling `useCapabilities`.
- Move the capability-gating decision into a small utility with focused tests.

## Why
- MetaMask iOS can leave `wallet_getCapabilities` pending on some chains, which leaves the swap button in `WalletCapabilitiesLoading` even after the quote, balances, and account render.
- Mobile injected wallets are now treated as capability-unknown, matching the existing mobile WalletConnect behavior and avoiding a blocker for regular swaps.
- Fixes #7700

## QA Testing

Developer verification:
- `pnpm exec jest --config libs/wallet/jest.config.ts --runTestsByPath libs/wallet/src/api/hooks/useWalletCapabilities.test.ts --runInBand`
- `pnpx nx run wallet:lint`
- `pnpm exec prettier --check libs/wallet/src/api/hooks/useWalletCapabilities.ts libs/wallet/src/api/hooks/useWalletCapabilities.utils.ts libs/wallet/src/api/hooks/useWalletCapabilities.test.ts`
- Local browser regression on `http://localhost:3001/#/56/swap/0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d/0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c?sellAmount=3.56584341`: mobile WebKit plus an injected MetaMask-like provider whose `wallet_getCapabilities` never resolves made zero `wallet_getCapabilities` calls and rendered `Approve and Swap` instead of the stuck-dot button.

Reviewer note:
- I did not run a real iOS MetaMask device from this branch. The browser regression reproduces the app-level failure mode observed on iOS by making only `wallet_getCapabilities` hang while quote and balance requests continue normally.
