### PR TITLE
fix: narrow down default focus selector to buttons only

### DIFF
--- a/apps/cowswap-frontend/src/legacy/components/Header/styled.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/Header/styled.tsx
@@ -15,7 +15,7 @@ export const HeaderControls = styled.div`
     margin: 0 0 0 auto;
     height: 56px;
     width: 100%;
-    position: sticky;
+    position: fixed;
     bottom: 0;
     left: 0;
     z-index: 10;

--- a/libs/ui/src/styles/global.ts
+++ b/libs/ui/src/styles/global.ts
@@ -38,22 +38,18 @@ export const baseGlobalStyles = css`
     appearance: none;
   }
 
-  // Inputs match :focus-visible on mouse click, so they keep outline: none.
-  button,
-  textarea,
-  select {
-    &:focus-visible {
-      outline: 1.5px dotted var(${UI.COLOR_TEXT});
-      outline-offset: 2px;
-    }
-  }
-
   button {
     user-select: none;
     cursor: pointer;
 
     &:disabled {
       cursor: not-allowed;
+    }
+
+    // Default outline only for buttons because inputs/textareas match :focus-visible on mouse click, so they keep outline: none.
+    &:focus-visible {
+      outline: 1.5px dotted var(${UI.COLOR_TEXT});
+      outline-offset: 2px;
     }
   }
 

--- a/libs/ui/src/styles/global.ts
+++ b/libs/ui/src/styles/global.ts
@@ -18,9 +18,8 @@ export const baseGlobalStyles = css`
     -moz-osx-font-smoothing: grayscale;
   }
 
-  /* Lock <html> too so Base UI sees the page as already locked and skips scrollbar-gutter. */
-  // This prevents the page content from moving right when the scrollbar is hidden, but causes the bottom navbar to move down, outside the viewport.
-  // Once we use the new Drawer for the network selector, we can re-enable this.
+  // This locks <html> too so Base UI sees the page as already locked and skips scrollbar-gutter.
+  // It also prevents the page content from moving right when the scrollbar is hidden.
   html:has(body.noScroll) {
     overflow: hidden;
   }

--- a/libs/ui/src/styles/global.ts
+++ b/libs/ui/src/styles/global.ts
@@ -19,6 +19,8 @@ export const baseGlobalStyles = css`
   }
 
   /* Lock <html> too so Base UI sees the page as already locked and skips scrollbar-gutter. */
+  // This prevents the page content from moving right when the scrollbar is hidden, but causes the bottom navbar to move down, outside the viewport.
+  // Once we use the new Drawer for the network selector, we can re-enable this.
   html:has(body.noScroll) {
     overflow: hidden;
   }


### PR DESCRIPTION
# Summary

- Target only buttons when applying the default focus outline.
- Fix network selector bottom bar/menu moving down outside the viewport when opened.

# To Test

- Load the page and start pressing <kbd>Tab</kbd>. You should see a dotted outline around some buttons that didn't have it before. Once you reach a select or input, they should not have the outline. If you click on them, they should still have no outline (other than for those that have a non-default one defined).

- Open the network selector modal and verify the bar/menu at the bottom is still where it should be.
