### PR TITLE
fix(cow-fi): widget preview cuts off in default state

### DIFF
--- a/apps/cow-fi/app/(main)/widget/page.tsx
+++ b/apps/cow-fi/app/(main)/widget/page.tsx
@@ -51,7 +51,7 @@ const widgetParams: CowSwapWidgetParams = {
   appCode: 'CoW Protocol: Widget Demo',
   theme: 'light',
   standaloneMode: true,
-  rootStyle: { width: '100%' },
+  rootStyle: { width: '100%', height: 'var(--dynamicHeight)' },
 }
 
 export default function Page(): ReactNode {


### PR DESCRIPTION
## Summary
 Fixes https://nomevlabs.slack.com/archives/C0361CDG8GP/p1788179521542099
<img width="2489" height="1210" alt="image" src="https://github.com/user-attachments/assets/273d4dca-78ea-4a04-82b4-ea1664a1d51e" />


- The "Try it out!" widget demo on https://cow.fi/widget was clipped to a tiny scrollable box instead of showing the full widget in its default state, unlike https://widget.cow.fi/ which renders it correctly.
- Root cause: `apps/cow-fi/app/(main)/widget/page.tsx`'s `widgetParams.rootStyle` only set `width: '100%'`, with no `height`. `widget-lib`'s container only tracks the widget's real content height when `rootStyle.height` is `var(--dynamicHeight)` (updated via a postMessage listener as the iframe's content grows) — without it, the injected iframe's `height: 100%` has no definite parent height to resolve against, so it collapses to the browser's tiny default iframe size.


## Test plan
- [ ] Visit https://cowfi-git-fix-cow-fi-widget-height-cowswap.vercel.app/widget and confirm the demo widget renders at full height in its default state (Swap tab, sell/buy inputs, connect wallet — no internal scrollbar).
- [ ] Confirm the widget still resizes correctly when switching tabs/settings that change its content height (e.g. opening advanced settings).
<img width="1384" height="874" alt="image" src="https://github.com/user-attachments/assets/2227c62f-faed-4d83-bd5b-5ca145d7b558" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved widget layout behavior by allowing its height to adjust dynamically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->