### PR TITLE
fix(zero-approval): stop logging expected USDT approve revert as an error

### DIFF
--- a/apps/cowswap-frontend/src/modules/zeroApproval/hooks/useShouldZeroApprove/shouldZeroApprove.test.ts
+++ b/apps/cowswap-frontend/src/modules/zeroApproval/hooks/useShouldZeroApprove/shouldZeroApprove.test.ts
@@ -1,0 +1,76 @@
+import { BaseError } from 'viem'
+import { simulateContract } from 'wagmi/actions'
+
+import { shouldZeroApprove } from './shouldZeroApprove'
+
+import type { Config } from 'wagmi'
+
+jest.mock('wagmi/actions', () => ({
+  simulateContract: jest.fn(),
+}))
+
+const simulateContractMock = simulateContract as jest.MockedFunction<typeof simulateContract>
+
+const baseParams = {
+  tokenAddress: '0xdAC17F958D2ee523a2206206994597C13D831ec7' as const,
+  spender: '0xC92E8bdf79f0507f65a392b0ab4667716BFE0110' as const,
+  // Only `quotient.toString()` is read by shouldZeroApprove
+  amountToApprove: { quotient: { toString: () => '4' } } as never,
+  config: {} as Config,
+  forceApprove: true,
+}
+
+describe('shouldZeroApprove', () => {
+  let errorSpy: jest.SpyInstance
+  let warnSpy: jest.SpyInstance
+  let debugSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+    debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    errorSpy.mockRestore()
+    warnSpy.mockRestore()
+    debugSpy.mockRestore()
+  })
+
+  it('returns null when required params are missing', async () => {
+    expect(await shouldZeroApprove({ ...baseParams, config: null })).toBe(null)
+    expect(simulateContractMock).not.toHaveBeenCalled()
+  })
+
+  it('returns false when the approve simulation succeeds (no zero-approval needed)', async () => {
+    simulateContractMock.mockResolvedValueOnce({} as never)
+
+    expect(await shouldZeroApprove(baseParams)).toBe(false)
+    expect(simulateContractMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('detects USDT-style tokens without logging a scary error', async () => {
+    // First (non-zero) approve reverts as USDT requires resetting the allowance to zero first,
+    // the zero-amount approve then succeeds.
+    simulateContractMock
+      .mockRejectedValueOnce(new BaseError('The contract function "approve" reverted'))
+      .mockResolvedValueOnce({} as never)
+
+    expect(await shouldZeroApprove(baseParams)).toBe(true)
+    expect(simulateContractMock).toHaveBeenCalledTimes(2)
+    // The expected revert must not surface as a red console error.
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(debugSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('warns (not errors) and returns false when both simulations revert', async () => {
+    simulateContractMock
+      .mockRejectedValueOnce(new BaseError('first revert'))
+      .mockRejectedValueOnce(new BaseError('second revert'))
+
+    expect(await shouldZeroApprove(baseParams)).toBe(false)
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/cowswap-frontend/src/modules/zeroApproval/hooks/useShouldZeroApprove/shouldZeroApprove.ts
+++ b/apps/cowswap-frontend/src/modules/zeroApproval/hooks/useShouldZeroApprove/shouldZeroApprove.ts
@@ -1,12 +1,18 @@
 import { Currency, CurrencyAmount } from '@cowprotocol/currency'
 
 import { Nullish } from 'types'
-import { Address } from 'viem'
+import { Address, BaseError } from 'viem'
 import { simulateContract } from 'wagmi/actions'
 
 import { ApprovalState } from 'modules/erc20Approve'
 
 import type { Config } from 'wagmi'
+
+// viem errors are multi-line `BaseError`s; logging the whole object floods the console with a
+// scary stack + docs links. We only need the one-line reason here.
+function getSimulationErrorReason(e: unknown): string {
+  return e instanceof BaseError ? e.shortMessage : String(e)
+}
 
 const erc20Abi = [
   {
@@ -63,7 +69,10 @@ export async function shouldZeroApprove({
 
     return false
   } catch (e) {
-    console.error('shouldZeroApprove #1 error', e)
+    // Approving a non-zero amount over an existing non-zero allowance reverts for USDT-style tokens
+    // that require resetting the allowance to zero first. This is expected and is exactly how we
+    // detect that a zero-approval is needed, so keep it as a quiet debug breadcrumb.
+    console.debug('shouldZeroApprove: approve simulation reverted, checking zero-approval', getSimulationErrorReason(e))
     try {
       await simulateContract(config, {
         address: tokenAddress,
@@ -73,7 +82,8 @@ export async function shouldZeroApprove({
       })
       return true
     } catch (e) {
-      console.error('shouldZeroApprove #2 error', e)
+      // The zero-amount approval also reverted, so we can't determine the allowance behaviour.
+      console.warn('shouldZeroApprove: zero-amount approve simulation reverted', getSimulationErrorReason(e))
       return false
     }
   }


### PR DESCRIPTION
# Summary

Fixes #7547

`shouldZeroApprove` figures out whether a token needs its allowance reset to zero first (USDT and friends) by simulating the `approve` and catching the revert. That revert is expected — it's the whole detection mechanism — but it was logged with `console.error(e)` where `e` is the full viem `BaseError`, so the console filled with a scary red stack (viem docs links, version, etc.) on every sell-amount change.

Now the expected first-pass revert is a quiet `console.debug` breadcrumb, and the genuinely-unexpected case (the zero-amount approve also reverting) is a `console.warn`. Both log only the error's `shortMessage` instead of the whole multi-line viem error.

# To Test

1. On Ethereum, have e.g. 2 USDT approved to the CoW vault relayer.
2. Enter a sell amount greater than the current approval (e.g. 4 USDT) and open the console.

- [ ] No red `shouldZeroApprove #1 error` stack with the viem error dump.
- [ ] At most a greyed-out `debug` breadcrumb; the zero-approval flow still works (USDT still prompts the reset-to-zero step).

# Background

The expected-revert path fires reactively on every keystroke via the zero-approval warning hook, so the noisy log was especially spammy.
