### PR TITLE
fix: fix surplus row layout for long texts

### DIFF
--- a/apps/cowswap-frontend/src/modules/orderProgressBar/pure/steps/styled.ts
+++ b/apps/cowswap-frontend/src/modules/orderProgressBar/pure/steps/styled.ts
@@ -442,19 +442,19 @@ export const ReceivedAmount = styled.span`
 export const SoldAmount = ReceivedAmount
 
 export const ExtraAmount = styled.p`
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  display: block;
+  text-align: center;
   width: 100%;
   color: var(${UI.COLOR_TEXT_OPACITY_70});
   font-size: 15px;
   margin: 0 auto;
-  gap: 4px;
+  line-height: 1.4;
 
   > i {
     color: var(${UI.COLOR_SUCCESS_TEXT});
     font-weight: bold;
     font-style: normal;
+    white-space: nowrap;
   }
 `
 


### PR DESCRIPTION
# Summary

Makes the surplus row in tx completed modal work for long texts.

# To Test

Place an order with surplus and make your window/viewport super narrow. The text should now wrap normally rather than stacking in 3 columns:

<img width="705" height="1130" alt="dafdsfdsf" src="https://github.com/user-attachments/assets/ed592aa1-e738-42ac-beaf-10a05da8a5a3" />

