### PR TITLE
chore: improve e2e stability

### DIFF
--- a/apps/cowswap-e2e-tests/playwright.config.ts
+++ b/apps/cowswap-e2e-tests/playwright.config.ts
@@ -11,16 +11,20 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   expect: { timeout: 10_000 },
   retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 2 : 6,
+  workers: process.env.CI ? 1 : 6,
   reporter: process.env.CI ? [['html', { open: 'never' }], ['github']] : [['list'], ['html', { open: 'never' }]],
   globalSetup: path.resolve(__dirname, 'src/support/globalSetup.ts'),
   globalTeardown: path.resolve(__dirname, 'src/support/globalTeardown.ts'),
   use: {
     baseURL: 'http://localhost:3000',
     screenshot: 'only-on-failure',
-    trace: 'retain-on-failure',
-    video: 'retain-on-failure',
-    actionTimeout: 15_000,
+    // `retain-on-failure` still records trace/video continuously through every passing test and
+    // only discards it afterwards — real CPU/memory overhead on the shared CI runner that we don't
+    // need for tests that pass first try. `on-first-retry` only starts recording once a test has
+    // already failed once, freeing up headroom for the timing-sensitive waits below.
+    trace: 'on-first-retry',
+    video: 'on-first-retry',
+    actionTimeout: 20_000,
     navigationTimeout: 30_000,
   },
   projects: [


### PR DESCRIPTION
# Summary

1. Disable parallel execution in CI (workers=1)
2. Bump actionTimeout to 20s
3. Disable video recording for successful cases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated test execution settings for more consistent CI and local runs.
  * Diagnostic traces and videos are now captured on the first retry rather than retained after every failure.
  * Increased the allowed action timeout to accommodate slower test interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->