### PR TITLE
fix: show explorer link on solana notifications popups

### DIFF
--- a/apps/cowswap-frontend/src/common/pure/OrderSubmittedContent/index.tsx
+++ b/apps/cowswap-frontend/src/common/pure/OrderSubmittedContent/index.tsx
@@ -63,7 +63,8 @@ export function OrderSubmittedContent({
 }: OrderSubmittedContentProps): ReactNode {
   const tx = {
     hash,
-    hashType: isSafeWallet && !isCowOrder('transaction', hash) ? HashType.GNOSIS_SAFE_TX : HashType.ETHEREUM_TX,
+    hashType:
+      isSafeWallet && !isCowOrder('transaction', hash, chainId) ? HashType.GNOSIS_SAFE_TX : HashType.ETHEREUM_TX,
     safeTransaction: {
       safeTxHash: hash,
       safe: account,

--- a/apps/cowswap-frontend/src/modules/orders/containers/TransactionContentWithLink/index.test.tsx
+++ b/apps/cowswap-frontend/src/modules/orders/containers/TransactionContentWithLink/index.test.tsx
@@ -1,3 +1,4 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
 import { useGnosisSafeInfo, useWalletInfo } from '@cowprotocol/wallet'
 
 import { render } from '@testing-library/react'
@@ -148,6 +149,43 @@ describe('TransactionContentWithLink', () => {
       const tx = getRenderedTx()
       expect(tx.hashType).toBe(HashType.ETHEREUM_TX)
       expect(tx.hash).toBe(ONCHAIN_TX_HASH)
+    })
+  })
+
+  // A Solana order is created by an on-chain transaction, so the link has to move from that
+  // transaction to the order once it exists — the same progression eth-flow makes.
+  describe('Solana orders', () => {
+    // 32 bytes hex, the same length as an EVM transaction hash — only the chain tells them apart.
+    const SOLANA_ORDER_ID = '0x' + 'c'.repeat(64)
+    const SOLANA_TX_SIGNATURE = '5x8VXqZ8pQ2mJ7Yb1kL3nR4tW6uH9dF2sG5cA7eB1vN3mK4pQ8rT2yU6iO9aS1dF'
+
+    beforeEach(() => {
+      useGnosisSafeInfoMock.mockReturnValue(undefined)
+      useWalletInfoMock.mockReturnValue({
+        account: '11111111111111111111111111111111',
+        chainId: SupportedChainId.SOLANA,
+      } as ReturnType<typeof useWalletInfo>)
+    })
+
+    it('links the creation transaction while the order is still being created', () => {
+      useOrderMock.mockReturnValue({ status: OrderStatus.CREATING } as ReturnType<typeof useOrder>)
+      renderComponent({ transactionHash: SOLANA_TX_SIGNATURE, orderUid: SOLANA_ORDER_ID })
+
+      expect(getRenderedTx().hash).toBe(SOLANA_TX_SIGNATURE)
+    })
+
+    it('links the order once it has been created', () => {
+      useOrderMock.mockReturnValue({ status: OrderStatus.PENDING } as ReturnType<typeof useOrder>)
+      renderComponent({ transactionHash: SOLANA_TX_SIGNATURE, orderUid: SOLANA_ORDER_ID })
+
+      expect(getRenderedTx().hash).toBe(SOLANA_ORDER_ID)
+    })
+
+    it('links the order when there is no creation transaction to fall back on', () => {
+      useOrderMock.mockReturnValue({ status: OrderStatus.CREATING } as ReturnType<typeof useOrder>)
+      renderComponent({ transactionHash: undefined, orderUid: SOLANA_ORDER_ID })
+
+      expect(getRenderedTx().hash).toBe(SOLANA_ORDER_ID)
     })
   })
 })

--- a/apps/cowswap-frontend/src/modules/orders/containers/TransactionContentWithLink/index.tsx
+++ b/apps/cowswap-frontend/src/modules/orders/containers/TransactionContentWithLink/index.tsx
@@ -1,6 +1,7 @@
 import { ReactElement, ReactNode } from 'react'
 
 import { isCowOrder } from '@cowprotocol/common-utils'
+import { isSolanaChain } from '@cowprotocol/cow-sdk'
 import { useGnosisSafeInfo, useWalletInfo } from '@cowprotocol/wallet'
 
 import styled from 'styled-components/macro'
