### PR TITLE
fix(twap): remove stray apostrophe in TWAP review part labels

### DIFF
--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/TwapConfirmDetails.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapConfirmModal/TwapConfirmDetails.tsx
@@ -51,7 +51,7 @@ export type TwapConfirmDetailsProps = {
 export const TwapConfirmDetails = React.memo(function TwapConfirmDetails(props: TwapConfirmDetailsProps) {
   const { partDuration, totalDuration, numOfParts } = props
 
-  const partsSuffix = ' ' + t`part` + ` (1/'${numOfParts})`
+  const partsSuffix = ' ' + t`part` + ` (1/${numOfParts})`
   const amountLabelSuffix = ' ' + t`amount per` + partsSuffix
 
   const partDurationDisplay = partDuration ? deadlinePartsDisplay(partDuration, true) : ''


### PR DESCRIPTION
## Summary
Fixes https://nomevlabs.slack.com/archives/C0361CDG8GP/p1788191535768989

- The TWAP review modal shows labels like "Sell amount per part (1/'2)" and "Start time first part (1/'2)" — there's a stray apostrophe before the part count.
- Root cause: `TwapConfirmDetails.tsx` built the suffix as `` `(1/'${numOfParts})` `` instead of `` `(1/${numOfParts})` ``.
- Fix: remove the stray apostrophe so it renders as "(1/2)".
<img width="1267" height="1542" alt="image" src="https://github.com/user-attachments/assets/95f20754-3059-466b-a0c2-2be815c1eeeb" />

## Test plan
- [ ] Open the TWAP review modal for an order split into multiple parts and confirm "Sell amount per part", "Buy amount per part", and "Start time first part" all read "(1/N)" with no apostrophe.
<img width="509" height="135" alt="image" src="https://github.com/user-attachments/assets/c61cfad2-53e0-4c55-8b8b-998100e4e700" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the TWAP confirmation details so the order-part count displays without an unintended apostrophe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->