### PR TITLE
fix(token-selector): show sell network panel for Rabby with Safe imported

### DIFF
--- a/apps/cowswap-frontend/src/modules/tokensList/containers/SelectTokenWidget/hooks/useChainPanelState.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/containers/SelectTokenWidget/hooks/useChainPanelState.ts
@@ -5,11 +5,12 @@ import { useMemo } from 'react'
 
 import { useIsBridgingEnabled } from '@cowprotocol/common-hooks'
 import { ChainInfo } from '@cowprotocol/cow-sdk'
-import { useIsSmartContractWallet } from '@cowprotocol/wallet'
 
 import { Field } from 'legacy/state/types'
 
 import { TradeType } from 'modules/trade'
+
+import { useShouldHideNetworkSelector } from 'common/hooks/useShouldHideNetworkSelector'
 
 import { useChainsToSelect } from '../../../hooks/useChainsToSelect'
 import { useOnSelectChain } from '../../../hooks/useOnSelectChain'
@@ -28,13 +29,15 @@ export function useChainPanelState(tradeType: TradeType | undefined, field?: Fie
   const chainsToSelect = useChainsToSelect()
   const onSelectChain = useOnSelectChain()
   const isBridgeFeatureEnabled = useIsBridgingEnabled()
-  const isSmartContractWallet = useIsSmartContractWallet()
+  // Hide the sell (INPUT) network panel only for wallets locked to a single chain (e.g. Safe app / Safe via WC),
+  // consistently with the main network selector. Notably Rabby (even with a Safe imported) is not locked.
+  const shouldHideNetworkSelector = useShouldHideNetworkSelector()
 
   const shouldDisableForYield = tradeType === TradeType.YIELD && !ENABLE_YIELD_CHAIN_PANEL
-  const shouldDisableForSmartContractWallet = field === Field.INPUT && isSmartContractWallet
+  const shouldDisableForSellField = field === Field.INPUT && shouldHideNetworkSelector
 
   const isEnabled =
-    !shouldDisableForSmartContractWallet &&
+    !shouldDisableForSellField &&
     isBridgeFeatureEnabled &&
     Boolean(chainsToSelect?.chains?.length) &&
     !shouldDisableForYield


### PR DESCRIPTION
Closes #7292

When connecting with Rabby using an imported Safe account, the sell token selector did not show the networks panel.

The sell (input) chain panel in `useChainPanelState` was gated on `useIsSmartContractWallet`, which is true for Rabby whenever a Safe is imported. That is inconsistent with the rest of the app: both the main network selector (`useShouldHideNetworkSelector`) and `useChainsToSelect` only hide network switching for wallets that are actually locked to a single chain (Safe app / Safe via WalletConnect), and explicitly keep it enabled for Rabby.

This switches the panel gate to the same `useShouldHideNetworkSelector` hook, so the sell networks panel is shown for Rabby+Safe while remaining hidden for a real Safe app / Safe via WC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network selection behavior based on the selected token field.
  * Network selection is now disabled in the appropriate scenarios while preserving existing yield-related restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->