### PR TITLE
fix: Fix wallet detection in widget

### DIFF
--- a/libs/wallet/src/updaters/WidgetStandaloneMode.updater.test.tsx
+++ b/libs/wallet/src/updaters/WidgetStandaloneMode.updater.test.tsx
@@ -1,6 +1,6 @@
 import { isInjectedWidget } from '@cowprotocol/common-utils'
 
-import { ConnectorController } from '@reown/appkit-controllers'
+import { ConnectorController, OptionsController } from '@reown/appkit-controllers'
 import { render, RenderResult, waitFor } from '@testing-library/react'
 import { useConnection } from 'wagmi'
 
@@ -30,7 +30,11 @@ jest.mock('../utils/getIsSafeAppIframe', () => ({
 
 jest.mock('../wagmi/config', () => ({
   reownAppKit: { disconnect: jest.fn() },
-  wagmiAdapter: { disconnect: jest.fn(), syncConnections: jest.fn() },
+  wagmiAdapter: { disconnect: jest.fn(), syncConnections: jest.fn(), syncConnectors: jest.fn() },
+}))
+
+jest.mock('../providerIsolation', () => ({
+  flushDeferredProviders: jest.fn(),
 }))
 
 jest.mock('../wagmi/hooks/useDisconnectWallet', () => ({
@@ -42,6 +46,9 @@ jest.mock('@reown/appkit-controllers', () => ({
     subscribe: jest.fn(),
     state: { connectors: [], allConnectors: [] },
   },
+  OptionsController: {
+    setEIP6963Enabled: jest.fn(),
+  },
 }))
 
 const isInjectedWidgetMock = isInjectedWidget as jest.Mock
@@ -52,6 +59,8 @@ const useDisconnectWalletMock = useDisconnectWallet as jest.Mock
 const reownAppKitDisconnectMock = reownAppKit.disconnect as jest.Mock
 const wagmiAdapterDisconnectMock = wagmiAdapter.disconnect as jest.Mock
 const wagmiAdapterSyncConnectionsMock = wagmiAdapter.syncConnections as jest.Mock
+const wagmiAdapterSyncConnectorsMock = wagmiAdapter.syncConnectors as jest.Mock
+const optionsControllerSetEIP6963EnabledMock = OptionsController.setEIP6963Enabled as jest.Mock
 const connectorControllerSubscribeMock = ConnectorController.subscribe as jest.Mock
 
 const disconnectMock = jest.fn()
@@ -139,6 +148,38 @@ describe('WidgetStandaloneModeUpdater', () => {
       rerender(<WidgetStandaloneModeUpdater standaloneMode={DAPP_MODE} />)
 
       expect(connectWalletByIdMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('standalone mode: injected wallet discovery', () => {
+    it('enables EIP-6963 in standalone mode', () => {
+      renderUpdater(STANDALONE_MODE)
+
+      expect(optionsControllerSetEIP6963EnabledMock).toHaveBeenCalledWith(true)
+      expect(wagmiAdapterSyncConnectorsMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('enables EIP-6963 when standalone mode is undefined', () => {
+      renderUpdater(undefined)
+
+      expect(optionsControllerSetEIP6963EnabledMock).toHaveBeenCalledWith(true)
+      expect(wagmiAdapterSyncConnectorsMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('disables EIP-6963 in dapp mode', () => {
+      renderUpdater(DAPP_MODE)
+
+      expect(optionsControllerSetEIP6963EnabledMock).toHaveBeenCalledWith(false)
+      expect(wagmiAdapterSyncConnectorsMock).not.toHaveBeenCalled()
+    })
+
+    it('does not change EIP-6963 outside injected widget mode', () => {
+      isInjectedWidgetMock.mockReturnValue(false)
+
+      renderUpdater(STANDALONE_MODE)
+
+      expect(optionsControllerSetEIP6963EnabledMock).not.toHaveBeenCalled()
+      expect(wagmiAdapterSyncConnectorsMock).not.toHaveBeenCalled()
     })
   })
 

--- a/libs/wallet/src/updaters/WidgetStandaloneMode.updater.tsx
+++ b/libs/wallet/src/updaters/WidgetStandaloneMode.updater.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef } from 'react'
 
 import { isInjectedWidget } from '@cowprotocol/common-utils'
 
-import { ConnectorController } from '@reown/appkit-controllers'
+import { ConnectorController, OptionsController } from '@reown/appkit-controllers'
 import { useConnection } from 'wagmi'
 
 import { COW_WIDGET_CONNECTOR_ID, SAFE_CONNECTOR_ID } from '../reown/consts'
@@ -12,6 +12,24 @@ import { connectWalletById } from '../utils/connectWalletById'
 import { getIsSafeAppIframe } from '../utils/getIsSafeAppIframe'
 import { reownAppKit, wagmiAdapter } from '../wagmi/config'
 import { useDisconnectWallet } from '../wagmi/hooks/useDisconnectWallet'
+
+/**
+ * In `libs/wallet/src/wagmi/config.ts`, we set `enableEIP6963: !isWidget`. However, if widget is being used in
+ * standalone mode, we need to re-enable EIP-6963 so browser wallets are discoverable.
+ */
+function syncInjectedWalletDiscovery(enableEIP6963: boolean): void {
+  OptionsController.setEIP6963Enabled(enableEIP6963)
+
+  if (!enableEIP6963) return
+
+  // Not strictly necessary, but ensures new providers are discovered immediately.
+  window.dispatchEvent(new Event('eip6963:requestProvider'))
+
+  // Note: Brave Wallet will not be discovered, even if we call `flushDeferredProviders()` here.
+  // TODO: See if that's related to Brave Shield or other setting.
+
+  void wagmiAdapter.syncConnectors()
+}
 
 interface WidgetStandaloneModeUpdaterProps {
   standaloneMode: boolean | undefined
@@ -51,6 +69,13 @@ export function WidgetStandaloneModeUpdater({ standaloneMode }: WidgetStandalone
   useEffect(() => {
     setAppWalletContext((state) => ({ ...state, standaloneMode }))
   }, [setAppWalletContext, standaloneMode])
+
+  useEffect(() => {
+    if (!isInjectedWidget() || isSafeApp) return
+
+    // Widget defaults to standalone when `standaloneMode` is omitted.
+    syncInjectedWalletDiscovery(standaloneMode !== false)
+  }, [isSafeApp, standaloneMode])
 
   /**
    * Once in Dapp mode, disconnect any current wallet and connect to the widget connector


### PR DESCRIPTION
# Summary

Closes https://github.com/cowprotocol/cowswap/issues/7811.

In `libs/wallet/src/wagmi/config.ts`, we hardcode `enableEIP6963: !isWidget`, but that value needs to be set to true if/when the widget is running in standalone mode.

# To Test

1. Open the widget configurator.
2. Set it to standalone mode.
3. Click Connect within the widget.
4. Verify your wallets appear there (will not work for Brave).
