### PR TITLE
feat(explorer): show network costs and protocol fee breakdown on order details

### DIFF
--- a/apps/explorer/src/api/operator/types.ts
+++ b/apps/explorer/src/api/operator/types.ts
@@ -124,8 +124,23 @@ export type ProtocolFee = {
   amount: BigNumber
   tokenAddress: AddressKey
   type: ProtocolFeeType
+  /**
+   * The fee policy's `factor`, when known. Its meaning is policy-specific: a fraction of trade
+   * volume, of price improvement, or of the surplus, per {@link type}.
+   */
+  factor?: number
   // Index in a fill's `executedProtocolFees`; preserves the order the fees were applied in.
   position: number
+  owner: ProtocolFeeOwner
+  /**
+   * Which partner charged the fee, counted from 1 in the order the partners' fees appear. Set on
+   * partner fees only. Partners are told apart but never named, so the label says "Partner 2"
+   * rather than who it is; fees sharing a {@link recipient} share a number. One partner using a
+   * different recipient per fee kind counts as two partners — see `numberPartners` for why.
+   */
+  partnerNumber?: number
+  /** The partner's fee recipient, when the fee mapped to a declared partner policy. */
+  recipient?: AddressKey
 }
 
 // TODO: drop the `gasCost` intersection once `EnrichedOrder` in @cowprotocol/cow-sdk declares it.
@@ -158,6 +173,16 @@ export type Trade = Pick<RawTrade, 'blockNumber' | 'logIndex' | 'owner' | 'txHas
 }
 
 export type WithNetworkId = { networkId: Network }
+
+/**
+ * Who a fee in `executedProtocolFees` was charged for. The API doesn't say, so it is derived by
+ * mapping the applied policies onto the partner fee policies the order declared in its app data.
+ */
+export enum ProtocolFeeOwner {
+  Protocol = 'protocol',
+  /** An integrator, from a `metadata.partnerFee` policy in the order's app data. */
+  Partner = 'partner',
+}
 
 export enum ProtocolFeeType {
   Surplus = 'surplus',

--- a/apps/explorer/src/components/orders/GasFeeDisplay/breakdown.ts
+++ b/apps/explorer/src/components/orders/GasFeeDisplay/breakdown.ts
@@ -4,24 +4,39 @@ import { TokenErc20 } from '@gnosis.pm/dex-js'
 import BigNumber from 'bignumber.js'
 import { ZERO_BIG_NUMBER } from 'const'
 
-import { ProtocolFee, ProtocolFeeType } from 'api/operator'
+import { ProtocolFee, ProtocolFeeOwner, ProtocolFeeType } from 'api/operator'
 
-// The API says how each fee was calculated but not who charged it, so labels name the policy.
-export const FEE_TYPE_LABELS: Record<ProtocolFeeType, string> = {
-  [ProtocolFeeType.Surplus]: 'Surplus fee',
-  [ProtocolFeeType.Volume]: 'Volume fee',
-  [ProtocolFeeType.PriceImprovement]: 'Price improvement fee',
-  [ProtocolFeeType.Unknown]: 'Fee',
+/**
+ * The protocol's own fees. Both ways of charging on price improvement read as the DAO's share of
+ * it; the policy that computed it is an implementation detail the user doesn't need.
+ */
+const PROTOCOL_FEE_LABELS: Record<ProtocolFeeType, string> = {
+  [ProtocolFeeType.Surplus]: 'DAO price improvement share',
+  [ProtocolFeeType.PriceImprovement]: 'DAO price improvement share',
+  [ProtocolFeeType.Volume]: 'Protocol fee',
+  [ProtocolFeeType.Unknown]: 'Protocol fee',
+}
+
+/** A partner's fees, appended to its number. Partners are numbered but never named. */
+const PARTNER_FEE_LABELS: Record<ProtocolFeeType, string> = {
+  [ProtocolFeeType.Surplus]: 'surplus fee',
+  [ProtocolFeeType.PriceImprovement]: 'price improvement share',
+  [ProtocolFeeType.Volume]: 'volume fee',
+  [ProtocolFeeType.Unknown]: 'fee',
 }
 
 export type LineItem = { label: string; tokenAddress: AddressKey; amount: BigNumber }
 
 /**
  * One row per cost: network costs first, then the fees in the order they were applied.
- * Repeated fee types get numbered so the rows stay distinguishable.
+ *
+ * The labels already tell the protocol's fees from each partner's. A label that still repeats gets
+ * a counter so the rows stay distinguishable: one partner charging the same kind of fee twice, or
+ * the protocol charging on price improvement both ways (its surplus and price improvement fees
+ * share a label, though today it applies one or the other per order class).
  */
 export function buildLineItems(protocolFees: ProtocolFee[], gasCost: BigNumber, nativeKey: AddressKey): LineItem[] {
-  const labels = protocolFees.map((fee) => FEE_TYPE_LABELS[fee.type])
+  const labels = protocolFees.map(getFeeLabel)
   const occurrences = new Map<string, number>()
   const numbered = new Map<string, number>()
 
@@ -36,6 +51,12 @@ export function buildLineItems(protocolFees: ProtocolFee[], gasCost: BigNumber, 
   })
 
   return [{ label: 'Network costs', tokenAddress: nativeKey, amount: gasCost }, ...feeItems]
+}
+
+export function getFeeLabel({ owner, type, partnerNumber }: ProtocolFee): string {
+  return owner === ProtocolFeeOwner.Partner
+    ? `Partner ${partnerNumber ?? 1} ${PARTNER_FEE_LABELS[type]}`
+    : PROTOCOL_FEE_LABELS[type]
 }
 
 /** Indexes whatever token metadata is available so line items can be rendered with decimals. */

--- a/apps/explorer/src/hooks/useOperatorTrades.ts
+++ b/apps/explorer/src/hooks/useOperatorTrades.ts
@@ -11,6 +11,7 @@ import { getProtocolFees, transformTrade } from 'utils'
 import { getTrades, Order, ProtocolFee, RawTrade, Trade } from 'api/operator'
 
 import { web3 } from '../explorer/api'
+import { getPartnerFeePolicies } from '../utils/partnerFeePolicies'
 
 type Result = {
   /** The requested page of fills. */
@@ -95,7 +96,12 @@ export function useOrderTrades(order: Order | null, offset = 0, limit = 10): Res
     })
   }, [order, pageTrades, tradesTimestamps])
 
