### PR TITLE
fix(wallet): auto connect mobile injected wallet

### DIFF
--- a/libs/wallet/src/wagmi/config.ts
+++ b/libs/wallet/src/wagmi/config.ts
@@ -1,5 +1,5 @@
 import { RPC_URLS, VIEM_CHAINS } from '@cowprotocol/common-const'
-import { getCurrentChainIdFromUrl } from '@cowprotocol/common-utils'
+import { getCurrentChainIdFromUrl, isMobile } from '@cowprotocol/common-utils'
 import { EvmChains, isEvmChain } from '@cowprotocol/cow-sdk'
 
 import { createAppKit } from '@reown/appkit/react'
@@ -122,6 +122,8 @@ const reownAppKit = createAppKit({
  */
 if (getIsSafeAppIframe()) {
   connectWalletById(SAFE_CONNECTOR_ID, 'safe')
+} else if (isMobile && window.ethereum) {
+  connectWalletById('injected', 'injected')
 }
 
 bindActiveProvider(wagmiAdapter)


### PR DESCRIPTION
# Summary

It should automatically connect window.ethereum if is open in injected mobile browser.

# To Test

1. Open CoW Swap in MM injected browser

- [ ] it should automatically connect the wallet
