### PR TITLE
fix: show twap part as cancelling

### DIFF
--- a/apps/cowswap-frontend/src/modules/twap/hooks/useEoaTwapPartOrders.test.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useEoaTwapPartOrders.test.tsx
@@ -114,6 +114,34 @@ describe('useEoaTwapPartOrders', () => {
     jest.clearAllMocks()
   })
 
+  it.each([
+    ['open', OrderStatus.PENDING],
+    ['unconfirmed', OrderStatus.SCHEDULED],
+  ] as const)('inherits and clears the parent cancellation flag for %s parts', async (status, expectedStatus) => {
+    fetchEoaTwapPartOrdersMock.mockResolvedValue(makePartPage('part', status))
+    const { result, rerender } = renderHook(({ order }) => useEoaTwapPartOrders(order, parent, 1, true), {
+      initialProps: { order: makeTwapOrder() },
+      wrapper: SwrTestProvider,
+    })
+
+    await waitFor(() => expect(result.current.orders[0]?.isCancelling).toBe(false))
+
+    rerender({ order: { ...makeTwapOrder(), status: TwapOrderStatus.Cancelling } })
+    await waitFor(() => expect(result.current.orders[0]?.isCancelling).toBe(true))
+    expect(result.current.orders[0]?.status).toBe(expectedStatus)
+
+    rerender({ order: makeTwapOrder() })
+    await waitFor(() => expect(result.current.orders[0]?.isCancelling).toBe(false))
+    expect(result.current.orders[0]?.status).toBe(expectedStatus)
+
+    rerender({ order: { ...makeTwapOrder(), status: TwapOrderStatus.Cancelling } })
+    await waitFor(() => expect(result.current.orders[0]?.isCancelling).toBe(true))
+
+    rerender({ order: { ...makeTwapOrder(), status: TwapOrderStatus.Cancelled } })
+    await waitFor(() => expect(result.current.orders[0]?.status).toBe(OrderStatus.CANCELLED))
+    expect(result.current.orders[0]?.isCancelling).toBe(false)
+  })
+
   it('loads candidate-only parents and promotes the same row without changing the count', async () => {
     const page = makePartPage('candidate')
     const candidate = {

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useEoaTwapPartOrders.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useEoaTwapPartOrders.ts
@@ -21,7 +21,7 @@ import { ORDERS_TABLE_PAGE_SIZE } from 'modules/ordersTable'
 import { parseOrder, type ParsedOrder } from 'utils/orderUtils/parseOrder'
 
 import { programmaticOrdersApi } from '../services/programmaticOrdersApi'
-import { type TwapOrderItem } from '../types'
+import { TwapOrderStatus, type TwapOrderItem } from '../types'
 import { getPartOrderStatus } from '../utils/getPartOrderStatus'
 
 interface EoaTwapPartOrdersResult {
@@ -144,6 +144,7 @@ function mapPartOrder(
     ...apiAdditionalInfo,
     id: partOrder.orderUid as UID,
     status: getPartOrderStatus(apiAdditionalInfo, twapOrder, isVirtualPart),
+    isCancelling: twapOrder.status === TwapOrderStatus.Cancelling,
     creationTime,
     isEoaTwapOrder: true,
     sellAmountBeforeFee: partOrder.sellAmount.toString(),


### PR DESCRIPTION
Fixes  https://linear.app/cowswap/issue/FE-495/when-cancelling-parent-order-parts-status-should-also-be-cancelling

