### PR TITLE
fix: authenticate release sync calls to avoid rate limitting

### DIFF
--- a/.github/actions/setup-release-sync/action.yml
+++ b/.github/actions/setup-release-sync/action.yml
@@ -54,12 +54,14 @@ runs:
       run: |
         set -euo pipefail
         user_id=$(curl -sf \
+          -H "Authorization: Bearer ${APP_TOKEN}" \
           -H "Accept: application/vnd.github+json" \
           "https://api.github.com/users/${APP_SLUG}%5Bbot%5D" \
           | jq -r .id)
         echo "user-id=${user_id}" >> "$GITHUB_OUTPUT"
       env:
         APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        APP_TOKEN: ${{ steps.app-token.outputs.token }}
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
# Summary

Fixing intermittent issue https://github.com/cowprotocol/cowswap/pull/8026#issuecomment-5397253505

Use authenticated GH API instead of the public one when fetching user id in the setup release sync action.
 
# To Test

Only after merge

### AI Review (Claude Opus 5, worked ~5 min)

Review completed. I found no new non-duplicate comments worth posting.

Checked beyond the diff itself:
- Confirmed create-github-app-token@v3.0.0 (dist/main.cjs:23230) calls core.setSecret on the
  token before exposing it as an output, so this change doesn't introduce a token-leak risk
  via log output.
- Confirmed GET /users/{username} needs no specific App permission scope, just a valid
  token for the higher rate-limit tier — no permission grant changes needed alongside this.
- CI green, no existing review threads to reconcile.

_Generated using the `pr-review` skill from the [CoW Protocol skills repo](https://github.com/cowprotocol/skills)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub App user ID lookup by correctly authenticating requests with the generated app token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->