### PR TITLE
fix: properly prevent solana recipient addresses on evm

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useQuoteParamsRecipient.test.ts
+++ b/apps/cowswap-frontend/src/modules/tradeQuote/hooks/useQuoteParamsRecipient.test.ts
@@ -267,6 +267,14 @@ describe('useQuoteParamsRecipient', () => {
       expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: COW_QUOTE_SOL_BRIDGE_RECIPIENT })
     })
 
+    it('should reject SOL address when output chain is EVM (chainId=1)', () => {
+      mockState(SOLANA_ADDRESS, undefined, 1)
+
+      const { result } = renderHook(() => useQuoteParamsRecipient())
+
+      expect(result.current).toEqual({ receiver: ACCOUNT_ADDRESS, bridgeRecipient: ACCOUNT_ADDRESS })
+    })
+
     it('should reject BTC address when output chain is EVM (chainId=1)', () => {
       mockState(BTC_ADDRESS, undefined, 1)
 

--- a/libs/common-utils/src/legacyAddressUtils.test.ts
+++ b/libs/common-utils/src/legacyAddressUtils.test.ts
@@ -19,10 +19,17 @@ describe('utils', () => {
       expect(isAddress('f164fc0ec4e93095b804a4795bbe1e041497b92a0')).toBe(false)
     })
 
-    it('returns the address as-is for a valid Solana address', () => {
-      expect(isAddress('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')).toBe(
-        'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
-      )
+    it('rejects a Solana address — this helper is EVM-only', () => {
+      expect(isAddress('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')).toBe(false)
+    })
+
+    it('rejects a BTC address — this helper is EVM-only', () => {
+      expect(isAddress('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4')).toBe(false)
+    })
+
+    // Base58-only hex (no `0` digit) also matches SOL_ADDRESS_PATTERN — must still checksum as EVM
+    it('checksums a prefix-less hex address that is also valid base58', () => {
+      expect(isAddress('abcdef1234abcdef1234abcdef1234abcdef1234')).toBe('0xAbcDEF1234ABCDEf1234ABcdef1234ABCDef1234')
     })
   })
 

--- a/libs/common-utils/src/legacyAddressUtils.ts
+++ b/libs/common-utils/src/legacyAddressUtils.ts
@@ -22,11 +22,15 @@ import { getSafeAbsoluteUrl } from './safeLink'
  */
 const BLOCK_EXPLORER_URL_OVERRIDE = process.env.REACT_APP_BLOCK_EXPLORER_URL
 
-// returns the checksummed address if the address is valid, otherwise returns false
+/**
+ * EVM only. Returns the checksummed EVM address if valid, otherwise false.
+ *
+ * Do not make this chain-aware: it has no `chainId` and ~23 call sites rely on the EVM contract
+ * (recipient validation, quote params). For chain-agnostic checks use `isSupportedAddress` /
+ * `getAddressKey` from `@cowprotocol/cow-sdk`.
+ */
 export function isAddress(value: string | undefined | null): string | false {
   if (!value) return false
-
-  if (isSolanaAddress(value)) return value // base58, case-sensitive — no checksum transform
 
   return checksumEvmAddress(value)
 }


### PR DESCRIPTION
# Summary

Fixes issue with Solana address being accepted in a EVM trade, causing the quote to fail. Introduced on #8099.
Now Solana address is properly rejected again.

# To Test

1. Open the preview and setup a trade. 
2. Enable the custom recipient setting.
3. Open the recipient field and paste a Solana address, e.g. `8iGxnJtNAsdYHy3AinTVFHmxHNGS57viHTRQKkkrKm2`.
* Field should show the inline error *"Enter a valid Ethereum address"*, and no malformed quote request is sent.

Reproduces only with Solana addresses. BTC addresses are unaffected

* Bridging to Solana should still work as before
* What was added on #8099 should still work

# Self-checks

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have manually tested changes on Vercel preview deployment
- [x] I have done self-review and (or) AI review
- [x] I have addressed all comments from @coderabbitai
- [x] I have less than three open PRs/Stacks in this repo at the moment of creating this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address validation to reject Solana and Bitcoin addresses where EVM addresses are required.
  * Ensured prefix-less hexadecimal addresses are correctly checksummed as EVM addresses.
  * Prevented Solana recipients from being used for EVM output chains, falling back to the connected account address instead.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->