### PR TITLE
fix(token-import): dedupe token present in multiple lists with different symbol

### DIFF
--- a/apps/cowswap-frontend/src/modules/tokensList/containers/TokenSearchResults/index.tsx
+++ b/apps/cowswap-frontend/src/modules/tokensList/containers/TokenSearchResults/index.tsx
@@ -2,7 +2,13 @@ import { ReactNode, useCallback, useEffect, useMemo } from 'react'
 
 import { doesTokenMatchSymbolOrAddress } from '@cowprotocol/common-utils'
 import { getAddressKey } from '@cowprotocol/cow-sdk'
-import { getTokenSearchFilter, TokenSearchResponse, useSearchToken } from '@cowprotocol/tokens'
+import {
+  excludeAlreadyActiveTokens,
+  getTokenSearchFilter,
+  TokenSearchResponse,
+  useSearchToken,
+  useTokensByAddressMap,
+} from '@cowprotocol/tokens'
 
 import { useAddTokenImportCallback } from '../../hooks/useAddTokenImportCallback'
 import { useSelectTokenWidgetState } from '../../hooks/useSelectTokenWidgetState'
@@ -65,6 +71,23 @@ export function TokenSearchResults(): ReactNode {
     }
   }, [allTokens, areTokensFromBridge, defaultSearchResults, filter, hasScopedListRestriction])
 
+  const tokensByAddress = useTokensByAddressMap()
+
+  /**
+   * Hide importable results whose address is already active: the same contract can sit in an active list
+   * and in an inactive one under a different symbol (CoinGecko ships AAPLC where the Coinbase RWA list
+   * ships AAPL), which otherwise renders it twice - once tradable, once behind an "Import" button.
+   */
+  const dedupedSearchResults: TokenSearchResponse = useMemo(
+    () => ({
+      ...searchResults,
+      inactiveListsResult: excludeAlreadyActiveTokens(searchResults.inactiveListsResult, tokensByAddress),
+      externalApiResult: excludeAlreadyActiveTokens(searchResults.externalApiResult, tokensByAddress),
+      blockchainResult: excludeAlreadyActiveTokens(searchResults.blockchainResult, tokensByAddress),
+    }),
+    [searchResults, tokensByAddress],
+  )
+
   const { activeListsResult } = searchResults
 
   const updateSelectTokenWidget = useUpdateSelectTokenWidgetState()
