### PR TITLE
feat(cow-fi): remove Bug Bounty and Affiliate menu links

### DIFF
--- a/apps/cow-fi/components/Layout/const.ts
+++ b/apps/cow-fi/components/Layout/const.ts
@@ -99,13 +99,7 @@ function getAboutNavItem(): MenuItem {
         href: 'https://grants.cow.fi/',
         external: true,
       },
-      {
-        label: 'Bug Bounty',
-        href: 'https://immunefi.com/bug-bounty/cowprotocol/information/',
-        external: true,
-      },
       { label: 'Careers', href: '/careers' },
-      { label: 'Affiliate Program', href: '/affiliate-program' },
     ],
   }
 }


### PR DESCRIPTION
## What changed
- Removed `Bug Bounty` and `Affiliate Program` from the cow.fi `About` dropdown.

## Why
- These links should no longer appear in the main menu, while their destination pages and routes stay untouched.

## QA Testing

<img width="636" height="350" alt="Screenshot 2026-07-07 at 12 22 02" src="https://github.com/user-attachments/assets/9e938061-0a38-4946-82e0-78aaeeb8d166" />


Preview URL QA:
- Open the cow.fi branch preview, expand the `About` menu, and confirm it shows `Stats`, `Governance`, `Grants`, and `Careers` without `Bug Bounty` or `Affiliate Program`.

Developer verification:
- `GITHUB_PACKAGES_TOKEN=dummy pnpm exec jest --config apps/cow-fi/jest.config.ts apps/cow-fi/components/Layout/const.test.ts --runInBand`
- `GITHUB_PACKAGES_TOKEN=dummy pnpm exec eslint apps/cow-fi/components/Layout/const.ts apps/cow-fi/components/Layout/const.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the About navigation menu to show only the Careers link.
  * Removed the Bug Bounty and Affiliate Program entries from that section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->