### PR TITLE
fix: remove `new` flag from Plasma and Ink chains

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/NetworksList/NetworksList.pure.tsx
+++ b/apps/cowswap-frontend/src/common/pure/NetworksList/NetworksList.pure.tsx
@@ -12,7 +12,7 @@ import { getLogo } from './NetworksList.utils'
 
 import { useDeprecatedChains } from '../../hooks/useDeprecatedChains'
 
-const NEW_NETWORK_IDS: Set<TargetChainId> = new Set([SupportedChainId.PLASMA, SupportedChainId.INK])
+const NEW_NETWORK_IDS: Set<TargetChainId> = new Set([])
 
 export interface NetworksListProps {
   currentChainId: SupportedChainId | null


### PR DESCRIPTION
# Summary

Remove `new` flags from Plasma and Ink chains

<img width="723" height="758" alt="image" src="https://github.com/user-attachments/assets/32734617-9528-4777-968f-79af8dc50a21" />


# To Test

1. Load app
2. Click on network selector
* There should be no chain with `new`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Removed the “NEW” badge from network entries.
  * Existing active and deprecated network indicators remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->