### PR TITLE
fix: remove e2e dir from changeset config to fix release change list action

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,7 +11,6 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [
-    "@cowprotocol/cowswap-e2e",
     "@cowprotocol/sdk-tools",
     "@cowprotocol/storybook"
   ]


### PR DESCRIPTION
fix: remove stale `@cowprotocol/cowswap-e2e` reference from changesets config

## What broke

The `Release` workflow failed on `main` right after merging the 2026-08-10 release branch:
https://github.com/cowprotocol/cowswap/actions/runs/31509114079/job/93838134979

## Root cause

#7958 removed the `apps/cowswap-frontend-e2e` app entirely (cypress e2e cleanup), but never
updated `.changeset/config.json`'s `ignore` list to drop the now-nonexistent
`@cowprotocol/cowswap-e2e` package. `changeset version` validates that list against the actual
workspace packages on every run and fails if an entry no longer resolves — this had been sitting
broken since #7958 merged, it just never got exercised by a `Release` run until now.

`develop` has the identical stale entry and will hit the same failure the next time its own
release runs — worth a follow-up PR there too.

## Fix

Removes the stale `"@cowprotocol/cowswap-e2e"` entry from `.changeset/config.json`'s `ignore`
array.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solana wrap and unwrap transaction reliability with automatic retries for expired blockhashes.
  * Improved error handling for failed Solana transactions, including clearer provider messages and proper modal behavior.
  * Wrap and unwrap trades no longer require or wait for captcha validation.
  * Corrected balance and allowance updates across supported EVM networks.
* **Refactor**
  * Simplified transaction flow and removed obsolete Solana approval screen behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->