### PR TITLE
fix: clear safe info after disconnect

### DIFF
--- a/libs/wallet/src/wagmi/updater.ts
+++ b/libs/wallet/src/wagmi/updater.ts
@@ -6,7 +6,7 @@ import { useEnsName } from 'wagmi'
 
 import { getCurrentChainIdFromUrl, getRawCurrentChainIdFromUrl, logSafeApi } from '@cowprotocol/common-utils'
 import { getSafeInfo, normalizeSafeError, SAFE_RATE_LIMIT_MSG } from '@cowprotocol/core'
-import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { areAddressesEqual, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { AccountType } from '@cowprotocol/types'
 import { useWalletProvider } from '@cowprotocol/wallet-provider'
 import type { SafeInfoResponse } from '@safe-global/api-kit'
@@ -281,6 +281,7 @@ function useSafeInfo(): GnosisSafeInfo | undefined {
       if (!shouldFetchSafeInfo) {
         clearInterval(longSafeInfoInterval !== null ? longSafeInfoInterval : undefined)
         longSafeInfoInterval = null
+        setSafeInfo(undefined)
         return
       }
     }
@@ -294,6 +295,10 @@ function useSafeInfo(): GnosisSafeInfo | undefined {
       longSafeInfoInterval = null
     }
   }, [chainId, account, safeAppsSdk, shouldFetchSafeInfo])
+
+  if (!safeInfo || !account || safeInfo.chainId !== chainId || !areAddressesEqual(safeInfo.address, account)) {
+    return undefined
+  }
 
   return safeInfo
 }


### PR DESCRIPTION
# Summary

Fix stale Safe wallet detection after switching from a Safe to an EOA.

Safe metadata is now cleared when Safe polling stops and ignored when its address or chain does not match the current wallet.

# To Test

1. Connect a Safe wallet and verify Safe-specific flows remain available.

2. Disconnect, then connect an EOA.

- [ ] Verify the app no longer treats the EOA as a Safe.
- [ ] Submit an EOA order.
- [ ] Verify the transaction is handled as an Ethereum transaction.
- [ ] Verify the app does not repeatedly query the Safe API for the EOA transaction hash.

# Background

PR #7729 added an early return when Safe polling was disabled. That return skipped the existing state-clearing path, leaving the previous Safe metadata active after switching wallets.

The address/chain check also prevents stale asynchronous Safe responses from leaking across wallet transitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Safe account information is now validated against the active account and network.
  * Stale safe information is cleared when the active account or network changes.
  * Prevented outdated safe details from being displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->