### PR TITLE
fix(common-utils): anchor getIntOrFloat regex to full string

### DIFF
--- a/libs/common-utils/src/getIntOrFloat.test.ts
+++ b/libs/common-utils/src/getIntOrFloat.test.ts
@@ -1,0 +1,23 @@
+import { getIntOrFloat } from './getIntOrFloat'
+
+describe('#getIntOrFloat', () => {
+  it('returns valid decimals unchanged', () => {
+    const valid = ['5', '5.4', '1.', '.12', '0.333', '0', '100', '12.5', '.5', '1.0']
+
+    valid.forEach((amount) => {
+      expect(getIntOrFloat(amount)).toEqual(amount)
+    })
+  })
+
+  it('returns null for malformed input', () => {
+    const malformed = ['1e5', '0x10', '  5', '1.2.3', 'abc12', '-5', '12,5', '+5', 'foo.99', '1.2.3.4']
+
+    malformed.forEach((amount) => {
+      expect(getIntOrFloat(amount)).toBeNull()
+    })
+  })
+
+  it('returns null for the empty string', () => {
+    expect(getIntOrFloat('')).toBeNull()
+  })
+})

--- a/libs/common-utils/src/getIntOrFloat.ts
+++ b/libs/common-utils/src/getIntOrFloat.ts
@@ -3,7 +3,7 @@
 export function getIntOrFloat(amount: string | null): string | null {
   if (!amount) return null
 
-  if (/^\.\d+|\d+\.?\d*$/.test(amount)) return amount
+  if (/^(\.\d+|\d+\.?\d*)$/.test(amount)) return amount
 
   return null
 }


### PR DESCRIPTION
### Problem

`getIntOrFloat` is documented to accept only an integer or float decimal (`5`, `5.4`, `1.`, `0.333`, `.12`). Its validation regex was mis-anchored:

```
/^\.\d+|\d+\.?\d*$/
```

Because alternation (`|`) has the lowest precedence, this parses as two branches: `^\.\d+` OR `\d+\.?\d*$`. The `^` anchor only applies to the first branch and the `$` anchor only to the second, so neither branch is anchored to the *whole* string. Any input containing a matching substring passes.

As a result these are all wrongly accepted as valid amounts: `1e5`, `0x10`, `  5` (leading whitespace), `1.2.3`, `abc12`, `-5`, `12,5`, `+5`, `foo.99`, `1.2.3.4`. Several of them also survive the downstream `+x > 0` numeric check in `useSetupTradeAmountsFromUrl.ts` (e.g. `1e5`, `0x10`, `  5`), so malformed URL amounts can flow through as if they were clean decimals.

### Fix

```
/^(\.\d+|\d+\.?\d*)$/
```

Grouping the alternation makes both `^` and `$` apply to the entire string, restoring the int/float-decimal-only contract. This tightening is intentional, not an oversight: the previously accepted inputs above are exactly the ones that should be rejected.

Every valid decimal is still accepted unchanged (`5`, `5.4`, `1.`, `.12`, `0.333`, `0`, `100`, `12.5`, `.5`, `1.0`).

### Test

Adds `getIntOrFloat.test.ts` covering all valid decimals (returned unchanged), all malformed inputs listed above (return `null`), and the empty string (`null`). Passes under `nx test common-utils`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric string handling so valid decimal formats like `.12` and `1.` are accepted consistently.
  * Rejected more malformed inputs, including scientific notation, hex values, spaced numbers, multiple decimals, signs, commas, and non-numeric text.
* **Tests**
  * Added coverage for accepted and rejected numeric string formats, including empty input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->