### PR TITLE
fix: fix bridging with bungee

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/__snapshots__/useTradeQuotePolling.test.tsx.snap
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/__snapshots__/useTradeQuotePolling.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`useTradeQuotePolling() When wallet is NOT connected Then the "receiver" field in the quote request should be undefined 1`] = `
 {
-  "account": "0xD711bD26Bf5B153001a7C0ACcb289782b6f775e9",
+  "account": "0x19E7E376E7C213B7E7e7e46cc70A5dD086DAff2A",
   "amount": 10000000n,
   "appCode": "CoW Swap",
   "buyTokenAddress": "0x0625aFB445C3B6B7B929342a04A22599fd5dBB59",
@@ -22,7 +22,7 @@ exports[`useTradeQuotePolling() When wallet is NOT connected Then the "receiver"
     "9745": "0xba3cb449bd2b4adddbc894d8697f5170800eadec",
   },
   "kind": "sell",
-  "owner": "0xD711bD26Bf5B153001a7C0ACcb289782b6f775e9",
+  "owner": "0x19E7E376E7C213B7E7e7e46cc70A5dD086DAff2A",
   "partiallyFillable": false,
   "receiver": undefined,
   "sellTokenAddress": "0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14",
@@ -63,10 +63,10 @@ exports[`useTradeQuotePolling() When wallet is connected Then should put account
     "sellTokenChainId": 11155111,
     "sellTokenDecimals": 18,
     "signer": {
-      "address": "0xD711bD26Bf5B153001a7C0ACcb289782b6f775e9",
+      "address": "0x19E7E376E7C213B7E7e7e46cc70A5dD086DAff2A",
       "getAddress": [Function],
       "nonceManager": undefined,
-      "publicKey": "0x04e08d5acfd3225da0cb2b0a781991200cb4dae9f02fe63394ddf5dc592643e572224c8172a2373fdfb3f6b034d10fbd91a3462d56f8d09a5df8e1fb6c02b0c98d",
+      "publicKey": "0x044f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa385b6b1b8ead809ca67454d9683fcf2ba03456d6fe2c4abe2b07f0fbdbb2f1c1",
       "sign": [Function],
       "signAuthorization": [Function],
       "signMessage": [Function],

--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useTradeQuotePolling.test.tsx
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useTradeQuotePolling.test.tsx
@@ -30,6 +30,23 @@ jest.mock('@cowprotocol/common-hooks', () => ({
   useIsWindowVisible: jest.fn().mockReturnValue(true),
 }))
 
+jest.mock('../utils/getBridgeQuoteSigner', () => {
+  const { privateKeyToAccount } = require('viem/accounts') as typeof import('viem/accounts')
+  const bridgeQuoteSigner = privateKeyToAccount('0x1111111111111111111111111111111111111111111111111111111111111111')
+
+  return {
+    BRIDGE_QUOTE_ACCOUNT: bridgeQuoteSigner.address,
+    COW_QUOTE_BTC_BRIDGE_RECIPIENT: 'bc1q5eapy5ptdr98vtx9c5pfaa2yd20ncd3n397ek4',
+    COW_QUOTE_SOL_BRIDGE_RECIPIENT: 'F2nKBvD1yak1zvvGSdZdBmjKraCQX2gE14rA12Wqt23b',
+    NON_EVM_CHAIN_CONFIG: [],
+    isNonEvmPlaceholderRecipient: jest.fn().mockReturnValue(false),
+    getBridgeQuoteSigner: jest.fn().mockReturnValue({
+      ...bridgeQuoteSigner,
+      getAddress: () => bridgeQuoteSigner.address,
+    }),
+  }
+})
+
 jest.mock('tradingSdk/bridgingSdk', () => ({
   bridgingSdk: {
     getQuote: jest.fn(),

--- a/apps/cowswap-frontend/src/modules/tradeQuote/state/bridgeQuoteSignerAtom.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/state/bridgeQuoteSignerAtom.ts
@@ -1,0 +1,19 @@
+import { atomWithStorage } from 'jotai/utils'
+
+import { isHex } from 'viem'
+import { generatePrivateKey } from 'viem/accounts'
+
+export type BridgeQuotePrivateKey = ReturnType<typeof generatePrivateKey>
+
+export const BRIDGE_QUOTE_PRIVATE_KEY_STORAGE_KEY = 'bridgeQuotePrivateKeyAtom:v1'
+
+export const bridgeQuotePrivateKeyAtom = atomWithStorage<BridgeQuotePrivateKey | null>(
+  BRIDGE_QUOTE_PRIVATE_KEY_STORAGE_KEY,
+  null,
+  undefined,
+  { getOnInit: true },
+)
+
+export function isBridgeQuotePrivateKey(value: unknown): value is BridgeQuotePrivateKey {
+  return isHex(value, { strict: true }) && value.length === 66
+}

--- a/apps/cowswap-frontend/src/modules/tradeQuote/utils/getBridgeQuoteSigner.test.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/utils/getBridgeQuoteSigner.test.ts
@@ -1,0 +1,61 @@
+import { areAddressesEqual } from '@cowprotocol/cow-sdk'
+
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
+
+import { BRIDGE_QUOTE_PRIVATE_KEY_STORAGE_KEY, isBridgeQuotePrivateKey } from '../state/bridgeQuoteSignerAtom'
+
+const LEGACY_BRIDGE_QUOTE_ACCOUNT = '0xD711bD26Bf5B153001a7C0ACcb289782b6f775e9'
+
+function loadBridgeQuoteSignerModule(): typeof import('./getBridgeQuoteSigner') {
+  let bridgeQuoteSignerModule: typeof import('./getBridgeQuoteSigner') | undefined
+
+  jest.isolateModules(() => {
+    bridgeQuoteSignerModule = require('./getBridgeQuoteSigner') as typeof import('./getBridgeQuoteSigner')
+  })
+
+  if (!bridgeQuoteSignerModule) throw new Error('Failed to load bridge quote signer module')
+
+  return bridgeQuoteSignerModule
+}
+
+describe('getBridgeQuoteSigner', () => {
+  beforeEach(() => {
+    window.localStorage.removeItem(BRIDGE_QUOTE_PRIVATE_KEY_STORAGE_KEY)
+  })
+
+  it('uses one stable account for the runtime', () => {
+    const { BRIDGE_QUOTE_ACCOUNT, getBridgeQuoteSigner } = loadBridgeQuoteSignerModule()
+    const firstSigner = getBridgeQuoteSigner(1)
+    const secondSigner = getBridgeQuoteSigner(8453)
+
+    expect(secondSigner.address).toBe(firstSigner.address)
+    expect(secondSigner.getAddress()).toBe(firstSigner.address)
+    expect(BRIDGE_QUOTE_ACCOUNT).toBe(firstSigner.address)
+  })
+
+  it('does not use the legacy bridge quote account', () => {
+    const { BRIDGE_QUOTE_ACCOUNT } = loadBridgeQuoteSignerModule()
+
+    expect(areAddressesEqual(BRIDGE_QUOTE_ACCOUNT, LEGACY_BRIDGE_QUOTE_ACCOUNT)).toBe(false)
+  })
+
+  it('stores the generated private key in the persisted atom storage', () => {
+    loadBridgeQuoteSignerModule()
+
+    const storedPrivateKey = window.localStorage.getItem(BRIDGE_QUOTE_PRIVATE_KEY_STORAGE_KEY)
+
+    expect(isBridgeQuotePrivateKey(storedPrivateKey ? JSON.parse(storedPrivateKey) : null)).toBe(true)
+  })
+
+  it('reuses the stored private key after module reload', () => {
+    const privateKey = generatePrivateKey()
+    const expectedAccount = privateKeyToAccount(privateKey)
+
+    window.localStorage.setItem(BRIDGE_QUOTE_PRIVATE_KEY_STORAGE_KEY, JSON.stringify(privateKey))
+
+    const { BRIDGE_QUOTE_ACCOUNT, getBridgeQuoteSigner } = loadBridgeQuoteSignerModule()
+
+    expect(BRIDGE_QUOTE_ACCOUNT).toBe(expectedAccount.address)
+    expect(getBridgeQuoteSigner(1).getAddress()).toBe(expectedAccount.address)
+  })
+})

--- a/apps/cowswap-frontend/src/modules/tradeQuote/utils/getBridgeQuoteSigner.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/utils/getBridgeQuoteSigner.ts
@@ -1,9 +1,12 @@
+import { jotaiStore } from '@cowprotocol/core'
 import { areAddressesEqual, isBtcAddress, isBtcChain, isSolanaAddress, isSolanaChain } from '@cowprotocol/cow-sdk'
 
 import { Nullish } from 'types'
-import { privateKeyToAccount } from 'viem/accounts'
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 
-export const BRIDGE_QUOTE_ACCOUNT = '0xD711bD26Bf5B153001a7C0ACcb289782b6f775e9' as const
+import { bridgeQuotePrivateKeyAtom, isBridgeQuotePrivateKey } from '../state/bridgeQuoteSignerAtom'
+
+import type { BridgeQuotePrivateKey } from '../state/bridgeQuoteSignerAtom'
 
 // Default BTC address used solely for fetching bridge quotes before the user sets a real receiver.
 export const COW_QUOTE_BTC_BRIDGE_RECIPIENT = 'bc1q5eapy5ptdr98vtx9c5pfaa2yd20ncd3n397ek4' as const
@@ -26,12 +29,8 @@ export function isNonEvmPlaceholderRecipient(address: Nullish<string>): boolean 
   return NON_EVM_CHAIN_CONFIG.some(({ defaultRecipient }) => areAddressesEqual(address, defaultRecipient))
 }
 
-const BRIDGE_QUOTE_PK = '0x68012a4467ce455b6b278b1a6815db9b7224deaa6bced68c3848ec21e6380f8a' as const
-
-/**
- * BridgingSDK expects a signer; when disconnected we use a static viem account so hooks can be signed for quoting.
- */
-const bridgeQuoteAccount = privateKeyToAccount(BRIDGE_QUOTE_PK as `0x${string}`)
+const bridgeQuoteAccount = privateKeyToAccount(getBridgeQuotePrivateKey())
+export const BRIDGE_QUOTE_ACCOUNT = bridgeQuoteAccount.address
 
 export function getBridgeQuoteSigner(_chainId: number): typeof bridgeQuoteAccount & { getAddress(): string } {
   return {
@@ -40,4 +39,16 @@ export function getBridgeQuoteSigner(_chainId: number): typeof bridgeQuoteAccoun
       return bridgeQuoteAccount.address
     },
   }
+}
+
+function getBridgeQuotePrivateKey(): BridgeQuotePrivateKey {
+  const storedPrivateKey = jotaiStore.get(bridgeQuotePrivateKeyAtom)
+
+  if (isBridgeQuotePrivateKey(storedPrivateKey)) return storedPrivateKey
+
+  const privateKey = generatePrivateKey()
+
+  jotaiStore.set(bridgeQuotePrivateKeyAtom, privateKey)
+
+  return privateKey
 }


### PR DESCRIPTION
# Summary

Fixes https://nomevlabs.slack.com/archives/C0361CDG8GP/p1783588361747839
<img width="1090" alt="image (2)" src="https://github.com/user-attachments/assets/f22ab07a-62c9-42df-91a0-9395486558f9" />

Replaces the shared hardcoded bridge quote signing account with a per-browser locally persisted EOA.

# To Test

1. Bridge via bundgee
2. You should get a quote

<img width="457"  alt="image" src="https://github.com/user-attachments/assets/4ce7ad6a-a030-4f74-be2e-087581ea3e37" />


# Background

The previous bridge quote signer used a static private key/account that was public for everyone to use and somebody called setCode on it (EIP 7702)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bridge quote signing now uses a saved key, so the same signer stays available across app reloads.

* **Bug Fixes**
  * Prevented fallback to an outdated bridge quote address.
  * Added safeguards to validate stored signer data and regenerate it if needed.

* **Tests**
  * Added coverage for signer stability, storage persistence, and reuse of an existing saved key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->