### PR TITLE
feat: bump sdk with near fix for btc amount calculation

### DIFF
--- a/apps/cowswap-frontend/package.json
+++ b/apps/cowswap-frontend/package.json
@@ -49,7 +49,7 @@
     "@cowprotocol/iframe-transport": "workspace:*",
     "@cowprotocol/multicall": "workspace:*",
     "@cowprotocol/permit-utils": "workspace:*",
-    "@cowprotocol/sdk-bridging": "4.4.0",
+    "@cowprotocol/sdk-bridging": "4.4.1",
     "@cowprotocol/sdk-contracts-ts": "3.3.2",
     "@cowprotocol/sdk-cow-shed": "0.4.4",
     "@cowprotocol/sdk-order-book": "4.0.1",

--- a/apps/explorer/package.json
+++ b/apps/explorer/package.json
@@ -30,7 +30,7 @@
     "@cowprotocol/core": "workspace:*",
     "@cowprotocol/cow-sdk": "9.2.5",
     "@cowprotocol/hook-dapp-lib": "workspace:*",
-    "@cowprotocol/sdk-bridging": "4.4.0",
+    "@cowprotocol/sdk-bridging": "4.4.1",
     "@cowprotocol/sdk-contracts-ts": "3.3.2",
     "@cowprotocol/sdk-subgraph": "1.2.0",
     "@cowprotocol/sdk-viem-adapter": "0.3.25",

--- a/libs/events/package.json
+++ b/libs/events/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@cowprotocol/cow-sdk": "9.2.5",
-    "@cowprotocol/sdk-bridging": "4.4.0",
+    "@cowprotocol/sdk-bridging": "4.4.1",
     "@cowprotocol/types": "workspace:*"
   }
 }

--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@cowprotocol/cow-sdk": "9.2.5",
-    "@cowprotocol/sdk-bridging": "4.4.0",
+    "@cowprotocol/sdk-bridging": "4.4.1",
     "@cowprotocol/currency": "workspace:*",
     "eventemitter3": "4.0.7"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -594,8 +594,8 @@ importers:
         specifier: workspace:*
         version: link:../../libs/permit-utils
       '@cowprotocol/sdk-bridging':
-        specifier: 4.4.0
-        version: 4.4.0(ajv@8.17.1)(cross-fetch@4.0.0(encoding@0.1.13))(encoding@0.1.13)(multiformats@14.0.0)
+        specifier: 4.4.1
+        version: 4.4.1(ajv@8.17.1)(cross-fetch@4.0.0(encoding@0.1.13))(encoding@0.1.13)(multiformats@14.0.0)
       '@cowprotocol/sdk-contracts-ts':
         specifier: 3.3.2
         version: 3.3.2
@@ -956,8 +956,8 @@ importers:
         specifier: workspace:*
         version: link:../../libs/hook-dapp-lib
       '@cowprotocol/sdk-bridging':
-        specifier: 4.4.0
-        version: 4.4.0(ajv@8.17.1)(cross-fetch@4.0.0(encoding@0.1.13))(encoding@0.1.13)(multiformats@14.0.0)
+        specifier: 4.4.1
+        version: 4.4.1(ajv@8.17.1)(cross-fetch@4.0.0(encoding@0.1.13))(encoding@0.1.13)(multiformats@14.0.0)
       '@cowprotocol/sdk-contracts-ts':
         specifier: 3.3.2
         version: 3.3.2
@@ -1766,8 +1766,8 @@ importers:
         specifier: 9.2.5
         version: 9.2.5(@openzeppelin/merkle-tree@1.0.8)(ajv@8.17.1)(cross-fetch@4.0.0(encoding@0.1.13))(encoding@0.1.13)(multiformats@14.0.0)
       '@cowprotocol/sdk-bridging':
