### PR TITLE
fix: make network selector cover mobile viewport

### DIFF
--- a/apps/cowswap-e2e-tests/src/pages/HeaderPage.ts
+++ b/apps/cowswap-e2e-tests/src/pages/HeaderPage.ts
@@ -16,12 +16,16 @@ export class HeaderPage {
 
   /**
    * Opens the app's network selector (its trigger is an unlabelled `<div>`, so it's targeted by
-   * the currently active network's own label text, scoped to the header to avoid ambiguity) and
-   * picks `targetNetworkLabel` from the resulting dialog — the same flow a user driving the UI
-   * would follow, as opposed to switching chains directly on the mocked wallet.
+   * the currently active network's own label text, scoped to the header to avoid ambiguity).
    */
-  async switchNetwork(currentNetworkLabel: string, targetNetworkLabel: string): Promise<void> {
+  async openNetworkSelector(currentNetworkLabel: string): Promise<void> {
     await this.header.getByText(currentNetworkLabel, { exact: true }).click()
+    await this.networkDialog.waitFor({ state: 'visible' })
+  }
+
+  /** Switches through the same UI flow a user would drive instead of changing the mocked wallet directly. */
+  async switchNetwork(currentNetworkLabel: string, targetNetworkLabel: string): Promise<void> {
+    await this.openNetworkSelector(currentNetworkLabel)
     await this.networkDialog.getByRole('button', { name: targetNetworkLabel, exact: true }).click()
   }
 }

--- a/apps/cowswap-e2e-tests/src/tests/network.spec.ts
+++ b/apps/cowswap-e2e-tests/src/tests/network.spec.ts
@@ -20,4 +20,23 @@ test.describe('Network', () => {
     await expect(swapPage.sellTokenSelect).toHaveAttribute('aria-label', 'Selected token: WXDAI')
     await expect(swapPage.buyTokenSelect).toHaveAttribute('aria-label', 'Selected token: USDC')
   })
+
+  test('[NW-02] Network selector covers the mobile and tablet viewport', async ({ swapPage, header }) => {
+    await swapPage.goto({ chainId: CHAIN_IDS.SEPOLIA })
+    await header.openNetworkSelector('Sepolia')
+    await swapPage.page.setViewportSize({ width: 960, height: 800 })
+
+    const uncoveredViewport = await header.networkDialog.evaluate((dialog) => {
+      const rect = dialog.getBoundingClientRect()
+
+      return {
+        top: Math.round(rect.top),
+        right: Math.round(window.innerWidth - rect.right),
+        bottom: Math.round(window.innerHeight - rect.bottom),
+        left: Math.round(rect.left),
+      }
+    })
+
+    expect(uncoveredViewport).toEqual({ top: 0, right: 0, bottom: 0, left: 0 })
+  })
 })

--- a/apps/cowswap-frontend/src/modules/application/containers/NetworkSelector/NetworkSelector.styled.ts
+++ b/apps/cowswap-frontend/src/modules/application/containers/NetworkSelector/NetworkSelector.styled.ts
@@ -102,13 +102,13 @@ export const FlyoutMenuContents = styled.div.attrs(() => ({
   max-height: calc(100dvh - 66px - 32px);
 
   ${Media.upToMedium()} {
-    bottom: 56px;
-    left: 0;
     position: fixed;
+    inset: 0;
     width: 100%;
-    border-radius: 12px 12px 0 0;
-    box-shadow: 0 -100vh 0 100vh ${transparentize('black', 0.4)};
-    max-height: calc(100dvh - 56px) !important;
+    height: 100dvh;
+    border-radius: 0;
+    box-shadow: none;
+    max-height: 100dvh !important;
   }
 `
 


### PR DESCRIPTION
## What changed
- Makes the network selector cover the full viewport on mobile and tablet widths.
- Removes the mobile-only rounded corners and backdrop shadow from the full-screen surface.
- Keeps the desktop network selector as a compact anchored popover.
- Adds Playwright coverage for the tablet breakpoint.

## Why
- At widths up to `960px`, the selector reserved a `56px` strip for the sticky mobile header.
- This exposed the footer or other page content beneath the open selector.

## QA Testing

Preview URL QA:
- Open the [swap-dev preview](https://swap-dev-git-fix-network-selector-mobile-fullscreen-cowswap-dev.vercel.app) in responsive mode at a mobile width and at `960 × 800`.
- Open the network selector from the header.
- Confirm the selector reaches all four viewport edges and no footer, sticky controls, or page content remains visible beneath it.
- Confirm the network list remains scrollable and the selector closes normally.
- At a width above `960px`, confirm the selector remains a compact anchored popover.

Developer verification:
- Playwright test `[NW-02] Network selector covers the mobile and tablet viewport` passes at `960 × 800` and verifies that no viewport edge remains uncovered.

## Preview URLs

| Surface | URL |
| --- | --- |
| swap-dev - branch preview URL | https://swap-dev-git-fix-network-selector-mobile-fullscreen-cowswap-dev.vercel.app |
| explorer-dev - branch preview URL | https://explorer-dev-git-fix-network-selector-mobile-216829-cowswap-dev.vercel.app |
| widget-configurator - branch preview URL | https://widget-configurator-git-fix-network-selector-57ce77-cowswap-dev.vercel.app |
| sdk-tools - branch preview URL | https://sdk-tools-git-fix-network-selector-mobile-fu-ad70cb-cowswap-dev.vercel.app |
| storybook - branch preview URL | https://storybook-git-fix-network-selector-mobile-fu-9ecf58-cowswap-dev.vercel.app |