### PR TITLE
fix: fix measure bundle loop

### DIFF
--- a/.github/workflows/generated-files.yml
+++ b/.github/workflows/generated-files.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Build projects
         run: pnpm build:all
+        env:
+          BUNDLE_SIZE_BUILD: 'true'
 
       - name: Measure bundle sizes
         run: pnpm bundle:size

--- a/apps/cowswap-frontend/vite.config.mts
+++ b/apps/cowswap-frontend/vite.config.mts
@@ -45,6 +45,10 @@ function getGitBuildInfo(): {
   commitDate: string
   releaseTag: string
 } {
+  if (process.env.BUNDLE_SIZE_BUILD === 'true') {
+    return { commitHash: '0000000', commitDate: '1970-01-01T00:00:00+00:00', releaseTag: 'v1.0.0' }
+  }
+
   try {
     const commitHash = execSync('git rev-parse --short=7 HEAD').toString().trim()
     const commitDate = execSync('git show -s --format=%cI HEAD').toString().trim()

--- a/bundle-size.jsonc
+++ b/bundle-size.jsonc
@@ -6,7 +6,7 @@
   "schemaVersion": 1,
   "apps": {
     "@cowprotocol/cow-fi": 6130633, // 5.85 MiB
-    "@cowprotocol/cowswap": 12985350, // 12.38 MiB
+    "@cowprotocol/cowswap": 12985231, // 12.38 MiB
     "@cowprotocol/explorer": 12753988, // 12.16 MiB
     "@cowprotocol/sdk-tools": 12411573, // 11.84 MiB
     "@cowprotocol/storybook": 4953374, // 4.72 MiB

--- a/bundle-size.jsonc
+++ b/bundle-size.jsonc
@@ -6,8 +6,8 @@
   "schemaVersion": 1,
   "apps": {
     "@cowprotocol/cow-fi": 6130633, // 5.85 MiB
-    "@cowprotocol/cowswap": 12985316, // 12.38 MiB
-    "@cowprotocol/explorer": 12753978, // 12.16 MiB
+    "@cowprotocol/cowswap": 12985350, // 12.38 MiB
+    "@cowprotocol/explorer": 12753988, // 12.16 MiB
     "@cowprotocol/sdk-tools": 12411573, // 11.84 MiB
     "@cowprotocol/storybook": 4953374, // 4.72 MiB
     "@cowprotocol/widget-configurator": 12887230, // 12.29 MiB


### PR DESCRIPTION
# Summary

Because we include the git commit and date in our builds, the bundle size measurement was running in a loop as you can see here: https://github.com/cowprotocol/cowswap/pull/7899/commits

Solution: remove git info from the measurement build

<img width="1953" height="1144" alt="image" src="https://github.com/user-attachments/assets/b45dd8f1-1e86-4b70-a074-bdc30eefe522" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the generated-files build workflow to enable bundle-size analysis using a dedicated environment flag.
  * Improved bundle-size build behavior by returning placeholder version details instead of reading repository Git metadata.
  * Refreshed the recorded bundle-size figures for the browser app to reflect the latest measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->