### PR TITLE
fix(balances): display zero balance instead of a blank value on wrap eth modal

### DIFF
--- a/bundle-size.jsonc
+++ b/bundle-size.jsonc
@@ -6,7 +6,7 @@
   "schemaVersion": 1,
   "apps": {
     "@cowprotocol/cow-fi": 6130637, // 5.85 MiB
-    "@cowprotocol/cowswap": 12986441, // 12.38 MiB
+    "@cowprotocol/cowswap": 12986447, // 12.38 MiB
     "@cowprotocol/explorer": 12754162, // 12.16 MiB
     "@cowprotocol/sdk-tools": 12411597, // 11.84 MiB
     "@cowprotocol/storybook": 4953374, // 4.72 MiB

--- a/bundle-size.jsonc
+++ b/bundle-size.jsonc
@@ -6,7 +6,7 @@
   "schemaVersion": 1,
   "apps": {
     "@cowprotocol/cow-fi": 6130637, // 5.85 MiB
-    "@cowprotocol/cowswap": 12986447, // 12.38 MiB
+    "@cowprotocol/cowswap": 12986458, // 12.38 MiB
     "@cowprotocol/explorer": 12754162, // 12.16 MiB
     "@cowprotocol/sdk-tools": 12411597, // 11.84 MiB
     "@cowprotocol/storybook": 4953374, // 4.72 MiB

--- a/libs/balances-and-allowances/src/hooks/useCurrencyAmountBalance.ts
+++ b/libs/balances-and-allowances/src/hooks/useCurrencyAmountBalance.ts
@@ -17,7 +17,8 @@ export function useCurrencyAmountBalance(
 
     const balance = balances[token.address.toLowerCase()]
 
-    if (!balance) return undefined
+    // A zero balance is a valid value, only a missing one means the balance is unknown
+    if (balance === undefined || balance === null) return undefined
 
     return CurrencyAmount.fromRawAmount(token, toHex(balance))
   }, [token, balances])

--- a/libs/balances-and-allowances/src/hooks/useCurrencyAmountBalance.ts
+++ b/libs/balances-and-allowances/src/hooks/useCurrencyAmountBalance.ts
@@ -18,7 +18,7 @@ export function useCurrencyAmountBalance(
     const balance = balances[token.address.toLowerCase()]
 
     // A zero balance is a valid value, only a missing one means the balance is unknown
-    if (balance === undefined || balance === null) return undefined
+    if (typeof balance !== 'bigint') return undefined
 
     return CurrencyAmount.fromRawAmount(token, toHex(balance))
   }, [token, balances])


### PR DESCRIPTION
# Summary

In the "Swap with Wrapped ETH" modal the wrapped token row rendered `Balance:` with no value when the connected account had 0 WETH.
<img width="855" height="534" alt="image" src="https://github.com/user-attachments/assets/85880134-0ee2-423d-ac8c-347771aaa86f" />

Root cause is in the shared `useCurrencyAmountBalance` hook:

- the balances map holds `bigint | undefined` values, and the hook did `if (!balance) return undefined`
- `0n` is falsy, so a genuine zero balance was collapsed into the same result as "balance not loaded yet"
- `<TokenAmount />` renders `null` for a nullish `amount`, so `WrapCard` printed the label with an empty value instead of `0`

The fix only treats a missing value as unknown, so `0n` reaches `CurrencyAmount.fromRawAmount` and is formatted as `0`. This matches the behaviour `useCurrencyAmountBalanceCombined` already implements (`if (!balance && balance !== 0n) return undefined`), so the two hooks are now consistent.

# To Test

1. Connect an account that holds some native ETH and exactly 0 WETH
2. Start a sell order with native ETH 
3. Expand 'Switch to the classic flow' section under the swap container
4. Press on the 'Wrap my ETH and Swap' button
5. Check WETH balance:


- [ ] The WETH card shows `Balance: 0` instead of an empty value
<img width="751" height="409" alt="image" src="https://github.com/user-attachments/assets/da7821ff-383c-4399-9131-fdf5c3f54ad3" />

- [ ] The native ETH card still shows the correct balance


# Background

Only the eth-flow wrap preview surfaced this visually, but the bug is in a shared hook, so every consumer was unable to distinguish "zero balance" from "balance unknown". Fixing it at the hook level avoids adding per-component fallbacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed currency amount balance handling so zero balances are recognized and displayed correctly instead of being treated as unavailable.
* **Chores**
  * Updated the recorded browser bundle size metric for the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->