### PR TITLE
fix: revert widget preview to vercel

### DIFF
--- a/apps/widget-configurator/src/utils/base-url/baseUrl.test.ts
+++ b/apps/widget-configurator/src/utils/base-url/baseUrl.test.ts
@@ -1,4 +1,4 @@
-import { branchNameToVercelPreviewUrl, getEnvLabel, getRelatedSwapPreviewUrl } from './baseUrl'
+import { getEnvLabel, getRelatedSwapPreviewUrl } from './baseUrl'
 
 describe('getRelatedSwapPreviewUrl', () => {
   it('uses the Vercel-provided swap branch URL', () => {
@@ -12,18 +12,6 @@ describe('getRelatedSwapPreviewUrl', () => {
     expect(getRelatedSwapPreviewUrl(relatedProjects)).toBe(
       'https://swap-dev-git-bla-dhqiwuhe-yay0000-weirdandlo-54bda8-cowswap-dev.vercel.app',
     )
-  })
-})
-
-describe('branchNameToVercelPreviewUrl', () => {
-  it('matches Vercel swap preview URLs', () => {
-    expect(branchNameToVercelPreviewUrl('release/2026-07-15')).toBe(
-      'https://swap-dev-git-release-2026-07-15-cowswap-dev.vercel.app',
-    )
-    expect(branchNameToVercelPreviewUrl('test-----a/-branch')).toBe(
-      'https://swap-dev-git-test-a-branch-cowswap-dev.vercel.app',
-    )
-    expect(branchNameToVercelPreviewUrl('test-----a-badna9878979/-long-andweird7896branchname')).toBeNull()
   })
 })
 

--- a/apps/widget-configurator/src/utils/base-url/baseUrl.test.ts
+++ b/apps/widget-configurator/src/utils/base-url/baseUrl.test.ts
@@ -5,9 +5,10 @@ describe('branchNameToVercelPreviewUrl', () => {
     expect(branchNameToVercelPreviewUrl('release/2026-07-15')).toBe(
       'https://swap-dev-git-release-2026-07-15-cowswap-dev.vercel.app',
     )
-    expect(branchNameToVercelPreviewUrl('feature/a-very-long-branch-name-that-exceeds-the-dns-label-limit')).toBe(
-      'https://swap-dev-git-feature-a-very-long-branch-name-that-e-cowswap-dev.vercel.app',
+    expect(branchNameToVercelPreviewUrl('test-----a/-branch')).toBe(
+      'https://swap-dev-git-test-a-branch-cowswap-dev.vercel.app',
     )
+    expect(branchNameToVercelPreviewUrl('test-----a-badna9878979/-long-andweird7896branchname')).toBeNull()
   })
 })
 

--- a/apps/widget-configurator/src/utils/base-url/baseUrl.test.ts
+++ b/apps/widget-configurator/src/utils/base-url/baseUrl.test.ts
@@ -1,4 +1,19 @@
-import { branchNameToVercelPreviewUrl, getEnvLabel } from './baseUrl'
+import { branchNameToVercelPreviewUrl, getEnvLabel, getRelatedSwapPreviewUrl } from './baseUrl'
+
+describe('getRelatedSwapPreviewUrl', () => {
+  it('uses the Vercel-provided swap branch URL', () => {
+    const relatedProjects = JSON.stringify([
+      {
+        project: { name: 'swap-dev' },
+        preview: { branch: 'swap-dev-git-bla-dhqiwuhe-yay0000-weirdandlo-54bda8-cowswap-dev.vercel.app' },
+      },
+    ])
+
+    expect(getRelatedSwapPreviewUrl(relatedProjects)).toBe(
+      'https://swap-dev-git-bla-dhqiwuhe-yay0000-weirdandlo-54bda8-cowswap-dev.vercel.app',
+    )
+  })
+})
 
 describe('branchNameToVercelPreviewUrl', () => {
   it('matches Vercel swap preview URLs', () => {

--- a/apps/widget-configurator/src/utils/base-url/baseUrl.test.ts
+++ b/apps/widget-configurator/src/utils/base-url/baseUrl.test.ts
@@ -1,25 +1,19 @@
-import { branchNameToCfPagesSubdomain, vercelPreviewSlugToCfPagesSubdomain } from './baseUrl'
+import { branchNameToVercelPreviewUrl, getEnvLabel } from './baseUrl'
 
-describe('branchNameToCfPagesSubdomain', () => {
-  it('matches Cloudflare Pages preview subdomains', () => {
-    expect(branchNameToCfPagesSubdomain('cf-preview/pr-7657')).toBe('cf-preview-pr-7657')
-    expect(branchNameToCfPagesSubdomain('Feature/API_fix')).toBe('feature-api-fix')
-    expect(branchNameToCfPagesSubdomain('fix/deepsec-high-frontend-hardening')).toBe('fix-deepsec-high-frontend-ha')
-    expect(branchNameToCfPagesSubdomain('test-----a-badna9878979/-long-andweird7896branchname')).toBe(
-      'test-----a-badna9878979--lon',
+describe('branchNameToVercelPreviewUrl', () => {
+  it('matches Vercel swap preview URLs', () => {
+    expect(branchNameToVercelPreviewUrl('release/2026-07-15')).toBe(
+      'https://swap-dev-git-release-2026-07-15-cowswap-dev.vercel.app',
     )
-    expect(branchNameToCfPagesSubdomain('test--branch--wierd/--')).toBe('test--branch--wierd')
-    expect(branchNameToCfPagesSubdomain('/feature/')).toBe('feature')
-    expect(branchNameToCfPagesSubdomain('---')).toBe('preview')
+    expect(branchNameToVercelPreviewUrl('feature/a-very-long-branch-name-that-exceeds-the-dns-label-limit')).toBe(
+      'https://swap-dev-git-feature-a-very-long-branch-name-that-e-cowswap-dev.vercel.app',
+    )
   })
 })
 
-describe('vercelPreviewSlugToCfPagesSubdomain', () => {
-  it('maps visible Vercel preview slugs to Cloudflare Pages aliases', () => {
-    expect(vercelPreviewSlugToCfPagesSubdomain('fix-permit-flow')).toBe('fix-permit-flow')
-    expect(vercelPreviewSlugToCfPagesSubdomain('fix-deepsec-high-fro-87dcc4')).toBe('fix-deepsec-high-fro')
-    expect(
-      vercelPreviewSlugToCfPagesSubdomain('fix-deepsec-high-fro-87dcc4', 'fix/deepsec-high-frontend-hardening'),
-    ).toBe('fix-deepsec-high-frontend-ha')
+describe('getEnvLabel', () => {
+  it('recognizes only Vercel preview URLs', () => {
+    expect(getEnvLabel('https://swap-dev-git-release-2026-07-15-cowswap-dev.vercel.app')).toBe('Preview')
+    expect(getEnvLabel('https://release-2026-07-15.swap-dev-5u6.pages.dev')).toBe('Unknown')
   })
 })

--- a/apps/widget-configurator/src/utils/base-url/baseUrl.ts
+++ b/apps/widget-configurator/src/utils/base-url/baseUrl.ts
@@ -1,25 +1,10 @@
 import { isDev, isLocalHost, isVercel } from '../env/env.constants'
 
-const vercelSwapPreviewPrefix = 'swap-dev-git-'
-const vercelPreviewScopeSuffix = '-cowswap-dev'
 const vercelPreviewDomain = '.vercel.app'
-const vercelDeploymentLabelMaxLength = 63
 
 type VercelRelatedProject = {
   project: { name: string }
   preview: { branch?: string }
-}
-
-export function branchNameToVercelPreviewUrl(branchName: string): string | null {
-  const branch = branchName
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
-  const deployment = `${vercelSwapPreviewPrefix}${branch}${vercelPreviewScopeSuffix}`
-
-  return branch && deployment.length <= vercelDeploymentLabelMaxLength
-    ? `https://${deployment}${vercelPreviewDomain}`
-    : null
 }
 
 export function getRelatedSwapPreviewUrl(value = process.env.VERCEL_RELATED_PROJECTS): string | null {
@@ -47,15 +32,7 @@ export function getBaseUrl(): string {
 
   if (isDev) return 'https://dev.swap.cow.fi'
 
-  if (isVercel) {
-    const previewUrl = getRelatedSwapPreviewUrl()
-
-    if (previewUrl) return previewUrl
-
-    const branchName = process.env.VERCEL_GIT_COMMIT_REF
-
-    if (branchName) return branchNameToVercelPreviewUrl(branchName) || 'https://swap.cow.fi'
-  }
+  if (isVercel) return getRelatedSwapPreviewUrl() || 'https://swap.cow.fi'
 
   return 'https://swap.cow.fi'
 }

--- a/apps/widget-configurator/src/utils/base-url/baseUrl.ts
+++ b/apps/widget-configurator/src/utils/base-url/baseUrl.ts
@@ -1,28 +1,17 @@
 import { isDev, isLocalHost, isVercel } from '../env/env.constants'
 
-const vercelWidgetConfiguratorPrefix = 'widget-configurator-git-'
-const cfPagesPreviewSuffix = `.swap-dev-5u6.pages.dev`
-const cfPagesPreviewSubdomainMaxLength = 28
-const cfPagesPreviewSubdomainFallback = 'preview'
-const vercelPreviewHashSuffix = /-[a-f0-9]{6}$/
+const vercelSwapPreviewPrefix = 'swap-dev-git-'
+const vercelPreviewScopeSuffix = '-cowswap-dev'
+const vercelPreviewDomain = '.vercel.app'
+const vercelBranchMaxLength = 63 - vercelSwapPreviewPrefix.length - vercelPreviewScopeSuffix.length
 
-export function branchNameToCfPagesSubdomain(branchName: string): string {
-  const subdomain = branchName
+export function branchNameToVercelPreviewUrl(branchName: string): string {
+  const branch = branchName
     .toLowerCase()
-    .replace(/[^a-z0-9]/g, '-')
-    .slice(0, cfPagesPreviewSubdomainMaxLength)
-    .replace(/^-+|-+$/g, '')
+    .replace(/[^a-z0-9-]/g, '-')
+    .slice(0, vercelBranchMaxLength)
 
-  return subdomain || cfPagesPreviewSubdomainFallback
-}
-
-export function vercelPreviewSlugToCfPagesSubdomain(
-  branchSlug: string,
-  branchName = process.env.VERCEL_GIT_COMMIT_REF,
-): string {
-  const branch = branchName || branchSlug.replace(vercelPreviewHashSuffix, '')
-
-  return branchNameToCfPagesSubdomain(branch)
+  return `https://${vercelSwapPreviewPrefix}${branch}${vercelPreviewScopeSuffix}${vercelPreviewDomain}`
 }
 
 /** Used by the configurator preview and as the default `baseUrl` in built params. */
@@ -39,10 +28,8 @@ export function getBaseUrl(): string {
 
   if (isDev) return 'https://dev.swap.cow.fi'
 
-  if (isVercel) {
-    const prKey = window.location.hostname.replace(vercelWidgetConfiguratorPrefix, '')
-
-    return `https://${vercelPreviewSlugToCfPagesSubdomain(prKey)}${cfPagesPreviewSuffix}`
+  if (isVercel && process.env.VERCEL_GIT_COMMIT_REF) {
+    return branchNameToVercelPreviewUrl(process.env.VERCEL_GIT_COMMIT_REF)
   }
 
   return 'https://swap.cow.fi'
@@ -51,7 +38,7 @@ export function getBaseUrl(): string {
 export function getEnvLabel(url: string): 'Local' | 'Preview' | 'Dev' | 'Production' | 'Unknown' {
   if (/^https?:\/\/(localhost|127\.0\.0\.1|::1|\.localhost):\d+/.test(url)) return 'Local'
 
-  if (url.includes(cfPagesPreviewSuffix)) return 'Preview'
+  if (url.includes(vercelPreviewDomain)) return 'Preview'
 
   if (url.startsWith('https://dev.swap.cow.fi') || url.startsWith('https://dev.widget.cow.fi')) return 'Dev'
 

--- a/apps/widget-configurator/src/utils/base-url/baseUrl.ts
+++ b/apps/widget-configurator/src/utils/base-url/baseUrl.ts
@@ -5,6 +5,11 @@ const vercelPreviewScopeSuffix = '-cowswap-dev'
 const vercelPreviewDomain = '.vercel.app'
 const vercelDeploymentLabelMaxLength = 63
 
+type VercelRelatedProject = {
+  project: { name: string }
+  preview: { branch?: string }
+}
+
 export function branchNameToVercelPreviewUrl(branchName: string): string | null {
   const branch = branchName
     .toLowerCase()
@@ -15,6 +20,17 @@ export function branchNameToVercelPreviewUrl(branchName: string): string | null 
   return branch && deployment.length <= vercelDeploymentLabelMaxLength
     ? `https://${deployment}${vercelPreviewDomain}`
     : null
+}
+
+export function getRelatedSwapPreviewUrl(value = process.env.VERCEL_RELATED_PROJECTS): string | null {
+  try {
+    const projects = JSON.parse(value || '[]') as VercelRelatedProject[]
+    const hostname = projects.find(({ project }) => project.name === 'swap-dev')?.preview.branch
+
+    return hostname ? `https://${hostname}` : null
+  } catch {
+    return null
+  }
 }
 
 /** Used by the configurator preview and as the default `baseUrl` in built params. */
@@ -31,10 +47,14 @@ export function getBaseUrl(): string {
 
   if (isDev) return 'https://dev.swap.cow.fi'
 
-  if (isVercel && process.env.VERCEL_GIT_COMMIT_REF) {
-    const previewUrl = branchNameToVercelPreviewUrl(process.env.VERCEL_GIT_COMMIT_REF)
+  if (isVercel) {
+    const previewUrl = getRelatedSwapPreviewUrl()
 
     if (previewUrl) return previewUrl
+
+    const branchName = process.env.VERCEL_GIT_COMMIT_REF
+
+    if (branchName) return branchNameToVercelPreviewUrl(branchName) || 'https://swap.cow.fi'
   }
 
   return 'https://swap.cow.fi'

--- a/apps/widget-configurator/src/utils/base-url/baseUrl.ts
+++ b/apps/widget-configurator/src/utils/base-url/baseUrl.ts
@@ -3,15 +3,18 @@ import { isDev, isLocalHost, isVercel } from '../env/env.constants'
 const vercelSwapPreviewPrefix = 'swap-dev-git-'
 const vercelPreviewScopeSuffix = '-cowswap-dev'
 const vercelPreviewDomain = '.vercel.app'
-const vercelBranchMaxLength = 63 - vercelSwapPreviewPrefix.length - vercelPreviewScopeSuffix.length
+const vercelDeploymentLabelMaxLength = 63
 
-export function branchNameToVercelPreviewUrl(branchName: string): string {
+export function branchNameToVercelPreviewUrl(branchName: string): string | null {
   const branch = branchName
     .toLowerCase()
-    .replace(/[^a-z0-9-]/g, '-')
-    .slice(0, vercelBranchMaxLength)
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+  const deployment = `${vercelSwapPreviewPrefix}${branch}${vercelPreviewScopeSuffix}`
 
-  return `https://${vercelSwapPreviewPrefix}${branch}${vercelPreviewScopeSuffix}${vercelPreviewDomain}`
+  return branch && deployment.length <= vercelDeploymentLabelMaxLength
+    ? `https://${deployment}${vercelPreviewDomain}`
+    : null
 }
 
 /** Used by the configurator preview and as the default `baseUrl` in built params. */
@@ -29,7 +32,9 @@ export function getBaseUrl(): string {
   if (isDev) return 'https://dev.swap.cow.fi'
 
   if (isVercel && process.env.VERCEL_GIT_COMMIT_REF) {
-    return branchNameToVercelPreviewUrl(process.env.VERCEL_GIT_COMMIT_REF)
+    const previewUrl = branchNameToVercelPreviewUrl(process.env.VERCEL_GIT_COMMIT_REF)
+
+    if (previewUrl) return previewUrl
   }
 
   return 'https://swap.cow.fi'

--- a/apps/widget-configurator/vercel.json
+++ b/apps/widget-configurator/vercel.json
@@ -1,0 +1,3 @@
+{
+  "relatedProjects": ["prj_GvBLCsuQlCvm2pVenPrfuihRRZiB"]
+}

--- a/apps/widget-configurator/vercel.json
+++ b/apps/widget-configurator/vercel.json
@@ -1,3 +1,0 @@
-{
-  "relatedProjects": ["prj_GvBLCsuQlCvm2pVenPrfuihRRZiB"]
-}

--- a/apps/widget-configurator/vercel.ts
+++ b/apps/widget-configurator/vercel.ts
@@ -44,6 +44,7 @@ const csp = buildCsp([
 // ---------------------------------------------------------------------------
 
 export const config: VercelConfig = {
+  relatedProjects: ['prj_GvBLCsuQlCvm2pVenPrfuihRRZiB'],
   buildCommand: 'cd ../../ && pnpm build:widget',
   outputDirectory: '../../build/widget-configurator',
   // Uses install:ci because this app may require SDK preview package switching.

--- a/apps/widget-configurator/vite.config.mts
+++ b/apps/widget-configurator/vite.config.mts
@@ -31,8 +31,9 @@ export default defineConfig(({ mode }) => {
     root: path.resolve(__dirname, './'),
     define: {
       ...getReactProcessEnv(mode),
-      // Maps Vercel env var into the build so the branch name can be reused inside the app
+      // Expose the Vercel metadata used to select the matching swap preview.
       'process.env.VERCEL_GIT_COMMIT_REF': JSON.stringify(process.env.VERCEL_GIT_COMMIT_REF || ''),
+      'process.env.VERCEL_RELATED_PROJECTS': JSON.stringify(process.env.VERCEL_RELATED_PROJECTS || ''),
     },
 
     cacheDir: '../../node_modules/.vite/widget-configurator',

--- a/apps/widget-configurator/vite.config.mts
+++ b/apps/widget-configurator/vite.config.mts
@@ -32,7 +32,6 @@ export default defineConfig(({ mode }) => {
     define: {
       ...getReactProcessEnv(mode),
       // Expose the Vercel metadata used to select the matching swap preview.
-      'process.env.VERCEL_GIT_COMMIT_REF': JSON.stringify(process.env.VERCEL_GIT_COMMIT_REF || ''),
       'process.env.VERCEL_RELATED_PROJECTS': JSON.stringify(process.env.VERCEL_RELATED_PROJECTS || ''),
     },
 


### PR DESCRIPTION
# Summary

https://linear.app/cowswap/issue/FE-233/use-vercel-preview-urls-on-widget

Bring back vercel to widget preview instead of cf-pages preview

# To Test

1. Open widget preview
* Should use vercel preview link to load cowswap

Additionally, created this PR with a long and weird branch name to test https://github.com/cowprotocol/cowswap/pull/7857

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved preview environment URL detection and labeling (now recognizes Vercel preview URLs).
  * Preview builds can derive the base URL from related swap preview project data when available, with a fallback when not.

* **Bug Fixes**
  * More reliable handling of missing or invalid related preview project information (returns a safe default instead of failing).

* **Tests**
  * Added/updated coverage for related preview URL generation and environment labeling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->