### PR TITLE
fix: use prod cms for correlated tokens as well

### DIFF
--- a/apps/cowswap-frontend/src/entities/correlatedTokens/updaters/CorrelatedTokensUpdater.test.tsx
+++ b/apps/cowswap-frontend/src/entities/correlatedTokens/updaters/CorrelatedTokensUpdater.test.tsx
@@ -13,13 +13,14 @@ import { CorrelatedTokensUpdater } from './CorrelatedTokensUpdater'
 import { correlatedTokensAtom } from '../state/correlatedTokensAtom'
 
 // Define GET inside the factory so it is guaranteed to be a jest.fn() when
-// the component captures `cmsClient = getCmsClient()` at module load time.
+// the component captures `cmsClient = getProdCmsClient()` at module load time.
 jest.mock('@cowprotocol/core', () => ({
-  getCmsClient: jest.fn().mockReturnValue({ GET: jest.fn() }),
+  getProdCmsClient: jest.fn().mockReturnValue({ GET: jest.fn() }),
 }))
 
 // Retrieve the stable mock reference after the factory has run.
-const mockGet: jest.Mock = (jest.requireMock('@cowprotocol/core') as { getCmsClient: jest.Mock }).getCmsClient().GET
+const mockGet: jest.Mock = (jest.requireMock('@cowprotocol/core') as { getProdCmsClient: jest.Mock }).getProdCmsClient()
+  .GET
 
 const UPDATE_TIME_KEY = 'correlatedTokensUpdateTime'
 
@@ -238,6 +239,27 @@ describe('CorrelatedTokensUpdater', () => {
 
     await waitFor(() => localStorage.getItem(UPDATE_TIME_KEY) !== null)
 
+    expect(store.get(correlatedTokensAtom)[SupportedChainId.MAINNET]).toEqual([])
+  })
+
+  // Regression: barn CMS serves correlated-tokens without the `network` relation, so every entry is
+  // skipped. Caching that empty result kept the volume fee applied to correlated pairs for 10 minutes.
+  it('should not cache the update timestamp when no chain resolved any list', async () => {
+    localStorage.setItem(UPDATE_TIME_KEY, '0') // expired timestamp forces a fetch
+    mockGet.mockResolvedValue({
+      data: { data: [{ attributes: { tokens: { '0xabc': 'TOKEN1' } } }] }, // no network relation
+      error: null,
+    })
+
+    const { store, TestComponent } = getWrapper()
+
+    act(() => {
+      render(<CorrelatedTokensUpdater />, { wrapper: TestComponent })
+    })
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalled())
+
+    expect(localStorage.getItem(UPDATE_TIME_KEY)).toBe('0')
     expect(store.get(correlatedTokensAtom)[SupportedChainId.MAINNET]).toEqual([])
   })
 })

--- a/apps/cowswap-frontend/src/entities/correlatedTokens/updaters/CorrelatedTokensUpdater.tsx
+++ b/apps/cowswap-frontend/src/entities/correlatedTokens/updaters/CorrelatedTokensUpdater.tsx
@@ -2,7 +2,7 @@ import { useSetAtom } from 'jotai'
 
 import { components } from '@cowprotocol/cms'
 import { isSupportedChainId } from '@cowprotocol/common-utils'
-import { getCmsClient } from '@cowprotocol/core'
+import { getProdCmsClient } from '@cowprotocol/core'
 import { getAddressKey, mapSupportedNetworks } from '@cowprotocol/cow-sdk'
 
 import ms from 'ms.macro'
@@ -22,7 +22,7 @@ const SWR_CONFIG: SWRConfiguration = {
 
 const UPDATE_TIME_KEY = 'correlatedTokensUpdateTime'
 
-const cmsClient = getCmsClient()
+const cmsClient = getProdCmsClient()
 
 const querySerializer = (params: unknown): string => {
   return qs.stringify(params, { encodeValuesOnly: true, arrayFormat: 'brackets' })
@@ -65,11 +65,14 @@ export function CorrelatedTokensUpdater(): null {
 
         const items = data.data as CorrelatedTokenItem[]
 
+        let skipped = 0
+
         const state = items.reduce(
           (acc, item) => {
             const chainId = item.attributes?.network?.data?.attributes?.chainId
 
             if (!chainId || !item.attributes?.tokens || !isSupportedChainId(chainId)) {
+              skipped++
               return acc
             }
 
@@ -85,6 +88,18 @@ export function CorrelatedTokensUpdater(): null {
           },
           mapSupportedNetworks<CorrelatedTokens[]>(() => []),
         )
+
+        if (skipped > 0) {
+          console.warn(
+            `Skipped ${skipped}/${items.length} correlated token lists with a missing or unsupported chainId`,
+          )
+        }
+
+        // Never cache an all-empty result: it silently re-enables the volume fee on correlated pairs
+        if (!Object.values(state).some((lists) => lists.length > 0)) {
+          console.error('Correlated tokens resolved to empty for every chain, not persisting')
+          return undefined
+        }
 
         localStorage.setItem(UPDATE_TIME_KEY, Date.now().toString())
         setCorrelatedTokens(state)

--- a/libs/core/src/cms/utils/getCmsClient.ts
+++ b/libs/core/src/cms/utils/getCmsClient.ts
@@ -26,6 +26,8 @@ export function getCmsClient(url: string = CMS_BASE_URL): CmsApiClient {
  * - `/solvers`: barn has no `solver_networks` data, so solvers there resolve to raw addresses instead
  *   of names and logos. Production carries both `barn` and `prod` addresses per solver.
  * - `/restricted-token-lists`: barn doesn't have them configured.
+ * - `/correlated-tokens`: barn's content type has no `network` relation, so every entry resolves to no
+ *   chainId and the volume fee stops being waived on correlated pairs.
  *
  * Everything else keeps using `getCmsClient()`: announcements, account notifications and cow-fi
  * content are environment-scoped, and barn is where they get staged.


### PR DESCRIPTION
# Summary

Make correlated tokens CMS query always point to CMS prod.

# To Test

1. Pick a correlated token to trade on Safe
- Check the Safe app fee is 0


# Self-checks

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have manually tested changes on Vercel preview deployment
- [x] I have done self-review and (or) AI review
- [x] I have addressed all comments from @coderabbitai
- [x] I have less than three open PRs/Stacks in this repo at the moment of creating this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved correlated-token list updates to prevent empty or incomplete CMS responses from overwriting existing data.
  - Correlated-token data is no longer published or timestamped when no valid chain-specific lists are available.
  - Added safeguards for entries with missing or unsupported network information, helping preserve accurate fee treatment for correlated pairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->