### PR TITLE
fix: add bottom padding to AccountModal with no activity

### DIFF
--- a/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/styled.ts
+++ b/apps/cowswap-frontend/src/modules/account/containers/AccountDetails/styled.ts
@@ -324,7 +324,7 @@ export const NoActivityMessage = styled.p`
   font-size: 14px;
   color: inherit;
   width: 100%;
-  padding: 24px 0 0;
+  margin: 24px 0 0;
   text-align: center;
   display: flex;
   justify-content: center;
@@ -337,13 +337,14 @@ export const LowerSection = styled.div`
   align-items: flex-start;
   justify-content: flex-start;
   color: inherit;
+  padding: 0 0 48px;
 
   > div {
     display: flex;
     flex-flow: column wrap;
     width: 100%;
     background-color: inherit;
-    padding: 0 0 48px;
+    padding: 0;
     color: inherit;
 
     > ${StyledLink} {


### PR DESCRIPTION
# Summary

Add bottom padding to `AccountModal` with no activity, just like it has when there's activity below the "View all orders" link:

<img width="1404" height="819" alt="image" src="https://github.com/user-attachments/assets/c7f05af3-8618-48fc-a80c-4de850d36d9b" />

# To Test

Open the account modal on a network/wallet with no activity and verify there's a padding below the text at the bottom of the modal.
