### PR TITLE
fix(notifications): unsubscribe via link

### DIFF
--- a/apps/cowswap-frontend/src/modules/notifications/pure/TelegramConnectionStatus/index.tsx
+++ b/apps/cowswap-frontend/src/modules/notifications/pure/TelegramConnectionStatus/index.tsx
@@ -50,18 +50,20 @@ export function TelegramConnectionStatus({
 
   return (
     <div>
-      {isSubscribed && botDeepLink ? (
+      {isSubscribed ? (
         // window.open() doesn't work inside an iframe - use a real <a> so the browser
-        // handles the navigation natively instead.
+        // handles the navigation natively instead. Falls back to a non-navigating
+        // span (still a no-op toggle) if botDeepLink hasn't loaded yet.
         <Toggle
-          root="a"
+          root={botDeepLink ? 'a' : 'span'}
           id="toggle-telegram-notifications"
           checked={isSubscribed}
           toggle={NOOP}
           inactiveBgColor={`var(${UI.COLOR_PAPER})`}
           href={botDeepLink}
-          target="_blank"
-          rel="noopener noreferrer"
+          target={botDeepLink ? '_blank' : undefined}
+          rel={botDeepLink ? 'noopener noreferrer' : undefined}
+          aria-label="Unsubscribe from Telegram notifications (opens Telegram)"
         />
       ) : (
         <Toggle

--- a/apps/cowswap-frontend/src/modules/notifications/pure/TelegramConnectionStatus/index.tsx
+++ b/apps/cowswap-frontend/src/modules/notifications/pure/TelegramConnectionStatus/index.tsx
@@ -1,10 +1,15 @@
 import { ReactNode, useCallback } from 'react'
 
 import { normalizeError } from '@cowprotocol/common-utils'
+import { Command } from '@cowprotocol/types'
 import { Loader, UI, Toggle } from '@cowprotocol/ui'
 
 import { ConnectTelegramModal } from '../../containers/ConnectTelegram/ConnectTelegramModal'
 import { ConnectState } from '../../hooks/useTelegramConnect'
+
+// The unsubscribed toggle click is a no-op: unsubscribing happens on the bot side,
+// this state renders as a plain link instead (see the `root="a"` Toggle below).
+const NOOP: Command = () => undefined
 
 interface TelegramConnectionStatusProps {
   isLoading: boolean
@@ -28,23 +33,16 @@ export function TelegramConnectionStatus({
   cancelConnect,
 }: TelegramConnectionStatusProps): ReactNode {
   const handleToggle = useCallback(async () => {
-    if (isSubscribed) {
-      // Unsubscribing only happens from the bot side - send the user there to tap
-      // "Unsubscribe" instead of toggling anything here. The toggle itself stays on
-      // until the next status refresh notices they actually unsubscribed.
-      if (botDeepLink) {
-        window.open(botDeepLink, '_blank', 'noopener,noreferrer')
-      }
-    } else {
-      try {
-        await connect()
-      } catch (err: unknown) {
-        // connect() handles its own errors internally (connectState becomes 'error'),
-        // this is just a safety net against an unhandled rejection.
-        console.error('[TelegramConnectionStatus] Failed to start Telegram connect flow', normalizeError(err))
-      }
+    // Unsubscribing only happens from the bot side (rendered as a plain link below),
+    // so this only ever handles the subscribe flow.
+    try {
+      await connect()
+    } catch (err: unknown) {
+      // connect() handles its own errors internally (connectState becomes 'error'),
+      // this is just a safety net against an unhandled rejection.
+      console.error('[TelegramConnectionStatus] Failed to start Telegram connect flow', normalizeError(err))
     }
-  }, [isSubscribed, botDeepLink, connect])
+  }, [connect])
 
   if (isLoading) {
     return <Loader size="33px" stroke={`var(${UI.COLOR_TEXT_OPACITY_50})`} />
@@ -52,12 +50,27 @@ export function TelegramConnectionStatus({
 
   return (
     <div>
-      <Toggle
-        id="toggle-telegram-notifications"
-        checked={isSubscribed}
-        toggle={handleToggle}
-        inactiveBgColor={`var(${UI.COLOR_PAPER})`}
-      />
+      {isSubscribed && botDeepLink ? (
+        // window.open() doesn't work inside an iframe - use a real <a> so the browser
+        // handles the navigation natively instead.
+        <Toggle
+          root="a"
+          id="toggle-telegram-notifications"
+          checked={isSubscribed}
+          toggle={NOOP}
+          inactiveBgColor={`var(${UI.COLOR_PAPER})`}
+          href={botDeepLink}
+          target="_blank"
+          rel="noopener noreferrer"
+        />
+      ) : (
+        <Toggle
+          id="toggle-telegram-notifications"
+          checked={isSubscribed}
+          toggle={handleToggle}
+          inactiveBgColor={`var(${UI.COLOR_PAPER})`}
+        />
+      )}
       <ConnectTelegramModal
         isOpen={connectState !== 'idle'}
         connectState={connectState}

--- a/libs/ui/src/pure/Toggle/Toggle.pure.tsx
+++ b/libs/ui/src/pure/Toggle/Toggle.pure.tsx
@@ -5,7 +5,7 @@ import { Command } from '@cowprotocol/types'
 import * as styledEl from './Toggle.styled'
 
 export interface ToggleProps {
-  root?: 'label' | 'span'
+  root?: 'label' | 'span' | 'a'
   id?: string
   checked: boolean
   toggle: Command
@@ -13,6 +13,9 @@ export interface ToggleProps {
   bgColor?: string
   inactiveBgColor?: string
   'data-click-event'?: string
+  href?: string
+  target?: string
+  rel?: string
 }
 
 export function Toggle({
@@ -24,11 +27,17 @@ export function Toggle({
   bgColor,
   inactiveBgColor,
   'data-click-event': dataClickEvent,
+  href,
+  target,
+  rel,
 }: ToggleProps): ReactNode {
   return (
     <styledEl.Wrapper
       as={Root}
       id={id}
+      href={href}
+      target={target}
+      rel={rel}
       $bgColor={bgColor}
       $inactiveBgColor={inactiveBgColor}
       data-click-event={dataClickEvent}

--- a/libs/ui/src/pure/Toggle/Toggle.pure.tsx
+++ b/libs/ui/src/pure/Toggle/Toggle.pure.tsx
@@ -16,6 +16,7 @@ export interface ToggleProps {
   href?: string
   target?: string
   rel?: string
+  'aria-label'?: string
 }
 
 export function Toggle({
@@ -30,7 +31,13 @@ export function Toggle({
   href,
   target,
   rel,
+  'aria-label': ariaLabel,
 }: ToggleProps): ReactNode {
+  // A checkbox nested in an <a> is invalid content model and reads as mixed
+  // "checkbox" + "link" semantics to assistive tech - hide it and describe the
+  // control via the anchor's aria-label instead.
+  const isLink = Root === 'a'
+
   return (
     <styledEl.Wrapper
       as={Root}
@@ -38,11 +45,18 @@ export function Toggle({
       href={href}
       target={target}
       rel={rel}
+      aria-label={isLink ? ariaLabel : undefined}
       $bgColor={bgColor}
       $inactiveBgColor={inactiveBgColor}
       data-click-event={dataClickEvent}
     >
-      <styledEl.Input type="checkbox" checked={checked} onChange={() => toggle()} disabled={disabled} />
+      <styledEl.Input
+        type="checkbox"
+        checked={checked}
+        onChange={() => toggle()}
+        disabled={disabled}
+        aria-hidden={isLink || undefined}
+      />
       <styledEl.ToggleThumb />
     </styledEl.Wrapper>
   )


### PR DESCRIPTION
# Summary

`window.open` is not allowed in iframes.
Instead of that, we make the Telegram subscription toggle `<a>` element.

# To Test

1. Open this PR preview in Safe
2. Subscribe to Telegram
- [ ] It should open a modal with QR
3. Unsubscribe from Telegram
- [ ] it should open a deep link to Telegram with /unsubscribe command