### PR TITLE
fix: remove safe fallback

### DIFF
--- a/libs/wallet/src/api/state/walletCapabilitiesAtom.test.ts
+++ b/libs/wallet/src/api/state/walletCapabilitiesAtom.test.ts
@@ -142,8 +142,8 @@ describe('resolveCapabilitiesForChain', () => {
     expect(resolveCapabilitiesForChain({ '0x1': capabilities }, MOCK_CHAIN_ID)).toEqual(capabilities)
   })
 
-  it('falls back to the first entry when no chain key matches', () => {
-    expect(resolveCapabilitiesForChain({ '0x64': capabilities }, MOCK_CHAIN_ID)).toEqual(capabilities)
+  it('returns null when no chain key matches', () => {
+    expect(resolveCapabilitiesForChain({ '0x64': capabilities }, MOCK_CHAIN_ID)).toBeNull()
   })
 
   it('returns null for empty capabilities', () => {
@@ -347,7 +347,7 @@ describe('walletCapabilitiesAtom', () => {
       expect(result).toEqual(capabilities)
     })
 
-    it('falls back to the first legacy capability entry when chain key is missing', async () => {
+    it('returns null when the legacy capabilities chain key is missing', async () => {
       const capabilities: WalletCapabilities = { atomic: { status: 'supported' } }
       mockGetCapabilities.mockRejectedValue(new Error('viem error'))
       const mockRequest = jest.fn().mockResolvedValue({ '0x64': capabilities })
@@ -357,7 +357,7 @@ describe('walletCapabilitiesAtom', () => {
 
       const result = await store.get(walletCapabilitiesAtom)
 
-      expect(result).toEqual(capabilities)
+      expect(result).toBeNull()
     })
 
     it('uses legacy fallback when getCapabilities times out', async () => {

--- a/libs/wallet/src/api/state/walletCapabilitiesAtom.ts
+++ b/libs/wallet/src/api/state/walletCapabilitiesAtom.ts
@@ -59,11 +59,8 @@ export function resolveCapabilitiesForChain(
 
   if (capabilitiesForChain) return capabilitiesForChain
 
-  // This fallback was initially here for Safe via WC, even thought it should return a value as shown in the example in
-  // the long TSDoc comment below. `Object.values` should not be needed, as we are already parsing this properly with
-  // `numberToHex` above:
-
-  return Object.values(capabilities)[0] || null
+  logWallet.warn('Cannot resolve wallet capabilities for chain', { chainId, capabilities })
+  return null
 }
 
 async function fetchWidgetProviderMetaInfo(


### PR DESCRIPTION
# Summary

Related to #6758 and #7673

The fallback caused MetaMask EOAs to inherit smart-account capabilities from another network. The app then selected the Safe approval bundle flow, skipping the normal approval or permit path and causing order submission to fail.

# To Test

1. Connect MetaMask with a regular EOA.

- [x] Select a token requiring an on-chain approval.
- [x] Confirm the approve tx doesn't fail

2. Select a token supporting permits.

- [x] Select a token supporting permits.
- [x] Confirm the permit signature doesn't fail

3. Connect through Safe WalletConnect and switch networks.

- [x] Verify capabilities are returned for the newly selected chain.
- [x] Verify bundled transactions continue to work.

# Background

Issue #6758 reported that `wallet_getCapabilities` returned capabilities for the previous chain after switching networks through Safe WalletConnect.

Although initially reported to Safe, the underlying bug was in WalletConnect's capability cache. Calls without explicit chain IDs were cached only by address, so switching networks reused the previous chain's response.

WalletConnect fixed this by including the active chain in the cache key: https://github.com/WalletConnect/walletconnect-monorepo/pull/7110

The first-entry fallback was our workaround for that upstream issue. It is no longer needed.

PR #7455 restricted the workaround to Safe WalletConnect.
PR #7673 later migrated capability detection from a hook to an atom and accidentally made the fallback unconditional.

Fun fact, back in Jan 13 I tried getting rid of this fallback by upgrading walletconnect, but couldn't: https://github.com/cowprotocol/cowswap/pull/6823#issuecomment-3749716531 
