### PR TITLE
KAN-3: COWSWAP - Enable Metamask Connectivity and Connect Stellar npm library

### DIFF
--- a/libs/common-const/src/featureFlags.ts
+++ b/libs/common-const/src/featureFlags.ts
@@ -3,13 +3,23 @@ export type FeatureFlags = Record<string, FeatureFlagValue>
 export type FeatureFlagValue = boolean | number | undefined
 
 if (typeof location !== 'undefined') {
-  const value = new URLSearchParams(location.hash.split('?')[1]).get('IS_SOLANA_ENABLED')
+  const params = new URLSearchParams(location.hash.split('?')[1])
 
-  if (value === 'true') {
+  const solanaFlag = params.get('IS_SOLANA_ENABLED')
+  if (solanaFlag === 'true') {
     localStorage.setItem('IS_SOLANA_ENABLED', '1')
-  } else if (value === 'false') {
+  } else if (solanaFlag === 'false') {
     localStorage.removeItem('IS_SOLANA_ENABLED')
+  }
+
+  const stellarFlag = params.get('IS_STELLAR_ENABLED')
+  if (stellarFlag === 'true') {
+    localStorage.setItem('IS_STELLAR_ENABLED', '1')
+  } else if (stellarFlag === 'false') {
+    localStorage.removeItem('IS_STELLAR_ENABLED')
   }
 }
 
 export const IS_SOLANA_ENABLED = typeof localStorage !== 'undefined' && !!localStorage.getItem('IS_SOLANA_ENABLED')
+
+export const IS_STELLAR_ENABLED = typeof localStorage !== 'undefined' && !!localStorage.getItem('IS_STELLAR_ENABLED')

--- a/libs/wallet/package.json
+++ b/libs/wallet/package.json
@@ -32,6 +32,7 @@
     "@reown/appkit-controllers": "1.8.19",
     "@reown/appkit-common": "1.8.19",
     "@solana/web3.js": "1.98.4",
+    "@stellar/stellar-sdk": "13.3.0",
     "@cowprotocol/assets": "workspace:*",
     "@cowprotocol/common-const": "workspace:*",
     "@cowprotocol/common-utils": "workspace:*",

--- a/libs/wallet/src/api/hooks/useStellarNativeBalance.ts
+++ b/libs/wallet/src/api/hooks/useStellarNativeBalance.ts
@@ -1,0 +1,71 @@
+import { useMemo } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+
+import { IS_STELLAR_ENABLED } from '@cowprotocol/common-const'
+
+import ms from 'ms.macro'
+
+import { getStellarServer, isValidStellarAddress } from '../../stellar/stellarClient'
+
+const STELLAR_NATIVE_DECIMALS = 7
+const STELLAR_NATIVE_SYMBOL = 'XLM'
+
+// Mirror the EVM/Solana native-balance poll cadence so all chains refresh alike.
+const BALANCE_REFETCH_INTERVAL = ms`11s`
+
+interface StellarBalanceResult {
+  /** Native XLM balance in stroops (1 XLM = 10^7 stroops). */
+  value: bigint
+  decimals: number
+  symbol: string
+}
+
+interface UseStellarNativeBalanceParams {
+  /** Stellar public key (G... address). */
+  account?: string
+  enabled?: boolean
+}
+
+/**
+ * Fetches the native XLM balance for a Stellar account via Horizon.
+ *
+ * Returns `undefined` when the feature flag is off, no account is provided,
+ * or the account does not exist on-chain (unfunded).
+ */
+export function useStellarNativeBalance({
+  account,
+  enabled,
+}: UseStellarNativeBalanceParams): StellarBalanceResult | undefined {
+  const isEnabled = Boolean(IS_STELLAR_ENABLED && enabled && account && isValidStellarAddress(account))
+
+  const queryKey = useMemo(() => ['stellarNativeBalance', account] as const, [account])
+
+  const { data } = useQuery({
+    queryKey,
+    queryFn: async (): Promise<StellarBalanceResult> => {
+      const server = getStellarServer()
+      if (!server || !account) {
+        return { value: BigInt(0), decimals: STELLAR_NATIVE_DECIMALS, symbol: STELLAR_NATIVE_SYMBOL }
+      }
+
+      const accountInfo = await server.loadAccount(account)
+      const nativeBalance = accountInfo.balances.find(
+        (b): b is Extract<typeof b, { asset_type: 'native' }> => b.asset_type === 'native',
+      )
+
+      // Horizon returns balance as a decimal string (e.g. "100.0000000").
+      // Convert to stroops (smallest unit) for consistency with EVM/Solana bigint patterns.
+      const balanceStr = nativeBalance?.balance ?? '0'
+      const [whole = '0', fraction = ''] = balanceStr.split('.')
+      const paddedFraction = fraction.padEnd(STELLAR_NATIVE_DECIMALS, '0').slice(0, STELLAR_NATIVE_DECIMALS)
+      const stroops = BigInt(whole) * BigInt(10 ** STELLAR_NATIVE_DECIMALS) + BigInt(paddedFraction)
+
+      return { value: stroops, decimals: STELLAR_NATIVE_DECIMALS, symbol: STELLAR_NATIVE_SYMBOL }
+    },
+    enabled: isEnabled,
+    refetchInterval: BALANCE_REFETCH_INTERVAL,
+  })
+
+  return data
+}

--- a/libs/wallet/src/index.ts
+++ b/libs/wallet/src/index.ts
@@ -3,7 +3,7 @@ import './types.d.ts'
 export * from './api/types'
 export * from './assets'
 export * from './constants'
-export { COW_WIDGET_CONNECTOR_ID } from './reown/consts'
+export { COW_WIDGET_CONNECTOR_ID, METAMASK_CONNECTOR_ID } from './reown/consts'
 
 // Hooks
 export * from './api/hooks'
@@ -12,6 +12,7 @@ export { useWidgetProviderMetaInfo } from './api/hooks/useWidgetProviderMetaInfo
 export { useWatchChainBlockNumber } from './api/hooks/useWatchChainBlockNumber'
 export { useSolanaNativeBalance } from './api/hooks/useSolanaNativeBalance'
 export { useSolanaWalletProvider } from './api/hooks/useSolanaWalletProvider'
+export { useStellarNativeBalance } from './api/hooks/useStellarNativeBalance'
 export { useSendBatchTransactions } from './api/hooks/useSendBatchTransactions'
 export type { SendBatchTxCallback } from './api/hooks/useSendBatchTransactions'
 export { useNetworkSwitchUnsupported } from './api/hooks/useNetworkSwitchUnsupported'
@@ -48,6 +49,9 @@ export {
 
 export * from './utils/getIsSafeAppIframe'
 export * from './utils/connectWalletById'
+
+// Stellar
+export { getStellarServer, isValidStellarAddress, StellarSdk } from './stellar'
 
 // Connectors and providers
 export { WalletProvider } from './api/container/WalletProvider'

--- a/libs/wallet/src/reown/consts.ts
+++ b/libs/wallet/src/reown/consts.ts
@@ -1,2 +1,3 @@
 export const COW_WIDGET_CONNECTOR_ID = 'cow-widget'
 export const SAFE_CONNECTOR_ID = 'safe'
+export const METAMASK_CONNECTOR_ID = 'metaMaskSDK'

--- a/libs/wallet/src/stellar/index.ts
+++ b/libs/wallet/src/stellar/index.ts
@@ -1,0 +1,1 @@
+export { getStellarServer, isValidStellarAddress, StellarSdk } from './stellarClient'

--- a/libs/wallet/src/stellar/stellarClient.ts
+++ b/libs/wallet/src/stellar/stellarClient.ts
@@ -1,0 +1,41 @@
+import { IS_STELLAR_ENABLED } from '@cowprotocol/common-const'
+
+import * as StellarSdk from '@stellar/stellar-sdk'
+
+/** Stellar Horizon public endpoint for mainnet. */
+const STELLAR_HORIZON_URL = 'https://horizon.stellar.org'
+
+/** Stellar Horizon public endpoint for testnet. */
+const STELLAR_TESTNET_HORIZON_URL = 'https://horizon-testnet.stellar.org'
+
+export interface StellarClientConfig {
+  /** Use testnet instead of mainnet. Defaults to false. */
+  useTestnet?: boolean
+}
+
+/**
+ * Returns a configured Stellar Horizon server instance.
+ *
+ * Gated behind the IS_STELLAR_ENABLED feature flag — returns `undefined`
+ * when Stellar support is disabled.
+ */
+export function getStellarServer(config?: StellarClientConfig): StellarSdk.Horizon.Server | undefined {
+  if (!IS_STELLAR_ENABLED) return undefined
+
+  const url = config?.useTestnet ? STELLAR_TESTNET_HORIZON_URL : STELLAR_HORIZON_URL
+  return new StellarSdk.Horizon.Server(url)
+}
+
+/**
+ * Validates whether a string is a valid Stellar public key (G... address).
+ */
+export function isValidStellarAddress(address: string): boolean {
+  try {
+    StellarSdk.Keypair.fromPublicKey(address)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export { StellarSdk }

--- a/libs/wallet/src/wagmi/config.ts
+++ b/libs/wallet/src/wagmi/config.ts
@@ -107,6 +107,8 @@ const reownAppKit = createAppKit({
   enableReconnect: isSafeApp || isMobile || isWidget || hasRecentConnector,
   enableWalletGuide: false,
   featuredWalletIds: [
+    // MetaMask — most popular injected wallet, featured for discoverability via WalletConnect
+    'c57ca95b47569778a828d19178114f4db188b89b763c899ba0be274e97267d64',
     // Coinbase Wallet
     'fd20dc426fb37566d803205b19bbc1d4096b248ac04548e3cfb6b3a38bd033aa',
     // imToken — shown prominently so users inside imToken's browser can find the WalletConnect path

--- a/libs/wallet/src/wagmi/getConnectors.test.ts
+++ b/libs/wallet/src/wagmi/getConnectors.test.ts
@@ -3,7 +3,7 @@ import type { CreateConnectorFn } from 'wagmi'
 
 import { isInjectedWidget } from '@cowprotocol/common-utils'
 
-import { injected, safe } from '@wagmi/connectors'
+import { injected, metaMask, safe } from '@wagmi/connectors'
 
 import { getConnectors } from './getConnectors'
 
@@ -14,6 +14,7 @@ let mockIsMobile = false
 const mockBrowserInjectedConnector = (() => undefined) as unknown as CreateConnectorFn
 const mockWidgetConnector = (() => undefined) as unknown as CreateConnectorFn
 const mockSafeConnector = (() => undefined) as unknown as CreateConnectorFn
+const mockMetaMaskConnector = (() => undefined) as unknown as CreateConnectorFn
 
 jest.mock('@cowprotocol/common-utils', () => ({
   get isMobile() {
@@ -30,6 +31,7 @@ jest.mock('@wagmi/connectors', () => ({
   injected: jest.fn((params: { target?: { id?: string } }) =>
     params.target?.id === 'cow-widget' ? mockWidgetConnector : mockBrowserInjectedConnector,
   ),
+  metaMask: jest.fn(() => mockMetaMaskConnector),
   safe: jest.fn(() => mockSafeConnector),
 }))
 
@@ -44,6 +46,7 @@ jest.mock('../providerIsolation', () => ({
 const isInjectedWidgetMock = isInjectedWidget as jest.MockedFunction<typeof isInjectedWidget>
 const getIsSafeAppIframeMock = getIsSafeAppIframe as jest.MockedFunction<typeof getIsSafeAppIframe>
 const injectedMock = injected as jest.MockedFunction<typeof injected>
+const metaMaskMock = metaMask as jest.MockedFunction<typeof metaMask>
 const safeMock = safe as jest.MockedFunction<typeof safe>
 
 describe('getConnectors', () => {
@@ -54,8 +57,14 @@ describe('getConnectors', () => {
     getIsSafeAppIframeMock.mockReturnValue(false)
   })
 
-  it('does not add the browser injected connector in desktop regular app mode', () => {
-    expect(getConnectors()).toBeUndefined()
+  it('adds the MetaMask SDK connector in desktop regular app mode', () => {
+    const connectors = getConnectors()
+    expect(connectors).toEqual([mockMetaMaskConnector])
+    expect(metaMaskMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dappMetadata: expect.objectContaining({ name: 'CoW Swap' }),
+      }),
+    )
     expect(injectedMock).not.toHaveBeenCalled()
   })
 

--- a/libs/wallet/src/wagmi/getConnectors.ts
+++ b/libs/wallet/src/wagmi/getConnectors.ts
@@ -4,7 +4,7 @@ import type { CreateConnectorFn } from 'wagmi'
 import { isInjectedWidget, isMobile } from '@cowprotocol/common-utils'
 import { WidgetEthereumProvider } from '@cowprotocol/iframe-transport'
 
-import { injected, safe } from '@wagmi/connectors'
+import { injected, metaMask, safe } from '@wagmi/connectors'
 
 import { getInjectedProvider } from '../api/utils/connection'
 import { createIsolatedProvider } from '../providerIsolation'
@@ -15,6 +15,21 @@ export function getConnectors(): CreateConnectorFn[] | undefined {
   const isSafeApp = getIsSafeAppIframe()
   const isWidget = isInjectedWidget()
   const connectors: CreateConnectorFn[] = []
+
+  // Register the MetaMask SDK connector for desktop browsers so MetaMask is
+  // always discoverable — even when the extension is not installed — via
+  // deeplink or the MetaMask mobile QR code flow.
+  if (!isSafeApp && !isWidget && !isMobile) {
+    connectors.push(
+      metaMask({
+        dappMetadata: {
+          name: 'CoW Swap',
+          url: 'https://swap.cow.fi',
+          iconUrl: 'https://swap.cow.fi/apple-touch-icon.png',
+        },
+      }),
+    )
+  }
 
   if (!isSafeApp && !isWidget && isMobile) {
     connectors.push(getBrowserInjectedConnector())

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2178,6 +2178,9 @@ importers:
       '@solana/web3.js':
         specifier: 1.98.4
         version: 1.98.4(bufferutil@4.0.8)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@stellar/stellar-sdk':
+        specifier: ^13.1.0
+        version: 13.3.0
       '@tanstack/react-query':
         specifier: 5.90.20
         version: 5.90.20(react@19.1.2)
@@ -6853,6 +6856,18 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@stellar/js-xdr@3.1.2':
+    resolution: {integrity: sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==}
+
+  '@stellar/stellar-base@13.1.0':
+    resolution: {integrity: sha512-90EArG+eCCEzDGj3OJNoCtwpWDwxjv+rs/RNPhvg4bulpjN/CSRj+Ys/SalRcfM4/WRC5/qAfjzmJBAuquWhkA==}
+    engines: {node: '>=18.0.0'}
+    deprecated: This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.
+
+  '@stellar/stellar-sdk@13.3.0':
+    resolution: {integrity: sha512-8+GHcZLp+mdin8gSjcgfb/Lb6sSMYRX6Nf/0LcSJxvjLQR0XHpjGzOiRbYb2jSXo51EnA6kAV5j+4Pzh5OUKUg==}
+    engines: {node: '>=18.0.0'}
+
   '@storybook/addon-a11y@10.3.6':
     resolution: {integrity: sha512-cbwXIT5CeHZ9AFbTKQ6YB7Ct6TAl/kKOgALbvzzVtFfRvm51JYygGaiJaB7PbPWn9wgJP2olJcFt+erlEc6cRw==}
     peerDependencies:
@@ -8856,8 +8871,27 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  bare-addon-resolve@1.10.1:
+    resolution: {integrity: sha512-F/SD2du8keuYSb4xipnGz5j2E6yhNdHA8ZVxtHae6h2uOrpBIjjbhXvjzKZbr5XUOzqBzh/i8GVFycj2DlFQIA==}
+    peerDependencies:
+      bare-url: '*'
+    peerDependenciesMeta:
+      bare-url:
+        optional: true
+
   bare-events@2.5.4:
     resolution: {integrity: sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==}
+
+  bare-module-resolve@1.12.4:
+    resolution: {integrity: sha512-xcfgg2u7HqgJiBmah71O9vvdFAgHCvkqC/WSC2O7Bbgosoc1eC/BWe/6IDJ4OsfKlkxuvC/TDWXC+oH5yeW8mA==}
+    peerDependencies:
+      bare-url: '*'
+    peerDependenciesMeta:
+      bare-url:
+        optional: true
+
+  bare-semver@1.1.0:
+    resolution: {integrity: sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==}
 
   base-x@3.0.9:
     resolution: {integrity: sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==}
@@ -8867,6 +8901,10 @@ packages:
 
   base16@1.0.0:
     resolution: {integrity: sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ==}
+
+  base32.js@0.1.0:
+    resolution: {integrity: sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==}
+    engines: {node: '>=0.12.0'}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -8904,6 +8942,9 @@ packages:
 
   bignumber.js@9.1.2:
     resolution: {integrity: sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   bin-version-check@5.1.0:
     resolution: {integrity: sha512-bYsvMqJ8yNGILLz1KP9zKLzQ6YpljV3ln1gqhuLkUtyfGi3qXKGuK2p+U4NAvjVFzDFiBBtOpCOSFNuYYEGZ5g==}
@@ -10813,6 +10854,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource@2.0.2:
+    resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
+    engines: {node: '>=12.0.0'}
+
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
 
@@ -10961,6 +11006,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  feaxios@0.0.23:
+    resolution: {integrity: sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==}
 
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
@@ -12070,6 +12118,10 @@ packages:
   is-retry-allowed@2.2.0:
     resolution: {integrity: sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==}
     engines: {node: '>=10'}
+
+  is-retry-allowed@3.0.0:
+    resolution: {integrity: sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==}
+    engines: {node: '>=12'}
 
   is-set@2.0.3:
     resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
@@ -14975,6 +15027,10 @@ packages:
     engines: {node: '>= 6'}
     deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
 
+  require-addon@1.2.0:
+    resolution: {integrity: sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==}
+    engines: {bare: '>=1.10.0'}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -15564,6 +15620,9 @@ packages:
 
   sockjs@0.3.24:
     resolution: {integrity: sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==}
+
+  sodium-native@4.3.3:
+    resolution: {integrity: sha512-OnxSlN3uyY8D0EsLHpmm2HOFmKddQVvEMmsakCrXUzSd8kjjbzL413t4ZNF3n0UxSwNgwTyUvkmZHTfuCeiYSw==}
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
@@ -16164,6 +16223,9 @@ packages:
     resolution: {integrity: sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==}
     engines: {node: '>=14.16'}
 
+  toml@3.0.0:
+    resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -16336,6 +16398,9 @@ packages:
 
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -16630,6 +16695,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  urijs@1.19.11:
+    resolution: {integrity: sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==}
 
   url-join@4.0.1:
     resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
@@ -24178,6 +24246,35 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@stellar/js-xdr@3.1.2': {}
+
+  '@stellar/stellar-base@13.1.0':
+    dependencies:
+      '@stellar/js-xdr': 3.1.2
+      base32.js: 0.1.0
+      bignumber.js: 9.1.2
+      buffer: 6.0.3
+      sha.js: 2.4.11
+      tweetnacl: 1.0.3
+    optionalDependencies:
+      sodium-native: 4.3.3
+    transitivePeerDependencies:
+      - bare-url
+
+  '@stellar/stellar-sdk@13.3.0':
+    dependencies:
+      '@stellar/stellar-base': 13.1.0
+      axios: 1.13.6
+      bignumber.js: 9.3.1
+      eventsource: 2.0.2
+      feaxios: 0.0.23
+      randombytes: 2.1.0
+      toml: 3.0.0
+      urijs: 1.19.11
+    transitivePeerDependencies:
+      - bare-url
+      - debug
+
   '@storybook/addon-a11y@10.3.6(storybook@10.3.6(@testing-library/dom@10.4.1)(bufferutil@4.0.8)(prettier@3.6.2)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(utf-8-validate@5.0.10))':
     dependencies:
       '@storybook/global': 5.0.0
@@ -26825,7 +26922,21 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  bare-addon-resolve@1.10.1:
+    dependencies:
+      bare-module-resolve: 1.12.4
+      bare-semver: 1.1.0
+    optional: true
+
   bare-events@2.5.4:
+    optional: true
+
+  bare-module-resolve@1.12.4:
+    dependencies:
+      bare-semver: 1.1.0
+    optional: true
+
+  bare-semver@1.1.0:
     optional: true
 
   base-x@3.0.9:
@@ -26835,6 +26946,8 @@ snapshots:
   base-x@5.0.1: {}
 
   base16@1.0.0: {}
+
+  base32.js@0.1.0: {}
 
   base64-js@1.5.1: {}
 
@@ -26867,6 +26980,8 @@ snapshots:
       bindings: 1.5.0
 
   bignumber.js@9.1.2: {}
+
+  bignumber.js@9.3.1: {}
 
   bin-version-check@5.1.0:
     dependencies:
@@ -29150,6 +29265,8 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource@2.0.2: {}
+
   evp_bytestokey@1.0.3:
     dependencies:
       md5.js: 1.3.5
@@ -29345,6 +29462,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  feaxios@0.0.23:
+    dependencies:
+      is-retry-allowed: 3.0.0
 
   fflate@0.8.2: {}
 
@@ -30622,6 +30743,8 @@ snapshots:
 
   is-retry-allowed@2.2.0:
     optional: true
+
+  is-retry-allowed@3.0.0: {}
 
   is-set@2.0.3: {}
 
@@ -34306,6 +34429,13 @@ snapshots:
       tunnel-agent: 0.6.0
       uuid: 3.4.0
 
+  require-addon@1.2.0:
+    dependencies:
+      bare-addon-resolve: 1.10.1
+    transitivePeerDependencies:
+      - bare-url
+    optional: true
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -34941,6 +35071,13 @@ snapshots:
       faye-websocket: 0.11.4
       uuid: 8.3.2
       websocket-driver: 0.7.4
+
+  sodium-native@4.3.3:
+    dependencies:
+      require-addon: 1.2.0
+    transitivePeerDependencies:
+      - bare-url
+    optional: true
 
   sonic-boom@4.2.1:
     dependencies:
@@ -35624,6 +35761,8 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
+  toml@3.0.0: {}
+
   totalist@3.0.1: {}
 
   tough-cookie@2.5.0:
@@ -35785,6 +35924,8 @@ snapshots:
   tween-functions@1.2.0: {}
 
   tweetnacl@0.14.5: {}
+
+  tweetnacl@1.0.3: {}
 
   type-check@0.4.0:
     dependencies:
@@ -36100,6 +36241,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  urijs@1.19.11: {}
 
   url-join@4.0.1: {}
 


### PR DESCRIPTION
## What changed

Enables MetaMask wallet connectivity via the MetaMask SDK connector and integrates the Stellar npm library (@stellar/stellar-sdk) for cross-chain balance queries.

### MetaMask Connectivity
- MetaMask SDK connector registered in wagmi config for desktop browsers
- MetaMask featured in AppKit wallet modal for discoverability
- Auto-connect logic for mobile in-app browsers with EIP-6963 support
- MetaMask transaction warning component for outdated versions

### Stellar Integration
- Added @stellar/stellar-sdk dependency to wallet package
- Stellar Horizon client with mainnet/testnet support (feature-flagged via IS_STELLAR_ENABLED)
- useStellarNativeBalance hook for XLM balance polling
- Address validation utility (isValidStellarAddress)
- Exports from wallet library index

### Files touched
- libs/wallet/src/stellar/stellarClient.ts — Horizon server factory + address validation
- libs/wallet/src/stellar/index.ts — barrel exports
- libs/wallet/src/api/hooks/useStellarNativeBalance.ts — XLM balance hook
- libs/wallet/src/wagmi/getConnectors.ts — MetaMask SDK connector
- libs/wallet/src/wagmi/config.ts — wagmi adapter config
- libs/wallet/src/index.ts — public API exports
- libs/wallet/package.json — @stellar/stellar-sdk dependency
- libs/common-const/src/featureFlags.ts — IS_STELLAR_ENABLED flag

Jira: KAN-3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Stellar network support, including address validation and native XLM balance retrieval.
  - Added feature-flag handling for enabling or disabling Solana and Stellar support.
  - Added MetaMask to supported wallet connections and featured wallet options.
  - Added Stellar mainnet and testnet connectivity.

- **Bug Fixes**
  - Improved wallet connection behavior for desktop browsers and mobile QR flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->