### PR TITLE
fix: add Safe preview/test urls to iframe allowlist

### DIFF
--- a/libs/wallet/src/utils/getIsSafeAppIframe.test.ts
+++ b/libs/wallet/src/utils/getIsSafeAppIframe.test.ts
@@ -1,0 +1,42 @@
+import { getParentOrigin } from '@cowprotocol/iframe-transport'
+
+import { getIsSafeAppIframe } from './getIsSafeAppIframe'
+
+jest.mock('@cowprotocol/iframe-transport', () => ({
+  getParentOrigin: jest.fn(),
+}))
+
+const getParentOriginMock = getParentOrigin as jest.MockedFunction<typeof getParentOrigin>
+
+describe('getIsSafeAppIframe', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it.each([
+    ['https://app.safe.global'],
+    ['https://safe-wallet-monorepo-cowswap-web.vercel.app'],
+    ['https://safe-wallet-web.dev.5afe.dev'],
+    ['https://safe-wallet-web.staging.5afe.dev'],
+    ['https://pr-123.review.5afe.dev'],
+    ['http://localhost:4003'],
+    ['http://localhost:3000'],
+  ])('returns true for supported Safe parent origin %s', (origin) => {
+    getParentOriginMock.mockReturnValue(origin)
+
+    expect(getIsSafeAppIframe()).toBe(true)
+  })
+
+  it.each([
+    undefined,
+    'https://review.5afe.dev',
+    'http://pr-123.review.5afe.dev',
+    'https://pr-123.review.5afe.dev:444',
+    'https://pr-123.review.5afe.dev.evil.com',
+    'https://evil-pr-123-review-5afe.dev',
+  ])('returns false for unsupported parent origin %s', (origin) => {
+    getParentOriginMock.mockReturnValue(origin)
+
+    expect(getIsSafeAppIframe()).toBe(false)
+  })
+})

--- a/libs/wallet/src/utils/getIsSafeAppIframe.test.ts
+++ b/libs/wallet/src/utils/getIsSafeAppIframe.test.ts
@@ -20,7 +20,6 @@ describe('getIsSafeAppIframe', () => {
     ['https://safe-wallet-web.staging.5afe.dev'],
     ['https://pr-123.review.5afe.dev'],
     ['http://localhost:4003'],
-    ['http://localhost:3000'],
   ])('returns true for supported Safe parent origin %s', (origin) => {
     getParentOriginMock.mockReturnValue(origin)
 
@@ -29,6 +28,7 @@ describe('getIsSafeAppIframe', () => {
 
   it.each([
     undefined,
+    'http://localhost:3000',
     'https://review.5afe.dev',
     'http://pr-123.review.5afe.dev',
     'https://pr-123.review.5afe.dev:444',

--- a/libs/wallet/src/utils/getIsSafeAppIframe.ts
+++ b/libs/wallet/src/utils/getIsSafeAppIframe.ts
@@ -2,13 +2,26 @@ import { getParentOrigin } from '@cowprotocol/iframe-transport'
 
 import { SAFE_APP_ORIGIN } from '../constants'
 
-const SAFE_APP_PREVIEW_URL = 'https://safe-wallet-monorepo-cowswap-web.vercel.app'
-const SAFE_APP_LOCAL_URL = 'http://localhost:4003'
-const SAFE_SUPPORTED_ORIGINS = [SAFE_APP_ORIGIN, SAFE_APP_PREVIEW_URL, SAFE_APP_LOCAL_URL]
+const SAFE_APP_PREVIEW_URLS = [
+  'https://safe-wallet-monorepo-cowswap-web.vercel.app', // Our internal Safe app for testing
+  'https://safe-wallet-web.dev.5afe.dev', // Safe's dev env
+  'https://safe-wallet-web.staging.5afe.dev', // Safe's staging env
+]
+const SAFE_APP_PREVIEW_HOST_SUFFIX = '.review.5afe.dev' // Safe's preview env
+const SAFE_APP_LOCAL_URLS = ['http://localhost:4003', 'http://localhost:3000']
+const SAFE_SUPPORTED_ORIGINS = [SAFE_APP_ORIGIN, ...SAFE_APP_PREVIEW_URLS, ...SAFE_APP_LOCAL_URLS].map(
+  (origin) => new URL(origin).origin,
+)
 
 export function getIsSafeAppIframe(): boolean {
   const origin = getParentOrigin()
 
   if (!origin) return false
-  return SAFE_SUPPORTED_ORIGINS.includes(origin)
+
+  const originUrl = new URL(origin)
+
+  return (
+    SAFE_SUPPORTED_ORIGINS.includes(originUrl.origin) ||
+    (originUrl.protocol === 'https:' && !originUrl.port && originUrl.hostname.endsWith(SAFE_APP_PREVIEW_HOST_SUFFIX))
+  )
 }

--- a/libs/wallet/src/utils/getIsSafeAppIframe.ts
+++ b/libs/wallet/src/utils/getIsSafeAppIframe.ts
@@ -8,8 +8,8 @@ const SAFE_APP_PREVIEW_URLS = [
   'https://safe-wallet-web.staging.5afe.dev', // Safe's staging env
 ]
 const SAFE_APP_PREVIEW_HOST_SUFFIX = '.review.5afe.dev' // Safe's preview env
-const SAFE_APP_LOCAL_URLS = ['http://localhost:4003', 'http://localhost:3000']
-const SAFE_SUPPORTED_ORIGINS = [SAFE_APP_ORIGIN, ...SAFE_APP_PREVIEW_URLS, ...SAFE_APP_LOCAL_URLS].map(
+const SAFE_APP_LOCAL_URL = 'http://localhost:4003'
+const SAFE_SUPPORTED_ORIGINS = [SAFE_APP_ORIGIN, ...SAFE_APP_PREVIEW_URLS, SAFE_APP_LOCAL_URL].map(
   (origin) => new URL(origin).origin,
 )
 


### PR DESCRIPTION
# Summary

Adding new preview/test urls to iframe allow-list specific for Safe.

- https://safe-wallet-web.dev.5afe.dev
- https://safe-wallet-web.staging.5afe.dev
- `.review.5afe.dev`
- http://localhost:3000

# To Test

1. Load app from one of those new iframe targets
* Should load as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded iframe origin checks so Safe app embeds are recognized across more supported preview, testing, and localhost environments.
  * Strengthened origin validation by accepting additional review subdomains and rejecting undefined, malformed, and non-matching origins.
* **Tests**
  * Added Jest coverage for trusted vs. untrusted parent iframe origins, including edge cases and malformed values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->