### PR TITLE
fix: add quoteId and allowsOffchainSigning tracking when order is sent to sign

### DIFF
--- a/apps/cowswap-frontend/src/modules/ethFlow/services/ethFlow/index.test.ts
+++ b/apps/cowswap-frontend/src/modules/ethFlow/services/ethFlow/index.test.ts
@@ -1,0 +1,141 @@
+import { CurrencyAmount, Token } from '@cowprotocol/currency'
+import { UiOrderType } from '@cowprotocol/types'
+
+import { EthFlowContext } from '../../types'
+
+import { ethFlow } from './index'
+
+jest.mock('@cowprotocol/common-const', () => ({
+  ...jest.requireActual('@cowprotocol/common-const'),
+  getEthFlowContractAddresses: jest.fn().mockReturnValue('0x0000000000000000000000000000000000e10w'),
+}))
+
+jest.mock('modules/appData', () => ({
+  removePermitHookFromAppData: jest.fn().mockResolvedValue({ fullAppData: '{}', doc: {} }),
+}))
+
+jest.mock('modules/orders', () => ({ emitPostedOrderEvent: jest.fn() }))
+
+jest.mock('modules/trade/utils/addPendingOrderStep', () => ({ addPendingOrderStep: jest.fn() }))
+
+jest.mock('modules/trade/utils/logger', () => ({ logTradeFlow: jest.fn() }))
+
+jest.mock('modules/tradeQuote', () => ({
+  assertValidBridgeRecipient: jest.fn(),
+  isQuoteExpired: jest.fn().mockReturnValue(false),
+}))
+
+jest.mock('legacy/utils/trade', () => ({
+  mapUnsignedOrderToOrder: jest.fn().mockReturnValue({ id: '0xorder' }),
+  wrapErrorInOperatorError: (fn: () => unknown) => fn(),
+}))
+
+const ETH_FLOW_CONTRACT_ADDRESS = '0x0000000000000000000000000000000000e10w'
+
+describe('ethFlow - Send analytics payload', () => {
+  const sellToken = new Token(1, '0x1111111111111111111111111111111111111111', 18, 'ETH', 'Ether')
+  const buyToken = new Token(1, '0x2222222222222222222222222222222222222222', 18, 'BUY', 'Buy Token')
+  const inputAmount = CurrencyAmount.fromRawAmount(sellToken, '1000000000000000000')
+  const outputAmount = CurrencyAmount.fromRawAmount(buyToken, '2000000000000000000')
+
+  const analytics = {
+    trade: jest.fn(),
+    sign: jest.fn(),
+    error: jest.fn(),
+  }
+
+  const postSwapOrderFromQuote = jest.fn().mockResolvedValue({
+    orderId: '0xorder',
+    txHash: '0xtxhash',
+    signature: '0xsig',
+    signingScheme: 'eip1271',
+    orderToSign: {},
+  })
+
+  function buildTradeContext(
+    quoteId: number | undefined,
+    allowsOffchainSigning: boolean,
+  ): Parameters<typeof ethFlow>[0]['tradeContext'] {
+    return {
+      tradeConfirmActions: { onSign: jest.fn(), onSuccess: jest.fn(), onError: jest.fn() },
+      swapFlowAnalyticsContext: {
+        account: '0xaccount',
+        orderType: UiOrderType.SWAP,
+        marketLabel: 'ETH,BUY',
+      },
+      context: { chainId: 1, inputAmount, outputAmount },
+      callbacks: {
+        addBridgeOrder: jest.fn(),
+        setSigningStep: jest.fn(),
+        closeModals: jest.fn(),
+        dispatch: jest.fn(),
+      },
+      orderParams: {
+        account: '0xaccount',
+        recipientAddressOrName: '0xaccount',
+        recipient: '0xaccount',
+        kind: 'sell',
+        appData: { fullAppData: '{}', doc: {} },
+        validTo: 1700000000,
+        isSafeWallet: false,
+        allowsOffchainSigning,
+      },
+      typedHooks: undefined,
+      tradeQuote: {
+        postSwapOrderFromQuote,
+        quoteResults: {
+          quoteResponse: {
+            id: quoteId,
+            quote: { feeAmount: '0' },
+          },
+        },
+      },
+      tradeQuoteState: {},
+      bridgeQuoteAmounts: null,
+    } as unknown as Parameters<typeof ethFlow>[0]['tradeContext']
+  }
+
+  const ethFlowContext = {
+    contract: { address: ETH_FLOW_CONTRACT_ADDRESS },
+    addTransaction: jest.fn(),
+    checkEthFlowOrderExists: jest.fn(),
+    addInFlightOrderId: jest.fn(),
+  } as unknown as EthFlowContext
+
+  function runEthFlow(quoteId: number | undefined, allowsOffchainSigning: boolean): Promise<void | boolean> {
+    return ethFlow({
+      tradeContext: buildTradeContext(quoteId, allowsOffchainSigning),
+      ethFlowContext,
+      priceImpactParams: { priceImpact: undefined } as never,
+      confirmPriceImpactWithoutFee: jest.fn().mockResolvedValue(true),
+      analytics: analytics as never,
+    })
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    postSwapOrderFromQuote.mockResolvedValue({
+      orderId: '0xorder',
+      txHash: '0xtxhash',
+      signature: '0xsig',
+      signingScheme: 'eip1271',
+      orderToSign: {},
+    })
+  })
+
+  it('propagates quoteId and allowsOffchainSigning on the Send analytics event', async () => {
+    await runEthFlow(123, true)
+
+    expect(analytics.trade).toHaveBeenCalledWith(expect.objectContaining({ quoteId: 123, allowsOffchainSigning: true }))
+  })
+
+  it('omits quoteId on the Send analytics event when the quote id is unavailable', async () => {
+    await runEthFlow(undefined, true)
+
+    // The undefined quoteId still flows through here; sendTradeAnalytics (tradeFlowAnalytics.ts)
+    // is what actually drops the key from the GTM payload when it's undefined.
+    expect(analytics.trade).toHaveBeenCalledWith(
+      expect.objectContaining({ quoteId: undefined, allowsOffchainSigning: true }),
+    )
+  })
+})

--- a/apps/cowswap-frontend/src/modules/ethFlow/services/ethFlow/index.test.ts
+++ b/apps/cowswap-frontend/src/modules/ethFlow/services/ethFlow/index.test.ts
@@ -128,14 +128,4 @@ describe('ethFlow - Send analytics payload', () => {
 
     expect(analytics.trade).toHaveBeenCalledWith(expect.objectContaining({ quoteId: 123, allowsOffchainSigning: true }))
   })
-
-  it('omits quoteId on the Send analytics event when the quote id is unavailable', async () => {
-    await runEthFlow(undefined, true)
-
-    // The undefined quoteId still flows through here; sendTradeAnalytics (tradeFlowAnalytics.ts)
-    // is what actually drops the key from the GTM payload when it's undefined.
-    expect(analytics.trade).toHaveBeenCalledWith(
-      expect.objectContaining({ quoteId: undefined, allowsOffchainSigning: true }),
-    )
-  })
 })

