### PR TITLE
fix: query bot ID using curl instead of gh

### DIFF
--- a/.github/actions/setup-release-sync/action.yml
+++ b/.github/actions/setup-release-sync/action.yml
@@ -51,10 +51,15 @@ runs:
     - name: Get GitHub App user ID
       id: app-user
       shell: bash
-      run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+      run: |
+        set -euo pipefail
+        user_id=$(curl -sf \
+          -H "Accept: application/vnd.github+json" \
+          "https://api.github.com/users/${APP_SLUG}%5Bbot%5D" \
+          | jq -r .id)
+        echo "user-id=${user_id}" >> "$GITHUB_OUTPUT"
       env:
         APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
-        GH_TOKEN: ${{ github.token }}
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/actions/setup-release-sync/action.yml
+++ b/.github/actions/setup-release-sync/action.yml
@@ -54,6 +54,7 @@ runs:
       run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
       env:
         APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        GH_TOKEN: ${{ github.token }}
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/actions/setup-release-sync/action.yml
+++ b/.github/actions/setup-release-sync/action.yml
@@ -54,7 +54,6 @@ runs:
       run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
       env:
         APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
-        GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/i18n-extract.yml
+++ b/.github/workflows/i18n-extract.yml
@@ -72,7 +72,6 @@ jobs:
         run: echo "user-id=$(gh api \"/users/${APP_SLUG}[bot]\" --jq .id)" >> "$GITHUB_OUTPUT"
         env:
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Commit and push if changed
         if: steps.changes.outputs.has_changes == 'true'

--- a/.github/workflows/i18n-extract.yml
+++ b/.github/workflows/i18n-extract.yml
@@ -69,10 +69,15 @@ jobs:
       - name: Resolve GitHub App bot identity
         if: steps.changes.outputs.has_changes == 'true'
         id: app-user
-        run: echo "user-id=$(gh api \"/users/${APP_SLUG}[bot]\" --jq .id)" >> "$GITHUB_OUTPUT"
+        run: |
+          set -euo pipefail
+          user_id=$(curl -sf \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/users/${APP_SLUG}%5Bbot%5D" \
+            | jq -r .id)
+          echo "user-id=${user_id}" >> "$GITHUB_OUTPUT"
         env:
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
-          GH_TOKEN: ${{ github.token }}
 
       - name: Commit and push if changed
         if: steps.changes.outputs.has_changes == 'true'

--- a/.github/workflows/i18n-extract.yml
+++ b/.github/workflows/i18n-extract.yml
@@ -50,7 +50,7 @@ jobs:
         id: changes
         run: |
           if git diff --quiet -- 'apps/cowswap-frontend/src/locales/*.po'; then
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/i18n-extract.yml
+++ b/.github/workflows/i18n-extract.yml
@@ -50,7 +50,7 @@ jobs:
         id: changes
         run: |
           if git diff --quiet -- 'apps/cowswap-frontend/src/locales/*.po'; then
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/i18n-extract.yml
+++ b/.github/workflows/i18n-extract.yml
@@ -72,6 +72,7 @@ jobs:
         run: echo "user-id=$(gh api \"/users/${APP_SLUG}[bot]\" --jq .id)" >> "$GITHUB_OUTPUT"
         env:
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Commit and push if changed
         if: steps.changes.outputs.has_changes == 'true'

--- a/apps/cowswap-frontend/src/common/pure/CurrencySelectButton/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/CurrencySelectButton/index.tsx
@@ -59,7 +59,7 @@ export function CurrencySelectButton(props: CurrencySelectButtonProps): ReactNod
     )
   }
 
