### PR TITLE
feat: enable renovate for pnpm

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,7 +15,7 @@
     // When both major and minor releases exist, propose only the latest bump
     // (typically major) instead of a separate minor PR.
     {
-      matchManagers: ["github-actions"],
+      matchManagers: ["github-actions", "pnpm"],
       schedule: ["on monday"],
       minimumReleaseAge: "14 days",
       // Track upgrades by semver tag, but pin the resolved version to its full

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,7 @@
 // easier to maintain.
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  // Disable every built-in manager (npm, dockerfile, ...) except github-actions.
+  // Disable every built-in manager (dockerfile, ...) except github-actions and npm (will use pnpm).
   enabledManagers: ["github-actions", "npm"],
   // PR titles use Conventional Commits: `deps(<action>): ...`
   semanticCommits: "enabled",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,7 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   // Disable every built-in manager (npm, dockerfile, ...) except github-actions.
-  enabledManagers: ["github-actions"],
+  enabledManagers: ["github-actions", "npm"],
   // PR titles use Conventional Commits: `deps(<action>): ...`
   semanticCommits: "enabled",
   semanticCommitType: "deps",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,7 +15,8 @@
     // When both major and minor releases exist, propose only the latest bump
     // (typically major) instead of a separate minor PR.
     {
-      matchManagers: ["github-actions", "pnpm"],
+      // Note that npm is used for pnpm as well, there's no specific pnpm value for matchManagers.
+      matchManagers: ["github-actions", "npm"],
       schedule: ["on monday"],
       minimumReleaseAge: "14 days",
       // Track upgrades by semver tag, but pin the resolved version to its full


### PR DESCRIPTION
# Summary

Enable renovate for pnpm.

Closes https://github.com/cowprotocol/cowswap/issues/7809.

Related to https://github.com/cowprotocol/cowswap/pull/7806


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to process `npm` packages in addition to GitHub Actions workflows.
  * Expanded the matching rules so both workflow and `npm`-related updates are detected consistently by the same automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->