### PR TITLE
fix(explorer): auto-update the user details orders table

### DIFF
--- a/apps/explorer/src/api/operator/accountOrderUtils.ts
+++ b/apps/explorer/src/api/operator/accountOrderUtils.ts
@@ -15,7 +15,7 @@ import { GetAccountOrdersParams, RawOrder } from './types'
  */
 export async function getAccountOrders(params: GetAccountOrdersParams): Promise<GetAccountOrdersResponse> {
   const { networkId, owner, offset = 0, limit = 20 } = params
-  const state = getState({ networkId, owner, limit })
+  const state = getState({ networkId, owner, limit }, canResetCache(params))
   const limitPlusOne = limit + 1
 
   const currentPage = Math.round(offset / limit)
@@ -76,6 +76,14 @@ export async function getAccountOrders(params: GetAccountOrdersParams): Promise<
   return { orders: [...currentPageOrders], hasNextPage: state.unmerged.length > 0 }
 }
 
+/**
+ * Pages are merged sequentially starting from the first one (leftovers are carried over in `unmerged`),
+ * so only the first page can drop the cache without skewing the pages that follow it
+ */
+function canResetCache({ skipCache, offset = 0 }: GetAccountOrdersParams): boolean {
+  return Boolean(skipCache) && offset === 0
+}
+
 const userOrdersCache = new Map<string, CacheState>()
 
 export type GetAccountOrdersResponse = {
@@ -107,11 +115,11 @@ const emptyState = (): CacheState => ({
   barnHasNext: true,
 })
 
-const getState = (cacheKey: CacheKey): CacheState => {
+const getState = (cacheKey: CacheKey, reset = false): CacheState => {
   const key = JSON.stringify(cacheKey)
   const cachedState = userOrdersCache.get(key)
 
-  if (!cachedState) {
+  if (!cachedState || reset) {
     userOrdersCache.set(key, emptyState())
     console.debug('User Orders: Cache reset', { key })
   }

--- a/apps/explorer/src/api/operator/types.ts
+++ b/apps/explorer/src/api/operator/types.ts
@@ -37,6 +37,11 @@ export type GetAccountOrdersParams = WithNetworkId & {
   owner: string
   offset?: number
   limit?: number
+  /**
+   * Discards the cached pages and re-fetches from the API.
+   * Only honoured for the first page, see `getAccountOrders`
+   */
+  skipCache?: boolean
 }
 
 export type GetOrderCompetitionStatusParams = WithNetworkId & {

--- a/apps/explorer/src/hooks/useGetOrders.tsx
+++ b/apps/explorer/src/hooks/useGetOrders.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { CHAIN_INFO } from '@cowprotocol/common-const'
 import { ALL_SUPPORTED_CHAIN_IDS, getAddressKey } from '@cowprotocol/cow-sdk'
@@ -11,6 +11,7 @@ import {
   MultipleOrders,
   tryGetOrderOnAllNetworksAndEnvironments,
 } from 'services/helpers/tryGetOrderOnAllNetworks'
+import { SingleErc20State } from 'state/erc20'
 import { useNetworkId } from 'state/network'
 import { Network, UiError } from 'types'
 import { transformOrder } from 'utils'
@@ -21,6 +22,13 @@ import { updateWeb3Provider } from 'api/web3'
 
 import { web3 } from '../explorer/api'
 import { ORDERS_QUERY_INTERVAL } from '../explorer/const'
+
+type FetchAccountOrdersOptions = {
+  /** Bypass the in-memory page cache so the request actually reaches the API */
+  skipCache?: boolean
+  /** Keep the current orders on screen instead of falling back to the loading placeholder */
+  isBackgroundUpdate?: boolean
+}
 
 type GetAccountOrdersResult = Result & {
   isThereNext: boolean
@@ -70,11 +78,16 @@ export function useGetAccountOrders(
   const [isThereNext, setIsThereNext] = useState(false)
 
   const fetchOrders = useCallback(
-    async (network: Network, owner: string): Promise<void> => {
-      setIsLoading(true)
+    async (network: Network, owner: string, options: FetchAccountOrdersOptions = {}): Promise<void> => {
+      const { skipCache = false, isBackgroundUpdate = false } = options
+
+      // A background update must not swap the table for the loading placeholder
+      if (!isBackgroundUpdate) {
+        setIsLoading(true)
+      }
 
       try {
-        const { orders, hasNextPage } = await getAccountOrders({ networkId: network, owner, offset, limit })
+        const { orders, hasNextPage } = await getAccountOrders({ networkId: network, owner, offset, limit, skipCache })
         setIsThereNext(hasNextPage)
         const newErc20Addresses = filterDuplicateErc20Addresses(orders)
         setErc20Addresses(newErc20Addresses)
@@ -87,7 +100,9 @@ export function useGetAccountOrders(
         console.error(msg, e)
         setError({ message: msg, type: 'error' })
       } finally {
-        setIsLoading(false)
+        if (!isBackgroundUpdate) {
+          setIsLoading(false)
+        }
       }
     },
     [limit, offset, setErc20Addresses, setMountNewOrders, setOrders],
@@ -98,13 +113,16 @@ export function useGetAccountOrders(
       return
     }
 
-    setIsThereNext(false)
-    fetchOrders(networkId, ownerAddress)
+    const isFirstPage = !pageIndex || pageIndex <= 1
 
-    if (pageIndex && pageIndex > 1) return
+    setIsThereNext(false)
+    // The first page is the one new orders land on, always get it fresh from the API
+    fetchOrders(networkId, ownerAddress, { skipCache: isFirstPage })
+
+    if (!isFirstPage) return
 
     const intervalId: NodeJS.Timeout = setInterval(() => {
-      fetchOrders(networkId, ownerAddress)
+      fetchOrders(networkId, ownerAddress, { skipCache: true, isBackgroundUpdate: true })
     }, ORDERS_QUERY_INTERVAL)
 
     return (): void => {
@@ -227,31 +245,48 @@ function useOrdersWithTokenInfo(networkId: Network | undefined): UseOrdersWithTo
   const [erc20Addresses, setErc20Addresses] = useState<string[]>([])
   const { value: valueErc20s, isLoading: areErc20Loading } = useMultipleErc20({ networkId, addresses: erc20Addresses })
   const [mountNewOrders, setMountNewOrders] = useState(false)
+  // `valueErc20s` is emptied every time the addresses to resolve are reset, so keep what was
+  // already resolved around. It lets a background refresh render its orders with token info
+  // right away, instead of blanking the token columns until the effect below kicks in
+  const resolvedErc20s = useRef<Record<string, SingleErc20State>>({})
 
   useEffect(() => {
+    resolvedErc20s.current = {}
     setOrders(undefined)
     setMountNewOrders(false)
   }, [networkId])
+
+  useEffect(() => {
+    if (isObjectEmpty(valueErc20s)) {
+      return
+    }
+
+    resolvedErc20s.current = { ...resolvedErc20s.current, ...valueErc20s }
+  }, [valueErc20s])
+
+  const updateOrders = useCallback((newOrders: Order[] | undefined): void => {
+    setOrders(newOrders?.map((order) => withTokenInfo(order, resolvedErc20s.current)))
+  }, [])
 
   useEffect(() => {
     if (!orders || areErc20Loading || isObjectEmpty(valueErc20s) || !mountNewOrders) {
       return
     }
 
-    const newOrders = orders.map((order) => {
-      order.buyToken = valueErc20s[getAddressKey(order.buyTokenAddress)] || order.buyToken
-      order.sellToken = valueErc20s[getAddressKey(order.sellTokenAddress)] || order.sellToken
-
-      return order
-    })
-
-    setOrders(newOrders)
+    setOrders(orders.map((order) => withTokenInfo(order, valueErc20s)))
     setMountNewOrders(false)
     setErc20Addresses([])
   }, [valueErc20s, networkId, areErc20Loading, mountNewOrders, orders])
 
   return useMemo(
-    () => ({ orders, areErc20Loading, setOrders, setMountNewOrders, setErc20Addresses }),
-    [orders, areErc20Loading, setOrders, setMountNewOrders, setErc20Addresses],
+    () => ({ orders, areErc20Loading, setOrders: updateOrders, setMountNewOrders, setErc20Addresses }),
+    [orders, areErc20Loading, updateOrders, setMountNewOrders, setErc20Addresses],
   )
+}
+
+function withTokenInfo(order: Order, erc20s: Record<string, SingleErc20State>): Order {
+  order.buyToken = erc20s[getAddressKey(order.buyTokenAddress)] || order.buyToken
+  order.sellToken = erc20s[getAddressKey(order.sellTokenAddress)] || order.sellToken
+
+  return order
 }

--- a/apps/explorer/src/hooks/useGetOrders.tsx
+++ b/apps/explorer/src/hooks/useGetOrders.tsx
@@ -76,10 +76,16 @@ export function useGetAccountOrders(
   const [error, setError] = useState<UiError>()
   const { orders, setOrders, setMountNewOrders, setErc20Addresses } = useOrdersWithTokenInfo(networkId)
   const [isThereNext, setIsThereNext] = useState(false)
+  // Requests are not cancellable, so tag each one and let only the most recent one write to the state.
+  // Switching owner, network or page, and polls slower than the interval, would otherwise let an
+  // older response land on top of newer orders
+  const latestRequestId = useRef(0)
 
   const fetchOrders = useCallback(
     async (network: Network, owner: string, options: FetchAccountOrdersOptions = {}): Promise<void> => {
       const { skipCache = false, isBackgroundUpdate = false } = options
+      const requestId = ++latestRequestId.current
+      const isStale = (): boolean => requestId !== latestRequestId.current
 
       // A background update must not swap the table for the loading placeholder
       if (!isBackgroundUpdate) {
@@ -88,6 +94,9 @@ export function useGetAccountOrders(
 
       try {
         const { orders, hasNextPage } = await getAccountOrders({ networkId: network, owner, offset, limit, skipCache })
+
+        if (isStale()) return
+
         setIsThereNext(hasNextPage)
         const newErc20Addresses = filterDuplicateErc20Addresses(orders)
         setErc20Addresses(newErc20Addresses)
@@ -98,9 +107,14 @@ export function useGetAccountOrders(
       } catch (e) {
         const msg = `Failed to fetch orders`
         console.error(msg, e)
+
+        if (isStale()) return
+
         setError({ message: msg, type: 'error' })
       } finally {
-        if (!isBackgroundUpdate) {
+        // Whichever request is the most recent one owns the loading state, background or not:
+        // a superseded request leaves it to the one that replaced it
+        if (!isStale()) {
           setIsLoading(false)
         }
       }

--- a/apps/explorer/src/test/api/operator/accountOrders.test.ts
+++ b/apps/explorer/src/test/api/operator/accountOrders.test.ts
@@ -1,0 +1,94 @@
+import { EnrichedOrder } from '@cowprotocol/cow-sdk'
+
+import { orderBookSDK } from 'cowSdk'
+import { Network } from 'types'
+
+import { getAccountOrders } from '../../../api/operator/accountOrderUtils'
+
+jest.mock('cowSdk', () => ({
+  orderBookSDK: {
+    getOrders: jest.fn(),
+  },
+}))
+
+const mockedOrderBookSDK = jest.mocked(orderBookSDK)
+
+const OLDER_ORDER = { uid: 'older-order', creationDate: '2023-01-01T00:00:00.000Z' }
+const OLD_ORDER = { uid: 'old-order', creationDate: '2024-01-01T00:00:00.000Z' }
+const NEW_ORDER = { uid: 'new-order', creationDate: '2024-06-01T00:00:00.000Z' }
+
+/**
+ * Queues one response per `orderBookSDK.getOrders` call, in order.
+ * A page hits the API once for prod and once for barn, but only while that env still has a next page
+ */
+function queueResponses(...responses: Partial<EnrichedOrder>[][]): void {
+  responses.forEach((orders) => {
+    mockedOrderBookSDK.getOrders.mockResolvedValueOnce(orders as EnrichedOrder[])
+  })
+}
+
+// The page cache is module level and keyed by owner, so every test uses its own one
+let ownerCount = 0
+function nextOwner(): string {
+  ownerCount += 1
+
+  return `0xowner${ownerCount}`
+}
+
+describe('getAccountOrders cache', () => {
+  beforeEach(() => {
+    mockedOrderBookSDK.getOrders.mockReset()
+  })
+
+  it('serves repeated requests for the same page from the cache', async () => {
+    const owner = nextOwner()
+    // prod, barn
+    queueResponses([OLD_ORDER], [])
+
+    const first = await getAccountOrders({ networkId: Network.MAINNET, owner, offset: 0, limit: 20 })
+    const second = await getAccountOrders({ networkId: Network.MAINNET, owner, offset: 0, limit: 20 })
+
+    expect(first.orders.map((order) => order.uid)).toEqual(['old-order'])
+    expect(second.orders.map((order) => order.uid)).toEqual(['old-order'])
+    // Only the first call reached the API
+    expect(mockedOrderBookSDK.getOrders).toHaveBeenCalledTimes(2)
+  })
+
+  it('refetches the first page when skipCache is set, so new orders show up', async () => {
+    const owner = nextOwner()
+    // prod, barn, then prod, barn again for the refresh
+    queueResponses([OLD_ORDER], [], [NEW_ORDER, OLD_ORDER], [])
+
+    await getAccountOrders({ networkId: Network.MAINNET, owner, offset: 0, limit: 20 })
+    const refreshed = await getAccountOrders({
+      networkId: Network.MAINNET,
+      owner,
+      offset: 0,
+      limit: 20,
+      skipCache: true,
+    })
+
+    expect(refreshed.orders.map((order) => order.uid)).toEqual(['new-order', 'old-order'])
+    expect(mockedOrderBookSDK.getOrders).toHaveBeenCalledTimes(4)
+  })
+
+  it('ignores skipCache beyond the first page, to not skew the merged pagination', async () => {
+    const owner = nextOwner()
+    // First page: prod has a next page, barn does not. Second page: prod only
+    queueResponses([NEW_ORDER, OLD_ORDER], [], [OLDER_ORDER])
+
+    await getAccountOrders({ networkId: Network.MAINNET, owner, offset: 0, limit: 1 })
+    const secondPage = await getAccountOrders({ networkId: Network.MAINNET, owner, offset: 1, limit: 1 })
+    const secondPageAgain = await getAccountOrders({
+      networkId: Network.MAINNET,
+      owner,
+      offset: 1,
+      limit: 1,
+      skipCache: true,
+    })
+
+    expect(secondPage.orders.map((order) => order.uid)).toEqual(['old-order'])
+    expect(secondPageAgain.orders.map((order) => order.uid)).toEqual(['old-order'])
+    expect(mockedOrderBookSDK.getOrders).toHaveBeenCalledTimes(3)
+  })
+})

--- a/apps/explorer/src/test/hooks/useGetAccountOrders.test.tsx
+++ b/apps/explorer/src/test/hooks/useGetAccountOrders.test.tsx
@@ -1,0 +1,118 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { useNetworkId } from 'state/network'
+import { Network } from 'types'
+
+import { getAccountOrders, Order } from 'api/operator'
+import { GetAccountOrdersResponse } from 'api/operator/accountOrderUtils'
+
+import { useGetAccountOrders } from '../../hooks/useGetOrders'
+
+jest.mock('state/network', () => ({
+  useNetworkId: jest.fn(),
+}))
+
+jest.mock('api/operator', () => ({
+  getAccountOrders: jest.fn(),
+  getTxOrders: jest.fn(),
+}))
+
+jest.mock('api/web3', () => ({
+  updateWeb3Provider: jest.fn(),
+}))
+
+jest.mock('../../explorer/api', () => ({
+  web3: { eth: { getTransaction: jest.fn() } },
+}))
+
+jest.mock('services/helpers/tryGetOrderOnAllNetworks', () => ({
+  tryGetOrderOnAllNetworksAndEnvironments: jest.fn(),
+}))
+
+// The token info layer is covered elsewhere, here it only needs to stay out of the way
+jest.mock('hooks/useErc20', () => ({
+  useMultipleErc20: () => ({ value: {}, isLoading: false }),
+}))
+
+jest.mock('utils', () => ({
+  transformOrder: jest.fn((order) => order),
+}))
+
+const mockedUseNetworkId = jest.mocked(useNetworkId)
+const mockedGetAccountOrders = jest.mocked(getAccountOrders)
+
+const OWNER_A = '0xowner-a'
+const OWNER_B = '0xowner-b'
+
+function deferred(): { promise: Promise<GetAccountOrdersResponse>; resolve: (v: GetAccountOrdersResponse) => void } {
+  let resolve!: (v: GetAccountOrdersResponse) => void
+  const promise = new Promise<GetAccountOrdersResponse>((res) => {
+    resolve = res
+  })
+
+  return { promise, resolve }
+}
+
+function order(uid: string): Order {
+  return { uid, buyToken: '0x1', sellToken: '0x2', buyTokenAddress: '0x1', sellTokenAddress: '0x2' } as unknown as Order
+}
+
+describe('useGetAccountOrders', () => {
+  beforeEach(() => {
+    mockedGetAccountOrders.mockReset()
+    mockedUseNetworkId.mockReturnValue(Network.MAINNET)
+  })
+
+  it('discards a response that a newer request has already superseded', async () => {
+    const slowFirstRequest = deferred()
+
+    mockedGetAccountOrders
+      .mockReturnValueOnce(slowFirstRequest.promise)
+      .mockResolvedValueOnce({ orders: [order('owner-b-order')], hasNextPage: false })
+
+    const { result, rerender } = renderHook(({ owner }) => useGetAccountOrders(owner, 20, 0, 1), {
+      initialProps: { owner: OWNER_A },
+    })
+
+    rerender({ owner: OWNER_B })
+
+    await waitFor(() => expect(result.current.orders?.map((o) => o.uid)).toEqual(['owner-b-order']))
+
+    // The request for the previous owner only lands now
+    await act(async () => {
+      slowFirstRequest.resolve({ orders: [order('owner-a-order')], hasNextPage: true })
+    })
+
+    expect(result.current.orders?.map((o) => o.uid)).toEqual(['owner-b-order'])
+    expect(result.current.isThereNext).toBe(false)
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('keeps the loading state owned by the most recent request', async () => {
+    const slowFirstRequest = deferred()
+    const slowSecondRequest = deferred()
+
+    mockedGetAccountOrders.mockReturnValueOnce(slowFirstRequest.promise).mockReturnValueOnce(slowSecondRequest.promise)
+
+    const { result, rerender } = renderHook(({ owner }) => useGetAccountOrders(owner, 20, 0, 1), {
+      initialProps: { owner: OWNER_A },
+    })
+
+    expect(result.current.isLoading).toBe(true)
+
+    rerender({ owner: OWNER_B })
+
+    // The superseded request settles first, but the one that replaced it is still in flight
+    await act(async () => {
+      slowFirstRequest.resolve({ orders: [order('owner-a-order')], hasNextPage: true })
+    })
+
+    expect(result.current.isLoading).toBe(true)
+
+    await act(async () => {
+      slowSecondRequest.resolve({ orders: [order('owner-b-order')], hasNextPage: false })
+    })
+
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.orders?.map((o) => o.uid)).toEqual(['owner-b-order'])
+  })
+})


### PR DESCRIPTION
Fixes #3710

## To test

1. Open https://explorer-dev-git-fix-3710-explorer-user-deta-d63fed-cowswap-dev.vercel.app/sepolia/address/...
2. Place an order on CoW Swap.
3. Within ~30s it should appear at the top of the table, without the table flashing a loading state and without a reload.
4. it should update the order status if the order is filled/expired/cancelled etc. without need to reload the page

<details>
## Summary

On `explorer.cow.fi/address/:address` a newly placed order only showed up after a manual page reload, even though the table is supposed to refresh every 30s.

The polling was already there (`useGetAccountOrders`, `ORDERS_QUERY_INTERVAL = 30s`) — the problem is one level down. `getAccountOrders` keeps a module-level `userOrdersCache` that stores each merged prod+barn page, and nothing ever invalidates it:

```ts
const cachedPageOrders = state.merged.get(currentPage)

if (cachedPageOrders) {
  return { orders: [...cachedPageOrders], ... }   // never reaches the API again
}
```

So every 30s tick re-read the same cached page for the whole session. A reload re-evaluates the module and empties the Map, which is why reloading "fixed" it.

## Changes

- `getAccountOrders` takes a `skipCache` param, honoured **only for the first page** — later pages are merged sequentially from it (leftovers are carried in `unmerged`), so dropping the cache mid-way would skew them.
- The 30s poll and the initial first-page fetch pass `skipCache`, so they actually hit the API.
- The poll no longer flips `isLoading`. `OrdersTableWithData` swaps the whole table for `<LoadingWrapper />` while loading, so without this the table would blink away every 30s instead of updating in place.
- Already-resolved ERC20s are kept in a ref, so a refresh renders its orders with token symbols immediately rather than blanking the token columns until the token-merge effect runs.

Pagination behaviour is unchanged: cached pages are still served for pages 2+, and polling is still limited to page 1.






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to bypass cached data when refreshing the first page of account orders.

* **Bug Fixes**
  * Prevented outdated polling responses from overwriting newer order data.
  * Improved loading-state handling when multiple order requests are active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->