### PR TITLE
fix(solvers): fetch solver info from cms prod only

### DIFF
--- a/apps/cowswap-frontend/src/common/updaters/SolversInfoUpdater.test.tsx
+++ b/apps/cowswap-frontend/src/common/updaters/SolversInfoUpdater.test.tsx
@@ -1,0 +1,103 @@
+import { Provider, createStore } from 'jotai'
+
+import { CmsSolversInfo, SolversInfo, solversInfoAtom } from '@cowprotocol/core'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import { render } from '@testing-library/react'
+
+import { useCmsSolversInfo } from 'common/hooks/useCmsSolversInfo'
+
+import { SolversInfoUpdater } from './SolversInfoUpdater'
+
+jest.mock('common/hooks/useCmsSolversInfo', () => ({
+  useCmsSolversInfo: jest.fn(),
+}))
+
+const useCmsSolversInfoMock = useCmsSolversInfo as jest.MockedFunction<typeof useCmsSolversInfo>
+
+const PERSISTED_SOLVERS: SolversInfo = [
+  {
+    solverId: 'baseline',
+    displayName: 'Baseline',
+    solverNetworks: [
+      {
+        chainId: SupportedChainId.ARBITRUM_ONE,
+        env: 'staging',
+        address: '0x2e6822f4Ab355E386d1A4fd34947ACE0F6f344a7',
+      },
+    ],
+  },
+]
+
+const CMS_SOLVERS = [
+  {
+    id: 1,
+    attributes: {
+      solverId: 'naive',
+      displayName: 'Naive',
+      active: true,
+      solver_networks: {
+        data: [
+          {
+            id: 10,
+            attributes: {
+              active: true,
+              address: '0x2222222222222222222222222222222222222222',
+              network: { data: { id: 1, attributes: { chainId: SupportedChainId.ARBITRUM_ONE } } },
+              environment: { data: { id: 2, attributes: { name: 'barn' } } },
+            },
+          },
+        ],
+      },
+    },
+  },
+] as unknown as CmsSolversInfo
+
+describe('SolversInfoUpdater', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useCmsSolversInfoMock.mockReset()
+  })
+
+  // An empty CMS result means the request hasn't resolved yet or failed; overwriting the persisted
+  // info leaves the progress bar rendering raw solver addresses
+  it('keeps already persisted solver info when the CMS returns nothing', () => {
+    const store = createStore()
+    store.set(solversInfoAtom, PERSISTED_SOLVERS)
+    useCmsSolversInfoMock.mockReturnValue([])
+
+    render(
+      <Provider store={store}>
+        <SolversInfoUpdater />
+      </Provider>,
+    )
+
+    expect(store.get(solversInfoAtom)).toEqual(PERSISTED_SOLVERS)
+  })
+
+  it('stores the mapped solver info when the CMS responds', () => {
+    const store = createStore()
+    store.set(solversInfoAtom, PERSISTED_SOLVERS)
+    useCmsSolversInfoMock.mockReturnValue(CMS_SOLVERS)
+
+    render(
+      <Provider store={store}>
+        <SolversInfoUpdater />
+      </Provider>,
+    )
+
+    expect(store.get(solversInfoAtom)).toEqual([
+      {
+        solverId: 'naive',
+        displayName: 'Naive',
+        solverNetworks: [
+          {
+            chainId: SupportedChainId.ARBITRUM_ONE,
+            env: 'staging',
+            address: '0x2222222222222222222222222222222222222222',
+          },
+        ],
+      },
+    ])
+  })
+})

