### PR TITLE
feat: re-enable token search

### DIFF
--- a/apps/cowswap-frontend/src/modules/tokensList/pure/ImportTokenModal/styled.ts
+++ b/apps/cowswap-frontend/src/modules/tokensList/pure/ImportTokenModal/styled.ts
@@ -8,7 +8,8 @@ export const Wrapper = styled.div`
   width: 100%;
   background: var(${UI.COLOR_PAPER});
   border-radius: 20px;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
 `
 
 export const Contents = styled.div`

--- a/apps/cowswap-frontend/src/modules/twap/services/programmaticOrdersApi.test.ts
+++ b/apps/cowswap-frontend/src/modules/twap/services/programmaticOrdersApi.test.ts
@@ -7,11 +7,7 @@ const LIVE_ORDER_HASH = '0xf8edb9707569dec76a362bb6bac1909fdf43d5afe70beca3e422e
 
 describe('fetchEoaTwapOrders', () => {
   it('maps a known EOA TWAP from the live programmatic orders API', async () => {
-    const { orders, totalCount } = await programmaticOrdersApi.fetchEoaTwapOrders(
-      EOA,
-      SupportedChainId.GNOSIS_CHAIN,
-      100,
-    )
+    const { orders } = await programmaticOrdersApi.fetchEoaTwapOrders(EOA, SupportedChainId.GNOSIS_CHAIN, 100)
     const order = Object.values(orders).find(({ hash }) => hash === LIVE_ORDER_HASH)
 
     expect(order?.id).toBeTruthy()
@@ -35,7 +31,6 @@ describe('fetchEoaTwapOrders', () => {
             executionInfo: order.executionInfo,
           }
         : null,
-      totalCount,
     }).toMatchInlineSnapshot(`
       {
         "order": {
@@ -61,7 +56,6 @@ describe('fetchEoaTwapOrders', () => {
           "safeAddress": "0x62587918b2f00176646679509217a5a4d1ebbfd5",
           "status": "Fulfilled",
         },
-        "totalCount": 13,
       }
     `)
   }, 30_000)

--- a/libs/tokens/src/hooks/tokens/useSearchToken.ts
+++ b/libs/tokens/src/hooks/tokens/useSearchToken.ts
@@ -66,11 +66,10 @@ export function useSearchToken(input: string | null): TokenSearchResponse {
   }, [debouncedInputInList, tokensFromActiveLists, tokensFromInactiveLists])
 
   // Search in external API
-  // TODO: Temporarily disabled since the API is no longer available. Re-enable when the API is fixed
-  const { data: apiResultTokens, isLoading: apiIsLoading } = { data: null, isLoading: false } /*useSearchTokensInApi(
+  const { data: apiResultTokens, isLoading: apiIsLoading } = useSearchTokensInApi(
     debouncedInputInExternals,
     isTokenAlreadyFoundByAddress,
-  )*/
+  )
 
   // Search in Blockchain
   const { data: tokenFromBlockChain, isLoading: blockchainIsLoading } = useFetchTokenFromBlockchain(
@@ -150,7 +149,6 @@ function useFetchTokenFromBlockchain(
   })
 }
 
-// eslint-disable-next-line unused-imports/no-unused-vars
 function useSearchTokensInApi(
   input: string | undefined,
   isTokenAlreadyFoundByAddress: boolean,


### PR DESCRIPTION
The proxy was already fixed for .cow.fi, but now cow.fi, so we can enable it.

Because it was failing on cow.fi we assumed it was not working for swap.cow.fi.

Related PR: https://github.com/cowprotocol/infrastructure/pull/6568

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Re-enabled token search through the external token API, improving token discovery during import.

* **Bug Fixes**
  * Improved token import modal scrolling by preventing unwanted horizontal overflow while preserving vertical scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->