### PR TITLE
fix(wallet): show wallet icon for Base Account connections

### DIFF
--- a/apps/cowswap-e2e-tests/src/tests/network.spec.ts
+++ b/apps/cowswap-e2e-tests/src/tests/network.spec.ts
@@ -18,6 +18,6 @@ test.describe('Network', () => {
 
     await expect(swapPage.page).toHaveURL(/\/#\/100\/swap/)
     await expect(swapPage.sellTokenSelect).toHaveAttribute('aria-label', 'Selected token: WXDAI')
-    await expect(swapPage.buyTokenSelect).toHaveAttribute('aria-label', 'Selected token: USDC')
+    await expect(swapPage.buyTokenSelect).toHaveAttribute('aria-label', 'Selected token: USDC.e')
   })
 })

--- a/apps/cowswap-frontend/src/locales/en-US.po
+++ b/apps/cowswap-frontend/src/locales/en-US.po
@@ -8255,6 +8255,10 @@ msgstr "Waiting for you to tap Start…"
 msgid "View cancellation"
 msgstr "View cancellation"
 
+#: apps/cowswap-frontend/src/modules/wallet/pure/StatusIcon/index.tsx
+msgid "Base Account"
+msgstr "Base Account"
+
 #: apps/cowswap-frontend/src/common/pure/LoadingApp/index.tsx
 msgid "Loading"
 msgstr "Loading"

--- a/apps/cowswap-frontend/src/modules/wallet/pure/StatusIcon/index.tsx
+++ b/apps/cowswap-frontend/src/modules/wallet/pure/StatusIcon/index.tsx
@@ -1,4 +1,4 @@
-import { Identicon, ConnectionType, svgCoinbaseSrc, iconWalletConnectSrc } from '@cowprotocol/wallet'
+import { Identicon, ConnectionType, svgBaseSrc, svgCoinbaseSrc, iconWalletConnectSrc } from '@cowprotocol/wallet'
 
 import { t } from '@lingui/core/macro'
 import styled from 'styled-components/macro'
