### PR TITLE
fix(rwa): point rwa list fetching to cms prod

### DIFF
--- a/apps/explorer/src/utils/fetchSolversInfo.ts
+++ b/apps/explorer/src/utils/fetchSolversInfo.ts
@@ -1,5 +1,5 @@
 import { CHAIN_INFO } from '@cowprotocol/common-const'
-import { getCmsClient, PROD_CMS_BASE_URL } from '@cowprotocol/core'
+import { getProdCmsClient, PROD_CMS_BASE_URL } from '@cowprotocol/core'
 
 import type {
   CmsEntity,
@@ -47,7 +47,7 @@ export async function fetchSolversInfo(network?: number): Promise<SolversInfo> {
 }
 
 async function fetchSolversInfoFromCms(): Promise<SolversInfo> {
-  const cmsClient = getCmsClient(PROD_CMS_BASE_URL)
+  const cmsClient = getProdCmsClient()
   const { data, error, response } = await cmsClient.GET('/solvers', {
     params: {
       query: {},

--- a/libs/core/src/cms/utils/getCmsClient.ts
+++ b/libs/core/src/cms/utils/getCmsClient.ts
@@ -1,23 +1,35 @@
 import { CmsClient } from '@cowprotocol/cms'
 
+type CmsApiClient = ReturnType<typeof CmsClient>
+
 /**
- * Solver info must always come from the production CMS: the barn instance dev/PR builds point at has
- * no `solver_networks` data, so solvers there resolve to raw addresses instead of names and logos.
- * The production CMS carries both `barn` and `prod` addresses per solver, so it serves every environment.
+ * Some CMS collections have no usable copy on the barn instance that dev/PR builds point at, so they
+ * must be read from production on every environment. See `getProdCmsClient`.
  */
 export const PROD_CMS_BASE_URL = 'https://cms.cow.fi/api'
 
 export const CMS_BASE_URL =
   process.env.REACT_APP_CMS_BASE_URL || process.env.NEXT_PUBLIC_CMS_BASE_URL || PROD_CMS_BASE_URL
 
-const cmsClients: Record<string, ReturnType<typeof CmsClient>> = {}
+const cmsClients: Record<string, CmsApiClient> = {}
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function getCmsClient(url: string = CMS_BASE_URL) {
+export function getCmsClient(url: string = CMS_BASE_URL): CmsApiClient {
   const client = cmsClients[url] || CmsClient({ url })
 
   cmsClients[url] = client
 
   return client
+}
+
+/**
+ * Client for the collections that only production serves usefully:
+ * - `/solvers`: barn has no `solver_networks` data, so solvers there resolve to raw addresses instead
+ *   of names and logos. Production carries both `barn` and `prod` addresses per solver.
+ * - `/restricted-token-lists`: barn doesn't have them configured.
+ *
+ * Everything else keeps using `getCmsClient()`: announcements, account notifications and cow-fi
+ * content are environment-scoped, and barn is where they get staged.
+ */
+export function getProdCmsClient(): CmsApiClient {
+  return getCmsClient(PROD_CMS_BASE_URL)
 }

--- a/libs/core/src/cms/utils/getRestrictedTokenLists.test.ts
+++ b/libs/core/src/cms/utils/getRestrictedTokenLists.test.ts
@@ -1,35 +1,77 @@
 const mockCmsGet = jest.fn<Promise<unknown>, [string, unknown]>()
+const cmsClientUrls: string[] = []
 
 jest.mock('@cowprotocol/cms', () => ({
-  CmsClient: () => ({ GET: mockCmsGet }),
-}))
+  CmsClient: ({ url }: { url: string }) => {
+    cmsClientUrls.push(url)
 
-import { getRestrictedTokenLists } from './getRestrictedTokenLists'
+    return { GET: mockCmsGet }
+  },
+}))
 
 const RESERVE_BNB_TOKEN_LIST_URL =
   'https://raw.githubusercontent.com/reserve-protocol/dtf-interface/1dbc095c95210f3342278acb8b865763a4d7d443/packages/dtf-catalog/tokenlists/index-dtf/restricted/bnb.tokenlist.json'
+const BARN_CMS_BASE_URL = 'https://cms.barn.cow.fi/api'
+const originalCmsBaseUrl = process.env.REACT_APP_CMS_BASE_URL
+
+const expectsReserveBnbFallback = expect.arrayContaining([
+  expect.objectContaining({
+    name: 'Reserve Protocol BNB Token List',
+    tokenListUrl: RESERVE_BNB_TOKEN_LIST_URL,
+    restrictedCountries: expect.arrayContaining(['US']),
+  }),
+])
+
+async function importGetRestrictedTokenLists(): Promise<typeof import('./getRestrictedTokenLists')> {
+  return import('./getRestrictedTokenLists')
+}
 
 describe('getRestrictedTokenLists', () => {
   beforeEach(() => {
     mockCmsGet.mockReset()
+    cmsClientUrls.length = 0
+    globalThis.localStorage?.clear()
+    jest.resetModules()
     jest.spyOn(console, 'error').mockImplementation(() => undefined)
   })
 
   afterEach(() => {
     jest.restoreAllMocks()
+
+    if (originalCmsBaseUrl === undefined) {
+      delete process.env.REACT_APP_CMS_BASE_URL
+    } else {
+      process.env.REACT_APP_CMS_BASE_URL = originalCmsBaseUrl
+    }
   })
 
   it('falls back to Reserve Protocol BNB token list when the CMS request fails', async () => {
     mockCmsGet.mockRejectedValue(new Error('CMS down'))
 
-    await expect(getRestrictedTokenLists()).resolves.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'Reserve Protocol BNB Token List',
-          tokenListUrl: RESERVE_BNB_TOKEN_LIST_URL,
-          restrictedCountries: expect.arrayContaining(['US']),
-        }),
-      ]),
-    )
+    const { getRestrictedTokenLists } = await importGetRestrictedTokenLists()
+
+    await expect(getRestrictedTokenLists()).resolves.toEqual(expectsReserveBnbFallback)
+  })
+
+  // openapi-fetch resolves non-2xx responses instead of rejecting: without a fallback here, an HTTP
+  // error leaves the app with zero restricted lists, silently disabling RWA geoblocking
+  it('falls back when the CMS answers with an error status instead of data', async () => {
+    mockCmsGet.mockResolvedValue({ error: { status: 403 }, response: { ok: false, status: 403 } })
+
+    const { getRestrictedTokenLists } = await importGetRestrictedTokenLists()
+
+    await expect(getRestrictedTokenLists()).resolves.toEqual(expectsReserveBnbFallback)
+  })
+
+  // The barn CMS returns 403 for the `restricted-token-lists` collection
+  it('reads restricted token lists from the production CMS even when the app points at the barn CMS', async () => {
+    process.env.REACT_APP_CMS_BASE_URL = BARN_CMS_BASE_URL
+    mockCmsGet.mockResolvedValue({ data: { data: [] }, response: { ok: true, status: 200 } })
+
+    const { getRestrictedTokenLists } = await importGetRestrictedTokenLists()
+
+    await getRestrictedTokenLists()
+
+    expect(cmsClientUrls).toEqual(['https://cms.cow.fi/api'])
   })
 })

