### PR TITLE
fix(ci): add cow-protocol to cla allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -31,4 +31,4 @@ jobs:
           branch: 'cla-signatures'
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/cowprotocol/cla/blob/main/Cow%20Services%20CLA.md'
-          allowlist: '${{ steps.team.outputs.result }},*[bot],lint-action,dependabot,mergify'
+          allowlist: '${{ steps.team.outputs.result }},*[bot],lint-action,dependabot,mergify,cow-protocol'


### PR DESCRIPTION
# Summary

Fixes the CLA check failing on automated `main` -> `develop` sync PRs (e.g. #7996) with:
```
3 out of 4 committers have signed the CLA.
✅ azebuado ✅ limitofzero ✅ kernelwhisperer
❌ @cow-protocol
```

`cow-protocol` is the service account that merges release PRs (e.g. #7979); its login doesn't end in `[bot]`, so it isn't covered by the `*[bot]` wildcard already in the allowlist, and it isn't showing up via the dynamic org-members lookup (`steps.team.outputs.result`) either. Since `automation/sync-main-to-develop` is rebuilt from scratch from `main` on every run, any merge commit `cow-protocol` is a co-author on gets pulled into the diff and fails the check.

# Changes

Adds `cow-protocol` to the static part of the CLA allowlist in `.github/workflows/cla.yml`, alongside the existing `*[bot]`/`lint-action`/`dependabot`/`mergify` entries.


