### PR TITLE
feat(notifications): promote trade alerts 

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/OrderSubmittedContent/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderSubmittedContent/index.tsx
@@ -109,7 +109,7 @@ export function OrderSubmittedContent({
             <Trans>New</Trans>
           </Badge>
           <GetNotifiedLink onClick={onGetNotifiedClick}>
-            <Trans>Get notified when your order fills</Trans>
+            <Trans>Get trade alerts</Trans>
           </GetNotifiedLink>
         </GetNotifiedMessage>
       )}

--- a/apps/cowswap-frontend/src/common/pure/OrderSubmittedContent/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderSubmittedContent/index.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react'
 
 import { isCowOrder } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { ButtonPrimary } from '@cowprotocol/ui'
+import { Badge, BadgeTypes, ButtonPrimary, UI } from '@cowprotocol/ui'
 
 import { Trans } from '@lingui/react/macro'
 import styled from 'styled-components/macro'
@@ -31,12 +31,51 @@ const ActionButton = styled(ButtonPrimary)`
   margin-top: 30px;
 `
 
+const GetNotifiedMessage = styled.p`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin: 0 auto;
+  font-size: 15px;
+  line-height: 1.4;
+  font-weight: 400;
+  white-space: nowrap;
+  color: inherit;
+`
+
+const GetNotifiedLink = styled.button`
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(${UI.COLOR_TEXT});
+  font-size: inherit;
+  font-weight: 500;
+  text-decoration: underline;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(${UI.COLOR_PRIMARY});
+    outline-offset: 2px;
+  }
+
+  &:active {
+    text-decoration: underline;
+  }
+`
+
 export interface OrderSubmittedContentProps {
   onDismiss(): void
   chainId: SupportedChainId
   isSafeWallet: boolean
   account: string
   hash: string
+  showGetNotifiedMessage?: boolean
+  onGetNotifiedClick?: () => void
 }
 
 export function OrderSubmittedContent({
@@ -45,6 +84,8 @@ export function OrderSubmittedContent({
   isSafeWallet,
   hash,
   onDismiss,
+  showGetNotifiedMessage,
+  onGetNotifiedClick,
 }: OrderSubmittedContentProps): ReactNode {
   const tx = {
     hash,
@@ -62,6 +103,16 @@ export function OrderSubmittedContent({
         <Trans>Order Submitted</Trans>
       </Caption>
       <EnhancedTransactionLink chainId={chainId} tx={tx} />
+      {showGetNotifiedMessage && onGetNotifiedClick && (
+        <GetNotifiedMessage>
+          <Badge type={BadgeTypes.ALERT2}>
+            <Trans>New</Trans>
+          </Badge>
+          <GetNotifiedLink onClick={onGetNotifiedClick}>
+            <Trans>Get notified when your order fills</Trans>
+          </GetNotifiedLink>
+        </GetNotifiedMessage>
+      )}
       <ActionButton onClick={onDismiss}>
         <Trans>Continue</Trans>
       </ActionButton>

--- a/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/AccountElement.pure.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Header/AccountElement/AccountElement.pure.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useRef, useState } from 'react'
+import { ReactNode, useCallback, useRef } from 'react'
 
 import { useFeatureFlags } from '@cowprotocol/common-hooks'
 import { useWalletInfo } from '@cowprotocol/wallet'
@@ -8,8 +8,11 @@ import { AffiliateTraderHeaderButton, useShouldShowAffiliateTraderHeaderButton }
 import {
   NotificationBell,
   NotificationSidebar,
+  useCloseNotificationSidebar,
   useHasNotificationSubscription,
   useNotificationAlertDismissal,
+  useNotificationSidebarState,
+  useOpenNotificationSidebar,
   useUnreadSidebarNotificationsCount,
 } from 'modules/notifications'
 import { WalletStatusButton } from 'modules/wallet'
@@ -33,8 +36,9 @@ export function AccountElement({ className }: AccountElementProps): ReactNode {
   const { areTelegramNotificationsEnabled } = useFeatureFlags()
   const { hasSubscription, isLoading } = useHasNotificationSubscription()
 
-  const [isSidebarOpen, setSidebarOpen] = useState(false)
-  const [shouldOpenSettings, setShouldOpenSettings] = useState(false)
+  const { isOpen: isSidebarOpen, initialSettingsOpen: shouldOpenSettings } = useNotificationSidebarState()
+  const openNotificationSidebar = useOpenNotificationSidebar()
+  const closeNotificationSidebar = useCloseNotificationSidebar()
   const wrapperRef = useRef<HTMLDivElement>(null)
   const notificationBellRef = useRef<HTMLButtonElement>(null)
 
@@ -42,8 +46,7 @@ export function AccountElement({ className }: AccountElementProps): ReactNode {
     areTelegramNotificationsEnabled && !!account && !isDismissed && !hasSubscription && !isLoading
 
   const handleEnableAlerts = (): void => {
-    setShouldOpenSettings(areTelegramNotificationsEnabled)
-    setSidebarOpen(true)
+    openNotificationSidebar(areTelegramNotificationsEnabled)
     dismiss()
   }
 
@@ -51,8 +54,8 @@ export function AccountElement({ className }: AccountElementProps): ReactNode {
     if (shouldShowPopover) {
       dismiss()
     }
-    setSidebarOpen(true)
-  }, [shouldShowPopover, dismiss])
+    openNotificationSidebar()
+  }, [shouldShowPopover, dismiss, openNotificationSidebar])
 
   return (
     <>
@@ -83,10 +86,7 @@ export function AccountElement({ className }: AccountElementProps): ReactNode {
 
       <NotificationSidebar
         isOpen={isSidebarOpen}
-        onClose={() => {
-          setSidebarOpen(false)
-          setShouldOpenSettings(false)
-        }}
+        onClose={closeNotificationSidebar}
         initialSettingsOpen={shouldOpenSettings}
       />
     </>

--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -1466,8 +1466,8 @@ msgstr "Not enough price data for one or both assets to calculate the price impa
 #~ msgstr "Unable to check"
 
 #: apps/cowswap-frontend/src/modules/account/containers/AccountDetails/index.tsx
-msgid "Get order notifications"
-msgstr "Get order notifications"
+#~ msgid "Get order notifications"
+#~ msgstr "Get order notifications"
 
 #: apps/cowswap-frontend/src/modules/account/containers/Transaction/StatusDetails.tsx
 msgid "Order Open"
@@ -6820,6 +6820,7 @@ msgstr "Executes at"
 #~ msgstr "From (incl. costs)"
 
 #: apps/cowswap-frontend/src/legacy/components/Header/NotificationAlertPopover/NotificationAlertPopover.pure.tsx
+#: apps/cowswap-frontend/src/modules/account/containers/AccountDetails/index.tsx
 msgid "Get trade alerts"
 msgstr "Get trade alerts"
 

--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -1465,6 +1465,10 @@ msgstr "Not enough price data for one or both assets to calculate the price impa
 #~ msgid "Unable to check"
 #~ msgstr "Unable to check"
 
+#: apps/cowswap-frontend/src/modules/account/containers/AccountDetails/index.tsx
+msgid "Get order notifications"
+msgstr "Get order notifications"
+
 #: apps/cowswap-frontend/src/modules/account/containers/Transaction/StatusDetails.tsx
 msgid "Order Open"
 msgstr "Order Open"
@@ -1495,6 +1499,10 @@ msgstr "This app/hook can only be used as a <0>{hookType}-hook</0>"
 #: apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersConfirmModal/index.tsx
 msgid "Place limit order"
 msgstr "Place limit order"
+
+#: apps/cowswap-frontend/src/modules/notifications/containers/NotificationsList/index.tsx
+msgid "<0>New!</0> Get Telegram notifications about your order status! <1>Get started</1>"
+msgstr "<0>New!</0> Get Telegram notifications about your order status! <1>Get started</1>"
 
 #: apps/cowswap-frontend/src/modules/affiliate/containers/AffiliatePartnerOnboard.tsx
 msgid "Become an affiliate"
@@ -6315,6 +6323,8 @@ msgstr "Volume referred"
 #~ msgstr "Token approval bundling"
 
 #: apps/cowswap-frontend/src/common/constants/routes.ts
+#: apps/cowswap-frontend/src/common/pure/OrderSubmittedContent/index.tsx
+#: apps/cowswap-frontend/src/modules/account/containers/AccountDetails/index.tsx
 #: apps/cowswap-frontend/src/modules/application/containers/App/menuConsts.tsx
 #: apps/cowswap-frontend/src/modules/application/containers/App/menuConsts.tsx
 msgid "New"
@@ -7596,6 +7606,10 @@ msgstr "CoW Swap <0>is back online</0>"
 #: apps/cowswap-frontend/src/modules/affiliate/pure/TraderReferralCodeModal/TraderReferralCodeModalContent.tsx
 #~ msgid "This wallet isn't eligible for that code."
 #~ msgstr "This wallet isn't eligible for that code."
+
+#: apps/cowswap-frontend/src/common/pure/OrderSubmittedContent/index.tsx
+msgid "Get notified when your order fills"
+msgstr "Get notified when your order fills"
 
 #: apps/cowswap-frontend/src/modules/hooksStore/containers/HookSearchInput/index.tsx
 msgid "Search hooks..."

--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -6819,6 +6819,7 @@ msgstr "Executes at"
 #~ msgid "From (incl. costs)"
 #~ msgstr "From (incl. costs)"
 
+#: apps/cowswap-frontend/src/common/pure/OrderSubmittedContent/index.tsx
 #: apps/cowswap-frontend/src/legacy/components/Header/NotificationAlertPopover/NotificationAlertPopover.pure.tsx
 #: apps/cowswap-frontend/src/modules/account/containers/AccountDetails/index.tsx
 msgid "Get trade alerts"
@@ -7609,8 +7610,8 @@ msgstr "CoW Swap <0>is back online</0>"
 #~ msgstr "This wallet isn't eligible for that code."
 
 #: apps/cowswap-frontend/src/common/pure/OrderSubmittedContent/index.tsx
-msgid "Get notified when your order fills"
-msgstr "Get notified when your order fills"
+#~ msgid "Get notified when your order fills"
+#~ msgstr "Get notified when your order fills"
 
 #: apps/cowswap-frontend/src/modules/hooksStore/containers/HookSearchInput/index.tsx
 msgid "Search hooks..."

--- a/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/index.tsx
@@ -202,11 +202,11 @@ export function AccountDetails({
                 </h5>
                 {showGetNotifiedRow && (
                   <GetNotifiedButton onClick={handleGetNotifiedClick}>
+                    <Bell size={16} />
+                    <Trans>Get trade alerts</Trans>
                     <Badge type={BadgeTypes.ALERT2}>
                       <Trans>New</Trans>
                     </Badge>
-                    <Bell size={16} />
-                    <Trans>Get trade alerts</Trans>
                   </GetNotifiedButton>
                 )}
                 {explorerOrdersLink && (

--- a/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/index.tsx
@@ -26,6 +26,7 @@ import {
 import { t } from '@lingui/core/macro'
 import { Trans } from '@lingui/react/macro'
 import { useInjectedWidgetParams } from 'entities/injectedWidget'
+import { Bell } from 'react-feather'
 
 import Copy from 'legacy/components/Copy'
 import { groupActivitiesByDay, useMultipleActivityDescriptors } from 'legacy/hooks/useRecentActivity'
@@ -44,8 +45,7 @@ import {
   AccountGroupingRow,
   AddressLink,
   CreationDateRow,
-  GetNotifiedLink,
-  GetNotifiedRow,
+  GetNotifiedButton,
   InfoCard,
   LowerSection,
   NetworkCard,
@@ -214,14 +214,13 @@ export function AccountDetails({
                     <CreationDateRow>
                       <CreationDateText>{date.toLocaleString(i18n.locale, DATE_FORMAT_OPTION)}</CreationDateText>
                       {index === 0 && showGetNotifiedRow && (
-                        <GetNotifiedRow>
+                        <GetNotifiedButton onClick={handleGetNotifiedClick}>
                           <Badge type={BadgeTypes.ALERT2}>
                             <Trans>New</Trans>
                           </Badge>
-                          <GetNotifiedLink onClick={handleGetNotifiedClick}>
-                            <Trans>Get order notifications</Trans>
-                          </GetNotifiedLink>
-                        </GetNotifiedRow>
+                          <Bell size={16} />
+                          <Trans>Get trade alerts</Trans>
+                        </GetNotifiedButton>
                       )}
                     </CreationDateRow>
                     <ActivitiesList activities={activities} />

--- a/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/index.tsx
@@ -43,6 +43,7 @@ import { ActivitiesList } from './ActivitiesList'
 import {
   AccountControl,
   AccountGroupingRow,
+  ActivityHeader,
   AddressLink,
   CreationDateRow,
   GetNotifiedButton,
@@ -195,33 +196,32 @@ export function AccountDetails({
 
           {activityTotalCount ? (
             <LowerSection>
-              <span>
-                {' '}
+              <ActivityHeader>
                 <h5>
                   <Trans>Recent Activity</Trans> <span>{`(${activityTotalCount})`}</span>
                 </h5>
+                {showGetNotifiedRow && (
+                  <GetNotifiedButton onClick={handleGetNotifiedClick}>
+                    <Badge type={BadgeTypes.ALERT2}>
+                      <Trans>New</Trans>
+                    </Badge>
+                    <Bell size={16} />
+                    <Trans>Get trade alerts</Trans>
+                  </GetNotifiedButton>
+                )}
                 {explorerOrdersLink && (
                   <ExternalLink href={explorerOrdersLink}>
                     <Trans>View all orders</Trans> ↗
                   </ExternalLink>
                 )}
-              </span>
+              </ActivityHeader>
 
               <div>
-                {activitiesGroupedByDate.map(({ date, activities }, index) => (
+                {activitiesGroupedByDate.map(({ date, activities }) => (
                   <Fragment key={date.getTime()}>
                     {/* TODO: style me! */}
                     <CreationDateRow>
                       <CreationDateText>{date.toLocaleString(i18n.locale, DATE_FORMAT_OPTION)}</CreationDateText>
-                      {index === 0 && showGetNotifiedRow && (
-                        <GetNotifiedButton onClick={handleGetNotifiedClick}>
-                          <Badge type={BadgeTypes.ALERT2}>
-                            <Trans>New</Trans>
-                          </Badge>
-                          <Bell size={16} />
-                          <Trans>Get trade alerts</Trans>
-                        </GetNotifiedButton>
-                      )}
                     </CreationDateRow>
                     <ActivitiesList activities={activities} />
                   </Fragment>

--- a/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/index.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/index.tsx
@@ -3,10 +3,16 @@ import { Fragment, ReactNode } from 'react'
 import { i18n } from '@lingui/core'
 
 import { CHAIN_INFO } from '@cowprotocol/common-const'
-import { styled } from '@cowprotocol/common-hooks'
-import { getEtherscanLink, getExplorerAddressLink, getExplorerLabel, shortenAddress } from '@cowprotocol/common-utils'
+import { styled, useFeatureFlags } from '@cowprotocol/common-hooks'
+import {
+  getEtherscanLink,
+  getExplorerAddressLink,
+  getExplorerLabel,
+  isInjectedWidget,
+  shortenAddress,
+} from '@cowprotocol/common-utils'
 import { Command } from '@cowprotocol/types'
-import { ExternalLink } from '@cowprotocol/ui'
+import { Badge, BadgeTypes, ExternalLink } from '@cowprotocol/ui'
 import {
   ConnectionType,
   getIsInjectedMobileBrowser,
@@ -26,6 +32,8 @@ import { groupActivitiesByDay, useMultipleActivityDescriptors } from 'legacy/hoo
 import { useAppDispatch } from 'legacy/state/hooks'
 import { updateSelectedWallet } from 'legacy/state/user/reducer'
 
+import { useHasNotificationSubscription, useOpenNotificationSidebar } from 'modules/notifications'
+
 import { useIsProviderNetworkUnsupported } from 'common/hooks/useIsProviderNetworkUnsupported'
 import { UnsupportedNetworksText } from 'common/pure/UnsupportedNetworksText'
 
@@ -35,6 +43,9 @@ import {
   AccountControl,
   AccountGroupingRow,
   AddressLink,
+  CreationDateRow,
+  GetNotifiedLink,
+  GetNotifiedRow,
   InfoCard,
   LowerSection,
   NetworkCard,
@@ -88,6 +99,17 @@ export function AccountDetails({
   const isChainIdUnsupported = useIsProviderNetworkUnsupported()
   const closeAccountModal = useCloseAccountModal()
   const { standaloneMode } = useInjectedWidgetParams()
+  const { areTelegramNotificationsEnabled } = useFeatureFlags()
+  const { hasSubscription, isLoading: isNotificationSubscriptionLoading } = useHasNotificationSubscription()
+  const openNotificationSidebar = useOpenNotificationSidebar()
+
+  const handleGetNotifiedClick = (): void => {
+    closeAccountModal()
+    openNotificationSidebar()
+  }
+
+  const showGetNotifiedRow =
+    areTelegramNotificationsEnabled && !isNotificationSubscriptionLoading && !hasSubscription && !isInjectedWidget()
 
   const explorerOrdersLink = account && getExplorerAddressLink(chainId, account)
   const explorerLabel = account ? getExplorerLabel(chainId, 'address', account) : undefined
@@ -186,10 +208,22 @@ export function AccountDetails({
               </span>
 
               <div>
-                {activitiesGroupedByDate.map(({ date, activities }) => (
+                {activitiesGroupedByDate.map(({ date, activities }, index) => (
                   <Fragment key={date.getTime()}>
                     {/* TODO: style me! */}
-                    <CreationDateText>{date.toLocaleString(i18n.locale, DATE_FORMAT_OPTION)}</CreationDateText>
+                    <CreationDateRow>
+                      <CreationDateText>{date.toLocaleString(i18n.locale, DATE_FORMAT_OPTION)}</CreationDateText>
+                      {index === 0 && showGetNotifiedRow && (
+                        <GetNotifiedRow>
+                          <Badge type={BadgeTypes.ALERT2}>
+                            <Trans>New</Trans>
+                          </Badge>
+                          <GetNotifiedLink onClick={handleGetNotifiedClick}>
+                            <Trans>Get order notifications</Trans>
+                          </GetNotifiedLink>
+                        </GetNotifiedRow>
+                      )}
+                    </CreationDateRow>
                     <ActivitiesList activities={activities} />
                   </Fragment>
                 ))}

--- a/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/styled.ts
+++ b/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/styled.ts
@@ -295,31 +295,39 @@ export const CreationDateRow = styled.div`
   justify-content: space-between;
   gap: 6px;
   width: 100%;
+  flex-wrap: wrap;
+
+  ${Media.upToSmall()} {
+    row-gap: 10px;
+  }
 `
 
-export const GetNotifiedRow = styled.div`
+export const GetNotifiedButton = styled.button`
   display: flex;
   align-items: center;
-  flex-wrap: nowrap;
+  flex: 0 0 auto;
   gap: 6px;
-  font-size: 14px;
-  line-height: 1.4;
-  font-weight: 400;
-  color: inherit;
-`
-
-export const GetNotifiedLink = styled.button`
-  background: none;
-  border: none;
-  padding: 0;
-  color: var(${UI.COLOR_TEXT});
-  font-size: inherit;
-  font-weight: 500;
-  text-decoration: underline;
   cursor: pointer;
+  border-radius: 16px;
+  background: var(${UI.COLOR_PAPER});
+  border: 1px solid var(${UI.COLOR_TEXT_OPACITY_10});
+  color: var(${UI.COLOR_TEXT});
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+  padding: 6px 12px;
+  transition:
+    background var(${UI.ANIMATION_DURATION}) ease-in-out,
+    border-color var(${UI.ANIMATION_DURATION}) ease-in-out;
+
+  > svg {
+    flex: 0 0 auto;
+    color: inherit;
+  }
 
   &:hover {
-    text-decoration: underline;
+    background: var(${UI.COLOR_PAPER_DARKER});
+    border-color: var(${UI.COLOR_PAPER_DARKER});
   }
 
   &:focus-visible {
@@ -327,8 +335,9 @@ export const GetNotifiedLink = styled.button`
     outline-offset: 2px;
   }
 
-  &:active {
-    text-decoration: underline;
+  ${Media.upToSmall()} {
+    width: 100%;
+    justify-content: center;
   }
 `
 

--- a/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/styled.ts
+++ b/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/styled.ts
@@ -295,11 +295,6 @@ export const CreationDateRow = styled.div`
   justify-content: space-between;
   gap: 6px;
   width: 100%;
-  flex-wrap: wrap;
-
-  ${Media.upToSmall()} {
-    row-gap: 10px;
-  }
 `
 
 export const GetNotifiedButton = styled.button`
@@ -359,17 +354,6 @@ export const LowerSection = styled.div`
   justify-content: flex-start;
   color: inherit;
 
-  > span {
-    display: flex;
-    color: inherit;
-    justify-content: space-between;
-    padding: 0 0 12px;
-
-    ${Media.upToMedium()} {
-      top: 42px;
-    }
-  }
-
   > div {
     display: flex;
     flex-flow: column wrap;
@@ -384,8 +368,23 @@ export const LowerSection = styled.div`
       margin: 24px auto 0;
     }
   }
+`
 
-  > span > h5 {
+export const ActivityHeader = styled.span`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  color: inherit;
+  gap: 8px 12px;
+  padding: 0 0 12px;
+  width: 100%;
+
+  ${Media.upToMedium()} {
+    top: 42px;
+  }
+
+  > h5 {
+    order: 1;
     margin: 0;
     font-weight: 500;
     color: inherit;
@@ -400,13 +399,26 @@ export const LowerSection = styled.div`
     }
   }
 
-  > span > ${StyledLink} {
+  > button {
+    order: 2;
+  }
+
+  > ${StyledLink} {
+    order: 3;
+    margin-left: auto;
     color: inherit;
     text-decoration: underline;
     font-size: 14px;
 
     &:hover {
       color: ${({ theme }) => theme.info};
+    }
+  }
+
+  ${Media.upToSmall()} {
+    > button {
+      order: 0;
+      flex: 1 1 100%;
     }
   }
 `

--- a/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/styled.ts
+++ b/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/styled.ts
@@ -310,7 +310,7 @@ export const GetNotifiedButton = styled.button`
   font-size: 14px;
   font-weight: 500;
   line-height: 1.4;
-  padding: 6px 12px;
+  padding: 12px;
   transition:
     background var(${UI.ANIMATION_DURATION}) ease-in-out,
     border-color var(${UI.ANIMATION_DURATION}) ease-in-out;
@@ -421,6 +421,7 @@ export const ActivityHeader = styled.span`
     > button {
       order: 0;
       flex: 1 1 100%;
+      margin-top: -12px;
     }
   }
 `

--- a/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/styled.ts
+++ b/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/styled.ts
@@ -416,6 +416,8 @@ export const ActivityHeader = styled.span`
   }
 
   ${Media.upToSmall()} {
+    row-gap: 24px;
+
     > button {
       order: 0;
       flex: 1 1 100%;

--- a/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/styled.ts
+++ b/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/styled.ts
@@ -289,6 +289,49 @@ export const AccountGroupingRow = styled.div`
   }
 `
 
+export const CreationDateRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  width: 100%;
+`
+
+export const GetNotifiedRow = styled.div`
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  gap: 6px;
+  font-size: 14px;
+  line-height: 1.4;
+  font-weight: 400;
+  color: inherit;
+`
+
+export const GetNotifiedLink = styled.button`
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(${UI.COLOR_TEXT});
+  font-size: inherit;
+  font-weight: 500;
+  text-decoration: underline;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(${UI.COLOR_PRIMARY});
+    outline-offset: 2px;
+  }
+
+  &:active {
+    text-decoration: underline;
+  }
+`
+
 export const NoActivityMessage = styled.p`
   font-size: 14px;
   color: inherit;

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersConfirmModal/index.tsx
@@ -96,7 +96,7 @@ export function LimitOrdersConfirmModal(props: LimitOrdersConfirmModalProps): Re
   )
 
   return (
-    <TradeConfirmModal title={CONFIRM_TITLE}>
+    <TradeConfirmModal title={CONFIRM_TITLE} showGetNotifiedMessage>
       <TradeConfirmation
         {...commonTradeConfirmContext}
         title={CONFIRM_TITLE}

--- a/apps/cowswap-frontend/src/modules/notifications/containers/NotificationsList/index.tsx
+++ b/apps/cowswap-frontend/src/modules/notifications/containers/NotificationsList/index.tsx
@@ -17,6 +17,8 @@ import {
   NotificationThumb,
   MessageReadIcon,
   EnableAlertsLink,
+  PromoBanner,
+  PromoBannerLink,
 } from './styled'
 
 import { NOTIFICATION_MARK_READ_DELAY_MS } from '../../constants'
@@ -30,6 +32,10 @@ import { groupNotificationsByDate } from '../../utils/groupNotificationsByDate'
 interface EmptyNotificationsProps {
   hasSubscription: boolean | undefined
   onToggleSettings: (() => void) | undefined
+}
+
+interface NotificationsPromoBannerProps {
+  onToggleSettings: () => void
 }
 
 function EmptyNotifications({ hasSubscription, onToggleSettings }: EmptyNotificationsProps): ReactNode {
@@ -57,6 +63,28 @@ function EmptyNotifications({ hasSubscription, onToggleSettings }: EmptyNotifica
         </p>
       )}
     </NoNotifications>
+  )
+}
+
+function NotificationsPromoBanner({ onToggleSettings }: NotificationsPromoBannerProps): ReactNode {
+  return (
+    <PromoBanner>
+      <p>
+        <Trans>
+          <strong>New!</strong> Get Telegram notifications about your order status!{' '}
+          <PromoBannerLink
+            onClick={onToggleSettings}
+            data-click-event={toCowSwapGtmEvent({
+              category: CowSwapAnalyticsCategory.NOTIFICATIONS,
+              action: 'Open notification settings',
+              label: 'promo banner',
+            })}
+          >
+            Get started
+          </PromoBannerLink>
+        </Trans>
+      </p>
+    </PromoBanner>
   )
 }
 
@@ -101,6 +129,9 @@ export function NotificationsList({ children, hasSubscription, onToggleSettings 
     <>
       {children}
       <ListWrapper>
+        {onToggleSettings && hasSubscription === false && (
+          <NotificationsPromoBanner onToggleSettings={onToggleSettings} />
+        )}
         {groups?.map((group) => (
           <>
             <h4>{group.date.toLocaleString(i18n.locale, DATE_FORMAT_OPTION)}</h4>

--- a/apps/cowswap-frontend/src/modules/notifications/containers/NotificationsList/styled.ts
+++ b/apps/cowswap-frontend/src/modules/notifications/containers/NotificationsList/styled.ts
@@ -138,6 +138,33 @@ export const MessageReadIcon = styled(SVG)`
   color: var(${UI.COLOR_TEXT_OPACITY_15});
 `
 
+export const PromoBanner = styled.div`
+  background: var(${UI.COLOR_SUCCESS_BG});
+  color: var(${UI.COLOR_SUCCESS_TEXT});
+  border-radius: 16px;
+  padding: 12px 14px;
+  margin: 0 0 16px;
+  text-align: left;
+
+  > p {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.4;
+    text-align: left;
+  }
+`
+
+export const PromoBannerLink = styled.button`
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+  font-size: inherit;
+  font-weight: var(${UI.FONT_WEIGHT_BOLD});
+  text-decoration: underline;
+  cursor: pointer;
+`
+
 export const EnableAlertsLink = styled.button`
   background: none;
   border: none;

--- a/apps/cowswap-frontend/src/modules/notifications/hooks/useNotificationSidebarState.ts
+++ b/apps/cowswap-frontend/src/modules/notifications/hooks/useNotificationSidebarState.ts
@@ -1,0 +1,28 @@
+import { useAtomValue, useSetAtom } from 'jotai'
+import { useCallback } from 'react'
+
+import { notificationSidebarStateAtom, updateNotificationSidebarStateAtom } from '../state/notificationSidebarState'
+
+import type { NotificationSidebarState } from '../state/notificationSidebarState'
+
+export function useCloseNotificationSidebar(): () => void {
+  const updateState = useSetAtom(updateNotificationSidebarStateAtom)
+
+  return useCallback(() => updateState({ isOpen: false, initialSettingsOpen: false }), [updateState])
+}
+
+export function useNotificationSidebarState(): NotificationSidebarState {
+  return useAtomValue(notificationSidebarStateAtom)
+}
+
+/**
+ * Opens the notification sidebar from anywhere in the app (e.g. from the order-submitted screen).
+ */
+export function useOpenNotificationSidebar(): (openSettings?: boolean) => void {
+  const updateState = useSetAtom(updateNotificationSidebarStateAtom)
+
+  return useCallback(
+    (openSettings = false) => updateState({ isOpen: true, initialSettingsOpen: openSettings }),
+    [updateState],
+  )
+}

--- a/apps/cowswap-frontend/src/modules/notifications/index.ts
+++ b/apps/cowswap-frontend/src/modules/notifications/index.ts
@@ -3,5 +3,10 @@ export { NotificationBell } from './pure/NotificationBell/NotificationBell.pure'
 export { useSpeechBubbleNotification } from './hooks/useSpeechBubbleNotification'
 export { useHasNotificationSubscription } from './hooks/useHasNotificationSubscription'
 export { useNotificationAlertDismissal } from './hooks/useNotificationAlertDismissal'
+export {
+  useNotificationSidebarState,
+  useOpenNotificationSidebar,
+  useCloseNotificationSidebar,
+} from './hooks/useNotificationSidebarState'
 export { useUnreadSidebarNotificationsCount } from './hooks/useUnreadSidebarNotificationsCount'
 export { getTrustedNotificationLink } from './utils/getTrustedNotificationLink'

--- a/apps/cowswap-frontend/src/modules/notifications/state/notificationSidebarState.ts
+++ b/apps/cowswap-frontend/src/modules/notifications/state/notificationSidebarState.ts
@@ -1,0 +1,11 @@
+import { atom } from 'jotai'
+
+import { atomWithPartialUpdate } from '@cowprotocol/common-utils'
+
+export interface NotificationSidebarState {
+  isOpen: boolean
+  initialSettingsOpen: boolean
+}
+
+export const { atom: notificationSidebarStateAtom, updateAtom: updateNotificationSidebarStateAtom } =
+  atomWithPartialUpdate(atom<NotificationSidebarState>({ isOpen: false, initialSettingsOpen: false }))

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeConfirmModal/index.tsx
@@ -1,5 +1,7 @@
-import { ReactNode } from 'react'
+import { ReactNode, useCallback } from 'react'
 
+import { useFeatureFlags } from '@cowprotocol/common-hooks'
+import { isInjectedWidget } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { Command } from '@cowprotocol/types'
 import { UI } from '@cowprotocol/ui'
@@ -7,6 +9,8 @@ import { useIsSafeWallet, useWalletInfo } from '@cowprotocol/wallet'
 
 import { useSigningStep } from 'entities/trade'
 import styled from 'styled-components/macro'
+
+import { useHasNotificationSubscription, useOpenNotificationSidebar } from 'modules/notifications'
 
 import { PermitModal } from 'common/containers/PermitModal'
 import { OrderSubmittedContent } from 'common/pure/OrderSubmittedContent'
@@ -30,6 +34,7 @@ const Container = styled.div`
 export interface TradeConfirmModalProps extends React.PropsWithChildren {
   title: string
   submittedContent?: ReactNode
+  showGetNotifiedMessage?: boolean
 }
 
 interface InnerComponentProps extends React.PropsWithChildren {
@@ -43,16 +48,26 @@ interface InnerComponentProps extends React.PropsWithChildren {
   permitSignatureState: string | undefined
   isSafeWallet: boolean
   submittedContent?: ReactNode
+  showGetNotifiedMessage?: boolean
+  onGetNotifiedClick: () => void
 }
 
 export function TradeConfirmModal(props: TradeConfirmModalProps): ReactNode {
-  const { children, submittedContent, title } = props
+  const { children, submittedContent, title, showGetNotifiedMessage } = props
 
   const { chainId, account } = useWalletInfo()
   const isSafeWallet = useIsSafeWallet()
   const { permitSignatureState, pendingTrade, transactionHash, error } = useTradeConfirmState()
   const { onDismiss } = useTradeConfirmActions()
   const signingStep = useSigningStep()
+  const { areTelegramNotificationsEnabled } = useFeatureFlags()
+  const { hasSubscription, isLoading: isNotificationSubscriptionLoading } = useHasNotificationSubscription()
+  const openNotificationSidebar = useOpenNotificationSidebar()
+
+  const handleGetNotifiedClick = useCallback(() => {
+    onDismiss()
+    openNotificationSidebar()
+  }, [onDismiss, openNotificationSidebar])
 
   if (!account) return null
 
@@ -70,6 +85,14 @@ export function TradeConfirmModal(props: TradeConfirmModalProps): ReactNode {
         permitSignatureState={signingStep ? undefined : permitSignatureState}
         isSafeWallet={isSafeWallet}
         submittedContent={submittedContent}
+        showGetNotifiedMessage={
+          showGetNotifiedMessage &&
+          areTelegramNotificationsEnabled &&
+          !isNotificationSubscriptionLoading &&
+          !hasSubscription &&
+          !isInjectedWidget()
+        }
+        onGetNotifiedClick={handleGetNotifiedClick}
       >
         {children}
       </InnerComponent>
@@ -90,6 +113,8 @@ function InnerComponent(props: InnerComponentProps): ReactNode {
     permitSignatureState,
     transactionHash,
     submittedContent,
+    showGetNotifiedMessage,
+    onGetNotifiedClick,
   } = props
 
   if (error) {
@@ -118,6 +143,8 @@ function InnerComponent(props: InnerComponentProps): ReactNode {
           isSafeWallet={isSafeWallet}
           onDismiss={onDismiss}
           hash={transactionHash}
+          showGetNotifiedMessage={showGetNotifiedMessage}
+          onGetNotifiedClick={onGetNotifiedClick}
         />
       )
     )

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/index.tsx
@@ -118,7 +118,7 @@ export function TwapConfirmModal(): ReactNode {
   const eoaTwapSigningStepElement = <EoaTwapSigningPendingContent />
 
   return (
-    <TradeConfirmModal title={CONFIRM_TITLE}>
+    <TradeConfirmModal title={CONFIRM_TITLE} showGetNotifiedMessage>
       <TradeConfirmation
         {...commonTradeConfirmContext}
         // TODO: Maybe better to use the same?

--- a/bundle-size.jsonc
+++ b/bundle-size.jsonc
@@ -6,7 +6,7 @@
   "schemaVersion": 2,
   "apps": {
     "@cowprotocol/cow-fi": 4.9,
-    "@cowprotocol/cowswap": 10.3,
+    "@cowprotocol/cowswap": 10.4,
     "@cowprotocol/explorer": 10.8,
     "@cowprotocol/sdk-tools": 9.9,
     "@cowprotocol/storybook": 3.5,


### PR DESCRIPTION
## What changed
- Order-submitted screen (Limit and TWAP orders only) shows a yellow "New" tag + a single "Get notified when your order fills" link that opens the notifications side panel.
- Notifications side panel shows a promo banner above the notification list with a "Get started" CTA to enable Telegram alerts; hidden once already subscribed.
- Account modal's "Recent Activity" section shows a yellow "New" tag + "Get order notifications" link, right-aligned on the same row as the first activity date; hidden once already subscribed.
- All three additions are hidden entirely when running as an embedded widget (`isInjectedWidget()`), since the feature only applies to the standalone app.
- Notification-sidebar open/settings state moved from `AccountElement`'s local `useState` into a shared Jotai atom, so it can be opened from anywhere (order-submitted screen, Account modal), not just from the header bell.

## Why
Fixes https://app.notion.com/p/cownation/3bf8da5f04ca80e0a266fb505a9c9050 — increase awareness of the existing Telegram trade-alerts feature at the two moments users are most likely to care about order status: right after placing a Limit/TWAP order, and while browsing recent activity.

## QA Testing

Preview URL QA (https://swap-dev-git-feat-limit-twap-notifications-a-cc87d2-cowswap-dev.vercel.app):
- Place a Limit order → on the "Order Submitted" screen, confirm the yellow "New" tag + "Get notified when your order fills" link appear on one line; click it and confirm it opens the notifications side panel.
<img width="723" height="565" alt="image" src="https://github.com/user-attachments/assets/2e6992f9-15e9-4bbd-88d7-12413a3be4d3" />

- Place a TWAP order → same check.
- Place a regular Swap → confirm the message does NOT appear
- Open the notifications side panel (bell icon in the header) → confirm the promo banner appears above the notification list.
<img width="655" height="231" alt="image" src="https://github.com/user-attachments/assets/ab62fc85-b78c-4215-8c93-fea9dfd20b85" />

- Open the Account modal (click the connected wallet in the header) → in "Recent Activity", confirm the "New" tag + "Get order notifications" link are right-aligned on the same row as the first activity date; click it and confirm it closes the Account modal and opens the notifications panel.
<img width="664" height="127" alt="image" src="https://github.com/user-attachments/assets/e209fdbd-398e-49d4-9d51-f188eeff6dcd" />

- Connect Telegram alerts via the notifications panel settings (gear icon) → confirm the notifications-panel promo banner disappears; re-open an order-submitted screen and the Account modal, and confirm both of those links also disappear (already-subscribed state).
- Widget mode regression: open https://widget-configurator-git-feat-limit-twap-noti-27b349-cowswap-dev.vercel.app, configure and load the embedded widget, place a Limit/TWAP order and open its Account view, and confirm neither "Get notified" link appears.

Developer verification:
- `areTelegramNotificationsEnabled` is a LaunchDarkly flag (already on in dev/preview environments); all new UI is additionally gated behind it, so it disappears if the flag is off.
- CI covers the usual lint, typecheck, and test gates.

## Preview URLs

| Surface | URL |
| --- | --- |
| swap-dev - branch preview URL | https://swap-dev-git-feat-limit-twap-notifications-a-cc87d2-cowswap-dev.vercel.app |
| explorer-dev - branch preview URL | https://explorer-dev-git-feat-limit-twap-notificatio-43e301-cowswap-dev.vercel.app |
| widget-configurator - branch preview URL | https://widget-configurator-git-feat-limit-twap-noti-27b349-cowswap-dev.vercel.app |
| storybook - branch preview URL | https://storybook-git-feat-limit-twap-notifications-9186b4-cowswap-dev.vercel.app |
| cowfi - branch preview URL | https://cowfi-git-feat-limit-twap-notifications-awareness-cowswap.vercel.app |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added prompts to enable order-fill and Telegram notifications from order confirmations and account details.
  * Added a notification promotion banner with a direct link to notification settings.
  * Added a notification sidebar accessible from the account menu, notification bell, and relevant prompts.
  * Added notification prompts to limit-order and TWAP confirmations.

* **UI Improvements**
  * Improved notification controls with responsive, accessible button styling.

* **Localization**
  * Added English translations for the new notification messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->