@@ -119,7 +142,7 @@ export function TokenSearchResults(): ReactNode {
         importToken={addTokenImportCallback}
         searchInput={searchInput}
         selectTokenContext={selectTokenContext}
-        searchResults={searchResults}
+        searchResults={dedupedSearchResults}
         areTokensFromBridge={areTokensFromBridge}
         bridgeSupportedTokensMap={bridgeSupportedTokensMap}
       />

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useNavigateOnCurrencySelection.test.tsx
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useNavigateOnCurrencySelection.test.tsx
@@ -1,6 +1,6 @@
-import { TokenWithLogo, USDC, WRAPPED_NATIVE_CURRENCIES } from '@cowprotocol/common-const'
+import { NATIVE_CURRENCIES, TokenWithLogo, USDC, WRAPPED_NATIVE_CURRENCIES } from '@cowprotocol/common-const'
 import { ALL_SUPPORTED_CHAINS, OrderKind, SupportedChainId } from '@cowprotocol/cow-sdk'
-import { useAreThereTokensWithSameSymbol } from '@cowprotocol/tokens'
+import { useAreThereTokensWithSameSymbol, useDoesSymbolResolveToToken } from '@cowprotocol/tokens'
 import { useWalletInfo } from '@cowprotocol/wallet'
 
 import { act, renderHook } from '@testing-library/react'
@@ -16,6 +16,7 @@ import { useTradeState } from './useTradeState'
 // Mock dependencies
 jest.mock('@cowprotocol/tokens', () => ({
   useAreThereTokensWithSameSymbol: jest.fn(),
+  useDoesSymbolResolveToToken: jest.fn(),
 }))
 
 jest.mock('@cowprotocol/wallet', () => ({
@@ -41,6 +42,9 @@ jest.mock('./useTradeState', () => ({
 const mockedUseAreThereTokensWithSameSymbol = useAreThereTokensWithSameSymbol as jest.MockedFunction<
   typeof useAreThereTokensWithSameSymbol
 >
+const mockedUseDoesSymbolResolveToToken = useDoesSymbolResolveToToken as jest.MockedFunction<
+  typeof useDoesSymbolResolveToToken
+>
 const mockedUseWalletInfo = useWalletInfo as jest.MockedFunction<typeof useWalletInfo>
 const mockedUseDerivedTradeState = useDerivedTradeState as jest.MockedFunction<typeof useDerivedTradeState>
 const mockedUseTradeNavigate = useTradeNavigate as jest.MockedFunction<typeof useTradeNavigate>
@@ -55,9 +59,16 @@ const USDC_MAINNET = USDC[SupportedChainId.MAINNET]
 const WETH_GNOSIS = WRAPPED_NATIVE_CURRENCIES[SupportedChainId.GNOSIS_CHAIN]
 const USDC_GNOSIS = USDC[SupportedChainId.GNOSIS_CHAIN]
 
+// Assigned by setupDefaultMocks; defaults to "the symbol resolves back to this token", which is the
+// case for any token already on an active list. Override per test to exercise the fallback.
+let mockDoesSymbolResolveToToken: jest.Mock
+
 function setupDefaultMocks(mockNavigate: jest.Mock, mockAreThereTokensWithSameSymbol: jest.Mock): void {
   mockedUseTradeNavigate.mockReturnValue(mockNavigate)
   mockedUseAreThereTokensWithSameSymbol.mockReturnValue(mockAreThereTokensWithSameSymbol)
+
+  mockDoesSymbolResolveToToken = jest.fn().mockReturnValue(true)
+  mockedUseDoesSymbolResolveToToken.mockReturnValue(mockDoesSymbolResolveToToken)
 
   mockedUseWalletInfo.mockReturnValue({
     chainId: SupportedChainId.MAINNET,
@@ -110,6 +121,59 @@ describe('useNavigateOnCurrencySelection - basic', () => {
         SupportedChainId.MAINNET,
         {
           inputCurrencyId: 'DAI',
+          outputCurrencyId: USDC_MAINNET.symbol,
+        },
+        undefined,
+      )
+    })
+
+    // Regression: the Coinbase RWA list ships AAPL at an address CoinGecko already ships as AAPLC, so
+    // the symbol never resolves back and a symbol URL re-triggers the import prompt in a loop
+    it('should use the address when the symbol does not resolve back to the token', () => {
+      // only AAPL is unresolvable; the untouched WETH side must keep its symbol
+      mockDoesSymbolResolveToToken.mockImplementation((symbol: string | null) => symbol !== 'AAPL')
+
+      const { result } = renderHook(() => useNavigateOnCurrencySelection())
+
+      const address = '0xb200000000000000000000C2e324d24d7eEcd1fb'
+      const newToken = new TokenWithLogo(
+        undefined,
+        SupportedChainId.MAINNET,
+        address,
+        18,
+        'AAPL',
+        'Apple (Coinbase Tokenized Stocks)',
+      )
+
+      act(() => {
+        result.current(Field.OUTPUT, newToken)
+      })
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        SupportedChainId.MAINNET,
+        {
+          inputCurrencyId: WETH_MAINNET.symbol,
+          outputCurrencyId: address,
+        },
+        undefined,
+      )
+    })
+
+    it('should keep the symbol for native currencies, which have no address to fall back to', () => {
+      // false even for the native symbol: the hook must not consult this for native currencies
+      mockDoesSymbolResolveToToken.mockImplementation((symbol: string | null) => symbol === USDC_MAINNET.symbol)
+
+      const { result } = renderHook(() => useNavigateOnCurrencySelection())
+      const native = NATIVE_CURRENCIES[SupportedChainId.MAINNET]
+
+      act(() => {
+        result.current(Field.INPUT, native)
+      })
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        SupportedChainId.MAINNET,
+        {
+          inputCurrencyId: native.symbol,
           outputCurrencyId: USDC_MAINNET.symbol,
         },
         undefined,

--- a/apps/cowswap-frontend/src/modules/trade/hooks/useNavigateOnCurrencySelection.ts
+++ b/apps/cowswap-frontend/src/modules/trade/hooks/useNavigateOnCurrencySelection.ts
@@ -1,10 +1,10 @@
 import { useCallback, useRef } from 'react'
 
 import { LpToken } from '@cowprotocol/common-const'
-import { getCurrencyAddress } from '@cowprotocol/common-utils'
+import { getCurrencyAddress, getIsNativeToken } from '@cowprotocol/common-utils'
 import { OrderKind } from '@cowprotocol/cow-sdk'
 import { Currency, Token } from '@cowprotocol/currency'
-import { useAreThereTokensWithSameSymbol } from '@cowprotocol/tokens'
+import { useAreThereTokensWithSameSymbol, useDoesSymbolResolveToToken } from '@cowprotocol/tokens'
 import { useWalletInfo } from '@cowprotocol/wallet'
 
 import { useBridgeSupportedNetworks } from 'entities/bridgeProvider'
@@ -168,15 +168,29 @@ export function useNavigateOnCurrencySelection(enableSellEqBuy = false): Currenc
 
 function useResolveCurrencyAddressOrSymbol(): (currency: Currency | null) => string | null {
   const areThereTokensWithSameSymbol = useAreThereTokensWithSameSymbol()
+  const doesSymbolResolveToToken = useDoesSymbolResolveToToken()
 
   return useCallback(
     (currency: Currency | null): string | null => {
       if (!currency) return null
 
-      return currency instanceof LpToken || areThereTokensWithSameSymbol(currency.symbol, currency.chainId)
-        ? (currency as Token).address
-        : currency.symbol || null
+      if (currency instanceof LpToken) return (currency as Token).address
+
+      const symbol = currency.symbol || null
+
+      // Native currencies are modelled as tokens with a fixed 0xeee... address, which is not a usable URL id
+      if (getIsNativeToken(currency)) return symbol
+
+      const { address, chainId } = currency as Token
+
+      // Prefer the address when the symbol is ambiguous, and also when it does not resolve back to this
+      // exact token: a token that is not active yet, or whose address is active under a different
+      // symbol, is unreachable by symbol and would re-trigger the import prompt forever.
+      const isSymbolUsable =
+        !areThereTokensWithSameSymbol(symbol, chainId) && doesSymbolResolveToToken(symbol, address, chainId)
+
+      return isSymbolUsable ? symbol : address
     },
-    [areThereTokensWithSameSymbol],
+    [areThereTokensWithSameSymbol, doesSymbolResolveToToken],
   )
 }

--- a/libs/tokens/src/hooks/tokens/useDoesSymbolResolveToToken.ts
+++ b/libs/tokens/src/hooks/tokens/useDoesSymbolResolveToToken.ts
@@ -1,0 +1,33 @@
+import { useAtomValue } from 'jotai'
+import { useCallback } from 'react'
+
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import { tokensBySymbolAtom } from '../../state/tokens/allTokensAtom'
+import { doesSymbolResolveToAddress } from '../../utils/tokenIdentity'
+
+export type DoesSymbolResolveToToken = (
+  symbol: string | null | undefined,
+  address: string | null | undefined,
+  chainId: SupportedChainId,
+) => boolean
+
+/**
+ * Whether a token can be referred to by its symbol, i.e. the symbol resolves back to that same address
+ * among the active tokens. See `doesSymbolResolveToAddress` for why that can be false.
+ *
+ * Returns `true` when the active token set is for another chain, so callers keep their previous
+ * behaviour instead of treating "cannot tell" as "does not resolve".
+ */
+export function useDoesSymbolResolveToToken(): DoesSymbolResolveToToken {
+  const tokensBySymbol = useAtomValue(tokensBySymbolAtom)
+
+  return useCallback(
+    (symbol, address, chainId) => {
+      if (tokensBySymbol.chainId !== chainId) return true
+
+      return doesSymbolResolveToAddress(tokensBySymbol.tokens, symbol, address)
+    },
+    [tokensBySymbol],
+  )
+}

--- a/libs/tokens/src/hooks/tokens/useSearchNonExistentToken.test.ts
+++ b/libs/tokens/src/hooks/tokens/useSearchNonExistentToken.test.ts
@@ -1,0 +1,62 @@
+import { TokenWithLogo } from '@cowprotocol/common-const'
+
+import { renderHook } from '@testing-library/react'
+
+import { useSearchNonExistentToken } from './useSearchNonExistentToken'
+import { useSearchToken } from './useSearchToken'
+import { useTokenBySymbolOrAddress } from './useTokenBySymbolOrAddress'
+import { useTokensByAddressMap } from './useTokensByAddressMap'
+
+jest.mock('./useSearchToken', () => ({ useSearchToken: jest.fn() }))
+jest.mock('./useTokenBySymbolOrAddress', () => ({ useTokenBySymbolOrAddress: jest.fn() }))
+jest.mock('./useTokensByAddressMap', () => ({ useTokensByAddressMap: jest.fn() }))
+
+const mockedUseSearchToken = useSearchToken as jest.MockedFunction<typeof useSearchToken>
+const mockedUseTokenBySymbolOrAddress = useTokenBySymbolOrAddress as jest.MockedFunction<
+  typeof useTokenBySymbolOrAddress
+>
+const mockedUseTokensByAddressMap = useTokensByAddressMap as jest.MockedFunction<typeof useTokensByAddressMap>
+
+// Real Base addresses: the Coinbase RWA list ships AAPL here, CoinGecko ships the same address as AAPLC
+const AAPL_ADDRESS = '0xb200000000000000000000C2e324d24d7eEcd1fb'
+
+const AAPL_FROM_INACTIVE_LIST = new TokenWithLogo(undefined, 8453, AAPL_ADDRESS, 18, 'AAPL', 'Apple')
+const AAPLC_ACTIVE = new TokenWithLogo(undefined, 8453, AAPL_ADDRESS.toLowerCase(), 18, 'AAPLC', 'Apple')
+
+function mockSearchResult(inactiveListsResult: TokenWithLogo[]): void {
+  mockedUseSearchToken.mockReturnValue({
+    isLoading: false,
+    activeListsResult: [],
+    inactiveListsResult,
+    externalApiResult: [],
+    blockchainResult: [],
+  })
+}
+
+describe('useSearchNonExistentToken', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // the symbol does not resolve among active tokens, which is what triggers the search
+    mockedUseTokenBySymbolOrAddress.mockReturnValue(null)
+  })
+
+  // Regression: AAPL only exists in an inactive list, but its address is already active as AAPLC.
+  // Returning it here made the import prompt reopen every time the user-added copy was pruned.
+  it('returns null when the found token address is already active under another symbol', () => {
+    mockSearchResult([AAPL_FROM_INACTIVE_LIST])
+    mockedUseTokensByAddressMap.mockReturnValue({ [AAPL_ADDRESS.toLowerCase()]: AAPLC_ACTIVE })
+
+    const { result } = renderHook(() => useSearchNonExistentToken('AAPL'))
+
+    expect(result.current).toBeNull()
+  })
+
+  it('still returns a token whose address is not active yet', () => {
+    mockSearchResult([AAPL_FROM_INACTIVE_LIST])
+    mockedUseTokensByAddressMap.mockReturnValue({})
+
+    const { result } = renderHook(() => useSearchNonExistentToken('AAPL'))
+
+    expect(result.current).toBe(AAPL_FROM_INACTIVE_LIST)
+  })
+})

--- a/libs/tokens/src/hooks/tokens/useSearchNonExistentToken.ts
+++ b/libs/tokens/src/hooks/tokens/useSearchNonExistentToken.ts
@@ -6,11 +6,14 @@ import { doesTokenMatchSymbolOrAddress } from '@cowprotocol/common-utils'
 
 import { useSearchToken } from './useSearchToken'
 import { useTokenBySymbolOrAddress } from './useTokenBySymbolOrAddress'
+import { useTokensByAddressMap } from './useTokensByAddressMap'
 
 import { tokenListsUpdatingAtom } from '../../state/tokenLists/tokenListsStateAtom'
+import { excludeAlreadyActiveTokens } from '../../utils/tokenIdentity'
 
 export function useSearchNonExistentToken(tokenId: string | null): TokenWithLogo | null {
   const tokenListsUpdating = useAtomValue(tokenListsUpdatingAtom)
+  const tokensByAddress = useTokensByAddressMap()
 
   const existingToken = useTokenBySymbolOrAddress(tokenId)
 
@@ -21,10 +24,13 @@ export function useSearchNonExistentToken(tokenId: string | null): TokenWithLogo
   return useMemo(() => {
     if (!inputTokenToSearch) return null
 
-    return (
-      [foundToken.inactiveListsResult, foundToken.externalApiResult, foundToken.blockchainResult]
-        .flat()
-        .filter((token) => !!token && doesTokenMatchSymbolOrAddress(token, inputTokenToSearch))[0] || null
-    )
-  }, [inputTokenToSearch, foundToken])
+    const matches = [foundToken.inactiveListsResult, foundToken.externalApiResult, foundToken.blockchainResult]
+      .flat()
+      .filter((token) => !!token && doesTokenMatchSymbolOrAddress(token, inputTokenToSearch))
+
+    // An address that is already active needs no import. Without this, a symbol that only exists in an
+    // inactive list keeps resolving to an importable token even though the address is already tradable,
+    // and the import prompt reopens every time the user-added copy is pruned as a duplicate.
+    return excludeAlreadyActiveTokens(matches, tokensByAddress)[0] || null
+  }, [inputTokenToSearch, foundToken, tokensByAddress])
 }

--- a/libs/tokens/src/index.ts
+++ b/libs/tokens/src/index.ts
@@ -54,6 +54,7 @@ export { useTokenBySymbolOrAddress } from './hooks/tokens/useTokenBySymbolOrAddr
 export { useTokenByAddress } from './hooks/tokens/useTokenByAddress'
 export { useTryFindToken } from './hooks/tokens/useTryFindToken'
 export { useAreThereTokensWithSameSymbol } from './hooks/tokens/useAreThereTokensWithSameSymbol'
+export { useDoesSymbolResolveToToken } from './hooks/tokens/useDoesSymbolResolveToToken'
 export { useSearchList } from './hooks/lists/useSearchList'
 export { useSearchToken } from './hooks/tokens/useSearchToken'
 export { useSearchNonExistentToken } from './hooks/tokens/useSearchNonExistentToken'
@@ -74,6 +75,7 @@ export { getTokenListViewLink } from './utils/getTokenListViewLink'
 export { getTokenLogoUrls } from './utils/getTokenLogoUrls'
 export { fetchTokenFromBlockchain } from './utils/fetchTokenFromBlockchain'
 export { getTokenSearchFilter } from './utils/getTokenSearchFilter'
+export { excludeAlreadyActiveTokens } from './utils/tokenIdentity'
 export { getChainCurrencySymbols } from './utils/getChainCurrencySymbols'
 
 // Services

--- a/libs/tokens/src/utils/tokenIdentity.test.ts
+++ b/libs/tokens/src/utils/tokenIdentity.test.ts
@@ -1,0 +1,60 @@
+import { TokenWithLogo } from '@cowprotocol/common-const'
+
+import { doesSymbolResolveToAddress, excludeAlreadyActiveTokens } from './tokenIdentity'
+
+// Real Base addresses: the Coinbase RWA list ships AAPL here, CoinGecko ships the same address as AAPLC
+const AAPL_ADDRESS = '0xb200000000000000000000C2e324d24d7eEcd1fb'
+const OTHER_ADDRESS = '0xb2000000000000000000002D0BA3164cc74f58B7'
+
+function token(symbol: string, address: string): TokenWithLogo {
+  return new TokenWithLogo(undefined, 8453, address, 18, symbol, symbol)
+}
+
+describe('doesSymbolResolveToAddress', () => {
+  it('resolves when the symbol maps back to the same address', () => {
+    const tokensBySymbol = { aapl: [token('AAPL', AAPL_ADDRESS)] }
+
+    expect(doesSymbolResolveToAddress(tokensBySymbol, 'AAPL', AAPL_ADDRESS)).toBe(true)
+  })
+
+  // The two lists ship the same address in different case: checksummed vs all-lowercase
+  it('matches a checksummed address against a lowercase one, and ignores symbol case', () => {
+    const tokensBySymbol = { aapl: [token('AAPL', AAPL_ADDRESS.toLowerCase())] }
+
+    expect(doesSymbolResolveToAddress(tokensBySymbol, 'aApL', AAPL_ADDRESS)).toBe(true)
+  })
+
+  // The regression: the address is active, but under AAPLC, so AAPL resolves to nothing
+  it('does not resolve when the address is active under a different symbol', () => {
+    const tokensBySymbol = { aaplc: [token('AAPLC', AAPL_ADDRESS)] }
+
+    expect(doesSymbolResolveToAddress(tokensBySymbol, 'AAPL', AAPL_ADDRESS)).toBe(false)
+  })
+
+  it('does not resolve when the symbol maps to a different address', () => {
+    const tokensBySymbol = { aapl: [token('AAPL', OTHER_ADDRESS)] }
+
+    expect(doesSymbolResolveToAddress(tokensBySymbol, 'AAPL', AAPL_ADDRESS)).toBe(false)
+  })
+
+  it('does not resolve for an unknown symbol or missing input', () => {
+    expect(doesSymbolResolveToAddress({}, 'AAPL', AAPL_ADDRESS)).toBe(false)
+    expect(doesSymbolResolveToAddress({}, null, AAPL_ADDRESS)).toBe(false)
+    expect(doesSymbolResolveToAddress({}, 'AAPL', undefined)).toBe(false)
+  })
+})
+
+describe('excludeAlreadyActiveTokens', () => {
+  it('drops tokens whose address is already active, regardless of address case', () => {
+    const importable = [token('AAPL', AAPL_ADDRESS), token('GOOGL', OTHER_ADDRESS)]
+    const tokensByAddress = { [AAPL_ADDRESS.toLowerCase()]: token('AAPLC', AAPL_ADDRESS.toLowerCase()) }
+
+    expect(excludeAlreadyActiveTokens(importable, tokensByAddress).map((t) => t.symbol)).toEqual(['GOOGL'])
+  })
+
+  it('keeps tokens that are not active', () => {
+    const importable = [token('AAPL', AAPL_ADDRESS)]
+
+    expect(excludeAlreadyActiveTokens(importable, {})).toHaveLength(1)
+  })
+})

--- a/libs/tokens/src/utils/tokenIdentity.ts
+++ b/libs/tokens/src/utils/tokenIdentity.ts
@@ -1,0 +1,41 @@
+import { TokenWithLogo } from '@cowprotocol/common-const'
+import { areAddressesEqual, getAddressKey } from '@cowprotocol/cow-sdk'
+
+import { TokensByAddress, TokensBySymbol } from '../state/tokens/allTokensAtom'
+
+/**
+ * Whether `symbol` resolves back to the token at `address`.
+ *
+ * `useTokenBySymbolOrAddress` resolves a symbol through `tokensBySymbolAtom`, which only holds active
+ * tokens and returns the first match. A token is therefore unreachable by symbol when it is not active
+ * yet, or when its address is active under a *different* symbol - the Coinbase RWA list ships `AAPL` at
+ * an address the CoinGecko list already ships as `AAPLC`. Referring to such a token by symbol produces
+ * a reference that stops resolving as soon as the user-added copy is pruned, which re-triggers the
+ * import prompt in a loop.
+ */
+export function doesSymbolResolveToAddress(
+  tokensBySymbol: TokensBySymbol,
+  symbol: string | null | undefined,
+  address: string | null | undefined,
+): boolean {
+  if (!symbol || !address) return false
+
+  const resolved = tokensBySymbol[symbol.toLowerCase()]?.[0]
+
+  if (!resolved) return false
+
+  return areAddressesEqual(resolved.address, address)
+}
+
+/**
+ * Drops tokens whose address is already among the active tokens.
+ *
+ * Used for the importable search buckets (inactive lists, external API, blockchain): an address that is
+ * already active needs no import, and offering one shows the same contract twice - once as a tradable
+ * token and once behind an "Import" button.
+ */
+export function excludeAlreadyActiveTokens(tokens: TokenWithLogo[], tokensByAddress: TokensByAddress): TokenWithLogo[] {
+  if (!tokens.length) return tokens
+
+  return tokens.filter((token) => !tokensByAddress[getAddressKey(token.address)])
+}


### PR DESCRIPTION
# Summary

Prevent issues when the same token address shows up in different lists with different symbols.
Also removes duplicated tokens showing up from different lists.

Not a RWA specific issue as first thought.

# To Test

1. Load the app on Base, from a non-restricted country
2. Search for `coinbase tokenized`
* You should not see duplicates
3. Pick a token that's not already loaded, and try to import it (for Coinback tokenized stocks, you'll need to disable all lists)
* Should import as usual

# Self-checks

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have manually tested changes on Vercel preview deployment
- [x] I have done self-review and (or) AI review
- [x] I have addressed all comments from @coderabbitai
- [ ] I have less than three open PRs/Stacks in this repo at the moment of creating this PR

## AI description 

<details>

## What changed

- The trade URL now carries a token's address instead of its symbol whenever the symbol does not resolve back to that exact token, not only when two active tokens share a symbol (`useNavigateOnCurrencySelection.ts`). Backed by a new `useDoesSymbolResolveToToken` hook over a pure `doesSymbolResolveToAddress`.
- `useSearchNonExistentToken` no longer returns an import candidate whose address is already active. If the contract is already tradable there is nothing to import.
- The token selector hides importable results (inactive lists, external API search, blockchain) whose address is already active, so one contract stops rendering twice with an `Import` button on the second copy.
- Native currencies keep using their symbol in the URL. They are modelled as tokens with the `0xEeee…` sentinel address, which is not a usable URL id.

## Why

On Base, importing a Coinbase RWA token left the import modal reopening forever, with `Removing user added tokens that already in token lists` in the console.

1. All four Coinbase tokens are in the **active** CoinGecko Base list at the same address under a different symbol: `AAPL` vs `AAPLC`.
3. Picking the RWA-list copy wrote the symbol into the URL (`#/8453/swap/WETH/AAPL`), because the old check only looked for two *active* tokens sharing a symbol, and the active twin is `AAPLC`.
4. `AAPL` then resolves to nothing among active tokens, so `useAutoImportTokensState` offers the import.
5. The import succeeds and `UserAddedTokensUpdater` immediately prunes it, correctly: that address is already active.
6. `AAPL` is unresolvable again, back to step 3. Loop.

It needed same address + *different* symbol + one of the lists active, which is why only Base hit it. Checked on Mainnet: Ondo shares 64 of 444 addresses with CoinGecko and xStocks 14 of 682, but every one of those is a case-only difference (`QBTSon`/`QBTSON`, `AAPLx`/`AAPLX`) that the lowercased symbol keys resolve fine. Only Coinbase's `AAPL`/`AAPLC` is a real mismatch.

Not RWA-specific: any inactive-list token sharing an address with a differently-symboled active token reproduces it.

## QA Testing

Preview URL QA:

- Original repro, on Base: open the token selector, search `coinbase tokenized`, pick a token and import it. It should import and the modal should close. The duplicated row should no longer appear at all.
- Coinbase `AAPL` by address, should resolve straight to the active token with no import prompt: https://swap-dev-git-fix-rwa-import-issue-cowswap-dev.vercel.app/#/8453/swap/USDC/0xb200000000000000000000C2e324d24d7eEcd1fb
- The previously broken symbol URL, should no longer loop; the buy field simply stays unset: https://swap-dev-git-fix-rwa-import-issue-cowswap-dev.vercel.app/#/8453/swap/USDC/AAPL
- Non-regression, a genuinely new token must still import. xStocks `BANKCx` on Mainnet, absent from the CowSwap, CoinGecko and Curve lists: https://swap-dev-git-fix-rwa-import-issue-cowswap-dev.vercel.app/#/1/swap/USDC/0xf758e87ca18824b767aa4f3ed58c188d3babe428

Developer verification:

- `libs/tokens/src/utils/tokenIdentity.test.ts`: 7 cases on the two pure helpers, including the `AAPL`/`AAPLC` mismatch and checksummed-vs-lowercase addresses.
- `apps/cowswap-frontend/src/modules/trade/hooks/useNavigateOnCurrencySelection.test.tsx`: adds the address-fallback and native-currency cases, 16 passing in that file.

Reviewer note:

- An RWA consent step may still appear before the import modal depending on geo and the geoblock flag. That is incidental to this fix; the failure was in token identity, not in the RWA flow.
- The `Removing user added tokens that already in token lists` log disappearing is a side effect of no longer offering the import, not a change to that pruning. `UserAddedTokensUpdater` is untouched and was behaving correctly.

## Risks

- The selector dedupe is visible beyond Base. On Mainnet roughly 78 Ondo and xStocks tokens share an address with the active CoinGecko list, so their inactive-list copies no longer show up as separate import candidates. Same contract, still tradable, but displayed with CoinGecko's symbol and metadata. Worth a product check if RWA-list branding in the selector matters.
- Trade URLs for any token not on an active list are now addresses rather than symbols. Existing symbol links keep working wherever the symbol still resolves.
- Native currencies previously fell back to the `0xEeee…` sentinel address in the URL when their symbol collided with a listed token, and now always use the symbol. Native is first in the active token list, so `ETH` resolves to the native currency.

## Preview URLs

| Surface | URL |
| --- | --- |
| swap-dev - branch preview URL | https://swap-dev-git-fix-rwa-import-issue-cowswap-dev.vercel.app |
| explorer-dev - branch preview URL | https://explorer-dev-git-fix-rwa-import-issue-cowswap-dev.vercel.app |
| storybook - branch preview URL | https://storybook-git-fix-rwa-import-issue-cowswap-dev.vercel.app |
| widget-configurator - branch preview URL | https://widget-configurator-git-fix-rwa-import-issue-cowswap-dev.vercel.app |
| sdk-tools - branch preview URL | https://sdk-tools-git-fix-rwa-import-issue-cowswap-dev.vercel.app |

---

AI usage: Claude traced the root cause, wrote the fixes and tests, and drafted this description from the checked diff and token-list data.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved token search results by hiding importable tokens that are already active.
  * Token selection now uses a token’s contract address when its symbol is ambiguous or does not uniquely identify it.
  * Native currencies continue to use their symbols during navigation.

* **Bug Fixes**
  * Prevented navigation to the wrong token when symbols overlap or resolve to a different token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->