--- a/libs/core/src/cms/utils/getRestrictedTokenLists.test.ts
+++ b/libs/core/src/cms/utils/getRestrictedTokenLists.test.ts
@@ -12,6 +12,14 @@ jest.mock('@cowprotocol/cms', () => ({
 const RESERVE_BNB_TOKEN_LIST_URL =
   'https://raw.githubusercontent.com/reserve-protocol/dtf-interface/1dbc095c95210f3342278acb8b865763a4d7d443/packages/dtf-catalog/tokenlists/index-dtf/restricted/bnb.tokenlist.json'
 const BARN_CMS_BASE_URL = 'https://cms.barn.cow.fi/api'
+const CMS_ITEM = {
+  id: 1,
+  attributes: {
+    name: 'Ondo Tokenized Stocks List',
+    tokenListUrl: 'https://example.com/ondo.tokenlist.json',
+    restrictedCountries: ['US'],
+  },
+}
 const originalCmsBaseUrl = process.env.REACT_APP_CMS_BASE_URL
 
 const expectsReserveBnbFallback = expect.arrayContaining([
@@ -63,10 +71,20 @@ describe('getRestrictedTokenLists', () => {
     await expect(getRestrictedTokenLists()).resolves.toEqual(expectsReserveBnbFallback)
   })
 
+  // An empty collection leaves the app with zero restricted lists, which is the same end state as a
+  // failed request, so it must not be treated as a valid answer and cached
+  it('falls back when the CMS returns an empty collection', async () => {
+    mockCmsGet.mockResolvedValue({ data: { data: [] }, response: { ok: true, status: 200 } })
+
+    const { getRestrictedTokenLists } = await importGetRestrictedTokenLists()
+
+    await expect(getRestrictedTokenLists()).resolves.toEqual(expectsReserveBnbFallback)
+  })
+
   // The barn CMS returns 403 for the `restricted-token-lists` collection
   it('reads restricted token lists from the production CMS even when the app points at the barn CMS', async () => {
     process.env.REACT_APP_CMS_BASE_URL = BARN_CMS_BASE_URL
-    mockCmsGet.mockResolvedValue({ data: { data: [] }, response: { ok: true, status: 200 } })
+    mockCmsGet.mockResolvedValue({ data: { data: [CMS_ITEM] }, response: { ok: true, status: 200 } })
 
     const { getRestrictedTokenLists } = await importGetRestrictedTokenLists()
 

--- a/libs/core/src/cms/utils/getRestrictedTokenLists.ts
+++ b/libs/core/src/cms/utils/getRestrictedTokenLists.ts
@@ -10,7 +10,7 @@ import {
   XStocks_FALLBACK_TOKEN_LIST,
 } from '../consts'
 import { RestrictedTokenList, RestrictedTokenLists } from '../types'
-import { getCmsClient } from '../utils'
+import { getProdCmsClient } from '../utils'
 
 interface CmsRestrictedTokenListItem {
   id: number
@@ -32,7 +32,15 @@ interface CmsRestrictedTokenListsResponse {
  */
 const CACHE_KEY = 'restricted-token-lists'
 
-const cache = new TTLCache<RestrictedTokenLists>('cmsRestrictedTokenLists:v0', true, DEFAULT_CMS_REQUEST_TTL)
+// v1: invalidates empty responses cached from the barn CMS, which doesn't have them configured
+const cache = new TTLCache<RestrictedTokenLists>('cmsRestrictedTokenLists:v1', true, DEFAULT_CMS_REQUEST_TTL)
+
+const FALLBACK_TOKEN_LISTS: RestrictedTokenLists = [
+  ONDO_FALLBACK_TOKEN_LIST,
+  XStocks_FALLBACK_TOKEN_LIST,
+  RESERVE_PROTOCOL_BNB_FALLBACK_TOKEN_LIST,
+  COINBASE_TOKENIZED_STOCKS_FALLBACK_TOKEN_LIST,
+]
 
 export async function getRestrictedTokenLists(): Promise<RestrictedTokenLists> {
   const cached = cache.get(CACHE_KEY)
@@ -48,7 +56,7 @@ export async function getRestrictedTokenLists(): Promise<RestrictedTokenLists> {
 }
 
 async function fetchRestrictedTokenLists(): Promise<RestrictedTokenLists | null> {
-  const cmsClient = getCmsClient()
+  const cmsClient = getProdCmsClient()
 
   return cmsClient
     .GET('/restricted-token-lists', {
@@ -60,9 +68,14 @@ async function fetchRestrictedTokenLists(): Promise<RestrictedTokenLists | null>
       },
       querySerializer,
     })
-    .then((res: { data: CmsRestrictedTokenListsResponse }) => {
+    .then((res: { data?: CmsRestrictedTokenListsResponse; response?: Response }) => {
       const items = res.data?.data
-      if (!items) return []
+
+      // openapi-fetch resolves non-2xx responses instead of rejecting, so an HTTP error arrives here
+      // with no data. Geoblocking must never silently turn itself off, so fall back instead.
+      if (!items) {
+        throw new Error(`Restricted token lists response had no data [${res.response?.status ?? 'unknown'}]`)
+      }
 
       return items.map(
         (item): RestrictedTokenList => ({
@@ -74,11 +87,6 @@ async function fetchRestrictedTokenLists(): Promise<RestrictedTokenLists | null>
     })
     .catch((error: Error) => {
       console.error('Failed to fetch restricted token lists', error)
-      return [
-        ONDO_FALLBACK_TOKEN_LIST,
-        XStocks_FALLBACK_TOKEN_LIST,
-        RESERVE_PROTOCOL_BNB_FALLBACK_TOKEN_LIST,
-        COINBASE_TOKENIZED_STOCKS_FALLBACK_TOKEN_LIST,
-      ]
+      return FALLBACK_TOKEN_LISTS
     })
 }

--- a/libs/core/src/cms/utils/getRestrictedTokenLists.ts
+++ b/libs/core/src/cms/utils/getRestrictedTokenLists.ts
@@ -72,8 +72,9 @@ async function fetchRestrictedTokenLists(): Promise<RestrictedTokenLists | null>
       const items = res.data?.data
 
       // openapi-fetch resolves non-2xx responses instead of rejecting, so an HTTP error arrives here
-      // with no data. Geoblocking must never silently turn itself off, so fall back instead.
-      if (!items) {
+      // with no data. An empty collection is treated the same way: geoblocking must never silently
+      // turn itself off, so fall back rather than caching zero restricted lists.
+      if (!items?.length) {
         throw new Error(`Restricted token lists response had no data [${res.response?.status ?? 'unknown'}]`)
       }
 

--- a/libs/core/src/cms/utils/getSolversInfo.ts
+++ b/libs/core/src/cms/utils/getSolversInfo.ts
@@ -5,7 +5,7 @@ import { querySerializer } from './querySerializer'
 
 import { DEFAULT_CMS_REQUEST_TTL } from '../consts'
 import { CmsSolversInfo } from '../types'
-import { getCmsClient, PROD_CMS_BASE_URL } from '../utils'
+import { getProdCmsClient } from '../utils'
 
 /**
  * Request parameters are static, hence the cache key is also static
@@ -29,7 +29,7 @@ export async function getSolversInfo(): Promise<CmsSolversInfo> {
 }
 
 async function fetchSolversInfo(): Promise<CmsSolversInfo | null> {
-  const cmsClient = getCmsClient(PROD_CMS_BASE_URL)
+  const cmsClient = getProdCmsClient()
 
   return cmsClient
     .GET('/solvers', {


### PR DESCRIPTION
# Summary

Point RWA list fetching to cms prod.
Prevent overwritting cached results with an empty list.

# To Test

1. Load app from a restricted location
2. Check RWA tokens
* Block should apply as expected
3. Repeat from a non-restricted location
* Should not be blocked

# Self-checks

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have manually tested changes on Vercel preview deployment
- [x] I have done self-review and (or) AI review
- [x] I have addressed all comments from @coderabbitai
- [ ] I have less than three open PRs/Stacks in this repo at the moment of creating this PR


## AI description

## What changed

- `/restricted-token-lists` is now read from the production CMS instead of the environment CMS, so RWA geoblocking data loads on every build. Same treatment `/solvers` got in #8067.
- Added `getProdCmsClient()` in `libs/core/src/cms/utils/getCmsClient.ts`. It replaces the inline `getCmsClient(PROD_CMS_BASE_URL)` at the two solver call sites and documents in one place which collections read prod and why.
- A CMS HTTP error now falls through to the hardcoded fallback lists instead of returning `[]`. `openapi-fetch` resolves non-2xx responses rather than rejecting, so the existing `.catch()` was never reachable from a 4xx/5xx.
- Bumped the restricted-lists cache key to `:v1`, so empty responses already cached in localStorage (1h TTL) get dropped.
- Typed `getCmsClient` properly and removed its `TODO` plus the `explicit-function-return-type` disable.

## Why

RWA geoblocking was completely off on dev and PR builds. Those builds point `REACT_APP_CMS_BASE_URL` at the barn CMS, which was not serving `/restricted-token-lists` — it answered 403. Since `openapi-fetch` resolves non-2xx instead of throwing, that landed in the success branch with no data and returned an empty list:

- no restricted tokens in the atom, so `useRwaTokenStatus` returns `Allowed`
- an RWA token could be imported from a restricted location with no warning
- RWA lists were not hidden from restricted locations

Production was unaffected, because the production CMS serves the data.

The barn permission has since been re-enabled, but barn holds a single stale row (Ondo, still pointing at a branch ref) against prod's four pinned rows. Reading barn would still leave previews with incomplete geoblocking, and keeping it in sync means maintaining compliance config in two places. These lists are identical in every environment and have nothing to stage, so prod is the right source.

Unrelated to this diff: the report about RWA lists being visible on prod comes from the CMS rows being re-pointed to pinned commits on Aug 25 while prod still ships branch refs. That one resolves when `release/2026-08-28` ships.

## QA Testing

Preview URL QA — needs the `isRwaGeoblockEnabled` flag on, and a VPN for the restricted-location cases:

- Coinbase AAPL on Base: https://swap-dev-git-fix-rwa-access-cowswap-dev.vercel.app/#/8453/swap/USDC/0xb200000000000000000000C2e324d24d7eEcd1fb
- Ondo USDon on Mainnet: https://swap-dev-git-fix-rwa-access-cowswap-dev.vercel.app/#/1/swap/USDC/0xAcE8E719899F6E91831B18AE746C9A965c2119F1
- From a restricted location, both tokens should refuse to import with `This token is not available in your region.` Before this fix the import went through with no warning.
- From a non-restricted location, both should show the normal import prompt with no restriction message.
- In the token selector's list manager, RWA lists should be hidden from a restricted location and visible (disabled) otherwise.
- Solver regression check, since the `getProdCmsClient` rename touches that path: open any recently settled order on https://explorer-dev-git-fix-rwa-access-cowswap-dev.vercel.app and confirm the solver renders with a name and logo rather than a raw address.

Developer verification:

- `libs/core/src/cms/utils/getRestrictedTokenLists.test.ts` covers three cases: a rejected request falls back, a resolved non-2xx response falls back, and the client reads `https://cms.cow.fi/api` even when `REACT_APP_CMS_BASE_URL` points at barn. The non-2xx test fails if `if (!items) return []` is restored.
- Explorer's four `fetchSolversInfo` tests still pass after the rename.

Reviewer note:

- The blocked-country path is only reachable through a VPN, so the fallback and prod-URL behaviour is pinned by the targeted tests above rather than by a preview URL.

## Follow-ups

- barn's `restricted-token-lists` collection still holds one stale Ondo row on a branch ref. Nothing reads it after this change; worth deleting so it isn't mistaken for live config.

## Preview URLs

| Surface | URL |
| --- | --- |
| swap-dev - branch preview URL | https://swap-dev-git-fix-rwa-access-cowswap-dev.vercel.app |
| explorer-dev - branch preview URL | https://explorer-dev-git-fix-rwa-access-cowswap-dev.vercel.app |
| cowfi - branch preview URL | https://cowfi-git-fix-rwa-access-cowswap.vercel.app |
| storybook - branch preview URL | https://storybook-git-fix-rwa-access-cowswap-dev.vercel.app |
| widget-configurator - branch preview URL | https://widget-configurator-git-fix-rwa-access-cowswap-dev.vercel.app |

---

AI usage: Claude helped investigate the root cause and draft this description from the checked diff and CMS responses.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Solver information and restricted token lists are now consistently retrieved from the production CMS.
  - Improved fallback behavior when restricted token list data is unavailable or empty, preventing geoblocking from being silently disabled.
  - Updated cached restricted token list data to ensure previously empty results are not reused.

- **Tests**
  - Added coverage for production CMS usage and fallback behavior when CMS requests fail or return no data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->