--- a/apps/cowswap-frontend/src/common/updaters/SolversInfoUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/SolversInfoUpdater.ts
@@ -15,7 +15,10 @@ export function SolversInfoUpdater() {
   useEffect(() => {
     const solversInfo = mapCmsSolversInfoToSolversInfo(cmsSolversInfo)
 
-    solversInfo && setSolversInfo(solversInfo)
+    // An empty result means the CMS request hasn't resolved yet or failed; keep whatever is already persisted
+    if (solversInfo.length) {
+      setSolversInfo(solversInfo)
+    }
   }, [cmsSolversInfo, setSolversInfo])
 
   return null

--- a/apps/explorer/src/utils/fetchSolversInfo.ts
+++ b/apps/explorer/src/utils/fetchSolversInfo.ts
@@ -1,5 +1,5 @@
 import { CHAIN_INFO } from '@cowprotocol/common-const'
-import { getCmsClient } from '@cowprotocol/core'
+import { getCmsClient, PROD_CMS_BASE_URL } from '@cowprotocol/core'
 
 import type {
   CmsEntity,
@@ -15,9 +15,7 @@ import type {
 
 export type { SolverDeployment, SolverInfo, SolverNetworkInfo, SolversInfo } from './fetchSolversInfo.types'
 
-const CMS_BASE_URL =
-  process.env.REACT_APP_CMS_BASE_URL || process.env.NEXT_PUBLIC_CMS_BASE_URL || 'https://cms.cow.fi/api'
-const CMS_ORIGIN = getCmsOrigin(CMS_BASE_URL)
+const CMS_ORIGIN = getCmsOrigin(PROD_CMS_BASE_URL)
 const CHAIN_INFO_BY_ID = CHAIN_INFO as Partial<Record<number, { label?: string }>>
 const SOLVERS_QUERY = [
   'fields[0]=solverId',
@@ -49,7 +47,7 @@ export async function fetchSolversInfo(network?: number): Promise<SolversInfo> {
 }
 
 async function fetchSolversInfoFromCms(): Promise<SolversInfo> {
-  const cmsClient = getCmsClient()
+  const cmsClient = getCmsClient(PROD_CMS_BASE_URL)
   const { data, error, response } = await cmsClient.GET('/solvers', {
     params: {
       query: {},

--- a/libs/core/src/cms/utils/getCmsClient.ts
+++ b/libs/core/src/cms/utils/getCmsClient.ts
@@ -1,17 +1,23 @@
 import { CmsClient } from '@cowprotocol/cms'
 
-export const CMS_BASE_URL =
-  process.env.REACT_APP_CMS_BASE_URL || process.env.NEXT_PUBLIC_CMS_BASE_URL || 'https://cms.cow.fi/api'
+/**
+ * Solver info must always come from the production CMS: the barn instance dev/PR builds point at has
+ * no `solver_networks` data, so solvers there resolve to raw addresses instead of names and logos.
+ * The production CMS carries both `barn` and `prod` addresses per solver, so it serves every environment.
+ */
+export const PROD_CMS_BASE_URL = 'https://cms.cow.fi/api'
 
-let cmsClient: ReturnType<typeof CmsClient> | undefined
+export const CMS_BASE_URL =
+  process.env.REACT_APP_CMS_BASE_URL || process.env.NEXT_PUBLIC_CMS_BASE_URL || PROD_CMS_BASE_URL
+
+const cmsClients: Record<string, ReturnType<typeof CmsClient>> = {}
 
 // TODO: Add proper return type annotation
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function getCmsClient() {
-  if (!cmsClient) {
-    cmsClient = CmsClient({
-      url: CMS_BASE_URL,
-    })
-  }
-  return cmsClient
+export function getCmsClient(url: string = CMS_BASE_URL) {
+  const client = cmsClients[url] || CmsClient({ url })
+
+  cmsClients[url] = client
+
+  return client
 }

--- a/libs/core/src/cms/utils/getSolversInfo.test.ts
+++ b/libs/core/src/cms/utils/getSolversInfo.test.ts
@@ -1,0 +1,41 @@
+const mockCmsGet = jest.fn<Promise<unknown>, [string, unknown]>()
+const cmsClientUrls: string[] = []
+
+jest.mock('@cowprotocol/cms', () => ({
+  CmsClient: ({ url }: { url: string }) => {
+    cmsClientUrls.push(url)
+
+    return { GET: mockCmsGet }
+  },
+}))
+
+const BARN_CMS_BASE_URL = 'https://cms.barn.cow.fi/api'
+const originalCmsBaseUrl = process.env.REACT_APP_CMS_BASE_URL
+
+describe('getSolversInfo', () => {
+  beforeEach(() => {
+    mockCmsGet.mockReset()
+    cmsClientUrls.length = 0
+    jest.resetModules()
+  })
+
+  afterEach(() => {
+    if (originalCmsBaseUrl === undefined) {
+      delete process.env.REACT_APP_CMS_BASE_URL
+    } else {
+      process.env.REACT_APP_CMS_BASE_URL = originalCmsBaseUrl
+    }
+  })
+
+  // The barn CMS has no `solver_networks` data, so solvers fetched from it render as raw addresses
+  it('reads solvers from the production CMS even when the app points at the barn CMS', async () => {
+    process.env.REACT_APP_CMS_BASE_URL = BARN_CMS_BASE_URL
+    mockCmsGet.mockResolvedValue({ data: { data: [] } })
+
+    const { getSolversInfo } = await import('./getSolversInfo')
+
+    await getSolversInfo()
+
+    expect(cmsClientUrls).toEqual(['https://cms.cow.fi/api'])
+  })
+})

--- a/libs/core/src/cms/utils/getSolversInfo.ts
+++ b/libs/core/src/cms/utils/getSolversInfo.ts
@@ -5,14 +5,15 @@ import { querySerializer } from './querySerializer'
 
 import { DEFAULT_CMS_REQUEST_TTL } from '../consts'
 import { CmsSolversInfo } from '../types'
-import { getCmsClient } from '../utils'
+import { getCmsClient, PROD_CMS_BASE_URL } from '../utils'
 
 /**
  * Request parameters are static, hence the cache key is also static
  */
 const CACHE_KEY = 'solvers-info'
 
-const cache = new TTLCache<CmsSolversInfo>('cmsSolversInfo:v0', true, DEFAULT_CMS_REQUEST_TTL)
+// v1: invalidates responses cached from the barn CMS, which returns solvers without `solver_networks`
+const cache = new TTLCache<CmsSolversInfo>('cmsSolversInfo:v1', true, DEFAULT_CMS_REQUEST_TTL)
 
 export async function getSolversInfo(): Promise<CmsSolversInfo> {
   const cached = cache.get(CACHE_KEY)
@@ -28,7 +29,7 @@ export async function getSolversInfo(): Promise<CmsSolversInfo> {
 }
 
 async function fetchSolversInfo(): Promise<CmsSolversInfo | null> {
-  const cmsClient = getCmsClient()
+  const cmsClient = getCmsClient(PROD_CMS_BASE_URL)
 
   return cmsClient
     .GET('/solvers', {


### PR DESCRIPTION
# Summary

Fix solvers info for non-prod envs.
Prod/staging should still work fine even without this.

# To Test

1. Open this PR/dev/etc
2. Perform a trade
* Should names should be mapped properly

## AI stuff
<details>
<summary>⚠️ <strong>AI Review</strong> (Claude Opus 5, worked ~5m): follow-up — clobber fix verified; release-scope question still open</summary>

**Rechecked** (prior [NON-BLOCKING] finding)

- Code path: `apps/cowswap-frontend/src/common/updaters/SolversInfoUpdater.ts:18` — now guarded with `if (solversInfo.length)`.
- Test coverage: `apps/cowswap-frontend/src/common/updaters/SolversInfoUpdater.test.tsx` — a seeded atom survives an empty CMS result, and a non-empty result still replaces it, so the guard cannot block valid data.
- **Result: Fixed.** An unresolved or failed CMS request no longer wipes the persisted `solversInfoAtom`.
- Trade-off worth knowing: if the CMS ever legitimately returned zero solvers, the last good list is now kept rather than cleared. Correct call for this failure mode.
- CI on `34d17be`: Test ✅, Typecheck ✅, Lint ✅, Agent Harness ✅.

**Finding:** [QUESTION] Carried over: should this ride `release/2026-08-28`?

- The original defect is barn/preview-only — production reads `cms.cow.fi` and was never affected, so nothing here fixes a production bug.
- The PR does now carry two production-visible effects: `cmsSolversInfo:v0` → `v1` (`libs/core/src/cms/utils/getSolversInfo.ts:16`) invalidates every production user's cached payload, costing one extra CMS request each on next load; and commit `34d17be` changes production behavior too — a CMS outage no longer clears solver names for users who already have them.
- Both are improvements, and shipping in the release is defensible since QA keeps hitting the original symptom on the release preview. I'd just want it to be a deliberate call rather than the default target.
- One consequence worth having on record: solver info can no longer be sourced from a local or barn CMS in either app (`apps/explorer/src/utils/fetchSolversInfo.ts:18` pins `CMS_ORIGIN` to prod as well).

<details>
<summary>Review scope and related context</summary>

- CodeRabbit reviewed `79bd7e6` only and reported no actionable comments; it has not seen `34d17be`. Its one substantive note — that the shared client "accepts arbitrary origins" and could use an allowlist — does not apply: every `getCmsClient` call site passes either nothing or the `PROD_CMS_BASE_URL` module constant, and no caller accepts user input.
- Its one failed pre-merge check is "Docstring Coverage 20%", a generic threshold rather than a defect in this diff.
- No human reviews or inline review comments on the PR yet, so nothing else to de-duplicate against.

</details>

*Generated using the `pr-review` skill from the [CoW Protocol skills repo](https://github.com/cowprotocol/skills).*

</details>






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Solver information is now consistently loaded from the production CMS.
  * Updated caching ensures refreshed solver data is used, including network details.
  * CMS connections now support separate endpoints without sharing incorrect cached clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->