### PR TITLE
feat: change sort-modules rule from warn to error and run lint:fix

### DIFF
--- a/apps/cowswap-frontend/src/common/updaters/orders/PendingOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/PendingOrdersUpdater.ts
@@ -63,6 +63,8 @@ import {
 
 import { removeOrdersToCancelAtom } from '../../../entities/ordersToCancel/ordersToCancel.atom'
 
+type FulfillOrdersBatchWithTypes = (params: FulfillOrdersBatchParams, orderTypesByUid?: OrderTypesByUid) => void
+
 interface HandlePresignedParams {
   presigned: EnrichedOrder[]
   orders: Order[]
@@ -93,8 +95,6 @@ interface UpdateOrdersParams {
   allTransactions: ReturnType<typeof useAllTransactions>
   markPollComplete?: (chainId: ChainId) => void
 }
-
-type FulfillOrdersBatchWithTypes = (params: FulfillOrdersBatchParams, orderTypesByUid?: OrderTypesByUid) => void
 
 // TODO: Break down this large function into smaller functions
 // eslint-disable-next-line max-lines-per-function

--- a/apps/cowswap-frontend/src/common/updaters/orders/utils.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/utils.ts
@@ -20,17 +20,6 @@ export type OrderTransitionData = {
 
 export type OrderTypesByUid = Record<string, UiOrderType>
 
-export function getOrdersFromTransitionData(orderData: OrderTransitionData[]): EnrichedOrder[] {
-  return orderData.map(({ order }) => order)
-}
-
-export function getOrderTypesByUid(orderData: OrderTransitionData[]): OrderTypesByUid {
-  return orderData.reduce<OrderTypesByUid>((acc, { order, orderType }) => {
-    acc[order.uid] = orderType
-    return acc
-  }, {})
-}
-
 export async function fetchAndClassifyOrder(
   orderFromStore: Order,
   chainId: ChainId,
@@ -57,6 +46,17 @@ export async function fetchAndClassifyOrder(
     )
     return null
   }
+}
+
+export function getOrdersFromTransitionData(orderData: OrderTransitionData[]): EnrichedOrder[] {
+  return orderData.map(({ order }) => order)
+}
+
+export function getOrderTypesByUid(orderData: OrderTransitionData[]): OrderTypesByUid {
+  return orderData.reduce<OrderTypesByUid>((acc, { order, orderType }) => {
+    acc[order.uid] = orderType
+    return acc
+  }, {})
 }
 
 export function getUltimateOrderTradeAmounts({

--- a/apps/cowswap-frontend/src/modules/affiliate/analytics/affiliateAnalytics.utils.ts
+++ b/apps/cowswap-frontend/src/modules/affiliate/analytics/affiliateAnalytics.utils.ts
@@ -40,15 +40,6 @@ export function getAffiliateModalViewKey(
   return [modalState, walletStatus].join(':')
 }
 
-export function trackAffiliateEvent({ analytics, action, chainId, ...customParams }: TrackAffiliateEventParams): void {
-  analytics.sendEvent({
-    category: CowSwapAnalyticsCategory.AFFILIATE,
-    action,
-    chainId,
-    ...customParams,
-  } as GtmEvent<CowSwapAnalyticsCategory.AFFILIATE>)
-}
-
 export function getAffiliatePartnerPageState({
   hasAccount,
   hasExistingCode,
@@ -115,4 +106,13 @@ export function normalizeAffiliatePartnerCodeCreateFailureReason(
     default:
       return AffiliatePartnerCodeCreateFailureReason.UNEXPECTED_ERROR
   }
+}
+
+export function trackAffiliateEvent({ analytics, action, chainId, ...customParams }: TrackAffiliateEventParams): void {
+  analytics.sendEvent({
+    category: CowSwapAnalyticsCategory.AFFILIATE,
+    action,
+    chainId,
+    ...customParams,
+  } as GtmEvent<CowSwapAnalyticsCategory.AFFILIATE>)
 }

--- a/apps/cowswap-frontend/src/modules/balancesAndAllowances/updaters/CommonPriorityBalancesAndAllowancesUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/balancesAndAllowances/updaters/CommonPriorityBalancesAndAllowancesUpdater.tsx
@@ -22,22 +22,6 @@ import { usePriorityTokenAddresses } from 'modules/trade'
 import { useBridgeCustomTokensForChain } from '../hooks/useBridgeCustomTokensForChain'
 import { useOrdersFilledEventsTrigger } from '../hooks/useOrdersFilledEventsTrigger'
 
-// Percentage-based rollout: hashes the wallet address into a stable 0..99
-// bucket and enables the watcher for buckets below `percentage`. Same account
-// -> same bucket, so the toggle is sticky per wallet across sessions/tabs.
-// - 100 -> everyone (including not-yet-connected wallets)
-// - 0 / undefined / out-of-range / non-number -> nobody
-// Non-EVM (e.g. Solana base58) accounts are rejected before BigInt() to avoid
-// a render-time SyntaxError; sourceChainId alone can't guard this because it
-// may be selector-derived while the wallet is on a non-EVM chain.
-function shouldEnableBalancesWatcher(account: string | undefined, percentage: number | boolean | undefined): boolean {
-  if (percentage === 100) return true
-  if (typeof percentage !== 'number' || !account || percentage < 0 || percentage > 100) return false
-  if (!isEvmAddress(account)) return false
-
-  return BigInt(account) % 100n < percentage
-}
-
 export function CommonPriorityBalancesAndAllowancesUpdater(): ReactNode {
   const { chainId: sourceChainId, source: sourceChainSource } = useSourceChainId()
   // Bridge buy-tokens are only meaningful for the output/buy selector. The input/sell selector on a non-wallet chain
@@ -126,4 +110,20 @@ export function CommonPriorityBalancesAndAllowancesUpdater(): ReactNode {
   }
 
   return multicallStack
+}
+
+// Percentage-based rollout: hashes the wallet address into a stable 0..99
+// bucket and enables the watcher for buckets below `percentage`. Same account
+// -> same bucket, so the toggle is sticky per wallet across sessions/tabs.
+// - 100 -> everyone (including not-yet-connected wallets)
+// - 0 / undefined / out-of-range / non-number -> nobody
+// Non-EVM (e.g. Solana base58) accounts are rejected before BigInt() to avoid
+// a render-time SyntaxError; sourceChainId alone can't guard this because it
+// may be selector-derived while the wallet is on a non-EVM chain.
+function shouldEnableBalancesWatcher(account: string | undefined, percentage: number | boolean | undefined): boolean {
+  if (percentage === 100) return true
+  if (typeof percentage !== 'number' || !account || percentage < 0 || percentage > 100) return false
+  if (!isEvmAddress(account)) return false
+
+  return BigInt(account) % 100n < percentage
 }

--- a/apps/cowswap-frontend/src/modules/orders/utils/getOrderTypeForLifecycleEvent.ts
+++ b/apps/cowswap-frontend/src/modules/orders/utils/getOrderTypeForLifecycleEvent.ts
@@ -2,15 +2,11 @@ import { UiOrderType } from '@cowprotocol/types'
 
 import { getUiOrderType, UiOrderTypeParams } from 'utils/orderUtils/getUiOrderType'
 
-export type LifecycleOrderTypeSource = Pick<UiOrderTypeParams, 'class' | 'composableCowInfo' | 'fullAppData'>
-
 export type LifecycleOrderPayloadInput<T extends { order: LifecycleOrderTypeSource }> = Omit<T, 'orderType'> & {
   orderType?: UiOrderType
 }
 
-export function getOrderTypeForLifecycleEvent(order: LifecycleOrderTypeSource): UiOrderType {
-  return getUiOrderType(order)
-}
+export type LifecycleOrderTypeSource = Pick<UiOrderTypeParams, 'class' | 'composableCowInfo' | 'fullAppData'>
 
 export function addOrderTypeToLifecyclePayload<T extends { order: LifecycleOrderTypeSource }>(
   payload: T & { orderType?: UiOrderType },
@@ -19,4 +15,8 @@ export function addOrderTypeToLifecyclePayload<T extends { order: LifecycleOrder
     ...payload,
     orderType: payload.orderType ?? getOrderTypeForLifecycleEvent(payload.order),
   }
+}
+
+export function getOrderTypeForLifecycleEvent(order: LifecycleOrderTypeSource): UiOrderType {
+  return getUiOrderType(order)
 }

--- a/apps/cowswap-frontend/src/modules/tokensList/utils/recentTokensStorage.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/utils/recentTokensStorage.ts
@@ -18,16 +18,6 @@ export interface StoredRecentToken {
 
 export type StoredRecentTokensByChain = Record<number, StoredRecentToken[]>
 
-export function buildTokenKeySet(tokens: TokenWithLogo[]): Set<string> {
-  const set = new Set<string>()
-
-  for (const token of tokens) {
-    set.add(getTokenId(token))
-  }
-
-  return set
-}
-
 export function buildNextStoredTokens(
   prev: StoredRecentTokensByChain,
   token: TokenWithLogo,
@@ -42,6 +32,16 @@ export function buildNextStoredTokens(
     ...prev,
     [chainId]: updatedChain,
   }
+}
+
+export function buildTokenKeySet(tokens: TokenWithLogo[]): Set<string> {
+  const set = new Set<string>()
+
+  for (const token of tokens) {
+    set.add(getTokenId(token))
+  }
+
+  return set
 }
 
 export function buildTokensByKey(tokens: TokenWithLogo[]): Map<string, TokenWithLogo> {

--- a/apps/cowswap-frontend/src/modules/twap/analytics/twapDemandAnalytics.types.ts
+++ b/apps/cowswap-frontend/src/modules/twap/analytics/twapDemandAnalytics.types.ts
@@ -1,3 +1,10 @@
+export interface TwapDemandAnalyticsParams {
+  wallet_type?: TwapDemandWalletType
+  has_form_input?: boolean
+  sell_amount_usd_bucket?: TwapSellAmountUsdBucket
+  encounter_count_bucket?: TwapEncounterCountBucket
+}
+
 export enum TwapDemandAnalyticsEvent {
   UNSUPPORTED_WALLET_SHOWN = 'twap_unsupported_wallet_shown',
   SETUP_LINK_CLICK = 'twap_setup_link_click',
@@ -15,14 +22,6 @@ export enum TwapDemandWalletType {
   UNKNOWN = 'unknown',
 }
 
-export enum TwapSellAmountUsdBucket {
-  NONE = 'none',
-  LT_1K = 'lt_1k',
-  FROM_1K_TO_10K = '1k_10k',
-  FROM_10K_TO_100K = '10k_100k',
-  GT_100K = 'gt_100k',
-}
-
 export enum TwapEncounterCountBucket {
   ONE = '1',
   TWO_TO_THREE = '2_3',
@@ -30,9 +29,10 @@ export enum TwapEncounterCountBucket {
   EIGHT_PLUS = '8_plus',
 }
 
-export interface TwapDemandAnalyticsParams {
-  wallet_type?: TwapDemandWalletType
-  has_form_input?: boolean
-  sell_amount_usd_bucket?: TwapSellAmountUsdBucket
-  encounter_count_bucket?: TwapEncounterCountBucket
+export enum TwapSellAmountUsdBucket {
+  NONE = 'none',
+  LT_1K = 'lt_1k',
+  FROM_1K_TO_10K = '1k_10k',
+  FROM_10K_TO_100K = '10k_100k',
+  GT_100K = 'gt_100k',
 }

--- a/apps/cowswap-frontend/src/modules/twap/analytics/twapDemandAnalytics.utils.ts
+++ b/apps/cowswap-frontend/src/modules/twap/analytics/twapDemandAnalytics.utils.ts
@@ -15,14 +15,56 @@ const SESSION_STORAGE_PREFIX = 'twap-demand-analytics:session:v1'
 const ENCOUNTER_COUNT_STORAGE_PREFIX = 'twap-demand-analytics:unsupported-wallet-encounters:v1'
 const INTEREST_STORAGE_PREFIX = 'twap-demand-analytics:interest:v1'
 
-type BrowserStorageName = 'localStorage' | 'sessionStorage'
-
 export interface GetTwapDemandWalletTypeParams {
   account?: string
   accountType: AccountType | undefined
   isSafeViaWc: boolean
   isSafeWallet: boolean
   isSmartContractWallet: boolean | undefined
+}
+
+type BrowserStorageName = 'localStorage' | 'sessionStorage'
+
+export function getAndIncrementTwapUnsupportedWalletEncounterCountBucket(account?: string): TwapEncounterCountBucket {
+  const storage = getBrowserStorage('localStorage')
+
+  if (!storage) return TwapEncounterCountBucket.ONE
+
+  const key = `${ENCOUNTER_COUNT_STORAGE_PREFIX}:${getTwapDemandAccountKey(account)}`
+  const encounterCount = getStoredCount(storage, key) + 1
+
+  storage.setItem(key, encounterCount.toString())
+
+  return getTwapEncounterCountBucket(encounterCount)
+}
+
+export function getHasTwapFormInput(
+  inputAmount: CurrencyAmount<Currency> | null | undefined,
+  outputAmount: CurrencyAmount<Currency> | null | undefined,
+): boolean {
+  return !isFractionFalsy(inputAmount) || !isFractionFalsy(outputAmount)
+}
+
+export function getIsTwapDemandWalletTypePending(params: GetTwapDemandWalletTypeParams): boolean {
+  const { account, accountType, isSafeViaWc, isSafeWallet } = params
+
+  if (!account) return false
+  if (isSafeWallet) return false
+  if (isSafeViaWc) return accountType === undefined
+
+  return accountType === undefined
+}
+
+export function getIsTwapInterestRegistered(account?: string): boolean {
+  const storage = getBrowserStorage('localStorage')
+
+  if (!storage) return false
+
+  return storage.getItem(getTwapInterestStorageKey(account)) === '1'
+}
+
+export function getTwapDemandSessionStorageKey(action: TwapDemandAnalyticsEvent, account?: string): string {
+  return `${SESSION_STORAGE_PREFIX}:${action}:${getTwapDemandAccountKey(account)}`
 }
 
 export function getTwapDemandWalletType(params: GetTwapDemandWalletTypeParams): TwapDemandWalletType {
@@ -48,21 +90,12 @@ export function getTwapDemandWalletType(params: GetTwapDemandWalletTypeParams): 
   return TwapDemandWalletType.UNKNOWN
 }
 
-export function getIsTwapDemandWalletTypePending(params: GetTwapDemandWalletTypeParams): boolean {
-  const { account, accountType, isSafeViaWc, isSafeWallet } = params
+export function getTwapEncounterCountBucket(encounterCount: number): TwapEncounterCountBucket {
+  if (encounterCount <= 1) return TwapEncounterCountBucket.ONE
+  if (encounterCount <= 3) return TwapEncounterCountBucket.TWO_TO_THREE
+  if (encounterCount <= 7) return TwapEncounterCountBucket.FOUR_TO_SEVEN
 
-  if (!account) return false
-  if (isSafeWallet) return false
-  if (isSafeViaWc) return accountType === undefined
-
-  return accountType === undefined
-}
-
-export function getHasTwapFormInput(
-  inputAmount: CurrencyAmount<Currency> | null | undefined,
-  outputAmount: CurrencyAmount<Currency> | null | undefined,
-): boolean {
-  return !isFractionFalsy(inputAmount) || !isFractionFalsy(outputAmount)
+  return TwapEncounterCountBucket.EIGHT_PLUS
 }
 
 export function getTwapSellAmountUsdBucket(
@@ -78,18 +111,6 @@ export function getTwapSellAmountUsdBucket(
   return TwapSellAmountUsdBucket.GT_100K
 }
 
-export function getTwapEncounterCountBucket(encounterCount: number): TwapEncounterCountBucket {
-  if (encounterCount <= 1) return TwapEncounterCountBucket.ONE
-  if (encounterCount <= 3) return TwapEncounterCountBucket.TWO_TO_THREE
-  if (encounterCount <= 7) return TwapEncounterCountBucket.FOUR_TO_SEVEN
-
-  return TwapEncounterCountBucket.EIGHT_PLUS
-}
-
-export function getTwapDemandSessionStorageKey(action: TwapDemandAnalyticsEvent, account?: string): string {
-  return `${SESSION_STORAGE_PREFIX}:${action}:${getTwapDemandAccountKey(account)}`
-}
-
 export function markTwapDemandEventTrackedInSession(storageKey: string): boolean {
   const storage = getBrowserStorage('sessionStorage')
 
@@ -101,48 +122,12 @@ export function markTwapDemandEventTrackedInSession(storageKey: string): boolean
   return true
 }
 
-export function getAndIncrementTwapUnsupportedWalletEncounterCountBucket(account?: string): TwapEncounterCountBucket {
-  const storage = getBrowserStorage('localStorage')
-
-  if (!storage) return TwapEncounterCountBucket.ONE
-
-  const key = `${ENCOUNTER_COUNT_STORAGE_PREFIX}:${getTwapDemandAccountKey(account)}`
-  const encounterCount = getStoredCount(storage, key) + 1
-
-  storage.setItem(key, encounterCount.toString())
-
-  return getTwapEncounterCountBucket(encounterCount)
-}
-
-export function getIsTwapInterestRegistered(account?: string): boolean {
-  const storage = getBrowserStorage('localStorage')
-
-  if (!storage) return false
-
-  return storage.getItem(getTwapInterestStorageKey(account)) === '1'
-}
-
 export function registerTwapInterest(account?: string): void {
   const storage = getBrowserStorage('localStorage')
 
   if (!storage) return
 
   storage.setItem(getTwapInterestStorageKey(account), '1')
-}
-
-function getTwapDemandAccountKey(account?: string): string {
-  return account ? getAddressKey(account) : UNKNOWN_ACCOUNT_KEY
-}
-
-function getTwapInterestStorageKey(account?: string): string {
-  return `${INTEREST_STORAGE_PREFIX}:${getTwapDemandAccountKey(account)}`
-}
-
-function getStoredCount(storage: Storage, key: string): number {
-  const storedValue = storage.getItem(key)
-  const parsedValue = storedValue ? Number.parseInt(storedValue, 10) : 0
-
-  return Number.isFinite(parsedValue) && parsedValue > 0 ? parsedValue : 0
 }
 
 function getBrowserStorage(storageName: BrowserStorageName): Storage | null {
@@ -153,4 +138,19 @@ function getBrowserStorage(storageName: BrowserStorageName): Storage | null {
   } catch {
     return null
   }
+}
+
+function getStoredCount(storage: Storage, key: string): number {
+  const storedValue = storage.getItem(key)
+  const parsedValue = storedValue ? Number.parseInt(storedValue, 10) : 0
+
+  return Number.isFinite(parsedValue) && parsedValue > 0 ? parsedValue : 0
+}
+
+function getTwapDemandAccountKey(account?: string): string {
+  return account ? getAddressKey(account) : UNKNOWN_ACCOUNT_KEY
+}
+
+function getTwapInterestStorageKey(account?: string): string {
+  return `${INTEREST_STORAGE_PREFIX}:${getTwapDemandAccountKey(account)}`
 }

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useTwapDemandAnalytics.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useTwapDemandAnalytics.ts
@@ -29,11 +29,6 @@ import {
   registerTwapInterest,
 } from '../analytics/twapDemandAnalytics.utils'
 
-interface UnsupportedWalletShownParams {
-  hasFormInput: boolean
-  sellAmountUsdBucket: TwapSellAmountUsdBucket
-}
-
 interface InterestClickParams {
   sellAmountUsdBucket: TwapSellAmountUsdBucket
 }
@@ -48,6 +43,11 @@ interface TwapDemandAnalytics {
   trackSetupLinkClick(): void
   trackTwapTabOpened(): void
   trackUnsupportedWalletShown(params: UnsupportedWalletShownParams): void
+}
+
+interface UnsupportedWalletShownParams {
+  hasFormInput: boolean
+  sellAmountUsdBucket: TwapSellAmountUsdBucket
 }
 
 const INTEREST_THANKS_VISIBLE_MS = ms`10s`
@@ -144,41 +144,23 @@ export function useTwapDemandAnalytics(): TwapDemandAnalytics {
   }
 }
 
-function useTwapInterestButtonState(account?: string): {
-  hideRegisteredInterest(): void
-  isInterestButtonVisible: boolean
-  isInterestRegistered: boolean
-  showRegisteredInterest(): void
-} {
-  const [isInterestRegistered, setIsInterestRegistered] = useState(() => getIsTwapInterestRegistered(account))
-  const [isInterestButtonVisible, setIsInterestButtonVisible] = useState(() => !getIsTwapInterestRegistered(account))
+function useTrackTwapDemandEventOncePerSession(
+  account?: string,
+): (action: TwapDemandAnalyticsEvent, trackEvent: () => void) => void {
+  const fallbackSessionKeys = useRef<Set<string>>(new Set())
 
-  useEffect(() => {
-    const isRegistered = getIsTwapInterestRegistered(account)
+  return useCallback(
+    (action: TwapDemandAnalyticsEvent, trackEvent: () => void) => {
+      const storageKey = getTwapDemandSessionStorageKey(action, account)
 
-    setIsInterestRegistered(isRegistered)
-    setIsInterestButtonVisible(!isRegistered)
-  }, [account])
+      if (fallbackSessionKeys.current.has(storageKey)) return
+      if (!markTwapDemandEventTrackedInSession(storageKey)) return
 
-  useEffect(() => {
-    if (!isInterestRegistered || !isInterestButtonVisible) return
-
-    const timeout = setTimeout(() => setIsInterestButtonVisible(false), INTEREST_THANKS_VISIBLE_MS)
-
-    return () => clearTimeout(timeout)
-  }, [isInterestButtonVisible, isInterestRegistered])
-
-  const hideRegisteredInterest = useCallback(() => {
-    setIsInterestRegistered(true)
-    setIsInterestButtonVisible(false)
-  }, [])
-
-  const showRegisteredInterest = useCallback(() => {
-    setIsInterestRegistered(true)
-    setIsInterestButtonVisible(true)
-  }, [])
-
-  return { hideRegisteredInterest, isInterestButtonVisible, isInterestRegistered, showRegisteredInterest }
+      fallbackSessionKeys.current.add(storageKey)
+      trackEvent()
+    },
+    [account],
+  )
 }
 
 function useTwapDemandWalletType(account?: string): {
@@ -214,21 +196,39 @@ function useTwapDemandWalletType(account?: string): {
   return { isSafeViaWc, isWalletTypePending, walletType }
 }
 
-function useTrackTwapDemandEventOncePerSession(
-  account?: string,
-): (action: TwapDemandAnalyticsEvent, trackEvent: () => void) => void {
-  const fallbackSessionKeys = useRef<Set<string>>(new Set())
+function useTwapInterestButtonState(account?: string): {
+  hideRegisteredInterest(): void
+  isInterestButtonVisible: boolean
+  isInterestRegistered: boolean
+  showRegisteredInterest(): void
+} {
+  const [isInterestRegistered, setIsInterestRegistered] = useState(() => getIsTwapInterestRegistered(account))
+  const [isInterestButtonVisible, setIsInterestButtonVisible] = useState(() => !getIsTwapInterestRegistered(account))
 
-  return useCallback(
-    (action: TwapDemandAnalyticsEvent, trackEvent: () => void) => {
-      const storageKey = getTwapDemandSessionStorageKey(action, account)
+  useEffect(() => {
+    const isRegistered = getIsTwapInterestRegistered(account)
 
-      if (fallbackSessionKeys.current.has(storageKey)) return
-      if (!markTwapDemandEventTrackedInSession(storageKey)) return
+    setIsInterestRegistered(isRegistered)
+    setIsInterestButtonVisible(!isRegistered)
+  }, [account])
 
-      fallbackSessionKeys.current.add(storageKey)
-      trackEvent()
-    },
-    [account],
-  )
+  useEffect(() => {
+    if (!isInterestRegistered || !isInterestButtonVisible) return
+
+    const timeout = setTimeout(() => setIsInterestButtonVisible(false), INTEREST_THANKS_VISIBLE_MS)
+
+    return () => clearTimeout(timeout)
+  }, [isInterestButtonVisible, isInterestRegistered])
+
+  const hideRegisteredInterest = useCallback(() => {
+    setIsInterestRegistered(true)
+    setIsInterestButtonVisible(false)
+  }, [])
+
+  const showRegisteredInterest = useCallback(() => {
+    setIsInterestRegistered(true)
+    setIsInterestButtonVisible(true)
+  }, [])
+
+  return { hideRegisteredInterest, isInterestButtonVisible, isInterestRegistered, showRegisteredInterest }
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -94,7 +94,7 @@ module.exports = [
     plugins: { perfectionist },
     rules: {
       'perfectionist/sort-modules': [
-        'warn',
+        'error',
         {
           groups: [
             ['export-interface', 'export-type'],

--- a/libs/analytics/src/widget/orderLifecycleAnalytics.ts
+++ b/libs/analytics/src/widget/orderLifecycleAnalytics.ts
@@ -24,8 +24,8 @@ type EnrichedOrderWithTokens = EnrichedOrder & {
   outputToken?: TokenInfo
 }
 
-type RawAmount = string | number | bigint | null | undefined
 type OrderTypeAnalyticsField = { orderType?: UiOrderType }
+type RawAmount = string | number | bigint | null | undefined
 
 type Tokenish = {
   address?: string

--- a/libs/balances-and-allowances/src/balancesWatcher/clientId.test.ts
+++ b/libs/balances-and-allowances/src/balancesWatcher/clientId.test.ts
@@ -3,10 +3,6 @@ import ms from 'ms.macro'
 const STORAGE_KEY = 'balances-watcher-client-id'
 const TTL_MS = ms`1 day`
 
-function store(id: string, createdAt: number): void {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify({ id, createdAt }))
-}
-
 // The module caches the client id at first call for the lifetime of the tab,
 // so each test needs a fresh module instance to exercise the read/generate
 // branch from a clean slate.
@@ -16,6 +12,10 @@ function loadModule(): typeof import('./clientId') {
     mod = require('./clientId')
   })
   return mod
+}
+
+function store(id: string, createdAt: number): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify({ id, createdAt }))
 }
 
 describe('getBalancesWatcherClientId', () => {

--- a/libs/balances-and-allowances/src/balancesWatcher/clientId.ts
+++ b/libs/balances-and-allowances/src/balancesWatcher/clientId.ts
@@ -30,21 +30,8 @@ export function getBalancesWatcherClientId(): string {
   return fresh.id
 }
 
-function readStored(): StoredClientId | null {
-  try {
-    return parseStored(localStorage.getItem(STORAGE_KEY))
-  } catch {
-    return null
-  }
-}
-
-function tryPersist(entry: StoredClientId): void {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(entry))
-  } catch {
-    // Storage disabled (private mode / quota / blocked). The in-memory cache
-    // above still keeps the id stable for this tab.
-  }
+function isExpired(entry: StoredClientId): boolean {
+  return Date.now() - entry.createdAt >= CLIENT_ID_TTL_MS
 }
 
 function parseStored(raw: string | null): StoredClientId | null {
@@ -65,6 +52,19 @@ function parseStored(raw: string | null): StoredClientId | null {
   return null
 }
 
-function isExpired(entry: StoredClientId): boolean {
-  return Date.now() - entry.createdAt >= CLIENT_ID_TTL_MS
+function readStored(): StoredClientId | null {
+  try {
+    return parseStored(localStorage.getItem(STORAGE_KEY))
+  } catch {
+    return null
+  }
+}
+
+function tryPersist(entry: StoredClientId): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entry))
+  } catch {
+    // Storage disabled (private mode / quota / blocked). The in-memory cache
+    // above still keeps the id stable for this tab.
+  }
 }

--- a/libs/common-utils/src/getIsSafeAppIframe.ts
+++ b/libs/common-utils/src/getIsSafeAppIframe.ts
@@ -10,9 +10,12 @@ const SAFE_APP_PREVIEW_URLS = [
 const SAFE_APP_PREVIEW_HOST_SUFFIX = '.review.5afe.dev' // Safe's per-PR review env
 const SAFE_APP_LOCAL_URL1 = 'http://localhost:4003'
 const SAFE_APP_LOCAL_URL2 = 'http://localhost:8080'
-const SAFE_SUPPORTED_ORIGINS = [SAFE_APP_ORIGIN, ...SAFE_APP_PREVIEW_URLS, SAFE_APP_LOCAL_URL1, SAFE_APP_LOCAL_URL2].map(
-  (origin) => new URL(origin).origin,
-)
+const SAFE_SUPPORTED_ORIGINS = [
+  SAFE_APP_ORIGIN,
+  ...SAFE_APP_PREVIEW_URLS,
+  SAFE_APP_LOCAL_URL1,
+  SAFE_APP_LOCAL_URL2,
+].map((origin) => new URL(origin).origin)
 
 export function getIsSafeAppIframe(): boolean {
   const origin = getParentOrigin()

--- a/libs/common-utils/src/misc.ts
+++ b/libs/common-utils/src/misc.ts
@@ -26,7 +26,14 @@ export const isTruthy = <T>(value: T | null | undefined | false): value is T => 
 export const delay = <T = void>(ms = 100, result?: T): Promise<T> =>
   new Promise((resolve) => setTimeout(resolve, ms, result))
 
+interface TimeoutOptions {
+  timeout: number
+  timeoutMessage: string
+}
+
 type WindowWithMapping = Window & typeof globalThis & Record<string, unknown>
+
+export class TimeoutError extends Error {}
 
 // TODO: Add proper return type annotation
 // TODO: Replace any with proper type definitions
@@ -58,13 +65,6 @@ export function isPromiseFulfilled<T>(
   promiseResult: PromiseSettledResult<T>,
 ): promiseResult is PromiseFulfilledResult<T> {
   return promiseResult.status === 'fulfilled'
-}
-
-export class TimeoutError extends Error {}
-
-interface TimeoutOptions {
-  timeout: number
-  timeoutMessage: string
 }
 
 export async function withTimeout<T>(promise: Promise<T>, options: TimeoutOptions): Promise<T> {


### PR DESCRIPTION
# Summary

Change sort-modules rule from warn to error and run `lint:fix`.

# To Test

Nothing to test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Reorganized internal code declarations and helper ordering across analytics, orders, balances, tokens, and TWAP modules.
  - Improved code-style enforcement by making module-order violations ESLint errors.
  - Applied minor formatting and readability updates without changing application behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->