### PR TITLE
ci: update release auth token 🔐

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.RELEASE_PLEASE_AUTH }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -72,7 +72,7 @@ jobs:
           title: "chore(main): release"
           createGithubReleases: false
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_AUTH }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
   publish:
     runs-on: ubuntu-latest
@@ -87,7 +87,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.RELEASE_PLEASE_AUTH }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -136,7 +136,7 @@ jobs:
       # this pushes are what triggers deployment.yml.
       - name: Create tags and GitHub releases
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_AUTH }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           PENDING_RELEASES: ${{ needs.release.outputs.pendingReleases }}
         run: |
           set -euo pipefail

--- a/docs/superpowers/specs/2026-05-13-changesets-migration-design.md
+++ b/docs/superpowers/specs/2026-05-13-changesets-migration-design.md
@@ -281,7 +281,7 @@ Permissions: `contents: write`, `pull-requests: write`.
 Steps:
 
 1. `actions/checkout@v4` with `fetch-depth: 0`, `fetch-tags: true`, and the
-   reused `RELEASE_PLEASE_AUTH` token. **Fetch depth and tags are essential**
+   `RELEASE_TOKEN` token. **Fetch depth and tags are essential**
    — without them `git log $TAG..HEAD` silently returns nothing.
 2. `pnpm/action-setup` + `actions/setup-node` (same pins as today).
 3. `pnpm install --frozen-lockfile`.
@@ -345,9 +345,6 @@ Internally ordered for review readability:
    - Add `.github/workflows/release.yml`.
    - Delete `.github/workflows/release-please.yml`,
      `release-please-config.json`, `.release-please-manifest.json`.
-
-The secret rename `RELEASE_PLEASE_AUTH` → `RELEASE_BOT_TOKEN` is a follow-up
-to avoid coordinating an Actions secret rename with the merge.
 
 ## First run
 


### PR DESCRIPTION
## Summary
- Rename the release workflow secret from `RELEASE_PLEASE_AUTH` to `RELEASE_TOKEN`
- Update the changesets migration design doc to match

## Test plan
- [ ] Confirm the `RELEASE_TOKEN` Actions secret exists before merge
- [ ] After merge to `main`, verify the release workflow still opens/updates the version PR and can push tags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Updated the release workflow authentication to use the current release token configuration for both checking out the code and creating/publishing releases.
* **Documentation**
  * Refreshed the release migration guidance to reflect the revised token naming used in the workflow, ensuring the documentation matches the new authentication setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->