### PR TITLE
fix: remove horizontal scrollbar in edit partial approval modal

### DIFF
--- a/apps/cowswap-frontend/src/modules/erc20Approve/containers/ChangeApproveAmountModal/styled.ts
+++ b/apps/cowswap-frontend/src/modules/erc20Approve/containers/ChangeApproveAmountModal/styled.ts
@@ -5,7 +5,8 @@ import styled from 'styled-components/macro'
 export const Wrapper = styled.div`
   display: block;
   width: 100%;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   background: var(${UI.COLOR_PAPER});
   border-radius: 21px;
 `


### PR DESCRIPTION
## Summary
Fixes 
<img width="1201" height="789" alt="image" src="https://github.com/user-attachments/assets/9fd04937-1827-484d-bf4b-201aa0bffe6b" />


## To test: 

1. Enable partial approvals option (if not enabled yet)
2. Pick a not approved token to sell
3. Open the "Edit partial approval" modal for a token/amount 
4. Confirm the modal still scrolls vertically when content overflows on small viewports.
5. Confirm that the modal does not have a horizontal scrollbar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal scrolling behavior by preventing unwanted horizontal scrolling while preserving vertical scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->