--- a/apps/cowswap-frontend/src/modules/ethFlow/services/ethFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/ethFlow/services/ethFlow/index.ts
@@ -67,7 +67,11 @@ export async function ethFlow({
   orderParams.appData = await removePermitHookFromAppData(orderParams.appData, typedHooks)
 
   logTradeFlow('ETH FLOW', 'STEP 2: send transaction')
-  analytics.trade(swapFlowAnalyticsContext)
+  analytics.trade({
+    ...swapFlowAnalyticsContext,
+    quoteId: tradeQuote.quoteResults.quoteResponse.id,
+    allowsOffchainSigning: orderParams.allowsOffchainSigning,
+  })
   tradeConfirmActions.onSign(tradeAmounts)
 
   try {

--- a/apps/cowswap-frontend/src/modules/limitOrders/services/safeBundleFlow/index.test.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/services/safeBundleFlow/index.test.ts
@@ -1,0 +1,124 @@
+import { CurrencyAmount, Token } from '@cowprotocol/currency'
+
+import { SafeBundleFlowContext } from '../types'
+
+import { safeBundleFlow } from './index'
+
+jest.mock('modules/appData', () => ({
+  removePermitHookFromAppData: jest.fn().mockResolvedValue({ fullAppData: '{}', doc: {} }),
+}))
+
+jest.mock('modules/limitOrders/utils/calculateLimitOrdersDeadline', () => ({
+  calculateLimitOrdersDeadline: () => 1700000000,
+}))
+
+jest.mock('modules/operations/bundle/buildApproveTx', () => ({
+  buildApproveTx: jest.fn().mockResolvedValue({ to: '0xapprove', data: '0xapprovedata', value: 0n }),
+}))
+
+jest.mock('modules/operations/bundle/buildZeroApproveTx', () => ({
+  buildZeroApproveTx: jest.fn().mockResolvedValue({ to: '0xzeroapprove', data: '0xzeroapprovedata', value: 0n }),
+}))
+
+jest.mock('modules/orders', () => ({ emitPostedOrderEvent: jest.fn() }))
+
+jest.mock('modules/trade/utils/addPendingOrderStep', () => ({ addPendingOrderStep: jest.fn() }))
+
+jest.mock('modules/trade/utils/logger', () => ({ logTradeFlow: jest.fn() }))
+
+jest.mock('modules/zeroApproval', () => ({ shouldZeroApprove: jest.fn().mockResolvedValue(false) }))
+
+jest.mock('legacy/utils/trade', () => ({
+  mapUnsignedOrderToOrder: jest.fn().mockReturnValue({ id: '0xorder' }),
+  wrapErrorInOperatorError: (fn: () => unknown) => fn(),
+}))
+
+jest.mock('legacy/state/orders/utils', () => ({ partialOrderUpdate: jest.fn() }))
+
+jest.mock('tradingSdk/tradingSdk', () => ({
+  tradingSdk: {
+    postLimitOrder: jest.fn().mockResolvedValue({
+      orderId: '0xorder',
+      signature: '0xsig',
+      signingScheme: 'presign',
+      orderToSign: {},
+    }),
+    getPreSignTransaction: jest.fn().mockResolvedValue({ to: '0xpresign', data: '0xpresigndata', value: '0' }),
+  },
+}))
+
+describe('limit orders safeBundleFlow - Send analytics payload', () => {
+  const sellToken = new Token(1, '0x1111111111111111111111111111111111111111', 18, 'SELL', 'Sell Token')
+  const buyToken = new Token(1, '0x2222222222222222222222222222222222222222', 18, 'BUY', 'Buy Token')
+  const inputAmount = CurrencyAmount.fromRawAmount(sellToken, '1000000000000000000')
+  const outputAmount = CurrencyAmount.fromRawAmount(buyToken, '2000000000000000000')
+
+  const analytics = {
+    trade: jest.fn(),
+    approveAndPresign: jest.fn(),
+    sign: jest.fn(),
+    error: jest.fn(),
+  }
+
+  function buildParams(quoteId: number | undefined, allowsOffchainSigning: boolean): SafeBundleFlowContext {
+    return {
+      chainId: 1,
+      dispatch: jest.fn(),
+      config: {},
+      spender: '0xspender',
+      sendBatchTransactions: jest.fn().mockResolvedValue('0xsafetxhash'),
+      quoteState: {},
+      postOrderParams: {
+        class: 'limit',
+        kind: 'sell',
+        account: '0xaccount',
+        chainId: 1,
+        signer: {},
+        sellToken,
+        buyToken,
+        recipient: '0xaccount',
+        recipientAddressOrName: '0xaccount',
+        allowsOffchainSigning,
+        feeAmount: CurrencyAmount.fromRawAmount(sellToken, 0),
+        inputAmount,
+        outputAmount,
+        sellAmountBeforeFee: inputAmount,
+        partiallyFillable: false,
+        appData: { fullAppData: '{}', doc: {} },
+        quoteId,
+        isSafeWallet: true,
+      },
+    } as unknown as SafeBundleFlowContext
+  }
+
+  function run(quoteId: number | undefined, allowsOffchainSigning: boolean): Promise<string> {
+    return safeBundleFlow({
+      params: buildParams(quoteId, allowsOffchainSigning),
+      priceImpact: { priceImpact: undefined } as never,
+      settingsState: {} as never,
+      confirmPriceImpactWithoutFee: jest.fn().mockResolvedValue(true),
+      analytics: analytics as never,
+      config: {} as never,
+    })
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('propagates quoteId and allowsOffchainSigning on the approveAndPresign analytics event', async () => {
+    await run(123, false)
+
+    expect(analytics.approveAndPresign).toHaveBeenCalledWith(
+      expect.objectContaining({ quoteId: 123, allowsOffchainSigning: false }),
+    )
+  })
+
+  it('omits quoteId on the approveAndPresign analytics event when the quote id is unavailable', async () => {
+    await run(undefined, false)
+
+    expect(analytics.approveAndPresign).toHaveBeenCalledWith(
+      expect.objectContaining({ quoteId: undefined, allowsOffchainSigning: false }),
+    )
+  })
+})

--- a/apps/cowswap-frontend/src/modules/limitOrders/services/safeBundleFlow/index.test.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/services/safeBundleFlow/index.test.ts
@@ -113,12 +113,4 @@ describe('limit orders safeBundleFlow - Send analytics payload', () => {
       expect.objectContaining({ quoteId: 123, allowsOffchainSigning: false }),
     )
   })
-
-  it('omits quoteId on the approveAndPresign analytics event when the quote id is unavailable', async () => {
-    await run(undefined, false)
-
-    expect(analytics.approveAndPresign).toHaveBeenCalledWith(
-      expect.objectContaining({ quoteId: undefined, allowsOffchainSigning: false }),
-    )
-  })
 })

--- a/apps/cowswap-frontend/src/modules/limitOrders/services/safeBundleFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/services/safeBundleFlow/index.ts
@@ -70,7 +70,11 @@ export async function safeBundleFlow({
   }
 
   logTradeFlow(LOG_PREFIX, 'STEP 2: send transaction')
-  analytics.approveAndPresign(swapFlowAnalyticsContext)
+  analytics.approveAndPresign({
+    ...swapFlowAnalyticsContext,
+    quoteId: params.postOrderParams.quoteId,
+    allowsOffchainSigning: params.postOrderParams.allowsOffchainSigning,
+  })
   beforeTrade?.()
 
   const { chainId, postOrderParams, spender, dispatch, sendBatchTransactions } = params

--- a/apps/cowswap-frontend/src/modules/limitOrders/services/tradeFlow/index.test.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/services/tradeFlow/index.test.ts
@@ -141,4 +141,23 @@ describe('limit orders tradeFlow - permit amount', () => {
 
     expect(analytics.error).not.toHaveBeenCalled()
   })
+
+  it('propagates quoteId and allowsOffchainSigning on the Send analytics event', async () => {
+    await runTradeFlow(buildParams())
+
+    expect(analytics.trade).toHaveBeenCalledWith(expect.objectContaining({ quoteId: 1, allowsOffchainSigning: true }))
+  })
+
+  it('omits quoteId on the Send analytics event when the quote id is unavailable', async () => {
+    const params = buildParams()
+    params.postOrderParams.quoteId = undefined
+
+    await runTradeFlow(params)
+
+    // The undefined quoteId still flows through here; sendTradeAnalytics (tradeFlowAnalytics.ts)
+    // is what actually drops the key from the GTM payload when it's undefined.
+    expect(analytics.trade).toHaveBeenCalledWith(
+      expect.objectContaining({ quoteId: undefined, allowsOffchainSigning: true }),
+    )
+  })
 })

--- a/apps/cowswap-frontend/src/modules/limitOrders/services/tradeFlow/index.test.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/services/tradeFlow/index.test.ts
@@ -147,17 +147,4 @@ describe('limit orders tradeFlow - permit amount', () => {
 
     expect(analytics.trade).toHaveBeenCalledWith(expect.objectContaining({ quoteId: 1, allowsOffchainSigning: true }))
   })
-
-  it('omits quoteId on the Send analytics event when the quote id is unavailable', async () => {
-    const params = buildParams()
-    params.postOrderParams.quoteId = undefined
-
-    await runTradeFlow(params)
-
-    // The undefined quoteId still flows through here; sendTradeAnalytics (tradeFlowAnalytics.ts)
-    // is what actually drops the key from the GTM payload when it's undefined.
-    expect(analytics.trade).toHaveBeenCalledWith(
-      expect.objectContaining({ quoteId: undefined, allowsOffchainSigning: true }),
-    )
-  })
 })

--- a/apps/cowswap-frontend/src/modules/limitOrders/services/tradeFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/limitOrders/services/tradeFlow/index.ts
@@ -90,7 +90,11 @@ export async function tradeFlow(
     }
 
     logTradeFlow('LIMIT ORDER FLOW', 'STEP 3: send transaction')
-    analytics.trade(swapFlowAnalyticsContext)
+    analytics.trade({
+      ...swapFlowAnalyticsContext,
+      quoteId: postOrderParams.quoteId,
+      allowsOffchainSigning: postOrderParams.allowsOffchainSigning,
+    })
 
     beforeTrade()
 