-  const protocolFees = useMemo(() => rawTrades && getProtocolFees(rawTrades), [rawTrades])
+  const partnerFeePolicies = useMemo(() => getPartnerFeePolicies(order?.fullAppData), [order?.fullAppData])
+
+  const protocolFees = useMemo(
+    () => rawTrades && getProtocolFees(rawTrades, partnerFeePolicies),
+    [rawTrades, partnerFeePolicies],
+  )
 
   const hasNextPage = (rawTrades?.length ?? 0) > offset + limit
   // SWR reports nothing pending without a key, but the caller is still waiting on the order itself.

--- a/apps/explorer/src/test/components/costsAndFeesBreakdown.test.tsx
+++ b/apps/explorer/src/test/components/costsAndFeesBreakdown.test.tsx
@@ -73,7 +73,13 @@ describe('costs & fees breakdown (integration)', () => {
     const fills = [fill(0), fill(1), fill(2)]
     mockedGetTrades.mockImplementation(async ({ offset = 0 }) => fills.slice(offset))
 
-    const order = { ...RICH_ORDER, gasCost: new BigNumber('2500000000000000') } // 0.0025 native
+    const order: Order = {
+      ...RICH_ORDER,
+      gasCost: new BigNumber('2500000000000000'), // 0.0025 native
+      // App data that declares no partner fee, so the attribution runs against it rather than
+      // falling back to the positional rule.
+      fullAppData: JSON.stringify({ version: '1.1.0', metadata: {} }),
+    }
     const { container } = renderHarness(order)
 
     await waitFor(() => expect(screen.queryByText('[+] Show more')).not.toBeNull())
@@ -90,9 +96,11 @@ describe('costs & fees breakdown (integration)', () => {
 
     fireEvent.click(screen.getByText('[+] Show more'))
     expect(screen.getByText('Network costs:')).not.toBeNull()
-    expect(screen.getByText('Volume fee:')).not.toBeNull()
-    expect(screen.getByText('Price improvement fee:')).not.toBeNull()
-    // The zero-amount fee (position 2) is dropped, so the volume fee is not numbered.
-    expect(screen.queryByText(/Volume fee \(/)).toBeNull()
+    expect(screen.getByText('Protocol fee:')).not.toBeNull()
+    expect(screen.getByText('DAO price improvement share:')).not.toBeNull()
+    // The order declares no partner fee, so both charged policies are the protocol's own.
+    expect(screen.queryByText(/^Partner /)).toBeNull()
+    // The zero-amount fee (position 2) is dropped, so no label is left repeating.
+    expect(screen.queryByText(/Protocol fee \(/)).toBeNull()
   })
 })

--- a/apps/explorer/src/test/components/costsAndFeesLineItems.test.ts
+++ b/apps/explorer/src/test/components/costsAndFeesLineItems.test.ts
@@ -3,7 +3,7 @@ import { getAddressKey } from '@cowprotocol/cow-sdk'
 import { TokenErc20 } from '@gnosis.pm/dex-js'
 import BigNumber from 'bignumber.js'
 
-import { ProtocolFee, ProtocolFeeType } from 'api/operator'
+import { ProtocolFee, ProtocolFeeOwner, ProtocolFeeType } from 'api/operator'
 
 import { buildLineItems, indexTokensByKey, sumByToken } from '../../components/orders/GasFeeDisplay/breakdown'
 import { TUSD, USDT, WETH } from '../data'
@@ -11,8 +11,25 @@ import { TUSD, USDT, WETH } from '../data'
 const NATIVE_KEY = getAddressKey('0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee')
 const GAS_COST = new BigNumber('2500000000000000')
 
-function fee(type: ProtocolFeeType, token: string, amount: string, position = 0): ProtocolFee {
-  return { type, tokenAddress: getAddressKey(token), amount: new BigNumber(amount), position }
+function fee(
+  type: ProtocolFeeType,
+  token: string,
+  amount: string,
+  position = 0,
+  owner = ProtocolFeeOwner.Protocol,
+  partnerNumber?: number,
+): ProtocolFee {
+  return { type, tokenAddress: getAddressKey(token), amount: new BigNumber(amount), position, owner, partnerNumber }
+}
+
+function partnerFee(
+  type: ProtocolFeeType,
+  token: string,
+  amount: string,
+  position: number,
+  partnerNumber: number,
+): ProtocolFee {
+  return fee(type, token, amount, position, ProtocolFeeOwner.Partner, partnerNumber)
 }
 
 describe('buildLineItems', () => {
@@ -24,38 +41,78 @@ describe('buildLineItems', () => {
 
   it('keeps the fees in the order they were applied', () => {
     const items = buildLineItems(
-      [fee(ProtocolFeeType.Surplus, WETH.address, '1'), fee(ProtocolFeeType.PriceImprovement, USDT.address, '2', 1)],
-      GAS_COST,
-      NATIVE_KEY,
-    )
-
-    expect(items.map((item) => item.label)).toEqual(['Network costs', 'Surplus fee', 'Price improvement fee'])
-  })
-
-  it('numbers repeated fee types so the rows stay distinguishable', () => {
-    const items = buildLineItems(
       [
-        fee(ProtocolFeeType.Volume, WETH.address, '1'),
-        fee(ProtocolFeeType.Surplus, WETH.address, '2', 1),
-        fee(ProtocolFeeType.Volume, USDT.address, '3', 2),
+        fee(ProtocolFeeType.PriceImprovement, WETH.address, '1'),
+        partnerFee(ProtocolFeeType.Volume, USDT.address, '2', 1, 1),
       ],
       GAS_COST,
       NATIVE_KEY,
     )
 
-    // Only the repeated type is numbered; the single surplus fee keeps its plain label.
     expect(items.map((item) => item.label)).toEqual([
       'Network costs',
-      'Volume fee (1)',
-      'Surplus fee',
-      'Volume fee (2)',
+      'DAO price improvement share',
+      'Partner 1 volume fee',
     ])
   })
 
-  it('labels a fee of an unrecognised policy generically', () => {
-    const items = buildLineItems([fee(ProtocolFeeType.Unknown, USDT.address, '1')], GAS_COST, NATIVE_KEY)
+  it('numbers a label that still repeats, so the rows stay distinguishable', () => {
+    const items = buildLineItems(
+      [
+        partnerFee(ProtocolFeeType.Volume, WETH.address, '1', 0, 1),
+        fee(ProtocolFeeType.Surplus, WETH.address, '2', 1),
+        partnerFee(ProtocolFeeType.Volume, USDT.address, '3', 2, 1),
+      ],
+      GAS_COST,
+      NATIVE_KEY,
+    )
 
-    expect(items[1].label).toBe('Fee')
+    // Same partner, same kind of fee, twice; the surplus fee is alone so it keeps its plain label.
+    expect(items.map((item) => item.label)).toEqual([
+      'Network costs',
+      'Partner 1 volume fee (1)',
+      'DAO price improvement share',
+      'Partner 1 volume fee (2)',
+    ])
+  })
+
+  it('falls back to the plain fee names for an unrecognised policy', () => {
+    const items = buildLineItems(
+      [fee(ProtocolFeeType.Unknown, USDT.address, '1'), partnerFee(ProtocolFeeType.Unknown, USDT.address, '2', 1, 1)],
+      GAS_COST,
+      NATIVE_KEY,
+    )
+
+    expect(items.map((item) => item.label)).toEqual(['Network costs', 'Protocol fee', 'Partner 1 fee'])
+  })
+
+  it('names the protocol fees and numbers the partners, per the agreed labels', () => {
+    const items = buildLineItems(
+      [
+        fee(ProtocolFeeType.PriceImprovement, WETH.address, '1'),
+        fee(ProtocolFeeType.Volume, WETH.address, '2', 1),
+        partnerFee(ProtocolFeeType.Volume, USDT.address, '3', 2, 1),
+        partnerFee(ProtocolFeeType.PriceImprovement, USDT.address, '4', 3, 1),
+        partnerFee(ProtocolFeeType.Volume, TUSD.address, '5', 4, 2),
+      ],
+      GAS_COST,
+      NATIVE_KEY,
+    )
+
+    expect(items.map((item) => item.label)).toEqual([
+      'Network costs',
+      'DAO price improvement share',
+      'Protocol fee',
+      'Partner 1 volume fee',
+      'Partner 1 price improvement share',
+      'Partner 2 volume fee',
+    ])
+  })
+
+  it('labels the protocol surplus fee as the DAO price improvement share', () => {
+    const items = buildLineItems([fee(ProtocolFeeType.Surplus, WETH.address, '1')], GAS_COST, NATIVE_KEY)
+
+    expect(items[1].label).toBe('DAO price improvement share')
   })
 })
 

--- a/apps/explorer/src/test/hooks/useOperatorTrades.test.tsx
+++ b/apps/explorer/src/test/hooks/useOperatorTrades.test.tsx
@@ -4,10 +4,12 @@ import { renderHook, waitFor } from '@testing-library/react'
 import BigNumber from 'bignumber.js'
 import { useNetworkId } from 'state/network'
 import { SWRConfig } from 'swr'
-import { transformTrade } from 'utils'
+import { getProtocolFees, transformTrade } from 'utils'
 
 import { getTrades, Order, RawTrade, Trade } from 'api/operator'
 
+// Not from `api/operator`: that module is mocked below to only its HTTP call.
+import { ProtocolFeeType } from '../../api/operator/types'
 import { ALL_TRADES_PAGE_SIZE, useOrderTrades } from '../../hooks/useOperatorTrades'
 
 jest.mock('state/network', () => ({
@@ -35,6 +37,7 @@ jest.mock('../../explorer/api', () => ({
 const mockedUseNetworkId = jest.mocked(useNetworkId)
 const mockedGetTrades = jest.mocked(getTrades)
 const mockedTransformTrade = jest.mocked(transformTrade)
+const mockedGetProtocolFees = jest.mocked(getProtocolFees)
 
 const ONE = new BigNumber(1)
 const TWO = new BigNumber(2)
@@ -74,6 +77,7 @@ beforeEach(() => {
   mockedUseNetworkId.mockReset()
   mockedGetTrades.mockReset()
   mockedTransformTrade.mockReset()
+  mockedGetProtocolFees.mockClear()
 
   mockedUseNetworkId.mockReturnValue(1)
   mockedTransformTrade.mockImplementation(
@@ -183,6 +187,21 @@ describe('useOrderTrades protocol fees', () => {
 
     await waitFor(() => expect(result.current.protocolFees).toHaveLength(ALL_TRADES_PAGE_SIZE))
     expect(mockedGetTrades).toHaveBeenCalledTimes(2)
+  })
+
+  it("hands the partner fee policies from the order's app data to the fee aggregation", async () => {
+    serveFills([createFill(0)])
+    const recipient = '0x1111111111111111111111111111111111111111'
+    const order = createMockOrder({
+      fullAppData: JSON.stringify({ version: '1.1.0', metadata: { partnerFee: { volumeBps: 20, recipient } } }),
+    })
+
+    const { result } = renderHook(() => useOrderTrades(order, 0, 10), { wrapper: FreshSwrCache })
+
+    await waitFor(() => expect(result.current.protocolFees).toHaveLength(1))
+    expect(mockedGetProtocolFees).toHaveBeenLastCalledWith(expect.any(Array), [
+      { type: ProtocolFeeType.Volume, factor: 0.002, recipient },
+    ])
   })
 
   it('does not report one order’s fees while another order is loading', async () => {

--- a/apps/explorer/src/test/utils/partnerFeeMapping.test.ts
+++ b/apps/explorer/src/test/utils/partnerFeeMapping.test.ts
@@ -1,0 +1,266 @@
+import { ProtocolFeeOwner, ProtocolFeeType, RawTrade } from '../../api/operator/types'
+import { getProtocolFees } from '../../utils/operator'
+import { getPartnerFeePolicies } from '../../utils/partnerFeePolicies'
+
+type ExecutedFee = NonNullable<RawTrade['executedProtocolFees']>[number]
+type Policy = ExecutedFee['policy']
+
+const VOLUME_25_BPS: Policy = { volume: { factor: 0.0025 } }
+const VOLUME_20_BPS: Policy = { volume: { factor: 0.002 } }
+const VOLUME_10_BPS: Policy = { volume: { factor: 0.001 } }
+const SURPLUS_POLICY: Policy = { surplus: { factor: 0.5, maxVolumeFactor: 0.01 } }
+const PRICE_IMPROVEMENT_POLICY: Policy = {
+  priceImprovement: {
+    factor: 0.25,
+    maxVolumeFactor: 0.01,
+    quote: { sellAmount: '1000', buyAmount: '2000', fee: '10' },
+  },
+}
+
+const TOKEN = '0xdac17f958d2ee523a2206206994597c13d831ec7'
+const PARTNER = '0x1111111111111111111111111111111111111111'
+const OTHER_PARTNER = '0x2222222222222222222222222222222222222222'
+
+function appData(partnerFee?: unknown): string {
+  return JSON.stringify({ version: '1.1.0', metadata: partnerFee ? { partnerFee } : {} })
+}
+
+function fee(policy: Policy, amount = '1000'): ExecutedFee {
+  return { amount, token: TOKEN, policy }
+}
+
+function owners(fullAppData: string | undefined, ...fees: ExecutedFee[]): ProtocolFeeOwner[] {
+  return getProtocolFees([trade(...fees)], getPartnerFeePolicies(fullAppData)).map((f) => f.owner)
+}
+
+function partners(fullAppData: string | undefined, ...fees: ExecutedFee[]): Array<number | undefined> {
+  return getProtocolFees([trade(...fees)], getPartnerFeePolicies(fullAppData)).map((f) => f.partnerNumber)
+}
+
+function trade(...fees: ExecutedFee[]): Pick<RawTrade, 'executedProtocolFees'> {
+  return { executedProtocolFees: fees }
+}
+
+describe('getPartnerFeePolicies', () => {
+  it('distinguishes unreadable app data from app data declaring no partner fee', () => {
+    expect(getPartnerFeePolicies(undefined)).toBeUndefined()
+    expect(getPartnerFeePolicies('not json')).toBeUndefined()
+    expect(getPartnerFeePolicies(appData())).toEqual([])
+  })
+
+  it('reads a single policy, a list of policies, and each policy shape', () => {
+    expect(getPartnerFeePolicies(appData({ volumeBps: 20, recipient: PARTNER }))).toEqual([
+      { type: ProtocolFeeType.Volume, factor: 0.002, recipient: PARTNER },
+    ])
+
+    expect(
+      getPartnerFeePolicies(
+        appData([
+          { surplusBps: 5000, maxVolumeBps: 100, recipient: PARTNER },
+          { priceImprovementBps: 2500, maxVolumeBps: 100, recipient: PARTNER },
+        ]),
+      ),
+    ).toEqual([
+      { type: ProtocolFeeType.Surplus, factor: 0.5, recipient: PARTNER },
+      { type: ProtocolFeeType.PriceImprovement, factor: 0.25, recipient: PARTNER },
+    ])
+  })
+
+  it('reads the legacy volume-only spelling, and skips policies without a rate or a recipient', () => {
+    expect(getPartnerFeePolicies(appData({ bps: 20, recipient: PARTNER }))).toEqual([
+      { type: ProtocolFeeType.Volume, factor: 0.002, recipient: PARTNER },
+    ])
+    expect(getPartnerFeePolicies(appData([{ recipient: PARTNER }, { volumeBps: 20 }, 'nonsense']))).toEqual([])
+  })
+
+  it('normalises the recipient, so differently cased spellings compare equal', () => {
+    const checksummed = '0xaBcDeF0123456789aBcDeF0123456789aBcDeF01'
+
+    expect(getPartnerFeePolicies(appData({ volumeBps: 20, recipient: checksummed }))).toEqual([
+      { type: ProtocolFeeType.Volume, factor: 0.002, recipient: checksummed.toLowerCase() },
+    ])
+  })
+})
+
+describe('protocol fee attribution', () => {
+  const { Protocol, Partner } = ProtocolFeeOwner
+
+  it('attributes the declared policies to the partner and the rest to the protocol', () => {
+    expect(owners(appData({ volumeBps: 10, recipient: PARTNER }), fee(SURPLUS_POLICY), fee(VOLUME_10_BPS))).toEqual([
+      Protocol,
+      Partner,
+    ])
+  })
+
+  it('attributes every fee to the protocol when no partner fee was declared', () => {
+    expect(owners(appData(), fee(VOLUME_20_BPS), fee(SURPLUS_POLICY))).toEqual([Protocol, Protocol])
+  })
+
+  it('carries the declared recipient onto the partner fee', () => {
+    const [, partnerFee] = getProtocolFees(
+      [trade(fee(VOLUME_20_BPS), fee(VOLUME_10_BPS))],
+      getPartnerFeePolicies(appData({ volumeBps: 10, recipient: PARTNER })),
+    )
+
+    expect(partnerFee).toMatchObject({ owner: Partner, recipient: PARTNER, partnerNumber: 1 })
+  })
+
+  it('accepts a partner fee the protocol capped below the declared rate', () => {
+    expect(owners(appData({ volumeBps: 200, recipient: PARTNER }), fee(VOLUME_20_BPS), fee(VOLUME_10_BPS))).toEqual([
+      Protocol,
+      Partner,
+    ])
+  })
+
+  it('matches within a fee type, so a partner fee the protocol did not apply last still resolves', () => {
+    // The ordering the autopilot is planned to move to: grouped by type, not partner fees last.
+    expect(
+      owners(
+        appData({ volumeBps: 10, recipient: PARTNER }),
+        fee(VOLUME_20_BPS),
+        fee(VOLUME_10_BPS),
+        fee(SURPLUS_POLICY),
+      ),
+    ).toEqual([Protocol, Partner, Protocol])
+  })
+
+  it('falls back to the positional rule when the applied policies do not match what was declared', () => {
+    // Declared 10 bps, but the only volume fee charged more than that, so it cannot be the partner's.
+    expect(owners(appData({ volumeBps: 10, recipient: PARTNER }), fee(VOLUME_20_BPS), fee(SURPLUS_POLICY))).toEqual([
+      Protocol,
+      Protocol,
+    ])
+  })
+
+  it("attributes a declared policy the order applied without one of the protocol's own", () => {
+    expect(
+      owners(
+        appData([
+          { volumeBps: 10, recipient: PARTNER },
+          { surplusBps: 100, maxVolumeBps: 100, recipient: PARTNER },
+        ]),
+        fee(VOLUME_10_BPS),
+      ),
+    ).toEqual([Partner])
+  })
+
+  it("keeps a declared but unapplied partner fee off the protocol's own cheaper fee", () => {
+    // Seen in production: a limit order declares a 30 bps partner fee, but only the protocol's
+    // 2 bps volume fee ran. Below the declared rate, yet not the partner's.
+    const declared = appData({ volumeBps: 30, recipient: PARTNER })
+    const protocolVolume: Policy = { volume: { factor: 0.0002 } }
+
+    expect(owners(declared, fee(PRICE_IMPROVEMENT_POLICY), fee(protocolVolume))).toEqual([Protocol, Protocol])
+  })
+
+  it('does not shift a missing declared policy onto the head of the run', () => {
+    // Two partners declared, only the second one's fee applied: the protocol's fee at the head
+    // cannot be the first partner's, so the run falls back to the positional rule.
+    const declared = appData([
+      { volumeBps: 25, recipient: PARTNER },
+      { volumeBps: 10, recipient: OTHER_PARTNER },
+    ])
+    const protocolVolume: Policy = { volume: { factor: 0.0002 } }
+
+    const fees = getProtocolFees([trade(fee(protocolVolume), fee(VOLUME_10_BPS))], getPartnerFeePolicies(declared))
+
+    expect(fees.map((f) => [f.owner, f.recipient])).toEqual([
+      [Protocol, undefined],
+      [Partner, undefined],
+    ])
+  })
+
+  it('uses the positional rule when the order has no app data to map against', () => {
+    // The protocol's policy of a type is always applied before any partner's.
+    expect(owners(undefined, fee(VOLUME_20_BPS), fee(VOLUME_10_BPS))).toEqual([Protocol, Partner])
+    expect(owners(undefined, fee(SURPLUS_POLICY), fee(VOLUME_20_BPS))).toEqual([Protocol, Protocol])
+  })
+
+  it('keeps the partner boundary when a fee policy charged nothing', () => {
+    // The zero-amount fee is dropped from the result but still counts as an applied policy.
+    const fees = getProtocolFees(
+      [trade(fee(SURPLUS_POLICY, '0'), fee(VOLUME_20_BPS), fee(VOLUME_10_BPS))],
+      getPartnerFeePolicies(appData({ volumeBps: 10, recipient: PARTNER })),
+    )
+
+    expect(fees.map((f) => [f.position, f.owner])).toEqual([
+      [1, Protocol],
+      [2, Partner],
+    ])
+  })
+
+  it('sums each policy across fills without disturbing attribution', () => {
+    const fills = [
+      trade(fee(VOLUME_20_BPS, '1000'), fee(VOLUME_10_BPS, '400')),
+      trade(fee(VOLUME_20_BPS, '2000'), fee(VOLUME_10_BPS, '600')),
+    ]
+
+    const fees = getProtocolFees(fills, getPartnerFeePolicies(appData({ volumeBps: 10, recipient: PARTNER })))
+
+    expect(fees.map((f) => [f.amount.toString(10), f.owner])).toEqual([
+      ['3000', Protocol],
+      ['1000', Partner],
+    ])
+  })
+})
+
+describe('partner numbering', () => {
+  it('gives one partner charging two kinds of fee the same number', () => {
+    const declared = appData([
+      { volumeBps: 10, recipient: PARTNER },
+      { priceImprovementBps: 2500, maxVolumeBps: 100, recipient: PARTNER },
+    ])
+
+    expect(partners(declared, fee(VOLUME_20_BPS), fee(VOLUME_10_BPS), fee(PRICE_IMPROVEMENT_POLICY))).toEqual([
+      undefined,
+      1,
+      1,
+    ])
+  })
+
+  it('numbers two partners charging the same kind of fee separately', () => {
+    // Kerberus injects its own volume fee on top of the integrator's.
+    const declared = appData([
+      { volumeBps: 25, recipient: PARTNER },
+      { volumeBps: 10, recipient: OTHER_PARTNER },
+    ])
+
+    expect(partners(declared, fee(VOLUME_20_BPS), fee(VOLUME_25_BPS), fee(VOLUME_10_BPS))).toEqual([undefined, 1, 2])
+  })
+
+  it('numbers a recipient the same however its address is cased', () => {
+    const declared = appData([
+      { volumeBps: 10, recipient: PARTNER.toUpperCase().replace('0X', '0x') },
+      { priceImprovementBps: 2500, maxVolumeBps: 100, recipient: PARTNER },
+    ])
+
+    expect(partners(declared, fee(VOLUME_10_BPS), fee(PRICE_IMPROVEMENT_POLICY))).toEqual([1, 1])
+  })
+
+  it('counts one partner using a different recipient per fee kind as two partners', () => {
+    // Accepted limitation, see `numberPartners`: nothing in the app data says which recipient
+    // addresses belong to the same integrator.
+    const declared = appData([
+      { volumeBps: 10, recipient: PARTNER },
+      { priceImprovementBps: 2500, maxVolumeBps: 100, recipient: OTHER_PARTNER },
+    ])
+
+    expect(partners(declared, fee(VOLUME_10_BPS), fee(PRICE_IMPROVEMENT_POLICY))).toEqual([1, 2])
+  })
+
+  it('starts at 1 with no gaps when a partner fee charged nothing', () => {
+    const declared = appData([
+      { volumeBps: 25, recipient: PARTNER },
+      { volumeBps: 10, recipient: OTHER_PARTNER },
+    ])
+
+    expect(partners(declared, fee(VOLUME_20_BPS), fee(VOLUME_25_BPS, '0'), fee(VOLUME_10_BPS, '500'))).toEqual([
+      undefined,
+      1,
+    ])
+  })
+
+  it('counts a partner fee with no known recipient as its own partner', () => {
+    expect(partners(undefined, fee(VOLUME_20_BPS), fee(VOLUME_25_BPS), fee(VOLUME_10_BPS))).toEqual([undefined, 1, 2])
+  })
+})

--- a/apps/explorer/src/utils/operator.ts
+++ b/apps/explorer/src/utils/operator.ts
@@ -10,6 +10,7 @@ import {
   Order,
   OrderStatus,
   ProtocolFee,
+  ProtocolFeeOwner,
   ProtocolFeeType,
   RAW_ORDER_STATUS,
   RawOrder,
@@ -18,6 +19,7 @@ import {
 } from 'api/operator/types'
 
 import { getOrderBridgeProviderId } from './getOrderBridgeProviderId'
+import { PartnerFeePolicy } from './partnerFeePolicies'
 
 import { PENDING_ORDERS_BUFFER } from '../explorer/const'
 
@@ -359,8 +361,14 @@ export function getOrderSurplus(order: RawOrder): Surplus {
  * Aggregates the fees charged across an order's fills into one total per (position, type, token).
  * Position alone is not a safe key: across fills it can carry a different token or policy, and
  * summing those would mix tokens.
+ *
+ * `partnerFeePolicies` comes from the order's app data (see {@link getPartnerFeePolicies}) and is
+ * what each fee's owner is derived from.
  */
-export function getProtocolFees(trades: Array<Pick<RawTrade, 'executedProtocolFees'>>): ProtocolFee[] {
+export function getProtocolFees(
+  trades: Array<Pick<RawTrade, 'executedProtocolFees'>>,
+  partnerFeePolicies?: PartnerFeePolicy[],
+): ProtocolFee[] {
   const feesByPolicy = new Map<string, ProtocolFee>()
 
   for (const { executedProtocolFees } of trades) {
@@ -369,7 +377,7 @@ export function getProtocolFees(trades: Array<Pick<RawTrade, 'executedProtocolFe
     executedProtocolFees.forEach(({ amount, token, policy }, position) => {
       if (!amount || !token) return
 
-      const type = getProtocolFeeType(policy)
+      const { type, factor } = describeFeePolicy(policy)
       const tokenAddress = getAddressKey(token)
       const key = `${position}-${type}-${tokenAddress}`
 
@@ -377,14 +385,30 @@ export function getProtocolFees(trades: Array<Pick<RawTrade, 'executedProtocolFe
       if (existing) {
         existing.amount = existing.amount.plus(amount)
       } else {
-        feesByPolicy.set(key, { amount: new BigNumber(amount), tokenAddress, type, position })
+        feesByPolicy.set(key, {
+          amount: new BigNumber(amount),
+          tokenAddress,
+          type,
+          factor,
+          position,
+          owner: ProtocolFeeOwner.Protocol,
+        })
       }
     })
   }
 
-  return Array.from(feesByPolicy.values())
-    .sort((a, b) => a.position - b.position)
-    .filter((fee) => fee.amount.isGreaterThan(0))
+  const fees = Array.from(feesByPolicy.values()).sort((a, b) => a.position - b.position)
+
+  // Before dropping the empty ones: a policy that charged nothing still occupies its place in its
+  // type's run, so it has to be there for the partner boundary to line up.
+  attributeFeeOwners(fees, partnerFeePolicies)
+
+  const charged = fees.filter((fee) => fee.amount.isGreaterThan(0))
+
+  // After dropping them, so the numbers the user sees start at 1 and have no gaps.
+  numberPartners(charged)
+
+  return charged
 }
 
 export function getTradeSurplus(rawTrade: TradeMetaData, order: Order): Surplus {
@@ -484,19 +508,148 @@ export function transformTrade(rawTrade: TradeMetaData, order: Order, executionT
   }
 }
 
-function getProtocolFeeType(policy: FeePolicy | undefined): ProtocolFeeType {
-  if (policy) {
-    if ('surplus' in policy) return ProtocolFeeType.Surplus
-    if ('volume' in policy) return ProtocolFeeType.Volume
-    if ('priceImprovement' in policy) return ProtocolFeeType.PriceImprovement
+/**
+ * Marks each applied fee policy as the protocol's or a partner's, in place.
+ *
+ * The API doesn't record who a fee belongs to, so it is derived per fee type. Within one type the
+ * protocol's own policy is applied before any partner's, and the partner policies keep the order
+ * the app data declared them in. Matching per type rather than over one trailing run keeps this
+ * correct both for today's ordering (the protocol's policies, then the app data's) and for the
+ * planned grouped ordering, where the partner fees are no longer a single run at the end.
+ *
+ * Each type's declarations are checked against the end of that type's run. If they don't line up,
+ * or there is no app data to check against, that type falls back to the positional rule alone: the
+ * first fee of a type is the protocol's, the rest are partners'.
+ */
+function attributeFeeOwners(fees: ProtocolFee[], partnerFeePolicies: PartnerFeePolicy[] | undefined): void {
+  const declaredByType = groupBy(partnerFeePolicies ?? [], (policy) => policy.type)
+
+  for (const [type, typeFees] of groupBy(fees, (fee) => fee.type)) {
+    // `undefined` means there is nothing to check against, as opposed to `[]` for app data that
+    // declares no partner fee of this type — then every fee of the type is the protocol's.
+    const declared = partnerFeePolicies && (declaredByType.get(type) ?? [])
+
+    attributeTypeOwners(typeFees, declared)
   }
-  return ProtocolFeeType.Unknown
+}
+
+/** Attributes one fee type's policies, in the order they were applied. */
+function attributeTypeOwners(typeFees: ProtocolFee[], declared: PartnerFeePolicy[] | undefined): void {
+  const matched = declared && matchDeclaredPolicies(typeFees, declared)
+  // Without a match to go by, everything past the protocol's own policy is a partner's.
+  const partnerStart = matched ? typeFees.length - matched.length : 1
+
+  typeFees.forEach((fee, index) => {
+    if (index < partnerStart) {
+      fee.owner = ProtocolFeeOwner.Protocol
+      return
+    }
+
+    fee.owner = ProtocolFeeOwner.Partner
+    fee.recipient = matched?.[index - partnerStart].recipient
+  })
+}
+
+/** The policy's kind and, when it has one, its rate (policy-specific; see {@link ProtocolFee.factor}). */
+function describeFeePolicy(policy: FeePolicy | undefined): Pick<ProtocolFee, 'type' | 'factor'> {
+  if (policy) {
+    if ('surplus' in policy) return { type: ProtocolFeeType.Surplus, factor: policy.surplus.factor }
+    if ('volume' in policy) return { type: ProtocolFeeType.Volume, factor: policy.volume.factor }
+    if ('priceImprovement' in policy) {
+      return { type: ProtocolFeeType.PriceImprovement, factor: policy.priceImprovement.factor }
+    }
+  }
+  return { type: ProtocolFeeType.Unknown }
 }
 
 function getReceiverAddress({ owner, receiver }: RawOrder): string {
   return !receiver || isZeroAddress(receiver) ? owner : receiver
 }
 
+/** Groups items by key, keeping the keys in first-seen order and the items in input order. */
+function groupBy<T, K>(items: T[], keyOf: (item: T) => K): Map<K, T[]> {
+  const groups = new Map<K, T[]>()
+
+  for (const item of items) {
+    const key = keyOf(item)
+    const group = groups.get(key)
+    if (group) group.push(item)
+    else groups.set(key, [item])
+  }
+
+  return groups
+}
+
 function isZeroAddress(address: string): boolean {
   return /^0x0{40}$/.test(address)
+}
+
+/**
+ * The declared policies matched onto the end of a fee type's run, from the bottom up, or
+ * `undefined` when they don't line up with what was applied.
+ */
+function matchDeclaredPolicies(typeFees: ProtocolFee[], declared: PartnerFeePolicy[]): PartnerFeePolicy[] | undefined {
+  // A partner can declare a policy the order never applied, so match only as far as both go.
+  const matched = declared.slice(Math.max(0, declared.length - typeFees.length))
+  const partnerStart = typeFees.length - matched.length
+
+  const linesUp = matched.every((policy, index) => {
+    const position = partnerStart + index
+    return matchesDeclaredRate(typeFees[position], policy, position === 0)
+  })
+
+  return linesUp ? matched : undefined
+}
+
+// Absorbs the rounding of bps to a fraction when comparing rates.
+const RATE_EPSILON = 1e-9
+
+/**
+ * Whether an applied fee can be the declared partner policy.
+ *
+ * The protocol caps partner fees, so the applied rate can be below the declared one, never above.
+ * At the head of a type's run the rate has to be equal: that is where the protocol's own policy
+ * sits when it charged one, and its rate is below most declared partner rates, so a partner fee
+ * that was declared but never applied (seen in production on limit orders) would otherwise pull
+ * the protocol's fee onto the partner. The trade-off is a capped partner fee on an order with no
+ * protocol fee of the same type, which the positional rule then calls the protocol's; that needs a
+ * declared rate above the cap (5% of volume on mainnet) and has not been seen.
+ */
+function matchesDeclaredRate(fee: ProtocolFee, declared: PartnerFeePolicy, exact: boolean): boolean {
+  if (fee.factor === undefined) return true
+
+  const difference = fee.factor - declared.factor
+  return exact ? Math.abs(difference) <= RATE_EPSILON : difference <= RATE_EPSILON
+}
+
+/**
+ * Numbers the partners from 1, in the order their fees appear.
+ *
+ * Partners are never named, so the number is what tells them apart: fees sharing a recipient share
+ * a number, which distinguishes one partner charging two fees from two partners charging one each
+ * (the Kerberus case). A partner fee with no known recipient counts as its own partner.
+ *
+ * Known limitation: the recipient is all the app data gives us, and an order may name a different
+ * recipient per fee kind — the volume fee paid to one address, the price improvement fee to
+ * another. One integrator splitting its fees over two addresses therefore counts as two partners.
+ * That is the accepted trade-off: nothing in the app data says which addresses belong together, and
+ * sharing a number between two addresses would misreport the more common case of two genuinely
+ * distinct partners.
+ */
+function numberPartners(fees: ProtocolFee[]): void {
+  const numberByPartner = new Map<string, number>()
+
+  for (const fee of fees) {
+    if (fee.owner !== ProtocolFeeOwner.Partner) continue
+
+    const key = fee.recipient ?? `${fee.position}-${fee.type}`
+    let number = numberByPartner.get(key)
+
+    if (number === undefined) {
+      number = numberByPartner.size + 1
+      numberByPartner.set(key, number)
+    }
+
+    fee.partnerNumber = number
+  }
 }

--- a/apps/explorer/src/utils/partnerFeePolicies.ts
+++ b/apps/explorer/src/utils/partnerFeePolicies.ts
@@ -1,0 +1,58 @@
+import { AddressKey, getAddressKey } from '@cowprotocol/cow-sdk'
+
+import { ProtocolFeeType } from 'api/operator/types'
+
+import { decodeFullAppData } from './decodeFullAppData'
+
+export type PartnerFeePolicy = {
+  type: ProtocolFeeType
+  /** Declared rate as a fraction (bps / 10 000), in the same units as `FeePolicy.factor`. */
+  factor: number
+  recipient: AddressKey
+}
+
+const BPS_DENOMINATOR = 10_000
+
+// `bps` is the original spelling of `volumeBps`, still used by older app data.
+const POLICY_TYPE_BY_RATE_FIELD: Array<[field: string, type: ProtocolFeeType]> = [
+  ['volumeBps', ProtocolFeeType.Volume],
+  ['surplusBps', ProtocolFeeType.Surplus],
+  ['priceImprovementBps', ProtocolFeeType.PriceImprovement],
+  ['bps', ProtocolFeeType.Volume],
+]
+
+/**
+ * Partner fee policies declared in an order's app data, in declaration order.
+ *
+ * `undefined` when the app data can't be read, as opposed to `[]` for app data declaring no partner
+ * fee — an order without app data can still have been charged partner fees.
+ */
+export function getPartnerFeePolicies(fullAppData: string | null | undefined): PartnerFeePolicy[] | undefined {
+  const appData = decodeFullAppData(fullAppData)
+  if (!appData) return undefined
+
+  const { partnerFee } = (appData.metadata ?? {}) as { partnerFee?: unknown }
+  if (!partnerFee) return []
+
+  const declared = Array.isArray(partnerFee) ? partnerFee : [partnerFee]
+
+  return declared.map(parsePartnerFeePolicy).filter((policy): policy is PartnerFeePolicy => policy !== null)
+}
+
+function parsePartnerFeePolicy(declared: unknown): PartnerFeePolicy | null {
+  if (typeof declared !== 'object' || declared === null) return null
+
+  const fields = declared as Record<string, unknown>
+  // Every partner fee shape requires a recipient; without one there is no partner to attribute to.
+  const { recipient } = fields
+  if (typeof recipient !== 'string') return null
+
+  for (const [field, type] of POLICY_TYPE_BY_RATE_FIELD) {
+    const bps = fields[field]
+    if (typeof bps !== 'number' || !Number.isFinite(bps)) continue
+
+    return { type, factor: bps / BPS_DENOMINATOR, recipient: getAddressKey(recipient) }
+  }
+
+  return null
+}


### PR DESCRIPTION
# Summary

Replaces the combined "fee" figure on order details with a costs & fees breakdown:

- **Network costs** from the orderbook's `gasCost` (read off `RawOrder` until the SDK ships it)
- **One row per applied fee policy**, summed across all fills rather than the visible Fills page
- Fees taken in wrapped native fold into the native total for the headline
- Orders with no `gasCost` keep the previous display

## Who charged each fee

The API does not say who a fee belongs to, so it is derived from the order's app data (`metadata.partnerFee`), per fee kind:

- Within one kind, the autopilot applies the protocol's own policy first and the partner policies after, in declaration order. The declared policies are matched onto the end of that kind's run.
- The applied rate must be at or below the declared one (partner fees are capped). At the **head** of a run the rate must be **equal**: that is where the protocol's own policy sits, and a partner fee that was declared but never applied would otherwise pull the protocol's cheaper fee onto the partner.
- If the declarations do not line up, or there is no app data, the kind falls back to the positional rule: first fee is the protocol's, the rest are partners'.
- Partners are numbered, never named. Fees sharing a recipient share a number, so one partner charging two kinds of fee reads as "Partner 1" twice, and two partners charging the same kind (Kerberus on top of an integrator) read as "Partner 1" and "Partner 2".

Labels: `DAO price improvement share`, `Protocol fee`, `Partner N volume fee`, `Partner N price improvement share`, `Partner N surplus fee`.

# To Test

1. Open an order settled against a backend that records `gasCost`
2. Expand **Costs & Fees**: check **Network costs** plus one row per fee
3. On an order declaring a `partnerFee`, confirm the **Partner 1 …** row vs **Protocol fee**
4. On an order with no `gasCost`, confirm the legacy display

# Background

Verified against the mainnet prod orderbook (`fee_policies` + `app_data`, last 20k auctions) and the autopilot source:

- The protocol's policies always come first and a partner's policy of the same kind always comes last in its run. The protocol never applies two policies of one kind to one order.
- A declared partner fee is sometimes not applied (3 of ~2066 limit orders in the window), which is what the head-equality rule guards against.
- Applied partner volume rates equalled the declared bps exactly; the mainnet `max-partner-fee` cap is 5%.
- Every fee is charged in the order's surplus token, fixed per side, so one policy never spans two tokens across fills.

Known limitation: a partner declaring a rate above the cap on an order with no protocol fee of the same kind would fall back to the positional rule and read as the protocol's. Not observed. The honest fix is the backend exposing the fee owner or recipient; until then an `Unknown` owner rendered as a neutral "Fee" is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
