### PR TITLE
fix(explorer): restore explorer's font size removed on the global reset

### DIFF
--- a/apps/explorer/src/theme/styles/global.ts
+++ b/apps/explorer/src/theme/styles/global.ts
@@ -11,6 +11,16 @@ export const StaticGlobalStyle = createGlobalStyle`
     appearance: auto;
   }
 
+  /* The shared reset's "font: inherit" resolves to body's 6.25px here (62.5% applied to html
+     and body both), so restore the ~13.3px UA default controls used to get. Real fix is body's font-size,
+     blocked on "line-height: 10px" below sharing that rule. */
+  button,
+  textarea,
+  select,
+  input:where(:not([type='checkbox'], [type='radio'], [type='range'])) {
+    font-size: 1.3rem;
+  }
+
   /* TEMPORARY: import variables */
   ${variables}
 

--- a/apps/explorer/src/theme/styles/global.ts
+++ b/apps/explorer/src/theme/styles/global.ts
@@ -11,14 +11,16 @@ export const StaticGlobalStyle = createGlobalStyle`
     appearance: auto;
   }
 
-  /* The shared reset's "font: inherit" resolves to body's 6.25px here (62.5% applied to html
-     and body both), so restore the ~13.3px UA default controls used to get. Real fix is body's font-size,
-     blocked on "line-height: 10px" below sharing that rule. */
+  /* The shared reset's "font: inherit" resolves to body's 6.25px font-size and 10px line-height here
+     (62.5% applied to html and body both), so restore the ~13.3px/normal UA defaults controls used to
+     get. Without the line-height a text button is 6px shorter with its glyphs cramped into a 10px line
+     box, and a textarea clips. Real fix is body's own font-size and line-height, too wide for now. */
   button,
   textarea,
   select,
   input:where(:not([type='checkbox'], [type='radio'], [type='range'])) {
     font-size: 1.3rem;
+    line-height: normal;
   }
 
   /* TEMPORARY: import variables */


### PR DESCRIPTION
# Summary

Restore Explorer's font size:

<img width="3440" height="1139" alt="Screenshot 2026-09-03 at 14 29 40" src="https://github.com/user-attachments/assets/f7530c91-32a0-4e77-8c13-aa14a848dde1" />

# To Test

1. Open Explorer Solvers page
2. Check the font size in the inputs
* Should be the same as current production
3. Check the rest of the Explorer app
* Fonts size should remain as it was

# Self-checks

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have manually tested changes on Vercel preview deployment
- [x] I have done self-review and (or) AI review
- [x] I have addressed all comments from @coderabbitai
- [x] I have less than three open PRs/Stacks in this repo at the moment of creating this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the default readable font size for buttons, text areas, dropdowns, and most text input fields in Explorer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->