### PR TITLE
feat(cow-fi): remove Bug Bounty and Affiliate menu links

### DIFF
--- a/apps/cow-fi/components/Layout/const.test.ts
+++ b/apps/cow-fi/components/Layout/const.test.ts
@@ -37,6 +37,16 @@ function getMoreItemLabels(isSolversEnabled: boolean): string[] {
   return moreItem.children.map((child) => child.label).filter((label): label is string => label !== undefined)
 }
 
+function getAboutItemLabels(): string[] {
+  const aboutItem = getNavItems(false).find((item) => item.label === 'About')
+
+  if (!aboutItem?.children) {
+    throw new Error('Missing About menu item')
+  }
+
+  return aboutItem.children.map((child) => child.label).filter((label): label is string => label !== undefined)
+}
+
 describe('getNavItems', () => {
   it('hides solvers menu item when the solvers flag is disabled', () => {
     expect(getMoreItemLabels(false)).not.toContain('Solvers')
@@ -44,5 +54,12 @@ describe('getNavItems', () => {
 
   it('shows solvers menu item when the solvers flag is enabled', () => {
     expect(getMoreItemLabels(true)).toContain('Solvers')
+  })
+
+  it('does not include Bug Bounty or Affiliate Program in the main menu', () => {
+    const labels = getAboutItemLabels()
+
+    expect(labels).not.toContain('Bug Bounty')
+    expect(labels).not.toContain('Affiliate Program')
   })
 })

--- a/apps/cow-fi/components/Layout/const.ts
+++ b/apps/cow-fi/components/Layout/const.ts
@@ -99,13 +99,7 @@ function getAboutNavItem(): MenuItem {
         href: 'https://grants.cow.fi/',
         external: true,
       },
-      {
-        label: 'Bug Bounty',
-        href: 'https://immunefi.com/bug-bounty/cowprotocol/information/',
-        external: true,
-      },
       { label: 'Careers', href: '/careers' },
-      { label: 'Affiliate Program', href: '/affiliate-program' },
     ],
   }
 }


### PR DESCRIPTION
## What changed
- Removed `Bug Bounty` and `Affiliate Program` from the cow.fi `About` dropdown.
- Added a regression test that checks those labels are not returned by `getNavItems`.

## Why
- These links should no longer appear in the main menu, while their destination pages and routes stay untouched.

## QA Testing

Preview URL QA:
- Open the cow.fi branch preview, expand the `About` menu, and confirm it shows `Stats`, `Governance`, `Grants`, and `Careers` without `Bug Bounty` or `Affiliate Program`.

Developer verification:
- `GITHUB_PACKAGES_TOKEN=dummy pnpm exec jest --config apps/cow-fi/jest.config.ts apps/cow-fi/components/Layout/const.test.ts --runInBand`
- `GITHUB_PACKAGES_TOKEN=dummy pnpm exec eslint apps/cow-fi/components/Layout/const.ts apps/cow-fi/components/Layout/const.test.ts`
- `git diff --check`