### PR TITLE
feat(solana): process order fulfillment

### DIFF
--- a/apps/cowswap-frontend/src/common/updaters/orders/OrdersFromApiUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/OrdersFromApiUpdater.ts
@@ -218,7 +218,10 @@ function _transformOrderBookOrderToStoreOrder(
   const storeOrder: Order = {
     ...order,
     // TODO: for some reason executedSellAmountBeforeFees is zero for limit-orders
-    sellAmountBeforeFee: order.class === OrderClass.LIMIT ? order.sellAmount : order.executedSellAmountBeforeFees,
+    sellAmountBeforeFee:
+      order.class === OrderClass.LIMIT
+        ? order.sellAmount
+        : (order.executedSellAmountBeforeFees ?? order.executedSellAmount),
     inputToken,
     outputToken,
     id,

--- a/apps/cowswap-frontend/src/common/updaters/orders/PendingOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/PendingOrdersUpdater.ts
@@ -363,7 +363,6 @@ async function _updateOrders({
   allTransactions,
   markPollComplete,
 }: UpdateOrdersParams): Promise<void> {
-  console.log('CCCCC', { chainId, orders })
   // Only check pending orders of current connected account
   const pending = orders.filter(({ owner }) => areAddressesEqual(owner, account))
 

--- a/apps/cowswap-frontend/src/common/updaters/orders/PendingOrdersUpdater.ts
+++ b/apps/cowswap-frontend/src/common/updaters/orders/PendingOrdersUpdater.ts
@@ -363,6 +363,7 @@ async function _updateOrders({
   allTransactions,
   markPollComplete,
 }: UpdateOrdersParams): Promise<void> {
+  console.log('CCCCC', { chainId, orders })
   // Only check pending orders of current connected account
   const pending = orders.filter(({ owner }) => areAddressesEqual(owner, account))
 

--- a/apps/cowswap-frontend/src/legacy/components/TransactionConfirmationModal/DisplayLink.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/TransactionConfirmationModal/DisplayLink.tsx
@@ -1,6 +1,11 @@
 import { ReactNode } from 'react'
 
-import { getChainExplorerLinkTitle, getCoWExplorerLinkTitle, getExplorerOrderLink } from '@cowprotocol/common-utils'
+import {
+  getChainExplorerLinkTitle,
+  getCoWExplorerLinkTitle,
+  getEtherscanUrl,
+  getExplorerOrderLink,
+} from '@cowprotocol/common-utils'
 
 import { OrderStatus } from 'legacy/state/orders/actions'
 import { useOrder } from 'legacy/state/orders/hooks'
@@ -26,7 +31,11 @@ export function DisplayLink({ id, chainId, leadToBridgeTab }: DisplayLinkProps):
       : undefined
 
   if (transactionHash) {
-    return <ExternalLinkCustom href={transactionHash}>{getChainExplorerLinkTitle(chainId)} ↗</ExternalLinkCustom>
+    return (
+      <ExternalLinkCustom href={getEtherscanUrl(chainId, transactionHash, 'transaction')}>
+        {getChainExplorerLinkTitle(chainId)} ↗
+      </ExternalLinkCustom>
+    )
   }
 
   return (

--- a/apps/cowswap-frontend/src/legacy/components/TransactionConfirmationModal/DisplayLink.tsx
+++ b/apps/cowswap-frontend/src/legacy/components/TransactionConfirmationModal/DisplayLink.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-import { getBlockExplorerUrl, getEtherscanLink, getExplorerLabel } from '@cowprotocol/common-utils'
+import { getChainExplorerLinkTitle, getCoWExplorerLinkTitle, getExplorerOrderLink } from '@cowprotocol/common-utils'
 
 import { OrderStatus } from 'legacy/state/orders/actions'
 import { useOrder } from 'legacy/state/orders/hooks'
@@ -20,14 +20,18 @@ export function DisplayLink({ id, chainId, leadToBridgeTab }: DisplayLinkProps):
     return null
   }
 
-  const ethFlowHash =
+  const transactionHash =
     orderCreationHash && (status === OrderStatus.CREATING || status === OrderStatus.FAILED)
       ? orderCreationHash
       : undefined
-  const href = ethFlowHash
-    ? getBlockExplorerUrl(chainId, 'transaction', ethFlowHash)
-    : getEtherscanLink(chainId, 'transaction', id) + (leadToBridgeTab ? '?tab=bridge' : '')
-  const label = getExplorerLabel(chainId, 'transaction', ethFlowHash || id)
 
-  return <ExternalLinkCustom href={href}>{label} ↗</ExternalLinkCustom>
+  if (transactionHash) {
+    return <ExternalLinkCustom href={transactionHash}>{getChainExplorerLinkTitle(chainId)} ↗</ExternalLinkCustom>
+  }
+
+  return (
+    <ExternalLinkCustom href={getExplorerOrderLink(chainId, id) + (leadToBridgeTab ? '?tab=bridge' : '')}>
+      {getCoWExplorerLinkTitle()} ↗
+    </ExternalLinkCustom>
+  )
 }

--- a/apps/cowswap-frontend/src/legacy/hooks/useRecentActivity.ts
+++ b/apps/cowswap-frontend/src/legacy/hooks/useRecentActivity.ts
@@ -161,7 +161,8 @@ export function useRecentActivity(): TransactionAndOrder[] {
             areAddressesEqual(tx.from, account) &&
             isTransactionRecent(tx) &&
             isNotEthFlowTx(tx) &&
-            isNotOnChainCancellationTx(tx)
+            isNotOnChainCancellationTx(tx) &&
+            isNotSolanaOrderCreationTx(tx)
           )
         })
         .map((tx) => {
@@ -269,6 +270,13 @@ function isNotEthFlowTx(tx: EnhancedTransactionDetails): boolean {
 
 function isNotOnChainCancellationTx(tx: EnhancedTransactionDetails): boolean {
   return !tx.onChainCancellation
+}
+
+// Solana orders are created by an on-chain transaction, like ETH-flow — the order (shown with its own
+// stepper) already represents this activity, so its creation tx is hidden here the same way `ethFlow`
+// creation txs are, instead of being listed a second time as a standalone transaction.
+function isNotSolanaOrderCreationTx(tx: EnhancedTransactionDetails): boolean {
+  return !tx.solanaOrderCreation
 }
 
 /**

--- a/apps/cowswap-frontend/src/legacy/state/enhancedTransactions/actions.ts
+++ b/apps/cowswap-frontend/src/legacy/state/enhancedTransactions/actions.ts
@@ -21,6 +21,7 @@ export type AddTransactionParams = WithChainId &
     | 'swapLockedGNOvCow'
     | 'ethFlow'
     | 'onChainCancellation'
+    | 'solanaOrderCreation'
   >
 
 export interface SerializableTransactionReceipt {

--- a/apps/cowswap-frontend/src/legacy/state/enhancedTransactions/reducer.ts
+++ b/apps/cowswap-frontend/src/legacy/state/enhancedTransactions/reducer.ts
@@ -46,6 +46,9 @@ export interface EnhancedTransactionDetails {
   swapLockedGNOvCow?: boolean
   ethFlow?: { orderId: string; subType: 'creation' | 'cancellation' | 'refund' }
   onChainCancellation?: { orderId: string; sellTokenSymbol: string }
+  // The Solana order-creation tx: like `ethFlow`, its own on-chain activity should be hidden from the
+  // activity list (the order it created is shown instead) — see `isNotSolanaOrderCreationTx`.
+  solanaOrderCreation?: boolean
   // Wallet specific
   safeTransaction?: SafeMultisigTransactionResponse // Gnosis Safe transaction info
 
@@ -113,6 +116,7 @@ export default createReducer(initialState, (builder) =>
             swapLockedGNOvCow,
             ethFlow,
             onChainCancellation,
+            solanaOrderCreation,
           },
         },
       ) => {
@@ -143,6 +147,7 @@ export default createReducer(initialState, (builder) =>
           swapLockedGNOvCow,
           ethFlow,
           onChainCancellation,
+          solanaOrderCreation,
         }
         transactions[chainId] = txs
       },

--- a/apps/cowswap-frontend/src/legacy/state/orders/utils.test.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/utils.test.ts
@@ -135,6 +135,7 @@ describe('classifyOrder', () => {
     buyAmount: '1000',
     sellAmount: '1000',
     executedBuyAmount: '0',
+    executedSellAmount: '0',
     executedSellAmountBeforeFees: '0',
     kind: OrderKind.SELL,
     signingScheme: SigningScheme.EIP712,
@@ -154,6 +155,22 @@ describe('classifyOrder', () => {
 
     it('is buy', () => {
       const order: typeof BASE_ORDER = { ...BASE_ORDER, executedBuyAmount: BASE_ORDER.buyAmount, kind: OrderKind.BUY }
+      expect(classifyOrder(order)).toBe('fulfilled')
+    })
+
+    // Solana's API doesn't return `executedSellAmountBeforeFees`, so the fallback to
+    // `executedSellAmount` has to cover both shapes it can arrive as. The casts are deliberate: the SDK
+    // types the field as a required string, which is exactly the assumption that doesn't hold here.
+    it.each([
+      ['absent', undefined],
+      ['null', null],
+    ])('is sell when executedSellAmountBeforeFees is %s but executedSellAmount is complete', (_label, missing) => {
+      const order: typeof BASE_ORDER = {
+        ...BASE_ORDER,
+        executedSellAmountBeforeFees: missing as unknown as string,
+        executedSellAmount: BASE_ORDER.sellAmount,
+      }
+
       expect(classifyOrder(order)).toBe('fulfilled')
     })
   })

--- a/apps/cowswap-frontend/src/legacy/state/orders/utils.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/utils.ts
@@ -131,8 +131,7 @@ export function isOrderFulfilled(
 ): boolean {
   const { buyAmount, sellAmount, executedBuyAmount, executedSellAmountBeforeFees, executedSellAmount, kind } = order
   // FIXME: Solana API doesn't return executedSellAmountBeforeFees. Need to ask backend to fix it
-  const filledSellAmount =
-    typeof executedSellAmountBeforeFees === 'undefined' ? executedSellAmount : executedSellAmountBeforeFees
+  const filledSellAmount = executedSellAmountBeforeFees ?? executedSellAmount
 
   if (isSellOrder(kind)) {
     return sellAmount === filledSellAmount

--- a/apps/cowswap-frontend/src/legacy/state/orders/utils.ts
+++ b/apps/cowswap-frontend/src/legacy/state/orders/utils.ts
@@ -40,6 +40,7 @@ export function classifyOrder(
     | 'invalidated'
     | 'buyAmount'
     | 'sellAmount'
+    | 'executedSellAmount'
     | 'executedBuyAmount'
     | 'executedSellAmountBeforeFees'
     | 'kind'
@@ -125,13 +126,16 @@ export function isOrderExpired(order: Pick<EnrichedOrder, 'validTo'>, threshold 
 export function isOrderFulfilled(
   order: Pick<
     EnrichedOrder,
-    'buyAmount' | 'sellAmount' | 'executedBuyAmount' | 'executedSellAmountBeforeFees' | 'kind'
+    'buyAmount' | 'sellAmount' | 'executedBuyAmount' | 'executedSellAmount' | 'executedSellAmountBeforeFees' | 'kind'
   >,
 ): boolean {
-  const { buyAmount, sellAmount, executedBuyAmount, executedSellAmountBeforeFees, kind } = order
+  const { buyAmount, sellAmount, executedBuyAmount, executedSellAmountBeforeFees, executedSellAmount, kind } = order
+  // FIXME: Solana API doesn't return executedSellAmountBeforeFees. Need to ask backend to fix it
+  const filledSellAmount =
+    typeof executedSellAmountBeforeFees === 'undefined' ? executedSellAmount : executedSellAmountBeforeFees
 
   if (isSellOrder(kind)) {
-    return sellAmount === executedSellAmountBeforeFees
+    return sellAmount === filledSellAmount
   } else {
     return buyAmount === executedBuyAmount
   }

--- a/apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
@@ -202,9 +202,12 @@ export function ActivityDetails(props: {
 
     isOrderFulfilled = !!order.apiAdditionalInfo && order.status === OrderStatus.FULFILLED
 
-    const { executedSellAmountBeforeFees, executedBuyAmount } = order.apiAdditionalInfo || {}
+    const { executedSellAmountBeforeFees, executedBuyAmount, executedSellAmount } = order.apiAdditionalInfo || {}
     const rateInputCurrencyAmount = isOrderFulfilled
-      ? CurrencyAmount.fromRawAmount(inputToken, executedSellAmountBeforeFees?.toString() || '0')
+      ? CurrencyAmount.fromRawAmount(
+          inputToken,
+          (executedSellAmountBeforeFees ?? executedSellAmount)?.toString() || '0',
+        )
       : inputAmount
 
     const rateOutputCurrencyAmount = isOrderFulfilled

--- a/apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
+++ b/apps/cowswap-frontend/src/modules/account/containers/Transaction/ActivityDetails.tsx
@@ -4,7 +4,7 @@ import { i18n } from '@lingui/core'
 
 import { COW_TOKEN_TO_CHAIN, V_COW, V_COW_CONTRACT_ADDRESS } from '@cowprotocol/common-const'
 import { ExplorerDataType, getExplorerLink, shortenAddress } from '@cowprotocol/common-utils'
-import { areAddressesEqual, SupportedChainId } from '@cowprotocol/cow-sdk'
+import { areAddressesEqual, isSolanaChain, SupportedChainId } from '@cowprotocol/cow-sdk'
 import { CurrencyAmount, Token } from '@cowprotocol/currency'
 import { useENS } from '@cowprotocol/ens'
 import { BridgeStatus } from '@cowprotocol/sdk-bridging'
@@ -24,6 +24,9 @@ import { OrderStatus } from 'legacy/state/orders/actions'
 import { useToggleAccountModal } from 'modules/account'
 import { BridgeActivitySummary } from 'modules/bridge'
 import { EthFlowStepper } from 'modules/ethFlow'
+// Reached directly (not via the module barrel) to avoid a cycle: the barrel's `OrderSubmittedContent`
+// pulls in `TransactionSubmittedContent`, which imports this same `account` module.
+import { SolanaOrderStepper } from 'modules/orderProgressBar/pure/SolanaOrderStepper'
 import { OrderFillability, useGetPendingOrdersPermitValidityState } from 'modules/ordersTable'
 import { ConfirmDetailsItem } from 'modules/trade'
 
@@ -482,7 +485,7 @@ export function ActivityDetails(props: {
         />
       </Summary>
 
-      <EthFlowStepper order={order} />
+      {isSolanaChain(chainId) ? <SolanaOrderStepper order={order} /> : <EthFlowStepper order={order} />}
     </>
   )
 }

--- a/apps/cowswap-frontend/src/modules/onchainTransactions/updaters/FinalizeTxUpdater/services/checkSolanaTransaction.ts
+++ b/apps/cowswap-frontend/src/modules/onchainTransactions/updaters/FinalizeTxUpdater/services/checkSolanaTransaction.ts
@@ -55,19 +55,21 @@ export function checkSolanaTransaction(
 
     dispatch(finalizeTransaction({ chainId, hash, receipt }))
 
-    emitOnchainTransactionEvent({
-      receipt: {
-        to: '',
-        from: transaction.from,
-        contractAddress: '',
-        transactionHash: hash as `0x${string}`,
-        blockNumber: slot,
-        status: status === 'success' ? 1 : 0,
-        replacementType: transaction.replacementType,
-      },
-      summary: transaction.summary || '',
-      isSafeTx: false,
-    })
+    if (!transaction.solanaOrderCreation) {
+      emitOnchainTransactionEvent({
+        receipt: {
+          to: '',
+          from: transaction.from,
+          contractAddress: '',
+          transactionHash: hash as `0x${string}`,
+          blockNumber: slot,
+          status: status === 'success' ? 1 : 0,
+          replacementType: transaction.replacementType,
+        },
+        summary: transaction.summary || '',
+        isSafeTx: false,
+      })
+    }
   }
 
   checkStatus(solanaConnection, hash, transaction)

--- a/apps/cowswap-frontend/src/modules/trade/services/solanaFlow/planCreateOrderStep.ts
+++ b/apps/cowswap-frontend/src/modules/trade/services/solanaFlow/planCreateOrderStep.ts
@@ -32,6 +32,7 @@ export async function planCreateOrderStep({
     step: {
       instructions: [instruction],
       summary: t`Swap ${sellSymbol} for ${buySymbol}`,
+      createsOrder: true,
     },
     orderId,
     signingScheme,

--- a/apps/cowswap-frontend/src/modules/trade/services/solanaFlow/sendSolanaFlow.test.ts
+++ b/apps/cowswap-frontend/src/modules/trade/services/solanaFlow/sendSolanaFlow.test.ts
@@ -77,6 +77,7 @@ describe('sendSolanaFlow', () => {
     expect(addTransaction).toHaveBeenCalledWith({
       hash: SIGNATURE,
       summary: 'Wrap 1 SOL, Approve WSOL',
+      solanaOrderCreation: true,
       data: { lastValidBlockHeight: LAST_VALID_BLOCK_HEIGHT },
     })
   })

--- a/apps/cowswap-frontend/src/modules/trade/services/solanaFlow/sendSolanaFlow.test.ts
+++ b/apps/cowswap-frontend/src/modules/trade/services/solanaFlow/sendSolanaFlow.test.ts
@@ -46,6 +46,10 @@ function dummyInstruction(): TransactionInstruction {
   return new TransactionInstruction({ keys: [], programId: OWNER, data: Buffer.from([]) })
 }
 
+function orderStep(instructions: TransactionInstruction[], summary: string): SolanaFlowStep {
+  return { instructions, summary, createsOrder: true }
+}
+
 function step(instructions: TransactionInstruction[], summary: string): SolanaFlowStep {
   return { instructions, summary }
 }
@@ -77,9 +81,31 @@ describe('sendSolanaFlow', () => {
     expect(addTransaction).toHaveBeenCalledWith({
       hash: SIGNATURE,
       summary: 'Wrap 1 SOL, Approve WSOL',
-      solanaOrderCreation: true,
+      solanaOrderCreation: false,
       data: { lastValidBlockHeight: LAST_VALID_BLOCK_HEIGHT },
     })
+  })
+
+  // The activity list hides order-creation transactions and shows the order instead, so the tag has to
+  // track what was actually bundled: mis-tagging a wrap- or delegate-only transaction would make a real
+  // transaction disappear from activity and suppress its confirmation event.
+  it('tags the transaction when a step creates an order', async () => {
+    const { context, addTransaction } = createHarness()
+
+    await sendSolanaFlow(context, [
+      step([dummyInstruction()], 'Wrap 1 SOL'),
+      orderStep([dummyInstruction()], 'Swap SOL for USDC'),
+    ])
+
+    expect(addTransaction).toHaveBeenCalledWith(expect.objectContaining({ solanaOrderCreation: true }))
+  })
+
+  it('leaves a wrap- or delegate-only transaction untagged, so it stays visible in activity', async () => {
+    const { context, addTransaction } = createHarness()
+
+    await sendSolanaFlow(context, [step([dummyInstruction()], 'Wrap 1 SOL')])
+
+    expect(addTransaction).toHaveBeenCalledWith(expect.objectContaining({ solanaOrderCreation: false }))
   })
 
   it('returns the transaction hash', async () => {

--- a/apps/cowswap-frontend/src/modules/trade/services/solanaFlow/sendSolanaFlow.ts
+++ b/apps/cowswap-frontend/src/modules/trade/services/solanaFlow/sendSolanaFlow.ts
@@ -27,7 +27,10 @@ export async function sendSolanaFlow(context: SolanaFlowContext, steps: SolanaFl
 
   const { hash, lastValidBlockHeight } = await sendSolanaTransaction(connection, provider, owner, instructions)
 
-  addTransaction({ hash, summary, data: { lastValidBlockHeight } })
+  // Tagged so the activity list hides this transaction and shows the order it created instead — see
+  // `isNotSolanaOrderCreationTx`. Every flow bundled here always ends in a `CreateOrder` instruction
+  // (see `solanaFlow`), so the resulting transaction is always the order's creation tx.
+  addTransaction({ hash, summary, solanaOrderCreation: true, data: { lastValidBlockHeight } })
 
   return { hash }
 }

--- a/apps/cowswap-frontend/src/modules/trade/services/solanaFlow/sendSolanaFlow.ts
+++ b/apps/cowswap-frontend/src/modules/trade/services/solanaFlow/sendSolanaFlow.ts
@@ -27,10 +27,12 @@ export async function sendSolanaFlow(context: SolanaFlowContext, steps: SolanaFl
 
   const { hash, lastValidBlockHeight } = await sendSolanaTransaction(connection, provider, owner, instructions)
 
-  // Tagged so the activity list hides this transaction and shows the order it created instead — see
-  // `isNotSolanaOrderCreationTx`. Every flow bundled here always ends in a `CreateOrder` instruction
-  // (see `solanaFlow`), so the resulting transaction is always the order's creation tx.
-  addTransaction({ hash, summary, solanaOrderCreation: true, data: { lastValidBlockHeight } })
+  // Tagging an order-creating transaction hides it from the activity list so the order shows instead —
+  // see `isNotSolanaOrderCreationTx`. Read off the steps rather than assumed, keeping this function
+  // agnostic about what a step means: a wrap- or delegate-only transaction must stay visible.
+  const solanaOrderCreation = steps.some((step) => step.createsOrder)
+
+  addTransaction({ hash, summary, solanaOrderCreation, data: { lastValidBlockHeight } })
 
   return { hash }
 }

--- a/apps/cowswap-frontend/src/modules/trade/services/solanaFlow/types.ts
+++ b/apps/cowswap-frontend/src/modules/trade/services/solanaFlow/types.ts
@@ -5,4 +5,8 @@ export interface SolanaFlowStep {
   instructions: TransactionInstruction[]
   // Joined with the other steps' summaries into one transaction-history entry.
   summary: string
+  // Set by the step contributing the `CreateOrder` instruction. `sendSolanaFlow` forwards it as the
+  // transaction's `solanaOrderCreation` tag, so the tag follows what was actually bundled rather than
+  // an assumption about the caller — steps here are assembled conditionally and can be skipped.
+  createsOrder?: boolean
 }

--- a/apps/cowswap-frontend/src/modules/tradeFlow/services/solanaFlow/index.test.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/services/solanaFlow/index.test.ts
@@ -7,6 +7,7 @@ import { Connection, PublicKey } from '@solana/web3.js'
 
 import { OrderStatus } from 'legacy/state/orders/actions'
 
+import { emitPostedOrderEvent } from 'modules/orders'
 import { planCreateOrderStep } from 'modules/trade/services/solanaFlow/planCreateOrderStep'
 import { planDelegateStep } from 'modules/trade/services/solanaFlow/planDelegateStep'
 import { planWrapStep } from 'modules/trade/services/solanaFlow/planWrapStep'
@@ -22,6 +23,7 @@ import { solanaFlow } from './index'
 import type { Provider as SolanaProvider } from '@reown/appkit-adapter-solana/react'
 
 jest.mock('modules/trade/utils/addPendingOrderStep')
+jest.mock('modules/orders', () => ({ emitPostedOrderEvent: jest.fn() }))
 
 // The step planners are unit-tested on their own; mocking them here keeps this a test of the flow's
 // composition, and keeps the real instruction builders (which need ed25519 curve math jsdom can't run)
@@ -35,6 +37,7 @@ const mockSendSolanaFlow = sendSolanaFlow as jest.MockedFunction<typeof sendSola
 const mockPlanWrapStep = planWrapStep as jest.MockedFunction<typeof planWrapStep>
 const mockPlanDelegateStep = planDelegateStep as jest.MockedFunction<typeof planDelegateStep>
 const mockPlanCreateOrderStep = planCreateOrderStep as jest.MockedFunction<typeof planCreateOrderStep>
+const mockEmitPostedOrderEvent = emitPostedOrderEvent as jest.MockedFunction<typeof emitPostedOrderEvent>
 
 // Canonical Solana System Program address (32 zero bytes) — always a syntactically
 // valid Solana pubkey, used here as a stand-in "connected account".
@@ -236,6 +239,24 @@ describe('solanaFlow', () => {
     expect(analytics.sign).toHaveBeenCalledWith(context.swapFlowAnalyticsContext)
   })
 
+  it('emits the posted-order event so the rich "Order submitted" snackbar shows, not the raw tx summary', async () => {
+    const context = buildContext()
+
+    await solanaFlow(context, buildAnalytics())
+
+    expect(mockEmitPostedOrderEvent).toHaveBeenCalledWith({
+      chainId: SOLANA_CHAIN_ID,
+      id: ORDER_ID,
+      owner: context.account,
+      kind: context.context.orderKind,
+      uiOrderType: context.swapFlowAnalyticsContext.orderType,
+      receiver: context.context.receiver,
+      inputAmount: context.context.inputAmount,
+      outputAmount: context.context.outputAmount,
+      orderCreationHash: TX_HASH,
+    })
+  })
+
   it('reports an error and adds nothing when sending rejects', async () => {
     mockSendSolanaFlow.mockRejectedValue(new Error('User rejected the request'))
     const context = buildContext()
@@ -245,6 +266,7 @@ describe('solanaFlow', () => {
 
     expect(result).toBeUndefined()
     expect(addPendingOrderStepModule.addPendingOrderStep).not.toHaveBeenCalled()
+    expect(mockEmitPostedOrderEvent).not.toHaveBeenCalled()
     expect(context.tradeConfirmActions.onSuccess).not.toHaveBeenCalled()
     expect(context.tradeConfirmActions.onError).toHaveBeenCalled()
     expect(analytics.error).toHaveBeenCalled()

--- a/apps/cowswap-frontend/src/modules/tradeFlow/services/solanaFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/services/solanaFlow/index.ts
@@ -1,10 +1,12 @@
 import { captureError, ERROR_TYPES, normalizeError } from '@cowprotocol/common-utils'
-import { OrderClass, OrderParameters } from '@cowprotocol/cow-sdk'
-import type { Token } from '@cowprotocol/currency'
+import { OrderClass, OrderKind, OrderParameters, SupportedChainId } from '@cowprotocol/cow-sdk'
+import type { Currency, CurrencyAmount, Token } from '@cowprotocol/currency'
 import type { SolanaSwapOrder } from '@cowprotocol/sdk-trading-solana'
+import type { UiOrderType } from '@cowprotocol/types'
 
 import { Order, OrderStatus } from 'legacy/state/orders/actions'
 
+import { emitPostedOrderEvent } from 'modules/orders'
 import { planCreateOrderStep, planDelegateStep, planWrapStep, sendSolanaFlow, SolanaFlowStep } from 'modules/trade'
 import { addPendingOrderStep } from 'modules/trade/utils/addPendingOrderStep'
 import { logTradeFlow } from 'modules/trade/utils/logger'
@@ -14,6 +16,7 @@ import { getSwapErrorMessage } from 'common/utils/getSwapErrorMessage'
 
 import { SolanaTradeFlowContext } from '../../types/TradeFlowContext'
 
+// eslint-disable-next-line max-lines-per-function
 export async function solanaFlow(
   input: SolanaTradeFlowContext,
   analytics: TradeFlowAnalytics,
@@ -33,7 +36,7 @@ export async function solanaFlow(
     delegationAmount,
     isNativeSell,
   } = input
-  const { inputAmount, outputAmount, chainId, validTo, receiver } = context
+  const { inputAmount, outputAmount, chainId, validTo, receiver, orderKind } = context
   const tradeAmounts = { inputAmount, outputAmount }
 
   logTradeFlow('SOLANA FLOW', 'STEP 1: sign and send wrap, delegate and create-order in one transaction')
@@ -92,6 +95,18 @@ export async function solanaFlow(
       callbacks.dispatch,
     )
 
+    emitSolanaPostedOrderEvent({
+      chainId,
+      orderId,
+      account,
+      orderKind,
+      uiOrderType: swapFlowAnalyticsContext.orderType,
+      receiver,
+      inputAmount,
+      outputAmount,
+      txHash: hash,
+    })
+
     logTradeFlow('SOLANA FLOW', 'STEP 2: show UI of the successfully sent transaction', orderId)
     // onSuccess takes the order id, not the tx hash: OrderSubmittedContent looks the order up
     // from Redux by this value via `useOrder({ id: transactionHash })`.
@@ -146,4 +161,32 @@ function buildSolanaOrder(params: {
     // The order is created on-chain by the transaction above; there is no off-chain signature to carry.
     signature: txHash,
   }
+}
+
+// Drives the rich "Order submitted" snackbar (OrderNotification); without this, the fallback
+// transaction-added toast shows the raw bundled tx summary instead (e.g. "Swap USDC for SOL").
+function emitSolanaPostedOrderEvent(params: {
+  chainId: SupportedChainId
+  orderId: string
+  account: string
+  orderKind: OrderKind
+  uiOrderType: UiOrderType
+  receiver: string
+  inputAmount: CurrencyAmount<Currency>
+  outputAmount: CurrencyAmount<Currency>
+  txHash: string
+}): void {
+  const { chainId, orderId, account, orderKind, uiOrderType, receiver, inputAmount, outputAmount, txHash } = params
+
+  emitPostedOrderEvent({
+    chainId,
+    id: orderId,
+    owner: account,
+    kind: orderKind,
+    uiOrderType,
+    receiver,
+    inputAmount,
+    outputAmount,
+    orderCreationHash: txHash,
+  })
 }

--- a/apps/cowswap-frontend/src/utils/orderUtils/getOrderExecutedAmounts.ts
+++ b/apps/cowswap-frontend/src/utils/orderUtils/getOrderExecutedAmounts.ts
@@ -14,17 +14,17 @@ export function getOrderExecutedAmounts(order: Order): {
 } {
   const { apiAdditionalInfo } = order
 
-  if (!apiAdditionalInfo || !apiAdditionalInfo.executedSellAmountBeforeFees) {
+  if (!apiAdditionalInfo) {
     return {
       executedBuyAmount: JSBI.BigInt(0),
       executedSellAmount: JSBI.BigInt(0),
     }
   }
 
-  const { executedBuyAmount, executedSellAmountBeforeFees } = apiAdditionalInfo
+  const { executedBuyAmount, executedSellAmountBeforeFees, executedSellAmount } = apiAdditionalInfo
 
   return {
     executedBuyAmount: JSBI.BigInt(executedBuyAmount),
-    executedSellAmount: JSBI.BigInt(executedSellAmountBeforeFees),
+    executedSellAmount: JSBI.BigInt(executedSellAmountBeforeFees ?? executedSellAmount),
   }
 }

--- a/apps/cowswap-frontend/src/utils/orderUtils/getOrderFilledAmount.test.ts
+++ b/apps/cowswap-frontend/src/utils/orderUtils/getOrderFilledAmount.test.ts
@@ -1,0 +1,41 @@
+import { OrderKind } from '@cowprotocol/cow-sdk'
+
+import { Order, OrderStatus } from 'legacy/state/orders/actions'
+
+import { getOrderFilledAmount } from './getOrderFilledAmount'
+
+function buildOrder(apiAdditionalInfo: Partial<NonNullable<Order['apiAdditionalInfo']>> | undefined): Order {
+  return {
+    kind: OrderKind.SELL,
+    sellAmount: '1000000',
+    status: OrderStatus.FULFILLED,
+    apiAdditionalInfo: apiAdditionalInfo as Order['apiAdditionalInfo'],
+  } as unknown as Order
+}
+
+describe('getOrderFilledAmount', () => {
+  it('returns zero when the order has no apiAdditionalInfo yet', () => {
+    const order = buildOrder(undefined)
+
+    expect(getOrderFilledAmount(order).amount.toString()).toBe('0')
+  })
+
+  it('subtracts the executed fee from the executed sell amount', () => {
+    const order = buildOrder({ executedSellAmount: '1000000', executedFeeAmount: '3000' })
+
+    expect(getOrderFilledAmount(order).amount.toString()).toBe('997000')
+  })
+
+  // Solana's order API doesn't return `executedFeeAmount` (unlike EVM chains) even though the SDK
+  // type declares it as required — treating the missing fee as zero avoids `BigNumber.minus(undefined)`
+  // producing NaN, which `legacyBigNumberToCurrencyAmount` (getFilledAmounts.ts) then silently displays
+  // as a sell amount of 0 in the "Order filled" snackbar.
+  it('treats a missing executed fee as zero instead of producing NaN', () => {
+    const order = buildOrder({ executedSellAmount: '1000000', executedFeeAmount: undefined })
+
+    const { amount } = getOrderFilledAmount(order)
+
+    expect(amount.isNaN()).toBe(false)
+    expect(amount.toString()).toBe('1000000')
+  })
+})

--- a/apps/cowswap-frontend/src/utils/orderUtils/getOrderFilledAmount.ts
+++ b/apps/cowswap-frontend/src/utils/orderUtils/getOrderFilledAmount.ts
@@ -25,8 +25,11 @@ export function getOrderFilledAmount(order: Order): FilledAmountResult {
   }
 
   if (isSellOrder(order.kind)) {
+    // Solana's order API doesn't return `executedFeeAmount` (unlike EVM chains), even though the SDK
+    // type declares it as required — falling back to '0' avoids `BigNumber.minus(undefined)` producing
+    // NaN, which downstream silently displays as a sell amount of 0.
     executedAmount = new BigNumber(order.apiAdditionalInfo.executedSellAmount).minus(
-      order.apiAdditionalInfo?.executedFeeAmount,
+      order.apiAdditionalInfo?.executedFeeAmount || '0',
     )
     totalAmount = new BigNumber(order.sellAmount.toString())
   } else {

--- a/apps/cowswap-frontend/src/utils/orderUtils/getOrderSurplus.ts
+++ b/apps/cowswap-frontend/src/utils/orderUtils/getOrderSurplus.ts
@@ -47,10 +47,10 @@ function _getFillOrKillBuySurplus(order: Order): Surplus | null {
     return null
   }
 
-  const { executedSellAmountBeforeFees } = apiAdditionalInfo
+  const { executedSellAmountBeforeFees, executedSellAmount } = apiAdditionalInfo
 
   const sellAmountBigNumber = new BigNumber(sellAmount)
-  const executedSellAmountBigNumber = new BigNumber(executedSellAmountBeforeFees)
+  const executedSellAmountBigNumber = new BigNumber(executedSellAmountBeforeFees ?? executedSellAmount)
 
   // BUY order has the buy amount fixed, so it'll sell AT MOST `sellAmount`
   // Surplus will come in the form of a "discount", selling less than `sellAmount`
@@ -91,10 +91,10 @@ function _getPartialFillBuySurplus(order: Order): Surplus | null {
     return null
   }
 
-  const { executedSellAmountBeforeFees, executedBuyAmount } = apiAdditionalInfo
+  const { executedSellAmountBeforeFees, executedSellAmount, executedBuyAmount } = apiAdditionalInfo
 
   const sellAmountBigNumber = new BigNumber(sellAmount)
-  const executedSellAmountBigNumber = new BigNumber(executedSellAmountBeforeFees)
+  const executedSellAmountBigNumber = new BigNumber(executedSellAmountBeforeFees ?? executedSellAmount)
   const buyAmountBigNumber = new BigNumber(buyAmount)
   const executedBuyAmountBigNumber = new BigNumber(executedBuyAmount)
 
@@ -117,10 +117,10 @@ function _getPartialFillSellSurplus(order: Order): Surplus | null {
     return null
   }
 
-  const { executedSellAmountBeforeFees, executedBuyAmount } = apiAdditionalInfo
+  const { executedSellAmountBeforeFees, executedSellAmount, executedBuyAmount } = apiAdditionalInfo
 
   const sellAmountBigNumber = new BigNumber(sellAmount)
-  const executedSellAmountBigNumber = new BigNumber(executedSellAmountBeforeFees)
+  const executedSellAmountBigNumber = new BigNumber(executedSellAmountBeforeFees ?? executedSellAmount)
   const buyAmountBigNumber = new BigNumber(buyAmount)
   const executedBuyAmountBigNumber = new BigNumber(executedBuyAmount)
 

--- a/libs/common-utils/src/legacyAddressUtils.ts
+++ b/libs/common-utils/src/legacyAddressUtils.ts
@@ -81,6 +81,7 @@ function makeAddressShorter(address: string, chars = 4): string {
 }
 
 const COW_ORDER_ID_LENGTH = 114 // 112 (56 bytes in hex) + 2 (it's prefixed with "0x")
+const SOLANA_COW_ORDER_ID_LENGTH = 66
 
 export type BlockExplorerLinkType =
   | 'transaction'
@@ -130,7 +131,7 @@ export function getExplorerLabel(chainId: SupportedChainId, type: BlockExplorerL
 export function isCowOrder(type: BlockExplorerLinkType, data?: string) {
   if (!data) return false
 
-  return type === 'transaction' && data.length === COW_ORDER_ID_LENGTH
+  return type === 'transaction' && (data.length === COW_ORDER_ID_LENGTH || data.length === SOLANA_COW_ORDER_ID_LENGTH)
 }
 
 export function shortenOrderId(orderId: string): string {

--- a/libs/common-utils/src/legacyAddressUtils.ts
+++ b/libs/common-utils/src/legacyAddressUtils.ts
@@ -128,6 +128,26 @@ export function getEtherscanLink(chainId: SupportedChainId, type: BlockExplorerL
   }
 }
 
+export function getEtherscanUrl(
+  chainId: TargetChainId,
+  data: string,
+  type: BlockExplorerLinkType,
+  base?: string,
+): string {
+  // Allow override via environment variable for local development (e.g., Otterscan)
+  const basePath =
+    getSafeAbsoluteUrl(BLOCK_EXPLORER_URL_OVERRIDE) ||
+    getSafeAbsoluteUrl(base) ||
+    getSafeAbsoluteUrl(CHAIN_INFO[chainId]?.explorer)
+
+  if (!basePath) return ''
+
+  if (isBtcChain(chainId)) return getBtcExplorerUrl(basePath, data, type)
+  // a dedicated explorer URL builder must be added here before this fallback.
+  if (isSolanaChain(chainId)) return getSolExplorerUrl(basePath, data, type)
+  return getEvmExplorerUrl(basePath, data, type)
+}
+
 export function getExplorerLabel(chainId: SupportedChainId, type: BlockExplorerLinkType, data?: string): string {
   return isCowOrder(type, data) ? getCoWExplorerLinkTitle() : getChainExplorerLinkTitle(chainId)
 }
@@ -160,21 +180,6 @@ function getBtcExplorerUrl(basePath: string, data: string, type: BlockExplorerLi
     case 'contract':
       return `${basePath}` // BTC has no token or contract page
   }
-}
-
-function getEtherscanUrl(chainId: TargetChainId, data: string, type: BlockExplorerLinkType, base?: string): string {
-  // Allow override via environment variable for local development (e.g., Otterscan)
-  const basePath =
-    getSafeAbsoluteUrl(BLOCK_EXPLORER_URL_OVERRIDE) ||
-    getSafeAbsoluteUrl(base) ||
-    getSafeAbsoluteUrl(CHAIN_INFO[chainId]?.explorer)
-
-  if (!basePath) return ''
-
-  if (isBtcChain(chainId)) return getBtcExplorerUrl(basePath, data, type)
-  // a dedicated explorer URL builder must be added here before this fallback.
-  if (isSolanaChain(chainId)) return getSolExplorerUrl(basePath, data, type)
-  return getEvmExplorerUrl(basePath, data, type)
 }
 
 function getEvmExplorerUrl(basePath: string, data: string, type: BlockExplorerLinkType): string {

--- a/libs/common-utils/src/legacyAddressUtils.ts
+++ b/libs/common-utils/src/legacyAddressUtils.ts
@@ -81,7 +81,6 @@ function makeAddressShorter(address: string, chars = 4): string {
 }
 
 const COW_ORDER_ID_LENGTH = 114 // 112 (56 bytes in hex) + 2 (it's prefixed with "0x")
-const SOLANA_COW_ORDER_ID_LENGTH = 66
 
 export type BlockExplorerLinkType =
   | 'transaction'
@@ -110,6 +109,15 @@ export function getBlockExplorerUrl(
   return getEtherscanUrl(chainId, data, type, base)
 }
 
+export function getChainExplorerLinkTitle(chainId: SupportedChainId): string {
+  const explorerTitle = CHAIN_INFO[chainId].explorerTitle
+
+  return t`View on` + ` ${explorerTitle}`
+}
+export function getCoWExplorerLinkTitle(): string {
+  return t`View on Explorer`
+}
+
 export function getEtherscanLink(chainId: SupportedChainId, type: BlockExplorerLinkType, data: string): string {
   if (isCowOrder(type, data)) {
     // Explorer for CoW orders:
@@ -121,9 +129,7 @@ export function getEtherscanLink(chainId: SupportedChainId, type: BlockExplorerL
 }
 
 export function getExplorerLabel(chainId: SupportedChainId, type: BlockExplorerLinkType, data?: string): string {
-  const explorerTitle = CHAIN_INFO[chainId].explorerTitle
-
-  return isCowOrder(type, data) ? t`View on Explorer` : t`View on` + ` ${explorerTitle}`
+  return isCowOrder(type, data) ? getCoWExplorerLinkTitle() : getChainExplorerLinkTitle(chainId)
 }
 
 // TODO: Add proper return type annotation
@@ -131,7 +137,8 @@ export function getExplorerLabel(chainId: SupportedChainId, type: BlockExplorerL
 export function isCowOrder(type: BlockExplorerLinkType, data?: string) {
   if (!data) return false
 
-  return type === 'transaction' && (data.length === COW_ORDER_ID_LENGTH || data.length === SOLANA_COW_ORDER_ID_LENGTH)
+  // FIXME: Solana order id has different length than COW_ORDER_ID_LENGTH
+  return type === 'transaction' && data.length === COW_ORDER_ID_LENGTH
 }
 
 export function shortenOrderId(orderId: string): string {


### PR DESCRIPTION

https://github.com/user-attachments/assets/686e1d53-bf0f-413f-8b20-d5402e750c64


## What changed

- Solana order fulfillment detection now falls back to `executedSellAmount` when `executedSellAmountBeforeFees` is absent (Solana's order API doesn't return it, unlike EVM chains) — fixes `isOrderFulfilled`, `getOrderExecutedAmounts`, `getOrderSurplus`, and `OrdersFromApiUpdater`'s `sellAmountBeforeFee`.
- "Order submitted" snackbar for Solana swaps now shows the real order (id, sell/buy amounts) instead of the raw bundled-transaction summary (e.g. "Swap USDC for SOL") — `solanaFlow` now emits the same `emitPostedOrderEvent` every other trade flow already emits.
- "Order filled" snackbar no longer shows the sell amount as `0` — `getOrderFilledAmount` now treats a missing `executedFeeAmount` (also absent from Solana's API) as zero instead of letting `BigNumber.minus(undefined)` silently produce `NaN`.
- Solana orders no longer show up twice in the activity list (once as the order, once as its on-chain creation transaction): the creation tx is now tagged (`solanaOrderCreation`) and filtered out of the standalone-transaction list, the same way ETH-flow creation txs already are. The same tag also suppresses a duplicate "transaction confirmed" event from `checkSolanaTransaction`.
- The activity list now renders `SolanaOrderStepper` ("Creating order on Solana") for Solana orders instead of the EVM-only `EthFlowStepper`.
- Explorer/"View order" links now recognize Solana order IDs (66-char) as CoW orders, not raw transactions.

## QA Testing

Preview URL QA:
- Open https://swap-dev-git-solana-order-fulfillment-1-cowswap-dev.vercel.app/#/1/swap?IS_SOLANA_ENABLED=1 once to enable Solana support (persisted to local storage), then switch network to Solana and connect a Solana wallet.
- Post a swap and confirm the "Order submitted" snackbar shows the order id and a "Sell X for at least Y" line, not a generic "Swap X for Y" transaction message.
- Open the account activity list while the order is pending and confirm it appears once (not once as an order and again as a transaction), with a "Creating order on Solana" step shown.
- Wait for the order to fill and confirm the "Order filled" snackbar shows the actual sold amount, not `0`.
- Click the order's explorer link and confirm it opens the order page, not a raw transaction page.

Developer verification:
- New/updated targeted tests cover the fixed behavior directly: `getOrderFilledAmount.test.ts` (missing-fee NaN regression), `sendSolanaFlow.test.ts` and `tradeFlow/services/solanaFlow/index.test.ts` (creation-tx tagging, posted-order event payload).

Reviewer note:
- The `executedSellAmountBeforeFees ?? executedSellAmount` / `executedFeeAmount || '0'` fallbacks are a frontend workaround for a backend gap (see inline `FIXME`/comments); they can be removed once Solana's order API returns the same fields as EVM's.

## Preview URLs

| Surface | URL |
| --- | --- |
| swap-dev - branch preview URL | https://swap-dev-git-solana-order-fulfillment-1-cowswap-dev.vercel.app |
| explorer-dev - branch preview URL | https://explorer-dev-git-solana-order-fulfillment-1-cowswap-dev.vercel.app |
| widget-configurator - branch preview URL | https://widget-configurator-git-solana-order-fulfillment-1-cowswap-dev.vercel.app |
| sdk-tools - branch preview URL | https://sdk-tools-git-solana-order-fulfillment-1-cowswap-dev.vercel.app |
| storybook - branch preview URL | https://storybook-git-solana-order-fulfillment-1-cowswap-dev.vercel.app |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer Solana order submission progress and confirmation details.
  - Explorer links now direct users to the relevant transaction or CoW Explorer order page.
  - Solana activity now distinguishes order-creating transactions from wrap-only transactions.

- **Bug Fixes**
  - Solana order-creation transactions no longer appear separately from their associated orders.
  - Improved order fulfillment, filled amount, and surplus calculations when execution data or fee information is unavailable.
  - Corrected transaction and order status handling for Solana trades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->