### PR TITLE
feat(cow-fi): remove LP on CoW AMM header CTA

### DIFF
--- a/apps/cow-fi/components/Layout/const.test.ts
+++ b/apps/cow-fi/components/Layout/const.test.ts
@@ -1,4 +1,4 @@
-import { getNavItems } from './const'
+import { getNavItems, NAV_ADDITIONAL_BUTTONS } from './const'
 
 jest.mock('@cowprotocol/analytics', () => ({
   initGtm: () => ({
@@ -44,5 +44,14 @@ describe('getNavItems', () => {
 
   it('shows solvers menu item when the solvers flag is enabled', () => {
     expect(getMoreItemLabels(true)).toContain('Solvers')
+  })
+})
+
+describe('NAV_ADDITIONAL_BUTTONS', () => {
+  it('does not include the LP on CoW AMM button', () => {
+    const labels = NAV_ADDITIONAL_BUTTONS.map((button) => button.label)
+
+    expect(labels).not.toContain('LP on CoW AMM')
+    expect(labels).toContain('Trade on CoW Swap')
   })
 })

--- a/apps/cow-fi/components/Layout/const.ts
+++ b/apps/cow-fi/components/Layout/const.ts
@@ -1,5 +1,5 @@
 import { initGtm } from '@cowprotocol/analytics'
-import { MenuItem, ProductVariant, Color, UI } from '@cowprotocol/ui'
+import { MenuItem, ProductVariant, UI } from '@cowprotocol/ui'
 
 import { CowFiCategory } from 'src/common/analytics/types'
 
@@ -111,21 +111,6 @@ function getAboutNavItem(): MenuItem {
 }
 
 export const NAV_ADDITIONAL_BUTTONS = [
-  {
-    label: 'LP on CoW AMM',
-    href: 'https://balancer.fi/pools/cow',
-    utmContent: 'menubar-nav-button-lp-on-cow-amm',
-    onClick: () =>
-      analytics.sendEvent({
-        category: CowFiCategory.NAVIGATION,
-        action: 'Click LP on CoW AMM',
-        label: 'menubar-nav-button',
-      }),
-    external: true,
-    isButton: true,
-    bgColor: Color.cowamm_dark_green,
-    color: Color.cowamm_green,
-  },
   {
     label: COW_SWAP_CTA.text,
     href: COW_SWAP_CTA.deeplinkHref,

--- a/apps/cow-fi/data/cow-amm/const.tsx
+++ b/apps/cow-fi/data/cow-amm/const.tsx
@@ -179,7 +179,7 @@ export const FAQ_DATA = [
       <>
         Anyone can create a CoW AMM pool easily and permissionlessly with the{' '}
         <Link
-          href="https://pool-creator.balancer.fi/cow"
+          href="https://balancer.fi/create/step-1-type"
           external
           utmContent="cow-amm-pool-creator"
           onClick={() =>

--- a/apps/cowswap-frontend/src/modules/tokensList/pure/LpTokenLists/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/LpTokenLists/index.tsx
@@ -182,7 +182,7 @@ export function LpTokenLists({
           <div>
             <Trans>Can't find the pool you're looking for?</Trans>
           </div>
-          <CreatePoolLink href="https://pool-creator.balancer.fi/cow">
+          <CreatePoolLink href="https://balancer.fi/create/step-1-type">
             <Trans>Create a pool</Trans> ↗
           </CreatePoolLink>
         </NoPoolWrapper>


### PR DESCRIPTION
## What changed
- Removed the `LP on CoW AMM` additional header CTA from Cow.fi's global `MenuBar` config.
- Kept the `Trade on CoW Swap` header CTA in place.
- Updated the stale Balancer pool creator URL from `https://pool-creator.balancer.fi/cow` to `https://balancer.fi/create/step-1-type` in both:
  - Cow.fi CoW AMM FAQ content
  - CoW Swap LP token-list empty-state link
- Added a regression assertion for the additional header button list.

## Why
- Cow.fi should no longer promote the Balancer LP flow from the global header.
- The old Balancer pool creator URL no longer works; this follows up on the review thread and points users to Balancer's current pool creation flow.

## QA Testing

Preview URL QA:
- Cow.fi header: open https://cowfi-git-feat-remove-cowfi-lp-amm-cta-cowswap.vercel.app/ and confirm the header shows `Trade on CoW Swap`, with no `LP on CoW AMM` header button.
- Cow.fi CoW AMM FAQ: open https://cowfi-git-feat-remove-cowfi-lp-amm-cta-cowswap.vercel.app/cow-amm and confirm the `CoW AMM pool creator` FAQ link points to `https://balancer.fi/create/step-1-type`.

Developer verification:
- `pnpm exec jest --config apps/cow-fi/jest.config.ts apps/cow-fi/components/Layout/const.test.ts --runInBand`
- `pnpm exec eslint apps/cow-fi/components/Layout/const.ts apps/cow-fi/components/Layout/const.test.ts`
- `pnpm exec eslint apps/cow-fi/data/cow-amm/const.tsx apps/cowswap-frontend/src/modules/tokensList/pure/LpTokenLists/index.tsx`

Reviewer note:
- Local `cow-fi:lint` could not complete because Nx project-graph calculation failed through the daemon and the daemon-disabled retry hung. File-level ESLint passed for the touched files.
- The CoW Swap LP token-list link change is covered by source-level verification unless QA has a state that shows the LP token-list empty state.

## Preview URLs

| Surface | URL |
| --- | --- |
| cowfi - branch preview URL | https://cowfi-git-feat-remove-cowfi-lp-amm-cta-cowswap.vercel.app |
| swap-dev - branch preview URL | https://swap-dev-git-feat-remove-cowfi-lp-amm-cta-cowswap-dev.vercel.app |
| explorer-dev - branch preview URL | https://explorer-dev-git-feat-remove-cowfi-lp-amm-cta-cowswap-dev.vercel.app |
| storybook - branch preview URL | https://storybook-git-feat-remove-cowfi-lp-amm-cta-cowswap-dev.vercel.app |
| widget-configurator - branch preview URL | https://widget-configurator-git-feat-remove-cowfi-lp-90561f-cowswap-dev.vercel.app |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the “LP on CoW AMM” navigation button from the app, while keeping “Trade on CoW Swap” available.

* **UI Updates**
  * Updated the “Create a pool” banner/FAQ link to point to the new Balancer destination.

* **Tests**
  * Expanded navigation button test coverage to ensure the additional buttons list matches the expected set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->