### PR TITLE
fix: solver CMS casing

### DIFF
--- a/apps/explorer/src/hooks/orderSolverShared.ts
+++ b/apps/explorer/src/hooks/orderSolverShared.ts
@@ -1,4 +1,5 @@
-import { areAddressesEqual } from '@cowprotocol/cow-sdk'
+import { shortenAddress } from '@cowprotocol/common-utils'
+import { areAddressesEqual, isEvmAddress } from '@cowprotocol/cow-sdk'
 
 import {
   getOrderCompetitionStatus,
@@ -66,11 +67,31 @@ export async function resolveSolverByTxHash(
   return buildSolverInfo(winnerSolverName, solvers)
 }
 
-function buildSolverInfo(winnerSolverName: string, solvers: SolverInfo[]): OrderSolverInfo {
-  const matchingSolver = matchSolverByName(winnerSolverName, solvers)
+function buildSolverInfo(winnerSolver: string, solvers: SolverInfo[]): OrderSolverInfo {
+  // Once the backend migrates, the competition `solver` field carries the on-chain solver address
+  // instead of the name. Resolve CMS branding by address in that case; otherwise fall back to the
+  // legacy name-based lookup (backend still returns a name, e.g. `naive`, `barter-solve`).
+  return isEvmAddress(winnerSolver)
+    ? buildSolverInfoFromAddress(winnerSolver, solvers)
+    : buildSolverInfoFromName(winnerSolver, solvers)
+}
+
+function buildSolverInfoFromAddress(address: string, solvers: SolverInfo[]): OrderSolverInfo {
+  const matchingSolver = matchSolverByAddress(address, solvers)
   return {
-    solverId: matchingSolver?.solverId || winnerSolverName,
-    displayName: matchingSolver?.displayName || winnerSolverName,
+    solverId: matchingSolver?.solverId || address,
+    // When the address isn't found in CMS, fall back to a shortened address for display so the
+    // full 42-char address doesn't break the UI layout.
+    displayName: matchingSolver?.displayName || shortenAddress(address),
+    image: matchingSolver?.image,
+  }
+}
+
+function buildSolverInfoFromName(solverName: string, solvers: SolverInfo[]): OrderSolverInfo {
+  const matchingSolver = matchSolverByName(solverName, solvers)
+  return {
+    solverId: matchingSolver?.solverId || solverName,
+    displayName: matchingSolver?.displayName || solverName,
     image: matchingSolver?.image,
   }
 }
@@ -103,10 +124,7 @@ function getWinnerSolverName(winner: unknown, solvers: SolverInfo[]): string | u
   const solverAddress = winner.solverAddress
 
   if (typeof solverAddress === 'string') {
-    return (
-      solvers.find((s) => s.deployments.some((d) => areAddressesEqual(d.address, solverAddress)))?.displayName ??
-      undefined
-    )
+    return matchSolverByAddress(solverAddress, solvers)?.displayName ?? undefined
   }
   return undefined
 }
@@ -123,6 +141,18 @@ function isNonZeroAmount(value: ExecutedAmounts['buy']): boolean {
   } catch {
     return false
   }
+}
+
+/**
+ * Joins the CMS solver deployments on the on-chain address.
+ *
+ * `areAddressesEqual` normalizes both sides, so CMS entries are matched regardless of the casing
+ * they were stored with (checksummed or lowercase) and regardless of the casing the backend returns.
+ */
+function matchSolverByAddress(address: string, solvers: SolverInfo[]): SolverInfo | undefined {
+  return solvers.find((candidate) =>
+    candidate.deployments.some((deployment) => areAddressesEqual(deployment.address, address)),
+  )
 }
 
 function matchSolverByName(solverName: string, solvers: SolverInfo[]): SolverInfo | undefined {

--- a/apps/explorer/src/test/hooks/useOrderSolverAddress.test.tsx
+++ b/apps/explorer/src/test/hooks/useOrderSolverAddress.test.tsx
@@ -1,0 +1,167 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import BigNumber from 'bignumber.js'
+import { useNetworkId } from 'state/network'
+
+import { getOrderCompetitionStatus, getSolverCompetitionByTxHash, Order, OrderCompetitionStatus } from 'api/operator'
+import { fetchSolversInfo, SolverInfo } from 'utils/fetchSolversInfo'
+
+import { useOrderSolver } from '../../hooks/useOrderSolver'
+
+jest.mock('state/network', () => ({
+  useNetworkId: jest.fn(),
+}))
+
+jest.mock('api/operator', () => ({
+  getOrderCompetitionStatus: jest.fn(),
+  getSolverCompetitionByTxHash: jest.fn(),
+}))
+
+jest.mock('utils/fetchSolversInfo', () => ({
+  fetchSolversInfo: jest.fn(),
+}))
+
+const mockedUseNetworkId = jest.mocked(useNetworkId)
+const mockedGetOrderCompetitionStatus = jest.mocked(getOrderCompetitionStatus)
+const mockedGetSolverCompetitionByTxHash = jest.mocked(getSolverCompetitionByTxHash)
+const mockedFetchSolversInfo = jest.mocked(fetchSolversInfo)
+
+const ZERO = new BigNumber(0)
+const ONE = new BigNumber(1)
+
+// Valid 42-char all-hex addresses, so `areAddressesEqual` and `shortenAddress` behave as in prod.
+const CMS_ADDRESS_CHECKSUMMED = '0xAbCdEf0000000000000000000000000000000123'
+const CMS_ADDRESS_LOWERCASE = CMS_ADDRESS_CHECKSUMMED.toLowerCase()
+const UNKNOWN_ADDRESS = '0x2222222222222222222222222222222222222222'
+
+function createMockOrder(): Order {
+  return {
+    uid: '0x1',
+    owner: '0x1234',
+    receiver: '0x5678',
+    kind: 'sell',
+    partiallyFillable: false,
+    signature: '0x',
+    class: 'limit',
+    appData: '0x',
+    fullAppData: null,
+    executedFeeToken: null,
+    creationDate: new Date(),
+    expirationDate: new Date(),
+    buyTokenAddress: '0xtoken1',
+    sellTokenAddress: '0xtoken2',
+    buyAmount: ONE,
+    sellAmount: ONE,
+    executedBuyAmount: ONE,
+    executedSellAmount: ONE,
+    feeAmount: ZERO,
+    executedFeeAmount: ZERO,
+    executedFee: null,
+    totalFee: ZERO,
+    cancelled: false,
+    status: 'filled',
+    partiallyFilled: false,
+    fullyFilled: true,
+    filledAmount: ONE,
+    filledPercentage: new BigNumber(100),
+    surplusAmount: ZERO,
+    surplusPercentage: ZERO,
+    txHash: '0xtx123',
+  } as unknown as Order
+}
+
+function createSolver(address: string): SolverInfo {
+  return {
+    solverId: 'onchainSolver',
+    displayName: 'On-chain Solver',
+    image: 'https://example.com/onchain.png',
+    networks: [],
+    deployments: [{ chainId: 1, chainName: 'mainnet', address, active: true }],
+  }
+}
+
+function mockCompetitionStatus(solver: string): OrderCompetitionStatus {
+  return {
+    type: 'traded' as OrderCompetitionStatus['type'],
+    value: [{ solver, executedAmounts: { sell: '1', buy: '1' } }],
+  }
+}
+
+/**
+ * Once the backend migrates, the competition `solver` field carries the on-chain solver address
+ * instead of the solver name, so CMS branding has to be joined on the address.
+ */
+describe('useOrderSolver - solver address resolution', () => {
+  beforeEach(() => {
+    jest.useRealTimers()
+    mockedUseNetworkId.mockReset()
+    mockedGetOrderCompetitionStatus.mockReset()
+    mockedGetSolverCompetitionByTxHash.mockReset()
+    mockedFetchSolversInfo.mockReset()
+
+    mockedUseNetworkId.mockReturnValue(1)
+  })
+
+  it('resolves CMS branding when the order competition returns an address', async () => {
+    mockedGetOrderCompetitionStatus.mockResolvedValueOnce(mockCompetitionStatus(CMS_ADDRESS_LOWERCASE))
+    mockedFetchSolversInfo.mockResolvedValueOnce([createSolver(CMS_ADDRESS_LOWERCASE)])
+
+    const { result } = renderHook(() => useOrderSolver(createMockOrder()))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.solver).toEqual({
+      solverId: 'onchainSolver',
+      displayName: 'On-chain Solver',
+      image: 'https://example.com/onchain.png',
+    })
+    expect(mockedGetSolverCompetitionByTxHash).not.toHaveBeenCalled()
+  })
+
+  it('matches a checksummed CMS address against a lowercase competition address', async () => {
+    mockedGetOrderCompetitionStatus.mockResolvedValueOnce(mockCompetitionStatus(CMS_ADDRESS_LOWERCASE))
+    mockedFetchSolversInfo.mockResolvedValueOnce([createSolver(CMS_ADDRESS_CHECKSUMMED)])
+
+    const { result } = renderHook(() => useOrderSolver(createMockOrder()))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.solver?.displayName).toBe('On-chain Solver')
+  })
+
+  it('matches a lowercase CMS address against a checksummed competition address', async () => {
+    mockedGetOrderCompetitionStatus.mockResolvedValueOnce(mockCompetitionStatus(CMS_ADDRESS_CHECKSUMMED))
+    mockedFetchSolversInfo.mockResolvedValueOnce([createSolver(CMS_ADDRESS_LOWERCASE)])
+
+    const { result } = renderHook(() => useOrderSolver(createMockOrder()))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.solver?.displayName).toBe('On-chain Solver')
+  })
+
+  it('falls back to a shortened address when the address is not in CMS', async () => {
+    mockedGetOrderCompetitionStatus.mockResolvedValueOnce(mockCompetitionStatus(UNKNOWN_ADDRESS))
+    mockedFetchSolversInfo.mockResolvedValueOnce([createSolver(CMS_ADDRESS_CHECKSUMMED)])
+
+    const { result } = renderHook(() => useOrderSolver(createMockOrder()))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.solver).toEqual({
+      solverId: UNKNOWN_ADDRESS,
+      displayName: '0x2222...2222',
+      image: undefined,
+    })
+  })
+
+  it('still resolves solver names for backends that have not migrated', async () => {
+    mockedGetOrderCompetitionStatus.mockResolvedValueOnce(mockCompetitionStatus('OnchainSolver-Solve'))
+    mockedFetchSolversInfo.mockResolvedValueOnce([createSolver(CMS_ADDRESS_CHECKSUMMED)])
+
+    const { result } = renderHook(() => useOrderSolver(createMockOrder()))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.solver?.displayName).toBe('On-chain Solver')
+  })
+})

