### PR TITLE
fix: exclude inputs from default outline

### DIFF
--- a/libs/ui/src/styles/global.ts
+++ b/libs/ui/src/styles/global.ts
@@ -36,7 +36,12 @@ export const baseGlobalStyles = css`
     font: inherit;
     color: inherit;
     appearance: none;
+  }
 
+  // Inputs match :focus-visible on mouse click, so they keep outline: none.
+  button,
+  textarea,
+  select {
     &:focus-visible {
       outline: 1.5px dotted var(${UI.COLOR_TEXT});
       outline-offset: 2px;


### PR DESCRIPTION
# Summary

Exclude inputs from default outline, as those display it as soon as we click on them.

# To Test

Open the trade form and click on any of the inputs. Verify the dotted outline is not shown.
