### PR TITLE
feat(quote): move to verified quotes

### DIFF
--- a/apps/cowswap-e2e-tests/src/mocks/cowProtocolApi/record.ts
+++ b/apps/cowswap-e2e-tests/src/mocks/cowProtocolApi/record.ts
@@ -70,7 +70,7 @@ const RECORDINGS: readonly Recording[] = [
       kind: 'sell',
       onchainOrder: false,
       signingScheme: 'eip712',
-      priceQuality: 'optimal',
+      priceQuality: 'verified',
     },
   },
 ]

--- a/apps/cowswap-frontend/src/common/updaters/orders/UnfillableOrdersUpdater/services/fetchOrderPrice.test.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/UnfillableOrdersUpdater/services/fetchOrderPrice.test.ts
@@ -1,0 +1,48 @@
+// Mocked before imports: `tradingSdk` resolves the chain id from the URL at module load
+jest.mock('tradingSdk/tradingSdk', () => ({
+  tradingSdk: { getQuote: jest.fn() },
+}))
+
+jest.mock('entities/captcha/state/captchaCanQuoteAtom', () => ({
+  captchaCanQuoteAtom: jest.requireActual('jotai').atom(true),
+}))
+
+import { OrderKind, PriceQuality, SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import { tradingSdk } from 'tradingSdk/tradingSdk'
+
+import { GenericOrder } from 'common/types'
+
+import { fetchOrderPrice } from './fetchOrderPrice'
+
+const order = {
+  kind: OrderKind.SELL,
+  owner: '0xfb3c7eb936caa12b5a884d612393969a557d4307',
+  receiver: '0xfb3c7eb936caa12b5a884d612393969a557d4307',
+  partiallyFillable: false,
+  sellAmountBeforeFee: '1000000000000000000',
+  buyAmount: '2000000000',
+  inputToken: { address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', decimals: 18 },
+  outputToken: { address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', decimals: 6 },
+} as unknown as GenericOrder
+
+describe('fetchOrderPrice()', () => {
+  beforeEach(() => {
+    jest.mocked(tradingSdk.getQuote).mockResolvedValue({ quoteResults: {} } as never)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  // This price quality must stay explicit: the SDK falls back to `optimal` on its own, so an
+  // omitted setting looks identical today and silently diverges from the rest of the app.
+  it('Requests an optimal quote, since this price only feeds the orders table and never places an order', async () => {
+    await fetchOrderPrice(SupportedChainId.MAINNET, order)
+
+    expect(tradingSdk.getQuote).toHaveBeenCalledTimes(1)
+    expect(jest.mocked(tradingSdk.getQuote).mock.calls[0]?.[1]).toEqual({
+      quoteRequest: { priceQuality: PriceQuality.OPTIMAL },
+    })
+  })
+})

--- a/apps/cowswap-frontend/src/common/updaters/orders/UnfillableOrdersUpdater/services/fetchOrderPrice.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/UnfillableOrdersUpdater/services/fetchOrderPrice.ts
@@ -1,12 +1,18 @@
 import { jotaiStore } from '@cowprotocol/core'
-import { AccountAddress, QuoteResults, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { AccountAddress, PriceQuality, QuoteResults, SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import { captchaCanQuoteAtom } from 'entities/captcha/state/captchaCanQuoteAtom'
-import { tradingSdk, QUOTE_SETTINGS } from 'tradingSdk/tradingSdk'
+import { tradingSdk } from 'tradingSdk/tradingSdk'
 
 import { getRemainderAmount } from 'legacy/state/orders/utils'
 
 import { GenericOrder } from 'common/types'
+
+// This quote is never placed as an order, it only drives the out-of-market badge and the estimated
+// execution price in the orders table, so it skips the simulation `verified` would cost on a poll
+// that runs per pending order. Not `fast`: that narrows the estimator set, which skews the price
+// we display.
+const ADVANCED_SETTINGS = { quoteRequest: { priceQuality: PriceQuality.OPTIMAL } }
 
 export async function fetchOrderPrice(chainId: SupportedChainId, order: GenericOrder): Promise<QuoteResults | null> {
   if (!jotaiStore.get(captchaCanQuoteAtom)) return null
@@ -27,7 +33,7 @@ export async function fetchOrderPrice(chainId: SupportedChainId, order: GenericO
         receiver: order.receiver,
         partiallyFillable: order.partiallyFillable,
       },
-      QUOTE_SETTINGS,
+      ADVANCED_SETTINGS,
     )
 
     return quote.quoteResults

--- a/apps/cowswap-frontend/src/common/updaters/orders/UnfillableOrdersUpdater/services/fetchOrderPrice.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/UnfillableOrdersUpdater/services/fetchOrderPrice.ts
@@ -2,7 +2,7 @@ import { jotaiStore } from '@cowprotocol/core'
 import { AccountAddress, QuoteResults, SupportedChainId } from '@cowprotocol/cow-sdk'
 
 import { captchaCanQuoteAtom } from 'entities/captcha/state/captchaCanQuoteAtom'
-import { tradingSdk } from 'tradingSdk/tradingSdk'
+import { tradingSdk, QUOTE_SETTINGS } from 'tradingSdk/tradingSdk'
 
 import { getRemainderAmount } from 'legacy/state/orders/utils'
 
@@ -14,18 +14,21 @@ export async function fetchOrderPrice(chainId: SupportedChainId, order: GenericO
   const amount = getRemainderAmount(order.kind, order)
 
   try {
-    const quote = await tradingSdk.getQuote({
-      chainId,
-      kind: order.kind,
-      owner: order.owner as AccountAddress,
-      sellToken: order.inputToken.address,
-      sellTokenDecimals: order.inputToken.decimals,
-      buyToken: order.outputToken.address,
-      buyTokenDecimals: order.outputToken.decimals,
-      amount,
-      receiver: order.receiver,
-      partiallyFillable: order.partiallyFillable,
-    })
+    const quote = await tradingSdk.getQuote(
+      {
+        chainId,
+        kind: order.kind,
+        owner: order.owner as AccountAddress,
+        sellToken: order.inputToken.address,
+        sellTokenDecimals: order.inputToken.decimals,
+        buyToken: order.outputToken.address,
+        buyTokenDecimals: order.outputToken.decimals,
+        amount,
+        receiver: order.receiver,
+        partiallyFillable: order.partiallyFillable,
+      },
+      QUOTE_SETTINGS,
+    )
 
     return quote.quoteResults
   } catch {

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapDebugPanel/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapDebugPanel/index.tsx
@@ -3,7 +3,6 @@ import { MouseEvent, ReactNode, useMemo, useState } from 'react'
 import { useChainId, useConnection, useWalletClient } from 'wagmi'
 
 import { isInjectedWidget, isMobile } from '@cowprotocol/common-utils'
-import { PriceQuality } from '@cowprotocol/cow-sdk'
 import { Currency, CurrencyAmount } from '@cowprotocol/currency'
 import { getParentOrigin } from '@cowprotocol/iframe-transport'
 import {
@@ -31,7 +30,7 @@ import {
 } from 'modules/trade'
 import { useTradeFlowContext, useTradeFlowType } from 'modules/tradeFlow'
 import { useGetTradeFormValidation, useIsTradeFormValidationPassed } from 'modules/tradeFormValidation'
-import { getOrderValidTo, useTradeQuote } from 'modules/tradeQuote'
+import { getIsFinalQuote, getOrderValidTo, useTradeQuote } from 'modules/tradeQuote'
 import { useHighFeeWarning } from 'modules/tradeWidgetAddons'
 
 import { useGP2SettlementContractData } from 'common/hooks/useContract'
@@ -260,7 +259,7 @@ function SwapDebugPanelContent({ contextIsReady, deadline }: SwapDebugPanelProps
       account: Boolean(walletInfo.account),
       appData: Boolean(appData),
       quote: Boolean(tradeQuote.quote),
-      quoteIsVerified: quotePriceQuality === PriceQuality.VERIFIED,
+      quoteIsFinal: getIsFinalQuote(tradeQuote.fetchParams),
       orderKind: Boolean(derivedTradeState?.orderKind),
       settlementContract: Boolean(settlementContract),
       uiOrderType: Boolean(uiOrderType),
@@ -275,9 +274,9 @@ function SwapDebugPanelContent({ contextIsReady, deadline }: SwapDebugPanelProps
       inputAmount,
       networkFee,
       outputAmount,
-      quotePriceQuality,
       sellAmountBeforeFee,
       settlementContract,
+      tradeQuote.fetchParams,
       tradeQuote.quote,
       uiOrderType,
       validTo,

--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapDebugPanel/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapDebugPanel/index.tsx
@@ -260,7 +260,7 @@ function SwapDebugPanelContent({ contextIsReady, deadline }: SwapDebugPanelProps
       account: Boolean(walletInfo.account),
       appData: Boolean(appData),
       quote: Boolean(tradeQuote.quote),
-      quoteIsOptimal: quotePriceQuality === PriceQuality.OPTIMAL,
+      quoteIsVerified: quotePriceQuality === PriceQuality.VERIFIED,
       orderKind: Boolean(derivedTradeState?.orderKind),
       settlementContract: Boolean(settlementContract),
       uiOrderType: Boolean(uiOrderType),

--- a/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useSolanaTradeFlowContext.test.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useSolanaTradeFlowContext.test.ts
@@ -1,4 +1,4 @@
-import { OrderKind, PriceQuality, QuoteAndPost, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { OrderKind, QuoteAndPost, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { CurrencyAmount, Token } from '@cowprotocol/currency'
 import { UiOrderType } from '@cowprotocol/types'
 
@@ -20,7 +20,7 @@ describe('getIsSolanaTradeFlowContextReady', () => {
     inputAmount: amount,
     outputAmount: amount,
     quote,
-    priceQuality: PriceQuality.OPTIMAL,
+    isFinalQuote: true,
     uiOrderType: UiOrderType.SWAP,
     orderKind: OrderKind.SELL,
     validTo: 1_700_000_000,
@@ -42,8 +42,8 @@ describe('getIsSolanaTradeFlowContextReady', () => {
     expect(getIsSolanaTradeFlowContextReady({ ...readyParams, quote: null })).toBe(false)
   })
 
-  it('is not ready when the quote is not the OPTIMAL price quality', () => {
-    expect(getIsSolanaTradeFlowContextReady({ ...readyParams, priceQuality: PriceQuality.FAST })).toBe(false)
+  it('is not ready when the quote is only the fast preview quote', () => {
+    expect(getIsSolanaTradeFlowContextReady({ ...readyParams, isFinalQuote: false })).toBe(false)
   })
 
   it('is not ready when amounts are missing', () => {

--- a/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useSolanaTradeFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useSolanaTradeFlowContext.ts
@@ -1,11 +1,4 @@
-import {
-  isSolanaAddress,
-  isSolanaChain,
-  OrderKind,
-  PriceQuality,
-  QuoteAndPost,
-  SupportedChainId,
-} from '@cowprotocol/cow-sdk'
+import { isSolanaAddress, isSolanaChain, OrderKind, QuoteAndPost, SupportedChainId } from '@cowprotocol/cow-sdk'
 import type { Currency, CurrencyAmount } from '@cowprotocol/currency'
 import { UiOrderType } from '@cowprotocol/types'
 import { useWalletInfo } from '@cowprotocol/wallet'
@@ -24,7 +17,7 @@ import {
   useTradeConfirmActions,
   useTradeTypeInfo,
 } from 'modules/trade'
-import { getOrderValidTo, useTradeQuote } from 'modules/tradeQuote'
+import { getIsFinalQuote, getOrderValidTo, useTradeQuote } from 'modules/tradeQuote'
 
 import { TradeFlowParams } from './useTradeFlowContext'
 
@@ -36,14 +29,14 @@ interface SolanaTradeFlowContextParams {
   inputAmount: CurrencyAmount<Currency> | undefined
   outputAmount: CurrencyAmount<Currency> | undefined
   quote: QuoteAndPost | null
-  priceQuality: PriceQuality | undefined
+  isFinalQuote: boolean
   uiOrderType: UiOrderType | null
   orderKind: OrderKind | undefined
   validTo: number
 }
 
 export function getIsSolanaTradeFlowContextReady(params: SolanaTradeFlowContextParams): boolean {
-  const { chainId, account, inputAmount, outputAmount, quote, priceQuality, uiOrderType, orderKind, validTo } = params
+  const { chainId, account, inputAmount, outputAmount, quote, isFinalQuote, uiOrderType, orderKind, validTo } = params
 
   return Boolean(
     isSolanaChain(chainId) &&
@@ -51,7 +44,7 @@ export function getIsSolanaTradeFlowContextReady(params: SolanaTradeFlowContextP
       inputAmount &&
       outputAmount &&
       quote &&
-      priceQuality === PriceQuality.OPTIMAL &&
+      isFinalQuote &&
       uiOrderType &&
       orderKind &&
       validTo > 0,
@@ -82,7 +75,7 @@ export function useSolanaTradeFlowContext({ deadline }: TradeFlowParams): Solana
     inputAmount,
     outputAmount,
     quote: tradeQuoteState.quote,
-    priceQuality: tradeQuoteState.fetchParams?.priceQuality,
+    isFinalQuote: getIsFinalQuote(tradeQuoteState.fetchParams),
     uiOrderType,
     orderKind,
     validTo,

--- a/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowContext.ts
@@ -1,6 +1,6 @@
 import { useConfig, useWalletClient } from 'wagmi'
 
-import { OrderClass, PriceQuality } from '@cowprotocol/cow-sdk'
+import { OrderClass } from '@cowprotocol/cow-sdk'
 import type { Token } from '@cowprotocol/currency'
 import { useIsSafeWallet, useWalletDetails, useWalletInfo } from '@cowprotocol/wallet'
 
@@ -23,7 +23,7 @@ import {
   useTradeConfirmActions,
   useTradeTypeInfo,
 } from 'modules/trade'
-import { getOrderValidTo, useTradeQuote } from 'modules/tradeQuote'
+import { getIsFinalQuote, getOrderValidTo, useTradeQuote } from 'modules/tradeQuote'
 
 import { useGP2SettlementContractData } from 'common/hooks/useContract'
 import { useEnoughAllowance } from 'common/hooks/useEnoughAllowance'
@@ -102,7 +102,7 @@ export function useTradeFlowContext({ deadline }: TradeFlowParams): TradeFlowCon
         account &&
         appData &&
         tradeQuote.quote &&
-        tradeQuote.fetchParams?.priceQuality === PriceQuality.VERIFIED &&
+        getIsFinalQuote(tradeQuote.fetchParams) &&
         orderKind &&
         settlementContract &&
         uiOrderType &&

--- a/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/hooks/useTradeFlowContext.ts
@@ -102,7 +102,7 @@ export function useTradeFlowContext({ deadline }: TradeFlowParams): TradeFlowCon
         account &&
         appData &&
         tradeQuote.quote &&
-        tradeQuote.fetchParams?.priceQuality === PriceQuality.OPTIMAL &&
+        tradeQuote.fetchParams?.priceQuality === PriceQuality.VERIFIED &&
         orderKind &&
         settlementContract &&
         uiOrderType &&

--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/__snapshots__/useTradeQuotePolling.test.tsx.snap
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/__snapshots__/useTradeQuotePolling.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`useTradeQuotePolling() When wallet is connected Then should put account
     "getCorrelatedTokens": [Function],
     "getSlippageSuggestion": undefined,
     "quoteRequest": {
-      "priceQuality": "optimal",
+      "priceQuality": "verified",
     },
     "quoteSigner": undefined,
   },

--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useTradeQuoteManager.test.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useTradeQuoteManager.test.ts
@@ -38,7 +38,7 @@ function makeParams(overrides: Partial<QuoteBridgeRequest> = {}): QuoteBridgeReq
 
 const fetchParams: TradeQuoteFetchParams = {
   hasParamsChanged: true,
-  priceQuality: PriceQuality.OPTIMAL,
+  priceQuality: PriceQuality.VERIFIED,
   fetchStartTimestamp: 1,
 }
 

--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useTradeQuoteManager.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useTradeQuoteManager.ts
@@ -1,7 +1,7 @@
 import { useSetAtom } from 'jotai'
 import { useMemo, useRef } from 'react'
 
-import { PriceQuality, QuoteAndPost, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { QuoteAndPost, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { BridgeQuoteResults, QuoteBridgeRequest } from '@cowprotocol/sdk-bridging'
 
 import { QuoteApiError, QuoteApiErrorCodes } from 'api/cowProtocol/errors/QuoteError'
@@ -11,6 +11,7 @@ import { useProcessUnsupportedTokenError } from './useProcessUnsupportedTokenErr
 import { TradeQuoteState, updateTradeQuoteAtom } from '../state/tradeQuoteAtom'
 import { SellTokenAddress } from '../state/tradeQuoteInputAtom'
 import { TradeQuoteFetchParams } from '../types'
+import { getIsFinalQuote } from '../utils/getIsFastQuote'
 
 export interface TradeQuoteManager {
   setLoading(hasParamsChanged: boolean, quoteParams: QuoteBridgeRequest): void
@@ -96,12 +97,10 @@ export function useTradeQuoteManager(sellTokenAddress: SellTokenAddress | undefi
         return
       }
 
-      const isVerifiedQuote = fetchParams.priceQuality === PriceQuality.VERIFIED
-
       update(sellTokenAddress, {
         quote,
         bridgeQuote,
-        ...(isVerifiedQuote ? { isLoading: false } : null),
+        ...(getIsFinalQuote(fetchParams) ? { isLoading: false } : null),
         error: null,
         hasParamsChanged: false,
         fetchParams,

--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useTradeQuoteManager.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useTradeQuoteManager.ts
@@ -96,12 +96,12 @@ export function useTradeQuoteManager(sellTokenAddress: SellTokenAddress | undefi
         return
       }
 
-      const isOptimalQuote = fetchParams.priceQuality === PriceQuality.OPTIMAL
+      const isVerifiedQuote = fetchParams.priceQuality === PriceQuality.VERIFIED
 
       update(sellTokenAddress, {
         quote,
         bridgeQuote,
-        ...(isOptimalQuote ? { isLoading: false } : null),
+        ...(isVerifiedQuote ? { isLoading: false } : null),
         error: null,
         hasParamsChanged: false,
         fetchParams,

--- a/apps/cowswap-frontend/src/modules/tradeQuote/services/doQuotePolling.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/services/doQuotePolling.ts
@@ -57,7 +57,7 @@ export function doQuotePolling({
   if (fastQuote && !isConfirmOpen && !isBridging) {
     fetchQuote({ hasParamsChanged, priceQuality: PriceQuality.FAST, fetchStartTimestamp })
   }
-  fetchQuote({ hasParamsChanged, priceQuality: PriceQuality.OPTIMAL, fetchStartTimestamp })
+  fetchQuote({ hasParamsChanged, priceQuality: PriceQuality.VERIFIED, fetchStartTimestamp })
 
   return true
 }

--- a/apps/cowswap-frontend/src/modules/tradeQuote/services/fetchAndProcessQuote.test.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/services/fetchAndProcessQuote.test.ts
@@ -222,10 +222,10 @@ describe('fetchAndProcessQuote', () => {
       })
     })
 
-    it('should use optimal quote for OPTIMAL price quality', async () => {
-      const optimalFetchParams = {
+    it('should use verified quote for VERIFIED price quality', async () => {
+      const verifiedFetchParams = {
         ...mockFetchParams,
-        priceQuality: PriceQuality.OPTIMAL,
+        priceQuality: PriceQuality.VERIFIED,
       }
 
       const mockQuoteAndPost: QuoteAndPost = {
@@ -239,7 +239,7 @@ describe('fetchAndProcessQuote', () => {
       } as any)
 
       await fetchAndProcessQuote(
-        optimalFetchParams,
+        verifiedFetchParams,
         mockQuoteParams,
         tradeQuotePollingParameters,
         mockAppData,
@@ -249,7 +249,7 @@ describe('fetchAndProcessQuote', () => {
       expect(mockBridgingSdk.getQuote).toHaveBeenCalledWith(mockQuoteParams, {
         allowIntermediateEqSellToken: true,
         quoteRequest: {
-          priceQuality: PriceQuality.OPTIMAL,
+          priceQuality: PriceQuality.VERIFIED,
         },
         appData: mockAppData,
         quoteSigner: undefined,

--- a/apps/cowswap-frontend/src/modules/tradeQuote/services/fetchAndProcessQuote.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/services/fetchAndProcessQuote.ts
@@ -1,6 +1,6 @@
 import { IS_SOLANA_ENABLED } from '@cowprotocol/common-const'
 import { onlyResolvesLast } from '@cowprotocol/common-utils'
-import { PriceQuality, SwapAdvancedSettings, QuoteAndPost, isSolanaChain } from '@cowprotocol/cow-sdk'
+import { SwapAdvancedSettings, QuoteAndPost, isSolanaChain } from '@cowprotocol/cow-sdk'
 import {
   BridgeProviderQuoteError,
   BridgeQuoteErrors,
@@ -23,10 +23,11 @@ import { getSolanaQuote } from './getSolanaQuote.service'
 import { TradeQuoteManager } from '../hooks/useTradeQuoteManager'
 import { SolanaSigningContext, TradeQuoteFetchParams, TradeQuotePollingParameters } from '../types'
 import { getBridgeQuoteSigner } from '../utils/getBridgeQuoteSigner'
+import { getIsFinalQuote } from '../utils/getIsFastQuote'
 
 const getQuote = bridgingSdk.getQuote.bind(bridgingSdk)
 const getFastQuote = onlyResolvesLast<CrossChainQuoteAndPost>(getQuote)
-const getVerifiedQuote = onlyResolvesLast<CrossChainQuoteAndPost>(getQuote)
+const getFinalQuote = onlyResolvesLast<CrossChainQuoteAndPost>(getQuote)
 const getBestQuote = onlyResolvesLast<MultiQuoteResult | null>(bridgingSdk.getBestQuote.bind(bridgingSdk))
 // Same per-tier "only the latest call wins" protection the EVM path gets above — without it, a slow
 // FAST Solana quote resolving after a newer OPTIMAL one (or an earlier poll's request resolving after
@@ -137,8 +138,7 @@ async function fetchSwapQuote(
   processQuoteError: (errorLocation: string, error: unknown) => void,
   solanaSigningContext?: SolanaSigningContext,
 ): Promise<void> {
-  const { priceQuality } = fetchParams
-  const isVerifiedQuote = priceQuality === PriceQuality.VERIFIED
+  const isVerifiedQuote = getIsFinalQuote(fetchParams)
 
   if (IS_SOLANA_ENABLED && isSolanaChain(quoteParams.sellTokenChainId)) {
     const solanaRequest = isVerifiedQuote
@@ -161,7 +161,7 @@ async function fetchSwapQuote(
   }
 
   const request = isVerifiedQuote
-    ? getVerifiedQuote(quoteParams, advancedSettings)
+    ? getFinalQuote(quoteParams, advancedSettings)
     : getFastQuote(quoteParams, advancedSettings)
 
   try {

--- a/apps/cowswap-frontend/src/modules/tradeQuote/services/fetchAndProcessQuote.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/services/fetchAndProcessQuote.ts
@@ -26,7 +26,7 @@ import { getBridgeQuoteSigner } from '../utils/getBridgeQuoteSigner'
 
 const getQuote = bridgingSdk.getQuote.bind(bridgingSdk)
 const getFastQuote = onlyResolvesLast<CrossChainQuoteAndPost>(getQuote)
-const getOptimalQuote = onlyResolvesLast<CrossChainQuoteAndPost>(getQuote)
+const getVerifiedQuote = onlyResolvesLast<CrossChainQuoteAndPost>(getQuote)
 const getBestQuote = onlyResolvesLast<MultiQuoteResult | null>(bridgingSdk.getBestQuote.bind(bridgingSdk))
 // Same per-tier "only the latest call wins" protection the EVM path gets above — without it, a slow
 // FAST Solana quote resolving after a newer OPTIMAL one (or an earlier poll's request resolving after
@@ -138,10 +138,10 @@ async function fetchSwapQuote(
   solanaSigningContext?: SolanaSigningContext,
 ): Promise<void> {
   const { priceQuality } = fetchParams
-  const isOptimalQuote = priceQuality === PriceQuality.OPTIMAL
+  const isVerifiedQuote = priceQuality === PriceQuality.VERIFIED
 
   if (IS_SOLANA_ENABLED && isSolanaChain(quoteParams.sellTokenChainId)) {
-    const solanaRequest = isOptimalQuote
+    const solanaRequest = isVerifiedQuote
       ? getOptimalSolanaQuote(quoteParams, solanaSigningContext)
       : getFastSolanaQuote(quoteParams, solanaSigningContext)
 
@@ -160,8 +160,8 @@ async function fetchSwapQuote(
     return
   }
 
-  const request = isOptimalQuote
-    ? getOptimalQuote(quoteParams, advancedSettings)
+  const request = isVerifiedQuote
+    ? getVerifiedQuote(quoteParams, advancedSettings)
     : getFastQuote(quoteParams, advancedSettings)
 
   try {

--- a/apps/cowswap-frontend/src/modules/tradeQuote/services/fetchAndProcessQuote.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/services/fetchAndProcessQuote.ts
@@ -138,10 +138,10 @@ async function fetchSwapQuote(
   processQuoteError: (errorLocation: string, error: unknown) => void,
   solanaSigningContext?: SolanaSigningContext,
 ): Promise<void> {
-  const isVerifiedQuote = getIsFinalQuote(fetchParams)
+  const isFinalQuote = getIsFinalQuote(fetchParams)
 
   if (IS_SOLANA_ENABLED && isSolanaChain(quoteParams.sellTokenChainId)) {
-    const solanaRequest = isVerifiedQuote
+    const solanaRequest = isFinalQuote
       ? getOptimalSolanaQuote(quoteParams, solanaSigningContext)
       : getFastSolanaQuote(quoteParams, solanaSigningContext)
 
@@ -160,7 +160,7 @@ async function fetchSwapQuote(
     return
   }
 
-  const request = isVerifiedQuote
+  const request = isFinalQuote
     ? getFinalQuote(quoteParams, advancedSettings)
     : getFastQuote(quoteParams, advancedSettings)
 

--- a/apps/cowswap-frontend/src/modules/tradeQuote/state/tradeQuoteAtom.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/state/tradeQuoteAtom.ts
@@ -48,7 +48,7 @@ export const updateTradeQuoteAtom = atom(
       const prevState = get(tradeQuotesAtom)
       const prevQuote = prevState[sellTokenAddress] || DEFAULT_TRADE_QUOTE_STATE
 
-      // Don't update state if Fast quote finished after Optimal quote
+      // Don't update state if Fast quote finished after Verified quote
       if (
         prevQuote.fetchParams?.fetchStartTimestamp === nextState.fetchParams?.fetchStartTimestamp &&
         nextState.quote &&

--- a/apps/cowswap-frontend/src/modules/tradeQuote/utils/getIsFastQuote.test.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/utils/getIsFastQuote.test.ts
@@ -1,0 +1,26 @@
+import { PriceQuality } from '@cowprotocol/cow-sdk'
+
+import { getIsFastQuote, getIsFinalQuote } from './getIsFastQuote'
+
+import { TradeQuoteFetchParams } from '../types'
+
+function params(priceQuality: PriceQuality): TradeQuoteFetchParams {
+  return { hasParamsChanged: false, priceQuality, fetchStartTimestamp: 1 }
+}
+
+describe('getIsFinalQuote()', () => {
+  it('Is false without fetch params, so gates relying on it stay closed until a quote is requested', () => {
+    expect(getIsFinalQuote(undefined)).toBe(false)
+    expect(getIsFinalQuote(null)).toBe(false)
+  })
+
+  it('Is false for the fast preview quote', () => {
+    expect(getIsFinalQuote(params(PriceQuality.FAST))).toBe(false)
+    expect(getIsFastQuote(params(PriceQuality.FAST))).toBe(true)
+  })
+
+  it('Is true for any non-fast price quality, so changing what we request does not close the gates', () => {
+    expect(getIsFinalQuote(params(PriceQuality.VERIFIED))).toBe(true)
+    expect(getIsFinalQuote(params(PriceQuality.OPTIMAL))).toBe(true)
+  })
+})

--- a/apps/cowswap-frontend/src/modules/tradeQuote/utils/getIsFastQuote.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/utils/getIsFastQuote.ts
@@ -6,3 +6,12 @@ import { TradeQuoteFetchParams } from '../types'
 export function getIsFastQuote(fetchParams: Nullish<TradeQuoteFetchParams>): boolean {
   return fetchParams?.priceQuality === PriceQuality.FAST
 }
+
+/**
+ * The definitive quote we place orders from, as opposed to the `fast` preview quote.
+ * Keyed off `fast` rather than a specific price quality so that changing what we request
+ * (`optimal` -> `verified`) doesn't silently turn every one of these checks false.
+ */
+export function getIsFinalQuote(fetchParams: Nullish<TradeQuoteFetchParams>): boolean {
+  return !!fetchParams && !getIsFastQuote(fetchParams)
+}

--- a/apps/cowswap-frontend/src/modules/twap/services/twap/eoa/placeEoaTwapOrder.ts
+++ b/apps/cowswap-frontend/src/modules/twap/services/twap/eoa/placeEoaTwapOrder.ts
@@ -18,7 +18,7 @@ import { ICoWShedCall } from '@cowprotocol/sdk-cow-shed'
 
 import { t } from '@lingui/core/macro'
 import { captchaCanQuoteAtom } from 'entities/captcha/state/captchaCanQuoteAtom'
-import { prodTradingSdk } from 'tradingSdk/tradingSdk'
+import { prodTradingSdk, QUOTE_SETTINGS } from 'tradingSdk/tradingSdk'
 
 import {
   assertFactoryDeployed,
@@ -344,6 +344,7 @@ To create the TWAP we will use an intermediate sell=buy order with a post hook:
       signer,
     },
     {
+      ...QUOTE_SETTINGS,
       appData: {
         metadata: {
           hooks: {

--- a/apps/cowswap-frontend/src/modules/twap/updaters/FullAmountQuoteUpdater.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/updaters/FullAmountQuoteUpdater.tsx
@@ -6,6 +6,7 @@ import { CrossChainQuoteAndPost, isBridgeQuoteAndPost } from '@cowprotocol/sdk-b
 
 import { captchaCanQuoteAtom } from 'entities/captcha/state/captchaCanQuoteAtom'
 import { bridgingSdk } from 'tradingSdk/bridgingSdk'
+import { QUOTE_SETTINGS } from 'tradingSdk/tradingSdk'
 
 import { useAdvancedOrdersDerivedState } from 'modules/advancedOrders'
 import { useTradeQuote, useQuoteParams } from 'modules/tradeQuote'
@@ -31,7 +32,7 @@ export function FullAmountQuoteUpdater() {
   useEffect(() => {
     if (!canQuote || error || isLoading || !partQuoteAmount || !quoteParams) return
 
-    getQuoteOnlyResolveLast(quoteParams)
+    getQuoteOnlyResolveLast(quoteParams, QUOTE_SETTINGS)
       .then((response) => {
         const { cancelled, data } = response
 

--- a/apps/cowswap-frontend/src/tradingSdk/tradingSdk.ts
+++ b/apps/cowswap-frontend/src/tradingSdk/tradingSdk.ts
@@ -5,11 +5,19 @@ import {
   getCurrentChainIdFromUrl,
   isBarnBackendEnv,
 } from '@cowprotocol/common-utils'
-import { TradingSdk } from '@cowprotocol/cow-sdk'
+import { PriceQuality, SwapAdvancedSettings, TradingSdk } from '@cowprotocol/cow-sdk'
 
 import { orderBookApi, prodOrderBookApi } from '../cowSdk'
 
 const chainId = getCurrentChainIdFromUrl()
+
+// CoW Swap prefers a fillable quote over a higher but unverifiable one, so every quote we may place
+// an order from asks for `verified`. `optimal` skips simulation (cowprotocol/services#4805) and the
+// SDK still defaults to it, so call sites have to be explicit. The tradeQuote polling path sets its
+// own price quality because it also fetches `fast` quotes.
+export const QUOTE_SETTINGS: SwapAdvancedSettings = {
+  quoteRequest: { priceQuality: PriceQuality.VERIFIED },
+}
 
 export const tradingSdk = new TradingSdk(
   {


### PR DESCRIPTION
# Summary

All "good" quotes are now `verified` instead of `optimal`.
`fast` quotes remains as they are.

<img width="475" height="338" alt="image" src="https://github.com/user-attachments/assets/e1795e93-8f97-46a1-b529-02e15cd97c13" />
<img width="486" height="255" alt="image" src="https://github.com/user-attachments/assets/50d87e05-84da-4712-a2ec-658a59121482" />


Historically, they have been the same. This will change on https://github.com/cowprotocol/services/pull/4805.

Switching to verified here preserves the current behaviour.

SDK is also changing the default https://github.com/cowprotocol/cow-sdk/pull/975, although we explicitly set the price quality in some areas. Changing here all to be always explicit.

## ⚠️ Notes:
- One path that is staying on `optimal`, and will be changed once backend changes, is the unfillable order updater.
As we don't intend to place orders using this value - it's only there for reference of the target price - switching to optimal should save backend resources and deliver the UI update faster.

# To Test

1. Load a price on SWAP, and check the `/quote` request in the console. Ignore the `fast` quality, those will still be there.
2. Check for the `priceQuality` in the request:
* Should be `verified`
3. Check the response:
* Should have `verified: true`

4. Check all order types
* All non `fast` quotes should be `verified` instead of `optimal`
* Order placing/execution should remain as is

5. When there's a pending limit order, the check the quote call for fetching the `fills at` column
* Request should be sent with priceQuality `optimal`.

# Self-checks

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have manually tested changes on Vercel preview deployment
- [x] I have done self-review and (or) AI review
- [x] I have addressed all comments from @coderabbitai
- [x] I have less than three open PRs/Stacks in this repo at the moment of creating this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standard swap quotes now use verified pricing.
  * Quote selection, polling, loading, and trade readiness now consistently recognize final quotes.
  * Price checks for unfillable orders now use optimized pricing.

* **Improvements**
  * TWAP and full-amount quotes now use shared quote settings.

* **Tests**
  * Updated automated coverage and fixtures for verified and final quote behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->