### PR TITLE
fix(trade): freeze the high-fee warning percentage while confirming

### DIFF
--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/HighFeeWarning/hooks/useHighFeeWarning.test.ts
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/HighFeeWarning/hooks/useHighFeeWarning.test.ts
@@ -1,0 +1,134 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { CurrencyAmount, Token } from '@cowprotocol/currency'
+
+import { renderHook } from '@testing-library/react'
+
+import { ReceiveAmountInfo, useGetReceiveAmountInfo } from 'modules/trade'
+
+import { useHighFeeWarning } from './useHighFeeWarning'
+
+import { useTradeConfirmState } from '../../../../trade/hooks/useTradeConfirmState'
+
+// Keep the real freeze hook so this covers the actual composition, and mock only the two seams:
+// the live quote and the confirm state that drives freezing.
+jest.mock('modules/trade', () => ({
+  useGetReceiveAmountInfo: jest.fn(),
+  useFreezeWhileConfirming: jest.requireActual('../../../../trade/hooks/useFreezeWhileConfirming')
+    .useFreezeWhileConfirming,
+}))
+
+jest.mock('../../../../trade/hooks/useTradeConfirmState', () => ({
+  useTradeConfirmState: jest.fn(),
+}))
+
+const mockedUseGetReceiveAmountInfo = useGetReceiveAmountInfo as jest.MockedFunction<typeof useGetReceiveAmountInfo>
+const mockedUseTradeConfirmState = useTradeConfirmState as jest.MockedFunction<typeof useTradeConfirmState>
+
+const USDC = new Token(SupportedChainId.MAINNET, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 6, 'USDC', 'USD Coin')
+const WETH = new Token(
+  SupportedChainId.MAINNET,
+  '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+  18,
+  'WETH',
+  'Wrapped Ether',
+)
+
+const ONE_WETH = CurrencyAmount.fromRawAmount(WETH, '1000000000000000000')
+const ZERO_WETH = CurrencyAmount.fromRawAmount(WETH, '0')
+const ZERO_USDC = CurrencyAmount.fromRawAmount(USDC, '0')
+
+/**
+ * Sell order buying 1 WETH, with `networkFeeInBuyCurrency` charged on top, so the resulting
+ * warning percentage is simply that fee expressed against 1 WETH.
+ */
+function buildReceiveAmountInfo(networkFeeInBuyCurrency: string): ReceiveAmountInfo {
+  const currencies = { sellAmount: ZERO_USDC, buyAmount: ONE_WETH }
+
+  return {
+    isSell: true,
+    quotePrice: null as never,
+    costs: {
+      networkFee: {
+        amountInSellCurrency: ZERO_USDC,
+        amountInBuyCurrency: CurrencyAmount.fromRawAmount(WETH, networkFeeInBuyCurrency),
+      },
+      partnerFee: { amount: ZERO_WETH, bps: 0 },
+    },
+    beforeAllFees: currencies,
+    beforeNetworkCosts: currencies,
+    afterNetworkCosts: currencies,
+    afterPartnerFees: currencies,
+    afterSlippage: currencies,
+    amountsToSign: currencies,
+  } as ReceiveAmountInfo
+}
+
+const QUOTE_34_PERCENT = buildReceiveAmountInfo('340000000000000000')
+const QUOTE_50_PERCENT = buildReceiveAmountInfo('500000000000000000')
+
+function mockIsConfirming(isConfirming: boolean): void {
+  mockedUseTradeConfirmState.mockReturnValue({
+    isOpen: true,
+    pendingTrade: null,
+    transactionHash: null,
+    error: null,
+    permitSignatureState: undefined,
+    forcePriceConfirmation: false,
+    isConfirming,
+  } as ReturnType<typeof useTradeConfirmState>)
+}
+
+describe('useHighFeeWarning', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('follows the live quote while the user has not confirmed yet', () => {
+    mockIsConfirming(false)
+    mockedUseGetReceiveAmountInfo.mockReturnValue(QUOTE_34_PERCENT)
+
+    const { result, rerender } = renderHook(() => useHighFeeWarning())
+
+    expect(result.current.feePercentage?.toFixed(0)).toBe('34')
+
+    mockedUseGetReceiveAmountInfo.mockReturnValue(QUOTE_50_PERCENT)
+    rerender()
+
+    expect(result.current.feePercentage?.toFixed(0)).toBe('50')
+  })
+
+  it('keeps the percentage of the confirmed quote when a refresh lands while confirming', () => {
+    mockIsConfirming(false)
+    mockedUseGetReceiveAmountInfo.mockReturnValue(QUOTE_34_PERCENT)
+
+    const { result, rerender } = renderHook(() => useHighFeeWarning())
+
+    expect(result.current.feePercentage?.toFixed(0)).toBe('34')
+
+    // User clicks confirm, then a quote refresh lands while the wallet prompt is open.
+    mockIsConfirming(true)
+    mockedUseGetReceiveAmountInfo.mockReturnValue(QUOTE_50_PERCENT)
+    rerender()
+
+    expect(result.current.feePercentage?.toFixed(0)).toBe('34')
+    expect(result.current.isHighFee).toBe(true)
+  })
+
+  it('resumes following the live quote once the confirm attempt is aborted', () => {
+    mockIsConfirming(false)
+    mockedUseGetReceiveAmountInfo.mockReturnValue(QUOTE_34_PERCENT)
+
+    const { result, rerender } = renderHook(() => useHighFeeWarning())
+
+    mockIsConfirming(true)
+    mockedUseGetReceiveAmountInfo.mockReturnValue(QUOTE_50_PERCENT)
+    rerender()
+
+    expect(result.current.feePercentage?.toFixed(0)).toBe('34')
+
+    mockIsConfirming(false)
+    rerender()
+
+    expect(result.current.feePercentage?.toFixed(0)).toBe('50')
+  })
+})

