### PR TITLE
feat: allow EIP7702 wallets to batch transactions

### DIFF
--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -1531,6 +1531,7 @@ msgid "Select an {accountProxyLabelString} to check for available refunds {chain
 msgstr "Select an {accountProxyLabelString} to check for available refunds {chain}"
 
 #: apps/cowswap-frontend/src/modules/twap/pure/PrimaryActionButton/index.tsx
+#: apps/cowswap-frontend/src/modules/twap/pure/PrimaryActionButton/index.tsx
 msgid "Unsupported wallet"
 msgstr "Unsupported wallet"
 

--- a/apps/cowswap-frontend/src/modules/erc20Approve/containers/TradeApproveWithAffectedOrderList/TradeApproveWithAffectedOrderList.tsx
+++ b/apps/cowswap-frontend/src/modules/erc20Approve/containers/TradeApproveWithAffectedOrderList/TradeApproveWithAffectedOrderList.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-import { useIsTxBundlingSupported } from '@cowprotocol/wallet'
+import { useIsTxBundlingSupported, useWalletDetails } from '@cowprotocol/wallet'
 
 import {
   ApproveRequiredReason,
@@ -16,8 +16,10 @@ import { TradeApproveToggle } from '../TradeApproveToggle'
 
 export function TradeApproveWithAffectedOrderList(): ReactNode {
   const isBundlingSupported = useIsTxBundlingSupported()
+  const { allowsOffchainSigning } = useWalletDetails()
   const { reason: isApproveRequired } = useIsApprovalOrPermitRequired({
     isBundlingSupportedOrEnabledForContext: isBundlingSupported,
+    allowsOffchainSigning,
   })
   const isPartialApprovalEnabledInSettings = useIsPartialApprovalModeSelected()
 

--- a/apps/cowswap-frontend/src/modules/erc20Approve/hooks/useIsApprovalOrPermitRequired.test.ts
+++ b/apps/cowswap-frontend/src/modules/erc20Approve/hooks/useIsApprovalOrPermitRequired.test.ts
@@ -553,22 +553,22 @@ describe('useIsApprovalOrPermitRequired', () => {
       expect(result.current.reason).toBe(expectedReason)
     })
 
-    it.each([TradeType.LIMIT_ORDER, TradeType.YIELD])(
-      'should prefer permits for offchain-signing %s wallets',
-      (tradeType) => {
-        mockUseDerivedTradeState.mockReturnValue(createMockTradeState({ tradeType }))
-        mockUsePermitInfo.mockReturnValue({ type: 'eip-2612' })
+    it.each([
+      [TradeType.LIMIT_ORDER, ApproveRequiredReason.NotRequired],
+      [TradeType.YIELD, ApproveRequiredReason.Eip2612PermitRequired],
+    ])('should return the expected permit requirement for offchain-signing %s wallets', (tradeType, expectedReason) => {
+      mockUseDerivedTradeState.mockReturnValue(createMockTradeState({ tradeType }))
+      mockUsePermitInfo.mockReturnValue({ type: 'eip-2612' })
 
-        const { result } = renderHook(() =>
-          useIsApprovalOrPermitRequired({
-            isBundlingSupportedOrEnabledForContext: true,
-            allowsOffchainSigning: true,
-          }),
-        )
+      const { result } = renderHook(() =>
+        useIsApprovalOrPermitRequired({
+          isBundlingSupportedOrEnabledForContext: true,
+          allowsOffchainSigning: true,
+        }),
+      )
 
-        expect(result.current.reason).toBe(ApproveRequiredReason.Eip2612PermitRequired)
-      },
-    )
+      expect(result.current.reason).toBe(expectedReason)
+    })
 
     it('should keep bundling limit-order permits without offchain signing', () => {
       mockUseDerivedTradeState.mockReturnValue(createMockTradeState({ tradeType: TradeType.LIMIT_ORDER }))

--- a/apps/cowswap-frontend/src/modules/erc20Approve/hooks/useIsApprovalOrPermitRequired.test.ts
+++ b/apps/cowswap-frontend/src/modules/erc20Approve/hooks/useIsApprovalOrPermitRequired.test.ts
@@ -494,7 +494,7 @@ describe('useIsApprovalOrPermitRequired', () => {
   })
 
   describe('when bundling is supported', () => {
-    it('should return BundleApproveRequired when bundling is enabled and approval is needed', () => {
+    it('should bundle approval for an unsupported permit despite offchain signing', () => {
       const nativeAmount = CurrencyAmount.fromRawAmount(mockNativeToken, '1000000000000000000')
       mockUseGetAmountToSignApprove.mockReturnValue(nativeAmount)
       mockUseDerivedTradeState.mockReturnValue(
@@ -510,7 +510,10 @@ describe('useIsApprovalOrPermitRequired', () => {
       mockUsePermitInfo.mockReturnValue({ type: 'unsupported' })
 
       const { result } = renderHook(() =>
-        useIsApprovalOrPermitRequired({ isBundlingSupportedOrEnabledForContext: true }),
+        useIsApprovalOrPermitRequired({
+          isBundlingSupportedOrEnabledForContext: true,
+          allowsOffchainSigning: true,
+        }),
       )
 
       expect(result.current.reason).toBe(ApproveRequiredReason.BundleApproveRequired)
@@ -529,6 +532,53 @@ describe('useIsApprovalOrPermitRequired', () => {
 
       const { result } = renderHook(() =>
         useIsApprovalOrPermitRequired({ isBundlingSupportedOrEnabledForContext: true }),
+      )
+
+      expect(result.current.reason).toBe(ApproveRequiredReason.BundleApproveRequired)
+    })
+
+    it.each([
+      ['eip-2612', ApproveRequiredReason.Eip2612PermitRequired],
+      ['dai-like', ApproveRequiredReason.DaiLikePermitRequired],
+    ] as const)('should prefer a %s permit for an offchain-signing swap wallet', (type, expectedReason) => {
+      mockUsePermitInfo.mockReturnValue({ type })
+
+      const { result } = renderHook(() =>
+        useIsApprovalOrPermitRequired({
+          isBundlingSupportedOrEnabledForContext: true,
+          allowsOffchainSigning: true,
+        }),
+      )
+
+      expect(result.current.reason).toBe(expectedReason)
+    })
+
+    it.each([TradeType.LIMIT_ORDER, TradeType.YIELD])(
+      'should prefer permits for offchain-signing %s wallets',
+      (tradeType) => {
+        mockUseDerivedTradeState.mockReturnValue(createMockTradeState({ tradeType }))
+        mockUsePermitInfo.mockReturnValue({ type: 'eip-2612' })
+
+        const { result } = renderHook(() =>
+          useIsApprovalOrPermitRequired({
+            isBundlingSupportedOrEnabledForContext: true,
+            allowsOffchainSigning: true,
+          }),
+        )
+
+        expect(result.current.reason).toBe(ApproveRequiredReason.Eip2612PermitRequired)
+      },
+    )
+
+    it('should keep bundling limit-order permits without offchain signing', () => {
+      mockUseDerivedTradeState.mockReturnValue(createMockTradeState({ tradeType: TradeType.LIMIT_ORDER }))
+      mockUsePermitInfo.mockReturnValue({ type: 'eip-2612' })
+
+      const { result } = renderHook(() =>
+        useIsApprovalOrPermitRequired({
+          isBundlingSupportedOrEnabledForContext: true,
+          allowsOffchainSigning: false,
+        }),
       )
 
       expect(result.current.reason).toBe(ApproveRequiredReason.BundleApproveRequired)

--- a/apps/cowswap-frontend/src/modules/erc20Approve/hooks/useIsApprovalOrPermitRequired.ts
+++ b/apps/cowswap-frontend/src/modules/erc20Approve/hooks/useIsApprovalOrPermitRequired.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 
 import { getIsNativeToken } from '@cowprotocol/common-utils'
 import { Currency, CurrencyAmount } from '@cowprotocol/currency'
-import { PermitType } from '@cowprotocol/permit-utils'
+import { isSupportedPermitInfo, PermitType } from '@cowprotocol/permit-utils'
 import { Nullish } from '@cowprotocol/types'
 
 import { usePermitInfo } from 'modules/permit'
@@ -26,16 +26,22 @@ type AdditionalParams = {
   // null is needed to prevent breaking changes, as this param was optional before
   // f.e. for approve and swap its allowed, but for just approve - no
   isBundlingSupportedOrEnabledForContext: boolean | null
+  /** Whether the connected wallet can sign orders and permits off-chain. */
+  allowsOffchainSigning?: boolean
 }
 
-export function useIsApprovalOrPermitRequired({ isBundlingSupportedOrEnabledForContext }: AdditionalParams): {
+export function useIsApprovalOrPermitRequired({
+  isBundlingSupportedOrEnabledForContext,
+  allowsOffchainSigning = false,
+}: AdditionalParams): {
   reason: ApproveRequiredReason
   currentAllowance: Nullish<bigint>
 } {
   const amountToApprove = useGetAmountToSignApprove()
   const { state: approvalState, currentAllowance } = useApproveState(amountToApprove)
   const { inputCurrency, tradeType } = useDerivedTradeState() || {}
-  const { type } = usePermitInfo(inputCurrency, tradeType) || {}
+  const permitInfo = usePermitInfo(inputCurrency, tradeType)
+  const type = permitInfo?.type
 
   const reason = (() => {
     if (!isApproveSupportedByFlowOrWallet(inputCurrency, tradeType, !!isBundlingSupportedOrEnabledForContext)) {
@@ -46,7 +52,11 @@ export function useIsApprovalOrPermitRequired({ isBundlingSupportedOrEnabledForC
       return ApproveRequiredReason.NotRequired
     }
 
-    const isPermitSupported = type && type !== 'unsupported'
+    const isPermitSupported = isSupportedPermitInfo(permitInfo)
+
+    if (allowsOffchainSigning && isPermitSupported) {
+      return getPermitRequirements(type)
+    }
 
     if (!isPermitSupported && isApprovalRequired(approvalState)) {
       return isBundlingSupportedOrEnabledForContext

--- a/apps/cowswap-frontend/src/modules/erc20Approve/hooks/useIsApprovalOrPermitRequired.ts
+++ b/apps/cowswap-frontend/src/modules/erc20Approve/hooks/useIsApprovalOrPermitRequired.ts
@@ -42,6 +42,8 @@ export function useIsApprovalOrPermitRequired({
   const { inputCurrency, tradeType } = useDerivedTradeState() || {}
   const permitInfo = usePermitInfo(inputCurrency, tradeType)
   const type = permitInfo?.type
+  const offchainPermitRequirement =
+    tradeType === TradeType.LIMIT_ORDER ? ApproveRequiredReason.NotRequired : getPermitRequirements(type)
 
   const reason = (() => {
     if (!isApproveSupportedByFlowOrWallet(inputCurrency, tradeType, !!isBundlingSupportedOrEnabledForContext)) {
@@ -55,7 +57,7 @@ export function useIsApprovalOrPermitRequired({
     const isPermitSupported = isSupportedPermitInfo(permitInfo)
 
     if (allowsOffchainSigning && isPermitSupported) {
-      return getPermitRequirements(type)
+      return offchainPermitRequirement
     }
 
     if (!isPermitSupported && isApprovalRequired(approvalState)) {

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersConfirmModal/index.tsx
@@ -80,7 +80,9 @@ export function LimitOrdersConfirmModal(props: LimitOrdersConfirmModalProps): Re
 
   const inputSymbol = inputAmount?.currency?.symbol || t`token`
   const canUsePermit = tradeContext.allowsOffchainSigning && isSupportedPermitInfo(tradeContext.permitInfo)
-  const isSafeApprovalBundle = useIsSafeApprovalBundle(inputAmount) && !canUsePermit
+  // Temporary: keep limit-order bundles Safe-only until EIP-5792 order lifecycle tracking lands.
+  const isSafeApprovalBundle =
+    useIsSafeApprovalBundle(inputAmount) && tradeContext.postOrderParams.isSafeWallet && !canUsePermit
   const buttonText = isInsufficientBalance ? (
     t`Insufficient ${inputSymbol} balance`
   ) : isSafeApprovalBundle ? (

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersConfirmModal/index.tsx
@@ -2,6 +2,7 @@ import { useAtom, useAtomValue } from 'jotai'
 import React, { ReactNode, useMemo } from 'react'
 
 import { getWrappedToken } from '@cowprotocol/common-utils'
+import { isSupportedPermitInfo } from '@cowprotocol/permit-utils'
 import { TokenSymbol } from '@cowprotocol/ui'
 
 import { t } from '@lingui/core/macro'
@@ -78,7 +79,8 @@ export function LimitOrdersConfirmModal(props: LimitOrdersConfirmModalProps): Re
   const isConfirmDisabled = (isTooLowRate ? !warningsAccepted : false) || isInsufficientBalance
 
   const inputSymbol = inputAmount?.currency?.symbol || t`token`
-  const isSafeApprovalBundle = useIsSafeApprovalBundle(inputAmount)
+  const canUsePermit = tradeContext.allowsOffchainSigning && isSupportedPermitInfo(tradeContext.permitInfo)
+  const isSafeApprovalBundle = useIsSafeApprovalBundle(inputAmount) && !canUsePermit
   const buttonText = isInsufficientBalance ? (
     t`Insufficient ${inputSymbol} balance`
   ) : isSafeApprovalBundle ? (

--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.test.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.test.tsx
@@ -150,6 +150,25 @@ describe('useHandleOrderPlacement', () => {
     expect(limitOrdersStateResultAfter.current.recipient).toBe(null)
   })
 
+  it('uses the regular permit flow instead of an approval bundle', async () => {
+    mockUseIsSafeApprovalBundle.mockReturnValue(true)
+    const permitTradeContext = {
+      ...tradeContextMock,
+      allowsOffchainSigning: true,
+      permitInfo: { type: 'eip-2612', name: 'USDC', version: '2' },
+    } as TradeFlowContext
+
+    const { result } = renderHook(
+      () =>
+        useHandleOrderPlacement(permitTradeContext, priceImpactMock, defaultLimitOrdersSettings, tradeConfirmActions),
+      { wrapper },
+    )
+    await act(result.current)
+
+    expect(mockTradeFlow).toHaveBeenCalled()
+    expect(mockSafeBundleFlow).not.toHaveBeenCalled()
+  })
+
   describe('partiallyFillableOverride', () => {
     it('When partiallyFillableOverride is undefined, then no override should be passed to tradeFlow', async () => {
       // Arrange

--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.test.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.test.tsx
@@ -68,6 +68,7 @@ const tradeContextMock = {
     partiallyFillable: true,
     inputAmount: CurrencyAmount.fromRawAmount(USDC_BASE, '1'),
     outputAmount: CurrencyAmount.fromRawAmount(USDT_BASE, '1'),
+    isSafeWallet: true,
   },
 } as never as TradeFlowContext
 const priceImpactMock: PriceImpact = {

--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.ts
@@ -5,6 +5,7 @@ import { useConfig } from 'wagmi'
 
 import { useCowAnalytics } from '@cowprotocol/analytics'
 import { getAddress } from '@cowprotocol/common-utils'
+import { isSupportedPermitInfo } from '@cowprotocol/permit-utils'
 import { UiOrderType } from '@cowprotocol/types'
 import { useIsSmartContractWallet } from '@cowprotocol/wallet'
 import { WidgetHookEvents } from '@cowprotocol/widget-lib'
@@ -60,6 +61,8 @@ export function useHandleOrderPlacement(
   // tx bundling stuff
   const safeBundleFlowContext = useSafeBundleFlowContext(tradeContext)
   const isSafeBundle = useIsSafeApprovalBundle(tradeContext?.postOrderParams.inputAmount)
+  const canUsePermit = tradeContext.allowsOffchainSigning && isSupportedPermitInfo(tradeContext.permitInfo)
+  const shouldUseSafeBundle = isSafeBundle && !canUsePermit
   const alternativeModalAnalytics = useAlternativeModalAnalytics()
   const analytics = useTradeFlowAnalytics()
   const { t } = useLingui()
@@ -110,7 +113,7 @@ export function useHandleOrderPlacement(
     const partiallyFillableState =
       typeof partiallyFillableOverride === 'boolean' ? { partiallyFillable: partiallyFillableOverride } : null
 
-    if (isSafeBundle) {
+    if (shouldUseSafeBundle) {
       if (!safeBundleFlowContext) throw new Error(t`safeBundleFlowContext is not set!`)
 
       return safeBundleFlow({
@@ -147,7 +150,7 @@ export function useHandleOrderPlacement(
     )
   }, [
     config,
-    isSafeBundle,
+    shouldUseSafeBundle,
     tradeContext,
     partiallyFillableOverride,
     priceImpact,

--- a/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/hooks/useHandleOrderPlacement.ts
@@ -62,7 +62,8 @@ export function useHandleOrderPlacement(
   const safeBundleFlowContext = useSafeBundleFlowContext(tradeContext)
   const isSafeBundle = useIsSafeApprovalBundle(tradeContext?.postOrderParams.inputAmount)
   const canUsePermit = tradeContext.allowsOffchainSigning && isSupportedPermitInfo(tradeContext.permitInfo)
-  const shouldUseSafeBundle = isSafeBundle && !canUsePermit
+  // Temporary: keep limit-order bundles Safe-only until EIP-5792 order lifecycle tracking lands.
+  const shouldUseSafeBundle = isSafeBundle && tradeContext.postOrderParams.isSafeWallet && !canUsePermit
   const alternativeModalAnalytics = useAlternativeModalAnalytics()
   const analytics = useTradeFlowAnalytics()
   const { t } = useLingui()

--- a/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowType.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowType.ts
@@ -1,3 +1,6 @@
+import { useIsTxBundlingSupported, useWalletDetails } from '@cowprotocol/wallet'
+
+import { ApproveRequiredReason, useIsApprovalOrPermitRequired } from 'modules/erc20Approve'
 import { useAmountsToSignFromQuote, useIsEoaEthFlow, useIsSafeEthFlow } from 'modules/trade'
 
 import { useIsSafeApprovalBundle } from 'common/hooks/useIsSafeApprovalBundle'
@@ -7,18 +10,32 @@ import { FlowType } from '../types/TradeFlowContext'
 export function useTradeFlowType(): FlowType {
   const isEoaEthFlow = useIsEoaEthFlow()
   const isSafeEthFlow = useIsSafeEthFlow()
+  const isBundlingSupported = useIsTxBundlingSupported()
+  const { allowsOffchainSigning } = useWalletDetails()
   const { maximumSendSellAmount } = useAmountsToSignFromQuote() || {}
-  // todo check this case
   const isSafeBundle = useIsSafeApprovalBundle(maximumSendSellAmount)
-  return getFlowType(isSafeBundle, isEoaEthFlow, isSafeEthFlow)
+  const { reason: approvalReason } = useIsApprovalOrPermitRequired({
+    isBundlingSupportedOrEnabledForContext: isBundlingSupported,
+    allowsOffchainSigning,
+  })
+  const isPermitRequired =
+    approvalReason === ApproveRequiredReason.Eip2612PermitRequired ||
+    approvalReason === ApproveRequiredReason.DaiLikePermitRequired
+
+  return getFlowType(isSafeBundle, isEoaEthFlow, isSafeEthFlow, isPermitRequired)
 }
 
-function getFlowType(isSafeBundle: boolean, isEoaEthFlow: boolean, isSafeEthFlow: boolean): FlowType {
+function getFlowType(
+  isSafeBundle: boolean,
+  isEoaEthFlow: boolean,
+  isSafeEthFlow: boolean,
+  isPermitRequired: boolean,
+): FlowType {
   if (isSafeEthFlow) {
     // Takes precedence over bundle approval
     return FlowType.SAFE_BUNDLE_ETH
   }
-  if (isSafeBundle) {
+  if (isSafeBundle && !isPermitRequired) {
     // Takes precedence over eth flow
     return FlowType.SAFE_BUNDLE_APPROVAL
   }

--- a/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowType.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowType.ts
@@ -31,6 +31,10 @@ function getFlowType(
   isSafeEthFlow: boolean,
   isPermitRequired: boolean,
 ): FlowType {
+  if (isEoaEthFlow) {
+    // Takes precedence when EIP-7702 also supports bundling
+    return FlowType.EOA_ETH_FLOW
+  }
   if (isSafeEthFlow) {
     // Takes precedence over bundle approval
     return FlowType.SAFE_BUNDLE_ETH
@@ -38,10 +42,6 @@ function getFlowType(
   if (isSafeBundle && !isPermitRequired) {
     // Takes precedence over eth flow
     return FlowType.SAFE_BUNDLE_APPROVAL
-  }
-  if (isEoaEthFlow) {
-    // Takes precedence over regular flow
-    return FlowType.EOA_ETH_FLOW
   }
   return FlowType.REGULAR
 }

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormValidationContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormValidationContext.ts
@@ -9,6 +9,7 @@ import { useIsTradeUnsupported, useIsXstockToken, useTryFindToken } from '@cowpr
 import {
   useGnosisSafeInfo,
   useIsRestoringConnection,
+  useIsSafeWallet,
   useIsTxBundlingSupported,
   useWalletDetails,
   useWalletInfo,
@@ -63,6 +64,7 @@ export function useTradeFormValidationContext(): TradeFormValidationCommonContex
   const isOutputCurrencyXstock = useIsXstockToken(getNonNativeCurrency(outputCurrency))
 
   const isBundlingSupported = useIsTxBundlingSupported()
+  const isSafeWallet = useIsSafeWallet()
   const isWrapUnwrap = useIsWrapOrUnwrap()
   const { allowsOffchainSigning, isSupportedWallet } = useWalletDetails()
   const gnosisSafeInfo = useGnosisSafeInfo()
@@ -75,8 +77,10 @@ export function useTradeFormValidationContext(): TradeFormValidationCommonContex
 
   const isSafeReadonlyUser = gnosisSafeInfo?.isReadOnly === true
 
+  // Temporary: keep limit-order bundles Safe-only until EIP-5792 order lifecycle tracking lands.
+  const isBundlingSupportedForContext = tradeType === TradeType.LIMIT_ORDER ? isSafeWallet : isBundlingSupported
   const isApproveRequired = useIsApprovalOrPermitRequired({
-    isBundlingSupportedOrEnabledForContext: isBundlingSupported,
+    isBundlingSupportedOrEnabledForContext: isBundlingSupportedForContext,
     allowsOffchainSigning,
   }).reason
 

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormValidationContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormValidationContext.ts
@@ -78,7 +78,8 @@ export function useTradeFormValidationContext(): TradeFormValidationCommonContex
   const isSafeReadonlyUser = gnosisSafeInfo?.isReadOnly === true
 
   // Temporary: keep limit-order bundles Safe-only until EIP-5792 order lifecycle tracking lands.
-  const isBundlingSupportedForContext = tradeType === TradeType.LIMIT_ORDER ? isSafeWallet : isBundlingSupported
+  const isBundlingSupportedForContext =
+    tradeType === TradeType.LIMIT_ORDER ? isSafeWallet && isBundlingSupported : isBundlingSupported
   const isApproveRequired = useIsApprovalOrPermitRequired({
     isBundlingSupportedOrEnabledForContext: isBundlingSupportedForContext,
     allowsOffchainSigning,

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormValidationContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormValidationContext.ts
@@ -64,7 +64,7 @@ export function useTradeFormValidationContext(): TradeFormValidationCommonContex
 
   const isBundlingSupported = useIsTxBundlingSupported()
   const isWrapUnwrap = useIsWrapOrUnwrap()
-  const { isSupportedWallet } = useWalletDetails()
+  const { allowsOffchainSigning, isSupportedWallet } = useWalletDetails()
   const gnosisSafeInfo = useGnosisSafeInfo()
   const hasHookBridgeProvidersEnabled = useHasHookBridgeProvidersEnabled()
   const { isLoading, data: proxyAccount } = useCurrentAccountProxy()
@@ -77,6 +77,7 @@ export function useTradeFormValidationContext(): TradeFormValidationCommonContex
 
   const isApproveRequired = useIsApprovalOrPermitRequired({
     isBundlingSupportedOrEnabledForContext: isBundlingSupported,
+    allowsOffchainSigning,
   }).reason
 
   const isInsufficientBalanceOrderAllowed = tradeType === TradeType.LIMIT_ORDER

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/index.tsx
@@ -96,7 +96,7 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
   return (
     <>
       {(() => {
-        if (localFormValidation === TwapFormState.TX_BUNDLING_NOT_SUPPORTED) {
+        if (isUnsupportedWallet(localFormValidation)) {
           return (
             <UnsupportedWalletWarning
               isSafeViaWc={isSafeViaWc}
@@ -150,4 +150,8 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
       })()}
     </>
   )
+}
+
+function isUnsupportedWallet(state: TwapFormState | null): boolean {
+  return state === TwapFormState.WALLET_NOT_SUPPORTED || state === TwapFormState.TX_BUNDLING_NOT_SUPPORTED
 }

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/warnings/UnsupportedWalletWarning.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/warnings/UnsupportedWalletWarning.tsx
@@ -7,7 +7,7 @@ import { ButtonSecondary, ExternalLink, InlineBanner, StatusColorVariant } from 
 import { Trans } from '@lingui/react/macro'
 import styled from 'styled-components/macro'
 
-import { UNSUPPORTED_WALLET_LINK } from 'modules/twap/const'
+import { UNSUPPORTED_WALLET_LINK } from '../../../const'
 
 const InterestButton = styled(ButtonSecondary).attrs({ type: 'button' })`
   width: fit-content;
@@ -17,6 +17,9 @@ const InterestButton = styled(ButtonSecondary).attrs({ type: 'button' })`
 export interface UnsupportedWalletWarningProps {
   chainId: SupportedChainId
   account?: string
+  /**
+   * If true, we want to suggest the user to try the Safe web app, because their wallet connection did not confirm tx bundling.
+   */
   isSafeViaWc: boolean
   isInterestButtonVisible: boolean
   isInterestRegistered: boolean

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWidget/index.tsx
@@ -135,7 +135,7 @@ export function TwapFormWidget({ tradeWarnings }: TwapFormWidget): ReactNode {
 
   useEffect(() => {
     if (account && verification) {
-      if (localFormValidation === TwapFormState.TX_BUNDLING_NOT_SUPPORTED) {
+      if (localFormValidation === TwapFormState.WALLET_NOT_SUPPORTED) {
         cowAnalytics.sendEvent({
           category: CowSwapAnalyticsCategory.TWAP,
           action: 'non-compatible',

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useTwapFormState.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useTwapFormState.ts
@@ -1,7 +1,7 @@
 import { useAtomValue } from 'jotai'
 
 import { useFeatureFlags } from '@cowprotocol/common-hooks'
-import { useIsTxBundlingSupported, useWalletInfo } from '@cowprotocol/wallet'
+import { isSafeAppAtom, isSafeViaWcAtom, useIsTxBundlingSupported, useWalletInfo } from '@cowprotocol/wallet'
 
 import { useGetReceiveAmountInfo } from 'modules/trade'
 import { tradeFormValidationContextAtom } from 'modules/tradeFormValidation'
@@ -28,9 +28,13 @@ export function useTwapFormState(): TwapFormState | null {
   const tradeFormValidationContext = useAtomValue(tradeFormValidationContextAtom)
 
   const verification = useFallbackHandlerVerification()
+  const isSafeApp = useAtomValue(isSafeAppAtom)
+  const isSafeViaWc = useAtomValue(isSafeViaWcAtom)
   const isTxBundlingSupported = useIsTxBundlingSupported()
+  const isWalletSupported = isSafeApp === null || isSafeViaWc === null ? null : isSafeApp || isSafeViaWc
 
   return getTwapFormState({
+    isWalletSupported,
     isTxBundlingSupported,
     verification,
     twapOrder,

--- a/apps/cowswap-frontend/src/modules/twap/pure/PrimaryActionButton/getTwapFormState.test.ts
+++ b/apps/cowswap-frontend/src/modules/twap/pure/PrimaryActionButton/getTwapFormState.test.ts
@@ -32,10 +32,36 @@ const baseParams = {
   partTime: 300,
   numberOfPartsValue: 1,
   tradeFormValidationContext: null,
+  isWalletSupported: true,
   isTwapEoaEnabled: false,
 } as const
 
 describe('getTwapFormState()', () => {
+  it('returns WALLET_NOT_SUPPORTED for a non-Safe wallet', () => {
+    const result = getTwapFormState({
+      ...baseParams,
+      isWalletSupported: false,
+      isTxBundlingSupported: true,
+      verification: ExtensibleFallbackVerification.HAS_NOTHING,
+      sellAmountPartFiat: null,
+      partTime: undefined,
+    })
+
+    expect(result).toEqual(TwapFormState.WALLET_NOT_SUPPORTED)
+  })
+
+  it('returns TX_BUNDLING_NOT_SUPPORTED for a Safe without batching support', () => {
+    const result = getTwapFormState({
+      ...baseParams,
+      isTxBundlingSupported: false,
+      verification: ExtensibleFallbackVerification.HAS_NOTHING,
+      sellAmountPartFiat: null,
+      partTime: undefined,
+    })
+
+    expect(result).toEqual(TwapFormState.TX_BUNDLING_NOT_SUPPORTED)
+  })
+
   describe('When sell fiat amount is under threshold', () => {
     it('And order has buy amount, then should return SELL_AMOUNT_TOO_SMALL', () => {
       const result = getTwapFormState({
@@ -91,6 +117,7 @@ describe('getTwapFormState()', () => {
     it('Skips Safe guards when EOA flag is on so unsupported wallets can proceed', () => {
       const result = getTwapFormState({
         ...baseParams,
+        isWalletSupported: false,
         isTxBundlingSupported: false,
         verification: null,
         isTwapEoaEnabled: true,

--- a/apps/cowswap-frontend/src/modules/twap/pure/PrimaryActionButton/getTwapFormState.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/pure/PrimaryActionButton/getTwapFormState.tsx
@@ -14,6 +14,7 @@ import { isPartTimeIntervalTooShort } from '../../utils/isPartTimeIntervalTooSho
 import { isSellAmountTooSmall } from '../../utils/isSellAmountTooSmall'
 
 export interface TwapFormStateParams {
+  isWalletSupported: boolean | null
   isTxBundlingSupported: boolean | null
   verification: ExtensibleFallbackVerification | null
   twapOrder: TWAPOrder | null
@@ -27,6 +28,7 @@ export interface TwapFormStateParams {
 
 export enum TwapFormState {
   LOADING_SAFE_INFO = 'LOADING_SAFE_INFO',
+  WALLET_NOT_SUPPORTED = 'WALLET_NOT_SUPPORTED',
   TX_BUNDLING_NOT_SUPPORTED = 'TX_BUNDLING_NOT_SUPPORTED',
   SELL_AMOUNT_TOO_SMALL = 'SELL_AMOUNT_TOO_SMALL',
   PART_TIME_INTERVAL_TOO_SHORT = 'PART_TIME_INTERVAL_TOO_SHORT',
@@ -36,6 +38,7 @@ export enum TwapFormState {
 
 export function getTwapFormState(props: TwapFormStateParams): TwapFormState | null {
   const {
+    isWalletSupported,
     twapOrder,
     isTxBundlingSupported,
     verification,
@@ -49,9 +52,12 @@ export function getTwapFormState(props: TwapFormStateParams): TwapFormState | nu
 
   // When TWAP for EOA is enabled, skip Safe/tx-bundling gates so EOAs can review and confirm.
   if (!isTwapEoaEnabled) {
+    if (isWalletSupported === false) return TwapFormState.WALLET_NOT_SUPPORTED
     if (isTxBundlingSupported === false) return TwapFormState.TX_BUNDLING_NOT_SUPPORTED
 
-    if (verification === null || isTxBundlingSupported === null) return TwapFormState.LOADING_SAFE_INFO
+    if (verification === null || isTxBundlingSupported === null || isWalletSupported === null) {
+      return TwapFormState.LOADING_SAFE_INFO
+    }
   }
 
   if (!isFractionFalsy(twapOrder?.buyAmount) && isSellAmountTooSmall(sellAmountPartFiat, chainId)) {

--- a/apps/cowswap-frontend/src/modules/twap/pure/PrimaryActionButton/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/pure/PrimaryActionButton/index.tsx
@@ -18,6 +18,11 @@ const buttonsMap: Record<TwapFormState, (_context: PrimaryActionButtonContext) =
       <Trans>Loading...</Trans>
     </ButtonPrimary>
   ),
+  [TwapFormState.WALLET_NOT_SUPPORTED]: () => (
+    <ButtonPrimary disabled={true} buttonSize={ButtonSize.BIG}>
+      <Trans>Unsupported wallet</Trans>
+    </ButtonPrimary>
+  ),
   [TwapFormState.TX_BUNDLING_NOT_SUPPORTED]: () => (
     <ButtonPrimary disabled={true} buttonSize={ButtonSize.BIG}>
       <Trans>Unsupported wallet</Trans>

--- a/libs/wallet/src/api/state/walletCapabilitiesAtom.test.ts
+++ b/libs/wallet/src/api/state/walletCapabilitiesAtom.test.ts
@@ -4,10 +4,8 @@ import type { EIP1193Provider, PublicClient } from 'viem'
 import type { Connector } from 'wagmi'
 
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { AccountType } from '@cowprotocol/types'
 
 import {
-  getShouldSkipCapabilitiesCheck,
   isAtomicBatchSupportedAtom,
   isAtomicBatchSupportedAsyncAtom,
   isAtomicBatchSupportedLoadableAtom,
@@ -16,25 +14,12 @@ import {
   walletCapabilitiesAtom,
 } from './walletCapabilitiesAtom'
 
-import {
-  accountTypeAtom,
-  isSafeAppAtom,
-  isSafeViaWcAtom,
-  isSafeWalletAtom,
-  isSmartContractWalletAtom,
-} from '../../wagmi/state/walletMetadata.atoms'
+import { isSafeAppAtom, isSafeViaWcAtom } from '../../wagmi/state/walletMetadata.atoms'
 import { walletInfoAtom } from '../state'
 
 /** Mocked module exports writable primitives; Jest widens atom types, so casts are required for store.set. */
 const writableIsSafeAppAtom = isSafeAppAtom as WritableAtom<boolean | null, [boolean | null], unknown>
 const writableIsSafeViaWcAtom = isSafeViaWcAtom as WritableAtom<boolean | null, [boolean | null], unknown>
-const writableAccountTypeAtom = accountTypeAtom as WritableAtom<AccountType | null, [AccountType | null], unknown>
-const writableIsSmartContractWalletAtom = isSmartContractWalletAtom as WritableAtom<
-  boolean | null,
-  [boolean | null],
-  unknown
->
-const writableIsSafeWalletAtom = isSafeWalletAtom as WritableAtom<boolean, [boolean], unknown>
 
 import type { WalletCapabilities } from './walletCapabilitiesAtom'
 import type { WalletInfo } from '../types'
@@ -45,9 +30,6 @@ jest.mock('../../wagmi/state/walletMetadata.atoms', () => {
   return {
     isSafeAppAtom: jotai.atom(false),
     isSafeViaWcAtom: jotai.atom(false),
-    accountTypeAtom: jotai.atom('EOA'),
-    isSmartContractWalletAtom: jotai.atom(false),
-    isSafeWalletAtom: jotai.atom(false),
   }
 })
 
@@ -57,24 +39,6 @@ const MOCK_CONNECTOR = { type: 'injected' } as Connector
 
 const mockGetCapabilities = jest.fn()
 const mockWagmiConfigGetClient = jest.fn()
-const mockGetIsWalletConnect = jest.fn()
-const mockIsMobile = { value: false }
-
-jest.mock('@cowprotocol/common-utils', () => {
-  const actual = jest.requireActual<typeof import('@cowprotocol/common-utils')>('@cowprotocol/common-utils')
-
-  return {
-    ...actual,
-    getCurrentChainIdFromUrl: () => 1,
-    get isMobile() {
-      return mockIsMobile.value
-    },
-  }
-})
-
-jest.mock('../../wagmi/hooks/useIsWalletConnect', () => ({
-  getIsWalletConnect: (...args: unknown[]) => mockGetIsWalletConnect(...args),
-}))
 
 jest.mock('viem/actions', () => ({
   getCapabilities: (...args: unknown[]) => mockGetCapabilities(...args),
@@ -92,26 +56,6 @@ function createMockEip1193Provider(request = jest.fn()): EIP1193Provider {
     on: jest.fn(),
     removeListener: jest.fn(),
   } as unknown as EIP1193Provider
-}
-
-function seedResolvedWalletMetadata(
-  store: ReturnType<typeof createStore>,
-  overrides: Partial<{
-    accountType: AccountType | null
-    isSafeWallet: boolean
-    isSmartContractWallet: boolean | null
-    isSafeViaWc: boolean
-    isSafeApp: boolean
-  }> = {},
-): void {
-  store.set(writableAccountTypeAtom, overrides.accountType ?? AccountType.EOA)
-  store.set(writableIsSafeWalletAtom, overrides.isSafeWallet ?? false)
-  store.set(
-    writableIsSmartContractWalletAtom,
-    'isSmartContractWallet' in overrides ? (overrides.isSmartContractWallet ?? null) : false,
-  )
-  store.set(writableIsSafeViaWcAtom, overrides.isSafeViaWc ?? false)
-  store.set(writableIsSafeAppAtom, overrides.isSafeApp ?? false)
 }
 
 function setWalletInfo(
@@ -151,29 +95,9 @@ describe('resolveCapabilitiesForChain', () => {
   })
 })
 
-describe('getShouldSkipCapabilitiesCheck', () => {
-  beforeEach(() => {
-    mockIsMobile.value = false
-    mockGetIsWalletConnect.mockReturnValue(false)
-  })
-
-  it('returns false on desktop', async () => {
-    expect(await getShouldSkipCapabilitiesCheck(MOCK_CONNECTOR, createMockEip1193Provider())).toBe(false)
-  })
-
-  it('returns true on mobile WalletConnect', async () => {
-    mockIsMobile.value = true
-    mockGetIsWalletConnect.mockReturnValue(true)
-
-    expect(await getShouldSkipCapabilitiesCheck(MOCK_CONNECTOR, createMockEip1193Provider())).toBe(true)
-  })
-})
-
 describe('walletCapabilitiesAtom', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockIsMobile.value = false
-    mockGetIsWalletConnect.mockReturnValue(false)
     mockGetCapabilities.mockResolvedValue({})
     mockWagmiConfigGetClient.mockReturnValue({ chainId: MOCK_CHAIN_ID })
   })
@@ -181,19 +105,6 @@ describe('walletCapabilitiesAtom', () => {
   it('returns null when isSafeViaWc is still loading', async () => {
     const store = createStore()
     store.set(writableIsSafeViaWcAtom, null)
-    setWalletInfo(store)
-
-    const result = await store.get(walletCapabilitiesAtom)
-
-    expect(result).toBeNull()
-    expect(mockGetCapabilities).not.toHaveBeenCalled()
-  })
-
-  it('returns null on mobile WalletConnect without fetching capabilities', async () => {
-    mockIsMobile.value = true
-    mockGetIsWalletConnect.mockReturnValue(true)
-
-    const store = createStore()
     setWalletInfo(store)
 
     const result = await store.get(walletCapabilitiesAtom)
@@ -347,7 +258,7 @@ describe('walletCapabilitiesAtom', () => {
       expect(result).toEqual(capabilities)
     })
 
-    it('returns null when the legacy capabilities chain key is missing', async () => {
+    it('returns null when the current chain capability is missing', async () => {
       const capabilities: WalletCapabilities = { atomic: { status: 'supported' } }
       mockGetCapabilities.mockRejectedValue(new Error('viem error'))
       const mockRequest = jest.fn().mockResolvedValue({ '0x64': capabilities })
@@ -408,15 +319,12 @@ describe('walletCapabilitiesAtom', () => {
 describe('isAtomicBatchSupportedAsyncAtom', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockIsMobile.value = false
-    mockGetIsWalletConnect.mockReturnValue(false)
     mockGetCapabilities.mockResolvedValue({})
     mockWagmiConfigGetClient.mockReturnValue({ chainId: MOCK_CHAIN_ID })
   })
 
   it('returns false when walletInfoAtom yields no capabilities (disconnected)', async () => {
     const store = createStore()
-    seedResolvedWalletMetadata(store)
     store.set(walletInfoAtom, { chainId: MOCK_CHAIN_ID } as WalletInfo)
 
     const result = await store.get(isAtomicBatchSupportedAsyncAtom)
@@ -456,7 +364,7 @@ describe('isAtomicBatchSupportedAsyncAtom', () => {
     expect(result).toBe(true)
   })
 
-  it('returns false when isSafeViaWcAtom and capabilities atomic status is ready', async () => {
+  it('returns true when isSafeViaWcAtom and capabilities atomic status is ready', async () => {
     const store = createStore()
     store.set(writableIsSafeViaWcAtom, true)
     mockGetCapabilities.mockResolvedValue({ atomic: { status: 'ready' } })
@@ -464,7 +372,7 @@ describe('isAtomicBatchSupportedAsyncAtom', () => {
 
     const result = await store.get(isAtomicBatchSupportedAsyncAtom)
 
-    expect(result).toBe(false)
+    expect(result).toBe(true)
   })
 
   it('returns true when atomicBatch.supported is true', async () => {
@@ -498,63 +406,11 @@ describe('isAtomicBatchSupportedAsyncAtom', () => {
 
     expect(result).toBe(true)
   })
-
-  it('does not wait on Safe info for EOA when gnosisSafeInfo is still undefined', async () => {
-    const store = createStore()
-    seedResolvedWalletMetadata(store, { accountType: AccountType.EOA, isSafeWallet: false })
-    mockGetCapabilities.mockResolvedValue({ atomic: { status: 'supported' } })
-    setWalletInfo(store)
-
-    const result = await store.get(isAtomicBatchSupportedAsyncAtom)
-
-    expect(result).toBe(true)
-    expect(mockGetCapabilities).toHaveBeenCalled()
-  })
-
-  it('returns false for smart contract wallet before Safe info confirms a Safe', async () => {
-    const store = createStore()
-    seedResolvedWalletMetadata(store, { isSmartContractWallet: true, isSafeWallet: false })
-    mockGetCapabilities.mockResolvedValue({ atomic: { status: 'supported' } })
-    setWalletInfo(store)
-
-    const result = await store.get(isAtomicBatchSupportedAsyncAtom)
-
-    expect(result).toBe(false)
-    expect(mockGetCapabilities).not.toHaveBeenCalled()
-  })
-
-  it('returns false for non-Safe smart contract wallet before checking capabilities', async () => {
-    const store = createStore()
-    store.set(writableIsSmartContractWalletAtom, true)
-    store.set(writableIsSafeWalletAtom, false)
-    mockGetCapabilities.mockResolvedValue({ atomic: { status: 'supported' } })
-    setWalletInfo(store)
-
-    const result = await store.get(isAtomicBatchSupportedAsyncAtom)
-
-    expect(result).toBe(false)
-    expect(mockGetCapabilities).not.toHaveBeenCalled()
-  })
-
-  it('returns false for EIP-7702 account before checking capabilities', async () => {
-    const store = createStore()
-    store.set(writableAccountTypeAtom, AccountType.EIP7702EOA)
-    store.set(writableIsSafeWalletAtom, false)
-    mockGetCapabilities.mockResolvedValue({ atomic: { status: 'supported' } })
-    setWalletInfo(store)
-
-    const result = await store.get(isAtomicBatchSupportedAsyncAtom)
-
-    expect(result).toBe(false)
-    expect(mockGetCapabilities).not.toHaveBeenCalled()
-  })
 })
 
 describe('isAtomicBatchSupportedLoadableAtom and isAtomicBatchSupportedAtom', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockIsMobile.value = false
-    mockGetIsWalletConnect.mockReturnValue(false)
     mockGetCapabilities.mockResolvedValue({})
     mockWagmiConfigGetClient.mockReturnValue({ chainId: MOCK_CHAIN_ID })
   })

--- a/libs/wallet/src/api/state/walletCapabilitiesAtom.ts
+++ b/libs/wallet/src/api/state/walletCapabilitiesAtom.ts
@@ -1,57 +1,20 @@
 import { atom } from 'jotai'
 import { loadable } from 'jotai/utils'
 
-import { EIP1193Provider, numberToHex, PublicClient } from 'viem'
-import { Connector } from 'wagmi'
+import { numberToHex } from 'viem'
 
-import {
-  isEip1193Provider,
-  isMobile,
-  logWallet,
-  normalizeError,
-  TimeoutError,
-  withTimeout,
-} from '@cowprotocol/common-utils'
-import { ProviderMetaInfoPayload, WidgetEthereumProvider } from '@cowprotocol/iframe-transport'
-import { AccountType } from '@cowprotocol/types'
+import { isEip1193Provider, logWallet, normalizeError, TimeoutError, withTimeout } from '@cowprotocol/common-utils'
 
 import ms from 'ms.macro'
 import { getCapabilities, type GetCapabilitiesReturnType } from 'viem/actions'
 
 import { wagmiConfig } from '../../wagmi/config'
-import { getIsWalletConnect } from '../../wagmi/hooks/useIsWalletConnect'
-import {
-  isSafeAppAtom,
-  isSafeViaWcAtom,
-  accountTypeAtom,
-  isSmartContractWalletAtom,
-  isSafeWalletAtom,
-} from '../../wagmi/state/walletMetadata.atoms'
+import { isSafeAppAtom, isSafeViaWcAtom } from '../../wagmi/state/walletMetadata.atoms'
 import { walletInfoAtom } from '../state'
 
 export type WalletCapabilities = GetCapabilitiesReturnType[number]
 
 export const REQUEST_TIMEOUT_MS = ms`30s`
-
-/**
- * WalletConnect in mobile browsers initiates a request with confirmation to the wallet
- * to get the capabilities. It breaks the flow with perpetual requests.
- */
-export async function getShouldSkipCapabilitiesCheck(
-  connector: Connector,
-  provider: EIP1193Provider | WidgetEthereumProvider | PublicClient,
-): Promise<boolean> {
-  if (!isMobile) return false
-
-  const isWalletConnect = getIsWalletConnect(connector)
-
-  if (isWalletConnect) return true
-
-  const widgetProviderMetaInfo = await fetchWidgetProviderMetaInfo(provider)
-  const isWalletConnectViaWidget = !!widgetProviderMetaInfo?.providerWcMetadata
-
-  return isWalletConnectViaWidget
-}
 
 /**
  * Safe WC returns EIP-5792 capabilities keyed by hex chain id (e.g. "0xaa36a7")
@@ -69,35 +32,11 @@ export function resolveCapabilitiesForChain(
   return null
 }
 
-async function fetchWidgetProviderMetaInfo(
-  provider: EIP1193Provider | WidgetEthereumProvider | PublicClient,
-): Promise<ProviderMetaInfoPayload | null> {
-  if (provider instanceof WidgetEthereumProvider) {
-    const providerMetaInfo = new Promise<ProviderMetaInfoPayload>((resolve) => {
-      provider.onProviderMetaInfo((data) => {
-        provider.clearProviderMetaInfoListener()
-        resolve(data)
-      })
-    })
-
-    return withTimeout(providerMetaInfo, {
-      timeout: REQUEST_TIMEOUT_MS,
-      timeoutMessage: `Widget provider meta info request timed out after ${REQUEST_TIMEOUT_MS}ms`,
-    }).catch(() => {
-      provider.clearProviderMetaInfoListener()
-      return null
-    })
-  }
-
-  return Promise.resolve(null)
-}
-
 /**
  * Async atom that fetches wallet capabilities (EIP-5792) via wagmi/viem.
  * Returns capabilities for the current account and chain, or null when disconnected or on error.
  */
 
-// eslint-disable-next-line complexity
 export const walletCapabilitiesAtom = atom(async (get): Promise<WalletCapabilities | null> => {
   const { account, chainId, provider, connector } = get(walletInfoAtom)
   const isSafeViaWc = get(isSafeViaWcAtom)
@@ -107,12 +46,6 @@ export const walletCapabilitiesAtom = atom(async (get): Promise<WalletCapabiliti
   let capabilities: WalletCapabilities | null = null
 
   try {
-    const shouldSkipCapabilitiesCheck = await getShouldSkipCapabilitiesCheck(connector, provider)
-
-    if (shouldSkipCapabilitiesCheck) {
-      return null
-    }
-
     /**
      * Viem takes care here of getting the capabilities for the exact chainId, so we don't need to do it manually.
      * However, keep in mind this branch MUST run for Safe via WC, but getCapabilities() will throw an error. However,
@@ -165,6 +98,7 @@ export const walletCapabilitiesAtom = atom(async (get): Promise<WalletCapabiliti
 
     logWallet.debug('Fetching wallet capabilities', { account, chainId })
 
+    // TODO remove this completely: it doesn't resolve capabilities for no wallet: MM, Safe, Ambire.
     capabilities = await withTimeout(
       getCapabilities(wagmiConfig.getClient({ chainId }), {
         account: account as `0x${string}`,
@@ -199,10 +133,11 @@ export const walletCapabilitiesAtom = atom(async (get): Promise<WalletCapabiliti
           timeoutMessage: `Wallet capabilities loading timed out after ${REQUEST_TIMEOUT_MS / 1000}s`,
         },
       )
+      logWallet.warn('getCapabilities() failed, but wallet_getCapabilities returned capabilities', legacyCapabilities)
 
       capabilities = resolveCapabilitiesForChain(legacyCapabilities, chainId)
 
-      logWallet.warn('getCapabilities() failed, but wallet_getCapabilities returned capabilities', legacyCapabilities)
+      logWallet.info('Wallet capabilities for this chain:', capabilities)
     } catch (err: unknown) {
       const rpcError = normalizeError(err)
 
@@ -222,42 +157,31 @@ export const walletCapabilitiesAtom = atom(async (get): Promise<WalletCapabiliti
   return capabilities
 })
 
-// eslint-disable-next-line complexity
 export const isAtomicBatchSupportedAsyncAtom = atom(async (get): Promise<boolean | null> => {
   const isSafeApp = get(isSafeAppAtom)
-
-  if (isSafeApp === null) return null
-
-  if (isSafeApp) return true
-
-  const accountType = get(accountTypeAtom)
-  const isSmartContractWallet = get(isSmartContractWalletAtom)
-  const isSafeWallet = get(isSafeWalletAtom)
   const isSafeViaWc = get(isSafeViaWcAtom)
 
-  if (accountType === null || isSmartContractWallet === null || isSafeViaWc === null) return null
-
-  // Smart accounts (ERC-4337, Coinbase Smart Wallet, EIP-7702, etc.) that are not a Safe lack the
-  // fallback handler mechanism TWAP requires, so we treat them as unsupported.
-  // Note: useIsSmartContractWallet() only detects AccountType.SMART_CONTRACT, not EIP-7702 accounts
-  // (which keep the same EOA address but have delegation bytecode). We check both explicitly.
-  if ((isSmartContractWallet || accountType === AccountType.EIP7702EOA) && !isSafeWallet && !isSafeViaWc) return false
+  /**
+   * A SafeWallet connected through SafeApp is assumed to have support.
+   * A SafeWallet connected through WC or any other provider needs to pass the capabilities check.
+   */
+  if (isSafeApp) return true
+  if (isSafeApp === null || isSafeViaWc === null) return null
 
   const walletCapabilities = await get(walletCapabilitiesAtom)
 
-  // If `walletCapabilitiesAtom` returns `null` it's because `shouldSkipCapabilitiesCheck === true`,
-  // or because some kind of API empty response or error. So, if we cannot check, then we must be false,
+  // If `walletCapabilitiesAtom` returns `null` it's because some kind of API empty response
+  // or error. So, if we cannot check, then we must be false,
   // not null (as some components/functions like `validateTradeForm` treat `null` as loading):
-  if (!walletCapabilities) return false
+  if (walletCapabilities === null) return false
 
-  const status = walletCapabilities.atomic?.status || ''
-  const supported = walletCapabilities?.atomicBatch?.supported
+  const status = walletCapabilities.atomic?.status
+  const isLegacyAtomicBatchSupported = Boolean(walletCapabilities?.atomicBatch?.supported)
 
   // See https://www.eip5792.xyz/getting-started:
   // - supported: The wallet will execute all calls atomically and contiguously
   // - ready: The wallet is able to upgrade to supported pending user approval (e.g. via EIP-7702)
-  return status === 'supported' || !!supported
-  // return status === 'supported' || status === 'ready'
+  return status === 'supported' || status === 'ready' || isLegacyAtomicBatchSupported
 })
 
 export const isAtomicBatchSupportedLoadableAtom = loadable(isAtomicBatchSupportedAsyncAtom)


### PR DESCRIPTION
# Summary

Implements https://linear.app/cowswap/issue/FE-265/batch-support-for-eoas-and-eip7702-delegated-eoas
Fixes #7661 

Adds EIP-7702 batching capability detection while keeping TWAP restricted to Safe wallets.

- Recognizes EIP-5792 `atomic.status` values `supported` and `ready`
- Preserves legacy `atomicBatch.supported` detection
- Removes the mobile WalletConnect capability-check bypass
- For TWAP, it keeps Safe App support implicit; Safe via WalletConnect must report batching capabilities

# To Test

1. Connect a MetaMask account **without** Smart account set up

- [x] Enable in Settings -> Transactions -> Smart account requests from dapps (should be on by default)
- [x] TWAP remains disabled & the unsupported-wallet warning appears
- [x] Swapping can batch approve & swap

<img width="423" height="185" alt="Image" src="https://github.com/user-attachments/assets/4040f264-0a2f-4362-a580-6f1ccd6accd8" />

[Screencast From 2026-07-10 10-58-16.webm](https://github.com/user-attachments/assets/c629de22-8872-475d-ae8b-6721af6cb130)


2. Connect a MetaMask account **with** Smart account set up

- [x] Enable in Settings -> Transactions -> Smart account requests from dapps (should be on by default)
- [x] Enable in Accounts -> Smart Accounts -> Enable for a network
- [x] TWAP remains disabled & the unsupported-wallet warning appears
- [x] Swapping can batch approve & swap

[Screencast From 2026-07-10 10-59-24.webm](https://github.com/user-attachments/assets/4d1a5a0b-7c31-4787-bfc6-3d3a7ac83b16)

3. Connect a SafeWallet through the Safe App

- [x] TWAP is available
- [x] No unsupported-wallet warning appears
- [x] Batching works in SWAP

4. Connect a SafeWallet through WalletConnect

- [x] TWAP is available
- [x] No unsupported-wallet warning appears
- [x] Batching works in SWAP

5. Connect an inactive (not yet deployed) SafeWallet through WalletConnect

- [x] TWAP is available
- [x] No unsupported-wallet warning appears
- [x] Batching works in SWAP


6. Connect an Ambire wallet

- [x] TWAP remains disabled
- [x] The unsupported-wallet warning appears
- [x] Batching works in SWAP

7. Connect a Rabby EOA wallet

- [x] Batching does not work in SWAP

# Background

Capability detection is independent from TWAP wallet eligibility: this change recognizes EIP-7702 batching, but TWAP remains restricted to Safe wallets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved TWAP UX for unsupported wallets with a disabled “Unsupported wallet” primary action and updated safe-app guidance.
  * Approval/permit and trade flow decisions now account for whether offchain signing is allowed, improving permit-vs-bundle behavior (including limit orders).

* **Bug Fixes**
  * Enhanced wallet capability resolution to use chain-specific capability keys and avoid incorrect fallbacks.
  * Refined atomic batch support detection and TWAP “non-compatible” analytics triggers for supported/unsupported wallet states.

* **Tests**
  * Expanded unit tests for unsupported-wallet states, safe readiness, chain capability resolution, atomic batch support, and offchain signing/permit routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->