### PR TITLE
refactor: remove wallet capabilities fallback

### DIFF
--- a/libs/wallet/package.json
+++ b/libs/wallet/package.json
@@ -41,7 +41,6 @@
     "@cowprotocol/iframe-transport": "workspace:*",
     "@cowprotocol/types": "workspace:*",
     "@cowprotocol/ui": "workspace:*",
-    "@cowprotocol/wallet-provider": "workspace:*",
     "@ethereumjs/util": "10.1.0",
     "@metamask/jazzicon": "2.0.0",
     "@metamask/sdk": "0.31.4",

--- a/libs/wallet/src/api/state/walletCapabilitiesAtom.test.ts
+++ b/libs/wallet/src/api/state/walletCapabilitiesAtom.test.ts
@@ -1,6 +1,5 @@
 import { createStore, type WritableAtom } from 'jotai'
 
-import type { EIP1193Provider, PublicClient } from 'viem'
 import type { Connector } from 'wagmi'
 
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
@@ -10,7 +9,6 @@ import {
   isAtomicBatchSupportedAsyncAtom,
   isAtomicBatchSupportedLoadableAtom,
   REQUEST_TIMEOUT_MS,
-  resolveCapabilitiesForChain,
   walletCapabilitiesAtom,
 } from './walletCapabilitiesAtom'
 
@@ -38,25 +36,14 @@ const MOCK_CHAIN_ID = SupportedChainId.MAINNET
 const MOCK_CONNECTOR = { type: 'injected' } as Connector
 
 const mockGetCapabilities = jest.fn()
-const mockWagmiConfigGetClient = jest.fn()
 