--- a/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/HighFeeWarning/hooks/useHighFeeWarning.ts
+++ b/apps/cowswap-frontend/src/modules/tradeWidgetAddons/containers/HighFeeWarning/hooks/useHighFeeWarning.ts
@@ -5,7 +5,7 @@ import { FEE_SIZE_THRESHOLD } from '@cowprotocol/common-const'
 import { FractionUtils } from '@cowprotocol/common-utils'
 import { Currency, CurrencyAmount, Fraction } from '@cowprotocol/currency'
 
-import { ReceiveAmountInfo, useGetReceiveAmountInfo } from 'modules/trade'
+import { ReceiveAmountInfo, useFreezeWhileConfirming, useGetReceiveAmountInfo } from 'modules/trade'
 
 import { useSafeEffect, useSafeMemo } from 'common/hooks/useSafeMemo'
 
@@ -29,7 +29,12 @@ interface UseHighFeeWarningReturn {
  * @description returns params related to high fee and a cb for checking/unchecking fee acceptance
  */
 export function useHighFeeWarning(): UseHighFeeWarningReturn {
-  const receiveAmountInfo = useGetReceiveAmountInfo()
+  const liveReceiveAmountInfo = useGetReceiveAmountInfo()
+  // The warning percentage is quote-derived, so it has to freeze together with the amounts shown
+  // next to it in the confirm modal. Otherwise a quote refresh landing while the wallet prompt is
+  // open keeps re-computing the percentage against a quote the user never confirmed, and the banner
+  // ends up contradicting the frozen amounts right above it.
+  const receiveAmountInfo = useFreezeWhileConfirming(liveReceiveAmountInfo)
 
   const [feeWarningAccepted, setFeeWarningAccepted] = useAtom(feeWarningAcceptedAtom)
 

--- a/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/index.tsx
+++ b/apps/cowswap-frontend/src/modules/twap/containers/TwapFormWarnings/index.tsx
@@ -7,7 +7,6 @@ import { useAdvancedOrdersDerivedState } from 'modules/advancedOrders'
 import { useTradeRouteContext } from 'modules/trade/hooks/useTradeRouteContext'
 import { useGetTradeFormValidation } from 'modules/tradeFormValidation'
 import { TradeFormValidation } from 'modules/tradeFormValidation/types'
-import { useTradeQuoteFeeFiatAmount } from 'modules/tradeQuote'
 import { SellNativeWarningBanner } from 'modules/tradeWidgetAddons'
 
 import {
@@ -22,7 +21,7 @@ import { SwapPriceDifferenceWarning } from './warnings/SwapPriceDifferenceWarnin
 
 import { getHasTwapFormInput, getTwapSellAmountUsdBucket } from '../../analytics/twapDemandAnalytics.utils'
 import { useIsFallbackHandlerRequired } from '../../hooks/useFallbackHandlerVerification'
-import { useSwapAmountDifference } from '../../hooks/useSwapAmountDifference'
+import { useSwapPriceDifferenceWarningProps } from '../../hooks/useSwapPriceDifferenceWarningProps'
 import { useTwapDemandAnalytics } from '../../hooks/useTwapDemandAnalytics'
 import { useTwapSlippage } from '../../hooks/useTwapSlippage'
 import { useTwapWarningsContext } from '../../hooks/useTwapWarningsContext'
@@ -41,12 +40,11 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
   const updateTwapOrdersSettings = useSetAtom(updateTwapOrdersSettingsAtom)
   const slippage = useTwapSlippage()
   const deadline = useAtomValue(twapDeadlineAtom)
-  const swapAmountDifference = useSwapAmountDifference()
+  const { swapAmountDifference, feeFiatAmount } = useSwapPriceDifferenceWarningProps()
   const primaryFormValidation = useGetTradeFormValidation()
 
   const { chainId, account } = useWalletInfo()
   const isFallbackHandlerRequired = useIsFallbackHandlerRequired()
-  const tradeQuoteFeeFiatAmount = useTradeQuoteFeeFiatAmount()
   const { canTrade, walletIsNotConnected } = useTwapWarningsContext()
   const tradeUrlParams = useTradeRouteContext()
   const { inputCurrencyAmount, outputCurrencyAmount, inputCurrencyFiatAmount } = useAdvancedOrdersDerivedState()
@@ -88,7 +86,7 @@ export function TwapFormWarnings({ localFormValidation, isConfirmationModal }: T
   const swapPriceDifferenceWarning = swapAmountDifference ? (
     <SwapPriceDifferenceWarning
       tradeUrlParams={tradeUrlParams}
-      feeFiatAmount={tradeQuoteFeeFiatAmount}
+      feeFiatAmount={feeFiatAmount}
       swapAmountDifference={swapAmountDifference}
     />
   ) : null

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useSwapPriceDifferenceWarningProps.test.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useSwapPriceDifferenceWarningProps.test.ts
@@ -1,0 +1,116 @@
+import { SupportedChainId } from '@cowprotocol/cow-sdk'
+import { CurrencyAmount, Percent, Token } from '@cowprotocol/currency'
+
+import { act, renderHook } from '@testing-library/react'
+
+import { useTradeConfirmActions } from 'modules/trade'
+import { useTradeQuoteFeeFiatAmount } from 'modules/tradeQuote'
+
+import { SwapAmountDifference, useSwapAmountDifference } from './useSwapAmountDifference'
+import { useSwapPriceDifferenceWarningProps } from './useSwapPriceDifferenceWarningProps'
+
+jest.mock('./useSwapAmountDifference', () => ({
+  useSwapAmountDifference: jest.fn(),
+}))
+
+jest.mock('modules/tradeQuote', () => ({
+  useTradeQuoteFeeFiatAmount: jest.fn(),
+}))
+
+const mockedUseSwapAmountDifference = useSwapAmountDifference as jest.MockedFunction<typeof useSwapAmountDifference>
+const mockedUseTradeQuoteFeeFiatAmount = useTradeQuoteFeeFiatAmount as jest.MockedFunction<
+  typeof useTradeQuoteFeeFiatAmount
+>
+
+const WETH = new Token(
+  SupportedChainId.MAINNET,
+  '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+  18,
+  'WETH',
+  'Wrapped Ether',
+)
+const USDC = new Token(SupportedChainId.MAINNET, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 6, 'USDC', 'USD Coin')
+
+function difference(rawAmount: string, percentNumerator: number): SwapAmountDifference {
+  return {
+    amount: CurrencyAmount.fromRawAmount(WETH, rawAmount),
+    percent: new Percent(percentNumerator, 100),
+  }
+}
+
+const CONFIRMED = difference('1000000000000000000', 2)
+const REFRESHED = difference('5000000000000000000', 9)
+const CONFIRMED_FEE = CurrencyAmount.fromRawAmount(USDC, '1000000')
+const REFRESHED_FEE = CurrencyAmount.fromRawAmount(USDC, '7000000')
+
+function renderWarningProps(): ReturnType<
+  typeof renderHook<
+    { values: ReturnType<typeof useSwapPriceDifferenceWarningProps>; setConfirming: (v: boolean) => void },
+    void
+  >
+> {
+  return renderHook(() => ({
+    values: useSwapPriceDifferenceWarningProps(),
+    setConfirming: useTradeConfirmActions().setConfirming,
+  }))
+}
+
+describe('useSwapPriceDifferenceWarningProps', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedUseSwapAmountDifference.mockReturnValue(CONFIRMED)
+    mockedUseTradeQuoteFeeFiatAmount.mockReturnValue(CONFIRMED_FEE)
+  })
+
+  it('follows the live quote while the user has not confirmed yet', () => {
+    const { result, rerender } = renderWarningProps()
+
+    act(() => result.current.setConfirming(false))
+
+    expect(result.current.values.swapAmountDifference).toBe(CONFIRMED)
+
+    mockedUseSwapAmountDifference.mockReturnValue(REFRESHED)
+    mockedUseTradeQuoteFeeFiatAmount.mockReturnValue(REFRESHED_FEE)
+    rerender()
+
+    expect(result.current.values.swapAmountDifference).toBe(REFRESHED)
+    expect(result.current.values.feeFiatAmount).toBe(REFRESHED_FEE)
+  })
+
+  it('holds the confirmed values when a quote refresh lands while confirming', () => {
+    const { result, rerender } = renderWarningProps()
+
+    act(() => result.current.setConfirming(false))
+
+    expect(result.current.values.swapAmountDifference).toBe(CONFIRMED)
+
+    // User clicks confirm, then a quote refresh lands while the wallet prompt is open.
+    act(() => result.current.setConfirming(true))
+
+    mockedUseSwapAmountDifference.mockReturnValue(REFRESHED)
+    mockedUseTradeQuoteFeeFiatAmount.mockReturnValue(REFRESHED_FEE)
+    rerender()
+
+    // Both halves of the banner must stay on the confirmed snapshot, never a mix of the two.
+    expect(result.current.values.swapAmountDifference).toBe(CONFIRMED)
+    expect(result.current.values.feeFiatAmount).toBe(CONFIRMED_FEE)
+  })
+
+  it('resumes following the live quote once the confirm attempt is aborted', () => {
+    const { result, rerender } = renderWarningProps()
+
+    act(() => result.current.setConfirming(false))
+    act(() => result.current.setConfirming(true))
+
+    mockedUseSwapAmountDifference.mockReturnValue(REFRESHED)
+    mockedUseTradeQuoteFeeFiatAmount.mockReturnValue(REFRESHED_FEE)
+    rerender()
+
+    expect(result.current.values.swapAmountDifference).toBe(CONFIRMED)
+
+    act(() => result.current.setConfirming(false))
+
+    expect(result.current.values.swapAmountDifference).toBe(REFRESHED)
+    expect(result.current.values.feeFiatAmount).toBe(REFRESHED_FEE)
+  })
+})

--- a/apps/cowswap-frontend/src/modules/twap/hooks/useSwapPriceDifferenceWarningProps.ts
+++ b/apps/cowswap-frontend/src/modules/twap/hooks/useSwapPriceDifferenceWarningProps.ts
@@ -1,0 +1,24 @@
+import { CurrencyAmount, Token } from '@cowprotocol/currency'
+
+import { useFreezeWhileConfirming } from 'modules/trade'
+import { useTradeQuoteFeeFiatAmount } from 'modules/tradeQuote'
+
+import { SwapAmountDifference, useSwapAmountDifference } from './useSwapAmountDifference'
+
+export interface SwapPriceDifferenceWarningValues {
+  swapAmountDifference: SwapAmountDifference | null
+  feeFiatAmount: CurrencyAmount<Token> | null
+}
+
+/**
+ * Both values are quote-derived and rendered by `SwapPriceDifferenceWarning`, which the TWAP
+ * confirm modal shows next to amounts it has already frozen. They are frozen here as one snapshot
+ * so a quote refresh landing while the wallet prompt is open can neither leave the warning
+ * contradicting the amounts above it, nor pair a fresh fee with a stale difference.
+ */
+export function useSwapPriceDifferenceWarningProps(): SwapPriceDifferenceWarningValues {
+  const swapAmountDifference = useSwapAmountDifference()
+  const feeFiatAmount = useTradeQuoteFeeFiatAmount()
+
+  return useFreezeWhileConfirming({ swapAmountDifference, feeFiatAmount })
+}


### PR DESCRIPTION
# Summary

Follow-up to #8133.
Fixes https://nomevlabs.slack.com/archives/C0361CDG8GP/p1789124085239879?thread_ts=1788859975.900369&cid=C0361CDG8GP

<img width="599" height="682" alt="image" src="https://github.com/user-attachments/assets/670de49b-b7da-4199-b544-7fc2181ee1bd" />



# To Test

1. Connect a wallet, go to **Swap**, and set up a trade small enough for the red high-fee banner to appear (the report used ~0.001 WETH → USDT, Ethereum → Arbitrum).

- [ ] The banner "Swap costs are at least X% of the swap amount" is visible on the form
- [ ] Its percentage still updates as quotes refresh (form behaviour must not change)

2. Open the Confirm modal and note both the banner percentage and the amounts above it.

3. Press **Confirm**, but do not sign in the wallet. Wait 30+ seconds for at least one quote refresh.

- [ ] The banner percentage does **not** change (before the fix it kept updating)
- [ ] It still agrees with the frozen amounts shown above it
- [ ] The ⓘ tooltip next to the banner shows the same frozen numbers

4. Reject or dismiss the wallet request.

- [ ] Back on the form, the banner resumes updating with fresh quotes

5. Repeat steps 1–4 for a **bridged** swap (different source/destination chain), which is the layout in the report.

- [ ] "Swap and bridge costs are at least X%" behaves the same way

6. Repeat on the **Yield** tab, which renders the same banner in its confirm modal.

- [ ] The banner holds its value while confirming

7. **TWAP** tab: set up a TWAP order whose parts differ enough from the full-amount quote for the "price difference" warning to show, open the confirm modal, press Confirm and hold the wallet prompt open across a refresh.

- [ ] The difference percentage and the fee amount in that warning both hold their values
- [ ] They stay consistent with the frozen amounts above them

8. Regression — **Limit**:

- [ ] No change. Limit uses a different small-volume warning and already pauses polling on the confirm screen.

9. Regression — the original #8133 behaviour:

- [ ] Amounts, rate, slippage, deadline and quote id still freeze on Confirm across Swap / TWAP / Yield

# Background

<details>

That PR froze the amounts on the confirm modal, but missed the high-fee banner sitting right below them. The percentage kept re-computing against every new quote while the amounts above it stayed frozen, so the banner ended up contradicting the numbers it was warning about — "Swap costs are at least 34% of the swap amount" ticking up and down next to amounts that never moved.

`HighFeeWarning` reads the live quote itself (`useHighFeeWarning` → `useGetReceiveAmountInfo`), so it never saw the snapshot the modal had already built. One line freezes it in step with everything else.

The TWAP confirm modal had the same gap: `SwapPriceDifferenceWarning` renders a price-difference percentage and a fee amount that both kept re-computing while `TwapConfirmModal` held its amounts frozen. Fixed here too, so all three confirm modals are now consistent.

**Root cause**

`SwapConfirmModal` builds the frozen snapshot and renders the banner next to it, but the banner never receives it:

```ts
// SwapConfirmModal/index.tsx
const { receiveAmountInfo: frozenReceiveAmountInfo, ... } = useFreezeWhileConfirming({ ... })
...
<HighFeeWarning readonlyMode />   // reads the live quote instead
```

`YieldConfirmModal` has the identical gap — it computes `frozenReceiveAmountInfo` and then renders `<HighFeeWarning readonlyMode />` without it.

**Fix**

One line in `useHighFeeWarning`:

```ts
const receiveAmountInfo = useFreezeWhileConfirming(liveReceiveAmountInfo)
```

Freezing inside the hook rather than threading a prop through each modal was deliberate:
- it covers both confirm modals that render the banner (swap incl. the bridge layout, and yield) in one place;
- the banner and the amounts then derive from the *same* snapshot, instead of two independently frozen copies that could in principle diverge.

**Blast radius**

`TradeButtons` reads `feeWarningAccepted` from the same hook, so its gate also freezes mid-confirm. That is the desired direction — the button should not flip while the user is signing. The trade-form banner is unaffected in practice, since `isConfirming` is only true while the confirm modal is open on top of it.

**Automated checks**

- New `useHighFeeWarning.test.ts`: the percentage follows the live quote before confirm, holds the confirmed quote's value when a refresh lands mid-confirm, and resumes once the attempt is aborted. The two behavioural cases fail without the fix (verified by reverting the line).
- `nx test cowswap-frontend` — 1745 passed, 1 skipped.
- `eslint` clean on the touched files.

**Target branch**

Originally opened against `main`, since #8133 shipped in the 2026-09-10 hotfix and `useFreezeWhileConfirming` did not exist on `develop` yet. Retargeted to `develop` now that #8144 synced main back into it.

That also clears the smoke failure seen on the earlier main-based revision: `[CS-59]` was failing on the stale "1 unit" auto-fill default (posting a 1 USDC order, leaving 1499 instead of 500 USDC), which the e2e hardening in #8091 / #8039 / #8108 already fixed on `develop` but had not reached `main`. Unrelated to this change — `[CS-59]` mocks `feeAmount: '0'`, so the high-fee banner never renders in it.

</details>

# Self-checks

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have manually tested changes on Vercel preview deployment — **not done**: reproducing needs a real quote refresh to land during an open wallet prompt. Covered by unit tests; the steps above are for a manual pass.
- [x] I have done self-review and (or) AI review
- [x] I have addressed all comments from @coderabbitai — none yet on this PR
- [x] I have less than three open PRs/Stacks in this repo at the moment of creating this PR — currently 4 open (#8095, #8128, #8140, this one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - High-fee warnings now remain consistent with the quote shown when trade confirmation begins.
  - Warning percentages stay fixed while the wallet confirmation prompt is open, even when refreshed quotes arrive.
  - Swap amount and fee warnings remain synchronized during confirmation.
  - Warnings resume updating with the latest quote after confirmation is canceled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
