### PR TITLE
fix: reduce cowfi contexts to a single user like other apps

### DIFF
--- a/apps/cow-fi/components/WithLDProvider/index.tsx
+++ b/apps/cow-fi/components/WithLDProvider/index.tsx
@@ -12,6 +12,11 @@ function InnerWithLDProvider({ children }: PropsWithChildren) {
 
 export const WithLDProvider = withLDProvider<PropsWithChildren & JSX.IntrinsicAttributes>({
   clientSideID: NEXT_PUBLIC_LAUNCH_DARKLY_KEY,
+  context: {
+    kind: 'user',
+    key: 'cow-fi',
+    name: 'cow-fi',
+  },
   options: {
     bootstrap: 'localStorage',
   },


### PR DESCRIPTION
# Summary

Reapply https://github.com/cowprotocol/cowswap/pull/7976
Which got revert on https://github.com/cowprotocol/cowswap/pull/7980
Because it accidentally had `develop` included, and all the changes got squashed.