@@ -43,19 +44,25 @@ export function TransactionContentWithLink(props: TransactionContentWithLinkProp
   const { transactionHash, orderUid, children, isEthFlow, isSafeTx: isSafeTxProp } = props
   const { status } = useOrder({ id: orderUid, chainId }) || {}
 
-  const isOrder = isCowOrder('transaction', orderUid)
-  const isSafeOrder = !!(isSafeWallet && orderUid && !isCowOrder('transaction', orderUid))
-  const isSafeTx = isSafeTxProp ?? !!(isSafeWallet && transactionHash && !isCowOrder('transaction', transactionHash))
+  const isOrder = isCowOrder('transaction', orderUid, chainId)
+  const isSafeOrder = !!(isSafeWallet && orderUid && !isCowOrder('transaction', orderUid, chainId))
+  const isSafeTx =
+    isSafeTxProp ?? !!(isSafeWallet && transactionHash && !isCowOrder('transaction', transactionHash, chainId))
 
-  const isEthFlowCreating =
-    isEthFlow && transactionHash && (status === OrderStatus.CREATING || status === OrderStatus.FAILED || !status)
+  const isCreatingOnChain = !!(
+    transactionHash &&
+    (status === OrderStatus.CREATING || status === OrderStatus.FAILED || !status) &&
+    // A Solana order is created by an on-chain transaction, so until that settles the transaction is the
+    // only thing worth linking to — same reasoning as eth-flow, where the order doesn't exist yet either.
+    (isEthFlow || isSolanaChain(chainId))
+  )
 
   let hash = ''
 
-  if (isOrder && !isEthFlow) {
-    hash = orderUid || ''
-  } else if (isEthFlowCreating) {
+  if (isCreatingOnChain) {
     hash = transactionHash || ''
+  } else if (isOrder && !isEthFlow) {
+    hash = orderUid || ''
   } else if (isSafeOrder) {
     hash = orderUid || ''
   } else {

--- a/libs/common-utils/src/legacyAddressUtils.test.ts
+++ b/libs/common-utils/src/legacyAddressUtils.test.ts
@@ -1,4 +1,6 @@
-import { getBlockExplorerUrl, isAddress, safeShortenAddress, shortenAddress } from './legacyAddressUtils'
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+
+import { getBlockExplorerUrl, isAddress, isCowOrder, safeShortenAddress, shortenAddress } from './legacyAddressUtils'
 
 describe('utils', () => {
   describe('#isAddress', () => {
@@ -53,6 +55,39 @@ describe('utils', () => {
   describe('#getBlockExplorerUrl', () => {
     it('does not introduce double slashes for bare explorer origins', () => {
       expect(getBlockExplorerUrl(1, 'transaction', 'abc', 'https://etherscan.io')).toBe('https://etherscan.io/tx/abc')
+    })
+  })
+
+  describe('#isCowOrder', () => {
+    // 56 bytes on EVM, 32 bytes on Solana. The Solana id is the same length as an EVM transaction hash,
+    // which is why the chain has to be part of the decision.
+    const EVM_ORDER_ID = `0x${'a'.repeat(112)}`
+    const SOLANA_ORDER_ID = `0x${'b'.repeat(64)}`
+    const EVM_TX_HASH = `0x${'c'.repeat(64)}`
+    // Solana transaction signatures are base58 and much longer than any order id.
+    const SOLANA_TX_SIGNATURE = '5x8VXqZ8pQ2mJ7Yb1kL3nR4tW6uH9dF2sG5cA7eB1vN3mK4pQ8rT2yU6iO9aS1dF'
+
+    it('recognises a Solana order id on a Solana chain', () => {
+      expect(isCowOrder('transaction', SOLANA_ORDER_ID, SupportedChainId.SOLANA)).toBe(true)
+    })
+
+    it('does not mistake an EVM transaction hash for an order, despite the identical length', () => {
+      expect(isCowOrder('transaction', EVM_TX_HASH, SupportedChainId.MAINNET)).toBe(false)
+      expect(isCowOrder('transaction', EVM_TX_HASH)).toBe(false)
+    })
+
+    it('does not mistake a Solana transaction signature for an order', () => {
+      expect(isCowOrder('transaction', SOLANA_TX_SIGNATURE, SupportedChainId.SOLANA)).toBe(false)
+    })
+
+    it('recognises an EVM order id, with or without a chain', () => {
+      expect(isCowOrder('transaction', EVM_ORDER_ID, SupportedChainId.MAINNET)).toBe(true)
+      expect(isCowOrder('transaction', EVM_ORDER_ID)).toBe(true)
+    })
+
+    it('only ever classifies transactions', () => {
+      expect(isCowOrder('address', SOLANA_ORDER_ID, SupportedChainId.SOLANA)).toBe(false)
+      expect(isCowOrder('transaction', undefined, SupportedChainId.SOLANA)).toBe(false)
     })
   })
 })

--- a/libs/common-utils/src/legacyAddressUtils.ts
+++ b/libs/common-utils/src/legacyAddressUtils.ts
@@ -81,6 +81,7 @@ function makeAddressShorter(address: string, chars = 4): string {
 }
 
 const COW_ORDER_ID_LENGTH = 114 // 112 (56 bytes in hex) + 2 (it's prefixed with "0x")
+const SOLANA_ORDER_ID_LENGTH = 66 // 64 (32 bytes in hex) + 2 (it's prefixed with "0x")
 
 export type BlockExplorerLinkType =
   | 'transaction'
@@ -119,7 +120,7 @@ export function getCoWExplorerLinkTitle(): string {
 }
 
 export function getEtherscanLink(chainId: SupportedChainId, type: BlockExplorerLinkType, data: string): string {
-  if (isCowOrder(type, data)) {
+  if (isCowOrder(type, data, chainId)) {
     // Explorer for CoW orders:
     //    If a transaction has the size of the CoW orderId, then it's a meta-tx
     return getExplorerOrderLink(chainId, data)
@@ -149,16 +150,22 @@ export function getEtherscanUrl(
 }
 
 export function getExplorerLabel(chainId: SupportedChainId, type: BlockExplorerLinkType, data?: string): string {
-  return isCowOrder(type, data) ? getCoWExplorerLinkTitle() : getChainExplorerLinkTitle(chainId)
+  return isCowOrder(type, data, chainId) ? getCoWExplorerLinkTitle() : getChainExplorerLinkTitle(chainId)
 }
 
-// TODO: Add proper return type annotation
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function isCowOrder(type: BlockExplorerLinkType, data?: string) {
-  if (!data) return false
+/**
+ * A CoW order id is told apart from a raw transaction hash by its length, which needs the chain to be
+ * unambiguous: Solana order ids are 32 bytes, exactly the length of an EVM transaction hash. Callers that
+ * pass no `chainId` keep the EVM rule, so an EVM transaction hash is never mistaken for an order.
+ */
+export function isCowOrder(type: BlockExplorerLinkType, data?: string, chainId?: TargetChainId): boolean {
+  if (!data || type !== 'transaction') return false
 
-  // FIXME: Solana order id has different length than COW_ORDER_ID_LENGTH
-  return type === 'transaction' && data.length === COW_ORDER_ID_LENGTH
+  if (chainId !== undefined && isSolanaChain(chainId)) {
+    return data.length === SOLANA_ORDER_ID_LENGTH
+  }
+
+  return data.length === COW_ORDER_ID_LENGTH
 }
 
 export function shortenOrderId(orderId: string): string {


### PR DESCRIPTION
# Summary

Solana order notifications linked to the wrong place: instead of the CoW Explorer order page, they built a Solana Explorer **transaction** URL out of an **order id**, labelled "View on Solana Explorer", which resolves to nothing. `isCowOrder` classified ids purely by length and only knew EVM's 114-char form, so every Solana order fell through to the chain-explorer branch. It is now chain-aware, and the link additionally follows the order's lifecycle: while the creating transaction is still confirming it points at that transaction, and switches to the CoW Explorer order page once the order exists. https://linear.app/cowswap/issue/FE-491/explorer-link-on-solana-order-modals-points-at-the-chain-explorer

# To Test

**Setup.** Solana is gated on the LaunchDarkly `isSolanaEnabled` flag 

> [!NOTE]
> Trade **SPL → SPL** (e.g. USDC → USDT). Native SOL quotes still fail for an unrelated reason — the app sends the System Program address to Jupiter instead of the WSOL mint (FE-485).

1. Place a swap and watch the **"Order submitted"** notification.

- [ ] The notification shows a link labelled **"View on Solana Explorer"**
- [ ] Clicking it opens `explorer.solana.com/tx/…` and the **creation transaction is found** (before this PR the URL contained the order id and resolved to nothing)
- [ ] If the notification is still open when the transaction confirms, the link switches by itself to "View on Explorer"

2. Wait for the order to fill and check the **"Order filled"** notification.

- [ ] The link is labelled **"View on Explorer"**
- [ ] It opens the CoW Explorer order page (`…/solana/orders/0x…`), not a Solana Explorer transaction page

3. EVM regression check — swap on Ethereum mainnet with a token that needs approval.

- [ ] The order's link still goes to the CoW Explorer order page
- [ ] The **approve transaction's** link still goes to **Etherscan**, not the CoW Explorer — this is the important one, see Background
- [ ] Safe wallet: order links still open the Safe UI where they did before



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction and order link handling for Solana and EVM orders.
  * Correctly distinguishes Solana order IDs from transaction hashes when selecting explorer links.
  * Ensures submitted orders use the appropriate transaction or order identifier across supported chains and order statuses.
* **Tests**
  * Added coverage for Solana and EVM order links, Safe and non-Safe transactions, missing signatures, and chain-specific identifier detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->