### PR TITLE
fix: add reverve protocol token list

### DIFF
--- a/libs/core/src/cms/consts.ts
+++ b/libs/core/src/cms/consts.ts
@@ -7,6 +7,9 @@ export const DEFAULT_CMS_REQUEST_TTL = ms`1h`
 export const ONDO_TOKEN_LIST_URL =
   'https://raw.githubusercontent.com/ondoprotocol/cowswap-global-markets-token-list/refs/heads/main/tokenlist.json'
 
+export const RESERVE_PROTOCOL_BNB_TOKEN_LIST_URL =
+  'https://raw.githubusercontent.com/reserve-protocol/dtf-interface/refs/heads/main/packages/dtf-catalog/tokenlists/index-dtf/restricted/bnb.tokenlist.json'
+
 export const RESTRICTED_COUNTRIES = [
   'AF',
   'DZ',
@@ -69,5 +72,11 @@ export const ONDO_FALLBACK_TOKEN_LIST: RestrictedTokenList = {
 export const XStocks_FALLBACK_TOKEN_LIST: RestrictedTokenList = {
   name: 'xStocks Token List',
   tokenListUrl: 'https://raw.githubusercontent.com/backed-fi/cowswap-xstocks-tokenlist/refs/heads/main/tokenlist.json',
+  restrictedCountries: [...RESTRICTED_COUNTRIES],
+} as const
+
+export const RESERVE_PROTOCOL_BNB_FALLBACK_TOKEN_LIST: RestrictedTokenList = {
+  name: 'Reserve Protocol BNB Token List',
+  tokenListUrl: RESERVE_PROTOCOL_BNB_TOKEN_LIST_URL,
   restrictedCountries: [...RESTRICTED_COUNTRIES],
 } as const

--- a/libs/core/src/cms/utils/getRestrictedTokenLists.test.ts
+++ b/libs/core/src/cms/utils/getRestrictedTokenLists.test.ts
@@ -1,0 +1,35 @@
+const mockCmsGet = jest.fn<Promise<unknown>, [string, unknown]>()
+
+jest.mock('@cowprotocol/cms', () => ({
+  CmsClient: () => ({ GET: mockCmsGet }),
+}))
+
+import { getRestrictedTokenLists } from './getRestrictedTokenLists'
+
+const RESERVE_BNB_TOKEN_LIST_URL =
+  'https://raw.githubusercontent.com/reserve-protocol/dtf-interface/refs/heads/main/packages/dtf-catalog/tokenlists/index-dtf/restricted/bnb.tokenlist.json'
+
+describe('getRestrictedTokenLists', () => {
+  beforeEach(() => {
+    mockCmsGet.mockReset()
+    jest.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('falls back to Reserve Protocol BNB token list when the CMS request fails', async () => {
+    mockCmsGet.mockRejectedValue(new Error('CMS down'))
+
+    await expect(getRestrictedTokenLists()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'Reserve Protocol BNB Token List',
+          tokenListUrl: RESERVE_BNB_TOKEN_LIST_URL,
+          restrictedCountries: expect.arrayContaining(['US']),
+        }),
+      ]),
+    )
+  })
+})

--- a/libs/core/src/cms/utils/getRestrictedTokenLists.ts
+++ b/libs/core/src/cms/utils/getRestrictedTokenLists.ts
@@ -2,7 +2,12 @@ import { TTLCache } from '@cowprotocol/cow-sdk'
 
 import { querySerializer } from './querySerializer'
 
-import { DEFAULT_CMS_REQUEST_TTL, ONDO_FALLBACK_TOKEN_LIST, XStocks_FALLBACK_TOKEN_LIST } from '../consts'
+import {
+  DEFAULT_CMS_REQUEST_TTL,
+  ONDO_FALLBACK_TOKEN_LIST,
+  RESERVE_PROTOCOL_BNB_FALLBACK_TOKEN_LIST,
+  XStocks_FALLBACK_TOKEN_LIST,
+} from '../consts'
 import { RestrictedTokenList, RestrictedTokenLists } from '../types'
 import { getCmsClient } from '../utils'
 
@@ -68,6 +73,6 @@ async function fetchRestrictedTokenLists(): Promise<RestrictedTokenLists | null>
     })
     .catch((error: Error) => {
       console.error('Failed to fetch restricted token lists', error)
-      return [ONDO_FALLBACK_TOKEN_LIST, XStocks_FALLBACK_TOKEN_LIST]
+      return [ONDO_FALLBACK_TOKEN_LIST, XStocks_FALLBACK_TOKEN_LIST, RESERVE_PROTOCOL_BNB_FALLBACK_TOKEN_LIST]
     })
 }

--- a/libs/tokens/src/const/tokensList.json
+++ b/libs/tokens/src/const/tokensList.json
@@ -167,6 +167,10 @@
     {
       "priority": 5,
       "source": "https://raw.githubusercontent.com/backed-fi/cowswap-xstocks-tokenlist/refs/heads/main/tokenlist.json"
+    },
+    {
+      "priority": 6,
+      "source": "https://raw.githubusercontent.com/reserve-protocol/dtf-interface/refs/heads/main/packages/dtf-catalog/tokenlists/index-dtf/restricted/bnb.tokenlist.json"
     }
   ],
   "59144": [

--- a/libs/tokens/src/const/tokensLists.test.ts
+++ b/libs/tokens/src/const/tokensLists.test.ts
@@ -1,0 +1,17 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import { DEFAULT_TOKENS_LISTS } from './tokensLists'
+
+const RESERVE_BNB_TOKEN_LIST_URL =
+  'https://raw.githubusercontent.com/reserve-protocol/dtf-interface/refs/heads/main/packages/dtf-catalog/tokenlists/index-dtf/restricted/bnb.tokenlist.json'
+
+describe('DEFAULT_TOKENS_LISTS', () => {
+  it('includes the Reserve Protocol BNB token list disabled by default', () => {
+    const reserveList = DEFAULT_TOKENS_LISTS[SupportedChainId.BNB]?.find(
+      (list) => list.source === RESERVE_BNB_TOKEN_LIST_URL,
+    )
+
+    expect(reserveList).toEqual(expect.objectContaining({ priority: 6, source: RESERVE_BNB_TOKEN_LIST_URL }))
+    expect(reserveList?.enabledByDefault).toBeUndefined()
+  })
+})


### PR DESCRIPTION
# Summary

Fixes https://linear.app/cowswap/issue/FE-263/add-reserve-protocol-bnb-token-list-to-geoblock-fallbacks

[Reserve Protocol token list](https://raw.githubusercontent.com/reserve-protocol/dtf-interface/refs/heads/main/packages/dtf-catalog/tokenlists/index-dtf/restricted/bnb.tokenlist.json) already is configured on CMS to be a restricted RWA list, similar to Ondo and xStocks.

This change makes it so:
1. It shows up in the UI as available tokens, in the non-blocked countries only
2. Has a local fallback in case the CMS is unreachable

# To Test

1. Open BNB network from a unblocked location
* Reserve protocol token list should be visible
<img width="727" height="150" alt="image" src="https://github.com/user-attachments/assets/8a8c4752-1ef3-4c4b-86d2-3af8e799fc25" />


2. Block CMS network calls to fetch the restricted tokens
3. Refresh the page/clear cache
4. Select for trade one of the tokens in the list
* Same RWA restrictions should apply