### PR TITLE
fix: do not show partial approval when unsupported 

### DIFF
--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWidget/index.tsx
@@ -250,9 +250,10 @@ export function TwapFormWidget({ tradeWarnings }: TwapFormWidget): ReactNode {
 
       <AmountParts />
 
-      {tradeWarnings}
+      {/* Local validation replaces the trade button with a disabled one, so trade hints and approval controls
+          are pointless: only the warning explaining the block stays visible */}
+      {!localFormValidation && tradeWarnings}
       <TwapFormWarnings localFormValidation={localFormValidation} />
-      {/* Local validation replaces the trade button with a disabled one, so approval controls are pointless */}
       {isPrimaryValidationPassed && !localFormValidation && <TradeApproveWithAffectedOrderList />}
       <ActionButtons
         fallbackHandlerIsNotSet={isFallbackHandlerRequired}

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWidget/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWidget/index.tsx
@@ -252,7 +252,8 @@ export function TwapFormWidget({ tradeWarnings }: TwapFormWidget): ReactNode {
 
       {tradeWarnings}
       <TwapFormWarnings localFormValidation={localFormValidation} />
-      {isPrimaryValidationPassed && <TradeApproveWithAffectedOrderList />}
+      {/* Local validation replaces the trade button with a disabled one, so approval controls are pointless */}
+      {isPrimaryValidationPassed && !localFormValidation && <TradeApproveWithAffectedOrderList />}
       <ActionButtons
         fallbackHandlerIsNotSet={isFallbackHandlerRequired}
         localFormValidation={localFormValidation}


### PR DESCRIPTION
# Summary

Don't show partial approval modal when unsupported

# To Test

1. Connect EOA wallet
2. Pick as sell token one that needs approval
3. Setup a trade requiring approval
* SWAP and LIMIT forms should show the approval modal
4. Go to TWAP (where EOAs aren't supported yet)
* Approval modal shouldn't be displayed
* Unsupported wallet should be shown
<img width="830" height="1025" alt="image" src="https://github.com/user-attachments/assets/06c20cc6-34e2-4c12-a57b-e236586e566f" />


# Self-checks

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have manually tested changes on Vercel preview deployment
- [x] I have done self-review and (or) AI review
- [x] I have addressed all comments from @coderabbitai
- [x] I have less than three open PRs/Stacks in this repo at the moment of creating this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * TWAP trade warnings are now hidden while local form validation errors are displayed, keeping the most relevant validation message visible.
  * Approval controls remain unavailable until the primary validation succeeds and all local validation errors are resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->