### PR TITLE
fix(order-progress): show cancelling screen from unfillable step

### DIFF
--- a/apps/cowswap-frontend/src/modules/orderProgressBar/hooks/useOrderProgressBarProps.test.ts
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/hooks/useOrderProgressBarProps.test.ts
@@ -1,4 +1,4 @@
-import { getProgressBarStepName } from './useOrderProgressBarProps'
+import { getProgressBarStepName, shouldUpdateStepImmediately } from './useOrderProgressBarProps'
 
 import { OrderProgressBarStepName } from '../constants'
 import { OrderProgressBarState } from '../types'
@@ -59,5 +59,38 @@ describe('getProgressBarStepName', () => {
     })
 
     expect(result).toBe(OrderProgressBarStepName.EXECUTING)
+  })
+})
+
+describe('shouldUpdateStepImmediately', () => {
+  const MINIMUM_STEP_DISPLAY_TIME = 5000 // ms`5s`
+  const RECENT_CHANGE = 1000 // less than MINIMUM_STEP_DISPLAY_TIME
+
+  it('bypasses the debounce for cancellation and terminal steps even when the last change is recent', () => {
+    const immediateSteps = [
+      OrderProgressBarStepName.CANCELLING,
+      OrderProgressBarStepName.CANCELLED,
+      OrderProgressBarStepName.CANCELLATION_FAILED,
+      OrderProgressBarStepName.EXPIRED,
+      OrderProgressBarStepName.FINISHED,
+    ]
+
+    immediateSteps.forEach((stepName) => {
+      expect(shouldUpdateStepImmediately(stepName, Date.now(), RECENT_CHANGE)).toBe(true)
+    })
+  })
+
+  it('debounces a normal step when the previous step was shown less than the minimum display time ago', () => {
+    expect(shouldUpdateStepImmediately(OrderProgressBarStepName.SOLVING, Date.now(), RECENT_CHANGE)).toBe(false)
+  })
+
+  it('shows a normal step immediately once the minimum display time has elapsed', () => {
+    expect(shouldUpdateStepImmediately(OrderProgressBarStepName.SOLVING, Date.now(), MINIMUM_STEP_DISPLAY_TIME)).toBe(
+      true,
+    )
+  })
+
+  it('shows the first step immediately when there is no previous change timestamp', () => {
+    expect(shouldUpdateStepImmediately(OrderProgressBarStepName.SOLVING, undefined, 0)).toBe(true)
   })
 })

--- a/apps/cowswap-frontend/src/modules/orderProgressBar/hooks/useOrderProgressBarProps.ts
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/hooks/useOrderProgressBarProps.ts
@@ -54,6 +54,15 @@ type UseOrderProgressBarPropsParams = {
 
 const MINIMUM_STEP_DISPLAY_TIME = ms`5s`
 
+// Steps that should be shown immediately, bypassing the minimum step-display debounce
+const IMMEDIATE_STEP_NAMES: OrderProgressBarStepName[] = [
+  OrderProgressBarStepName.FINISHED,
+  OrderProgressBarStepName.CANCELLATION_FAILED,
+  OrderProgressBarStepName.CANCELLING,
+  OrderProgressBarStepName.CANCELLED,
+  OrderProgressBarStepName.EXPIRED,
+]
+
 /**
  * Hook for fetching ProgressBar props
  * TODO FIXME: refactor this
@@ -459,10 +468,7 @@ function useProgressBarStepNameUpdater(
     if (
       lastTimeChangedSteps === undefined ||
       timeSinceLastChange >= MINIMUM_STEP_DISPLAY_TIME ||
-      stepName === OrderProgressBarStepName.FINISHED ||
-      stepName === OrderProgressBarStepName.CANCELLATION_FAILED ||
-      stepName === OrderProgressBarStepName.CANCELLED ||
-      stepName === OrderProgressBarStepName.EXPIRED
+      IMMEDIATE_STEP_NAMES.includes(stepName)
     ) {
       updateStepName(stepName)
 

--- a/apps/cowswap-frontend/src/modules/orderProgressBar/hooks/useOrderProgressBarProps.ts
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/hooks/useOrderProgressBarProps.ts
@@ -63,6 +63,20 @@ const IMMEDIATE_STEP_NAMES: OrderProgressBarStepName[] = [
   OrderProgressBarStepName.EXPIRED,
 ]
 
+// A step is shown immediately when it's the first change, when the previous step has been
+// displayed long enough, or when it's a terminal/cancellation step that must not be debounced.
+export function shouldUpdateStepImmediately(
+  stepName: OrderProgressBarStepName,
+  lastTimeChangedSteps: number | undefined,
+  timeSinceLastChange: number,
+): boolean {
+  return (
+    lastTimeChangedSteps === undefined ||
+    timeSinceLastChange >= MINIMUM_STEP_DISPLAY_TIME ||
+    IMMEDIATE_STEP_NAMES.includes(stepName)
+  )
+}
+
 /**
  * Hook for fetching ProgressBar props
  * TODO FIXME: refactor this
@@ -465,11 +479,7 @@ function useProgressBarStepNameUpdater(
 
     const timeSinceLastChange = lastTimeChangedSteps ? Date.now() - lastTimeChangedSteps : 0
 
-    if (
-      lastTimeChangedSteps === undefined ||
-      timeSinceLastChange >= MINIMUM_STEP_DISPLAY_TIME ||
-      IMMEDIATE_STEP_NAMES.includes(stepName)
-    ) {
+    if (shouldUpdateStepImmediately(stepName, lastTimeChangedSteps, timeSinceLastChange)) {
       updateStepName(stepName)
 
       // schedule update for temporary steps


### PR DESCRIPTION
Closes #6881

When an order is showing the *unfillable / price out of market* screen and the user cancels it, the cancelling screen was never shown — the progress bar jumped straight from unfillable to cancelled.

Cause: the minimum step-display debounce delays a step change if the previous step was shown for less than the minimum time. `CANCELLING` was not in the list of steps exempt from this debounce, so the delayed update was still pending when the order reached the cancelled state, and it got cleared before firing.

Fix: show `CANCELLING` immediately, alongside the other terminal user-facing steps (finished, cancelled, expired, cancellation failed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the order progress bar so cancellation/terminal and early step transitions render immediately, rather than waiting for the minimum-display debounce.
  * Preserved debounce behavior for normal intermediate steps until the minimum display time has elapsed.
* **Tests**
  * Added/expanded unit tests covering immediate vs debounced step updates, including recent changes, elapsed minimum time, and first-step rendering when no prior timestamp exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->