### PR TITLE
fix(wallet): reconnect in embedded contexts so widget/Safe don't show 'Connect Wallet'

### DIFF
--- a/libs/wallet/src/wagmi/config.ts
+++ b/libs/wallet/src/wagmi/config.ts
@@ -1,5 +1,5 @@
 import { IS_SOLANA_ENABLED, RPC_URLS } from '@cowprotocol/common-const'
-import { isMobile } from '@cowprotocol/common-utils'
+import { isInjectedWidget, isMobile } from '@cowprotocol/common-utils'
 import { EvmChains } from '@cowprotocol/cow-sdk'
 
 import { createAppKit } from '@reown/appkit/react'
@@ -79,6 +79,10 @@ OptionsController.setOptions({ ...OptionsController.state, enableInjected: false
 const isSafeApp = getIsSafeAppIframe()
 const hasRecentConnector =
   typeof localStorage !== 'undefined' && Boolean(localStorage.getItem(`${wagmiStorage.key}.recentConnectorId`))
+// Embedded contexts (Safe App iframe, injected widget / dapp mode) (re)establish the connection
+// through the host on every load and don't persist a `recentConnectorId`, so they must reconnect
+// regardless. Without this they'd render a "Connect Wallet" prompt while actually connected.
+const shouldReconnect = hasRecentConnector || isSafeApp || isInjectedWidget()
 
 const reownAppKit = createAppKit({
   adapters: IS_SOLANA_ENABLED ? [wagmiAdapter, solanaAdapter] : [wagmiAdapter],
@@ -87,7 +91,7 @@ const reownAppKit = createAppKit({
   defaultNetwork: getReownDefaultNetwork(),
   enableEIP6963: true,
   enableInjected: false,
-  enableReconnect: hasRecentConnector,
+  enableReconnect: shouldReconnect,
   enableWalletGuide: false,
   featuredWalletIds: [
     // Coinbase Wallet


### PR DESCRIPTION
Fixes #7777

@elena-zh confirmed this regressed in #7757, which changed `enableReconnect: true` → `enableReconnect: hasRecentConnector`.

Embedded contexts — a Safe App iframe, or the injected widget in dapp mode — (re)establish the connection through the host on every load and don't persist a `recentConnectorId`. So reconnect is now disabled for them: the account stays empty and the trade form renders a (disabled) "Connect Wallet" while the wallet is actually connected.

Fix: also enable reconnect when in a Safe App iframe or injected widget, keeping the `hasRecentConnector` gate for the standalone/mobile path #7757 was guarding.

Repro (from the issue): open a Safe App pointing at the widget — `https://app.safe.global/apps/open?safe=<your_safe>&appUrl=https%3A%2F%2Fdev.widget.cow.fi`.

@fairlighteth since this touches the `enableReconnect` gate you added in #7757 — this keeps your mobile-injected guard intact and only restores reconnect for the Safe-app / injected-widget contexts. Does that look right to you?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automatic reconnect behavior for the wallet experience.
  * Reconnect now works in more cases, including Safe App and injected widget/dapp environments, not just previously used connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->