### PR TITLE
fix: order parsing when executed amounts are zero

### DIFF
--- a/apps/cowswap-frontend/src/utils/__tests__/getExecutedSummaryData.test.ts
+++ b/apps/cowswap-frontend/src/utils/__tests__/getExecutedSummaryData.test.ts
@@ -6,6 +6,8 @@ import JSBI from 'jsbi'
 
 import { OrderStatus } from 'legacy/state/orders/actions'
 
+import { GenericOrder } from 'common/types'
+
 import { getExecutedSummaryData } from '../getExecutedSummaryData'
 
 import type { ParsedOrder } from '../orderUtils/parseOrder'
@@ -272,5 +274,62 @@ describe('getExecutedSummaryData', () => {
     expect(result.surplusAmount.currency.address).toBe(polygonWeth.address)
     expect(result.surplusAmount.currency.decimals).toBe(18)
     expect(result.surplusAmount.toExact()).toBe('0.000000000000025')
+  })
+
+  it('keeps the parsed output token when executed sell amount is zero', () => {
+    const order1 = {
+      owner: '0xowner',
+      executedBuyAmount: '1000000', // 1 USDC
+      executedSellAmount: '0',
+      executedSellAmountBeforeFees: '0',
+      executedFeeAmount: '0',
+      executedFee: '0',
+      executedFeeToken: baseWeth.address,
+      invalidated: false,
+      status: 'fulfilled',
+      class: 'limit',
+      sellToken: baseWeth.address,
+      buyToken: baseUsdc.address,
+      sellAmount: '500000000000000', // 0.0005 WETH
+      buyAmount: '1000000', // 1 USDC
+      feeAmount: '0',
+      kind: OrderKind.BUY,
+      sellTokenBalance: 'erc20',
+      buyTokenBalance: 'erc20',
+      totalFee: '0',
+      sellAmountBeforeFee: '500000000000000', // 0.0005 WETH
+      inputToken: {
+        chainId: baseWeth.chainId,
+        decimals: baseWeth.decimals,
+        symbol: baseWeth.symbol,
+        name: baseWeth.symbol,
+        isNative: baseWeth.isNative,
+        isToken: baseWeth.isToken,
+        address: baseWeth.address,
+      },
+      outputToken: {
+        chainId: baseUsdc.chainId,
+        decimals: baseUsdc.decimals,
+        symbol: baseUsdc.symbol,
+        name: baseUsdc.symbol,
+        isNative: baseUsdc.isNative,
+        isToken: baseUsdc.isToken,
+        address: baseUsdc.address,
+      },
+      id: '0xorderid',
+      isCancelling: false,
+    } as unknown as GenericOrder
+
+    const result = getExecutedSummaryData(order1, null)
+    console.log('Result:', result) // Log the result for debugging
+
+    expect(result.formattedSwappedAmount.currency.address).toBe(baseWeth.address)
+    expect(result.formattedSwappedAmount.currency.chainId).toBe(baseWeth.chainId)
+    expect(result.surplusAmount.currency.address).toBe(baseWeth.address)
+    expect(result.surplusToken.address).toBe(baseWeth.address)
+    // Verify denominators are not zero to avoid division by zero errors
+    expect(result.surplusAmount.denominator).not.toBe('0')
+    expect(result.formattedFilledAmount.denominator).toBe('0')
+    expect(result.formattedSwappedAmount.denominator).not.toBe('0')
   })
 })

--- a/apps/cowswap-frontend/src/utils/__tests__/getExecutedSummaryData.test.ts
+++ b/apps/cowswap-frontend/src/utils/__tests__/getExecutedSummaryData.test.ts
@@ -286,8 +286,12 @@ describe('getExecutedSummaryData', () => {
       executedFee: '0',
       executedFeeToken: baseWeth.address,
       invalidated: false,
-      status: 'fulfilled',
-      class: 'limit',
+      status: OrderStatus.FULFILLED,
+      class: OrderClass.LIMIT,
+      apiAdditionalInfo: {
+        executedBuyAmount: '1000000',
+        executedSellAmountBeforeFees: '0',
+      },
       sellToken: baseWeth.address,
       buyToken: baseUsdc.address,
       sellAmount: '500000000000000', // 0.0005 WETH
@@ -321,15 +325,14 @@ describe('getExecutedSummaryData', () => {
     } as unknown as GenericOrder
 
     const result = getExecutedSummaryData(order1, null)
-    console.log('Result:', result) // Log the result for debugging
 
     expect(result.formattedSwappedAmount.currency.address).toBe(baseWeth.address)
     expect(result.formattedSwappedAmount.currency.chainId).toBe(baseWeth.chainId)
     expect(result.surplusAmount.currency.address).toBe(baseWeth.address)
     expect(result.surplusToken.address).toBe(baseWeth.address)
     // Verify denominators are not zero to avoid division by zero errors
-    expect(result.surplusAmount.denominator).not.toBe('0')
-    expect(result.formattedFilledAmount.denominator).toBe('0')
-    expect(result.formattedSwappedAmount.denominator).not.toBe('0')
+    expect(result.surplusAmount.denominator).not.toBe(0n)
+    expect(result.formattedFilledAmount.denominator).not.toBe(0n)
+    expect(result.formattedSwappedAmount.denominator).not.toBe(0n)
   })
 })

