### PR TITLE
fix: increase wallet capabilities timeout from 5s to 30s

### DIFF
--- a/libs/wallet/src/api/state/walletCapabilitiesAtom.test.ts
+++ b/libs/wallet/src/api/state/walletCapabilitiesAtom.test.ts
@@ -11,6 +11,7 @@ import {
   isAtomicBatchSupportedAtom,
   isAtomicBatchSupportedAsyncAtom,
   isAtomicBatchSupportedLoadableAtom,
+  REQUEST_TIMEOUT_MS,
   resolveCapabilitiesForChain,
   walletCapabilitiesAtom,
 } from './walletCapabilitiesAtom'
@@ -322,7 +323,7 @@ describe('walletCapabilitiesAtom', () => {
 
       try {
         const resultPromise = store.get(walletCapabilitiesAtom)
-        await jest.advanceTimersByTimeAsync(5_000)
+        await jest.advanceTimersByTimeAsync(REQUEST_TIMEOUT_MS)
         const result = await resultPromise
 
         expect(result).toBeNull()
@@ -370,7 +371,7 @@ describe('walletCapabilitiesAtom', () => {
 
       try {
         const resultPromise = store.get(walletCapabilitiesAtom)
-        await jest.advanceTimersByTimeAsync(5_000)
+        await jest.advanceTimersByTimeAsync(REQUEST_TIMEOUT_MS)
         const result = await resultPromise
 
         expect(result).toEqual(capabilities)
@@ -393,7 +394,7 @@ describe('walletCapabilitiesAtom', () => {
 
       try {
         const resultPromise = store.get(walletCapabilitiesAtom)
-        await jest.advanceTimersByTimeAsync(5_000)
+        await jest.advanceTimersByTimeAsync(REQUEST_TIMEOUT_MS)
         const result = await resultPromise
 
         expect(result).toBeNull()

--- a/libs/wallet/src/api/state/walletCapabilitiesAtom.ts
+++ b/libs/wallet/src/api/state/walletCapabilitiesAtom.ts
@@ -25,7 +25,7 @@ import { walletInfoAtom } from '../state'
 
 export type WalletCapabilities = GetCapabilitiesReturnType[number]
 
-const REQUEST_TIMEOUT_MS = ms`5s`
+const REQUEST_TIMEOUT_MS = ms`30s`
 
 /**
  * WalletConnect in mobile browsers initiates a request with confirmation to the wallet

--- a/libs/wallet/src/api/state/walletCapabilitiesAtom.ts
+++ b/libs/wallet/src/api/state/walletCapabilitiesAtom.ts
@@ -25,7 +25,7 @@ import { walletInfoAtom } from '../state'
 
 export type WalletCapabilities = GetCapabilitiesReturnType[number]
 
-const REQUEST_TIMEOUT_MS = ms`30s`
+export const REQUEST_TIMEOUT_MS = ms`30s`
 
 /**
  * WalletConnect in mobile browsers initiates a request with confirmation to the wallet


### PR DESCRIPTION
# Summary

The timeout was too short for some users, causing them to see this screen:

<img width="1408" height="1609" alt="image" src="https://github.com/user-attachments/assets/67ffeef9-b127-4287-9297-944b3281356d" />

## To test

1. Safe+WC
2. You can place a TWAP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the wait time for wallet capability and provider information requests, reducing premature timeouts during slower connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->