### PR TITLE
chore: remove staging deployment v1 step

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,10 +1,6 @@
 name: Deployment
 
 on:
-  # build when pushing to main/develop, or create a release
-  push:
-    branches: [ main, develop ]
-    tags: [ cowswap-v*, explorer-v* ]
   workflow_dispatch: # Manually trigger it via UI/CLI/API
     inputs:
       app:
@@ -17,21 +13,6 @@ on:
           - ALL
 
 jobs:
-
-  vercel-pre-prod:
-    # Deploys to Vercel staging environment only when there is a tag for CowSwap or Explorer
-    name: Vercel pre-prod
-    if: startsWith(github.ref, 'refs/tags')
-    uses: ./.github/workflows/vercel.yml
-    secrets: inherit
-    strategy:
-      matrix:
-        env_name: [ staging ] # deploys both in parallel
-    with:
-      env_name: ${{ matrix.env_name }}
-      # Pick app according to published tag
-      app: ${{ startsWith(github.ref, 'refs/tags/explorer') && 'EXPLORER' || 'COWSWAP' }}
-      disable_nx_cache: true
 
   vercel-prod:
     # Deploys to Vercel prod environment
@@ -49,7 +30,7 @@ jobs:
 
   notify-failure:
     name: Notify Slack on Failure
-    needs: [ vercel-pre-prod, vercel-prod ]
+    needs: [ vercel-prod ]
     runs-on: ubuntu-latest
     if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
 


### PR DESCRIPTION
# Summary

Already moved staging 100% to the new build flow.
Removing it from the deployment v1 workflow.

# To Test

Only once deployed.
The test: 
- No more staging builds triggered when a new tag is published
- Workflow no longer triggers on pushes to main/develop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deployment workflows can now be started manually rather than automatically from branch or tag changes.
  * Removed automatic pre-production deployments.
  * Failure notifications now track production deployment results only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->