-  const selectedToken = t`Selected token:` + ' ' + currency?.symbol || ''
+  const selectedToken = t`Selected token: ${currency?.symbol || ''}`
 
   return (
     <styledEl.CurrencySelectWrapper

--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -5288,6 +5288,11 @@ msgstr "The token pair is constrained"
 msgid "Created"
 msgstr "Created"
 
+#. placeholder {0}: currency?.symbol || ''
+#: apps/cowswap-frontend/src/common/pure/CurrencySelectButton/index.tsx
+msgid "Selected token: {0}"
+msgstr "Selected token: {0}"
+
 #: apps/cowswap-frontend/src/modules/affiliate/containers/AffiliatePartnerCodeCreation.tsx
 #~ msgid "Wallet signer unavailable."
 #~ msgstr "Wallet signer unavailable."

--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -5284,6 +5284,11 @@ msgstr "The token pair is constrained"
 msgid "Created"
 msgstr "Created"
 
+#. placeholder {0}: currency?.symbol || ''
+#: apps/cowswap-frontend/src/common/pure/CurrencySelectButton/index.tsx
+msgid "Selected token: {0}"
+msgstr "Selected token: {0}"
+
 #: apps/cowswap-frontend/src/modules/affiliate/containers/AffiliatePartnerCodeCreation.tsx
 #~ msgid "Wallet signer unavailable."
 #~ msgstr "Wallet signer unavailable."

--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -5288,11 +5288,6 @@ msgstr "The token pair is constrained"
 msgid "Created"
 msgstr "Created"
 
-#. placeholder {0}: currency?.symbol || ''
-#: apps/cowswap-frontend/src/common/pure/CurrencySelectButton/index.tsx
-msgid "Selected token: {0}"
-msgstr "Selected token: {0}"
-
 #: apps/cowswap-frontend/src/modules/affiliate/containers/AffiliatePartnerCodeCreation.tsx
 #~ msgid "Wallet signer unavailable."
 #~ msgstr "Wallet signer unavailable."

--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -250,10 +250,6 @@ msgstr "Network costs (est.)"
 msgid "The account address which will/did receive the bought amount."
 msgstr "The account address which will/did receive the bought amount."
 
-#: apps/cowswap-frontend/src/common/pure/CurrencySelectButton/index.tsx
-#~ msgid "Selected token: {sym}"
-#~ msgstr "Selected token: {sym}"
-
 #: apps/cowswap-frontend/src/modules/affiliate/pure/AffiliateTraderActivityTable.tsx
 #~ msgid "Volume"
 #~ msgstr "Volume"

--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -5288,6 +5288,11 @@ msgstr "The token pair is constrained"
 msgid "Created"
 msgstr "Created"
 
+#. placeholder {0}: currency?.symbol || ''
+#: apps/cowswap-frontend/src/common/pure/CurrencySelectButton/index.tsx
+msgid "Selected token: {0}"
+msgstr "Selected token: {0}"
+
 #: apps/cowswap-frontend/src/modules/affiliate/containers/AffiliatePartnerCodeCreation.tsx
 #~ msgid "Wallet signer unavailable."
 #~ msgstr "Wallet signer unavailable."
@@ -5990,8 +5995,8 @@ msgid "Order Expired"
 msgstr "Order Expired"
 
 #: apps/cowswap-frontend/src/common/pure/CurrencySelectButton/index.tsx
-msgid "Selected token:"
-msgstr "Selected token:"
+#~ msgid "Selected token:"
+#~ msgstr "Selected token:"
 
 #: apps/cowswap-frontend/src/legacy/components/Badge/RangeBadge.tsx
 msgid "Out of range"

--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -5284,11 +5284,6 @@ msgstr "The token pair is constrained"
 msgid "Created"
 msgstr "Created"
 
-#. placeholder {0}: currency?.symbol || ''
-#: apps/cowswap-frontend/src/common/pure/CurrencySelectButton/index.tsx
-msgid "Selected token: {0}"
-msgstr "Selected token: {0}"
-
 #: apps/cowswap-frontend/src/modules/affiliate/containers/AffiliatePartnerCodeCreation.tsx
 #~ msgid "Wallet signer unavailable."
 #~ msgstr "Wallet signer unavailable."

--- a/apps/cowswap-frontend/src/locales/es-ES.po
+++ b/apps/cowswap-frontend/src/locales/es-ES.po
@@ -28,7 +28,7 @@ msgstr "Cartera no conectada"
 
 #: apps/cowswap-frontend/src/common/pure/CurrencySelectButton/index.tsx
 #~ msgid "Selected token: "
-#~ msgstr "Token seleccionado: "
+#~ msgstr "Selected token: "
 
 #: apps/cowswap-frontend/src/modules/ordersTable/containers/MultipleCancellationMenu/MultipleCancellationMenu.container.tsx
 msgid "selected"

--- a/apps/cowswap-frontend/src/locales/es-ES.po
+++ b/apps/cowswap-frontend/src/locales/es-ES.po
@@ -28,7 +28,7 @@ msgstr "Cartera no conectada"
 
 #: apps/cowswap-frontend/src/common/pure/CurrencySelectButton/index.tsx
 #~ msgid "Selected token: "
-#~ msgstr "Selected token: "
+#~ msgstr "Token seleccionado: "
 
 #: apps/cowswap-frontend/src/modules/ordersTable/containers/MultipleCancellationMenu/MultipleCancellationMenu.container.tsx
 msgid "selected"


### PR DESCRIPTION
# Summary

That endpoint is public and works just fine if you query it from the browser:

```
fetch('https://api.github.com/users/cowswap-release-sync%5Bbot%5D', {
  headers: { Accept: 'application/vnd.github+json' },
})
  .then((r) => r.json().then((body) => ({ status: r.status, body })))
  .then(console.log)
```

Tried removing `GH_TOKEN`, but `gh` would require it anyway. Changed it for `github.token`, but still failed. Replaced `gh` with `curl` and removed the token.

# To Test

1. Verify the `i18n Extract / Extract i18n strings (pull_request)` action is running fine. 

    I triggered this one by manually changing the action file: https://github.com/cowprotocol/cowswap/actions/runs/28859807795/job/85595285766?pr=7817


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “Selected token” label to avoid showing an undefined token symbol when token details are incomplete, instead falling back cleanly.
  * Updated the label to use a parameterized format so the UI reliably renders the selected token’s symbol/name dynamically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->