@@ -28,6 +28,9 @@ export function StatusIcon({ connectionType, account, size = 16 }: StatusIconPro
   switch (connectionType) {
     case ConnectionType.COINBASE_WALLET:
       image = <img src={svgCoinbaseSrc} alt={t`Coinbase Wallet`} />
+      break
+    case ConnectionType.BASE_ACCOUNT:
+      image = <img src={svgBaseSrc} alt={t`Base Account`} />
       break
     case ConnectionType.INJECTED:
       image = <Identicon account={account} />

--- a/libs/wallet/src/api/assets/base.svg
+++ b/libs/wallet/src/api/assets/base.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="12" fill="#0052FF"/>
+</svg>

--- a/libs/wallet/src/api/types.ts
+++ b/libs/wallet/src/api/types.ts
@@ -1,10 +1,11 @@
 import { Connector as WagmiConnector } from 'wagmi'
-import { injected, walletConnect, coinbaseWallet, safe } from 'wagmi/connectors'
+import { injected, walletConnect, coinbaseWallet, baseAccount, safe } from 'wagmi/connectors'
 
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import type { SafeInfoResponse } from '@safe-global/api-kit'
 
 export const ConnectionType = {
+  BASE_ACCOUNT: baseAccount.type,
   COINBASE_WALLET: coinbaseWallet.type,
   GNOSIS_SAFE: safe.type,
   INJECTED: injected.type,

--- a/libs/wallet/src/api/types.ts
+++ b/libs/wallet/src/api/types.ts
@@ -1,11 +1,13 @@
 import { Connector as WagmiConnector } from 'wagmi'
-import { injected, walletConnect, coinbaseWallet, baseAccount, safe } from 'wagmi/connectors'
+import { injected, walletConnect, coinbaseWallet, safe } from 'wagmi/connectors'
 
 import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import type { SafeInfoResponse } from '@safe-global/api-kit'
 
 export const ConnectionType = {
-  BASE_ACCOUNT: baseAccount.type,
+  // wagmi's `baseAccount` connector doesn't expose a static `.type` like the other
+  // connector factories do, so this is hardcoded to match its runtime connector.type.
+  BASE_ACCOUNT: 'baseAccount',
   COINBASE_WALLET: coinbaseWallet.type,
   GNOSIS_SAFE: safe.type,
   INJECTED: injected.type,

--- a/libs/wallet/src/assets.ts
+++ b/libs/wallet/src/assets.ts
@@ -1,5 +1,6 @@
+import svgBaseSrc from './api/assets/base.svg'
 import svgCoinbaseSrc from './api/assets/coinbase.svg'
 import imgMetamaskSrc from './api/assets/metamask.png'
 import iconWalletConnectSrc from './api/assets/walletConnectIcon.svg'
 
-export { svgCoinbaseSrc, iconWalletConnectSrc, imgMetamaskSrc }
+export { svgCoinbaseSrc, iconWalletConnectSrc, imgMetamaskSrc, svgBaseSrc }

--- a/libs/wallet/src/wagmi/hooks/useWalletMetadata.ts
+++ b/libs/wallet/src/wagmi/hooks/useWalletMetadata.ts
@@ -6,6 +6,7 @@ import { useConnectionType } from './useConnectionType'
 
 import { useGnosisSafeInfo } from '../../api/hooks'
 import { ConnectionType } from '../../api/types'
+import { svgBaseSrc } from '../../assets'
 import { COW_WIDGET_CONNECTOR_ID } from '../../reown/consts'
 import { reownAppKit } from '../config'
 
@@ -21,6 +22,19 @@ const METADATA_DISCONNECTED: WalletMetaData = {
 const METADATA_SAFE: WalletMetaData = {
   walletName: SAFE_APP_NAME,
   icon: SAFE_ICON_URL,
+}
+
+const METADATA_BASE_ACCOUNT: WalletMetaData = {
+  walletName: 'Base Account',
+  icon: svgBaseSrc,
+}
+
+// Connector types whose metadata is fixed and shouldn't fall back to walletMetaData (which is
+// populated by reownAppKit.subscribeWalletInfo and can be stale for connectors, like baseAccount,
+// whose own connect flow doesn't go through AppKit's wallet-selection UI).
+const STATIC_METADATA_BY_CONNECTOR_TYPE: Partial<Record<ConnectionType, WalletMetaData>> = {
+  [ConnectionType.GNOSIS_SAFE]: METADATA_SAFE,
+  [ConnectionType.BASE_ACCOUNT]: METADATA_BASE_ACCOUNT,
 }
 
 export interface WalletMetaData {
@@ -114,9 +128,10 @@ export function useWalletMetaData(): WalletMetaData {
       return wcPeerMetadata
     }
 
-    if (connector.type === ConnectionType.GNOSIS_SAFE) {
-      // TODO: potentially here is where we'll need to work to show the multiple flavours of Safe wallets
-      return METADATA_SAFE
+    // TODO: potentially here is where we'll need to work to show the multiple flavours of Safe wallets
+    const staticMetadata = STATIC_METADATA_BY_CONNECTOR_TYPE[connector.type as ConnectionType]
+    if (staticMetadata) {
+      return staticMetadata
     }
 
     return {


### PR DESCRIPTION
## Summary

<img width="372" height="170" alt="missing icon" src="https://github.com/user-attachments/assets/5491db45-9819-4ce6-a5c2-8044fbf1041f" />

- The account modal showed no icon at all for wallets connected via "Base Account" (Coinbase's `@base-org/account` SDK, wired in through wagmi's `baseAccount` connector, `type: "baseAccount"`).
- The wrap/unwrap and approve confirmation modals (and anywhere else using `AccountIcon`/`useWalletDetails`) instead showed the *wrong* wallet icon (e.g. a stale Rabby icon) for Base Account connections.
- Root causes:
  - `StatusIcon`'s switch statement only had cases for `COINBASE_WALLET`, `INJECTED`, and `WALLET_CONNECT_V2` — an unmatched connection type rendered nothing.
  - `useWalletMetaData()`'s generic fallback used `connector.icon ?? walletMetaData?.icon`. The `baseAccount` connector never sets `connector.icon`, so it fell back to `walletMetaData`, a value populated by `reownAppKit.subscribeWalletInfo` that isn't updated by Base Account's own connect flow — leaving it stale from whatever wallet was last selected through the AppKit modal (e.g. an injected Rabby wallet).
- Fix:
  - Added `BASE_ACCOUNT` to `ConnectionType` (matching the connector's runtime `connector.type`, since `baseAccount` doesn't expose a static `.type` like the other connector factories do) and a Base logomark SVG asset.
  - Added a matching case in `StatusIcon` for the top-right header wallet button.
  - Added fixed metadata for `GNOSIS_SAFE`/`BASE_ACCOUNT` via a lookup map in `useWalletMetaData()` so Base Account always gets its own name/icon instead of falling back to stale global wallet-info state — this covers the account modal, wrap, unwrap, and approve confirmation modals in one fix.
- Also fixed an unrelated pre-existing `@smoke` e2e failure (`network.spec.ts`) whose assertion was stale after a separate merged PR (#8072) changed the default Gnosis buy token from USDC to USDC.e.

## Test plan
- [ ] Connect a wallet via "Base Account" and confirm the Base icon shows in: the header wallet button, the account modal, and the wrap/unwrap/approve confirmation modals.
- [ ] Confirm other wallet types (MetaMask/injected, Coinbase Wallet, WalletConnect, Safe) still show their existing icons in all of the above.
<img width="347" height="186" alt="image" src="https://github.com/user-attachments/assets/cc8f7deb-0ee8-4573-9041-573fd390f128" />


## Summary by CodeRabbit

* **New Features**
  * Added support for identifying Base Account connections in the wallet interface.
  * Base Account connections now display dedicated branding and the “Base Account” label.
  * Added consistent wallet metadata for Base Account and Gnosis Safe connections.

* **Documentation**
  * Added English localization for the new “Base Account” label.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for identifying Base Account connections in the wallet interface.
  - Added a Base Account wallet icon and localized display label.
  - Base Account and Gnosis Safe connections now display consistent wallet metadata.

- **Tests**
  - Updated network-switching coverage to reflect USDC.e as the default buy token on Gnosis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->