### PR TITLE
feat(rwa): add st0x rwa token list

### DIFF
--- a/libs/core/src/cms/consts.ts
+++ b/libs/core/src/cms/consts.ts
@@ -86,3 +86,9 @@ export const COINBASE_TOKENIZED_STOCKS_FALLBACK_TOKEN_LIST: RestrictedTokenList 
   tokenListUrl: 'https://raw.githubusercontent.com/afahdenCB/coinbase-tokenized-stocks/main/CowSwap.json',
   restrictedCountries: [...RESTRICTED_COUNTRIES],
 } as const
+
+export const ST0X_FALLBACK_TOKEN_LIST: RestrictedTokenList = {
+  name: 'ST0x Base Token List',
+  tokenListUrl: 'https://raw.githubusercontent.com/ST0x-Technology/st0x.registry/main/token-lists/base.json',
+  restrictedCountries: [...RESTRICTED_COUNTRIES],
+} as const

--- a/libs/core/src/cms/utils/getRestrictedTokenLists.ts
+++ b/libs/core/src/cms/utils/getRestrictedTokenLists.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_CMS_REQUEST_TTL,
   ONDO_FALLBACK_TOKEN_LIST,
   RESERVE_PROTOCOL_BNB_FALLBACK_TOKEN_LIST,
+  ST0X_FALLBACK_TOKEN_LIST,
   XStocks_FALLBACK_TOKEN_LIST,
 } from '../consts'
 import { RestrictedTokenList, RestrictedTokenLists } from '../types'
@@ -79,6 +80,7 @@ async function fetchRestrictedTokenLists(): Promise<RestrictedTokenLists | null>
         XStocks_FALLBACK_TOKEN_LIST,
         RESERVE_PROTOCOL_BNB_FALLBACK_TOKEN_LIST,
         COINBASE_TOKENIZED_STOCKS_FALLBACK_TOKEN_LIST,
+        ST0X_FALLBACK_TOKEN_LIST,
       ]
     })
 }

--- a/libs/tokens/src/const/tokensList.json
+++ b/libs/tokens/src/const/tokensList.json
@@ -112,6 +112,10 @@
     {
       "priority": 6,
       "source": "https://raw.githubusercontent.com/afahdenCB/coinbase-tokenized-stocks/main/CowSwap.json"
+    },
+    {
+      "priority": 7,
+      "source": "https://raw.githubusercontent.com/ST0x-Technology/st0x.registry/main/token-lists/base.json"
     }
   ],
   "137": [


### PR DESCRIPTION
# Summary

Fixes https://linear.app/cowswap/issue/BUS-3/enable-st0x-base-token-list-with-rwa-geoblocking

Add St0x RWA token list

<img width="760" height="841" alt="image" src="https://github.com/user-attachments/assets/6781a95a-e493-433c-b3d7-8fd9bc30e202" />

It has already been added to CMS, geoblocking already in effect in production.
<img width="901" height="77" alt="image" src="https://github.com/user-attachments/assets/f8601f52-a170-4d4d-9f7f-d5998ba4a9a8" />

# To Test

1. Open the app on base from an allowed country
2. Open the token selector
* St0x token list should be shown disabled
3. Repeat from a blocked country
* List should not show up

* Same restrictions should apply as usual

# Self-checks

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have manually tested changes on Vercel preview deployment
- [x] I have done self-review and (or) AI review
- [x] I have addressed all comments from @coderabbitai
- [ ] I have less than three open PRs/Stacks in this repo at the moment of creating this PR

### AI review

<details>
<summary>✅ <strong>AI Review</strong> (Claude Sonnet 5, worked ~3m): follow-up addressed</summary>

**Rechecked**
- Author response: PR description now states "It has already been added to CMS, geoblocking already in effect in production," with two screenshots.
- Evidence: the second screenshot shows a `restricted-token-lists` CMS row — "St0x token list on base" — pointing at the same `raw.githubusercontent.com/ST0x-Tec…` URL used in the code fallback, created Monday, August 24, 2026 at 6:10 PM. The first screenshot shows the Base token selector treating st0x tokens (WTCOIN, WTSGOV, wtAAPL, wtAMAT, …) as an inactive/"Import"-required list, matching the expected geoblocked-but-visible UX for an allowed country.
- Code path: `libs/core/src/cms/utils/getRestrictedTokenLists.ts:76-84` is unchanged (still additions-only, 12/0/3 files) — the CMS record, not a code change, is what closes the gap.
- Self-checks: "manually tested on Vercel preview deployment" is now checked.

**Result:** Addressed. The CMS entry exists (per the dated screenshot), so `getRestrictedTokenLists()` will return real `restrictedCountries` data for the ST0x list on the success path, not just via the CMS-failure fallback — the scenario where ST0x tokens could ship with zero geoblocking no longer applies.

**Residual (non-blocking) note**
- Only the allowed-country scenario has screenshot evidence in the PR body; the blocked-country case from "To Test" step 3 isn't pictured. Low risk since the blocking mechanism itself is generic/shared with the four other RWA lists and untouched by this diff — not worth holding the PR on, but worth a quick manual check before merge if convenient.

_Generated using the `pr-review` skill from the [CoW Protocol skills repo](https://github.com/cowprotocol/skills)._

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ST0x token-list support for the Base network.
  * Added a fallback token list to keep restricted-token data available when the CMS cannot be reached.
  * Included the ST0x registry as a priority-7 token-list source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->