### PR TITLE
fix: update EURe and GBPe on Gnosis

### DIFF
--- a/bundle-size.jsonc
+++ b/bundle-size.jsonc
@@ -8,7 +8,7 @@
     "@cowprotocol/cow-fi": 5988, // 5.85 MiB
     "@cowprotocol/cowswap": 12691, // 12.39 MiB
     "@cowprotocol/explorer": 12456, // 12.16 MiB
-    "@cowprotocol/sdk-tools": 12121, // 11.84 MiB
+    "@cowprotocol/sdk-tools": 12122, // 11.84 MiB
     "@cowprotocol/storybook": 4838, // 4.72 MiB
     "@cowprotocol/widget-configurator": 12586, // 12.29 MiB
   },

--- a/bundle-size.jsonc
+++ b/bundle-size.jsonc
@@ -5,12 +5,12 @@
 {
   "schemaVersion": 1,
   "apps": {
-    "@cowprotocol/cow-fi": 5987, // 5.85 MiB
-    "@cowprotocol/cowswap": 12690, // 12.39 MiB
-    "@cowprotocol/explorer": 12455, // 12.16 MiB
-    "@cowprotocol/sdk-tools": 12121, // 11.84 MiB
-    "@cowprotocol/storybook": 4837, // 4.72 MiB
-    "@cowprotocol/widget-configurator": 12585, // 12.29 MiB
+    "@cowprotocol/cow-fi": 5988, // 5.85 MiB
+    "@cowprotocol/cowswap": 12691, // 12.39 MiB
+    "@cowprotocol/explorer": 12456, // 12.16 MiB
+    "@cowprotocol/sdk-tools": 12122, // 11.84 MiB
+    "@cowprotocol/storybook": 4838, // 4.72 MiB
+    "@cowprotocol/widget-configurator": 12586, // 12.29 MiB
   },
   "packages": {
     "@cowprotocol/currency": 12, // 12 KiB

--- a/libs/common-const/src/tokens.ts
+++ b/libs/common-const/src/tokens.ts
@@ -142,12 +142,12 @@ export const GNO_GNOSIS_CHAIN = new TokenWithLogo(
 )
 
 export const EURE_GNOSIS_CHAIN = new TokenWithLogo(
-  cowprotocolTokenLogoUrl('0xcb444e90d8198415266c6a2724b7900fb12fc56e', SupportedChainId.GNOSIS_CHAIN),
+  cowprotocolTokenLogoUrl('0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430', SupportedChainId.GNOSIS_CHAIN),
   SupportedChainId.GNOSIS_CHAIN,
-  '0xcb444e90d8198415266c6a2724b7900fb12fc56e',
+  '0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430',
   18,
   'EURe',
-  'Monerium EUR emoney',
+  'Monerium EURe',
 )
 
 // Arbitrum
@@ -684,7 +684,7 @@ export const GNO: Record<SupportedChainId, TokenWithLogo | null> = {
 }
 
 const SDAI_GNOSIS_CHAIN_ADDRESS = '0xaf204776c7245bf4147c2612bf6e5972ee483701'
-const GBPE_GNOSIS_CHAIN_ADDRESS = '0x5cb9073902f2035222b9749f8fb0c9bfe5527108'
+const GBPE_GNOSIS_CHAIN_ADDRESS = '0x8e34bfec4f6eb781f9743d9b4af99cd23f9b7053'
 
 const MAINNET_STABLECOINS = [
   USDC_MAINNET.address,

--- a/libs/tokens/src/const/tokensOverrides.ts
+++ b/libs/tokens/src/const/tokensOverrides.ts
@@ -1,0 +1,9 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import { TokenInfo } from '@uniswap/token-lists'
+
+export const GLOBAL_TOKENS_OVERRIDES: Partial<Record<number, { [address: string]: TokenInfo | null }>> = {
+  [SupportedChainId.GNOSIS_CHAIN]: {
+    '0xcb444e90d8198415266c6a2724b7900fb12fc56e': null, // Legacy EURe
+  },
+}

--- a/libs/tokens/src/state/tokens/allTokensAtom.ts
+++ b/libs/tokens/src/state/tokens/allTokensAtom.ts
@@ -1,12 +1,14 @@
 import { atom } from 'jotai'
 
 import { NATIVE_CURRENCIES, TokenWithLogo } from '@cowprotocol/common-const'
+import { getAddressKey } from '@cowprotocol/cow-sdk'
 import { TokenInfo } from '@cowprotocol/types'
 
 import { blockedListSourcesAtom } from './blockedListSourcesAtom'
 import { favoriteTokensAtom } from './favoriteTokensAtom'
 import { userAddedTokensAtom } from './userAddedTokensAtom'
 
+import { GLOBAL_TOKENS_OVERRIDES } from '../../const/tokensOverrides'
 import { getSourceAsKey } from '../../hooks/lists/useIsListBlocked'
 import { TokensBySymbolState, TokensMap } from '../../types'
 import { lowerCaseTokensMap } from '../../utils/lowerCaseTokensMap'
@@ -52,23 +54,33 @@ const tokensStateAtom = atom(async (get) => {
           const isListEnabled = listsEnabledState[list.source] || selectedLists?.includes(list.source)
           const lpTokenProvider = list.lpTokenProvider
 
+          // eslint-disable-next-line complexity
           list.list.tokens.forEach((token) => {
             const tokenInfo = parseTokenInfo(chainId, token)
-            const tokenAddressKey = tokenInfo?.address.toLowerCase()
+            const tokenAddressKey = tokenInfo?.address ? getAddressKey(tokenInfo?.address) : null
 
             if (!tokenInfo || !tokenAddressKey) return
+
+            const override = GLOBAL_TOKENS_OVERRIDES[tokenInfo.chainId]?.[tokenAddressKey]
+
+            // Filter out tokens which are overriden with null
+            if (override === null) return
 
             if (lpTokenProvider) {
               tokenInfo.lpTokenProvider = lpTokenProvider
             }
 
+            const mappedTokenInfo = override ? parseTokenInfo(chainId, override) : tokenInfo
+
+            if (!mappedTokenInfo) return
+
             if (isListEnabled) {
               if (!acc.activeTokens[tokenAddressKey]) {
-                acc.activeTokens[tokenAddressKey] = tokenInfo
+                acc.activeTokens[tokenAddressKey] = mappedTokenInfo
               }
             } else {
               if (!acc.inactiveTokens[tokenAddressKey]) {
-                acc.inactiveTokens[tokenAddressKey] = tokenInfo
+                acc.inactiveTokens[tokenAddressKey] = mappedTokenInfo
               }
             }
           })


### PR DESCRIPTION
# Summary

Related to https://github.com/cowprotocol/token-lists/pull/1491 and https://github.com/cowprotocol/token-lists/pull/1488

1. Updated EURe in favorite tokens 
2. Updated `GBPE_GNOSIS_CHAIN_ADDRESS`
3. Added `GLOBAL_TOKENS_OVERRIDES` to exclude legacy EURe token from the app. I didn't really want to do it, but the legacy token is in [Honeyswap tokens list](https://tokens.honeyswap.org/).

# To Test

There should not be EURe and GBPe tokens besides:
- https://etherscan.io/token/0x39b8B6385416f4cA36a20319F70D28621895279D
- https://gnosisscan.io/token/0x8E34bfEC4f6Eb781f9743D9b4af99CD23F9b7053
- https://gnosisscan.io/token/0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430
- 
<img width="815" height="557" alt="image" src="https://github.com/user-attachments/assets/d70f2cbb-2bd6-4940-889c-f957452a67f7" />

<img width="800" height="730" alt="image" src="https://github.com/user-attachments/assets/099c58f5-95df-4985-bfe9-49b58d2ba76e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated EURe token information on Gnosis Chain, including its contract address and logo.
  - Updated the Gnosis Chain GBPe stablecoin contract address.
  - Removed the legacy EURe token from active token listings to prevent outdated token information from appearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->