### PR TITLE
fix(account): avoid Invalid Date in surplus tooltip start date

### DIFF
--- a/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/SurplusCard.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/SurplusCard.tsx
@@ -22,17 +22,20 @@ import useNativeCurrency from 'lib/hooks/useNativeCurrency'
 
 import { InfoCard } from './styled'
 
-const DEFAULT_START_DATE = 'March 2023'
-const ARBITRUM_ONE_START_DATE = 'May 2024'
-const BASE_START_DATE = 'December 2024'
-const POLYGON_START_DATE = 'June 2025'
-const AVALANCHE_START_DATE = 'June 2025'
-const BNB_START_DATE = 'September 2025'
-const LINEA_START_DATE = 'November 2025'
-const PLASMA_START_DATE = 'January 2026'
-const INK_START_DATE = 'February 2026'
+// Month is 0-indexed (Date constructor), constructed explicitly instead of parsed from a
+// string like 'June 2025' because non-ISO date string parsing is implementation-defined
+// and can yield Invalid Date in some browsers/locales.
+const DEFAULT_START_DATE = new Date(2023, 2)
+const ARBITRUM_ONE_START_DATE = new Date(2024, 4)
+const BASE_START_DATE = new Date(2024, 11)
+const POLYGON_START_DATE = new Date(2025, 5)
+const AVALANCHE_START_DATE = new Date(2025, 5)
+const BNB_START_DATE = new Date(2025, 8)
+const LINEA_START_DATE = new Date(2025, 10)
+const PLASMA_START_DATE = new Date(2026, 0)
+const INK_START_DATE = new Date(2026, 1)
 
-const START_DATE: Record<SupportedChainId, string> = {
+const START_DATE: Record<SupportedChainId, Date> = {
   [SupportedChainId.MAINNET]: DEFAULT_START_DATE,
   [SupportedChainId.GNOSIS_CHAIN]: DEFAULT_START_DATE,
   [SupportedChainId.ARBITRUM_ONE]: ARBITRUM_ONE_START_DATE,
@@ -177,7 +180,7 @@ export function SurplusCard() {
   const surplusUsdAmount = useUsdAmount(showSurplusAmount ? surplusAmount : undefined).value
   const native = useNativeCurrency()
   const nativeSymbol = native.symbol || 'ETH'
-  const startDate = new Date(START_DATE[native.chainId as SupportedChainId]).toLocaleDateString(i18n.locale, {
+  const startDate = START_DATE[native.chainId as SupportedChainId].toLocaleDateString(i18n.locale, {
     year: 'numeric',
     month: 'long',
   })


### PR DESCRIPTION
## Summary
- The surplus tooltip on the account page showed "since Invalid Date" (e.g. for POL) because `START_DATE` values were plain strings like `'June 2025'` passed to `new Date(string)`.
- Non-ISO date string parsing is implementation-defined per the JS spec, so some browsers/locales fail to parse `"June 2025"` and return an Invalid Date.
- Fix: construct `Date` objects explicitly with `new Date(year, monthIndex)` instead of parsing strings.

Fixes https://nomevlabs.slack.com/archives/C036G0J90BU/p1788350842152419


## Test plan
- [ ] Verify the "Your total surplus" tooltip on the account details page shows a valid formatted date (e.g. "since June 2025") for chains including Polygon, Avalanche, BNB, Linea, Plasma, Ink, Base, Arbitrum, and Mainnet/Gnosis.
<img width="434" height="97" alt="image" src="https://github.com/user-attachments/assets/cf6f06cd-8f3f-44ee-8b94-2ca9d7e3a050" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of per-chain surplus date handling.
  * Corrected date formatting to avoid inconsistent results caused by non-standard date parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->