### PR TITLE
ci: alert slack if sync pr failed

### DIFF
--- a/.github/workflows/deployment-v2.yml
+++ b/.github/workflows/deployment-v2.yml
@@ -133,6 +133,16 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           PR_URL: ${{ steps.create-pr.outputs.pull-request-url }}
 
+      - name: Notify Slack for develop sync failure
+        if: failure()
+        run: |
+          curl -X POST -H "Content-type: application/json" \
+            --data "{\"text\": \"❌ Develop sync automation failed. <$RUN_URL|Open workflow run>.\"}" \
+            "$SLACK_WEBHOOK_URL"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
   sync-staging:
     name: Fast-forward staging to main
     if: startsWith(github.ref, 'refs/tags/cowswap-') || startsWith(github.ref, 'refs/tags/explorer-')


### PR DESCRIPTION
# Summary

It can happen due to conflicts https://github.com/cowprotocol/cowswap/actions/runs/29912295914

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an additional Slack notification that triggers when the develop synchronization workflow fails.
  * The alert includes a direct link to the specific workflow run to speed up troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->