### PR TITLE
feat: use own indexer for twap

### DIFF
--- a/apps/cowswap-frontend/.env
+++ b/apps/cowswap-frontend/.env
@@ -86,7 +86,8 @@ REACT_APP_NETWORK_URL_11155111=https://ethereum-sepolia-rpc.publicnode.com
 # Order book API urls
 #REACT_APP_ORDER_BOOK_URLS='{"1":"https://YOUR_HOST","100":"https://YOUR_HOST","5":"https://YOUR_HOST"}'
 
-
+# Programmatic orders API URL
+# REACT_APP_PROGRAMMATIC_ORDERS_API_URL=https://programmatic-orders.cow.fi/
 
 
 

--- a/apps/cowswap-frontend/src/modules/twap/services/programmaticOrdersApi.ts
+++ b/apps/cowswap-frontend/src/modules/twap/services/programmaticOrdersApi.ts
@@ -8,8 +8,11 @@ import { getTwapOrderStatus } from '../utils/getTwapOrderStatus'
 import type { TWAPOrderStruct } from '../types'
 import type { TwapOrdersList } from 'entities/twap'
 
+const PROGRAMMATIC_ORDERS_API_URL =
+  process.env.REACT_APP_PROGRAMMATIC_ORDERS_API_URL || 'https://programmatic-orders.cow.fi/'
+
 class ProgrammaticOrdersApi {
-  private readonly api = new ProgrammaticOrderApi()
+  private readonly api = new ProgrammaticOrderApi({ apiUrl: PROGRAMMATIC_ORDERS_API_URL })
 
   async fetchEoaTwapOrders(
     resolvedOwner: string,


### PR DESCRIPTION
# Summary

Change from bleu indexer to our own. Theirs is degraded because they are getting rate limited by our orderbook API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring the programmatic orders API endpoint through the application environment.
  - The application uses the configured endpoint when available and falls back to the standard programmatic orders service URL otherwise.

- **Documentation**
  - Documented the programmatic orders API endpoint setting in the environment configuration template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->