### PR TITLE
fix: use viem's default urls for wallets

### DIFF
--- a/bundle-size.jsonc
+++ b/bundle-size.jsonc
@@ -5,10 +5,10 @@
 {
   "schemaVersion": 1,
   "apps": {
-    "@cowprotocol/cow-fi": 6130633, // 5.85 MiB
-    "@cowprotocol/cowswap": 12985211, // 12.38 MiB
+    "@cowprotocol/cow-fi": 6130621, // 5.85 MiB
+    "@cowprotocol/cowswap": 12985236, // 12.38 MiB
     "@cowprotocol/explorer": 12753953, // 12.16 MiB
-    "@cowprotocol/sdk-tools": 12411573, // 11.84 MiB
+    "@cowprotocol/sdk-tools": 12411597, // 11.84 MiB
     "@cowprotocol/storybook": 4953374, // 4.72 MiB
     "@cowprotocol/widget-configurator": 12887230, // 12.29 MiB
   },

--- a/bundle-size.jsonc
+++ b/bundle-size.jsonc
@@ -5,7 +5,7 @@
 {
   "schemaVersion": 1,
   "apps": {
-    "@cowprotocol/cow-fi": 6130621, // 5.85 MiB
+    "@cowprotocol/cow-fi": 6130633, // 5.85 MiB
     "@cowprotocol/cowswap": 12985236, // 12.38 MiB
     "@cowprotocol/explorer": 12753953, // 12.16 MiB
     "@cowprotocol/sdk-tools": 12411597, // 11.84 MiB

--- a/libs/wallet/src/wagmi/config.ts
+++ b/libs/wallet/src/wagmi/config.ts
@@ -1,9 +1,9 @@
 import { http } from 'viem'
 import { type Transport } from 'wagmi'
 
-import { IS_SOLANA_ENABLED, RPC_URLS } from '@cowprotocol/common-const'
+import { IS_SOLANA_ENABLED, RPC_URLS, VIEM_CHAINS } from '@cowprotocol/common-const'
 import { isInjectedWidget, isMobile } from '@cowprotocol/common-utils'
-import { EvmChains, TargetChainId } from '@cowprotocol/cow-sdk'
+import { EvmChains } from '@cowprotocol/cow-sdk'
 
 import { createAppKit } from '@reown/appkit/react'
 import { SolanaAdapter } from '@reown/appkit-adapter-solana'
@@ -35,10 +35,10 @@ const wagmiTransports = SUPPORTED_REOWN_NETWORKS.reduce(
   {} as Record<EvmChains, Transport>,
 )
 
-/** CAIP-shaped RPCs for AppKit UI / network metadata (pairs with `wagmiTransports`). */
+/** Public RPCs for AppKit's UI and wallet network-add prompts. */
 const customRpcUrls: Record<string, Array<{ url: string }>> = {}
 for (const chain of SUPPORTED_REOWN_NETWORKS) {
-  const url = RPC_URLS[chain.id as TargetChainId]
+  const url = VIEM_CHAINS[chain.id as EvmChains]?.rpcUrls.default.http[0]
   if (url) {
     customRpcUrls[`eip155:${chain.id}`] = [{ url }]
   }


### PR DESCRIPTION
# Summary

Fixes https://linear.app/cowswap/issue/FE-238/use-public-rpc-endpoints-for-wallet-network-suggestions

RPC suggestion to wallets now use default viem urls instead of our private nodes.

<img width="437" height="699" alt="Screenshot 2026-07-29 at 17 53 36" src="https://github.com/user-attachments/assets/aef9db72-ae7d-4720-99a4-af7f1028cb6c" />

# To Test

1. Make sure you don't have sepolia or another network already configured in your wallet. Rabby works best as it doesn't ship with Sepolia.
2. Connect to the app.
3. Switch to Sepolia.
* The network add prompt should NOT use our ovh rpc node
* Network should work as usual

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated wallet custom RPC configuration to use each network’s default HTTP endpoint, improving compatibility with AppKit connections.
  * Standardized the RPC metadata to follow the expected CAIP-shaped format for supported networks.
* **Chores**
  * Refreshed bundle size measurements for selected builds and packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->