### PR TITLE
fix(sentry): ignore launchdarkly noisy NetworkError

### DIFF
--- a/apps/cowswap-frontend/src/cow-react/sentry/beforeSend.test.ts
+++ b/apps/cowswap-frontend/src/cow-react/sentry/beforeSend.test.ts
@@ -1,0 +1,75 @@
+import { ErrorEvent as SentryErrorEvent } from '@sentry/types'
+
+import { beforeSend } from './beforeSend'
+
+function buildEvent(overrides: Partial<SentryErrorEvent> = {}): SentryErrorEvent {
+  return {
+    type: undefined,
+    exception: {
+      values: [
+        {
+          type: 'Error',
+          value: 'Something went wrong',
+        },
+      ],
+    },
+    ...overrides,
+  } as SentryErrorEvent
+}
+
+describe('beforeSend', () => {
+  it('passes through regular errors', () => {
+    const event = buildEvent()
+    expect(beforeSend(event, {})).toBe(event)
+  })
+
+  it('ignores network errors originating from the LaunchDarkly SDK', () => {
+    const event = buildEvent({
+      exception: {
+        values: [
+          {
+            type: 'NetworkError',
+            value: 'A network error occurred.',
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    '../../../node_modules/.pnpm/launchdarkly-js-client-sdk@3.1.3/node_modules/launchdarkly-js-client-sdk/dist/ldclient.es.js',
+                },
+                { filename: '[native code]' },
+              ],
+            },
+          },
+        ],
+      },
+    })
+
+    expect(beforeSend(event, {})).toBeNull()
+  })
+
+  it('does NOT ignore network errors from unrelated sources', () => {
+    const event = buildEvent({
+      exception: {
+        values: [
+          {
+            type: 'NetworkError',
+            value: 'A network error occurred.',
+            stacktrace: {
+              frames: [{ filename: '../../../node_modules/some-other-lib/dist/index.js' }],
+            },
+          },
+        ],
+      },
+    })
+
+    expect(beforeSend(event, {})).toBe(event)
+  })
+
+  it('ignores errors based on extra serialized code', () => {
+    const event = buildEvent({
+      extra: { __serialized__: { code: -32000, message: 'header not found' } },
+    })
+
+    expect(beforeSend(event, {})).toBeNull()
+  })
+})

--- a/apps/cowswap-frontend/src/cow-react/sentry/beforeSend.ts
+++ b/apps/cowswap-frontend/src/cow-react/sentry/beforeSend.ts
@@ -8,6 +8,8 @@ export function beforeSend(event: SentryErrorEvent, _hint: Sentry.EventHint) {
     return null
   } else if (shouldIgnoreErrorBasedOnBreadcrumbs(event)) {
     return null
+  } else if (shouldIgnoreLaunchDarklyNetworkError(event)) {
+    return null
   } else {
     return event
   }
@@ -115,4 +117,30 @@ function isMetamaskRpcError(breadcrumb: Sentry.Breadcrumb): boolean {
     return false
   }
   return /MetaMask.*RPC Error/i.test(breadcrumb.message)
+}
+
+const NETWORK_ERROR_VALUES = new Set(['A network error occurred.'])
+
+function isNetworkError(type: string | undefined, value: string | undefined): boolean {
+  return type === 'NetworkError' || NETWORK_ERROR_VALUES.has(value ?? '')
+}
+
+/**
+ * Ignore network errors thrown by the launchdarkly-js-client-sdk.
+ *
+ * The SDK flushes analytics events synchronously on `pagehide` (e.g. when a mobile browser
+ * tab is backgrounded or the connection drops). On mobile Safari/WKWebView the underlying XHR
+ * often fails with a `NetworkError`, which Sentry captures via its instrumented XHR wrapper.
+ * These are benign (feature-flag analytics, no user impact) and generate a large volume of noise.
+ */
+function shouldIgnoreLaunchDarklyNetworkError(error: SentryErrorEvent): boolean {
+  const exception = error.exception?.values?.[0]
+
+  if (!exception || !isNetworkError(exception.type, exception.value)) {
+    return false
+  }
+
+  const frames = exception.stacktrace?.frames
+
+  return Boolean(frames?.some((frame) => frame.filename?.includes('launchdarkly-js-client-sdk')))
 }


### PR DESCRIPTION
# Summary

Fixes https://cowprotocol.sentry.io/issues/7230547234/?project=5905822&query=is%3Aunresolved&referrer=issue-stream

The Sentry issue NetworkError: A network error occurred., 42,780 occurrences, 0 users impacted) is noise from launchdarkly-js-client-sdk. The full stacktrace is entirely inside LaunchDarkly's flush → sendEvents → sendChunk → httpRequest → XHR send, and the event's extra data shows type: "pagehide".                                                                               
                                                                                                                                                                                                           
The SDK flushes analytics events synchronously on pagehide — when a mobile browser tab is backgrounded or connectivity drops. On mobile Safari/WKWebView (all the samples are iOS) the underlying XHR fails with a NetworkError, which Sentry's instrumented XHR wrapper (sentryWrapped) captures. It's benign feature-flag telemetry with no user impact, so silencing it is correct.                         

# To Test

Don't really know how to test it without a debugger.
There are unit-tests covering the scenario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error monitoring by filtering out known, non-actionable LaunchDarkly network errors.
  * Continued reporting network errors from other sources.
  * Suppressed specific “header not found” errors that do not require action.
  * Preserved reporting for normal, unrelated errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->