--- a/apps/cowswap-frontend/src/modules/trade/utils/tradeFlowAnalytics.test.ts
+++ b/apps/cowswap-frontend/src/modules/trade/utils/tradeFlowAnalytics.test.ts
@@ -1,0 +1,65 @@
+import { useCowAnalytics } from '@cowprotocol/analytics'
+import { UiOrderType } from '@cowprotocol/types'
+
+import { renderHook } from '@testing-library/react'
+
+import { CowSwapAnalyticsCategory } from 'common/analytics/types'
+
+import { useTradeFlowAnalytics } from './tradeFlowAnalytics'
+
+jest.mock('@cowprotocol/analytics', () => {
+  const actualModule = jest.requireActual('@cowprotocol/analytics')
+
+  return {
+    ...actualModule,
+    __resetGtmInstance: jest.fn(),
+    useCowAnalytics: jest.fn(),
+  }
+})
+
+const useCowAnalyticsMock = useCowAnalytics as jest.MockedFunction<typeof useCowAnalytics>
+
+describe('useTradeFlowAnalytics.trade', () => {
+  const sendEvent = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    useCowAnalyticsMock.mockReturnValue({ sendEvent } as unknown as ReturnType<typeof useCowAnalytics>)
+  })
+
+  it('includes quoteId and allowsOffchainSigning on the Send event when provided', () => {
+    const { result } = renderHook(() => useTradeFlowAnalytics())
+
+    result.current.trade({
+      account: '0xaccount',
+      orderType: UiOrderType.SWAP,
+      marketLabel: 'WETH,COW',
+      quoteId: 123,
+      allowsOffchainSigning: true,
+    })
+
+    expect(sendEvent).toHaveBeenCalledWith({
+      category: CowSwapAnalyticsCategory.TRADE,
+      action: 'Send',
+      label: `${UiOrderType.SWAP}|WETH,COW`,
+      isBridgeOrder: undefined,
+      quoteId: 123,
+      allowsOffchainSigning: true,
+    })
+  })
+
+  it('omits quoteId and allowsOffchainSigning when not provided', () => {
+    const { result } = renderHook(() => useTradeFlowAnalytics())
+
+    result.current.trade({
+      account: '0xaccount',
+      orderType: UiOrderType.SWAP,
+      marketLabel: 'WETH,COW',
+    })
+
+    const payload = sendEvent.mock.calls[0]?.[0] as Record<string, unknown>
+
+    expect(payload).not.toHaveProperty('quoteId')
+    expect(payload).not.toHaveProperty('allowsOffchainSigning')
+  })
+})

--- a/apps/cowswap-frontend/src/modules/trade/utils/tradeFlowAnalytics.test.ts
+++ b/apps/cowswap-frontend/src/modules/trade/utils/tradeFlowAnalytics.test.ts
@@ -5,7 +5,7 @@ import { renderHook } from '@testing-library/react'
 
 import { CowSwapAnalyticsCategory } from 'common/analytics/types'
 
