### PR TITLE
feat: track captcha analytics

### DIFF
--- a/apps/cowswap-frontend/jest.setup.ts
+++ b/apps/cowswap-frontend/jest.setup.ts
@@ -29,11 +29,21 @@ jest.mock('@cowprotocol/analytics', () => {
     'tokenSymbol',
     'chainId',
   ])
+  const mockCowAnalytics = {
+    sendEvent: jest.fn(),
+  }
 
   return {
     __esModule: true,
     AnalyticsCategory: {},
     Category: {},
+    createCowTracker: (category: string, options: { enabled?: boolean } = {}) => {
+      return (event: Record<string, unknown>) => {
+        if (options.enabled === false) return
+
+        mockCowAnalytics.sendEvent({ category, ...event })
+      }
+    },
     CowAnalytics: class MockCowAnalytics {
       sendEvent = jest.fn()
     },
@@ -58,9 +68,7 @@ jest.mock('@cowprotocol/analytics', () => {
       return JSON.stringify(ga4Event)
     },
     useAnalyticsReporter: jest.fn(),
-    useCowAnalytics: jest.fn().mockImplementation(() => ({
-      sendEvent: jest.fn(),
-    })),
+    useCowAnalytics: jest.fn().mockImplementation(() => mockCowAnalytics),
     waitForAnalytics: jest.fn().mockResolvedValue(undefined),
     WebVitalsAnalytics: class MockWebVitalsAnalytics {
       constructor(_cowAnalytics?: unknown) {}

--- a/apps/cowswap-frontend/src/common/analytics/types.ts
+++ b/apps/cowswap-frontend/src/common/analytics/types.ts
@@ -23,6 +23,7 @@ export enum CowSwapAnalyticsCategory {
   SURPLUS_MODAL = 'Surplus Modal',
   COWSWAP = 'CoWSwap',
   LIMIT_ORDER_SETTINGS = 'Limit Order Settings',
+  CAPTCHA = 'Captcha',
 
   // UI Categories
   WALLET = 'Wallet',

--- a/apps/cowswap-frontend/src/modules/affiliate/analytics/affiliateAnalytics.test.ts
+++ b/apps/cowswap-frontend/src/modules/affiliate/analytics/affiliateAnalytics.test.ts
@@ -14,7 +14,6 @@ import {
 } from './affiliateAnalytics.utils'
 
 import { useAffiliateStateViewAnalytics } from '../hooks/useAffiliateStateViewAnalytics'
-import { logAffiliate } from '../utils/logger'
 
 import type { TraderWalletStatus as TraderWalletStatusType } from '../hooks/useAffiliateTraderWallet'
 
@@ -38,23 +37,18 @@ jest.mock('@cowprotocol/analytics', () => {
   }
 })
 
-jest.mock('../utils/logger', () => ({
-  logAffiliate: jest.fn(),
-}))
-
 jest.mock('../hooks/useAffiliateTraderWallet', () => ({
   TraderWalletStatus,
 }))
 
 const useCowAnalyticsMock = useCowAnalytics as jest.MockedFunction<typeof useCowAnalytics>
-const logAffiliateMock = logAffiliate as jest.MockedFunction<typeof logAffiliate>
 
 describe('trackAffiliateEvent', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
-  it('sends affiliate analytics payloads without undefined fields', () => {
+  it('sends affiliate analytics payloads', () => {
     const sendEvent = jest.fn()
     const analytics = { sendEvent } as unknown as CowAnalytics
 
@@ -73,28 +67,7 @@ describe('trackAffiliateEvent', () => {
       action: 'affiliate_trader_page_state_viewed',
       chainId: 1,
       walletStatus: TraderWalletStatus.LINKED,
-    })
-    expect(Object.keys(payload)).toEqual(['category', 'action', 'chainId', 'walletStatus'])
-    expect(Object.prototype.hasOwnProperty.call(payload, 'optionalField')).toBe(false)
-  })
-
-  it('swallows analytics transport failures', () => {
-    const sendEvent = jest.fn(() => {
-      throw new Error('analytics failed')
-    })
-    const analytics = { sendEvent } as unknown as CowAnalytics
-
-    expect(() =>
-      trackAffiliateEvent({
-        analytics,
-        action: 'affiliate_trader_page_state_viewed',
-        walletStatus: TraderWalletStatus.LINKED,
-      }),
-    ).not.toThrow()
-
-    expect(logAffiliateMock).toHaveBeenCalledWith('Failed to send analytics event', {
-      action: 'affiliate_trader_page_state_viewed',
-      error: expect.any(Error),
+      optionalField: undefined,
     })
   })
 })

--- a/apps/cowswap-frontend/src/modules/affiliate/analytics/affiliateAnalytics.utils.ts
+++ b/apps/cowswap-frontend/src/modules/affiliate/analytics/affiliateAnalytics.utils.ts
@@ -12,7 +12,6 @@ import {
 
 import { TraderWalletStatus } from '../hooks/useAffiliateTraderWallet'
 import { AffiliatePartnerCodeCreateError } from '../lib/affiliatePartnerCodeCreateError'
-import { logAffiliate } from '../utils/logger'
 
 interface AffiliatePartnerPageStateParams {
   hasAccount: boolean
@@ -39,6 +38,15 @@ export function getAffiliateModalViewKey(
   }
 
   return [modalState, walletStatus].join(':')
+}
+
+export function trackAffiliateEvent({ analytics, action, chainId, ...customParams }: TrackAffiliateEventParams): void {
+  analytics.sendEvent({
+    category: CowSwapAnalyticsCategory.AFFILIATE,
+    action,
+    chainId,
+    ...customParams,
+  } as GtmEvent<CowSwapAnalyticsCategory.AFFILIATE>)
 }
 
 export function getAffiliatePartnerPageState({
@@ -107,23 +115,4 @@ export function normalizeAffiliatePartnerCodeCreateFailureReason(
     default:
       return AffiliatePartnerCodeCreateFailureReason.UNEXPECTED_ERROR
   }
-}
-
-export function trackAffiliateEvent({ analytics, action, chainId, ...customParams }: TrackAffiliateEventParams): void {
-  try {
-    analytics.sendEvent(
-      compactRecord({
-        category: CowSwapAnalyticsCategory.AFFILIATE,
-        action,
-        chainId,
-        ...customParams,
-      }) as GtmEvent<CowSwapAnalyticsCategory.AFFILIATE>,
-    )
-  } catch (error) {
-    logAffiliate('Failed to send analytics event', { action, error })
-  }
-}
-
-function compactRecord(value: Record<string, unknown>): Record<string, unknown> {
-  return Object.fromEntries(Object.entries(value).filter(([, entryValue]) => entryValue !== undefined))
 }

--- a/apps/cowswap-frontend/src/modules/affiliate/hooks/useAffiliatePartnerCodeCreate.test.tsx
+++ b/apps/cowswap-frontend/src/modules/affiliate/hooks/useAffiliatePartnerCodeCreate.test.tsx
@@ -159,31 +159,4 @@ describe('useAffiliatePartnerCodeCreate', () => {
       result: 'success',
     })
   })
-
-  it('continues code creation if the start event throws', async () => {
-    const walletClient = createWalletClient()
-
-    sendEvent.mockImplementationOnce(() => {
-      throw new Error('analytics failed')
-    })
-    createCodeMock.mockResolvedValue({ code: 'COW-123' } as Awaited<ReturnType<typeof bffAffiliateApi.createCode>>)
-
-    const { result } = renderHook(() =>
-      useAffiliatePartnerCodeCreate({
-        account: '0x1111111111111111111111111111111111111111',
-        walletClient,
-        code: 'COW-123',
-        setError,
-      }),
-    )
-
-    await act(async () => {
-      await result.current.onCreate()
-    })
-
-    expect(walletClient.signTypedData).toHaveBeenCalledTimes(1)
-    expect(createCodeMock).toHaveBeenCalledTimes(1)
-    expect(mutatePartnerInfo).toHaveBeenCalledTimes(1)
-    expect(setError.mock.calls).toEqual([[undefined]])
-  })
 })

--- a/apps/cowswap-frontend/src/modules/captcha/containers/CaptchaWidget.container.tsx
+++ b/apps/cowswap-frontend/src/modules/captcha/containers/CaptchaWidget.container.tsx
@@ -1,6 +1,7 @@
 import { useAtom, useAtomValue } from 'jotai'
 import { ReactNode, useEffect, useRef, useState } from 'react'
 
+import { createCowTracker } from '@cowprotocol/analytics'
 import { useTheme } from '@cowprotocol/common-hooks'
 import { getJwtTtl } from '@cowprotocol/common-utils'
 
@@ -8,13 +9,15 @@ import { Turnstile, type TurnstileInstance } from '@marsidev/react-turnstile'
 import { setBearerToken } from 'cowSdk'
 import { captchaJwtAtom } from 'entities/captcha/state/captchaJwtAtom'
 
+import { CowSwapAnalyticsCategory } from 'common/analytics/types'
 import { featureFlagsAtom } from 'common/state/featureFlagsState'
 
 import { exchangeTurnstileToken } from '../api/captchaApi'
-import { TURNSTILE_SITE_KEY } from '../config/captcha.const'
+import { TURNSTILE_DEMO_INTERACTIVE_SITE_KEY, TURNSTILE_SITE_KEY } from '../config/captcha.const'
 import { useCaptchaDebugControls } from '../hooks/useCaptchaDebugControls'
 import { logCaptcha } from '../logger'
 
+/* eslint-disable max-lines-per-function */
 export function CaptchaWidget(): ReactNode {
   const [captchaJwt, setCaptchaJwt] = useAtom(captchaJwtAtom)
   const { isCaptchaEnabled } = useAtomValue(featureFlagsAtom)
@@ -22,6 +25,10 @@ export function CaptchaWidget(): ReactNode {
   const exchangeRequestIdRef = useRef(0)
   const [siteKey, setSiteKey] = useState(TURNSTILE_SITE_KEY)
   const theme = useTheme()
+
+  const trackCaptcha = createCowTracker(CowSwapAnalyticsCategory.CAPTCHA, {
+    enabled: siteKey !== TURNSTILE_DEMO_INTERACTIVE_SITE_KEY,
+  })
 
   useEffect(() => {
     if (!isCaptchaEnabled) {
@@ -82,13 +89,16 @@ export function CaptchaWidget(): ReactNode {
       }}
       onWidgetLoad={(widgetId) => {
         logCaptcha.debug('Challenge starting', { widgetId })
+        trackCaptcha({ action: 'captcha_challenge_started' })
         captchaRef.current?.execute()
       }}
       onBeforeInteractive={() => {
         logCaptcha.debug('Challenge requires interaction')
+        trackCaptcha({ action: 'captcha_interaction_required' })
       }}
       onAfterInteractive={() => {
         logCaptcha.debug('Challenge interaction completed')
+        trackCaptcha({ action: 'captcha_interaction_completed' })
       }}
       onSuccess={async (token: string) => {
         const requestId = exchangeRequestIdRef.current + 1
@@ -107,6 +117,7 @@ export function CaptchaWidget(): ReactNode {
           }
 
           logCaptcha.info('JWT received', { requestId })
+          trackCaptcha({ action: 'captcha_challenge_solved' })
           setCaptchaJwt(jwt)
         } catch (error) {
           if (exchangeRequestIdRef.current !== requestId) {
@@ -114,23 +125,29 @@ export function CaptchaWidget(): ReactNode {
           }
 
           logCaptcha.error('JWT exchange failed', { requestId, error })
+          trackCaptcha({ action: 'captcha_challenge_failed', reason: 'jwtExchangeFailed' })
           setCaptchaJwt(null)
         }
       }}
       onExpire={() => {
         exchangeRequestIdRef.current += 1
+
         logCaptcha.warn('Challenge expired')
+        trackCaptcha({ action: 'captcha_challenge_failed', reason: 'turnstileExpired' })
         setCaptchaJwt(null)
         logCaptcha.debug('Challenge re-starting')
         captchaRef.current?.reset()
       }}
       onError={(errorCode) => {
         exchangeRequestIdRef.current += 1
+
         logCaptcha.error('Challenge errored', { errorCode, hostname: window.location.hostname })
+        trackCaptcha({ action: 'captcha_challenge_failed', reason: 'turnstileError' })
         setCaptchaJwt(null)
       }}
       onUnsupported={() => {
         logCaptcha.warn('Challenge unsupported by browser')
+        trackCaptcha({ action: 'captcha_challenge_failed', reason: 'browserUnsupported' })
       }}
     />
   )

--- a/apps/cowswap-frontend/src/modules/captcha/containers/CaptchaWidget.container.tsx
+++ b/apps/cowswap-frontend/src/modules/captcha/containers/CaptchaWidget.container.tsx
@@ -17,6 +17,9 @@ import { TURNSTILE_DEMO_INTERACTIVE_SITE_KEY, TURNSTILE_SITE_KEY } from '../conf
 import { useCaptchaDebugControls } from '../hooks/useCaptchaDebugControls'
 import { logCaptcha } from '../logger'
 
+const trackCaptchaEvent = createCowTracker(CowSwapAnalyticsCategory.CAPTCHA)
+const ignoreCaptchaEvent: typeof trackCaptchaEvent = () => undefined
+
 /* eslint-disable max-lines-per-function */
 export function CaptchaWidget(): ReactNode {
   const [captchaJwt, setCaptchaJwt] = useAtom(captchaJwtAtom)
@@ -26,9 +29,7 @@ export function CaptchaWidget(): ReactNode {
   const [siteKey, setSiteKey] = useState(TURNSTILE_SITE_KEY)
   const theme = useTheme()
 
-  const trackCaptcha = createCowTracker(CowSwapAnalyticsCategory.CAPTCHA, {
-    enabled: siteKey !== TURNSTILE_DEMO_INTERACTIVE_SITE_KEY,
-  })
+  const trackCaptcha = siteKey === TURNSTILE_DEMO_INTERACTIVE_SITE_KEY ? ignoreCaptchaEvent : trackCaptchaEvent
 
   useEffect(() => {
     if (!isCaptchaEnabled) {

--- a/apps/cowswap-frontend/vercel.ts
+++ b/apps/cowswap-frontend/vercel.ts
@@ -67,6 +67,8 @@ const csp = buildCsp([
   ['upgrade-insecure-requests', []],
 ])
 
+const crossOriginOpenerPolicy = process.env.VERCEL_ENV === 'production' ? 'same-origin-allow-popups' : 'unsafe-none'
+
 // ---------------------------------------------------------------------------
 // Vercel config
 // ---------------------------------------------------------------------------
@@ -87,9 +89,8 @@ export const config: VercelConfig = {
     routes.header('/(.*)', [
       // Controls which resources the browser is allowed to load; prevents XSS and data injection attacks.
       { key: 'Content-Security-Policy', value: csp },
-      // Isolates the browsing context so cross-origin pages cannot access window.opener,
-      // while still allowing this page to open popups (needed for wallet connections).
-      { key: 'Cross-Origin-Opener-Policy', value: 'same-origin-allow-popups' },
+      // Preview deploys use unsafe-none so Tag Assistant can keep its cross-origin debug connection.
+      { key: 'Cross-Origin-Opener-Policy', value: crossOriginOpenerPolicy },
       // Allows any origin to load this page as an iframe, required for the embeddable widget.
       { key: 'Cross-Origin-Resource-Policy', value: 'cross-origin' },
       // Prevents browsers from MIME-sniffing a response away from the declared Content-Type.

--- a/apps/cowswap-frontend/vercel.ts
+++ b/apps/cowswap-frontend/vercel.ts
@@ -67,8 +67,6 @@ const csp = buildCsp([
   ['upgrade-insecure-requests', []],
 ])
 
-const crossOriginOpenerPolicy = process.env.VERCEL_ENV === 'production' ? 'same-origin-allow-popups' : 'unsafe-none'
-
 // ---------------------------------------------------------------------------
 // Vercel config
 // ---------------------------------------------------------------------------
@@ -89,8 +87,9 @@ export const config: VercelConfig = {
     routes.header('/(.*)', [
       // Controls which resources the browser is allowed to load; prevents XSS and data injection attacks.
       { key: 'Content-Security-Policy', value: csp },
-      // Preview deploys use unsafe-none so Tag Assistant can keep its cross-origin debug connection.
-      { key: 'Cross-Origin-Opener-Policy', value: crossOriginOpenerPolicy },
+      // Isolates the browsing context so cross-origin pages cannot access window.opener,
+      // while still allowing this page to open popups (needed for wallet connections).
+      { key: 'Cross-Origin-Opener-Policy', value: 'same-origin-allow-popups' },
       // Allows any origin to load this page as an iframe, required for the embeddable widget.
       { key: 'Cross-Origin-Resource-Policy', value: 'cross-origin' },
       // Prevents browsers from MIME-sniffing a response away from the declared Content-Type.

--- a/libs/analytics/src/CowAnalytics.ts
+++ b/libs/analytics/src/CowAnalytics.ts
@@ -1,9 +1,11 @@
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
+export type AnalyticsEvent = string | EventOptions | (EventOptions & Record<string, unknown>)
+
 export interface CowAnalytics {
   setUserAccount(account: string | undefined, walletName?: string): void
   sendPageView(path?: string, params?: string[], title?: string): void
-  sendEvent(event: string | EventOptions, params?: unknown): void
+  sendEvent(event: AnalyticsEvent, params?: unknown): void
   sendTiming(timingCategory: string, timingVar: string, timingValue: number, timingLabel: string): void
   sendError(error: Error, errorInfo?: string): void
   outboundLink(params: OutboundLinkParams): void
@@ -11,11 +13,30 @@ export interface CowAnalytics {
 }
 
 export type EventOptions = {
+  /**
+   * Event name/action, also used as the GTM `event` name.
+   */
   action: string
+  /**
+   * High-level event bucket used for reporting.
+   */
   category: string
+  /**
+   * Optional free-form text label, kept for existing GTM/GA event_label flows.
+   * Prefer named custom params for new metadata when the meaning is specific.
+   */
   label?: string
+  /**
+   * Optional GA-style numeric metric. Use custom params for text metadata like failure reasons.
+   */
   value?: number
+  /**
+   * Whether the event should not affect interaction/bounce metrics.
+   */
   nonInteraction?: boolean
+  /**
+   * Optional chain id attached to chain-specific events.
+   */
   chainId?: SupportedChainId
 }
 

--- a/libs/analytics/src/createCowTracker.ts
+++ b/libs/analytics/src/createCowTracker.ts
@@ -2,19 +2,11 @@ import { getCowAnalytics } from './utils'
 
 import type { EventOptions } from './CowAnalytics'
 
-type CowTrackerEvent = Omit<EventOptions, 'category'> & Record<string, unknown>
 type CowTracker = (event: CowTrackerEvent) => void
+type CowTrackerEvent = Omit<EventOptions, 'category'> & Record<string, unknown>
 
-type CowTrackerOptions = {
-  enabled?: boolean
-}
-
-export function createCowTracker(category: string, options: CowTrackerOptions = {}): CowTracker {
-  const { enabled = true } = options
-
+export function createCowTracker(category: string): CowTracker {
   return (event) => {
-    if (!enabled) return
-
     getCowAnalytics()?.sendEvent({ category, ...event })
   }
 }

--- a/libs/analytics/src/createCowTracker.ts
+++ b/libs/analytics/src/createCowTracker.ts
@@ -1,0 +1,20 @@
+import { getCowAnalytics } from './utils'
+
+import type { EventOptions } from './CowAnalytics'
+
+type CowTrackerEvent = Omit<EventOptions, 'category'> & Record<string, unknown>
+type CowTracker = (event: CowTrackerEvent) => void
+
+type CowTrackerOptions = {
+  enabled?: boolean
+}
+
+export function createCowTracker(category: string, options: CowTrackerOptions = {}): CowTracker {
+  const { enabled = true } = options
+
+  return (event) => {
+    if (!enabled) return
+
+    getCowAnalytics()?.sendEvent({ category, ...event })
+  }
+}

--- a/libs/analytics/src/gtm/CowAnalyticsGtm.test.ts
+++ b/libs/analytics/src/gtm/CowAnalyticsGtm.test.ts
@@ -1,3 +1,5 @@
+import { logAnalytics } from '@cowprotocol/common-utils'
+
 import { CowAnalyticsGtm } from './CowAnalyticsGtm'
 
 import { AnalyticsContext } from '../CowAnalytics'
@@ -131,6 +133,44 @@ describe('CowAnalyticsGtm wallet lifecycle events', () => {
       orderId,
       orderType,
       walletAddress: '0x1111111111111111111111111111111111111111',
+    })
+  })
+
+  it('omits undefined custom event params', () => {
+    analytics.sendEvent({
+      category: 'Captcha',
+      action: 'captcha_challenge_solved',
+      reason: undefined,
+    } as GtmEvent<string> & { reason?: string })
+
+    expect(getLastEvent('captcha_challenge_solved')).toEqual(
+      expect.not.objectContaining({
+        reason: expect.anything(),
+      }),
+    )
+  })
+
+  it('logs and suppresses data layer push failures', () => {
+    const warnSpy = jest.spyOn(logAnalytics, 'warn')
+
+    analytics.destroy()
+    window.cowAnalyticsInstance = undefined
+    window.dataLayer = {
+      push() {
+        throw new Error('data layer failed')
+      },
+    } as unknown as unknown[]
+    analytics = new CowAnalyticsGtm()
+
+    expect(() => analytics.sendEvent({ category: 'Trade', action: 'Quote', label: undefined })).not.toThrow()
+    expect(warnSpy).toHaveBeenCalledWith('Data layer push failed', {
+      data: {
+        event: 'Quote',
+        category: 'Trade',
+        action: 'Quote',
+        label: undefined,
+      },
+      error: expect.any(Error),
     })
   })
 })

--- a/libs/analytics/src/gtm/CowAnalyticsGtm.ts
+++ b/libs/analytics/src/gtm/CowAnalyticsGtm.ts
@@ -35,6 +35,7 @@ function sanitizeRecord(record: Record<string, unknown>): Record<string, unknown
 declare global {
   interface Window {
     dataLayer: unknown[]
+    enableGaLogging?: boolean
     /** GTM or noop implementation; widened from CowAnalyticsGtm so both can register. */
     cowAnalyticsInstance?: CowAnalytics
   }
@@ -312,8 +313,7 @@ export class CowAnalyticsGtm implements CowAnalytics {
 
       const dataLayerEvent = sanitizeRecord({ ...data }) as DataLayerEvent
 
-      // Debug log in development environment
-      if (process.env.NODE_ENV === 'development') {
+      if (process.env.NODE_ENV === 'development' || window.enableGaLogging === true) {
         logAnalytics.debug('Pushing to data layer', dataLayerEvent)
       }
 

--- a/libs/analytics/src/gtm/CowAnalyticsGtm.ts
+++ b/libs/analytics/src/gtm/CowAnalyticsGtm.ts
@@ -1,7 +1,7 @@
-import { debounce } from '@cowprotocol/common-utils'
+import { debounce, logAnalytics } from '@cowprotocol/common-utils'
 import { areAddressesEqual } from '@cowprotocol/cow-sdk'
 
-import { AnalyticsContext, CowAnalytics, EventOptions, OutboundLinkParams } from '../CowAnalytics'
+import { AnalyticsContext, AnalyticsEvent, CowAnalytics, OutboundLinkParams } from '../CowAnalytics'
 import { Category, GtmEvent } from '../types'
 
 type DataLayer = DataLayerEvent[]
@@ -235,7 +235,7 @@ export class CowAnalyticsGtm implements CowAnalytics {
     })
   }
 
-  sendEvent(event: string | EventOptions, params?: unknown): void {
+  sendEvent(event: AnalyticsEvent, params?: unknown): void {
     const gtmEvent = event as GtmEvent<Category>
 
     const eventData: DataLayerEvent =
@@ -307,15 +307,19 @@ export class CowAnalyticsGtm implements CowAnalytics {
   }
 
   private pushToDataLayer(data: DataLayerEvent): void {
-    if (typeof window !== 'undefined') {
+    try {
+      if (typeof window === 'undefined') return
+
       const dataLayerEvent = sanitizeRecord({ ...data }) as DataLayerEvent
 
       // Debug log in development environment
       if (process.env.NODE_ENV === 'development') {
-        console.debug('[GTM] Pushing to data layer:', dataLayerEvent)
+        logAnalytics.debug('Pushing to data layer', dataLayerEvent)
       }
 
       this.dataLayer.push(dataLayerEvent)
+    } catch (error) {
+      logAnalytics.warn('Data layer push failed', { data, error })
     }
   }
 

--- a/libs/analytics/src/index.ts
+++ b/libs/analytics/src/index.ts
@@ -24,6 +24,7 @@ export type { AnalyticsCategory, BaseGtmEvent, GtmEvent } from './types'
 export type { AnalyticsContext, CowAnalytics } from './CowAnalytics'
 
 // Utils
+export { createCowTracker } from './createCowTracker'
 export { getCowAnalytics } from './utils'
 
 export * from './CowAnalytics'

--- a/libs/analytics/src/noop/createNoopCowAnalytics.ts
+++ b/libs/analytics/src/noop/createNoopCowAnalytics.ts
@@ -2,7 +2,7 @@
  * No-op analytics implementation for environments where third-party scripts must not load (e.g. embedded widget).
  */
 
-import { AnalyticsContext, CowAnalytics, EventOptions, OutboundLinkParams } from '../CowAnalytics'
+import { AnalyticsContext, AnalyticsEvent, CowAnalytics, OutboundLinkParams } from '../CowAnalytics'
 
 const state = {
   instance: null as CowAnalytics | null,
@@ -49,7 +49,7 @@ class CowAnalyticsNoop implements CowAnalytics {
 
   sendPageView(_path?: string, _params?: string[], _title?: string): void {}
 
-  sendEvent(_event: string | EventOptions, _params?: unknown): void {}
+  sendEvent(_event: AnalyticsEvent, _params?: unknown): void {}
 
   sendTiming(_timingCategory: string, _timingVar: string, _timingValue: number, _timingLabel: string): void {}
 

--- a/libs/common-utils/src/logger.ts
+++ b/libs/common-utils/src/logger.ts
@@ -38,3 +38,4 @@ function logCow(level: CowLogLevel, scope: string, ...args: unknown[]): void {
 
 export const logSafeApi = createCowLogger('SafeAPI')
 export const logWallet = createCowLogger('Wallet')
+export const logAnalytics = createCowLogger('Analytics')


### PR DESCRIPTION
# Summary

Adds captcha analytics and simplifies shared analytics tracking.

- Add `createCowTracker()` helper for category-scoped analytics events
- Allow analytics event objects to carry custom params like `reason`
- Move analytics transport failure handling into GTM data layer push
- Replace GTM debug `console.debug` with `logAnalytics`
- Track captcha challenge lifecycle events, excluding Turnstile demo site key traffic
- Simplify affiliate analytics by relying on shared analytics handling


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added analytics tracking across the CAPTCHA Turnstile lifecycle, including start, interaction, success, and failure states.
  - Expanded analytics event support for custom fields and optional chain-specific reporting.
  - Introduced a dedicated event-tracking utility for consistent analytics category usage.

- **Bug Fixes**
  - Hardened GTM analytics delivery: data layer pushes are now safely handled and failures trigger warnings without breaking the app.
  - Improved payload sanitization so undefined optional fields (e.g., `reason`) are omitted.

- **Tests**
  - Updated analytics-related mocks and assertions to reflect the new tracking and payload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->