### PR TITLE
feat: EOA TWAP title fixes

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/PermitModal/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/common/pure/PermitModal/index.cosmos.tsx
@@ -1,5 +1,6 @@
 import { USDC_MAINNET, WBTC } from '@cowprotocol/common-const'
 import { CurrencyAmount } from '@cowprotocol/currency'
+import { UiOrderType } from '@cowprotocol/types'
 import { Identicon } from '@cowprotocol/wallet'
 
 import styled from 'styled-components/macro'
@@ -30,7 +31,7 @@ const PermitModalFixtures = {
         outputAmount={OUTPUT_AMOUNT}
         step="approve"
         icon={WALLET_ICON}
-        orderType={'Swap'}
+        orderType={UiOrderType.SWAP}
       />
     </Wrapper>
   ),
@@ -41,7 +42,7 @@ const PermitModalFixtures = {
         outputAmount={OUTPUT_AMOUNT}
         step="submit"
         icon={WALLET_ICON}
-        orderType={'Swap'}
+        orderType={UiOrderType.SWAP}
       />
     </Wrapper>
   ),
@@ -52,7 +53,7 @@ const PermitModalFixtures = {
         outputAmount={OUTPUT_AMOUNT}
         step="approve"
         icon={WALLET_ICON}
-        orderType={'Limit Order'}
+        orderType={UiOrderType.LIMIT}
       />
     </Wrapper>
   ),
@@ -63,19 +64,19 @@ const PermitModalFixtures = {
         outputAmount={OUTPUT_AMOUNT}
         step="submit"
         icon={WALLET_ICON}
-        orderType={'Limit Order'}
+        orderType={UiOrderType.LIMIT}
       />
     </Wrapper>
   ),
   // These two cases should happen, but including for completeness as the parameters allow it
   'Missing amounts on approve': (
     <Wrapper>
-      <PermitModal inputAmount={undefined} outputAmount={undefined} step="approve" orderType={'Swap'} />
+      <PermitModal inputAmount={undefined} outputAmount={undefined} step="approve" orderType={UiOrderType.SWAP} />
     </Wrapper>
   ),
   'Missing amounts on submit': (
     <Wrapper>
-      <PermitModal inputAmount={undefined} outputAmount={undefined} step="submit" orderType={'Swap'} />
+      <PermitModal inputAmount={undefined} outputAmount={undefined} step="submit" orderType={UiOrderType.SWAP} />
     </Wrapper>
   ),
 }

--- a/apps/cowswap-frontend/src/common/pure/PermitModal/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/PermitModal/index.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 
 import { Currency, CurrencyAmount } from '@cowprotocol/currency'
+import { UiOrderType } from '@cowprotocol/types'
 import { TokenAmount, TokenSymbol } from '@cowprotocol/ui'
 
 import { t } from '@lingui/core/macro'
@@ -18,7 +19,7 @@ export type PermitModalProps = NewModalProps & {
   inputAmount: Nullish<CurrencyAmount<Currency>>
   outputAmount: Nullish<CurrencyAmount<Currency>>
   step: 'approve' | 'submit'
-  orderType: string
+  orderType: UiOrderType
   icon?: React.ReactNode
 }
 