--- a/bundle-size.jsonc
+++ b/bundle-size.jsonc
@@ -7,7 +7,7 @@
   "apps": {
     "@cowprotocol/cow-fi": 6130633, // 5.85 MiB
     "@cowprotocol/cowswap": 12985211, // 12.38 MiB
-    "@cowprotocol/explorer": 12753953, // 12.16 MiB
+    "@cowprotocol/explorer": 12754162, // 12.16 MiB
     "@cowprotocol/sdk-tools": 12411573, // 11.84 MiB
     "@cowprotocol/storybook": 4953374, // 4.72 MiB
     "@cowprotocol/widget-configurator": 12887230, // 12.29 MiB


### PR DESCRIPTION
# Summary

Fixes the failure to resolve solver addresses in prod, the issue was considering addresses case sensitively — the CMS has upper-case addresses while BE returns all lower case.

From the build:
<img width="417" height="120" alt="Screenshot 2026-07-30 at 09 53 04" src="https://github.com/user-attachments/assets/11e7cda0-f23e-4d53-8554-4510c4924b13" />

# To Test

1. Order (arb1) `0x57718b1bed2f36c46fe179a11e3e5fe9c382d06929167231f1a43d6d5d3a0e63ba3cb449bd2b4adddbc894d8697f5170800eadecffffffff` currently shows the address in prod
2. Check in the explorer build
