### PR TITLE
feat(bridge): show approximate bridging time while order is pending

### DIFF
--- a/apps/cowswap-frontend/src/common/hooks/useSwapAndBridgeContext.ts
+++ b/apps/cowswap-frontend/src/common/hooks/useSwapAndBridgeContext.ts
@@ -194,7 +194,9 @@ export function useSwapAndBridgeContext(
     const quoteBridgeContext: QuoteBridgeContext = {
       chainName: destChainData.label,
       bridgeFee,
-      estimatedTime: null,
+      // Prefer the ETA captured from the quote; fall back to the live status estimate
+      estimatedTime:
+        bridgeQuoteAmounts?.expectedFillTimeSeconds ?? crossChainOrder.statusResult.fillTimeInSeconds ?? null,
       recipient: crossChainOrder.bridgingParams.recipient,
       sellAmount: swapAndBridgeOverview.targetAmounts.sellAmount,
       buyAmount: swapAndBridgeOverview.targetAmounts.buyAmount,
@@ -229,6 +231,7 @@ export function useSwapAndBridgeContext(
     swapAndBridgeOverview,
     bridgeFee,
     bridgeMinReceiveAmount,
+    bridgeQuoteAmounts,
   ])
 
   const isLoading = isCrossChainOrderLoading

--- a/apps/cowswap-frontend/src/entities/bridgeOrders/state/bridgeOrdersStateSerializer.ts
+++ b/apps/cowswap-frontend/src/entities/bridgeOrders/state/bridgeOrdersStateSerializer.ts
@@ -44,6 +44,7 @@ export function deserializeQuoteAmounts(amounts: BridgeQuoteAmounts<SerializedAm
           amountInIntermediateCurrency: deserializeAmount(amounts.bridgeFeeAmounts.amountInIntermediateCurrency),
         }
       : undefined,
+    expectedFillTimeSeconds: amounts.expectedFillTimeSeconds,
   }
 }
 
@@ -61,6 +62,7 @@ export function serializeQuoteAmounts(amounts: BridgeQuoteAmounts): BridgeQuoteA
           amountInIntermediateCurrency: serializeAmount(amounts.bridgeFeeAmounts.amountInIntermediateCurrency),
         }
       : undefined,
+    expectedFillTimeSeconds: amounts.expectedFillTimeSeconds,
   }
 }
 

--- a/apps/cowswap-frontend/src/modules/bridge/hooks/useBridgeQuoteAmounts.ts
+++ b/apps/cowswap-frontend/src/modules/bridge/hooks/useBridgeQuoteAmounts.ts
@@ -32,6 +32,7 @@ export function useBridgeQuoteAmounts(): BridgeQuoteAmounts | null {
       bridgeMinReceiveAmount,
       bridgeFee: receiveAmountInfo.costs.bridgeFee.amountInDestinationCurrency,
       bridgeFeeAmounts: receiveAmountInfo.costs.bridgeFee,
+      expectedFillTimeSeconds: bridgeQuote.expectedFillTimeSeconds,
     }
   }, [receiveAmountInfo, swapReceiveAmountInfo, bridgeQuote])
 }

--- a/libs/types/src/bridge.ts
+++ b/libs/types/src/bridge.ts
@@ -24,6 +24,9 @@ export interface BridgeQuoteAmounts<Amount = CurrencyAmount<Currency>> {
     amountInIntermediateCurrency: Amount
     amountInDestinationCurrency: Amount
   }
+  // Estimated time (in seconds) the bridge leg takes to fill, captured from the quote
+  // so it can be shown while the order is bridging (see issue #6459)
+  expectedFillTimeSeconds?: number
 }
 
 export type SerializedAmount = {


### PR DESCRIPTION
## Summary

Fixes #6459.

When a swap+bridge order is in the **Bridging** state there was no indication of how long bridging might take (it can be 18–20 min). The UI already has an "Est. bridge time" row (`QuoteBridgeContent`), but it stayed hidden during pending because `estimatedTime` was hardcoded to `null` when building the pending context — the quote's `expectedFillTimeSeconds` was never persisted with the order.

## Changes

- Add optional `expectedFillTimeSeconds` to `BridgeQuoteAmounts` and capture it in `useBridgeQuoteAmounts` from the bridge quote. It then rides along with every persisted bridge order (all `addBridgeOrder` call sites already store `quoteAmounts`), so no per-flow plumbing is needed.
- Persist it through the bridge-orders serializer.
- In `useSwapAndBridgeContext`, set the pending `estimatedTime` from the persisted quote ETA, falling back to the live `statusResult.fillTimeInSeconds` when present.

The rendering component is unchanged — it already displays the row once `estimatedTime` is non-null.

## Testing steps

1. Do a swap+bridge order to a slower destination chain.
2. While the order is in the **Bridging** state, open the order progress details.
3. The "Est. bridge time" row now shows `~ X min` instead of being hidden.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bridge quotes now include an estimated fill time, which can be shown during swap-and-bridge flows.
  * The estimated bridge time is now carried through to the bridge context so timing details stay up to date.
* **Bug Fixes**
  * Improved timing updates so changes to quote-derived fill estimates are reflected correctly in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->