### PR TITLE
fix(swap): include slippage in Swap balance validation

### DIFF
--- a/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/index.tsx
+++ b/apps/cowswap-frontend/src/modules/swap/containers/SwapConfirmModal/index.tsx
@@ -100,20 +100,22 @@ export function SwapConfirmModal(props: SwapConfirmModalProps): ReactNode {
 
   // TODO: Reduce function complexity by extracting logic
   const { disableConfirm, isInsufficientBalance } = useMemo(() => {
-    const current = inputCurrencyInfo?.amount?.currency
-    const hasCurrentCurrency = Boolean(current)
+    const hasCurrentCurrency = Boolean(inputCurrencyInfo?.amount?.currency)
+    // Must cover the slippage-inclusive maximum sell amount, not just the expected sell amount,
+    // otherwise the order can be placed while unfillable if the price moves against the user up to slippage.
+    const maximumSellAmount = receiveAmountInfo?.afterSlippage.sellAmount ?? inputCurrencyInfo?.amount
+    const current = maximumSellAmount?.currency
     let isBalanceEnough = false
 
     if (current) {
       const normalisedAddress = getAddressKey(getCurrencyAddress(current))
       const balance = balances[normalisedAddress]
       const balanceAsCurrencyAmount = CurrencyAmount.fromRawAmount(current, balance?.toString() ?? '0')
-      const inputAmount = inputCurrencyInfo?.amount
 
       isBalanceEnough = Boolean(
         balanceAsCurrencyAmount &&
-          inputAmount &&
-          (inputAmount.equalTo(balanceAsCurrencyAmount) || inputAmount.lessThan(balanceAsCurrencyAmount)),
+          maximumSellAmount &&
+          (maximumSellAmount.equalTo(balanceAsCurrencyAmount) || maximumSellAmount.lessThan(balanceAsCurrencyAmount)),
       )
     }
 
@@ -131,6 +133,7 @@ export function SwapConfirmModal(props: SwapConfirmModalProps): ReactNode {
     balances,
     bridgeQuoteAmounts,
     inputCurrencyInfo,
+    receiveAmountInfo,
     isQuoteLoading,
     isQuoteStale,
     isTradeContextReady,

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormValidationContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormValidationContext.ts
@@ -194,7 +194,7 @@ function getNonNativeCurrency(currency: Nullish<Currency>): Token | null {
 }
 
 function getSwapMaximumSellAmount(
-  tradeType: TradeType | undefined,
+  tradeType: TradeType | null | undefined,
   receiveAmountInfo: ReceiveAmountInfo | null,
 ): CurrencyAmount<Currency> | null {
   if (tradeType !== TradeType.SWAP) return null

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormValidationContext.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/hooks/useTradeFormValidationContext.ts
@@ -4,7 +4,7 @@ import { useMemo } from 'react'
 import { useIsOnline } from '@cowprotocol/common-hooks'
 import { getIsNativeToken } from '@cowprotocol/common-utils'
 import { Nullish } from '@cowprotocol/cow-sdk'
-import { Currency, Token } from '@cowprotocol/currency'
+import { Currency, CurrencyAmount, Token } from '@cowprotocol/currency'
 import { useENSAddress } from '@cowprotocol/ens'
 import { useIsTradeUnsupported, useIsXstockToken, useTryFindToken } from '@cowprotocol/tokens'
 import {
@@ -25,7 +25,14 @@ import { useCurrentAccountProxy } from 'modules/accountProxy'
 import { useTokensBalancesCombined } from 'modules/combinedBalances'
 import { useApproveState, useGetAmountToSignApprove, useIsApprovalOrPermitRequired } from 'modules/erc20Approve'
 import { RwaTokenStatus, useRwaTokenStatus } from 'modules/rwa'
-import { useDerivedTradeState, useIsWrapOrUnwrap, useNonEvmReceiverConfirmed, useTradePriceImpact } from 'modules/trade'
+import {
+  ReceiveAmountInfo,
+  useDerivedTradeState,
+  useGetReceiveAmountInfo,
+  useIsWrapOrUnwrap,
+  useNonEvmReceiverConfirmed,
+  useTradePriceImpact,
+} from 'modules/trade'
 import { TradeQuoteState, useTradeQuote } from 'modules/tradeQuote'
 
 import { QuoteApiError, QuoteApiErrorCodes } from 'api/cowProtocol/errors/QuoteError'
@@ -89,6 +96,9 @@ export function useTradeFormValidationContext(): TradeFormValidationCommonContex
 
   const isInsufficientBalanceOrderAllowed = tradeType === TradeType.LIMIT_ORDER
 
+  const receiveAmountInfo = useGetReceiveAmountInfo()
+  const swapMaximumSellAmount = getSwapMaximumSellAmount(tradeType, receiveAmountInfo)
+
   const { token: intermediateBuyToken, toBeImported } = useTryFindToken(
     getBridgeIntermediateTokenAddress(tradeQuote.bridgeQuote),
   )
@@ -135,6 +145,7 @@ export function useTradeFormValidationContext(): TradeFormValidationCommonContex
         featureFlagsStatus === 'loading' ||
         (featureFlagsStatus === 'ready' && !canQuote && !captchaInteractionRequired),
       isCaptchaRequired: featureFlagsStatus === 'ready' && !canQuote && captchaInteractionRequired,
+      swapMaximumSellAmount,
     }
   }, [
     hasFirstLoad,
@@ -170,6 +181,7 @@ export function useTradeFormValidationContext(): TradeFormValidationCommonContex
     featureFlagsStatus,
     canQuote,
     captchaInteractionRequired,
+    swapMaximumSellAmount,
   ])
 }
 
@@ -179,6 +191,15 @@ function getNonNativeCurrency(currency: Nullish<Currency>): Token | null {
   }
 
   return currency
+}
+
+function getSwapMaximumSellAmount(
+  tradeType: TradeType | undefined,
+  receiveAmountInfo: ReceiveAmountInfo | null,
+): CurrencyAmount<Currency> | null {
+  if (tradeType !== TradeType.SWAP) return null
+
+  return receiveAmountInfo?.afterSlippage.sellAmount ?? null
 }
 
 function isUnsupportedTokenInQuote(state: TradeQuoteState): boolean {

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.test.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.test.ts
@@ -279,6 +279,10 @@ describe('validateTradeForm - balance vs slippage', () => {
   test('falls back to raw input amount when swapMaximumSellAmount is not provided (e.g. limit/TWAP orders)', () => {
     const context = {
       ...baseContext,
+      derivedTradeState: {
+        ...baseContext.derivedTradeState,
+        tradeType: TradeType.LIMIT_ORDER,
+      },
       swapMaximumSellAmount: null,
     } as unknown as TradeFormValidationContext
 

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.test.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.test.ts
@@ -210,6 +210,83 @@ describe('validateTradeForm - xStock logic', () => {
   })
 })
 
+describe('validateTradeForm - balance vs slippage', () => {
+  const baseContext: Partial<TradeFormValidationContext> = {
+    derivedTradeState: {
+      orderKind: OrderKind.BUY,
+      inputCurrencyAmount: mockCurrencyAmount('100'),
+      outputCurrencyAmount: mockCurrencyAmount('100'),
+      inputCurrency: { address: '0x1', chainId: 1 } as unknown as Currency,
+      outputCurrency: { address: '0x2', chainId: 1 } as unknown as Currency,
+      inputCurrencyBalance: mockCurrencyAmount('120'),
+      outputCurrencyBalance: mockCurrencyAmount('1000'),
+      inputCurrencyFiatAmount: null,
+      outputCurrencyFiatAmount: null,
+      recipient: '0x123',
+      isQuoteBasedOrder: true,
+      tradeType: TradeType.SWAP,
+      slippage: null,
+    },
+    tradeQuote: { isLoading: false, quote: {} } as unknown as TradeQuoteState,
+    isOnline: true,
+    isSupportedWallet: true,
+    account: '0x123',
+    isApproveRequired: ApproveRequiredReason.NotRequired,
+    isWrapUnwrap: false,
+    isSafeReadonlyUser: false,
+    isSwapUnsupported: false,
+    recipientEnsAddress: null,
+    isInsufficientBalanceOrderAllowed: false,
+    isProviderNetworkUnsupported: false,
+    isProviderNetworkDeprecated: false,
+    intermediateTokenToBeImported: false,
+    isAccountProxyLoading: false,
+    isProxySetupValid: true,
+    customTokenError: undefined,
+    isRestrictedForCountry: false,
+    isBalancesLoading: false,
+    isBundlingSupported: true,
+    isInputCurrencyXstock: false,
+    isOutputCurrencyXstock: false,
+    injectedWidgetParams: {},
+    tradePriceImpact: { loading: false, priceImpact: undefined },
+    isNonEvmReceiverConfirmed: false,
+    isCaptchaPending: false,
+    isCaptchaRequired: false,
+  }
+
+  // balance (120) covers the raw input amount (100) but not the slippage-inclusive maximum sell amount (150)
+  test('shows BalanceInsufficient for swap when balance covers input amount but not maximum sell amount with slippage', () => {
+    const context = {
+      ...baseContext,
+      swapMaximumSellAmount: mockCurrencyAmount('150'),
+    } as unknown as TradeFormValidationContext
+
+    const result = validateTradeForm(context)
+    expect(result).toContain(TradeFormValidation.BalanceInsufficient)
+  })
+
+  test('does not show BalanceInsufficient for swap when balance covers the maximum sell amount with slippage', () => {
+    const context = {
+      ...baseContext,
+      swapMaximumSellAmount: mockCurrencyAmount('110'),
+    } as unknown as TradeFormValidationContext
+
+    const result = validateTradeForm(context)
+    expect(result || []).not.toContain(TradeFormValidation.BalanceInsufficient)
+  })
+
+  test('falls back to raw input amount when swapMaximumSellAmount is not provided (e.g. limit/TWAP orders)', () => {
+    const context = {
+      ...baseContext,
+      swapMaximumSellAmount: null,
+    } as unknown as TradeFormValidationContext
+
+    const result = validateTradeForm(context)
+    expect(result || []).not.toContain(TradeFormValidation.BalanceInsufficient)
+  })
+})
+
 describe('validateTradeForm - price impact loading', () => {
   const baseContext: Partial<TradeFormValidationContext> = {
     derivedTradeState: {

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/services/validateTradeForm.ts
@@ -40,6 +40,7 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
     isRestoringConnection,
     isCaptchaPending,
     isCaptchaRequired,
+    swapMaximumSellAmount,
   } = context
 
   const {
@@ -170,7 +171,11 @@ export function validateTradeForm(context: TradeFormValidationContext): TradeFor
       validations.push(TradeFormValidation.BalancesNotLoaded)
     }
 
-    if (inputCurrencyBalance && inputCurrencyAmount && inputCurrencyBalance.lessThan(inputCurrencyAmount)) {
+    // For Swap, the balance must cover the slippage-inclusive maximum sell amount, not just the raw input
+    // amount, otherwise the order could be unfillable if the price moves against the user up to slippage.
+    const balanceCheckAmount = swapMaximumSellAmount ?? inputCurrencyAmount
+
+    if (inputCurrencyBalance && balanceCheckAmount && inputCurrencyBalance.lessThan(balanceCheckAmount)) {
       validations.push(TradeFormValidation.BalanceInsufficient)
     }
   }

--- a/apps/cowswap-frontend/src/modules/tradeFormValidation/types.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFormValidation/types.ts
@@ -61,6 +61,13 @@ export interface TradeFormValidationCommonContext {
   isRestoringConnection: boolean
   isCaptchaPending: boolean
   isCaptchaRequired: boolean
+  /**
+   * For Swap only: the maximum sell amount the order can pull from the wallet, including slippage.
+   * Used instead of the raw input amount when checking balance sufficiency, since a swap order
+   * (unlike limit/TWAP orders) must never be placed if the wallet can't cover slippage in the worst case.
+   * Null for non-swap trade types, where the raw input amount is used instead.
+   */
+  swapMaximumSellAmount: CurrencyAmount<Currency> | null
 }
 
 export interface TradeFormValidationContext extends TradeFormValidationCommonContext {}


### PR DESCRIPTION
## Summary
Fixes an issue when slippage was not included into the swap form validation resultied  in placing unfilllable swap orders 
<img width="586" height="350" alt="no balance check" src="https://github.com/user-attachments/assets/1627f89e-9a96-4016-859f-2c25e497f552" />

and #5726 


## To test: 
1. Connect to a wallet
2. Pick a sell token with balance of 2 dai (as an example)
3. Pick a buy correlated token (usdt, as an example(
4. Set 50% slippage
5. buy 1.5 USDT --> the button should say 'insufficient balance' 
<img width="539" height="470" alt="image" src="https://github.com/user-attachments/assets/f091ca85-8032-419b-98a9-06cd9adcc784" />


<details>
- The Swap form and Confirm Swap modal only checked the wallet balance against the raw sell amount, ignoring the slippage buffer added on top for buy orders (the "Maximum sent" amount shown in the review screen).
- This let users place swap orders they didn't have enough balance to cover in the worst case (price moves against them up to the slippage tolerance), resulting in orders that can't actually be filled/settled.
- Both the Swap button (`validateTradeForm.ts`, shared across trade types) and the Confirm Swap button (`SwapConfirmModal`) now compare the balance against the slippage-inclusive maximum sell amount (`receiveAmountInfo.afterSlippage.sellAmount`), scoped to `TradeType.SWAP` only.
- Limit orders and TWAP/Advanced orders are intentionally **not** touched — they already have their own separate, independent balance-check logic (`useIsZeroBalance` for Limit, `useHasEnoughBalanceForAmount` for TWAP), and `validateTradeForm.ts`'s shared balance check falls back to the previous (raw input amount) behavior whenever `swapMaximumSellAmount` is `null`.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved swap balance validation to account for the maximum amount required when prices move within the allowed slippage.
  - Prevented swap orders from being placed when the wallet balance may be insufficient to fulfill them.
  - Preserved standard balance validation for non-swap trades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->