### PR TITLE
feat: show eoa twap funding warnings

### DIFF
--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTable/Row/Group/OrdersTableRowGroup.pure.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/OrdersTable/Row/Group/OrdersTableRowGroup.pure.tsx
@@ -51,6 +51,7 @@ export interface OrdersTableRowGroupProps {
 
 // TODO: Break down this large function into smaller functions
 // TODO: Add proper return type annotation
+// eslint-disable-next-line max-lines-per-function
 export function OrdersTableRowGroup({
   item,
   prices,
@@ -101,6 +102,9 @@ export function OrdersTableRowGroup({
     balancesAndAllowances,
   }
 
+  const eoaTwapPartSellAmount = isEoaTwapOrder ? twapOrder?.order.partSellAmount : undefined
+  const parentOrderParams = getOrderParams(chainId, balancesAndAllowances, parent, undefined, eoaTwapPartSellAmount)
+
   // Create an array of child order data with their orderParams
   const childrenWithParams = buildChildrenWithParams(usesLocalChildren ? children : [], chainId, balancesAndAllowances)
 
@@ -111,7 +115,7 @@ export function OrdersTableRowGroup({
         key={parent.id}
         isRowSelected={isRowSelected}
         order={parent}
-        orderParams={getOrderParams(chainId, balancesAndAllowances, parent)}
+        orderParams={parentOrderParams}
         onClick={() => orderActions.selectReceiptOrder(parent)}
         isExpanded={!isCollapsed}
         childOrders={usesLocalChildren ? children : undefined}
@@ -126,6 +130,7 @@ export function OrdersTableRowGroup({
             onToggle={() => setIsCollapsed((state) => !state)}
             onClick={() => orderActions.selectReceiptOrder(parent)}
             childOrders={childrenWithParams}
+            parentOrderParams={parentOrderParams}
           />
         )}
       </OrderRow>
@@ -144,7 +149,13 @@ export function OrdersTableRowGroup({
               isChild={true}
               isRowSelected={false}
               order={child}
-              orderParams={getOrderParams(chainId, balancesAndAllowances, child)}
+              orderParams={getOrderParams(
+                chainId,
+                balancesAndAllowances,
+                child,
+                undefined,
+                isEoaTwapOrder ? child.sellAmount : undefined,
+              )}
               onClick={() => orderActions.selectReceiptOrder(child)}
             />
           ))}

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/TwapStatusAndToggle/TwapStatusAndToggle.pure.test.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/TwapStatusAndToggle/TwapStatusAndToggle.pure.test.tsx
@@ -70,18 +70,20 @@ function renderToggle(props: {
   parent: ParsedOrder
   isFallbackHandlerRequired?: boolean
   childOrders?: { order: ParsedOrder; orderParams: OrderParams }[]
+  parentOrderParams?: OrderParams
 }): void {
   render(
     <I18nProvider i18n={i18n}>
       <StyledComponentsThemeProvider theme={getCowswapTheme(false)}>
         <TwapStatusAndToggle
           parent={props.parent}
-          childrenLength={props.childOrders?.length ?? 0}
+          totalParts={props.childOrders?.length ?? 0}
           isCollapsed={true}
           isFallbackHandlerRequired={props.isFallbackHandlerRequired}
           onToggle={() => undefined}
           onClick={() => undefined}
           childOrders={props.childOrders ?? []}
+          parentOrderParams={props.parentOrderParams}
           approveOrderToken={() => undefined}
         />
       </StyledComponentsThemeProvider>
@@ -124,6 +126,30 @@ describe('TwapStatusAndToggle()', () => {
     })
 
     expect(screen.getByText('FALLBACK_HANDLER_WARNING')).not.toBeNull()
+    expect(screen.queryByText('BALANCE_ALLOWANCE_WARNING')).toBeNull()
+  })
+
+  it('surfaces a parent funding warning without loaded child orders', () => {
+    renderToggle({
+      parent: parentOrder({ status: OrderStatus.PENDING, isEoaTwapOrder: true }),
+      parentOrderParams: {
+        hasEnoughBalance: false,
+        hasEnoughAllowance: true,
+      } as OrderParams,
+    })
+
+    expect(screen.getByText('BALANCE_ALLOWANCE_WARNING')).not.toBeNull()
+  })
+
+  it('does not surface a funding warning once the parent is no longer open', () => {
+    renderToggle({
+      parent: parentOrder({ status: OrderStatus.FULFILLED, isEoaTwapOrder: true }),
+      parentOrderParams: {
+        hasEnoughBalance: false,
+        hasEnoughAllowance: false,
+      } as OrderParams,
+    })
+
     expect(screen.queryByText('BALANCE_ALLOWANCE_WARNING')).toBeNull()
   })
 })

--- a/apps/cowswap-frontend/src/modules/ordersTable/pure/TwapStatusAndToggle/TwapStatusAndToggle.pure.tsx
+++ b/apps/cowswap-frontend/src/modules/ordersTable/pure/TwapStatusAndToggle/TwapStatusAndToggle.pure.tsx
@@ -29,6 +29,7 @@ interface TwapStatusAndToggleProps {
   onToggle: () => void
   onClick: () => void
   childOrders: ChildOrderItems[]
+  parentOrderParams?: OrderParams
   approveOrderToken(token: Token): void
 }
 
@@ -42,8 +43,14 @@ export function TwapStatusAndToggle({
   onToggle,
   onClick,
   childOrders,
+  parentOrderParams,
   approveOrderToken,
 }: TwapStatusAndToggleProps) {
+  const isParentOpen = parent.status === OrderStatus.PENDING || parent.status === OrderStatus.SCHEDULED
+  const hasParentAllowanceWarning = isParentOpen && parentOrderParams?.hasEnoughAllowance === false
+  const hasParentBalanceWarning = isParentOpen && parentOrderParams?.hasEnoughBalance === false
+  const hasParentFundingWarning = isParentOpen && (hasParentAllowanceWarning || hasParentBalanceWarning)
+
   // Check if any child has insufficient balance or allowance
   const childWithAllowanceWarning = childOrders.find(
     (child) =>
@@ -70,10 +77,18 @@ export function TwapStatusAndToggle({
       <OrderStatusBox
         order={parent}
         onClick={onClick}
-        withWarning={!!warningChild || isFallbackHandlerBlocked}
+        withWarning={hasParentFundingWarning || !!warningChild || isFallbackHandlerBlocked}
         WarningTooltip={
           isFallbackHandlerBlocked ? (
             <FallbackHandlerWarningTooltip />
+          ) : hasParentFundingWarning ? (
+            <WarningTooltip
+              hasEnoughBalance={!hasParentBalanceWarning}
+              hasEnoughAllowance={!hasParentAllowanceWarning}
+              inputTokenSymbol={parent.inputToken.symbol || ''}
+              isOrderScheduled={parent.status === OrderStatus.SCHEDULED}
+              onApprove={() => approveOrderToken(parent.inputToken)}
+            />
           ) : warningChild ? (
             <WarningTooltip
               hasEnoughBalance={!childWithBalanceWarning}

--- a/apps/cowswap-frontend/src/modules/ordersTable/state/ordersTable.atoms.test.ts
+++ b/apps/cowswap-frontend/src/modules/ordersTable/state/ordersTable.atoms.test.ts
@@ -402,8 +402,14 @@ describe('observeReduxOrders', () => {
     const account = '0x2222222222222222222222222222222222222222'
     const spender = '0x3333333333333333333333333333333333333333'
     const tokenAddress = '0x1111111111111111111111111111111111111111'
-    const emulatedTwapOrder = { id: 'emulated-twap', status: OrderStatus.PENDING, isEoaTwapOrder: true }
-    const safeTwapOrder = { id: 'safe-twap', status: OrderStatus.PENDING }
+    const inputToken = { address: tokenAddress }
+    const emulatedTwapOrder = {
+      id: 'emulated-twap',
+      status: OrderStatus.PENDING,
+      isEoaTwapOrder: true,
+      inputToken,
+    }
+    const safeTwapOrder = { id: 'safe-twap', status: OrderStatus.PENDING, inputToken }
     const emulatedPartOrder = { id: 'emulated-part', status: OrderStatus.PENDING }
     const virtualPartOrder = {
       composableCowInfo: { isVirtualPart: true },
@@ -440,7 +446,7 @@ describe('observeReduxOrders', () => {
       lastCheckedBlock: 123,
     })
     ;(getReduxOrdersByOrderTypeFromNetworkState as jest.Mock).mockReturnValue({
-      ordersTokensSet: new Set([tokenAddress]),
+      ordersTokensSet: new Set(),
       reduxOrders: [virtualPartOrder, discreteTwapOrder],
     })
     getOrdersTableList.mockReturnValue(ordersList)
@@ -475,6 +481,13 @@ describe('observeReduxOrders', () => {
       account,
       reduxOrdersStateInCurrentChain: { lastCheckedBlock: 123 },
       uiOrderType: UiOrderType.TWAP,
+    })
+    expect(tokenAllowancesFamily).toHaveBeenLastCalledWith({
+      connector,
+      chainId: 1,
+      account,
+      spender,
+      tokenAddresses: [tokenAddress],
     })
     expect(getOrdersTableList).toHaveBeenCalledWith(
       expectedReduxOrders,

--- a/apps/cowswap-frontend/src/modules/ordersTable/state/ordersTable.atoms.ts
+++ b/apps/cowswap-frontend/src/modules/ordersTable/state/ordersTable.atoms.ts
@@ -12,6 +12,7 @@ import {
 } from '@cowprotocol/balances-and-allowances'
 import { COW_PROTOCOL_VAULT_RELAYER_ADDRESS } from '@cowprotocol/common-utils'
 import { jotaiStore } from '@cowprotocol/core'
+import { getAddressKey } from '@cowprotocol/cow-sdk'
 import { UiOrderType } from '@cowprotocol/types'
 import { walletInfoAtom } from '@cowprotocol/wallet'
 
@@ -212,6 +213,7 @@ export function observeReduxOrders(get: Getter, set: Setter): void {
     const discreteTwapOrders = reduxOrders.filter((order) => order.composableCowInfo?.isVirtualPart === false)
 
     reduxOrders = emulatedTwapOrders.concat(emulatedPartOrders, discreteTwapOrders)
+    emulatedTwapOrders.forEach((order) => ordersTokensSet.add(getAddressKey(order.inputToken.address)))
   }
 
   logOrdersTableDebug(`2. reduxOrders (${orderType} / ${uiOrderType}) =`, reduxOrders)

--- a/apps/cowswap-frontend/src/modules/ordersTable/utils/getOrderParams.test.ts
+++ b/apps/cowswap-frontend/src/modules/ordersTable/utils/getOrderParams.test.ts
@@ -118,4 +118,58 @@ describe('getOrderParams', () => {
     expect(result.hasEnoughBalance).toBeUndefined()
     expect(result.hasEnoughAllowance).toBeUndefined()
   })
+
+  describe('EOA TWAP JIT funding', () => {
+    const PART_SELL_AMOUNT = '100'
+    const EOA_TWAP_ORDER = {
+      ...BASE_ORDER,
+      isEoaTwapOrder: true,
+      partiallyFillable: true,
+    }
+
+    function funding(balance?: bigint, allowance?: bigint): BalancesAndAllowances {
+      const tokenKey = BASE_ORDER.inputToken.address.toLowerCase()
+
+      return {
+        balances: balance === undefined ? {} : { [tokenKey]: balance },
+        allowances: allowance === undefined ? {} : { [tokenKey]: allowance },
+        isLoading: false,
+      }
+    }
+
+    it('checks the next part amount instead of the full TWAP amount', () => {
+      const result = getOrderParams(1, funding(100n, 100n), EOA_TWAP_ORDER, undefined, PART_SELL_AMOUNT)
+
+      expect(result.hasEnoughBalance).toBe(true)
+      expect(result.hasEnoughAllowance).toBe(true)
+    })
+
+    it('reports insufficient balance for the next part', () => {
+      const result = getOrderParams(1, funding(99n, 100n), EOA_TWAP_ORDER, undefined, PART_SELL_AMOUNT)
+
+      expect(result.hasEnoughBalance).toBe(false)
+      expect(result.hasEnoughAllowance).toBe(true)
+    })
+
+    it('reports insufficient allowance for the next part', () => {
+      const result = getOrderParams(1, funding(100n, 99n), EOA_TWAP_ORDER, undefined, PART_SELL_AMOUNT)
+
+      expect(result.hasEnoughBalance).toBe(true)
+      expect(result.hasEnoughAllowance).toBe(false)
+    })
+
+    it('does not report a warning when JIT funding data is missing', () => {
+      const result = getOrderParams(1, funding(), EOA_TWAP_ORDER, undefined, PART_SELL_AMOUNT)
+
+      expect(result.hasEnoughBalance).toBeUndefined()
+      expect(result.hasEnoughAllowance).toBeUndefined()
+    })
+
+    it('requires the full next part even when the parent is partially fillable', () => {
+      const result = getOrderParams(1, funding(1n, 1n), EOA_TWAP_ORDER, undefined, PART_SELL_AMOUNT)
+
+      expect(result.hasEnoughBalance).toBe(false)
+      expect(result.hasEnoughAllowance).toBe(false)
+    })
+  })
 })

--- a/apps/cowswap-frontend/src/modules/ordersTable/utils/getOrderParams.ts
+++ b/apps/cowswap-frontend/src/modules/ordersTable/utils/getOrderParams.ts
@@ -20,21 +20,27 @@ export interface OrderParams {
 
 const PERCENTAGE_FOR_PARTIAL_FILLS = new Percent(5, 10000) // 0.05%
 
+// eslint-disable-next-line complexity
 export function getOrderParams(
   chainId: SupportedChainId,
   balancesAndAllowances: BalancesAndAllowances,
   order: ParsedOrder,
   pendingOrdersPermitValidityState?: PendingOrdersPermitValidityState,
+  eoaTwapPartSellAmount?: string,
 ): OrderParams {
   const isOrderAtLeastOnceFilled = order.executionData.filledAmount.gt(0)
   const sellAmount = CurrencyAmount.fromRawAmount(order.inputToken, order.sellAmount)
+  const eoaTwapFundingAmount = order.isEoaTwapOrder === true ? eoaTwapPartSellAmount : undefined
+  const shouldCheckFunding = order.isEoaTwapOrder !== true || eoaTwapFundingAmount !== undefined
+  const fundingAmount = CurrencyAmount.fromRawAmount(order.inputToken, eoaTwapFundingAmount ?? order.sellAmount)
   const buyAmount = CurrencyAmount.fromRawAmount(order.outputToken, order.buyAmount)
   const isPermitInvalid = pendingOrdersPermitValidityState
     ? pendingOrdersPermitValidityState[order.id] === false
     : false
-  const shouldCheckFunding = order.isEoaTwapOrder !== true
   const permitAmount =
-    shouldCheckFunding && !isPermitInvalid ? getOrderPermitAmount(chainId, order) || undefined : undefined
+    shouldCheckFunding && order.isEoaTwapOrder !== true && !isPermitInvalid
+      ? getOrderPermitAmount(chainId, order) || undefined
+      : undefined
 
   const rateInfoParams: RateInfoParams = {
     chainId,
@@ -49,8 +55,8 @@ export function getOrderParams(
   const allowance = shouldCheckFunding ? allowances[getAddressKey(order.inputToken.address)] : undefined
 
   const { hasEnoughBalance, hasEnoughAllowance } = _hasEnoughBalanceAndAllowance({
-    partiallyFillable: order.partiallyFillable,
-    sellAmount,
+    partiallyFillable: eoaTwapFundingAmount === undefined && order.partiallyFillable,
+    sellAmount: fundingAmount,
     balance,
     // If the order has been filled at least once, we should not consider the permit amount
     allowance: !isOrderAtLeastOnceFilled ? getBiggerAmount(allowance, permitAmount) : allowance,

--- a/apps/cowswap-frontend/src/modules/twap/updaters/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/updaters/index.tsx
@@ -18,6 +18,7 @@ import { QuoteObserverUpdater } from './QuoteObserverUpdater'
 import { QuoteParamsUpdater } from './QuoteParamsUpdater'
 import { TwapOrdersUpdater } from './TwapOrdersUpdater'
 
+import { COMPOSABLE_COW_POLLER_ADDRESS } from '../composable-cow-poller/composable-cow-poller.constants'
 import { useTwapSlippage } from '../hooks/useTwapSlippage'
 
 export function TwapUpdaters(): ReactNode {
@@ -28,10 +29,15 @@ export function TwapUpdaters(): ReactNode {
   const twapOrderSlippage = useTwapSlippage()
   const { enablePartialApprovalBySettings } = useAtomValue(advancedOrdersSettingsAtom)
 
-  const shouldLoadTwapOrders = !!((isSafeWallet || isSafeViaWc) && account && composableCowContract.address)
+  const isSafe = isSafeWallet || isSafeViaWc
+  const shouldLoadTwapOrders = !!(isSafe && account && composableCowContract.address)
   const composableCowChainId = composableCowContract.chainId
-  // TWAP orders always approve against the production vault relayer regardless of the current environment.
-  const spenderAddress = chainId ? COW_PROTOCOL_VAULT_RELAYER_ADDRESS_PROD[chainId] : undefined
+  // Safe funds settle through the Vault Relayer; EOA funds are pulled just in time by the poller.
+  const spenderAddress = chainId
+    ? isSafe
+      ? COW_PROTOCOL_VAULT_RELAYER_ADDRESS_PROD[chainId]
+      : COMPOSABLE_COW_POLLER_ADDRESS[chainId]
+    : undefined
 
   return (
     <>


### PR DESCRIPTION
# Summary

Fixes [[FE-348](https://linear.app/cowswap/issue/FE-348/add-eoa-twap-balance-and-allowance-warnings)](https://linear.app/cowswap/issue/FE-348/add-eoa-twap-balance-and-allowance-warnings)

Adds balance and allowance warnings for EOA TWAPs, based on the tokens required for the next part. Reuses the existing TWAP warning and approval UI.

# To Test

1. Connect an EOA wallet and create a TWAP.

- [x] The parent row shows no funding warning when balance and Poller allowance cover the next part.

2. Reduce the sell-token balance below one part’s amount.

- [x] The parent row shows an insufficient-balance warning, including when collapsed.
- [x] Restore enough tokens; the warning disappears after refresh.

<img width="1723" height="321" alt="image" src="https://github.com/user-attachments/assets/3bc3d466-d2e1-43c5-b4a3-f640503b18e7" />

3. Revoke or reduce the sell-token allowance for `ComposableCowPoller`.

- [x] The parent row shows an insufficient-allowance warning.
- [x] The warning’s Approve action requests approval for the Poller.
- [ ] After approval confirms, the warning disappears after refresh.

<img width="1223" height="157" alt="image" src="https://github.com/user-attachments/assets/838f2a66-1c9f-46ea-95ed-8e3e27863280" />


# Background

EOA TWAPs pull funds from the wallet just before each part executes. Checks therefore use the wallet’s balance and Poller allowance for one part.

The table’s allowance query now includes indexed TWAP sell tokens. Previously, missing tokens left allowance unknown and suppressed warnings.

The warning’s approval action retains the existing unlimited-approval behavior used by Safe TWAPs.

# Self-checks

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have manually tested changes on Vercel preview deployment
- [x] I have done self-review and (or) AI review
- [x] I have addressed all comments from @coderabbitai
- [x] I have less than three open PRs/Stacks in this repo at the moment of creating this PR




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TWAP order funding checks by evaluating the next order part’s required balance and allowance.
  - Added clearer warnings and approval actions when parent TWAP orders lack sufficient funding.
  - Ensured token allowances are loaded for emulated TWAP orders.
  - Corrected approval spender selection for safe wallets and externally owned accounts.
  - Prevented funding warnings from appearing when parent orders are no longer open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->