### PR TITLE
fix(order-progress): match countdown to reduced solve deadlines

### DIFF
--- a/apps/cowswap-frontend/src/modules/orderProgressBar/constants.ts
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/constants.ts
@@ -35,6 +35,10 @@ export enum OrderProgressBarStepName {
 
 export const DEFAULT_STEP_NAME: OrderProgressBarStepName = OrderProgressBarStepName.INITIAL
 
+// Progress bar countdown durations, matching the solve deadlines per chain (in seconds)
+const PROGRESS_BAR_TIMER_DURATION_MAINNET = 10
+const PROGRESS_BAR_TIMER_DURATION_DEFAULT = 7
+
 /**
  * Visual states for progress bar steps UI presentation.
  * These are purely for styling and visual feedback, determining:
@@ -54,9 +58,15 @@ export enum StepStatus {
   FUTURE = 'future',
   DONE = 'done',
 }
-type BridgeStepConfig = (isBridgingTrade: boolean) => StepConfig
 
+type BridgeStepConfig = (isBridgingTrade: boolean) => StepConfig
 type StepConfig = { title: MessageDescriptor; description?: MessageDescriptor }
+
+export function getProgressBarTimerDuration(chainId: SupportedChainId): number {
+  return chainId === SupportedChainId.MAINNET
+    ? PROGRESS_BAR_TIMER_DURATION_MAINNET
+    : PROGRESS_BAR_TIMER_DURATION_DEFAULT
+}
 
 export const STEPS: (StepConfig | BridgeStepConfig)[] = [
   {

--- a/apps/cowswap-frontend/src/modules/orderProgressBar/hooks/useOrderProgressBarProps.ts
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/hooks/useOrderProgressBarProps.ts
@@ -28,7 +28,7 @@ import { ActivityDerivedState } from 'common/types/activity'
 import { ApiSolverCompetition, SolverCompetition } from 'common/types/soverCompetition'
 import { getIsFinalizedOrder } from 'utils/orderUtils/getIsFinalizedOrder'
 
-import { DEFAULT_STEP_NAME, OrderProgressBarStepName } from '../constants'
+import { DEFAULT_STEP_NAME, getProgressBarTimerDuration, OrderProgressBarStepName } from '../constants'
 import {
   ordersProgressBarStateAtom,
   setOrderProgressBarCancellationTriggered,
@@ -53,7 +53,6 @@ type UseOrderProgressBarPropsParams = {
 }
 
 const MINIMUM_STEP_DISPLAY_TIME = ms`5s`
-export const PROGRESS_BAR_TIMER_DURATION = 15 // in seconds
 
 /**
  * Hook for fetching ProgressBar props
@@ -232,6 +231,7 @@ function useOrderBaseProgressBarProps(params: UseOrderProgressBarPropsParams): U
     countdown,
     backendApiStatus,
     isUnfillable || isCancelled || isCancelling || isExpired,
+    chainId,
   )
 
   return useMemo(() => {
@@ -369,6 +369,7 @@ function useCountdownStartUpdater(
   countdown: OrderProgressBarState['countdown'],
   backendApiStatus: OrderProgressBarState['backendApiStatus'],
   shouldDisableCountdown: boolean,
+  chainId: SupportedChainId,
 ): void {
   const setCountdown = useSetExecutingOrderCountdownCallback()
 
@@ -388,12 +389,12 @@ function useCountdownStartUpdater(
     // Start countdown immediately when backend becomes active to reflect real protocol timing
     // The solver competition genuinely starts when backend is active, regardless of UI delays
     if (countdown == null && backendApiStatus === CompetitionOrderStatus.type.ACTIVE) {
-      setCountdown(orderId, PROGRESS_BAR_TIMER_DURATION)
+      setCountdown(orderId, getProgressBarTimerDuration(chainId))
     } else if (backendApiStatus !== CompetitionOrderStatus.type.ACTIVE && countdown != null) {
       // Every time backend status is not `active` and countdown is set, reset the countdown
       setCountdown(orderId, null)
     }
-  }, [backendApiStatus, setCountdown, countdown, orderId, shouldDisableCountdown])
+  }, [backendApiStatus, setCountdown, countdown, orderId, shouldDisableCountdown, chainId])
 }
 
 // local updaters

--- a/apps/cowswap-frontend/src/modules/orderProgressBar/pure/ProgressTopSection/index.tsx
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/pure/ProgressTopSection/index.tsx
@@ -1,6 +1,6 @@
 import type { Order } from 'legacy/state/orders/actions'
 
-import { OrderProgressBarStepName } from '../../types'
+import { OrderProgressBarProps, OrderProgressBarStepName } from '../../types'
 import { ProgressImageWrapper } from '../ProgressImageWrapper'
 import {
   CancelledCancellingTopSection,
@@ -17,6 +17,7 @@ export interface ProgressTopSectionProps {
   stepName: OrderProgressBarStepName
   order: Order | undefined
   countdown: number
+  chainId: OrderProgressBarProps['chainId']
   randomImage: string
   shouldShowSurplus: boolean | undefined | null
   surplusPercentValue: string
@@ -33,6 +34,7 @@ export function ProgressTopSection({
   stepName,
   order,
   countdown,
+  chainId,
   randomImage,
   randomBenefit,
   shouldShowSurplus,
@@ -61,7 +63,7 @@ export function ProgressTopSection({
   if (stepName === 'solving') {
     return (
       <ProgressImageWrapper stepName={stepName}>
-        <SolvingTopSection countdown={countdown} />
+        <SolvingTopSection countdown={countdown} chainId={chainId} />
       </ProgressImageWrapper>
     )
   }

--- a/apps/cowswap-frontend/src/modules/orderProgressBar/pure/RenderProgressTopSection.tsx
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/pure/RenderProgressTopSection.tsx
@@ -20,6 +20,7 @@ interface ProgressContentProps {
   stepName: OrderProgressBarProps['stepName']
   order: OrderProgressBarProps['order']
   countdown: number
+  chainId: OrderProgressBarProps['chainId']
   randomImage: string
   surplusPercentValue: string
   randomBenefit: string
@@ -66,6 +67,7 @@ export function RenderProgressTopSection({
     stepName,
     order,
     countdown: countdown || 0,
+    chainId,
     randomImage,
     surplusPercentValue,
     randomBenefit,
@@ -94,6 +96,7 @@ function ProgressContent({
   stepName,
   order,
   countdown,
+  chainId,
   randomImage,
   surplusPercentValue,
   randomBenefit,
@@ -125,6 +128,7 @@ function ProgressContent({
               stepName={stepName}
               order={order}
               countdown={countdown}
+              chainId={chainId}
               randomImage={randomImage}
               surplusPercentValue={surplusPercentValue}
               randomBenefit={randomBenefit}

--- a/apps/cowswap-frontend/src/modules/orderProgressBar/pure/RenderProgressTopSection.tsx
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/pure/RenderProgressTopSection.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useMemo, lazy, Suspense } from 'react'
 
 import { getRandomInt } from '@cowprotocol/common-utils'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import { useLingui } from '@lingui/react/macro'
 import { useInjectedWidgetParams } from 'entities/injectedWidget'
@@ -20,7 +21,7 @@ interface ProgressContentProps {
   stepName: OrderProgressBarProps['stepName']
   order: OrderProgressBarProps['order']
   countdown: number
-  chainId: OrderProgressBarProps['chainId']
+  chainId: SupportedChainId
   randomImage: string
   surplusPercentValue: string
   randomBenefit: string

--- a/apps/cowswap-frontend/src/modules/orderProgressBar/pure/TopSections.tsx
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/pure/TopSections.tsx
@@ -39,6 +39,7 @@ interface InitialTopSectionProps extends BaseTopSectionProps {
 
 interface SolvingTopSectionProps {
   countdown: number
+  chainId: OrderProgressBarProps['chainId']
 }
 
 // delayed, submissionFailed, solved
@@ -163,7 +164,7 @@ export function InitialTopSection({ stepName, order }: InitialTopSectionProps): 
   )
 }
 
-export function SolvingTopSection({ countdown }: SolvingTopSectionProps): ReactNode {
+export function SolvingTopSection({ countdown, chainId }: SolvingTopSectionProps): ReactNode {
   return (
     <div
       style={{
@@ -181,6 +182,7 @@ export function SolvingTopSection({ countdown }: SolvingTopSectionProps): ReactN
       />
       <CircularCountdown
         countdown={countdown || 0}
+        chainId={chainId}
         isDelayed={countdown === 0}
         bgColor={PROCESS_IMAGE_WRAPPER_BG_COLOR.solving}
       />

--- a/apps/cowswap-frontend/src/modules/orderProgressBar/pure/TopSections.tsx
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/pure/TopSections.tsx
@@ -5,6 +5,7 @@ import svgProgressbarStepExpiredSrc from '@cowprotocol/assets/cow-swap/progressb
 import svgProgressbarStepSolvingSrc from '@cowprotocol/assets/cow-swap/progressbar-step-solving.svg'
 import svgProgressbarStepUnfillableSrc from '@cowprotocol/assets/cow-swap/progressbar-step-unfillable.svg'
 import LOTTIE_TIME_EXPIRED_DARK from '@cowprotocol/assets/lottie/time-expired-dark.json'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { ProductLogo, ProductVariant, UI } from '@cowprotocol/ui'
 
 import { t } from '@lingui/core/macro'
@@ -39,7 +40,7 @@ interface InitialTopSectionProps extends BaseTopSectionProps {
 
 interface SolvingTopSectionProps {
   countdown: number
-  chainId: OrderProgressBarProps['chainId']
+  chainId: SupportedChainId
 }
 
 // delayed, submissionFailed, solved

--- a/apps/cowswap-frontend/src/modules/orderProgressBar/pure/steps/CircularCountdown.tsx
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/pure/steps/CircularCountdown.tsx
@@ -1,16 +1,19 @@
 import { ReactElement } from 'react'
 
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
 import * as styledEl from './styled'
 
-import { PROGRESS_BAR_TIMER_DURATION } from '../../hooks/useOrderProgressBarProps'
+import { getProgressBarTimerDuration } from '../../constants'
 
 interface CircularCountdownProps {
   countdown: number
+  chainId: SupportedChainId
   isDelayed?: boolean
   bgColor?: string
 }
 
-export function CircularCountdown({ countdown, isDelayed, bgColor }: CircularCountdownProps): ReactElement {
+export function CircularCountdown({ countdown, chainId, isDelayed, bgColor }: CircularCountdownProps): ReactElement {
   const radius = 45
   const circumference = 2 * Math.PI * radius
   const displayValue = Math.max(countdown, 1)
@@ -25,7 +28,7 @@ export function CircularCountdown({ countdown, isDelayed, bgColor }: CircularCou
           r={radius}
           strokeDasharray={circumference}
           startAt={countdown}
-          end={PROGRESS_BAR_TIMER_DURATION}
+          end={getProgressBarTimerDuration(chainId)}
         />
       </styledEl.CircularProgress>
       <styledEl.CountdownText $shouldPulse={shouldPulse}>{displayValue}</styledEl.CountdownText>


### PR DESCRIPTION
Closes #7808

The order progress bar countdown was a flat 15s on every chain, so orders were shown with several seconds still on the clock after they had already settled under the reduced solve deadlines.

This sets the countdown to **10s on mainnet** and **7s on all other chains**, via a `getProgressBarTimerDuration(chainId)` helper. The circular countdown animation uses the same per-chain duration so its scale stays correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Updated the order progress countdown to use network-specific timing.
  * Updated the circular countdown to reflect the connected network’s duration.
  * Ensured progress steps respect a consistent minimum display time for smoother visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->