### PR TITLE
fix: new ondo tokens, updating fallback pin

### DIFF
--- a/libs/core/src/cms/consts.ts
+++ b/libs/core/src/cms/consts.ts
@@ -5,7 +5,7 @@ import type { RestrictedTokenList } from './types'
 export const DEFAULT_CMS_REQUEST_TTL = ms`1h`
 
 export const ONDO_TOKEN_LIST_URL =
-  'https://raw.githubusercontent.com/ondoprotocol/cowswap-global-markets-token-list/cf97552db394cc10bffab7ac942805a89a882039/tokenlist.json'
+  'https://raw.githubusercontent.com/ondoprotocol/cowswap-global-markets-token-list/4ae87da178469e53f44b1b8cae1820c02c999907/tokenlist.json'
 
 export const RESERVE_PROTOCOL_BNB_TOKEN_LIST_URL =
   'https://raw.githubusercontent.com/reserve-protocol/dtf-interface/1dbc095c95210f3342278acb8b865763a4d7d443/packages/dtf-catalog/tokenlists/index-dtf/restricted/bnb.tokenlist.json'

--- a/libs/tokens/src/const/tokensList.json
+++ b/libs/tokens/src/const/tokensList.json
@@ -16,7 +16,7 @@
     },
     {
       "priority": 4,
-      "source": "https://raw.githubusercontent.com/ondoprotocol/cowswap-global-markets-token-list/cf97552db394cc10bffab7ac942805a89a882039/tokenlist.json"
+      "source": "https://raw.githubusercontent.com/ondoprotocol/cowswap-global-markets-token-list/4ae87da178469e53f44b1b8cae1820c02c999907/tokenlist.json"
     },
     {
       "priority": 5,
@@ -166,7 +166,7 @@
     },
     {
       "priority": 4,
-      "source": "https://raw.githubusercontent.com/ondoprotocol/cowswap-global-markets-token-list/cf97552db394cc10bffab7ac942805a89a882039/tokenlist.json"
+      "source": "https://raw.githubusercontent.com/ondoprotocol/cowswap-global-markets-token-list/4ae87da178469e53f44b1b8cae1820c02c999907/tokenlist.json"
     },
     {
       "priority": 5,


### PR DESCRIPTION
# Summary

New Ondo tokens added to their list.
Manually pinning the new version after verification.

<img width="624" height="822" alt="image" src="https://github.com/user-attachments/assets/d610b157-9db9-42bf-865c-a727c7c6b5f4" />

CMS record already updated to point to https://raw.githubusercontent.com/ondoprotocol/cowswap-global-markets-token-list/4ae87da178469e53f44b1b8cae1820c02c999907/tokenlist.json, which means the new tokens are already available on prod.

# To Test

1. Check from a non-restricted location
- The new tokens should be visible, both on Ethereum and BNB chains

## AI description

<details>

## What changed

Re-pins the Ondo Tokenized Stocks List from `cf97552d` to `4ae87da1` (upstream list version 11 → 12), in the two places the SHA is written:

- `libs/core/src/cms/consts.ts` — `ONDO_TOKEN_LIST_URL` (the CMS-failure fallback entry).
- `libs/tokens/src/const/tokensList.json` — the mainnet (`1`) and BNB (`56`) `priority: 4` sources.

No new fallback entry or chain array is needed: the list still covers only chains 1 and 56, and `ONDO_FALLBACK_TOKEN_LIST` is already wired into `FALLBACK_TOKEN_LISTS`.

## Why

Ondo added 8 new tickers. Nothing was removed and no existing token's `symbol`, `name`, `decimals` or `logoURI` changed — the diff between the two pinned commits is 16 additions (8 tickers × 2 chains), 0 removals, 0 modifications:

| Symbol | Name | Mainnet | BNB |
|---|---|---|---|
| `HYDBon` | iShares High Yield Systematic Bond ETF (Ondo Tokenized) | `0xe109dFbF450eC2b9944900830b8DA22EaA59F1A3` | `0x97B2FD5fC2F3e0dfD72D45734e360961528B6c63` |
| `USHYon` | iShares Broad USD High Yield Corporate Bond ETF (Ondo Tokenized) | `0x6830f7BBFD274e393a32846918DA9De210879AE4` | `0xc992e5f8dA1b99cB941B0a259bE9014CFfE89Ccf` |
| `NEARon` | iShares Short Duration Bond Active ETF (Ondo Tokenized) | `0x7E37ac5d67ebe99851193CD036D7725b6730c53D` | `0x031d85943ba7ca0304323195e7086a76c35366fB` |
| `GOOGon` | Alphabet Inc. Class C (Ondo Tokenized) | `0x36B90aDcDC99Be31BF39A3c031288bAa0B457E10` | `0x817f1f6780F99BCaAc394A59CB0261962df5Da8b` |
| `RXRXon` | Recursion Pharmaceuticals (Ondo Tokenized) | `0xDaA3b81a3ACFcB60b875eBA1D26852376BC38486` | `0xCB6D74afF24AFc94514727eE0FCDA6bb6B64f3F9` |
| `HTZon` | Hertz Global Holdings (Ondo Tokenized) | `0x7E95779D2d7B4a654A4ac80cB6423aE8998Cf1e7` | `0xB18C6A83490DDDbc9A83b011173b5B2Fb5dC1272` |
| `WENon` | Wendy's (Ondo Tokenized) | `0x613518b520241f90c3E023Bb6006c63A5019CA7B` | `0x79ed7f4d9668E8e7AaadD12A711d19064840B9A5` |
| `AIon` | C3.ai (Ondo Tokenized) | `0x4554ad55ccA5e7CB97B77813f486aAf6D4D9AB62` | `0xBb8c10f7E828E3279df8CC3397A5212F845C509b` |

All 16 are `decimals: 18`.

## ⚠️ CMS record must be re-pointed before this ships

The CMS record exists but still points at the **old** commit. Queried live from `https://cms.cow.fi/api/restricted-token-lists` on 2026-09-09:

```
id: 1
name: "Ondo Tokenized Stocks List"
tokenListUrl: ".../cowswap-global-markets-token-list/cf97552db394cc10bffab7ac942805a89a882039/tokenlist.json"
updatedAt: 2026-08-25T13:30:20.508Z
restrictedCountries: 50 entries (matches RESTRICTED_COUNTRIES)
```

`RestrictedTokensListUpdater` builds `countriesPerToken` / `consentHashPerToken` by fetching **the CMS record's `tokenListUrl`**, not the source in `tokensList.json`. So if this merges while the CMS record still holds `cf97552d`:

- **List-level geoblocking is fine.** `getSourceAsKey` strips the git ref for `raw.githubusercontent.com` URLs, so old and new SHAs resolve to the same key and `blockedCountriesPerList` still matches.
- **Per-token geoblocking misses the 16 new tokens.** They are absent from the old list, so `useRestrictedToken` returns `undefined` for them — which is what gates custom-token import (`useRestrictedTokenImportStatus`) and the trade-form restriction on a selected token.

**Action:** update CMS entry id `1` to `.../4ae87da178469e53f44b1b8cae1820c02c999907/tokenlist.json` at or before merge. Owner: *TODO — assign*. `restrictedCountries` needs no change.

## Pre-flight validation

Ran the RWA onboarding pre-flight check against the candidate ref before touching any file:

- **Status: PASS.** 904 tokens, chains `[1, 56]`, resolved permalink `4ae87da178469e53f44b1b8cae1820c02c999907`.
- **Brand check: 0 violations.** Every token's `name` carries `Ondo`; no unrelated contract snuck into the list (this is the check that would have caught the USDC-in-ST0x incident, cowswap#8030 / #8041). None of the 16 new addresses collide with any configured source.
- **Collisions: 161, all pre-existing.** 160 are `routine` — CoinGecko's per-chain index lists, which catalogue the same real tokens; geoblocking is keyed by address regardless of which list surfaced the token, so this does not weaken enforcement.
- **One `default-list` collision, justified:** `USDY` / "Ondo U.S. Dollar Yield" / `0x96F6eF951840721AdBF46Ac996b59E0235CB985C` on mainnet is in `files.cow.fi/tokens/CowSwap.json`. It is Ondo's own tokenized-treasury product, it is the RWA whose jurisdictional restrictions this list exists to enforce, and it was already in the previously pinned commit — this PR does not change its status. No configured source was unreachable during the check.

## Verification

- `npx nx run core:lint` — passes, no new findings.
- `npx nx run core:test --testFile=src/cms/utils/getRestrictedTokenLists.test.ts` — 4/4 pass.
- `npx nx run tokens:test --testFile=src/state/tokenLists/tokenListsStateAtom.test.ts` — 11/11 pass, including `surfaces only the shipped URL when a list was re-pinned`, which is the re-pin path this PR exercises. It derives the URL from `DEFAULT_TOKENS_LISTS` rather than hardcoding a SHA, so it needed no update.
- The newly pinned URL fetches `200` and returns `Ondo Tokenized Stocks List` at version `12.0.0` (previous pin: `11.0.0`).

## QA

Once the CMS record is re-pointed, worth spot-checking one of the 8 new tickers end to end from a restricted-country VPN — search `GOOGon` in the token picker on mainnet and on BNB, confirm the restriction notice appears, and confirm importing `0x36B90aDcDC99Be31BF39A3c031288bAa0B457E10` by address hits the same block rather than importing clean.

</details>

# Self-checks

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have manually tested changes on Vercel preview deployment
- [x] I have done self-review and (or) AI review
- [x] I have addressed all comments from @coderabbitai
- [x] I have less than three open PRs/Stacks in this repo at the moment of creating this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the Ondo token list source to a newer version.
  - Updated the CoW Swap global markets token list for supported networks to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->