@@ -31,6 +32,7 @@ export type PermitModalProps = NewModalProps & {
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function PermitModal(props: PermitModalProps) {
   const { inputAmount, outputAmount, step, icon: inputIcon, orderType, ...rest } = props
+  const orderTypeLabel = getPermitOrderTypeLabel(orderType)
 
   const steps: StepProps[] = useMemo(
     () => [
@@ -62,9 +64,9 @@ export function PermitModal(props: PermitModalProps) {
           </Trans>
         </>
       ) : (
-        t`Confirm ${orderType}`
+        t`Confirm ${orderTypeLabel}`
       ),
-    [inputAmount?.currency, orderType, step],
+    [inputAmount?.currency, orderTypeLabel, step],
   )
 
   const body = useMemo(
@@ -96,6 +98,21 @@ export function PermitModal(props: PermitModalProps) {
       </NewModalContentBottom>
     </NewModal>
   )
+}
+
+function getPermitOrderTypeLabel(orderType: UiOrderType): string {
+  switch (orderType) {
+    case UiOrderType.SWAP:
+      return t`Swap`
+    case UiOrderType.LIMIT:
+      return t`Limit Order`
+    case UiOrderType.TWAP:
+      return t`TWAP`
+    case UiOrderType.HOOKS:
+      return t`Hooks`
+    case UiOrderType.YIELD:
+      return t`Yield`
+  }
 }
 
 const SignDescription = styled.p`

--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -3577,6 +3577,7 @@ msgid "Bridge costs are at least {formattedBridgeFeePercentage}% of the swap amo
 msgstr "Bridge costs are at least {formattedBridgeFeePercentage}% of the swap amount"
 
 #: apps/cowswap-frontend/src/modules/twap/containers/ActionButtons/index.tsx
+#: apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/index.tsx
 msgid "TWAP order"
 msgstr "TWAP order"
 

--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -883,7 +883,6 @@ msgstr "Approve and Swap"
 
 #: apps/cowswap-frontend/src/common/constants/routes.ts
 #: apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersConfirmModal/index.tsx
-#: apps/cowswap-frontend/src/utils/orderUtils/getUiOrderType.ts
 msgid "Limit order"
 msgstr "Limit order"
 
@@ -1975,6 +1974,10 @@ msgstr "Connect Wallet"
 #: apps/cowswap-frontend/src/modules/account/containers/AccountDetails/index.tsx
 msgid "View all orders"
 msgstr "View all orders"
+
+#: apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/index.tsx
+msgid "Review TWAP"
+msgstr "Review TWAP"
 
 #: apps/cowswap-frontend/src/modules/accountProxy/accountProxy.constants.ts
 msgid "Need help"
@@ -3417,6 +3420,7 @@ msgid "Liquidity pools on CoW AMM grow faster than on other AMMs because they do
 msgstr "Liquidity pools on CoW AMM grow faster than on other AMMs because they don't lose money to arbitrage bots."
 
 #: apps/cowswap-frontend/src/common/constants/routes.ts
+#: apps/cowswap-frontend/src/common/pure/PermitModal/index.tsx
 #: apps/cowswap-frontend/src/modules/advancedOrders/containers/AdvancedOrdersWidget/index.tsx
 #: apps/cowswap-frontend/src/modules/ordersTable/pure/ReceiptModal/fields/OrderTypeField.tsx
 msgid "TWAP"
@@ -3573,8 +3577,6 @@ msgid "Bridge costs are at least {formattedBridgeFeePercentage}% of the swap amo
 msgstr "Bridge costs are at least {formattedBridgeFeePercentage}% of the swap amount"
 
 #: apps/cowswap-frontend/src/modules/twap/containers/ActionButtons/index.tsx
-#: apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/index.tsx
-#: apps/cowswap-frontend/src/utils/orderUtils/getUiOrderType.ts
 msgid "TWAP order"
 msgstr "TWAP order"
 
@@ -4429,6 +4431,7 @@ msgstr "Expected sell amount"
 msgid "orders"
 msgstr "orders"
 
+#: apps/cowswap-frontend/src/common/pure/PermitModal/index.tsx
 #: apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersConfirmModal/index.tsx
 msgid "Limit Order"
 msgstr "Limit Order"
@@ -4575,8 +4578,8 @@ msgstr "Price change"
 
 #: apps/cowswap-frontend/src/common/constants/routes.ts
 #: apps/cowswap-frontend/src/common/constants/routes.ts
+#: apps/cowswap-frontend/src/common/pure/PermitModal/index.tsx
 #: apps/cowswap-frontend/src/modules/ordersTable/pure/ReceiptModal/fields/OrderTypeField.tsx
-#: apps/cowswap-frontend/src/utils/orderUtils/getUiOrderType.ts
 msgid "Yield"
 msgstr "Yield"
 
@@ -6425,9 +6428,9 @@ msgstr "This is the estimated amount you will receive for each part of the TWAP 
 
 #: apps/cowswap-frontend/src/common/constants/routes.ts
 #: apps/cowswap-frontend/src/common/containers/OrderHooksDetails/index.tsx
+#: apps/cowswap-frontend/src/common/pure/PermitModal/index.tsx
 #: apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
 #: apps/cowswap-frontend/src/modules/ordersTable/pure/ReceiptModal/fields/OrderTypeField.tsx
-#: apps/cowswap-frontend/src/utils/orderUtils/getUiOrderType.ts
 msgid "Hooks"
 msgstr "Hooks"
 
@@ -7167,6 +7170,10 @@ msgstr "signing"
 #~ msgid "Cow meditating..."
 #~ msgstr "Cow meditating..."
 
+#: apps/cowswap-frontend/src/common/pure/PermitModal/index.tsx
+msgid "Confirm {orderTypeLabel}"
+msgstr "Confirm {orderTypeLabel}"
+
 #: apps/cowswap-frontend/src/modules/application/containers/App/menuConsts.tsx
 msgid "About CoW Swap"
 msgstr "About CoW Swap"
@@ -7339,8 +7346,8 @@ msgstr "Select"
 #~ msgstr "It isn't a valid referral code."
 
 #: apps/cowswap-frontend/src/common/pure/PermitModal/index.tsx
-msgid "Confirm {orderType}"
-msgstr "Confirm {orderType}"
+#~ msgid "Confirm {orderType}"
+#~ msgstr "Confirm {orderType}"
 
 #: apps/cowswap-frontend/src/modules/twap/utils/buildEoaTwapConfirmationPendingSteps.ts
 #~ msgid "Order created"
@@ -7781,6 +7788,7 @@ msgid "Because you are using a smart contract wallet"
 msgstr "Because you are using a smart contract wallet"
 
 #: apps/cowswap-frontend/src/common/constants/routes.ts
+#: apps/cowswap-frontend/src/common/pure/PermitModal/index.tsx
 #: apps/cowswap-frontend/src/legacy/utils/trade.ts
 #: apps/cowswap-frontend/src/modules/bridge/pure/BridgeActivitySummary/SwapStepRow.tsx
 #: apps/cowswap-frontend/src/modules/ethFlow/pure/EthFlowModalContent/configs.ts
@@ -7788,7 +7796,6 @@ msgstr "Because you are using a smart contract wallet"
 #: apps/cowswap-frontend/src/modules/trade/hooks/useGetConfirmButtonLabel.ts
 #: apps/cowswap-frontend/src/modules/yield/containers/TradeButtons/index.tsx
 #: apps/cowswap-frontend/src/modules/yield/containers/YieldWidget/elements.tsx
-#: apps/cowswap-frontend/src/utils/orderUtils/getUiOrderType.ts
 msgid "Swap"
 msgstr "Swap"
 

--- a/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/limitOrders/containers/LimitOrdersConfirmModal/index.tsx
@@ -3,6 +3,7 @@ import React, { ReactNode, useMemo } from 'react'
 
 import { getWrappedToken } from '@cowprotocol/common-utils'
 import { isSupportedPermitInfo } from '@cowprotocol/permit-utils'
+import { UiOrderType } from '@cowprotocol/types'
 import { TokenSymbol } from '@cowprotocol/ui'
 
 import { t } from '@lingui/core/macro'
@@ -96,7 +97,7 @@ export function LimitOrdersConfirmModal(props: LimitOrdersConfirmModalProps): Re
   )
 
   return (
-    <TradeConfirmModal title={CONFIRM_TITLE} showGetNotifiedMessage>
+    <TradeConfirmModal orderType={UiOrderType.LIMIT} showGetNotifiedMessage>
       <TradeConfirmation
         {...commonTradeConfirmContext}
         title={CONFIRM_TITLE}

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/index.tsx
@@ -3,7 +3,7 @@ import { ReactNode, useMemo } from 'react'
 import { getCurrencyAddress } from '@cowprotocol/common-utils'
 import { getAddressKey } from '@cowprotocol/cow-sdk'
 import { CurrencyAmount } from '@cowprotocol/currency'
-import { Nullish } from '@cowprotocol/types'
+import { Nullish, UiOrderType } from '@cowprotocol/types'
 import { useWalletInfo } from '@cowprotocol/wallet'
 
 import { useLingui } from '@lingui/react/macro'
@@ -157,7 +157,7 @@ export function SwapConfirmModal(props: SwapConfirmModalProps): ReactNode {
   }, [confirmText, inputCurrencyInfo, isInsufficientBalance, t])
 
   return (
-    <TradeConfirmModal title={CONFIRM_TITLE} submittedContent={submittedContent}>
+    <TradeConfirmModal orderType={UiOrderType.SWAP} submittedContent={submittedContent}>
       <TradeConfirmation
         {...commonTradeConfirmContext}
         title={CONFIRM_TITLE}

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeConfirmModal/index.cosmos.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeConfirmModal/index.cosmos.tsx
@@ -2,6 +2,7 @@ import { useSetAtom } from 'jotai'
 import { useEffect } from 'react'
 
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { UiOrderType } from '@cowprotocol/types'
 import { walletInfoAtom } from '@cowprotocol/wallet'
 
 import { inputCurrencyInfoMock, outputCurrencyInfoMock, priceImpactMock } from 'mocks/tradeStateMock'
@@ -72,7 +73,7 @@ function Custom({ stateValue }: { stateValue: string }) {
   }, [updateWalletInfo])
 
   return (
-    <TradeConfirmModal title="Swap">
+    <TradeConfirmModal orderType={UiOrderType.SWAP}>
       <TradeConfirmation {...confirmationState} onDismiss={console.log}>
         {() => <span>Some content</span>}
       </TradeConfirmation>

--- a/apps/cowswap-frontend/src/modules/trade/containers/TradeConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/containers/TradeConfirmModal/index.tsx
@@ -3,7 +3,7 @@ import { ReactNode, useCallback } from 'react'
 import { useFeatureFlags } from '@cowprotocol/common-hooks'
 import { isInjectedWidget } from '@cowprotocol/common-utils'
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
-import { Command } from '@cowprotocol/types'
+import { Command, UiOrderType } from '@cowprotocol/types'
 import { UI } from '@cowprotocol/ui'
 import { useIsSafeWallet, useWalletInfo } from '@cowprotocol/wallet'
 
@@ -36,7 +36,7 @@ const Container = styled.div`
 `
 
 export interface TradeConfirmModalProps extends React.PropsWithChildren {
-  title: string
+  orderType: UiOrderType
   submittedContent?: ReactNode
   showGetNotifiedMessage?: boolean
 }
@@ -44,7 +44,7 @@ export interface TradeConfirmModalProps extends React.PropsWithChildren {
 interface InnerComponentProps extends React.PropsWithChildren {
   chainId: SupportedChainId
   account: string
-  title: string // TODO: This is actually order type...
+  orderType: UiOrderType
   error: string | null
   pendingTrade: TradeAmounts | null
   transactionHash: string | null
@@ -58,7 +58,7 @@ interface InnerComponentProps extends React.PropsWithChildren {
 }
 
 export function TradeConfirmModal(props: TradeConfirmModalProps): ReactNode {
-  const { children, submittedContent, title, showGetNotifiedMessage } = props
+  const { children, submittedContent, orderType, showGetNotifiedMessage } = props
 
   const { chainId, account } = useWalletInfo()
   const isSafeWallet = useIsSafeWallet()
@@ -82,7 +82,7 @@ export function TradeConfirmModal(props: TradeConfirmModalProps): ReactNode {
         chainId={chainId}
         account={account}
         error={error}
-        title={title}
+        orderType={orderType}
         pendingTrade={pendingTrade}
         transactionHash={transactionHash}
         onDismiss={onDismiss}
@@ -115,7 +115,7 @@ function InnerComponent(props: InnerComponentProps): ReactNode {
     error,
     isSafeWallet,
     onDismiss,
-    title,
+    orderType,
     pendingTrade,
     permitSignatureState,
     transactionHash,
@@ -137,7 +137,7 @@ function InnerComponent(props: InnerComponentProps): ReactNode {
         outputAmount={pendingTrade.outputAmount}
         step={step}
         onDismiss={onDismiss}
-        orderType={title}
+        orderType={orderType}
       />
     )
   }

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, ReactNode } from 'react'
 
+import { UiOrderType } from '@cowprotocol/types'
 import { useWalletInfo } from '@cowprotocol/wallet'
 
 import { t } from '@lingui/core/macro'
@@ -29,8 +30,6 @@ import { useTwapOrder } from '../../hooks/useTwapOrder'
 import { useTwapSlippage } from '../../hooks/useTwapSlippage'
 import { EoaTwapSigningPendingContent } from '../EoaTwapSigningPendingContent/EoaTwapSigningPendingContent'
 import { TwapFormWarnings } from '../TwapFormWarnings'
-
-const CONFIRM_TITLE = 'TWAP'
 
 const TwapTradeConfirmationDetails = styled(TwapTradeConfirmationDetailsBase)`
   margin-top: -4px;
@@ -118,11 +117,10 @@ export function TwapConfirmModal(): ReactNode {
   const eoaTwapSigningStepElement = <EoaTwapSigningPendingContent />
 
   return (
-    <TradeConfirmModal title={CONFIRM_TITLE} showGetNotifiedMessage>
+    <TradeConfirmModal orderType={UiOrderType.TWAP} showGetNotifiedMessage>
       <TradeConfirmation
         {...commonTradeConfirmContext}
-        // TODO: Maybe better to use the same?
-        title={hasSigningPlan ? t`TWAP order` : CONFIRM_TITLE}
+        title={t`Review TWAP`}
         inputCurrencyInfo={inputCurrencyInfo}
         outputCurrencyInfo={outputCurrencyInfo}
         onConfirm={() => createTwapOrder(fallbackHandlerIsNotSet)}

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/index.tsx
@@ -120,7 +120,7 @@ export function TwapConfirmModal(): ReactNode {
     <TradeConfirmModal orderType={UiOrderType.TWAP} showGetNotifiedMessage>
       <TradeConfirmation
         {...commonTradeConfirmContext}
-        title={t`Review TWAP`}
+        title={hasSigningPlan ? t`TWAP order` : t`Review TWAP`}
         inputCurrencyInfo={inputCurrencyInfo}
         outputCurrencyInfo={outputCurrencyInfo}
         onConfirm={() => createTwapOrder(fallbackHandlerIsNotSet)}

--- a/apps/cowswap-frontend/src/modules/yield/containers/YieldConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/yield/containers/YieldConfirmModal/index.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useMemo } from 'react'
 
-import { Nullish } from '@cowprotocol/types'
+import { Nullish, UiOrderType } from '@cowprotocol/types'
 
 import { t } from '@lingui/core/macro'
 
@@ -61,7 +61,7 @@ export function YieldConfirmModal(props: YieldConfirmModalProps): ReactNode {
   const submittedContent = <OrderSubmittedContent onDismiss={tradeConfirmActions.onDismiss} />
 
   return (
-    <TradeConfirmModal title={CONFIRM_TITLE} submittedContent={submittedContent}>
+    <TradeConfirmModal orderType={UiOrderType.YIELD} submittedContent={submittedContent}>
       <TradeConfirmation
         {...commonTradeConfirmContext}
         title={CONFIRM_TITLE}

--- a/apps/cowswap-frontend/src/utils/orderUtils/getUiOrderType.ts
+++ b/apps/cowswap-frontend/src/utils/orderUtils/getUiOrderType.ts
@@ -1,8 +1,6 @@
 import { OrderClass } from '@cowprotocol/cow-sdk'
 import { UiOrderType } from '@cowprotocol/types'
 
-import { t } from '@lingui/core/macro'
-
 import { Order } from 'legacy/state/orders/actions'
 
 import { AppDataMetadataOrderClass } from 'modules/appData/types'
@@ -43,14 +41,4 @@ export function getUiOrderType({ fullAppData, composableCowInfo, class: orderCla
   // 3. As a last resort, map it to API classification.
   // Least precise as it doesn't distinguish twap type and uses backend logic which doesn't match frontend's classification
   return API_ORDER_CLASS_TO_UI_ORDER_TYPE_MAP[orderClass]
-}
-
-export function getUiOrderTypeTitles(): Record<UiOrderType, string> {
-  return {
-    [UiOrderType.SWAP]: t`Swap`,
-    [UiOrderType.LIMIT]: t`Limit order`,
-    [UiOrderType.TWAP]: t`TWAP order`,
-    [UiOrderType.HOOKS]: t`Hooks`,
-    [UiOrderType.YIELD]: t`Yield`,
-  }
 }


### PR DESCRIPTION
# Summary

The title will now be "Review TWAP" across all screens/steps of the confirmation/review process.

Some other component props have also been updated, as before they were incorrectly named `title` when the actual thing being passed was the order type.

# To Test

Place a TWAP for EOA order and verify the title at the top is "Review TWAP" across all steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Confirmation modals now display consistent, localized labels for swaps, limit orders, TWAP, yield, and hooks.
  * Confirmation flows provide clearer titles, including a dedicated “Review TWAP” step.
  * Order type information is handled consistently across trade confirmation and permit approval dialogs.
* **Bug Fixes**
  * Improved consistency between the selected order type and the title shown during confirmation and signing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->