### PR TITLE
fix(ui): fix typescript errors so the lib can be typechecked

### DIFF
--- a/libs/ui/project.json
+++ b/libs/ui/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "tags": [],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit -p libs/ui/tsconfig.lib.json"
+      }
+    },
     "lint": {
       "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"],

--- a/libs/ui/src/declarations.d.ts
+++ b/libs/ui/src/declarations.d.ts
@@ -1,0 +1,2 @@
+declare module '*.woff'
+declare module '*.woff2'


### PR DESCRIPTION
Part of #7828 — scoped to the `ui` lib (one lib per PR, as the issue suggests).

`tsc -p libs/ui/tsconfig.lib.json` failed with 25 TS2307 errors, all from the `.woff2` font imports in `src/fonts.ts` having no module declaration. (`skipLibCheck` doesn't help here — the fonts are bare module specifiers, not third-party `.d.ts`.)

- Add ambient `*.woff`/`*.woff2` declarations in `libs/ui/src/declarations.d.ts`, matching the pattern already used in `apps/explorer` and `apps/widget-configurator`.
- Add a `typecheck` target to `libs/ui/project.json` (same as `cowswap-frontend`) so the lib is covered going forward.

`nx typecheck ui` now passes cleanly. Happy to follow up with the remaining libs in separate PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added automated type checking for the UI library to help catch issues earlier.
  * Improved support for importing WOFF and WOFF2 font files, enabling more reliable custom font usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->