### PR TITLE
feat: show scheduled parts in eoa twap

### DIFF
--- a/apps/cowswap-frontend/src/modules/twap/hooks/useEoaTwapPartOrders.test.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useEoaTwapPartOrders.test.tsx
@@ -114,6 +114,55 @@ describe('useEoaTwapPartOrders', () => {
     jest.clearAllMocks()
   })
 
+  it('loads candidate-only parents and promotes the same row without changing the count', async () => {
+    const page = makePartPage('candidate')
+    const candidate = {
+      ...page.items[0],
+      status: 'unconfirmed',
+      executedSellAmount: null,
+      executedBuyAmount: null,
+      executedFeeAmount: null,
+    } as TwapPartOrder
+    fetchEoaTwapPartOrdersMock
+      .mockResolvedValueOnce({ totalCount: 1, items: [candidate] })
+      .mockResolvedValueOnce({ totalCount: 1, items: [{ ...candidate, status: 'open' }] })
+    const { result, rerender } = renderHook(({ order }) => useEoaTwapPartOrders(order, parent, 1, true), {
+      initialProps: { order: makeTwapOrder(1, '1') },
+      wrapper: SwrTestProvider,
+    })
+
+    await waitFor(() => expect(result.current.orders[0]?.status).toBe(OrderStatus.SCHEDULED))
+    expect(result.current.orders[0]?.composableCowInfo?.isVirtualPart).toBe(true)
+
+    rerender({ order: makeTwapOrder(1, '2') })
+
+    await waitFor(() => expect(result.current.orders[0]?.status).toBe(OrderStatus.PENDING))
+    expect(result.current.orders[0]?.id).toBe('candidate')
+    expect(result.current.orders[0]?.composableCowInfo?.isVirtualPart).toBe(false)
+    expect(fetchEoaTwapPartOrdersMock).toHaveBeenCalledTimes(2)
+  })
+
+  it.each([
+    [TwapOrderStatus.Cancelled, OrderStatus.CANCELLED],
+    [TwapOrderStatus.Expired, OrderStatus.EXPIRED],
+  ])('does not show candidates as scheduled under a %s parent', async (status, expected) => {
+    const page = makePartPage('candidate')
+    fetchEoaTwapPartOrdersMock.mockResolvedValue({
+      ...page,
+      items: page.items.map((part) => ({
+        ...part,
+        status: 'unconfirmed',
+        executedSellAmount: null,
+        executedBuyAmount: null,
+        executedFeeAmount: null,
+      })),
+    })
+    const { result } = renderHook(() => useEoaTwapPartOrders({ ...makeTwapOrder(), status }, parent, 1, true), {
+      wrapper: SwrTestProvider,
+    })
+    await waitFor(() => expect(result.current.orders[0]?.status).toBe(expected))
+  })
+
   it('remaps parent snapshots and refetches when the part count changes', async () => {
     fetchEoaTwapPartOrdersMock
       .mockResolvedValueOnce(makePartPage('part-1'))
@@ -143,6 +192,16 @@ describe('useEoaTwapPartOrders', () => {
     rerender({ parentOrder: parent, twapOrder: makeTwapOrder(2) })
     await waitFor(() => expect(result.current.orders[0]?.id).toBe('part-2'))
     expect(fetchEoaTwapPartOrdersMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('requests the selected server page and marks its final part using the unified count', async () => {
+    fetchEoaTwapPartOrdersMock.mockResolvedValue({ ...makePartPage('last'), totalCount: 11 })
+    const { result } = renderHook(() => useEoaTwapPartOrders(makeTwapOrder(11), parent, 2, true), {
+      wrapper: SwrTestProvider,
+    })
+    await waitFor(() => expect(result.current.orders[0]?.id).toBe('last'))
+    expect(fetchEoaTwapPartOrdersMock).toHaveBeenCalledWith('event', SupportedChainId.GNOSIS_CHAIN, 2, 10)
+    expect(result.current.orders[0]?.composableCowInfo?.isTheLastPart).toBe(true)
   })
 
   it('ignores stale responses and clears row failures', async () => {

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useEoaTwapPartOrders.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useEoaTwapPartOrders.ts
@@ -139,10 +139,11 @@ function mapPartOrder(
 ): ParsedOrder {
   const creationTime = new Date(partOrder.createdAt * 1000).toISOString()
   const apiAdditionalInfo = mapApiAdditionalInfo(partOrder, twapOrder, parent, creationTime)
+  const isVirtualPart = partOrder.status === 'unconfirmed'
   const order = {
     ...apiAdditionalInfo,
     id: partOrder.orderUid as UID,
-    status: getPartOrderStatus(apiAdditionalInfo, twapOrder, false),
+    status: getPartOrderStatus(apiAdditionalInfo, twapOrder, isVirtualPart),
     creationTime,
     isEoaTwapOrder: true,
     sellAmountBeforeFee: partOrder.sellAmount.toString(),
@@ -150,7 +151,7 @@ function mapPartOrder(
     outputToken: parent.outputToken,
     fullAppData: parent.fullAppData,
     composableCowInfo: {
-      isVirtualPart: false,
+      isVirtualPart,
       isTheLastPart,
       parentId: twapOrder.id,
       twapOrderHash: twapOrder.hash,
@@ -162,7 +163,8 @@ function mapPartOrder(
 }
 
 function mapSdkPartOrderStatus(status: TwapPartOrderStatus): SdkOrderStatus {
-  if (status === 'open') return SdkOrderStatus.OPEN
+  // Virtual parts use the scheduled/parent-aware status above, not this placeholder.
+  if (status === 'open' || status === 'unconfirmed') return SdkOrderStatus.OPEN
   if (status === 'fulfilled') return SdkOrderStatus.FULFILLED
   if (status === 'cancelled') return SdkOrderStatus.CANCELLED
 


### PR DESCRIPTION
Instead of querying only "discrete" parts, now we query candidates as well (scheduled).

Depends on https://github.com/cowprotocol/cow-programmatic-orders-api/pull/7
Depends on https://github.com/cowprotocol/cow-sdk/pull/1002

Part of [FE-479 Show Sheduled parts for TWAPs for EOAs](https://linear.app/cowswap/issue/FE-479/show-sheduled-parts-for-twaps-for-eoas)

<img width="1209" height="256" alt="image" src="https://github.com/user-attachments/assets/d0aa282b-2c89-4375-8a68-4bf71c136a5d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TWAP order status handling for unconfirmed part orders.
  - Candidate-only parts now transition correctly from scheduled placeholders to pending orders after refresh.
  - Cancelled or expired parent orders no longer expose candidates as scheduled.
  - Pagination now correctly respects server page size, selected pages, and final-part indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->