### PR TITLE
chore(renovate): run github-actions updates monthly in renovate config 🗓️

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,7 @@
   semanticCommits: "enabled",
   semanticCommitType: "deps",
   packageRules: [
-    // GitHub Actions updates: run weekly, skip releases newer than 2 weeks
+    // GitHub Actions updates: run monthly, skip releases newer than 2 weeks
     // to avoid picking up freshly published versions that may be unstable or
     // compromised, and pin to full commit SHAs (with the version as a
     // trailing comment) rather than mutable tags.
@@ -17,7 +17,7 @@
     {
       // Note that npm is used for pnpm as well, there's no specific pnpm value for matchManagers.
       matchManagers: ["github-actions", "npm"],
-      schedule: ["on monday"],
+      schedule: ["* 0-3 1 * *"],
       minimumReleaseAge: "14 days",
       // Track upgrades by semver tag, but pin the resolved version to its full
       // commit SHA (semver tag kept as a trailing comment). Use the coerced


### PR DESCRIPTION
- switch schedule from weekly (on monday) to monthly (1st of month, `* 0-3 1 * *`)
- keep 14-day minimumReleaseAge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the schedule for automated GitHub Actions dependency updates from weekly to monthly.
  * Updates now run during the first week of each month.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->