### PR TITLE
chore: disable explorer vercel build on develop merges

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -18,19 +18,6 @@ on:
 
 jobs:
 
-  vercel-dev:
-    # Deploys to Vercel dev environment
-    name: Vercel dev
-    if: github.ref == 'refs/heads/develop'
-    uses: ./.github/workflows/vercel.yml
-    secrets: inherit
-    strategy:
-      matrix:
-        app: [ EXPLORER ]
-    with:
-      env_name: dev
-      app: ${{ matrix.app }}
-
   vercel-pre-prod:
     # Deploys to Vercel staging environment only when there is a tag for CowSwap or Explorer
     name: Vercel pre-prod
@@ -62,7 +49,7 @@ jobs:
 
   notify-failure:
     name: Notify Slack on Failure
-    needs: [ vercel-dev, vercel-pre-prod, vercel-prod ]
+    needs: [ vercel-pre-prod, vercel-prod ]
     runs-on: ubuntu-latest
     if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
 


### PR DESCRIPTION
# Summary

Same as https://github.com/cowprotocol/cowswap/pull/7793, but for Explorer.
Now the `production` develop build on GH actions will be completely disabled.

# To Test

Needs to be merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deployment flow to better match release and tag-based deployments.
  * Adjusted failure notifications so they now wait on the active deployment jobs only.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->