-        specifier: 4.4.0
-        version: 4.4.0(ajv@8.17.1)(cross-fetch@4.0.0(encoding@0.1.13))(encoding@0.1.13)(multiformats@14.0.0)
+        specifier: 4.4.1
+        version: 4.4.1(ajv@8.17.1)(cross-fetch@4.0.0(encoding@0.1.13))(encoding@0.1.13)(multiformats@14.0.0)
       '@cowprotocol/types':
         specifier: workspace:*
         version: link:../types
@@ -1974,8 +1974,8 @@ importers:
         specifier: workspace:*
         version: link:../currency
       '@cowprotocol/sdk-bridging':
-        specifier: 4.4.0
-        version: 4.4.0(ajv@8.17.1)(cross-fetch@4.0.0(encoding@0.1.13))(encoding@0.1.13)(multiformats@14.0.0)
+        specifier: 4.4.1
+        version: 4.4.1(ajv@8.17.1)(cross-fetch@4.0.0(encoding@0.1.13))(encoding@0.1.13)(multiformats@14.0.0)
       eventemitter3:
         specifier: 4.0.7
         version: 4.0.7
@@ -3304,8 +3304,8 @@ packages:
   '@cowprotocol/sdk-bridging@4.2.2':
     resolution: {integrity: sha512-WCrFxNMwNzExQPTF1o/GuMl3D4MrWIildWip7o2cP66FlbUfSSh3n5c3xSSxmg065woFOlsM+dme/PMGcSU29g==}
 
-  '@cowprotocol/sdk-bridging@4.4.0':
-    resolution: {integrity: sha512-TPuFHemANOop2FPA6ZSZR2WTTgVHZLmv9piyeDqGBx9XeUsEdnEQtKl5ofm3LkLzCqg3WaPk92BVICJSFExJKg==}
+  '@cowprotocol/sdk-bridging@4.4.1':
+    resolution: {integrity: sha512-crwa2tpWrk5vmIsKm8tAIMpyRTiUkYTwCov8OPy+gfZbNoYqPbwG+s8NthlK+VddiCFYxZhYvrNshpe8c9UNZQ==}
 
   '@cowprotocol/sdk-common@0.10.1':
     resolution: {integrity: sha512-2EYpgXDwD0F5KR9W+jT2Vr/vzaJ8meAvEPm4fGjJUVr2otrUkhUG7ayx68L1AgKZWYzDtNrlM/+1EeyEjjEaWg==}
@@ -19319,7 +19319,7 @@ snapshots:
       - multiformats
       - supports-color
 
-  '@cowprotocol/sdk-bridging@4.4.0(ajv@8.17.1)(cross-fetch@4.0.0(encoding@0.1.13))(encoding@0.1.13)(multiformats@14.0.0)':
+  '@cowprotocol/sdk-bridging@4.4.1(ajv@8.17.1)(cross-fetch@4.0.0(encoding@0.1.13))(encoding@0.1.13)(multiformats@14.0.0)':
     dependencies:
       '@cowprotocol/sdk-app-data': 5.3.2(ajv@8.17.1)(cross-fetch@4.0.0(encoding@0.1.13))(encoding@0.1.13)(multiformats@14.0.0)
       '@cowprotocol/sdk-common': 0.12.0


### PR DESCRIPTION
# Summary

Fixes #7426 

This pr contains sdk fix(from Near team):  https://github.com/cowprotocol/cow-sdk/pull/929 for correct calculation expected/min received amount. 

# To test

[ ] - Need regress for different (not btc) bridge, e.g Main -> Base(or different one, it doesn't matter), should works as expected
[ ] - btc bridge should display correct expected/min received amount, min received should less or equal  to expected amount 

No need to review it right now, pls don't pay attention on the failed builds, it's expected, will be fixed after approve from QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release metadata across frontend applications, libraries, and supporting packages.
  * Refreshed package versions to align components across the product suite.
  * Improved compatibility across bridging, wallet, and analytics integrations through coordinated package updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->