-import { useTradeFlowAnalytics } from './tradeFlowAnalytics'
+import { TradeFlowAnalytics, useTradeFlowAnalytics } from './tradeFlowAnalytics'
 
 jest.mock('@cowprotocol/analytics', () => {
   const actualModule = jest.requireActual('@cowprotocol/analytics')
@@ -19,7 +19,17 @@ jest.mock('@cowprotocol/analytics', () => {
 
 const useCowAnalyticsMock = useCowAnalytics as jest.MockedFunction<typeof useCowAnalytics>
 
-describe('useTradeFlowAnalytics.trade', () => {
+const PRE_SIGNATURE_METHODS: Array<{
+  method: 'trade' | 'placeAdvancedOrder' | 'approveAndPresign' | 'wrapApproveAndPresign'
+  action: string
+}> = [
+  { method: 'trade', action: 'Send' },
+  { method: 'placeAdvancedOrder', action: 'Place Advanced Order' },
+  { method: 'approveAndPresign', action: 'Bundle Approve and Swap' },
+  { method: 'wrapApproveAndPresign', action: 'Bundled Eth Flow' },
+]
+
+describe.each(PRE_SIGNATURE_METHODS)('useTradeFlowAnalytics.$method', ({ method, action }) => {
   const sendEvent = jest.fn()
 
   beforeEach(() => {
@@ -27,10 +37,13 @@ describe('useTradeFlowAnalytics.trade', () => {
     useCowAnalyticsMock.mockReturnValue({ sendEvent } as unknown as ReturnType<typeof useCowAnalytics>)
   })
 
-  it('includes quoteId and allowsOffchainSigning on the Send event when provided', () => {
+  function call(context: Parameters<TradeFlowAnalytics[typeof method]>[0]): void {
     const { result } = renderHook(() => useTradeFlowAnalytics())
+    result.current[method](context)
+  }
 
-    result.current.trade({
+  it(`includes quoteId and allowsOffchainSigning on the ${action} event when provided`, () => {
+    call({
       account: '0xaccount',
       orderType: UiOrderType.SWAP,
       marketLabel: 'WETH,COW',
@@ -40,7 +53,7 @@ describe('useTradeFlowAnalytics.trade', () => {
 
     expect(sendEvent).toHaveBeenCalledWith({
       category: CowSwapAnalyticsCategory.TRADE,
-      action: 'Send',
+      action,
       label: `${UiOrderType.SWAP}|WETH,COW`,
       isBridgeOrder: undefined,
       quoteId: 123,
@@ -49,9 +62,7 @@ describe('useTradeFlowAnalytics.trade', () => {
   })
 
   it('omits quoteId and allowsOffchainSigning when not provided', () => {
-    const { result } = renderHook(() => useTradeFlowAnalytics())
-
-    result.current.trade({
+    call({
       account: '0xaccount',
       orderType: UiOrderType.SWAP,
       marketLabel: 'WETH,COW',

--- a/apps/cowswap-frontend/src/modules/trade/utils/tradeFlowAnalytics.ts
+++ b/apps/cowswap-frontend/src/modules/trade/utils/tradeFlowAnalytics.ts
@@ -22,6 +22,8 @@ export interface TradeFlowAnalyticsContext {
   marketLabel?: string
   isBridgeOrder?: boolean
   orderType: UiOrderType
+  quoteId?: number
+  allowsOffchainSigning?: boolean
 }
 
 export function useTradeFlowAnalytics(): TradeFlowAnalytics {
@@ -34,6 +36,8 @@ export function useTradeFlowAnalytics(): TradeFlowAnalytics {
       marketLabel?: string,
       value?: number,
       isBridgeOrder?: boolean,
+      quoteId?: number,
+      allowsOffchainSigning?: boolean,
     ): void => {
       analytics.sendEvent({
         category: CowSwapAnalyticsCategory.TRADE,
@@ -41,12 +45,22 @@ export function useTradeFlowAnalytics(): TradeFlowAnalytics {
         label: `${orderType}|${marketLabel}`,
         ...(value !== undefined && { value }),
         isBridgeOrder,
+        ...(quoteId !== undefined && { quoteId }),
+        ...(allowsOffchainSigning !== undefined && { allowsOffchainSigning }),
       } as GtmEvent<CowSwapAnalyticsCategory.TRADE>)
     }
 
     return {
       trade(context: TradeFlowAnalyticsContext) {
-        sendTradeAnalytics('Send', context.orderType, context.marketLabel, undefined, context.isBridgeOrder)
+        sendTradeAnalytics(
+          'Send',
+          context.orderType,
+          context.marketLabel,
+          undefined,
+          context.isBridgeOrder,
+          context.quoteId,
+          context.allowsOffchainSigning,
+        )
       },
       sign(context: TradeFlowAnalyticsContext) {
         const { marketLabel, orderType } = context

--- a/apps/cowswap-frontend/src/modules/trade/utils/tradeFlowAnalytics.ts
+++ b/apps/cowswap-frontend/src/modules/trade/utils/tradeFlowAnalytics.ts
@@ -30,15 +30,9 @@ export function useTradeFlowAnalytics(): TradeFlowAnalytics {
   const analytics = useCowAnalytics()
 
   return useMemo(() => {
-    const sendTradeAnalytics = (
-      action: string,
-      orderType: UiOrderType,
-      marketLabel?: string,
-      value?: number,
-      isBridgeOrder?: boolean,
-      quoteId?: number,
-      allowsOffchainSigning?: boolean,
-    ): void => {
+    const sendTradeAnalytics = (action: string, context: TradeFlowAnalyticsContext, value?: number): void => {
+      const { orderType, marketLabel, isBridgeOrder, quoteId, allowsOffchainSigning } = context
+
       analytics.sendEvent({
         category: CowSwapAnalyticsCategory.TRADE,
         action,
@@ -52,39 +46,25 @@ export function useTradeFlowAnalytics(): TradeFlowAnalytics {
 
     return {
       trade(context: TradeFlowAnalyticsContext) {
-        sendTradeAnalytics(
-          'Send',
-          context.orderType,
-          context.marketLabel,
-          undefined,
-          context.isBridgeOrder,
-          context.quoteId,
-          context.allowsOffchainSigning,
-        )
+        sendTradeAnalytics('Send', context)
       },
       sign(context: TradeFlowAnalyticsContext) {
-        const { marketLabel, orderType } = context
-        sendTradeAnalytics('Sign', orderType, marketLabel, undefined, context.isBridgeOrder)
+        sendTradeAnalytics('Sign', context)
       },
       approveAndPresign(context: TradeFlowAnalyticsContext) {
-        const { marketLabel, orderType } = context
-        sendTradeAnalytics('Bundle Approve and Swap', orderType, marketLabel, undefined, context.isBridgeOrder)
+        sendTradeAnalytics('Bundle Approve and Swap', context)
       },
       placeAdvancedOrder(context: TradeFlowAnalyticsContext) {
-        const { marketLabel, orderType } = context
-        sendTradeAnalytics('Place Advanced Order', orderType, marketLabel, undefined, context.isBridgeOrder)
+        sendTradeAnalytics('Place Advanced Order', context)
       },
       wrapApproveAndPresign(context: TradeFlowAnalyticsContext) {
-        const { marketLabel, orderType } = context
-        sendTradeAnalytics('Bundled Eth Flow', orderType, marketLabel, undefined, context.isBridgeOrder)
+        sendTradeAnalytics('Bundled Eth Flow', context)
       },
       error(error: Error & { code?: number }, errorMessage: string, context: TradeFlowAnalyticsContext) {
-        const { marketLabel, orderType } = context
-
         if (errorMessage === USER_SWAP_REJECTED_ERROR) {
-          sendTradeAnalytics('Reject', orderType, marketLabel, undefined, context.isBridgeOrder)
+          sendTradeAnalytics('Reject', context)
         } else {
-          sendTradeAnalytics('Error', orderType, marketLabel, error.code, context.isBridgeOrder)
+          sendTradeAnalytics('Error', context, error.code)
         }
       },
     }

--- a/apps/cowswap-frontend/src/modules/tradeFlow/services/safeBundleFlow/safeBundleApprovalFlow.test.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/services/safeBundleFlow/safeBundleApprovalFlow.test.ts
@@ -131,12 +131,4 @@ describe('safeBundleApprovalFlow - Send analytics payload', () => {
       expect.objectContaining({ quoteId: 123, allowsOffchainSigning: false }),
     )
   })
-
-  it('omits quoteId on the approveAndPresign analytics event when the quote id is unavailable', async () => {
-    await run(undefined, false)
-
-    expect(analytics.approveAndPresign).toHaveBeenCalledWith(
-      expect.objectContaining({ quoteId: undefined, allowsOffchainSigning: false }),
-    )
-  })
 })

--- a/apps/cowswap-frontend/src/modules/tradeFlow/services/safeBundleFlow/safeBundleApprovalFlow.test.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/services/safeBundleFlow/safeBundleApprovalFlow.test.ts
@@ -1,0 +1,142 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { CurrencyAmount, Token } from '@cowprotocol/currency'
+import { UiOrderType } from '@cowprotocol/types'
+
+import { safeBundleApprovalFlow } from './safeBundleApprovalFlow'
+
+import { SafeBundleFlowContext, TradeFlowContext } from '../../types/TradeFlowContext'
+
+jest.mock('modules/appData', () => ({
+  removePermitHookFromAppData: jest.fn().mockResolvedValue({ fullAppData: '{}', doc: {} }),
+}))
+
+jest.mock('modules/operations/bundle/buildApproveTx', () => ({
+  buildApproveTx: jest.fn().mockResolvedValue({ to: '0xapprove', data: '0xapprovedata', value: 0n }),
+}))
+
+jest.mock('modules/operations/bundle/buildZeroApproveTx', () => ({
+  buildZeroApproveTx: jest.fn().mockResolvedValue({ to: '0xzeroapprove', data: '0xzeroapprovedata', value: 0n }),
+}))
+
+jest.mock('modules/orders', () => ({ emitPostedOrderEvent: jest.fn() }))
+
+jest.mock('modules/trade/utils/addPendingOrderStep', () => ({ addPendingOrderStep: jest.fn() }))
+
+jest.mock('modules/trade/utils/logger', () => ({ logTradeFlow: jest.fn() }))
+
+jest.mock('modules/tradeQuote', () => ({ assertValidBridgeRecipient: jest.fn() }))
+
+jest.mock('modules/zeroApproval', () => ({ shouldZeroApprove: jest.fn().mockResolvedValue(false) }))
+
+jest.mock('legacy/utils/trade', () => ({
+  mapUnsignedOrderToOrder: jest.fn().mockReturnValue({ id: '0xorder' }),
+  wrapErrorInOperatorError: (fn: () => unknown) => fn(),
+}))
+
+jest.mock('legacy/state/orders/utils', () => ({ partialOrderUpdate: jest.fn() }))
+
+jest.mock('tradingSdk/tradingSdk', () => ({
+  tradingSdk: {
+    getPreSignTransaction: jest.fn().mockResolvedValue({ to: '0xpresign', data: '0xpresigndata', value: '0' }),
+  },
+}))
+
+describe('safeBundleApprovalFlow - Send analytics payload', () => {
+  const sellToken = new Token(
+    SupportedChainId.MAINNET,
+    '0x1111111111111111111111111111111111111111',
+    18,
+    'SELL',
+    'Sell',
+  )
+  const buyToken = new Token(SupportedChainId.MAINNET, '0x2222222222222222222222222222222222222222', 18, 'BUY', 'Buy')
+  const inputAmount = CurrencyAmount.fromRawAmount(sellToken, '1000000000000000000')
+  const outputAmount = CurrencyAmount.fromRawAmount(buyToken, '2000000000000000000')
+
+  const analytics = {
+    trade: jest.fn(),
+    approveAndPresign: jest.fn(),
+    sign: jest.fn(),
+    error: jest.fn(),
+  }
+
+  const postSwapOrderFromQuote = jest.fn().mockResolvedValue({
+    orderId: '0xorder',
+    signature: '0xsig',
+    signingScheme: 'presign',
+    orderToSign: {},
+  })
+
+  function buildTradeContext(quoteId: number | undefined, allowsOffchainSigning: boolean): TradeFlowContext {
+    return {
+      context: { chainId: SupportedChainId.MAINNET, inputAmount, outputAmount },
+      callbacks: { closeModals: jest.fn(), dispatch: jest.fn(), addBridgeOrder: jest.fn() },
+      swapFlowAnalyticsContext: {
+        account: '0xaccount',
+        orderType: UiOrderType.SWAP,
+        marketLabel: 'SELL,BUY',
+      },
+      tradeConfirmActions: { onSign: jest.fn(), onSuccess: jest.fn(), onError: jest.fn() },
+      typedHooks: undefined,
+      tradeQuote: { postSwapOrderFromQuote },
+      bridgeQuoteAmounts: null,
+      orderParams: {
+        account: '0xaccount',
+        recipientAddressOrName: '0xaccount',
+        recipient: '0xaccount',
+        kind: 'sell',
+        appData: { fullAppData: '{}', doc: {} },
+        validTo: 1700000000,
+        isSafeWallet: true,
+        inputAmount,
+        outputAmount,
+        allowsOffchainSigning,
+        quoteId,
+      },
+    } as unknown as TradeFlowContext
+  }
+
+  const safeBundleContext = {
+    spender: '0xspender',
+    sendBatchTransactions: jest.fn().mockResolvedValue('0xsafetxhash'),
+    tokenAddress: sellToken.address,
+    amountToApprove: inputAmount,
+  } as unknown as SafeBundleFlowContext
+
+  function run(quoteId: number | undefined, allowsOffchainSigning: boolean): Promise<void | boolean> {
+    return safeBundleApprovalFlow({
+      tradeContext: buildTradeContext(quoteId, allowsOffchainSigning),
+      safeBundleContext,
+      priceImpactParams: { priceImpact: undefined } as never,
+      confirmPriceImpactWithoutFee: jest.fn().mockResolvedValue(true),
+      analytics: analytics as never,
+      config: {} as never,
+    })
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    postSwapOrderFromQuote.mockResolvedValue({
+      orderId: '0xorder',
+      signature: '0xsig',
+      signingScheme: 'presign',
+      orderToSign: {},
+    })
+  })
+
+  it('propagates quoteId and allowsOffchainSigning on the approveAndPresign analytics event', async () => {
+    await run(123, false)
+
+    expect(analytics.approveAndPresign).toHaveBeenCalledWith(
+      expect.objectContaining({ quoteId: 123, allowsOffchainSigning: false }),
+    )
+  })
+
+  it('omits quoteId on the approveAndPresign analytics event when the quote id is unavailable', async () => {
+    await run(undefined, false)
+
+    expect(analytics.approveAndPresign).toHaveBeenCalledWith(
+      expect.objectContaining({ quoteId: undefined, allowsOffchainSigning: false }),
+    )
+  })
+})

--- a/apps/cowswap-frontend/src/modules/tradeFlow/services/safeBundleFlow/safeBundleApprovalFlow.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/services/safeBundleFlow/safeBundleApprovalFlow.ts
@@ -69,7 +69,11 @@ export async function safeBundleApprovalFlow({
   const tradeAmounts = { inputAmount, outputAmount }
   const isBridgingOrder = inputAmount.currency.chainId !== outputAmount.currency.chainId
 
-  analytics.approveAndPresign(swapFlowAnalyticsContext)
+  analytics.approveAndPresign({
+    ...swapFlowAnalyticsContext,
+    quoteId: orderParams.quoteId,
+    allowsOffchainSigning: orderParams.allowsOffchainSigning,
+  })
   tradeConfirmActions.onSign(tradeAmounts)
 
   try {

--- a/apps/cowswap-frontend/src/modules/tradeFlow/services/safeBundleFlow/safeBundleEthFlow.test.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/services/safeBundleFlow/safeBundleEthFlow.test.ts
@@ -123,12 +123,4 @@ describe('safeBundleEthFlow - Send analytics payload', () => {
       expect.objectContaining({ quoteId: 123, allowsOffchainSigning: false }),
     )
   })
-
-  it('omits quoteId on the wrapApproveAndPresign analytics event when the quote id is unavailable', async () => {
-    await run(undefined, false)
-
-    expect(analytics.wrapApproveAndPresign).toHaveBeenCalledWith(
-      expect.objectContaining({ quoteId: undefined, allowsOffchainSigning: false }),
-    )
-  })
 })

--- a/apps/cowswap-frontend/src/modules/tradeFlow/services/safeBundleFlow/safeBundleEthFlow.test.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/services/safeBundleFlow/safeBundleEthFlow.test.ts
@@ -1,0 +1,134 @@
+import { WETH_MAINNET } from '@cowprotocol/common-const'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { CurrencyAmount, Token } from '@cowprotocol/currency'
+import { UiOrderType } from '@cowprotocol/types'
+
+import { safeBundleEthFlow } from './safeBundleEthFlow'
+
+import { SafeBundleFlowContext, TradeFlowContext } from '../../types/TradeFlowContext'
+
+jest.mock('modules/appData', () => ({
+  removePermitHookFromAppData: jest.fn().mockResolvedValue({ fullAppData: '{}', doc: {} }),
+}))
+
+jest.mock('modules/operations/bundle/buildApproveTx', () => ({
+  buildApproveTx: jest.fn().mockResolvedValue({ to: '0xapprove', data: '0xapprovedata', value: 0n }),
+}))
+
+jest.mock('modules/operations/bundle/buildWrapTx', () => ({
+  buildWrapTx: jest.fn().mockReturnValue({ to: '0xwrap', data: '0xwrapdata', value: 0n }),
+}))
+
+jest.mock('modules/orders', () => ({ emitPostedOrderEvent: jest.fn() }))
+
+jest.mock('modules/trade/utils/addPendingOrderStep', () => ({ addPendingOrderStep: jest.fn() }))
+
+jest.mock('modules/trade/utils/logger', () => ({ logTradeFlow: jest.fn() }))
+
+jest.mock('modules/tradeQuote', () => ({ assertValidBridgeRecipient: jest.fn() }))
+
+jest.mock('legacy/utils/trade', () => ({
+  mapUnsignedOrderToOrder: jest.fn().mockReturnValue({ id: '0xorder' }),
+  wrapErrorInOperatorError: (fn: () => unknown) => fn(),
+}))
+
+jest.mock('legacy/state/orders/utils', () => ({ partialOrderUpdate: jest.fn() }))
+
+jest.mock('tradingSdk/tradingSdk', () => ({
+  tradingSdk: {
+    getPreSignTransaction: jest.fn().mockResolvedValue({ to: '0xpresign', data: '0xpresigndata', value: '0' }),
+  },
+}))
+
+describe('safeBundleEthFlow - Send analytics payload', () => {
+  const buyToken = new Token(SupportedChainId.MAINNET, '0x2222222222222222222222222222222222222222', 18, 'BUY', 'Buy')
+  const inputAmount = CurrencyAmount.fromRawAmount(WETH_MAINNET, '1000000000000000000')
+  const outputAmount = CurrencyAmount.fromRawAmount(buyToken, '2000000000000000000')
+
+  const analytics = {
+    trade: jest.fn(),
+    wrapApproveAndPresign: jest.fn(),
+    sign: jest.fn(),
+    error: jest.fn(),
+  }
+
+  const postSwapOrderFromQuote = jest.fn().mockResolvedValue({
+    orderId: '0xorder',
+    signature: '0xsig',
+    signingScheme: 'presign',
+    orderToSign: {},
+  })
+
+  function buildTradeContext(quoteId: number | undefined, allowsOffchainSigning: boolean): TradeFlowContext {
+    return {
+      context: { chainId: SupportedChainId.MAINNET, inputAmount, outputAmount },
+      callbacks: { closeModals: jest.fn(), dispatch: jest.fn(), addBridgeOrder: jest.fn() },
+      swapFlowAnalyticsContext: {
+        account: '0xaccount',
+        orderType: UiOrderType.SWAP,
+        marketLabel: 'WETH,BUY',
+      },
+      tradeConfirmActions: { onSign: jest.fn(), onSuccess: jest.fn(), onError: jest.fn() },
+      typedHooks: undefined,
+      tradeQuote: { postSwapOrderFromQuote },
+      bridgeQuoteAmounts: null,
+      orderParams: {
+        account: '0xaccount',
+        recipientAddressOrName: '0xaccount',
+        recipient: '0xaccount',
+        kind: 'sell',
+        appData: { fullAppData: '{}', doc: {} },
+        validTo: 1700000000,
+        isSafeWallet: true,
+        allowsOffchainSigning,
+        quoteId,
+      },
+    } as unknown as TradeFlowContext
+  }
+
+  const safeBundleContext = {
+    spender: '0xspender',
+    sendBatchTransactions: jest.fn().mockResolvedValue('0xsafetxhash'),
+    wrappedNativeContract: { address: WETH_MAINNET.address },
+    needsApproval: true,
+    tokenAddress: WETH_MAINNET.address,
+    amountToApprove: inputAmount,
+    maximumSendSellAmount: inputAmount,
+  } as unknown as SafeBundleFlowContext
+
+  function run(quoteId: number | undefined, allowsOffchainSigning: boolean): Promise<void | boolean> {
+    return safeBundleEthFlow(
+      buildTradeContext(quoteId, allowsOffchainSigning),
+      safeBundleContext,
+      { priceImpact: undefined } as never,
+      jest.fn().mockResolvedValue(true),
+      analytics as never,
+    )
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    postSwapOrderFromQuote.mockResolvedValue({
+      orderId: '0xorder',
+      signature: '0xsig',
+      signingScheme: 'presign',
+      orderToSign: {},
+    })
+  })
+
+  it('propagates quoteId and allowsOffchainSigning on the wrapApproveAndPresign analytics event', async () => {
+    await run(123, false)
+
+    expect(analytics.wrapApproveAndPresign).toHaveBeenCalledWith(
+      expect.objectContaining({ quoteId: 123, allowsOffchainSigning: false }),
+    )
+  })
+
+  it('omits quoteId on the wrapApproveAndPresign analytics event when the quote id is unavailable', async () => {
+    await run(undefined, false)
+
+    expect(analytics.wrapApproveAndPresign).toHaveBeenCalledWith(
+      expect.objectContaining({ quoteId: undefined, allowsOffchainSigning: false }),
+    )
+  })
+})

--- a/apps/cowswap-frontend/src/modules/tradeFlow/services/safeBundleFlow/safeBundleEthFlow.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/services/safeBundleFlow/safeBundleEthFlow.ts
@@ -70,7 +70,11 @@ export async function safeBundleEthFlow(
   const { account, recipientAddressOrName, kind } = orderParams
   const isBridgingOrder = inputAmount.currency.chainId !== outputAmount.currency.chainId
 
-  analytics.wrapApproveAndPresign(swapFlowAnalyticsContext)
+  analytics.wrapApproveAndPresign({
+    ...swapFlowAnalyticsContext,
+    quoteId: orderParams.quoteId,
+    allowsOffchainSigning: orderParams.allowsOffchainSigning,
+  })
   // Wrap the max sell amount (slippage-adjusted for buy orders); inputAmount alone underwraps buy orders and makes them unfillable.
   const nativeAmountInWei = maximumSendSellAmount.quotient.toString()
   const tradeAmounts = { inputAmount, outputAmount }

--- a/apps/cowswap-frontend/src/modules/tradeFlow/services/swapFlow/index.test.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/services/swapFlow/index.test.ts
@@ -1,0 +1,106 @@
+import { CurrencyAmount, Token } from '@cowprotocol/currency'
+import { UiOrderType } from '@cowprotocol/types'
+
+import { handlePermit } from 'modules/permit'
+
+import { TradeFlowContext } from '../../types/TradeFlowContext'
+
+import { swapFlow } from './index'
+
+jest.mock('modules/permit', () => ({
+  callDataContainsPermitSigner: jest.fn().mockReturnValue(false),
+  handlePermit: jest.fn().mockResolvedValue({ fullAppData: '{}', doc: {} }),
+}))
+jest.mock('modules/injectedWidget', () => {
+  class WidgetHookDeclineError extends Error {}
+  return { WidgetHookDeclineError }
+})
+jest.mock('modules/orders', () => ({ emitPostedOrderEvent: jest.fn() }))
+jest.mock('modules/trade/utils/addPendingOrderStep', () => ({ addPendingOrderStep: jest.fn() }))
+jest.mock('modules/trade/utils/logger', () => ({ logTradeFlow: jest.fn() }))
+jest.mock('modules/tradeQuote', () => ({ assertValidBridgeRecipient: jest.fn() }))
+jest.mock('legacy/state/orders/utils', () => ({ partialOrderUpdate: jest.fn() }))
+jest.mock('legacy/utils/trade', () => ({
+  mapUnsignedOrderToOrder: jest.fn().mockReturnValue({ id: '0xorder' }),
+  wrapErrorInOperatorError: (fn: () => unknown) => fn(),
+}))
+jest.mock('tradingSdk/tradingSdk', () => ({ tradingSdk: { getPreSignTransaction: jest.fn() } }))
+jest.mock('wagmi/actions', () => ({ sendTransaction: jest.fn() }))
+
+const mockHandlePermit = handlePermit as jest.MockedFunction<typeof handlePermit>
+
+describe('swapFlow - Send analytics payload', () => {
+  const sellToken = new Token(1, '0x1111111111111111111111111111111111111111', 18, 'SELL', 'Sell Token')
+  const buyToken = new Token(1, '0x2222222222222222222222222222222222222222', 18, 'BUY', 'Buy Token')
+  const inputAmount = CurrencyAmount.fromRawAmount(sellToken, '1000000000000000000')
+  const outputAmount = CurrencyAmount.fromRawAmount(buyToken, '2000000000000000000')
+
+  const analytics = {
+    trade: jest.fn(),
+    sign: jest.fn(),
+    error: jest.fn(),
+  }
+
+  const postSwapOrderFromQuote = jest.fn().mockResolvedValue({
+    orderId: '0xorder',
+    signature: '0xsig',
+    signingScheme: 'eip712',
+    orderToSign: {},
+  })
+
+  function buildTradeContext(): TradeFlowContext {
+    return {
+      context: { chainId: 1, inputAmount, outputAmount },
+      callbacks: {
+        addBridgeOrder: jest.fn(),
+        closeModals: jest.fn(),
+        dispatch: jest.fn(),
+        getCachedPermit: jest.fn().mockResolvedValue(undefined),
+        setSigningStep: jest.fn(),
+      },
+      flags: { allowsOffchainSigning: true },
+      orderParams: {
+        account: '0xaccount',
+        allowsOffchainSigning: true,
+        appData: { fullAppData: '{}', doc: {} },
+        isSafeWallet: false,
+        kind: 'sell',
+        quoteId: 123,
+        recipient: '0xaccount',
+        recipientAddressOrName: '0xaccount',
+        validTo: 1700000000,
+      },
+      swapFlowAnalyticsContext: {
+        account: '0xaccount',
+        marketLabel: 'SELL,BUY',
+        orderType: UiOrderType.SWAP,
+      },
+      tradeConfirmActions: { onError: jest.fn(), onSign: jest.fn(), onSuccess: jest.fn() },
+      tradeQuote: { postSwapOrderFromQuote },
+      tradeQuoteState: {},
+      typedHooks: undefined,
+    } as unknown as TradeFlowContext
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockHandlePermit.mockResolvedValue({ fullAppData: '{}', doc: {} } as never)
+    postSwapOrderFromQuote.mockResolvedValue({
+      orderId: '0xorder',
+      signature: '0xsig',
+      signingScheme: 'eip712',
+      orderToSign: {},
+    })
+  })
+
+  it('forwards quoteId and allowsOffchainSigning to the Send analytics event', async () => {
+    await swapFlow(
+      buildTradeContext(),
+      { priceImpact: undefined } as never,
+      jest.fn().mockResolvedValue(true),
+      analytics as never,
+    )
+
+    expect(analytics.trade).toHaveBeenCalledWith(expect.objectContaining({ quoteId: 123, allowsOffchainSigning: true }))
+  })
+})

--- a/apps/cowswap-frontend/src/modules/tradeFlow/services/swapFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/services/swapFlow/index.ts
@@ -115,7 +115,11 @@ export async function swapFlow(
     }
 
     logTradeFlow('SWAP FLOW', 'STEP 3: send transaction')
-    analytics.trade(swapFlowAnalyticsContext)
+    analytics.trade({
+      ...swapFlowAnalyticsContext,
+      quoteId: orderParams.quoteId,
+      allowsOffchainSigning: orderParams.allowsOffchainSigning,
+    })
 
     tradeConfirmActions.onSign(tradeAmounts)
 

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useCreateTwapOrder.test.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useCreateTwapOrder.test.tsx
@@ -1,0 +1,194 @@
+import { useSetAtom } from 'jotai'
+
+import { useCowAnalytics } from '@cowprotocol/analytics'
+import { useFeatureFlags } from '@cowprotocol/common-hooks'
+import {
+  useIsSafeViaWc,
+  useIsSafeWallet,
+  useSendBatchTransactions,
+  useWalletDetails,
+  useWalletInfo,
+} from '@cowprotocol/wallet'
+
+import { act, renderHook } from '@testing-library/react'
+
+import {
+  useAdvancedOrdersDerivedState,
+  useComposableCowContractData,
+  useUpdateAdvancedOrdersRawState,
+} from 'modules/advancedOrders'
+import { uploadAppDataDocOrderbookApi, useAppData } from 'modules/appData'
+import { callWidgetHook } from 'modules/injectedWidget'
+import { useNavigateToOrdersTableTab } from 'modules/ordersTable'
+import { useGeneratePermitHook, usePermitInfo } from 'modules/permit'
+import { getCowSoundSend } from 'modules/sounds'
+import { useTradeConfirmActions, useTradePriceImpact } from 'modules/trade'
+
+import { useAppSigner } from 'common/hooks/useAppSigner'
+import { useConfirmPriceImpactWithoutFee } from 'common/hooks/useConfirmPriceImpactWithoutFee'
+
+import { useCreateTwapOrder } from './useCreateTwapOrder'
+import { useExtensibleFallbackContext } from './useExtensibleFallbackContext'
+import { useTwapOrder } from './useTwapOrder'
+import { useTwapOrderCreationContext } from './useTwapOrderCreationContext'
+
+import { placeEoaTwapOrder } from '../services/twap/eoa/placeEoaTwapOrder'
+import { waitForFundingOrderSettlementTx } from '../services/twap/eoa/waitForFundingOrderSettlementTx'
+import { getConditionalOrderId } from '../utils/getConditionalOrderId'
+
+jest.mock('jotai', () => ({ ...jest.requireActual('jotai'), useSetAtom: jest.fn() }))
+jest.mock('wagmi', () => ({ ...jest.requireActual('wagmi'), useConfig: jest.fn(() => ({})) }))
+jest.mock('@cowprotocol/analytics', () => ({ __resetGtmInstance: jest.fn(), useCowAnalytics: jest.fn() }))
+jest.mock('@cowprotocol/common-hooks', () => ({ useFeatureFlags: jest.fn() }))
+jest.mock('@cowprotocol/wallet', () => ({
+  useIsSafeViaWc: jest.fn(),
+  useIsSafeWallet: jest.fn(),
+  useSendBatchTransactions: jest.fn(),
+  useWalletDetails: jest.fn(),
+  useWalletInfo: jest.fn(),
+}))
+jest.mock('modules/advancedOrders', () => ({
+  useAdvancedOrdersDerivedState: jest.fn(),
+  useComposableCowContractData: jest.fn(),
+  useUpdateAdvancedOrdersRawState: jest.fn(),
+}))
+jest.mock('modules/appData', () => ({ uploadAppDataDocOrderbookApi: jest.fn(), useAppData: jest.fn() }))
+jest.mock('modules/injectedWidget', () => ({
+  buildTradeWidgetHookPayload: jest.fn(() => ({})),
+  callWidgetHook: jest.fn(),
+}))
+jest.mock('modules/orders', () => ({ emitPostedOrderEvent: jest.fn() }))
+jest.mock('modules/ordersTable', () => ({ useNavigateToOrdersTableTab: jest.fn() }))
+jest.mock('modules/permit', () => ({ useGeneratePermitHook: jest.fn(), usePermitInfo: jest.fn() }))
+jest.mock('modules/sounds', () => ({ getCowSoundSend: jest.fn() }))
+jest.mock('modules/trade', () => ({
+  useTradeConfirmActions: jest.fn(),
+  useTradePriceImpact: jest.fn(),
+}))
+jest.mock('common/hooks/useAppSigner', () => ({ useAppSigner: jest.fn() }))
+jest.mock('common/hooks/useConfirmPriceImpactWithoutFee', () => ({ useConfirmPriceImpactWithoutFee: jest.fn() }))
+jest.mock('common/utils/getAreBridgeCurrencies', () => ({ getAreBridgeCurrencies: jest.fn(() => false) }))
+jest.mock('./useExtensibleFallbackContext', () => ({ useExtensibleFallbackContext: jest.fn() }))
+jest.mock('./useTwapOrder', () => ({ useTwapOrder: jest.fn() }))
+jest.mock('./useTwapOrderCreationContext', () => ({ useTwapOrderCreationContext: jest.fn() }))
+jest.mock('../services/twap/eoa/placeEoaTwapOrder', () => ({ placeEoaTwapOrder: jest.fn() }))
+jest.mock('../services/twap/eoa/waitForFundingOrderSettlementTx', () => ({
+  waitForFundingOrderSettlementTx: jest.fn(),
+}))
+jest.mock('../state/twapOrdersListAtom', () => ({ addTwapOrderToListAtom: {} }))
+jest.mock('../utils/buildTwapOrderParamsStruct', () => ({ buildTwapOrderParamsStruct: jest.fn(() => ({})) }))
+jest.mock('../utils/getConditionalOrderId', () => ({ getConditionalOrderId: jest.fn() }))
+jest.mock('../utils/twapOrderToStruct', () => ({ twapOrderToStruct: jest.fn(() => ({})) }))
+
+const mockedUseSetAtom = useSetAtom as jest.MockedFunction<typeof useSetAtom>
+const mockedUseCowAnalytics = useCowAnalytics as jest.MockedFunction<typeof useCowAnalytics>
+const mockedUseFeatureFlags = useFeatureFlags as jest.MockedFunction<typeof useFeatureFlags>
+const mockedUseIsSafeViaWc = useIsSafeViaWc as jest.MockedFunction<typeof useIsSafeViaWc>
+const mockedUseIsSafeWallet = useIsSafeWallet as jest.MockedFunction<typeof useIsSafeWallet>
+const mockedUseSendBatchTransactions = useSendBatchTransactions as jest.MockedFunction<typeof useSendBatchTransactions>
+const mockedUseWalletDetails = useWalletDetails as jest.MockedFunction<typeof useWalletDetails>
+const mockedUseWalletInfo = useWalletInfo as jest.MockedFunction<typeof useWalletInfo>
+const mockedUseAdvancedOrdersDerivedState = useAdvancedOrdersDerivedState as jest.MockedFunction<
+  typeof useAdvancedOrdersDerivedState
+>
+const mockedUseComposableCowContractData = useComposableCowContractData as jest.MockedFunction<
+  typeof useComposableCowContractData
+>
+const mockedUseUpdateAdvancedOrdersRawState = useUpdateAdvancedOrdersRawState as jest.MockedFunction<
+  typeof useUpdateAdvancedOrdersRawState
+>
+const mockedUseAppData = useAppData as jest.MockedFunction<typeof useAppData>
+const mockedCallWidgetHook = callWidgetHook as jest.MockedFunction<typeof callWidgetHook>
+const mockedUseNavigateToOrdersTableTab = useNavigateToOrdersTableTab as jest.MockedFunction<
+  typeof useNavigateToOrdersTableTab
+>
+const mockedUseGeneratePermitHook = useGeneratePermitHook as jest.MockedFunction<typeof useGeneratePermitHook>
+const mockedUsePermitInfo = usePermitInfo as jest.MockedFunction<typeof usePermitInfo>
+const mockedGetCowSoundSend = getCowSoundSend as jest.MockedFunction<typeof getCowSoundSend>
+const mockedUseTradeConfirmActions = useTradeConfirmActions as jest.MockedFunction<typeof useTradeConfirmActions>
+const mockedUseTradePriceImpact = useTradePriceImpact as jest.MockedFunction<typeof useTradePriceImpact>
+const mockedUseAppSigner = useAppSigner as jest.MockedFunction<typeof useAppSigner>
+const mockedUseConfirmPriceImpactWithoutFee = useConfirmPriceImpactWithoutFee as jest.MockedFunction<
+  typeof useConfirmPriceImpactWithoutFee
+>
+const mockedUseExtensibleFallbackContext = useExtensibleFallbackContext as jest.MockedFunction<
+  typeof useExtensibleFallbackContext
+>
+const mockedUseTwapOrder = useTwapOrder as jest.MockedFunction<typeof useTwapOrder>
+const mockedUseTwapOrderCreationContext = useTwapOrderCreationContext as jest.MockedFunction<
+  typeof useTwapOrderCreationContext
+>
+const mockedPlaceEoaTwapOrder = placeEoaTwapOrder as jest.MockedFunction<typeof placeEoaTwapOrder>
+const mockedWaitForFundingOrderSettlementTx = waitForFundingOrderSettlementTx as jest.MockedFunction<
+  typeof waitForFundingOrderSettlementTx
+>
+const mockedGetConditionalOrderId = getConditionalOrderId as jest.MockedFunction<typeof getConditionalOrderId>
+
+describe('useCreateTwapOrder', () => {
+  const sendEvent = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockedUseSetAtom.mockReturnValue(jest.fn())
+    mockedUseCowAnalytics.mockReturnValue({ sendEvent } as ReturnType<typeof useCowAnalytics>)
+    mockedUseFeatureFlags.mockReturnValue({ isTwapEoaEnabled: true } as ReturnType<typeof useFeatureFlags>)
+    mockedUseWalletInfo.mockReturnValue({ chainId: 1, account: '0xaccount' } as ReturnType<typeof useWalletInfo>)
+    mockedUseWalletDetails.mockReturnValue({ allowsOffchainSigning: false } as ReturnType<typeof useWalletDetails>)
+    mockedUseIsSafeWallet.mockReturnValue(false)
+    mockedUseIsSafeViaWc.mockReturnValue(false)
+    mockedUseSendBatchTransactions.mockReturnValue(jest.fn())
+    mockedUseAdvancedOrdersDerivedState.mockReturnValue({
+      inputCurrencyAmount: { currency: { symbol: 'SELL' } },
+      outputCurrencyAmount: { currency: { symbol: 'BUY' } },
+    } as ReturnType<typeof useAdvancedOrdersDerivedState>)
+    mockedUseComposableCowContractData.mockReturnValue({} as ReturnType<typeof useComposableCowContractData>)
+    mockedUseUpdateAdvancedOrdersRawState.mockReturnValue(jest.fn())
+    mockedUseAppData.mockReturnValue({ appDataKeccak256: '0xappdata', fullAppData: '{}' } as ReturnType<
+      typeof useAppData
+    >)
+    mockedUseNavigateToOrdersTableTab.mockReturnValue(jest.fn())
+    mockedUseGeneratePermitHook.mockReturnValue(jest.fn())
+    mockedUsePermitInfo.mockReturnValue({} as ReturnType<typeof usePermitInfo>)
+    mockedGetCowSoundSend.mockReturnValue({ play: jest.fn() })
+    mockedUseTradeConfirmActions.mockReturnValue({
+      onSign: jest.fn(),
+      onSuccess: jest.fn(),
+      onError: jest.fn(),
+    } as ReturnType<typeof useTradeConfirmActions>)
+    mockedUseTradePriceImpact.mockReturnValue({ priceImpact: undefined } as ReturnType<typeof useTradePriceImpact>)
+    mockedUseAppSigner.mockReturnValue({} as ReturnType<typeof useAppSigner>)
+    mockedUseConfirmPriceImpactWithoutFee.mockReturnValue({
+      confirmPriceImpactWithoutFee: jest.fn().mockResolvedValue(true),
+    } as ReturnType<typeof useConfirmPriceImpactWithoutFee>)
+    mockedUseExtensibleFallbackContext.mockReturnValue(null)
+    mockedUseTwapOrder.mockReturnValue({
+      receiver: '0xreceiver',
+      sellAmount: {},
+      buyAmount: {},
+    } as ReturnType<typeof useTwapOrder>)
+    mockedUseTwapOrderCreationContext.mockReturnValue(null)
+    mockedCallWidgetHook.mockResolvedValue(true)
+    mockedGetConditionalOrderId.mockReturnValue('0xtwap')
+    mockedPlaceEoaTwapOrder.mockResolvedValue({
+      proxyAddress: '0xproxy',
+      orderPostingResult: { orderId: '0xfunding-order' },
+    } as Awaited<ReturnType<typeof placeEoaTwapOrder>>)
+    mockedWaitForFundingOrderSettlementTx.mockResolvedValue(undefined)
+    ;(uploadAppDataDocOrderbookApi as jest.MockedFunction<typeof uploadAppDataDocOrderbookApi>).mockResolvedValue(
+      undefined,
+    )
+  })
+
+  it('tracks the wallet off-chain signing capability instead of the EOA TWAP route', async () => {
+    const { result } = renderHook(useCreateTwapOrder)
+
+    await act(async () => {
+      await result.current(false)
+    })
+
+    expect(sendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'Place Advanced Order', allowsOffchainSigning: false }),
+    )
+  })
+})

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useCreateTwapOrder.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useCreateTwapOrder.tsx
@@ -204,7 +204,13 @@ export function useCreateTwapOrder() {
         const twapOrderId = getConditionalOrderId(paramsStruct)
 
         tradeConfirmActions.onSign(pendingTrade)
-        tradeFlowAnalytics.placeAdvancedOrder(twapFlowAnalyticsContext)
+        tradeFlowAnalytics.placeAdvancedOrder({
+          ...twapFlowAnalyticsContext,
+          // No quote/quoteId exists yet at this point for either TWAP path (the EOA path only fetches
+          // one later, inside placeEoaTwapOrder); isEoaTwap is the accurate proxy for off-chain vs
+          // on-chain signing since it's what actually decides which code path below executes.
+          allowsOffchainSigning: isEoaTwap,
+        })
         sendTwapConversionAnalytics('posted', fallbackHandlerIsNotSet)
 
         await uploadAppDataDocOrderbookApi({

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useCreateTwapOrder.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useCreateTwapOrder.tsx
@@ -9,7 +9,13 @@ import { COW_PROTOCOL_VAULT_RELAYER_ADDRESS_PROD, createCowLogger } from '@cowpr
 import { OrderKind } from '@cowprotocol/cow-sdk'
 import { CurrencyAmount, Token } from '@cowprotocol/currency'
 import { UiOrderType } from '@cowprotocol/types'
-import { useIsSafeViaWc, useIsSafeWallet, useSendBatchTransactions, useWalletInfo } from '@cowprotocol/wallet'
+import {
+  useIsSafeViaWc,
+  useIsSafeWallet,
+  useSendBatchTransactions,
+  useWalletDetails,
+  useWalletInfo,
+} from '@cowprotocol/wallet'
 import { WidgetHookEvents } from '@cowprotocol/widget-lib'
 
 import { OrderTabId } from 'entities/routes/routes.atom'
@@ -73,6 +79,7 @@ const log = createCowLogger('CreateTwapOrder')
 // eslint-disable-next-line max-lines-per-function, @typescript-eslint/explicit-function-return-type
 export function useCreateTwapOrder() {
   const { chainId, account } = useWalletInfo()
+  const { allowsOffchainSigning } = useWalletDetails()
   const twapOrder = useTwapOrder()
   const addTwapOrderToList = useSetAtom(addTwapOrderToListAtom)
   const navigateToOrdersTableTab = useNavigateToOrdersTableTab()
@@ -207,9 +214,8 @@ export function useCreateTwapOrder() {
         tradeFlowAnalytics.placeAdvancedOrder({
           ...twapFlowAnalyticsContext,
           // No quote/quoteId exists yet at this point for either TWAP path (the EOA path only fetches
-          // one later, inside placeEoaTwapOrder); isEoaTwap is the accurate proxy for off-chain vs
-          // on-chain signing since it's what actually decides which code path below executes.
-          allowsOffchainSigning: isEoaTwap,
+          // one later, inside placeEoaTwapOrder).
+          allowsOffchainSigning,
         })
         sendTwapConversionAnalytics('posted', fallbackHandlerIsNotSet)
 
@@ -325,6 +331,7 @@ export function useCreateTwapOrder() {
       isTwapEoaEnabled,
       isSafeWallet,
       isSafeViaWc,
+      allowsOffchainSigning,
       eoaSigner,
       config,
       chainId,

--- a/bundle-size.jsonc
+++ b/bundle-size.jsonc
@@ -5,12 +5,12 @@
 {
   "schemaVersion": 1,
   "apps": {
-    "@cowprotocol/cow-fi": 5987, // 5.85 MiB
-    "@cowprotocol/cowswap": 12690, // 12.39 MiB
-    "@cowprotocol/explorer": 12455, // 12.16 MiB
-    "@cowprotocol/sdk-tools": 12121, // 11.84 MiB
-    "@cowprotocol/storybook": 4837, // 4.72 MiB
-    "@cowprotocol/widget-configurator": 12585, // 12.29 MiB
+    "@cowprotocol/cow-fi": 5988, // 5.85 MiB
+    "@cowprotocol/cowswap": 12692, // 12.39 MiB
+    "@cowprotocol/explorer": 12456, // 12.16 MiB
+    "@cowprotocol/sdk-tools": 12122, // 11.84 MiB
+    "@cowprotocol/storybook": 4838, // 4.72 MiB
+    "@cowprotocol/widget-configurator": 12586, // 12.29 MiB
   },
   "packages": {
     "@cowprotocol/currency": 12, // 12 KiB


### PR DESCRIPTION
# Summary

Adding 2 new fields to be tracked when the order is sent to be signed.

# To Test

1. In the browser console, before testing a flow:

```
     const dataLayerStart = window.dataLayer.length
     const trackedActions = new Set([
       'Send',
       'Bundle Approve and Swap',
       'Bundled Eth Flow',
       'Place Advanced Order',
     ])

     const tradeEvents = () =>
       window.dataLayer
         .slice(dataLayerStart)
         .filter((event) => event?.category === 'Trade' && trackedActions.has(event?.action))
```

  2. Move each flow to its signing step, then inspect the events:

```
     console.table(
       tradeEvents().map(({ action, quoteId, allowsOffchainSigning }) => ({
         action,
         quoteId,
         allowsOffchainSigning,
       })),
     )
```


    - Regular swap, ETH flow, and limit order: Send
    - Smart-account approve + swap bundle: Bundle Approve and Swap
    - Smart-account native-ETH wrap + bundle: Bundled Eth Flow
    - TWAP: Place Advanced Order
      
  
<img width="475" height="170" alt="image" src="https://github.com/user-attachments/assets/81995d98-7a25-49d9-92ce-ad683cf22cf7" />

  * allowsOffchainSigning is present for every event and reflects the wallet/flow: EOA flows are true; smart-account and Safe-backed flows are false.
  * quoteId is present for swap, ETH flow, limit, and bundle events. It is intentionally absent for TWAP because its quote is created later in the flow.

No other event should change/contain those keys

## Summary by CodeRabbit

* **Analytics**
  * Enhanced swap and trade event tracking with quote identifiers and off-chain signing availability when provided.
  * Preserved existing event behavior when these details are unavailable.

* **Tests**
  * Added coverage to verify that analytics events include or omit the new details appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Analytics
* Trade, swap, ETH, limit order, Safe, and TWAP events now capture the associated quote ID and whether off-chain signing is available.
* Missing quote IDs are handled consistently without affecting event delivery.
* Analytics more accurately reflects the signing method used for TWAP orders.

## Tests
* Added coverage validating analytics payloads across standard trades, swaps, ETH flows, limit orders, and Safe transaction flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->