### PR TITLE
refactor: cow logger's error method

### DIFF
--- a/apps/cowswap-frontend/src/modules/captcha/containers/CaptchaWidget.container.tsx
+++ b/apps/cowswap-frontend/src/modules/captcha/containers/CaptchaWidget.container.tsx
@@ -3,7 +3,7 @@ import { ReactNode, useEffect, useRef, useState } from 'react'
 
 import { createCowTracker } from '@cowprotocol/analytics'
 import { useTheme } from '@cowprotocol/common-hooks'
-import { getJwtTtl } from '@cowprotocol/common-utils'
+import { getJwtTtl, normalizeError } from '@cowprotocol/common-utils'
 
 import { Turnstile, type TurnstileInstance } from '@marsidev/react-turnstile'
 import { setBearerToken } from 'cowSdk'
@@ -120,12 +120,12 @@ export function CaptchaWidget(): ReactNode {
           logCaptcha.info('JWT received', { requestId })
           trackCaptcha({ action: 'captcha_challenge_solved' })
           setCaptchaJwt(jwt)
-        } catch (error) {
+        } catch (err: unknown) {
           if (exchangeRequestIdRef.current !== requestId) {
             return
           }
 
-          logCaptcha.error('JWT exchange failed', { requestId, error })
+          logCaptcha.error(new Error('JWT exchange failed', { cause: normalizeError(err) }), undefined, { requestId })
           trackCaptcha({ action: 'captcha_challenge_failed', reason: 'jwtExchangeFailed' })
           setCaptchaJwt(null)
         }
