### PR TITLE
fix(notifications): do not close settings on popover click

### DIFF
--- a/apps/cowswap-frontend/src/modules/notifications/containers/NotificationSidebar/NotificationSidebar.container.tsx
+++ b/apps/cowswap-frontend/src/modules/notifications/containers/NotificationSidebar/NotificationSidebar.container.tsx
@@ -37,6 +37,7 @@ interface NotificationsHeaderProps {
   shouldShowSettingsPopover: boolean
   onDismissSettingsPopover: () => void
   headerRef: React.RefObject<HTMLDivElement | null>
+  settingsPopoverContentRef: React.RefObject<HTMLDivElement | null>
 }
 
 interface NotificationSidebarProps {
@@ -57,6 +58,7 @@ export function NotificationSidebar({
   const [isSettingsOpen, setIsSettingsOpen] = useState(initialSettingsOpen)
   const sidebarRef = useRef<HTMLDivElement>(null)
   const headerRef = useRef<HTMLDivElement>(null)
+  const settingsPopoverContentRef = useRef<HTMLDivElement>(null)
   const isMobile = useMediaQuery(Media.upToSmall(false))
   const isAnyModalOpen = useAtomValue(openModalState)
 
@@ -81,7 +83,9 @@ export function NotificationSidebar({
   // Don't dismiss the sidebar on outside clicks while a modal (e.g. the Telegram
   // connect modal) is open - it portals outside `sidebarRef`'s DOM subtree, so any
   // click inside it would otherwise be treated as "outside the sidebar" and close it.
-  useOnClickOutside([sidebarRef], isAnyModalOpen ? undefined : onDismiss)
+  // The settings popover content is portaled the same way, so it's excluded explicitly
+  // via `settingsPopoverContentRef` rather than being gated behind a boolean.
+  useOnClickOutside([sidebarRef, settingsPopoverContentRef], isAnyModalOpen ? undefined : onDismiss)
 
   const toggleSettingsOpen = useCallback(() => {
     setIsSettingsOpen((prev) => !prev)
@@ -118,6 +122,7 @@ export function NotificationSidebar({
             shouldShowSettingsPopover={shouldShowSettingsPopover}
             onDismissSettingsPopover={dismissSettingsPopover}
             headerRef={headerRef}
+            settingsPopoverContentRef={settingsPopoverContentRef}
           />
         </NotificationsList>
       )}
@@ -139,6 +144,7 @@ function NotificationsHeader({
   shouldShowSettingsPopover,
   onDismissSettingsPopover,
   headerRef,
+  settingsPopoverContentRef,
 }: NotificationsHeaderProps): ReactNode {
   return (
     <SidebarHeader ref={headerRef}>
@@ -161,6 +167,7 @@ function NotificationsHeader({
             show={shouldShowSettingsPopover}
             onDismiss={onDismissSettingsPopover}
             containerRef={headerRef}
+            contentRef={settingsPopoverContentRef}
           >
             <NotificationSettingsIcon
               onClick={onToggleSettings}

--- a/apps/cowswap-frontend/src/modules/notifications/pure/NotificationSettingsPopover.tsx
+++ b/apps/cowswap-frontend/src/modules/notifications/pure/NotificationSettingsPopover.tsx
@@ -91,6 +91,7 @@ interface NotificationSettingsPopoverProps {
   show: boolean
   onDismiss: Command
   containerRef: RefObject<HTMLElement | null>
+  contentRef?: RefObject<HTMLDivElement | null>
 }
 
 export function NotificationSettingsPopover({
@@ -98,6 +99,7 @@ export function NotificationSettingsPopover({
   show,
   onDismiss,
   containerRef,
+  contentRef,
 }: NotificationSettingsPopoverProps): ReactNode {
   const primaryButtonRef = useRef<HTMLButtonElement>(null)
 
@@ -125,6 +127,7 @@ export function NotificationSettingsPopover({
 
   const popoverContent = (
     <PopoverContent
+      ref={contentRef}
       role="dialog"
       aria-label={t`Trade alert settings info`}
       aria-describedby="notification-settings-description"


### PR DESCRIPTION
# Summary

Fixes https://app.notion.com/p/cownation/Mobile-impossible-to-dismiss-the-banner-3c18da5f04ca80fa9be8fa326468d3c6?source=copy_link

**Root cause**: `NotificationSettingsPopover's` content is rendered through a `@reach/portal`, which appends it to `document.body` outside of `sidebarRef's` DOM subtree. `NotificationSidebar's` `useOnClickOutside([sidebarRef], onDismiss)` only checks `sidebarRef.current.contains(e.target)`, so a click on `PrimaryButton` (in the portal) is wrongly classified as "outside the sidebar," and `onDismiss` fires — closing the whole sidebar. This is the exact same class of issue already called out for the Telegram modal in the surrounding comment; that popover just wasn't accounted for.                   

**Fix**: threaded a `settingsPopoverContentRef` from `NotificationSidebar` down through `NotificationsHeader` into `NotificationSettingsPopover` (attached to its `PopoverContent`), and added it to the sidebar's `useOnClickOutside` node list: `useOnClickOutside([sidebarRef, settingsPopoverContentRef], ...)`. Now a click anywhere in the popover (including "Got it") is recognized as inside, and only calls the popover's own `onDismiss` (which just marks it dismissed), without triggering the sidebar's close.                                                                                                         

# To Test

See https://app.notion.com/p/cownation/Mobile-impossible-to-dismiss-the-banner-3c18da5f04ca80fa9be8fa326468d3c6?source=copy_link