### PR TITLE
chore: disable cowswap build on develop merges

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -26,7 +26,7 @@ jobs:
     secrets: inherit
     strategy:
       matrix:
-        app: [ EXPLORER, COWSWAP ]
+        app: [ EXPLORER ]
     with:
       env_name: dev
       app: ${{ matrix.app }}


### PR DESCRIPTION
# Summary

Disable CoW Swap build for develop merges.
It'll now be built entirely on Vercel.

If successful will proceed with Explorer

# To Test

Needs to be merged to test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the develop-branch deployment process so only the Explorer app is deployed there now.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->