### PR TITLE
ci: disable cypress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
 
   integration-tests:
     name: Cypress
-    if: ${{ !startsWith(github.head_ref, 'cf-preview/pr-') }}
+    if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,7 @@ jobs:
     name: Notify Slack on Failure
     needs: [setup, test, lint, typecheck, agent-harness, integration-tests]
     runs-on: ubuntu-latest
-    if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
+    if: always() && failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
 
     steps:
       - name: Notify Failure


### PR DESCRIPTION
Cypress been broken for a while, it will get replaced with a new playwright setup, less brittle :crossed_fingers: .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled the Cypress integration test job in the continuous integration pipeline.
  * Cypress-related failure notifications are no longer triggered as part of the CI run; the Slack payload behavior was adjusted so Cypress is only treated as failed when the integration-tests job reports a failure result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->