### PR TITLE
fix(order-progress-bar): fix progress bars cards alignment

### DIFF
--- a/apps/cowswap-frontend/src/modules/orderProgressBar/pure/OrderProgressBar/index.tsx
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/pure/OrderProgressBar/index.tsx
@@ -69,7 +69,7 @@ export function OrderProgressBar(props: OrderProgressBarProps): ReactNode {
   }, [currentStep, getDuration, analytics])
 
   return (
-    <div id="order-progress-bar-modal">
+    <div id="order-progress-bar-modal" style={{ width: '100%' }}>
       <OrderProgressStepFactory step={stepName} props={props} />
       {debugMode && <DebugPanel stepName={currentStep} setDebugStep={setDebugStep} />}
     </div>

--- a/apps/cowswap-frontend/src/modules/orderProgressBar/pure/styled.ts
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/pure/styled.ts
@@ -166,7 +166,7 @@ export const FinishedTagLine = styled.div`
   padding: 0;
   flex: 1 1 auto;
   min-height: 0;
-  overflow: visible;
+  overflow: hidden;
 
   ${Media.upToSmall()} {
     flex: 0 0 auto;


### PR DESCRIPTION
## Summary
Fixes 
<img width="518" height="610" alt="Screenshot_1" src="https://github.com/user-attachments/assets/24031fb9-f173-4ecc-823b-44bb4d3bea7e" />
<img width="628" height="535" alt="Screenshot_3" src="https://github.com/user-attachments/assets/475bc383-c996-4420-afba-d287c24d8c62" />


Two root causes:
1. `FinishedTagLine` (#6551, the `useAutoFitText` refactor) was changed from `overflow: hidden` to `overflow: visible`. When the autofit hook can't shrink the surplus text/percentage enough to fit, the `white-space: nowrap` text spills out of its card into the mascot image instead of staying clipped.
2. The `#order-progress-bar-modal` wrapper div (in `OrderProgressBar/index.tsx`) had no explicit width. As a flex item of the row-wrap `Section` container, it fell back to content-based (shrink-to-fit) sizing instead of a definite width, so its `width: 100%` descendants (solver rankings, mascot+surplus card, share button) resolved inconsistently against an indeterminate containing block — instead of matching the "Close" button, which sits in `ButtonGroup` (an explicit `width: 100%` sibling).

## Fix
- Restore `overflow: hidden` on `FinishedTagLine` so residual overflow is clipped within its own card.
- Give `#order-progress-bar-modal` an explicit `width: 100%` so it resolves to the same definite width as `ButtonGroup`, making all finished-step elements consistent with the "Close" button's width.

## To test:
1. Place a swap order and wait till it fixed
2. check the progress bar modal layout
3. repeat the test with and without generated surplus
4. check in  deiffrent screen resolutions


## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the order progress bar modal layout by ensuring it spans the available width.
  - Prevented completed-status content from overflowing its designated area, improving visual consistency on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->