@@ -142,7 +142,7 @@ export function CaptchaWidget(): ReactNode {
       onError={(errorCode) => {
         exchangeRequestIdRef.current += 1
 
-        logCaptcha.error('Challenge errored', { errorCode, hostname: window.location.hostname })
+        logCaptcha.error(new Error('Challenge errored'), undefined, { errorCode, hostname: window.location.hostname })
         trackCaptcha({ action: 'captcha_challenge_failed', reason: 'turnstileError' })
         setCaptchaJwt(null)
       }}

--- a/apps/cowswap-frontend/src/modules/twap/services/fetchCachedTwapOrdersFromSafe.ts
+++ b/apps/cowswap-frontend/src/modules/twap/services/fetchCachedTwapOrdersFromSafe.ts
@@ -1,4 +1,4 @@
-import { isTruthy, logSafeApi } from '@cowprotocol/common-utils'
+import { isTruthy, logSafeApi, normalizeError } from '@cowprotocol/common-utils'
 import { localForageJotai } from '@cowprotocol/core'
 import { getAddressKey, SupportedChainId } from '@cowprotocol/cow-sdk'
 
@@ -73,10 +73,11 @@ async function fetchFreshTwapOrders(
     undefined,
     [],
     onProgress,
-  ).catch((error) => {
-    if (!cached) throw error
+  ).catch((err: unknown) => {
+    const error = normalizeError(err)
+    logSafeApi.error(new Error('Failed to fetch TWAP orders from Safe', { cause: error }))
 
-    logSafeApi.error('Error fetching TWAP orders from Safe', { safeAddress }, error)
+    if (!cached) throw error
     return null
   })
 }

--- a/apps/cowswap-frontend/src/modules/twap/services/fetchTwapOrdersFromSafe.ts
+++ b/apps/cowswap-frontend/src/modules/twap/services/fetchTwapOrdersFromSafe.ts
@@ -158,7 +158,7 @@ async function fetchRecentlyExecutedTransactions(
     if (error.statusCode === 429) {
       logSafeApi.error(new Error(SAFE_RATE_LIMIT_MSG))
     } else {
-      logSafeApi.error('Error fetching executed Safe transactions', { safeAddress }, error)
+      logSafeApi.error(new Error('Failed to fetch executed Safe transactions', { cause: error }))
     }
     return { orders: [], complete: false }
   }
@@ -184,7 +184,7 @@ async function fetchSafeTransactionsChunk(
       if (error.statusCode === 429) {
         logSafeApi.error(new Error(SAFE_RATE_LIMIT_MSG))
       } else {
-        logSafeApi.error('Error fetching Safe transactions', { safeAddress, nextUrl }, error)
+        logSafeApi.error(new Error('Failed to fetch Safe transactions', { cause: error }), undefined, { nextUrl })
       }
 
       return { results: [], count: 0, fetchError: true }
@@ -201,7 +201,7 @@ async function fetchSafeTransactionsChunk(
     if (error.statusCode === 429) {
       logSafeApi.error(new Error(SAFE_RATE_LIMIT_MSG))
     } else {
-      logSafeApi.error('Error fetching Safe transactions', { safeAddress }, error)
+      logSafeApi.error(new Error('Failed to fetch Safe transactions', { cause: error }))
     }
 
     return { results: [], count: 0, fetchError: true }

--- a/apps/cowswap-frontend/src/modules/usdAmount/updaters/UsdPricesUpdater.ts
+++ b/apps/cowswap-frontend/src/modules/usdAmount/updaters/UsdPricesUpdater.ts
@@ -1,7 +1,7 @@
 import { useAtomValue, useSetAtom } from 'jotai'
 import { useEffect, useMemo } from 'react'
 
-import { getWrappedToken } from '@cowprotocol/common-utils'
+import { getWrappedToken, normalizeError } from '@cowprotocol/common-utils'
 import { Token } from '@cowprotocol/currency'
 
 import ms from 'ms.macro'
@@ -65,7 +65,7 @@ export function UsdPricesUpdater() {
     }
 
     if (error) {
-      logUsdPrices.error('Error loading USD prices', error)
+      logUsdPrices.error(new Error('Failed to load USD prices', { cause: normalizeError(error) }))
       return
     }
 

--- a/libs/common-utils/src/logger.ts
+++ b/libs/common-utils/src/logger.ts
@@ -1,8 +1,11 @@
 import { captureError } from './sentry'
 
-export type CowLogger = Record<CowLogLevel, (...args: unknown[]) => void>
+export type CowLogger = Record<Exclude<CowLogLevel, 'error'>, (...args: unknown[]) => void> & {
+  error: (error: Error, tags?: Record<string, string>, context?: Record<string, SentryPrimitive>) => void
+}
 
 export type CowLogLevel = 'debug' | 'info' | 'warn' | 'error'
+type SentryPrimitive = string | number | boolean | null
 
 const LOG_STYLE: Record<CowLogLevel, string> = {
   debug: 'font-weight: bold; color: #6b7280',
@@ -16,18 +19,11 @@ export function createCowLogger(scope: string): CowLogger {
     debug: (...args) => logCow('debug', scope, ...args),
     info: (...args) => logCow('info', scope, ...args),
     warn: (...args) => logCow('warn', scope, ...args),
-    error: (...args) => {
-      logCow('error', scope, ...args)
-      captureCowError(scope, args)
+    error: (error, tags, context) => {
+      logCow('error', scope, error, ...(tags || context ? [{ tags, context }] : []))
+      captureError(error, undefined, context, { ...tags, scope })
     },
   }
-}
-
-function captureCowError(scope: string, args: unknown[]): void {
-  const message = typeof args[0] === 'string' ? args[0] : `${scope} error`
-  const error = args.find((arg) => arg instanceof Error)
-
-  captureError(error || new Error(message), undefined, { args }, { scope })
 }
 
 function logCow(level: CowLogLevel, scope: string, ...args: unknown[]): void {

--- a/libs/wallet/src/api/state/walletCapabilitiesAtom.ts
+++ b/libs/wallet/src/api/state/walletCapabilitiesAtom.ts
@@ -175,7 +175,10 @@ export const walletCapabilitiesAtom = atom(async (get): Promise<WalletCapabiliti
     const wagmiError = normalizeError(err)
 
     if (!isEip1193Provider(provider)) {
-      logWallet.error('Cannot fetch wallet capabilities via wagmi', { account, chainId }, wagmiError)
+      logWallet.error(new Error('Failed to fetch wallet capabilities via wagmi', { cause: wagmiError }), undefined, {
+        account,
+        chainId,
+      })
       return null
     }
 
@@ -200,7 +203,10 @@ export const walletCapabilitiesAtom = atom(async (get): Promise<WalletCapabiliti
       if (rpcError instanceof TimeoutError) {
         logWallet.warn(rpcError.message)
       } else {
-        logWallet.error('Cannot fetch wallet capabilities via rpc', { account, chainId }, rpcError)
+        logWallet.error(new Error('Failed to fetch wallet capabilities via RPC', { cause: rpcError }), undefined, {
+          account,
+          chainId,
+        })
       }
 
       return null

--- a/libs/wallet/src/wagmi/updater.ts
+++ b/libs/wallet/src/wagmi/updater.ts
@@ -256,7 +256,7 @@ function useSafeInfo(): GnosisSafeInfo | undefined {
               logSafeApi.warn('Fetching safe info: NOT a safe', account)
               setIsKnownNotSafe(true)
             } else {
-              logSafeApi.error(`Unhandled safe error ${error.statusCode}`, account)
+              logSafeApi.error(new Error('Failed to fetch Safe info', { cause: error }))
             }
             setSafeInfo(undefined)
           }


### PR DESCRIPTION
# Summary

Changes the error method from accepting a bunch of parameters to only accepting:

```ts
    error: (error, tags, context) => {
      logCow('error', scope, error, ...(tags || context ? [{ tags, context }] : []))
      captureError(error, undefined, context, { ...tags, scope })
    },
```

so that it matches sentry reporting and it's flexible in allowing `tags` and `context`.

This use case became evident in #7868 and #7873

IMO we should get rid of `errorType`, that's basically `scope` :shrug: 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved failure reporting across CAPTCHA verification, Safe transaction/TWAP order fetching, USD price loading, wallet capability detection, and Safe information retrieval.
  - Standardized error details by logging structured `Error` objects (with underlying causes), while preserving existing fallback behavior (e.g., cached results and `null` returns where applicable).

- **Refactor**
  - Updated the shared logger so `error` logs consistently with typed `Error` inputs and structured tags/context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->