### PR TITLE
feat(disclaimer): add content disclaimer component and integrate into…

### DIFF
--- a/apps/cow-fi/app/(learn)/learn/layout.tsx
+++ b/apps/cow-fi/app/(learn)/learn/layout.tsx
@@ -1,5 +1,8 @@
+import type { ReactNode } from 'react'
+
 import { Metadata } from 'next'
 
+import { ContentDisclaimer } from '@/components/ContentDisclaimer'
 import { CONFIG } from '@/const/meta'
 import { getPageMetadata } from '@/util/getPageMetadata'
 
@@ -16,6 +19,11 @@ export const metadata: Metadata = {
   },
 }
 
-export default function LayoutPage({ children }: { children: React.ReactNode }) {
-  return children
+export default function LayoutPage({ children }: { children: ReactNode }): ReactNode {
+  return (
+    <>
+      {children}
+      <ContentDisclaimer />
+    </>
+  )
 }

--- a/apps/cow-fi/app/(main)/tokens/layout.tsx
+++ b/apps/cow-fi/app/(main)/tokens/layout.tsx
@@ -1,5 +1,8 @@
+import type { ReactNode } from 'react'
+
 import { Metadata } from 'next'
 
+import { ContentDisclaimer } from '@/components/ContentDisclaimer'
 import { getPageMetadata } from '@/util/getPageMetadata'
 
 export const metadata: Metadata = {
@@ -10,6 +13,11 @@ export const metadata: Metadata = {
   }),
 }
 
