### PR TITLE
fix(explorer): scope TokenDisplay flex-wrap to bridge network labels

### DIFF
--- a/apps/explorer/src/components/common/TokenDisplay/index.tsx
+++ b/apps/explorer/src/components/common/TokenDisplay/index.tsx
@@ -47,7 +47,7 @@ export function TokenDisplay(props: Readonly<TokenDisplayProps>): ReactNode {
   )
 
   return (
-    <Wrapper>
+    <Wrapper $wrap={showNetworkName}>
       <StyledImg address={imageAddress} network={network} tokenLogo={tokenLogo} />
       {isNativeToken(erc20.address) ? (
         nativeTokenDisplay

--- a/apps/explorer/src/components/common/TokenDisplay/styled.ts
+++ b/apps/explorer/src/components/common/TokenDisplay/styled.ts
@@ -3,13 +3,13 @@ import { Color } from '@cowprotocol/ui'
 import { TokenImg } from 'components/common/TokenImg'
 import styled from 'styled-components/macro'
 
-export const Wrapper = styled.div`
+export const Wrapper = styled.div<{ $wrap?: boolean }>`
   display: flex;
   align-items: center;
-  flex-flow: row wrap;
+  flex-flow: row ${({ $wrap }) => ($wrap ? 'wrap' : 'nowrap')};
   font-size: inherit;
   gap: 4px;
-  overflow-wrap: break-word;
+  overflow-wrap: ${({ $wrap }) => ($wrap ? 'break-word' : 'normal')};
   word-break: normal;
 `
 


### PR DESCRIPTION
## Summary
Fixes https://nomevlabs.slack.com/archives/C0361CDG8GP/p1786521572715679?thread_ts=1786376305.377609&cid=C0361CDG8GP
<img width="1638" height="756" alt="image" src="https://github.com/user-attachments/assets/97f0d78d-db00-41d4-9175-a23026587f5b" />


## Test plan
- [ ] [Order history page](https://explorer-dev-git-fix-token-display-wrap-orde-b26a1a-cowswap-dev.vercel.app/address/0x9fa3c00a92ec5f96b1ad2527ab41b3932efeda58) (Sepolia/mainnet): confirm Sell amount / Buy amount columns render on a single line again, no layout gap/shift, all columns (Tags, Created, Status) visible without overflow.
<img width="629" height="444" alt="image" src="https://github.com/user-attachments/assets/1d3c3342-269b-4f61-83cb-2c48067538b3" />

- [ ] Bridge order details page, mobile viewport, "Amounts" row: confirm long bridge-network labels still wrap at word boundaries (no regression of #7973's original fix).
**To test:** open this [order](https://explorer-dev-git-fix-token-display-wrap-orde-b26a1a-cowswap-dev.vercel.app/orders/0xfec1dc1dd717288923a39079ab9d30045334c360fb5f6d637f17c703997f443c9fa3c00a92ec5f96b1ad2527ab41b3932efeda586a4fd8fb?tab=bridge), bridge tab, in a mobile view

- [ ] Sanity-check Token table and Transaction table token cells still render inline.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token display formatting when network names are shown.
  * Long token and network names can now wrap cleanly instead of overflowing or being cut off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->