### PR TITLE
fix(solana): provide order ttl deadline from the settings

### DIFF
--- a/apps/cowswap-frontend/src/modules/trade/services/solanaFlow/planCreateOrderStep.test.ts
+++ b/apps/cowswap-frontend/src/modules/trade/services/solanaFlow/planCreateOrderStep.test.ts
@@ -21,6 +21,9 @@ const quote = {
   },
 } as unknown as SolanaSwapOrderQuote
 
+// The user's deadline, deliberately different from anything the quote would carry.
+const VALID_TO = 1_700_000_600
+
 const builtOrder = {
   instruction: 'CREATE_ORDER_IX',
   orderId: '0xdeadbeef',
@@ -34,25 +37,44 @@ describe('planCreateOrderStep', () => {
   })
 
   it('delegates instruction building to the SDK', async () => {
-    const { step } = await planCreateOrderStep({ ...quote, sellSymbol: 'SOL', buySymbol: 'USDC' })
+    const { step } = await planCreateOrderStep({ ...quote, sellSymbol: 'SOL', buySymbol: 'USDC', validTo: VALID_TO })
 
-    expect(mockBuildSolanaSwapOrder).toHaveBeenCalledWith({
-      quoteResults: quote.quoteResults,
-      solanaQuote: quote.solanaQuote,
-    })
+    expect(mockBuildSolanaSwapOrder).toHaveBeenCalledWith(
+      {
+        quoteResults: quote.quoteResults,
+        solanaQuote: quote.solanaQuote,
+      },
+      { quoteRequest: { validTo: VALID_TO } },
+    )
     expect(step.instructions).toEqual(['CREATE_ORDER_IX'])
   })
 
   it('carries the order identity out of the same call that built the instruction', async () => {
     // Not derived from `solanaQuote.uid`: a receiver/validTo override re-derives it inside the SDK.
-    const { orderId, signingScheme } = await planCreateOrderStep({ ...quote, sellSymbol: 'SOL', buySymbol: 'USDC' })
+    const { orderId, signingScheme } = await planCreateOrderStep({
+      ...quote,
+      sellSymbol: 'SOL',
+      buySymbol: 'USDC',
+      validTo: VALID_TO,
+    })
 
     expect(orderId).toBe('0xdeadbeef')
     expect(signingScheme).toBe(SigningScheme.PRESIGN)
   })
 
+  // Without this the instruction inherits the quote's own TTL, so the on-chain order expires at a time
+  // the UI never showed — the deadline setting appears to be ignored.
+  it("applies the user's deadline to the instruction, not just to the local order", async () => {
+    await planCreateOrderStep({ ...quote, sellSymbol: 'SOL', buySymbol: 'USDC', validTo: VALID_TO })
+
+    expect(mockBuildSolanaSwapOrder).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ quoteRequest: expect.objectContaining({ validTo: VALID_TO }) }),
+    )
+  })
+
   it('summarises the swap with both symbols', async () => {
-    const { step } = await planCreateOrderStep({ ...quote, sellSymbol: 'SOL', buySymbol: 'USDC' })
+    const { step } = await planCreateOrderStep({ ...quote, sellSymbol: 'SOL', buySymbol: 'USDC', validTo: VALID_TO })
 
     expect(step.summary).toContain('SOL')
     expect(step.summary).toContain('USDC')
@@ -61,8 +83,8 @@ describe('planCreateOrderStep', () => {
   it('propagates an SDK failure instead of sending a partial bundle', async () => {
     mockBuildSolanaSwapOrder.mockRejectedValue(new Error('bad receiver'))
 
-    await expect(planCreateOrderStep({ ...quote, sellSymbol: 'SOL', buySymbol: 'USDC' })).rejects.toThrow(
-      'bad receiver',
-    )
+    await expect(
+      planCreateOrderStep({ ...quote, sellSymbol: 'SOL', buySymbol: 'USDC', validTo: VALID_TO }),
+    ).rejects.toThrow('bad receiver')
   })
 })

--- a/apps/cowswap-frontend/src/modules/trade/services/solanaFlow/planCreateOrderStep.ts
+++ b/apps/cowswap-frontend/src/modules/trade/services/solanaFlow/planCreateOrderStep.ts
@@ -7,6 +7,8 @@ import { SolanaFlowStep } from './types'
 export interface PlanCreateOrderStepParams extends SolanaSwapOrderQuote {
   sellSymbol: string
   buySymbol: string
+  /** The user's deadline setting, which the quote knows nothing about — it carries the quote's own TTL. */
+  validTo: number
 }
 
 export interface PlannedCreateOrderStep {
@@ -16,17 +18,25 @@ export interface PlannedCreateOrderStep {
 }
 
 /**
- * The SDK owns the order's identity as well as its instruction: overriding `receiver`/`validTo` re-derives
- * `uid` and the order PDA, so `orderId` has to come from the same call that built the instruction rather
- * than from the quoted `solanaQuote.uid`.
+ * `validTo` has to reach the instruction, not just the local order: the quoted intent carries the quote's
+ * own TTL rather than the user's deadline, so an order built straight from the quote expires at a time the
+ * UI never showed.
+ *
+ * The SDK owns the order's identity as well as its instruction: overriding `validTo` re-derives `uid` and
+ * the order PDA, so `orderId` has to come from the same call that built the instruction rather than from
+ * the quoted `solanaQuote.uid`.
  */
 export async function planCreateOrderStep({
   quoteResults,
   solanaQuote,
   sellSymbol,
   buySymbol,
+  validTo,
 }: PlanCreateOrderStepParams): Promise<PlannedCreateOrderStep> {
-  const { instruction, orderId, signingScheme } = await buildSolanaSwapOrder({ quoteResults, solanaQuote })
+  const { instruction, orderId, signingScheme } = await buildSolanaSwapOrder(
+    { quoteResults, solanaQuote },
+    { quoteRequest: { validTo } },
+  )
 
   return {
     step: {

--- a/apps/cowswap-frontend/src/modules/tradeFlow/services/solanaFlow/index.test.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/services/solanaFlow/index.test.ts
@@ -176,6 +176,16 @@ describe('solanaFlow', () => {
     expect(mockPlanWrapStep).toHaveBeenCalledWith(expect.objectContaining({ sellAmount: SELL_AMOUNT }))
   })
 
+  // The quoted intent carries the quote's own TTL, so the deadline has to be handed to the order
+  // planner explicitly — otherwise the on-chain order expires at a time the UI never showed.
+  it("hands the user's deadline to the order planner", async () => {
+    const context = buildContext()
+
+    await solanaFlow(context, buildAnalytics())
+
+    expect(mockPlanCreateOrderStep).toHaveBeenCalledWith(expect.objectContaining({ validTo: context.context.validTo }))
+  })
+
   it('delegates the amount the approve switcher chose, not the sell amount', async () => {
     const unlimited = 2n ** 64n - 1n
 

--- a/apps/cowswap-frontend/src/modules/tradeFlow/services/solanaFlow/index.ts
+++ b/apps/cowswap-frontend/src/modules/tradeFlow/services/solanaFlow/index.ts
@@ -57,6 +57,7 @@ export async function solanaFlow(
       solanaQuote,
       sellSymbol,
       buySymbol,
+      validTo,
     })
 
     // Wrap only applies to a native SOL sell and delegate only when the existing delegation is short —
@@ -142,9 +143,9 @@ function buildSolanaOrder(params: {
 
   return {
     ...quoteParams,
-    // Override the quote's own receiver/validTo: they can be stale by the time the order is
-    // actually submitted (see the postSwapOrderFromQuote call above), and the local CREATING
-    // order must match what was really posted, not what the quote a moment ago.
+    // Override the quote's own receiver/validTo: the quote carries its own TTL rather than the user's
+    // deadline, and may be a moment stale. `planCreateOrderStep` applies the same `validTo` to the
+    // instruction, so the deadline shown here is the one the on-chain order actually has.
     receiver,
     validTo,
     id: orderId,


### PR DESCRIPTION
# Summary

Solana orders ignored the swap deadline setting and were always created with a 30-minute lifetime. The order-creation instruction was built straight from the quote, and the quote carries its own TTL rather than the user's deadline — while the pending order shown in the app *was* built with the user's value, so the UI and the chain disagreed about when the order expires. The deadline is now handed to `planCreateOrderStep` and applied to the `CreateOrder` instruction, so the on-chain order expires when the UI says it does. Reported by @elena-zh during QA of #8127; tracked as [FE-500](https://linear.app/cowswap/issue/FE-500/swap-deadline-setting-is-ignored-for-solana-orders-on-chain-order).

# To Test

**Setup.** Solana is gated on the LaunchDarkly `isSolanaEnabled` flag, so it must be enabled for the environment you test on. Connect a Solana wallet holding USDC and a little SOL for fees.

**How to read the real deadline.** Do not read it off the app — see the warning below. Instead:

1. In the "Order submitted" / "Order filled" notification, right-click **View on Explorer** → copy link address. The order id is the part after `/orders/`, a `0x` + 64 hex string.
2. Open the order in the order-book API — a plain GET, works straight in a browser:

   ```
   https://barn.api.cow.fi/solana/api/v1/orders/<ORDER_ID>     ← dev / preview
   https://api.cow.fi/solana/api/v1/orders/<ORDER_ID>          ← prod
   ```

   Worked example (an order placed with a 2-minute deadline):
   [`…/orders/0xd2a46f…e15f0`](https://barn.api.cow.fi/solana/api/v1/orders/0xd2a46fcaa12798182177bc97ab8d413bd6a2b341c6f848741f86aac3e6ae15f0) → `"validTo": 1789067192`

3. `validTo` is a Unix timestamp in seconds. Convert with [epochconverter.com](https://www.epochconverter.com), or in the browser console: `new Date(1789067192 * 1000)`.

> [!WARNING]
> **Do not verify this from the UI.** The order screen and the orders table render the *local* order, which is built from the setting — so they show the expected value even when the chain has a different one. That divergence **is** the bug, so a UI-only check would confirm a fix that isn't there. The API (or the transaction itself) is the source of truth.

> [!NOTE]
> The deadline is counted from when the app builds the trade context — roughly when the confirmation screen opens — not from when the transaction lands in a block. So `validTo` minus the transaction's block time is always a bit *less* than the configured deadline, by however long signing and confirmation took (e.g. ~99s observed for a 2-minute deadline). Judge the absolute time, or use step 2's comparison.

1. Trade widget → gear icon → set **Swap deadline** to something clearly different from the default, e.g. `5` minutes.

- [ ] Place a swap
- [ ] `validTo` is ~5 minutes after the confirmation screen opened, not 30

2. Set the deadline to `10` minutes and place another swap, then compare the two orders.

- [ ] The difference between the two orders' `validTo` values is ~5 minutes — confirms the setting is actually read, and this comparison is immune to how long signing took

3. Compare what the app showed with what the order really has, for the same order.

- [ ] The expiry shown in the app while the order is pending matches `validTo` from the API (before this change the app showed the setting's value while the chain had 30 minutes)
- [ ] The order id stays the same throughout — the notification, the orders table and the explorer link all refer to one order (see Background: overriding the deadline re-derives the id)

4. Leave the deadline at its default and place a swap.

- [ ] Still works, with a 30-minute expiry — no change for anyone who doesn't touch the setting

5. EVM regression check — place a swap on Ethereum mainnet with a non-default deadline.

- [ ] Deadline handling is unchanged (this touches only the Solana flow, but it shares the trade context)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Solana orders now consistently use the user-selected expiration deadline when creating the order and its on-chain instruction.
  - Order identifiers remain aligned with the instruction generated for the selected deadline.

- **Tests**
  - Added coverage confirming deadline values are passed through the Solana trading flow and applied to order instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->