-export default function LayoutPage({ children }: { children: React.ReactNode }) {
-  return children
+export default function LayoutPage({ children }: { children: ReactNode }): ReactNode {
+  return (
+    <>
+      {children}
+      <ContentDisclaimer />
+    </>
+  )
 }

--- a/apps/cow-fi/components/ContentDisclaimer.test.tsx
+++ b/apps/cow-fi/components/ContentDisclaimer.test.tsx
@@ -1,0 +1,52 @@
+/** @jest-environment jsdom */
+
+import type { HTMLAttributes } from 'react'
+
+import { render, screen } from '@testing-library/react'
+
+import { ContentDisclaimer } from './ContentDisclaimer'
+
+import { CONFIG } from '@/const/meta'
+
+jest.mock('@cowprotocol/ui', () => ({
+  Font: {
+    weight: {
+      regular: 400,
+      bold: 700,
+    },
+  },
+  Media: {
+    upToMedium: () => '',
+  },
+  UI: {
+    COLOR_NEUTRAL_100: '--color-neutral-100',
+    COLOR_NEUTRAL_90: '--color-neutral-90',
+    COLOR_NEUTRAL_40: '--color-neutral-40',
+    COLOR_NEUTRAL_0: '--color-neutral-0',
+  },
+}))
+
+jest.mock('styled-components/macro', () => {
+  const React = jest.requireActual<typeof import('react')>('react')
+  const styled = new Proxy(
+    {},
+    {
+      get: (_target, tagName: string) => () => (props: HTMLAttributes<HTMLElement>) =>
+        React.createElement(tagName, props),
+    },
+  )
+
+  return { __esModule: true, default: styled }
+})
+
+const DISCLAIMER_TEXT = `${CONFIG.contentDisclaimer.title} ${CONFIG.contentDisclaimer.body}`
+
+describe('ContentDisclaimer', () => {
+  it('renders the configured disclaimer as an accessible note', () => {
+    render(<ContentDisclaimer />)
+
+    const disclaimer = screen.getByRole('note', { name: 'Content disclaimer' })
+
+    expect(disclaimer.textContent?.replace(/\s+/g, ' ').trim()).toBe(DISCLAIMER_TEXT)
+  })
+})

--- a/apps/cow-fi/components/ContentDisclaimer.test.tsx
+++ b/apps/cow-fi/components/ContentDisclaimer.test.tsx
@@ -16,6 +16,7 @@ jest.mock('@cowprotocol/ui', () => ({
     },
   },
   Media: {
+    upToLarge: () => '',
     upToMedium: () => '',
   },
   UI: {

--- a/apps/cow-fi/components/ContentDisclaimer.tsx
+++ b/apps/cow-fi/components/ContentDisclaimer.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import type { ReactNode } from 'react'
+
+import { Font, Media, UI } from '@cowprotocol/ui'
+
+import styled from 'styled-components/macro'
+
+import { CONFIG } from '@/const/meta'
+
+const Disclaimer = styled.aside`
+  width: 100%;
+  max-width: 1760px;
+  margin: 9.6rem auto 4rem;
+  padding: 0;
+  background: transparent;
+  color: var(${UI.COLOR_NEUTRAL_40});
+  font-size: 1.3rem;
+  font-weight: ${Font.weight.regular};
+  line-height: 1.5;
+
+  strong {
+    color: var(${UI.COLOR_NEUTRAL_0});
+    font-weight: ${Font.weight.bold};
+    line-height: inherit;
+  }
+
+  ${Media.upToMedium()} {
+    margin: 8.8rem auto 2.4rem;
+  }
+`
+
+export function ContentDisclaimer(): ReactNode {
+  const { title, body } = CONFIG.contentDisclaimer
+
+  return (
+    <Disclaimer role="note" aria-label="Content disclaimer">
+      <strong>{title}</strong> {body}
+    </Disclaimer>
+  )
+}

--- a/apps/cow-fi/components/ContentDisclaimer.tsx
+++ b/apps/cow-fi/components/ContentDisclaimer.tsx
@@ -25,6 +25,10 @@ const Disclaimer = styled.aside`
     line-height: inherit;
   }
 
+  ${Media.upToLarge()} {
+    padding: 0 2.4rem;
+  }
+
   ${Media.upToMedium()} {
     margin: 8.8rem auto 2.4rem;
   }

--- a/apps/cow-fi/const/meta.ts
+++ b/apps/cow-fi/const/meta.ts
@@ -44,6 +44,8 @@ export const CONFIG = {
     utmSource: 'cow.fi',
     utmMedium: 'web',
   },
-  tokenDisclaimer:
-    'IMPORTANT DISCLAIMER: The information presented on the Interface, including hyperlinked sites, associated applications, forums, blogs, social media accounts, and other platforms, serves as general information sourced from third-party providers. We want to emphasise that we do not provide any warranties regarding the accuracy or up-to-dateness of the content. None of the content should be interpreted as financial, tax, legal, or any other type of advice. Your use or reliance on the content is entirely at your own discretion and risk. Before making any decisions, it is crucial that you undertake your own research, review, analysis, and verification of our content. Trading carries significant risks and can result in substantial losses, so it is advisable to consult your own legal, financial, tax, or other professional advisors prior to making any decisions. None of the content on the Interface is intended as a solicitation or offer.',
+  contentDisclaimer: {
+    title: 'IMPORTANT DISCLAIMER:',
+    body: 'Content on cow.fi is provided for general informational and educational purposes only. No representation or warranty is made regarding its accuracy, completeness, or currency. Nothing in this content constitutes financial, investment, legal, tax, or other professional advice, or a recommendation, solicitation, or offer to buy, sell, hold, or use any asset, product, or service. Digital assets and decentralised technologies involve significant risks and may result in substantial losses. You should conduct your own research and consult appropriate professional advisers before making decisions. Any use of or reliance on this content is at your own risk and discretion.',
+  },
 }


### PR DESCRIPTION
# Summary

Linear: FE-456

Adds a shared content disclaimer before the footer across CoW DAO’s Learn and token pages.

- Centralizes the disclaimer copy in `CONFIG.contentDisclaimer`
- Adds an accessible `ContentDisclaimer` component using `role="note"`
- Applies it through the shared layouts for:
  - `/learn` and all nested Learn pages, including articles and topics
  - `/tokens` and all token detail pages
- Uses a lightweight, borderless presentation with transparent background, zero padding, and `1.3rem` text
- Adds unit coverage for the configured copy and accessible note

# To Test

1. Start cow-fi with `pnpm start:cowfi`.

2. Check the Learn routes:

- [ ] Open `/learn`
- [ ] Open `/learn/articles`
- [ ] Open a topic and an article detail page
- [ ] Verify the disclaimer appears exactly once, immediately before the footer
- [ ] Verify the wording and styling are consistent across each page

3. Check the token routes:

- [ ] Open `/tokens`
- [ ] Open any `/tokens/[tokenId]` detail page
- [ ] Verify the same disclaimer appears exactly once before the footer

4. Check responsive styling:

- [ ] Verify the disclaimer remains readable on desktop and mobile
- [ ] Verify it has no border, background, or padding

# Background

FE-456 requested a disclaimer on the Learn index and article detail pages so visitors landing directly on content still see it.

The disclaimer is mounted at the route-layout level instead of individual pages. This ensures consistent coverage for all current and future routes under `/learn/**` and `/tokens/**` without duplicating the implementation.

Local verification completed on `/learn`, an article detail page, `/tokens`, and a token detail page. The cow-fi test suite passes with 36 tests.

# Self-checks

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have manually tested changes on Vercel preview deployment
- [x] I have done self-review and (or) AI review
- [ ] I have addressed all comments from @coderabbitai
- [ ] I have less than three open PRs/Stacks in this repo at the moment of creating this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an accessible content disclaimer to the Learn and Tokens pages, with distinct title and body text.
  - Updated disclaimer wording and referenced website for clearer guidance.

- **Improvements**
  - Confirmation dialogs now use clearer “Review Swap” and “Review Limit Order” titles.
  - Solver information remains available when refreshed data is temporarily unavailable.

- **Tests**
  - Added coverage for disclaimer accessibility, displayed content, and solver information updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->