-jest.mock('viem/actions', () => ({
+jest.mock('wagmi/actions', () => ({
   getCapabilities: (...args: unknown[]) => mockGetCapabilities(...args),
 }))
 
 jest.mock('../../wagmi/config', () => ({
-  wagmiConfig: {
-    getClient: (...args: unknown[]) => mockWagmiConfigGetClient(...args),
-  },
+  wagmiConfig: {},
 }))
-
-function createMockEip1193Provider(request = jest.fn()): EIP1193Provider {
-  return {
-    request,
-    on: jest.fn(),
-    removeListener: jest.fn(),
-  } as unknown as EIP1193Provider
-}
 
 function setWalletInfo(
   store: ReturnType<typeof createStore>,
@@ -64,53 +51,19 @@ function setWalletInfo(
     account: string
     chainId: SupportedChainId
     connector: Connector
-    provider: NonNullable<WalletInfo['provider']>
   }> = {},
 ): void {
   store.set(walletInfoAtom, {
     chainId: overrides.chainId ?? MOCK_CHAIN_ID,
     account: overrides.account ?? MOCK_ACCOUNT,
     connector: overrides.connector ?? MOCK_CONNECTOR,
-    provider: overrides.provider ?? createMockEip1193Provider(),
   })
 }
-
-describe('resolveCapabilitiesForChain', () => {
-  const capabilities: WalletCapabilities = { atomic: { status: 'supported' } }
-
-  it('matches numeric chain id key', () => {
-    expect(resolveCapabilitiesForChain({ [MOCK_CHAIN_ID]: capabilities }, MOCK_CHAIN_ID)).toEqual(capabilities)
-  })
-
-  it('matches hex chain id key', () => {
-    expect(resolveCapabilitiesForChain({ '0x1': capabilities }, MOCK_CHAIN_ID)).toEqual(capabilities)
-  })
-
-  it('returns null when no chain key matches', () => {
-    expect(resolveCapabilitiesForChain({ '0x64': capabilities }, MOCK_CHAIN_ID)).toBeNull()
-  })
-
-  it('returns null for empty capabilities', () => {
-    expect(resolveCapabilitiesForChain({}, MOCK_CHAIN_ID)).toBeNull()
-  })
-})
 
 describe('walletCapabilitiesAtom', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockGetCapabilities.mockResolvedValue({})
-    mockWagmiConfigGetClient.mockReturnValue({ chainId: MOCK_CHAIN_ID })
-  })
-
-  it('returns null when isSafeViaWc is still loading', async () => {
-    const store = createStore()
-    store.set(writableIsSafeViaWcAtom, null)
-    setWalletInfo(store)
-
-    const result = await store.get(walletCapabilitiesAtom)
-
-    expect(result).toBeNull()
-    expect(mockGetCapabilities).not.toHaveBeenCalled()
   })
 
   describe('walletInfoAtom state: missing required fields', () => {
@@ -119,7 +72,6 @@ describe('walletCapabilitiesAtom', () => {
       store.set(walletInfoAtom, {
         chainId: MOCK_CHAIN_ID,
         connector: MOCK_CONNECTOR,
-        provider: createMockEip1193Provider(),
       })
 
       const result = await store.get(walletCapabilitiesAtom)
@@ -133,7 +85,6 @@ describe('walletCapabilitiesAtom', () => {
       store.set(walletInfoAtom, {
         account: MOCK_ACCOUNT,
         connector: MOCK_CONNECTOR,
-        provider: createMockEip1193Provider(),
       } as WalletInfo)
 
       const result = await store.get(walletCapabilitiesAtom)
@@ -147,21 +98,6 @@ describe('walletCapabilitiesAtom', () => {
       store.set(walletInfoAtom, {
         chainId: MOCK_CHAIN_ID,
         account: MOCK_ACCOUNT,
-        provider: createMockEip1193Provider(),
-      })
-
-      const result = await store.get(walletCapabilitiesAtom)
-
-      expect(result).toBeNull()
-      expect(mockGetCapabilities).not.toHaveBeenCalled()
-    })
-
-    it('returns null when provider is missing', async () => {
-      const store = createStore()
-      store.set(walletInfoAtom, {
-        chainId: MOCK_CHAIN_ID,
-        account: MOCK_ACCOUNT,
-        connector: MOCK_CONNECTOR,
       })
 
       const result = await store.get(walletCapabilitiesAtom)
@@ -171,7 +107,7 @@ describe('walletCapabilitiesAtom', () => {
     })
   })
 
-  describe('getCapabilities (viem)', () => {
+  describe('getCapabilities (wagmi)', () => {
     it('returns capabilities when getCapabilities resolves for the current chain', async () => {
       const capabilities: WalletCapabilities = { atomic: { status: 'supported' } }
       mockGetCapabilities.mockResolvedValue(capabilities)
@@ -182,8 +118,14 @@ describe('walletCapabilitiesAtom', () => {
       const result = await store.get(walletCapabilitiesAtom)
 
       expect(result).toEqual(capabilities)
-      expect(mockGetCapabilities).toHaveBeenCalled()
-      expect(mockWagmiConfigGetClient).toHaveBeenCalledWith({ chainId: MOCK_CHAIN_ID })
+      expect(mockGetCapabilities).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          account: MOCK_ACCOUNT,
+          chainId: MOCK_CHAIN_ID,
+          connector: MOCK_CONNECTOR,
+        }),
+      )
     })
 
     it('returns empty capabilities object when getCapabilities resolves with no fields', async () => {
@@ -197,111 +139,23 @@ describe('walletCapabilitiesAtom', () => {
       expect(result).toEqual({})
     })
 
-    it('returns null when getCapabilities and wallet_getCapabilities both fail', async () => {
-      mockGetCapabilities.mockRejectedValue(new Error('viem error'))
-      const mockRequest = jest.fn().mockRejectedValue(new Error('legacy error'))
+    it('returns null when getCapabilities fails', async () => {
+      mockGetCapabilities.mockRejectedValue(new Error('wagmi error'))
 
       const store = createStore()
-      setWalletInfo(store, { provider: createMockEip1193Provider(mockRequest) })
-
-      const result = await store.get(walletCapabilitiesAtom)
-
-      expect(result).toBeNull()
-      expect(mockRequest).toHaveBeenCalledWith({
-        method: 'wallet_getCapabilities',
-        params: [MOCK_ACCOUNT],
-      })
-    })
-
-    it('returns null when getCapabilities fails and provider does not support EIP-1193 requests', async () => {
-      const error = new Error('viem error')
-      mockGetCapabilities.mockRejectedValue(error)
-
-      const store = createStore()
-      setWalletInfo(store, { provider: {} as PublicClient })
+      setWalletInfo(store)
 
       const result = await store.get(walletCapabilitiesAtom)
 
       expect(result).toBeNull()
     })
 
-    it('returns null when getCapabilities times out and provider does not support EIP-1193 requests', async () => {
+    it('returns null when getCapabilities times out', async () => {
       jest.useFakeTimers()
       mockGetCapabilities.mockImplementation(() => new Promise(() => undefined))
 
       const store = createStore()
-      setWalletInfo(store, { provider: {} as PublicClient })
-
-      try {
-        const resultPromise = store.get(walletCapabilitiesAtom)
-        await jest.advanceTimersByTimeAsync(REQUEST_TIMEOUT_MS)
-        const result = await resultPromise
-
-        expect(result).toBeNull()
-      } finally {
-        jest.useRealTimers()
-      }
-    })
-  })
-
-  describe('wallet_getCapabilities legacy fallback', () => {
-    it('returns capabilities resolved from hex chain id key when viem throws', async () => {
-      const capabilities: WalletCapabilities = { atomic: { status: 'supported' } }
-      mockGetCapabilities.mockRejectedValue(new Error('viem error'))
-      const mockRequest = jest.fn().mockResolvedValue({ '0x1': capabilities })
-
-      const store = createStore()
-      setWalletInfo(store, { provider: createMockEip1193Provider(mockRequest) })
-
-      const result = await store.get(walletCapabilitiesAtom)
-
-      expect(result).toEqual(capabilities)
-    })
-
-    it('returns null when the current chain capability is missing', async () => {
-      const capabilities: WalletCapabilities = { atomic: { status: 'supported' } }
-      mockGetCapabilities.mockRejectedValue(new Error('viem error'))
-      const mockRequest = jest.fn().mockResolvedValue({ '0x64': capabilities })
-
-      const store = createStore()
-      setWalletInfo(store, { provider: createMockEip1193Provider(mockRequest) })
-
-      const result = await store.get(walletCapabilitiesAtom)
-
-      expect(result).toBeNull()
-    })
-
-    it('uses legacy fallback when getCapabilities times out', async () => {
-      jest.useFakeTimers()
-      const capabilities: WalletCapabilities = { atomic: { status: 'supported' } }
-      mockGetCapabilities.mockImplementation(() => new Promise(() => undefined))
-      const mockRequest = jest.fn().mockResolvedValue({ '0x1': capabilities })
-
-      const store = createStore()
-      setWalletInfo(store, { provider: createMockEip1193Provider(mockRequest) })
-
-      try {
-        const resultPromise = store.get(walletCapabilitiesAtom)
-        await jest.advanceTimersByTimeAsync(REQUEST_TIMEOUT_MS)
-        const result = await resultPromise
-
-        expect(result).toEqual(capabilities)
-        expect(mockRequest).toHaveBeenCalledWith({
-          method: 'wallet_getCapabilities',
-          params: [MOCK_ACCOUNT],
-        })
-      } finally {
-        jest.useRealTimers()
-      }
-    })
-
-    it('returns null when legacy fallback times out', async () => {
-      jest.useFakeTimers()
-      mockGetCapabilities.mockRejectedValue(new Error('viem error'))
-      const mockRequest = jest.fn().mockImplementation(() => new Promise(() => undefined))
-
-      const store = createStore()
-      setWalletInfo(store, { provider: createMockEip1193Provider(mockRequest) })
+      setWalletInfo(store)
 
       try {
         const resultPromise = store.get(walletCapabilitiesAtom)
@@ -320,7 +174,6 @@ describe('isAtomicBatchSupportedAsyncAtom', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockGetCapabilities.mockResolvedValue({})
-    mockWagmiConfigGetClient.mockReturnValue({ chainId: MOCK_CHAIN_ID })
   })
 
   it('returns false when walletInfoAtom yields no capabilities (disconnected)', async () => {
@@ -412,7 +265,6 @@ describe('isAtomicBatchSupportedLoadableAtom and isAtomicBatchSupportedAtom', ()
   beforeEach(() => {
     jest.clearAllMocks()
     mockGetCapabilities.mockResolvedValue({})
-    mockWagmiConfigGetClient.mockReturnValue({ chainId: MOCK_CHAIN_ID })
   })
 
   it('isAtomicBatchSupportedAtom returns null while loading', async () => {
@@ -439,9 +291,7 @@ describe('isAtomicBatchSupportedLoadableAtom and isAtomicBatchSupportedAtom', ()
     store.set(writableIsSafeViaWcAtom, false)
     store.set(writableIsSafeAppAtom, false)
     mockGetCapabilities.mockRejectedValue(new Error('network error'))
-    setWalletInfo(store, {
-      provider: createMockEip1193Provider(jest.fn().mockRejectedValue(new Error('legacy error'))),
-    })
+    setWalletInfo(store)
 
     store.get(isAtomicBatchSupportedLoadableAtom)
     const asyncResult = await store.get(isAtomicBatchSupportedAsyncAtom)

--- a/libs/wallet/src/api/state/walletCapabilitiesAtom.ts
+++ b/libs/wallet/src/api/state/walletCapabilitiesAtom.ts
@@ -1,12 +1,11 @@
 import { atom } from 'jotai'
 import { loadable } from 'jotai/utils'
 
-import { numberToHex } from 'viem'
+import { getCapabilities, type GetCapabilitiesReturnType } from 'wagmi/actions'
 
-import { isEip1193Provider, logWallet, normalizeError, TimeoutError, withTimeout } from '@cowprotocol/common-utils'
+import { logWallet, normalizeError, TimeoutError, withTimeout } from '@cowprotocol/common-utils'
 
 import ms from 'ms.macro'
-import { getCapabilities, type GetCapabilitiesReturnType } from 'viem/actions'
 
 import { wagmiConfig } from '../../wagmi/config'
 import { isSafeAppAtom, isSafeViaWcAtom } from '../../wagmi/state/walletMetadata.atoms'
@@ -17,92 +16,23 @@ export type WalletCapabilities = GetCapabilitiesReturnType[number]
 export const REQUEST_TIMEOUT_MS = ms`30s`
 
 /**
- * Safe WC returns EIP-5792 capabilities keyed by hex chain id (e.g. "0xaa36a7")
- * while walletInfoAtom.chainId is numeric (e.g. 11155111). Numeric lookup alone misses them.
- */
-export function resolveCapabilitiesForChain(
-  capabilities: Record<string, WalletCapabilities>,
-  chainId: number,
-): WalletCapabilities | null {
-  const capabilitiesForChain = capabilities[chainId] ?? capabilities[numberToHex(chainId)]
-
-  if (capabilitiesForChain) return capabilitiesForChain
-
-  logWallet.warn('Cannot resolve wallet capabilities for chain', { chainId, capabilities })
-  return null
-}
-
-/**
  * Async atom that fetches wallet capabilities (EIP-5792) via wagmi/viem.
  * Returns capabilities for the current account and chain, or null when disconnected or on error.
  */
 
 export const walletCapabilitiesAtom = atom(async (get): Promise<WalletCapabilities | null> => {
-  const { account, chainId, provider, connector } = get(walletInfoAtom)
-  const isSafeViaWc = get(isSafeViaWcAtom)
+  const { account, chainId, connector } = get(walletInfoAtom)
 
-  if (!account || !chainId || !connector || !provider || isSafeViaWc === null) return null
-
-  let capabilities: WalletCapabilities | null = null
+  if (!account || !chainId || !connector) return null
 
   try {
-    /**
-     * Viem takes care here of getting the capabilities for the exact chainId, so we don't need to do it manually.
-     * However, keep in mind this branch MUST run for Safe via WC, but getCapabilities() will throw an error. However,
-     * using `wallet_getCapabilities` directly does work. You can test this with:
-     *
-     * ```
-     * const allCapabilities = await getCapabilities(wagmiConfig.getClient({ chainId }), {
-     *   account: account as `0x${string}`,
-     * }).catch((error) => {
-     *   console.error('Cannot fetchallCapabilities', error)
-     *   return {} as GetCapabilitiesReturnType
-     * })
-     *
-     * const capabilitiesForChain = await getCapabilities(wagmiConfig.getClient({ chainId }), {
-     *   account: account as `0x${string}`,
-     *   chainId,
-     * }).catch((error) => {
-     *   console.error('Cannot fetch capabilitiesForChain', error)
-     *   return {} as GetCapabilitiesReturnType
-     * })
-     *
-     * const legacyCapabilities = isEip1193Provider(provider)
-     *   ? await provider
-     *     .request({
-     *     method: 'wallet_getCapabilities',
-     *     params: [account],
-     *   })
-     *   .catch((error) => {
-     *     console.error('Cannot fetch legacyCapabilities', error)
-     *     return {} as GetCapabilitiesReturnType
-     *   })
-     * : null
-     * ```
-     *
-     * The last one should return:
-     *
-     * ```json
-     * {
-     *   "0xaa36a7": {
-     *     "atomicBatch": {
-     *       "supported": true
-     *     },
-     *     "atomic": {
-     *       "status": "supported"
-     *     }
-     *   }
-     * }
-     * ```
-     */
-
     logWallet.debug('Fetching wallet capabilities', { account, chainId })
 
-    // TODO remove this completely: it doesn't resolve capabilities for no wallet: MM, Safe, Ambire.
-    capabilities = await withTimeout(
-      getCapabilities(wagmiConfig.getClient({ chainId }), {
+    const capabilities = await withTimeout(
+      getCapabilities(wagmiConfig, {
         account: account as `0x${string}`,
         chainId,
+        connector,
       }),
       {
         timeout: REQUEST_TIMEOUT_MS,
@@ -111,50 +41,21 @@ export const walletCapabilitiesAtom = atom(async (get): Promise<WalletCapabiliti
     )
 
     logWallet.debug('Fetched wallet capabilities', { account, chainId, capabilities })
+    return capabilities
   } catch (err: unknown) {
-    const wagmiError = normalizeError(err)
+    const error = normalizeError(err)
 
-    if (!isEip1193Provider(provider)) {
-      logWallet.error(new Error('Failed to fetch wallet capabilities via wagmi', { cause: wagmiError }), undefined, {
+    if (error instanceof TimeoutError) {
+      logWallet.warn(error.message)
+    } else {
+      logWallet.error(new Error('Failed to fetch wallet capabilities', { cause: error }), undefined, {
         account,
         chainId,
       })
-      return null
     }
 
-    try {
-      const legacyCapabilities = await withTimeout(
-        provider.request({
-          method: 'wallet_getCapabilities',
-          params: [account],
-        }),
-        {
-          timeout: REQUEST_TIMEOUT_MS,
-          timeoutMessage: `Wallet capabilities loading timed out after ${REQUEST_TIMEOUT_MS / 1000}s`,
-        },
-      )
-      logWallet.warn('getCapabilities() failed, but wallet_getCapabilities returned capabilities', legacyCapabilities)
-
-      capabilities = resolveCapabilitiesForChain(legacyCapabilities, chainId)
-
-      logWallet.info('Wallet capabilities for this chain:', capabilities)
-    } catch (err: unknown) {
-      const rpcError = normalizeError(err)
-
-      if (rpcError instanceof TimeoutError) {
-        logWallet.warn(rpcError.message)
-      } else {
-        logWallet.error(new Error('Failed to fetch wallet capabilities via RPC', { cause: rpcError }), undefined, {
-          account,
-          chainId,
-        })
-      }
-
-      return null
-    }
+    return null
   }
-
-  return capabilities
 })
 
 export const isAtomicBatchSupportedAsyncAtom = atom(async (get): Promise<boolean | null> => {

--- a/libs/wallet/src/api/types.ts
+++ b/libs/wallet/src/api/types.ts
@@ -1,9 +1,7 @@
-import { EIP1193Provider, PublicClient } from 'viem'
 import { Connector as WagmiConnector } from 'wagmi'
 import { injected, walletConnect, coinbaseWallet, safe } from 'wagmi/connectors'
 
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { WidgetEthereumProvider } from '@cowprotocol/iframe-transport'
 import type { SafeInfoResponse } from '@safe-global/api-kit'
 
 export const ConnectionType = {
@@ -41,8 +39,6 @@ export interface WalletInfo {
   account?: string
   active?: boolean
   connector?: WagmiConnector
-  provider?: EIP1193Provider | WidgetEthereumProvider | PublicClient
-  isConnectionRestoring?: boolean
 }
 
 export enum WalletType {

--- a/libs/wallet/src/wagmi/updater.ts
+++ b/libs/wallet/src/wagmi/updater.ts
@@ -8,7 +8,6 @@ import { getCurrentChainIdFromUrl, getRawCurrentChainIdFromUrl, logSafeApi } fro
 import { getSafeInfo, normalizeSafeError, SAFE_RATE_LIMIT_MSG } from '@cowprotocol/core'
 import { areAddressesEqual, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { AccountType } from '@cowprotocol/types'
-import { useWalletProvider } from '@cowprotocol/wallet-provider'
 import type { SafeInfoResponse } from '@safe-global/api-kit'
 import type { SafeInfoExtended } from '@safe-global/safe-apps-sdk'
 
@@ -47,8 +46,7 @@ function useBrowserUrlKey(): string {
 function useWalletInfo(): WalletInfo {
   // TODO: Replace urlKey with locationNetworkAtom, which will also trigger the useMemo below less often.
   const urlKey = useBrowserUrlKey()
-  const { address, chainId, isConnected, status, connector } = useAccountState()
-  const isConnectionRestoring = status === 'reconnecting'
+  const { address, chainId, isConnected, connector } = useAccountState()
   const isChainIdUnsupported = !!chainId && !(chainId in SupportedChainId)
   const [lastStableChainId, setLastStableChainId] = useState<SupportedChainId | undefined>(undefined)
   const [lastResolvedChainId, setLastResolvedChainId] = useState<SupportedChainId>(() => getCurrentChainIdFromUrl())
@@ -84,19 +82,8 @@ function useWalletInfo(): WalletInfo {
       active: isConnected,
       account: address,
       connector,
-      isConnectionRestoring,
     }
-  }, [
-    address,
-    chainId,
-    isConnected,
-    connector,
-    isChainIdUnsupported,
-    isConnectionRestoring,
-    lastStableChainId,
-    lastResolvedChainId,
-    urlKey,
-  ])
+  }, [address, chainId, isConnected, connector, isChainIdUnsupported, lastStableChainId, lastResolvedChainId, urlKey])
 
   useEffect(() => {
     setLastResolvedChainId(walletInfo.chainId)
@@ -141,7 +128,7 @@ let shortSafeInfoInterval: ReturnType<typeof setInterval> | null = null
 let longSafeInfoInterval: ReturnType<typeof setInterval> | null = null
 
 export function WalletUpdater(): null {
-  const { chainId, active, account, connector, isConnectionRestoring } = useWalletInfo()
+  const { chainId, active, account, connector } = useWalletInfo()
 
   const walletDetails = useWalletDetails(account)
   const gnosisSafeInfo = useSafeInfo()
@@ -150,11 +137,9 @@ export function WalletUpdater(): null {
   const setWalletDetails = useSetAtom(walletDetailsAtom)
   const setGnosisSafeInfo = useSetAtom(gnosisSafeInfoAtom)
 
-  const provider = useWalletProvider()
-
   useEffect(() => {
-    setWalletInfo({ chainId, active, account, connector, isConnectionRestoring, provider })
-  }, [chainId, active, account, connector, isConnectionRestoring, provider, setWalletInfo])
+    setWalletInfo({ chainId, active, account, connector })
+  }, [chainId, active, account, connector, setWalletInfo])
 
   useEffect(() => {
     const walletType = getWalletType({ gnosisSafeInfo, isSmartContractWallet: walletDetails.isSmartContractWallet })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2124,9 +2124,6 @@ importers:
       '@cowprotocol/ui':
         specifier: workspace:*
         version: link:../ui
-      '@cowprotocol/wallet-provider':
-        specifier: workspace:*
-        version: link:../wallet-provider
       '@ethereumjs/util':
         specifier: 10.1.0
         version: 10.1.0


### PR DESCRIPTION
# Summary

- Fix wallet capability checks by routing them through the connected wallet.
- Remove the now-unnecessary direct RPC fallback.
- Remove the unused provider and connection-restoring state from `WalletInfo`.

# Background

Capability requests were incorrectly sent to the chain’s public RPC, which does not expose wallet capabilities. Using the connected wallet fixes detection and makes the fallback/provider plumbing unnecessary (seems to work in Safe via WC too).

<img width="2260" height="453" alt="image" src="https://github.com/user-attachments/assets/4b60173c-5ab6-4c75-8101-9832c3b2bcf3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Wallet capability detection now uses the connected wallet connector, with a 30-second timeout.
  * Removed legacy provider fallback handling for capability checks.
  * Simplified wallet connection state by removing provider and connection-restoring details.
  * Capability requests now safely return no capabilities when required wallet information is unavailable, rejected, or times out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->