### PR TITLE
feat: fetch twap deltas

### DIFF
--- a/apps/cowswap-frontend/package.json
+++ b/apps/cowswap-frontend/package.json
@@ -57,7 +57,7 @@
     "@cowprotocol/sdk-trading": "2.4.1",
     "@cowprotocol/sdk-trading-solana": "0.4.1",
     "@cowprotocol/sdk-viem-adapter": "0.3.28",
-    "@cowprotocol/sdk-composable": "1.4.2",
+    "@cowprotocol/sdk-composable": "1.5.0",
     "@cowprotocol/snackbars": "workspace:*",
     "@cowprotocol/tokens": "workspace:*",
     "@cowprotocol/types": "workspace:*",

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useEoaTwapPartOrders.test.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useEoaTwapPartOrders.test.tsx
@@ -75,7 +75,7 @@ function makePartPage(uid: string, status: TwapPartOrderStatus = 'fulfilled'): Q
   }
 }
 
-function makeTwapOrder(partOrdersCount = 1): TwapOrderItem {
+function makeTwapOrder(partOrdersCount = 1, updatedAtBlock = '1'): TwapOrderItem {
   return {
     id: 'event',
     hash: 'hash',
@@ -85,6 +85,7 @@ function makeTwapOrder(partOrdersCount = 1): TwapOrderItem {
     status: TwapOrderStatus.Pending,
     submissionDate: new Date(0).toISOString(),
     partOrdersCount,
+    updatedAtBlock,
     order: {
       sellToken: parent.inputToken.address,
       buyToken: parent.outputToken.address,
@@ -181,30 +182,21 @@ describe('useEoaTwapPartOrders', () => {
     expect(fetchEoaTwapPartOrdersMock).toHaveBeenCalledTimes(1)
   })
 
-  it('refreshes an expanded part page', async () => {
-    jest.useFakeTimers()
+  it('refreshes an expanded part page when the parent cursor changes', async () => {
     fetchEoaTwapPartOrdersMock
       .mockResolvedValueOnce(makePartPage('stale-part'))
       .mockResolvedValueOnce(makePartPage('updated-part'))
+    const { result, rerender } = renderHook(({ twapOrder }) => useEoaTwapPartOrders(twapOrder, parent, 1, true), {
+      initialProps: { twapOrder: makeTwapOrder() },
+      wrapper: SwrTestProvider,
+    })
 
-    try {
-      const { result } = renderHook(() => useEoaTwapPartOrders(makeTwapOrder(), parent, 1, true), {
-        wrapper: SwrTestProvider,
-      })
+    await waitFor(() => expect(result.current.orders[0]?.id).toBe('stale-part'))
 
-      await act(async () => {
-        await jest.advanceTimersByTimeAsync(0)
-      })
-      expect(result.current.orders[0]?.id).toBe('stale-part')
+    rerender({ twapOrder: makeTwapOrder(1, '2') })
 
-      await act(async () => {
-        await jest.advanceTimersByTimeAsync(30_000)
-      })
-      expect(result.current.orders[0]?.id).toBe('updated-part')
-      expect(fetchEoaTwapPartOrdersMock).toHaveBeenCalledTimes(2)
-    } finally {
-      jest.useRealTimers()
-    }
+    await waitFor(() => expect(result.current.orders[0]?.id).toBe('updated-part'))
+    expect(fetchEoaTwapPartOrdersMock).toHaveBeenCalledTimes(2)
   })
 
   it('refreshes parts when the parent status changes', async () => {

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useEoaTwapPartOrders.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useEoaTwapPartOrders.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 
-import { ORDER_BOOK_API_UPDATE_INTERVAL, SWR_NO_REFRESH_OPTIONS } from '@cowprotocol/common-const'
+import { SWR_NO_REFRESH_OPTIONS } from '@cowprotocol/common-const'
 import { logTwap, normalizeError } from '@cowprotocol/common-utils'
 import {
   type EnrichedOrder,
@@ -45,6 +45,7 @@ export function useEoaTwapPartOrders(
           page,
           ORDERS_TABLE_PAGE_SIZE,
           partOrdersCount,
+          twapOrder.updatedAtBlock,
           twapOrder.status,
           twapOrder.executionInfo,
         ] as const)
@@ -71,7 +72,6 @@ export function useEoaTwapPartOrders(
     },
     {
       ...SWR_NO_REFRESH_OPTIONS,
-      refreshInterval: ORDER_BOOK_API_UPDATE_INTERVAL,
       shouldRetryOnError: false,
     },
   )

--- a/apps/cowswap-frontend/src/modules/twap/services/programmaticOrdersApi.ts
+++ b/apps/cowswap-frontend/src/modules/twap/services/programmaticOrdersApi.ts
@@ -45,19 +45,17 @@ class ProgrammaticOrdersApi {
     resolvedOwner: string,
     chainId: SupportedChainId,
     updatedAtBlock: string,
-    knownOrderIds: ReadonlySet<string>,
   ): Promise<EoaTwapOrdersDelta> {
     const cursor = BigInt(updatedAtBlock)
     const { items } = await this.api.getTwapOrders(
       { resolvedOwner, chainId, updatedAtBlockGte: cursor },
       { limit: 1000 },
     )
-    const changedItems = items.filter((item) => item.updatedAtBlock > cursor || !knownOrderIds.has(item.eventId))
 
-    logTwap.debug('Polled TWAP delta', changedItems.length)
+    logTwap.debug('Polled TWAP delta', items.length)
 
     return {
-      orders: mapTwapOrders(changedItems),
+      orders: mapTwapOrders(items),
       updatedAtBlock: getLatestUpdatedAtBlock(items, cursor).toString(),
     }
   }

--- a/apps/cowswap-frontend/src/modules/twap/services/programmaticOrdersApi.ts
+++ b/apps/cowswap-frontend/src/modules/twap/services/programmaticOrdersApi.ts
@@ -1,7 +1,7 @@
 import { logTwap } from '@cowprotocol/common-utils'
 import type { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { ProgrammaticOrderApi } from '@cowprotocol/sdk-composable'
-import type { QueryPage, TwapPartOrder } from '@cowprotocol/sdk-composable'
+import type { QueryPage, TwapOrder, TwapPartOrder } from '@cowprotocol/sdk-composable'
 
 import { getTwapOrderStatus } from '../utils/getTwapOrderStatus'
 
@@ -11,6 +11,14 @@ import type { TwapOrdersList } from 'entities/twap'
 const PROGRAMMATIC_ORDERS_API_URL =
   process.env.REACT_APP_PROGRAMMATIC_ORDERS_API_URL || 'https://programmatic-orders.cow.fi/'
 
+type EoaTwapOrdersDelta = Omit<EoaTwapOrdersResult, 'totalCount'>
+
+interface EoaTwapOrdersResult {
+  orders: TwapOrdersList
+  totalCount: number
+  updatedAtBlock: string
+}
+
 class ProgrammaticOrdersApi {
   private readonly api = new ProgrammaticOrderApi({ apiUrl: PROGRAMMATIC_ORDERS_API_URL })
 
@@ -18,65 +26,40 @@ class ProgrammaticOrdersApi {
     resolvedOwner: string,
     chainId: SupportedChainId,
     limit: number,
-  ): Promise<{ orders: TwapOrdersList; totalCount: number }> {
+  ): Promise<EoaTwapOrdersResult> {
     const { items: twapOrders, totalCount } = await this.api.getTwapOrders(
       { resolvedOwner, chainId },
       { direction: 'desc', limit },
     )
-    const orders = twapOrders.reduce<TwapOrdersList>((result, twapOrder) => {
-      const { schedule, executedAmounts } = twapOrder
-      const order: TWAPOrderStruct = {
-        sellToken: schedule.sellToken,
-        buyToken: schedule.buyToken,
-        receiver: schedule.receiver,
-        partSellAmount: schedule.partSellAmount.toString(),
-        minPartLimit: schedule.minPartLimit.toString(),
-        t0: schedule.effectiveStartTime,
-        n: schedule.numberOfParts,
-        t: schedule.timeBetweenParts,
-        span: schedule.durationOfPart,
-        appData: schedule.appData,
-      }
-      const executionInfo = {
-        // TODO rename this to isCompleted, this is its only purpose and it is confusing to have a count of confirmed parts when we only ever use it as a boolean
-        confirmedPartsCount: twapOrder.status === 'Completed' ? schedule.numberOfParts : 0,
-        info: {
-          executedSellAmount: executedAmounts.executedSellAmount.toString(),
-          executedBuyAmount: executedAmounts.executedBuyAmount.toString(),
-          executedFeeAmount: executedAmounts.executedFeeAmount.toString(),
-        },
-      }
-      const createdAt = new Date(twapOrder.createdAt * 1000)
-
-      result[twapOrder.eventId] = {
-        id: twapOrder.eventId,
-        hash: twapOrder.hash,
-        chainId: twapOrder.chainId,
-        safeAddress: twapOrder.owner,
-        resolvedOwner: twapOrder.resolvedOwner,
-        order,
-        status: getTwapOrderStatus({
-          execution: executionInfo,
-          executionDate: createdAt,
-          isCancelled: twapOrder.status === 'Cancelled',
-          isWaitingForSignature: false,
-          order,
-        }),
-        submissionDate: createdAt.toISOString(),
-        executedDate: createdAt.toISOString(),
-        partOrdersCount: twapOrder.partOrdersCount,
-        executionInfo,
-      }
-
-      return result
-    }, {})
+    const orders = mapTwapOrders(twapOrders)
 
     logTwap.debug('Fetched EOA TWAP orders', {
       chainId,
       orderCount: Object.keys(orders).length,
     })
 
-    return { orders, totalCount }
+    return { orders, totalCount, updatedAtBlock: getLatestUpdatedAtBlock(twapOrders).toString() }
+  }
+
+  async fetchChangedEoaTwapOrders(
+    resolvedOwner: string,
+    chainId: SupportedChainId,
+    updatedAtBlock: string,
+    knownOrderIds: ReadonlySet<string>,
+  ): Promise<EoaTwapOrdersDelta> {
+    const cursor = BigInt(updatedAtBlock)
+    const { items } = await this.api.getTwapOrders(
+      { resolvedOwner, chainId, updatedAtBlockGte: cursor },
+      { limit: 1000 },
+    )
+    const changedItems = items.filter((item) => item.updatedAtBlock > cursor || !knownOrderIds.has(item.eventId))
+
+    logTwap.debug('Polled TWAP delta', changedItems.length)
+
+    return {
+      orders: mapTwapOrders(changedItems),
+      updatedAtBlock: getLatestUpdatedAtBlock(items, cursor).toString(),
+    }
   }
 
   fetchEoaTwapPartOrders(
@@ -107,6 +90,64 @@ class ProgrammaticOrdersApi {
 
     return latestPart?.status === 'open' ? latestPart : undefined
   }
+}
+
+function getLatestUpdatedAtBlock(twapOrders: TwapOrder[], initialValue = 0n): bigint {
+  return twapOrders.reduce(
+    (latest, order) => (order.updatedAtBlock > latest ? order.updatedAtBlock : latest),
+    initialValue,
+  )
+}
+
+function mapTwapOrders(twapOrders: TwapOrder[]): TwapOrdersList {
+  return twapOrders.reduce<TwapOrdersList>((result, twapOrder) => {
+    const { schedule, executedAmounts } = twapOrder
+    const order: TWAPOrderStruct = {
+      sellToken: schedule.sellToken,
+      buyToken: schedule.buyToken,
+      receiver: schedule.receiver,
+      partSellAmount: schedule.partSellAmount.toString(),
+      minPartLimit: schedule.minPartLimit.toString(),
+      t0: schedule.effectiveStartTime,
+      n: schedule.numberOfParts,
+      t: schedule.timeBetweenParts,
+      span: schedule.durationOfPart,
+      appData: schedule.appData,
+    }
+    const executionInfo = {
+      // TODO rename this to isCompleted, this is its only purpose and it is confusing to have a count of confirmed parts when we only ever use it as a boolean
+      confirmedPartsCount: twapOrder.status === 'Completed' ? schedule.numberOfParts : 0,
+      info: {
+        executedSellAmount: executedAmounts.executedSellAmount.toString(),
+        executedBuyAmount: executedAmounts.executedBuyAmount.toString(),
+        executedFeeAmount: executedAmounts.executedFeeAmount.toString(),
+      },
+    }
+    const createdAt = new Date(twapOrder.createdAt * 1000)
+
+    result[twapOrder.eventId] = {
+      id: twapOrder.eventId,
+      hash: twapOrder.hash,
+      chainId: twapOrder.chainId,
+      safeAddress: twapOrder.owner,
+      resolvedOwner: twapOrder.resolvedOwner,
+      order,
+      status: getTwapOrderStatus({
+        execution: executionInfo,
+        executionDate: createdAt,
+        isCancelled: twapOrder.status === 'Cancelled',
+        isWaitingForSignature: false,
+        order,
+      }),
+      submissionDate: createdAt.toISOString(),
+      executedDate: createdAt.toISOString(),
+      partOrdersCount: twapOrder.partOrdersCount,
+      updatedAtBlock: twapOrder.updatedAtBlock.toString(),
+      executionInfo,
+    }
+
+    return result
+  }, {})
 }
 
 export const programmaticOrdersApi = new ProgrammaticOrdersApi()

--- a/apps/cowswap-frontend/src/modules/twap/services/programmaticOrdersApi.ts
+++ b/apps/cowswap-frontend/src/modules/twap/services/programmaticOrdersApi.ts
@@ -31,14 +31,14 @@ class ProgrammaticOrdersApi {
       { resolvedOwner, chainId },
       { direction: 'desc', limit },
     )
-    const orders = mapTwapOrders(twapOrders)
+    const { orders, updatedAtBlock } = mapTwapOrders(twapOrders)
 
     logTwap.debug('Fetched EOA TWAP orders', {
       chainId,
       orderCount: Object.keys(orders).length,
     })
 
-    return { orders, totalCount, updatedAtBlock: getLatestUpdatedAtBlock(twapOrders).toString() }
+    return { orders, totalCount, updatedAtBlock }
   }
 
   async fetchChangedEoaTwapOrders(
@@ -54,10 +54,7 @@ class ProgrammaticOrdersApi {
 
     logTwap.debug('Polled TWAP delta', items.length)
 
-    return {
-      orders: mapTwapOrders(items),
-      updatedAtBlock: getLatestUpdatedAtBlock(items, cursor).toString(),
-    }
+    return mapTwapOrders(items, cursor)
   }
 
   fetchEoaTwapPartOrders(
@@ -90,15 +87,9 @@ class ProgrammaticOrdersApi {
   }
 }
 
-function getLatestUpdatedAtBlock(twapOrders: TwapOrder[], initialValue = 0n): bigint {
-  return twapOrders.reduce(
-    (latest, order) => (order.updatedAtBlock > latest ? order.updatedAtBlock : latest),
-    initialValue,
-  )
-}
-
-function mapTwapOrders(twapOrders: TwapOrder[]): TwapOrdersList {
-  return twapOrders.reduce<TwapOrdersList>((result, twapOrder) => {
+function mapTwapOrders(twapOrders: TwapOrder[], updatedAtBlock = 0n): EoaTwapOrdersDelta {
+  const orders: TwapOrdersList = {}
+  for (const twapOrder of twapOrders) {
     const { schedule, executedAmounts } = twapOrder
     const order: TWAPOrderStruct = {
       sellToken: schedule.sellToken,
@@ -123,7 +114,7 @@ function mapTwapOrders(twapOrders: TwapOrder[]): TwapOrdersList {
     }
     const createdAt = new Date(twapOrder.createdAt * 1000)
 
-    result[twapOrder.eventId] = {
+    orders[twapOrder.eventId] = {
       id: twapOrder.eventId,
       hash: twapOrder.hash,
       chainId: twapOrder.chainId,
@@ -144,8 +135,10 @@ function mapTwapOrders(twapOrders: TwapOrder[]): TwapOrdersList {
       executionInfo,
     }
 
-    return result
-  }, {})
+    if (twapOrder.updatedAtBlock > updatedAtBlock) updatedAtBlock = twapOrder.updatedAtBlock
+  }
+
+  return { orders, updatedAtBlock: updatedAtBlock.toString() }
 }
 
 export const programmaticOrdersApi = new ProgrammaticOrdersApi()

--- a/apps/cowswap-frontend/src/modules/twap/state/eoaTwapOrdersEffectAtom.test.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/state/eoaTwapOrdersEffectAtom.test.tsx
@@ -26,7 +26,7 @@ jest.mock('@cowprotocol/wallet', () => ({
   accountTypeAtom: jest.requireActual('jotai').atom(jest.requireActual('@cowprotocol/types').AccountType.EOA),
 }))
 jest.mock('../services/programmaticOrdersApi', () => ({
-  programmaticOrdersApi: { fetchEoaTwapOrders: jest.fn() },
+  programmaticOrdersApi: { fetchEoaTwapOrders: jest.fn(), fetchChangedEoaTwapOrders: jest.fn() },
 }))
 jest.mock('entities/twap', () => ({
   ...jest.requireActual('entities/twap/state/eoaTwapOrdersAtom'),
@@ -39,6 +39,9 @@ const CHAIN_ID = SupportedChainId.GNOSIS_CHAIN
 
 const fetchEoaTwapOrdersMock = programmaticOrdersApi.fetchEoaTwapOrders as jest.MockedFunction<
   typeof programmaticOrdersApi.fetchEoaTwapOrders
+>
+const fetchChangedEoaTwapOrdersMock = programmaticOrdersApi.fetchChangedEoaTwapOrders as jest.MockedFunction<
+  typeof programmaticOrdersApi.fetchChangedEoaTwapOrders
 >
 const writableAccountTypeAtom = accountTypeAtom as PrimitiveAtom<AccountType | null>
 
@@ -68,6 +71,7 @@ function makeOrder(id: string, resolvedOwner: string): TwapOrderItem {
       info: { executedSellAmount: '0', executedBuyAmount: '0', executedFeeAmount: '0' },
     },
     partOrdersCount: 0,
+    updatedAtBlock: '1',
   }
 }
 
@@ -89,7 +93,8 @@ describe('eoaTwapOrdersEffectAtom', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     localStorage.clear()
-    fetchEoaTwapOrdersMock.mockResolvedValue({ orders: {}, totalCount: 0 })
+    fetchEoaTwapOrdersMock.mockResolvedValue({ orders: {}, totalCount: 0, updatedAtBlock: '0' })
+    fetchChangedEoaTwapOrdersMock.mockResolvedValue({ orders: {}, updatedAtBlock: '0' })
   })
 
   it('loads only explicitly detected EOAs while the feature is enabled', () => {
@@ -123,7 +128,10 @@ describe('eoaTwapOrdersEffectAtom', () => {
     const store = createStore()
     store.set(walletInfoAtom, { account: EOA_A, chainId: CHAIN_ID })
     store.set(featureFlagsAtom, { isTwapEoaEnabled: true })
-    const resolvers = new Map<string, (result: { orders: Record<string, TwapOrderItem>; totalCount: number }) => void>()
+    const resolvers = new Map<
+      string,
+      (result: { orders: Record<string, TwapOrderItem>; totalCount: number; updatedAtBlock: string }) => void
+    >()
     fetchEoaTwapOrdersMock.mockImplementation((owner) => new Promise((resolve) => resolvers.set(owner, resolve)))
 
     render(<Effect />, { wrapper: testWrapper(store) })
@@ -137,11 +145,11 @@ describe('eoaTwapOrdersEffectAtom', () => {
     await waitFor(() => expect(fetchEoaTwapOrdersMock).toHaveBeenCalledWith(EOA_B, CHAIN_ID, 100))
     await waitFor(() => expect(store.get(eoaTwapOrdersAtom)).toEqual({}))
 
-    act(() => resolvers.get(EOA_A)?.({ orders: { [orderA.id]: orderA }, totalCount: 1 }))
+    act(() => resolvers.get(EOA_A)?.({ orders: { [orderA.id]: orderA }, totalCount: 1, updatedAtBlock: '1' }))
     await waitFor(() => expect(store.get(eoaTwapOrdersAtom)).toEqual({}))
 
     const orderB = makeOrder('event-b', EOA_B)
-    act(() => resolvers.get(EOA_B)?.({ orders: { [orderB.id]: orderB }, totalCount: 1 }))
+    act(() => resolvers.get(EOA_B)?.({ orders: { [orderB.id]: orderB }, totalCount: 1, updatedAtBlock: '1' }))
     await waitFor(() => expect(store.get(eoaTwapOrdersAtom)).toEqual({ [orderB.id]: orderB }))
   })
 
@@ -164,7 +172,11 @@ describe('eoaTwapOrdersEffectAtom', () => {
     store.set(walletInfoAtom, { account: EOA_A, chainId: CHAIN_ID })
     store.set(featureFlagsAtom, { isTwapEoaEnabled: true })
     store.set(eoaTwapOrdersAtom, { [cachedOrder.id]: cachedOrder })
-    fetchEoaTwapOrdersMock.mockResolvedValue({ orders: { [fetchedOrder.id]: fetchedOrder }, totalCount: 1 })
+    fetchEoaTwapOrdersMock.mockResolvedValue({
+      orders: { [fetchedOrder.id]: fetchedOrder },
+      totalCount: 1,
+      updatedAtBlock: '1',
+    })
 
     render(<Effect />, { wrapper: testWrapper(store) })
 
@@ -190,7 +202,11 @@ describe('eoaTwapOrdersEffectAtom', () => {
     store.set(walletInfoAtom, { account: EOA_A, chainId: CHAIN_ID })
     store.set(featureFlagsAtom, { isTwapEoaEnabled: true })
     store.set(eoaTwapOrdersAtom, { [cancellingOrder.id]: cancellingOrder })
-    fetchEoaTwapOrdersMock.mockResolvedValue({ orders: { [staleApiOrder.id]: staleApiOrder }, totalCount: 1 })
+    fetchEoaTwapOrdersMock.mockResolvedValue({
+      orders: { [staleApiOrder.id]: staleApiOrder },
+      totalCount: 1,
+      updatedAtBlock: '1',
+    })
 
     render(<Effect />, { wrapper: testWrapper(store) })
 
@@ -210,7 +226,11 @@ describe('eoaTwapOrdersEffectAtom', () => {
     store.set(walletInfoAtom, { account: EOA_A, chainId: CHAIN_ID })
     store.set(featureFlagsAtom, { isTwapEoaEnabled: true })
     store.set(twapOrdersAtom, { [optimisticOrder.id]: optimisticOrder })
-    fetchEoaTwapOrdersMock.mockResolvedValue({ orders: { [indexedOrder.id]: indexedOrder }, totalCount: 1 })
+    fetchEoaTwapOrdersMock.mockResolvedValue({
+      orders: { [indexedOrder.id]: indexedOrder },
+      totalCount: 1,
+      updatedAtBlock: '1',
+    })
 
     render(<Effect />, { wrapper: testWrapper(store) })
 

--- a/apps/cowswap-frontend/src/modules/twap/state/eoaTwapOrdersQueryAtom.ts
+++ b/apps/cowswap-frontend/src/modules/twap/state/eoaTwapOrdersQueryAtom.ts
@@ -31,12 +31,7 @@ export const eoaTwapOrdersQueryAtom = atomWithQuery<EoaTwapOrdersQueryData>((get
       const previous = queryClient.getQueryData<EoaTwapOrdersQueryData>(queryKey)
       if (!previous) return programmaticOrdersApi.fetchEoaTwapOrders(owner, chainId, limit)
 
-      const changes = await programmaticOrdersApi.fetchChangedEoaTwapOrders(
-        owner,
-        chainId,
-        previous.updatedAtBlock,
-        new Set(Object.keys(previous.orders)),
-      )
+      const changes = await programmaticOrdersApi.fetchChangedEoaTwapOrders(owner, chainId, previous.updatedAtBlock)
 
       if (changes.updatedAtBlock === previous.updatedAtBlock && Object.keys(changes.orders).length === 0) {
         return previous

--- a/apps/cowswap-frontend/src/modules/twap/state/eoaTwapOrdersQueryAtom.ts
+++ b/apps/cowswap-frontend/src/modules/twap/state/eoaTwapOrdersQueryAtom.ts
@@ -1,9 +1,9 @@
-import { ORDER_BOOK_API_UPDATE_INTERVAL } from '@cowprotocol/common-const'
 import { getAddressKey } from '@cowprotocol/cow-sdk'
 import { AccountType } from '@cowprotocol/types'
 import { accountTypeAtom, walletInfoAtom } from '@cowprotocol/wallet'
 
-import { atomWithQuery } from 'jotai-tanstack-query'
+import { atomWithQuery, queryClientAtom } from 'jotai-tanstack-query'
+import ms from 'ms.macro'
 
 import { ordersLimitAtom } from 'modules/orders/state/ordersLimitAtom'
 
@@ -12,6 +12,7 @@ import { featureFlagsAtom } from 'common/state/featureFlagsState'
 import { programmaticOrdersApi } from '../services/programmaticOrdersApi'
 
 type EoaTwapOrdersQueryData = Awaited<ReturnType<typeof programmaticOrdersApi.fetchEoaTwapOrders>>
+const EOA_TWAP_ORDERS_UPDATE_INTERVAL = ms`1s`
 
 export const eoaTwapOrdersQueryAtom = atomWithQuery<EoaTwapOrdersQueryData>((get) => {
   const { account, chainId } = get(walletInfoAtom)
@@ -19,12 +20,29 @@ export const eoaTwapOrdersQueryAtom = atomWithQuery<EoaTwapOrdersQueryData>((get
   const limit = get(ordersLimitAtom)
   const accountType = get(accountTypeAtom)
 
-  return {
-    queryKey: ['eoaTwapOrders', chainId, owner, limit] as const,
-    queryFn: async () => {
-      if (!chainId || !owner) return { orders: {}, totalCount: 0 }
+  const queryClient = get(queryClientAtom)
+  const queryKey = ['eoaTwapOrders', chainId, owner, limit] as const
 
-      return programmaticOrdersApi.fetchEoaTwapOrders(owner, chainId, limit)
+  return {
+    queryKey,
+    queryFn: async () => {
+      if (!chainId || !owner) return { orders: {}, totalCount: 0, updatedAtBlock: '0' }
+
+      const previous = queryClient.getQueryData<EoaTwapOrdersQueryData>(queryKey)
+      if (!previous) return programmaticOrdersApi.fetchEoaTwapOrders(owner, chainId, limit)
+
+      const changes = await programmaticOrdersApi.fetchChangedEoaTwapOrders(
+        owner,
+        chainId,
+        previous.updatedAtBlock,
+        new Set(Object.keys(previous.orders)),
+      )
+
+      if (changes.updatedAtBlock === previous.updatedAtBlock && Object.keys(changes.orders).length === 0) {
+        return previous
+      }
+
+      return { ...changes, totalCount: previous.totalCount, orders: { ...previous.orders, ...changes.orders } }
     },
     enabled:
       get(featureFlagsAtom).isTwapEoaEnabled === true &&
@@ -33,7 +51,7 @@ export const eoaTwapOrdersQueryAtom = atomWithQuery<EoaTwapOrdersQueryData>((get
       !!owner,
     placeholderData: (previousData, previousQuery) =>
       previousQuery?.queryKey[1] === chainId && previousQuery.queryKey[2] === owner ? previousData : undefined,
-    refetchInterval: ORDER_BOOK_API_UPDATE_INTERVAL,
+    refetchInterval: EOA_TWAP_ORDERS_UPDATE_INTERVAL,
     staleTime: 0,
   }
 })

--- a/apps/cowswap-frontend/src/modules/twap/types.ts
+++ b/apps/cowswap-frontend/src/modules/twap/types.ts
@@ -52,6 +52,8 @@ export interface TwapOrderItem {
   safeTxParams?: SafeTransactionParams
   /** Indexed part-order count. Undefined for Safe and optimistic rows. */
   partOrdersCount?: number
+  /** Indexer change cursor. Undefined for Safe and optimistic rows. */
+  updatedAtBlock?: string
   executionInfo: TwapOrdersExecution
 }
 

--- a/apps/sdk-tools/package.json
+++ b/apps/sdk-tools/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@cowprotocol/common-const": "workspace:*",
     "@cowprotocol/cow-sdk": "9.2.9",
-    "@cowprotocol/sdk-composable": "1.4.2",
+    "@cowprotocol/sdk-composable": "1.5.0",
     "@cowprotocol/sdk-viem-adapter": "0.3.28",
     "@cowprotocol/wallet": "workspace:*",
     "viem": "2.48.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -635,8 +635,8 @@ importers:
         specifier: 4.4.5
         version: 4.4.5(ajv@8.17.1)(encoding@0.1.13)(multiformats@14.0.0)
       '@cowprotocol/sdk-composable':
-        specifier: 1.4.2
-        version: 1.4.2(encoding@0.1.13)(typescript@5.9.3)
+        specifier: 1.5.0
+        version: 1.5.0(encoding@0.1.13)(typescript@5.9.3)
       '@cowprotocol/sdk-contracts-ts':
         specifier: 3.5.1
         version: 3.5.1
@@ -1198,8 +1198,8 @@ importers:
         specifier: 9.2.9
         version: 9.2.9(@openzeppelin/merkle-tree@1.0.8)(ajv@8.17.1)(cross-fetch@4.0.0(encoding@0.1.13))(encoding@0.1.13)(multiformats@14.0.0)
       '@cowprotocol/sdk-composable':
-        specifier: 1.4.2
-        version: 1.4.2(encoding@0.1.13)(typescript@5.9.3)
+        specifier: 1.5.0
+        version: 1.5.0(encoding@0.1.13)(typescript@5.9.3)
       '@cowprotocol/sdk-viem-adapter':
         specifier: 0.3.28
         version: 0.3.28(viem@2.48.8(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
@@ -3380,8 +3380,8 @@ packages:
   '@cowprotocol/sdk-common@0.12.3':
     resolution: {integrity: sha512-2FRTKMS1yoiLpTTRgk1U8rUa7x7LhM/AXZjQWRMTJt6QCQjS9PzNIMCmCrrC7w0cZaXfS+BVQgK277wOuwa3pw==}
 
-  '@cowprotocol/sdk-composable@1.4.2':
-    resolution: {integrity: sha512-3QM/+pDVXxhlNGGltkbEdVDx267qlyqvPIYSOKAL9f0dWOM5FqbeHIcn7YPiWn1lEGELy/d7VfMCNOsOEi9SMQ==}
+  '@cowprotocol/sdk-composable@1.5.0':
+    resolution: {integrity: sha512-MXvdGFfOB2zFHJoM2S0QulgTRH1TtfbpWXW1ld4iUK2730Ri1zce7qWOVCBXKlLojx+ccLxARPeNRpZVjP4K2A==}
 
   '@cowprotocol/sdk-config@1.2.0':
     resolution: {integrity: sha512-upZ2OPycc+rikwAnfNt58qBMlYb+7zpFPzG6zT/sfE50FS1f2ba4SMtw37HVq+v0e9R32o/rWZFcDZT5Ty5yyQ==}
@@ -19402,8 +19402,8 @@ snapshots:
 
   '@coinbase/cdp-sdk@1.47.0(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@solana-program/system': 0.10.0(@solana/kit@5.5.1(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10))
-      '@solana-program/token': 0.9.0(@solana/kit@5.5.1(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10))
+      '@solana-program/system': 0.10.0(@solana/kit@5.5.1(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))
+      '@solana-program/token': 0.9.0(@solana/kit@5.5.1(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/kit': 5.5.1(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       abitype: 1.0.6(typescript@5.9.3)(zod@3.25.76)
       axios: 1.13.6
@@ -19720,7 +19720,7 @@ snapshots:
     dependencies:
       '@cowprotocol/sdk-config': 2.6.0
 
-  '@cowprotocol/sdk-composable@1.4.2(encoding@0.1.13)(typescript@5.9.3)':
+  '@cowprotocol/sdk-composable@1.5.0(encoding@0.1.13)(typescript@5.9.3)':
     dependencies:
       '@cowprotocol/sdk-common': 0.12.3
       '@cowprotocol/sdk-config': 2.6.0
@@ -24477,12 +24477,12 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
-  '@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10))':
+  '@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/kit': 5.5.1(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
     optional: true
 
-  '@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.0.8)(typescript@5.9.3)(utf-8-validate@5.0.10))':
+  '@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/kit': 5.5.1(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
     optional: true


### PR DESCRIPTION
# Summary

Fixes: [FE-349](https://linear.app/cowswap/issue/FE-349/optimize-refreshes-to-fetch-only-twaps-that-changed)

Depends on https://github.com/cowprotocol/cow-programmatic-orders-api/pull/5
Depends on https://github.com/cowprotocol/cow-sdk/pull/996

- Poll EOA TWAP parents every second (previously it was 10s), fetching only changes since the previous indexed block.
- Merge changes into cached orders.
- Refresh expanded parts when their parent changes, removing their separate polling timer.
- Log the number of parent updates after each successful delta poll.

# To Test

1. Place a TWAP
2. The `OPEN` part state should become observable, it should not jump directly to filled.

# Background

The indexer updates the parent’s `updatedAtBlock` when its parts change, including candidate-to-discrete transitions. Expanded parts therefore refresh through parent updates.

The pagination total stays unchanged during delta polling. A full fetch, such as a page reload, refreshes it.

<img width="3374" height="1206" alt="image" src="https://github.com/user-attachments/assets/5526ab3d-38d4-4179-9942-aba3fbb9892c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - TWAP order lists now refresh more efficiently by retrieving only orders that have changed.
  - Updates are detected promptly, helping order status and expanded order details stay current.
  - Existing order information is preserved when no changes are available, reducing unnecessary full refreshes.
- **Bug Fixes**
  - Improved TWAP order refresh behavior so changes are reflected reliably without waiting for periodic full updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->