--- a/apps/cowswap-frontend/src/utils/orderUtils/parseOrder.ts
+++ b/apps/cowswap-frontend/src/utils/orderUtils/parseOrder.ts
@@ -76,13 +76,13 @@ export const parseOrder = (order: Order): ParsedOrder => {
   const fullyFilled = isOrderFilled(order)
   const partiallyFilled = isPartiallyFilled(order)
   const filledPercentDisplay = filledPercentage.times(100).toString()
-
-  const executedPrice = JSBI.greaterThan(executedBuyAmount, JSBI.BigInt(0))
-    ? new Price({
-        baseAmount: CurrencyAmount.fromRawAmount(order.inputToken, executedSellAmount),
-        quoteAmount: CurrencyAmount.fromRawAmount(order.outputToken, executedBuyAmount),
-      })
-    : null
+  const executedPrice =
+    JSBI.greaterThan(executedBuyAmount, JSBI.BigInt(0)) && JSBI.greaterThan(executedSellAmount, JSBI.BigInt(0))
+      ? new Price({
+          baseAmount: CurrencyAmount.fromRawAmount(order.inputToken, executedSellAmount),
+          quoteAmount: CurrencyAmount.fromRawAmount(order.outputToken, executedBuyAmount),
+        })
+      : null
   const showCreationTxLink =
     (order.status === OrderStatus.CREATING || order.status === OrderStatus.FAILED) &&
     order.orderCreationHash &&


### PR DESCRIPTION
# Summary

The UI crashes when displaying "My orders" or when visiting "Limit" order tabs due to errors when parsing an order has `executedSellAmount` as ZERO

Event ID: b7a43e6e23fd4e62aa8f066eff60e600

<img width="685" height="660" alt="Screenshot 2026-08-07 at 15 27 22" src="https://github.com/user-attachments/assets/9b0edca5-3b48-4b3c-8f63-19f77620b5bc" />

# To Test

**Given a user that has an order where the executed amount is zero.** 

1. <<Step one>> Open the page `My Orders` or select Trading Mode "Limit"
<img width="128" height="48" alt="Screenshot 2026-08-07 at 15 30 16" src="https://github.com/user-attachments/assets/036f4d74-f3f4-40a4-abe7-413d0208ddce" />


- [ ] The UI should not crash and display all the past orders. 
- [ ] The price cant be calculated, but it should not crash


## Notes 
Use this user to reproduce the error when clicking on "My Orders" or make a script to filter any order with sellAmount==0


Chain Arbitrum 
```
  {
    "blockNumber": 489299825,
    "transactionHash": "0x99632b459d1ec4f05bf55440d86d700640134d23a8a989f2656393208795ff06",
    "logIndex": 6,
    "owner": "0x04f74E0E991aa36B02b2e5cA3Da3381371b2db34",
    "sellToken": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
    "buyToken": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
    "sellAmount": "0",
    "buyAmount": "20568799",
    "feeAmount": "0",
    "orderUid": "0x14c95b7fb4e49c51f1b75a918ff835c9bb31b3a66091e6a8ab1d619e9b6cf8f704f74e0e991aa36b02b2e5ca3da3381371b2db346a6b4dac",
    "solver": "0xc9a8F83F653FfA849F98DB9334E71d93cC764fB2"
  },
 ```
  
  

# Self-checks

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have manually tested changes on Vercel preview deployment
- [x] I have manually tested changes by overriding the JS on the browser to load the fixed minified js. 
- [x] I have done self-review and (or) AI review
- [ ] I have addressed all comments from @coderabbitai
- [x] I have less than three open PRs/Stacks in this repo at the moment of creating this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Fixed executed price calculations when an order has no executed sell amount.
- Improved order summaries to display the correct currencies and avoid invalid or zero-denominator values in affected scenarios.

## Tests

- Added regression coverage for buy orders with zero executed sell amounts and no surplus-token override.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->